### PR TITLE
Delete used proof records

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -91,8 +91,8 @@ contract TaikoL1 is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     event BlockProposed(uint256 indexed id, BlockContext context);
     event BlockProven(
         uint256 indexed id,
-        BlockHeader header,
-        bytes32 blockHash
+        bytes32 parentHash,
+        ProofRecord record
     );
     event BlockProvenInvalid(uint256 indexed id);
     event BlockFinalized(uint256 indexed id, ShortHeader header);
@@ -191,7 +191,7 @@ contract TaikoL1 is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             proofs[1]
         );
 
-        proofRecords[context.id][header.parentHash] = ProofRecord({
+        ProofRecord memory record = ProofRecord({
             prover: msg.sender,
             header: ShortHeader({
                 blockHash: blockHash,
@@ -199,7 +199,9 @@ contract TaikoL1 is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             })
         });
 
-        emit BlockProven(context.id, header, blockHash);
+        proofRecords[context.id][header.parentHash] = record;
+
+        emit BlockProven(context.id, header.parentHash, record);
     }
 
     function proveBlocksInvalid(

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -294,6 +294,8 @@ contract TaikoL1 is OwnableUpgradeable, ReentrancyGuardUpgradeable {
                 .header;
 
             if (header.blockHash != 0x0) {
+                delete proofRecords[nextId][parent.blockHash];
+
                 lastFinalizedHeight += 1;
 
                 finalizedBlocks[lastFinalizedHeight] = header;
@@ -305,7 +307,7 @@ contract TaikoL1 is OwnableUpgradeable, ReentrancyGuardUpgradeable {
                 proofRecords[nextId][JUMP_MARKER].header.blockHash ==
                 JUMP_MARKER
             ) {
-                // Do nothing
+                delete proofRecords[nextId][JUMP_MARKER];
             } else {
                 break;
             }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -89,7 +89,11 @@ contract TaikoL1 is OwnableUpgradeable, ReentrancyGuardUpgradeable {
      **********************/
 
     event BlockProposed(uint256 indexed id, BlockContext context);
-    event BlockProven(uint256 indexed id, BlockHeader header);
+    event BlockProven(
+        uint256 indexed id,
+        BlockHeader header,
+        bytes32 blockHash
+    );
     event BlockProvenInvalid(uint256 indexed id);
     event BlockFinalized(uint256 indexed id, ShortHeader header);
 
@@ -195,7 +199,7 @@ contract TaikoL1 is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             })
         });
 
-        emit BlockProven(context.id, header);
+        emit BlockProven(context.id, header, blockHash);
     }
 
     function proveBlocksInvalid(


### PR DESCRIPTION
If in the same transaction the next-to-be-finalized block is just proven, then deleting the proof records will avoid a SSTORE for the transaction's proof record.