### PR TITLE
Remove stateRoot from finalizedBlock records

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -112,7 +112,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
     Stats private _stats; // 1 slot
 
-    uint256[41] private __gap;
+    uint256[40] private __gap;
 
     /**********************
      * Events             *

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -39,8 +39,8 @@ struct Snippet {
 }
 
 struct Evidence {
-    uint256 proverFee;
     address prover;
+    uint256 proverFee;
     uint64 proposedAt;
     uint64 provenAt;
     Snippet snippet;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -454,7 +454,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
         emit BlockFinalized(id, height, evidence);
 
-        // Delete the evidence
+        // Delete the evidence to potentially avoid a sstore.
         evidence.prover = address(0);
         evidence.proverFee = 0;
         evidence.proposedAt = 0;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -159,7 +159,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
             !AddressUpgradeable.isContract(_keyManagerAddress),
             "invalid keyManager"
         );
-        require(_taikoL2Address != address(0), "invalid keyManager");
+        require(_taikoL2Address != address(0), "invalid taikoL2Address");
 
         proverBaseFee = _proverBaseFee;
         proverGasPrice = _proverGasPrice;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -198,20 +198,13 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         );
         validateContext(context);
 
-        uint256 proverFee = context.gasLimit * proverGasPrice + proverBaseFee;
-        require(msg.value >= proverFee, "insufficient prover fee");
-
-        if (msg.value > proverFee) {
-            bool success;
-            (success, ) = msg.sender.call{value: msg.value - proverFee}("");
-        }
-
         context.id = nextPendingId;
         context.proposedAt = block.timestamp.toUint64();
         context.txListHash = txList.hashTxList();
-        context.proverFee = context.gasLimit * proverGasPrice + proverBaseFee;
-        require(msg.value >= proverFee, "insufficient prover fee");
 
+        context.proverFee = context.gasLimit * proverGasPrice + proverBaseFee;
+
+        require(msg.value >= proverFee, "insufficient prover fee");
         if (msg.value > context.proverFee) {
             payable(msg.sender).transfer(msg.value - context.proverFee);
         }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -216,12 +216,6 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
         context.proverFee = context.gasLimit * proverGasPrice + proverBaseFee;
 
-        require(msg.value >= context.proverFee, "insufficient fee");
-
-        if (msg.value > context.proverFee) {
-            payable(msg.sender).transfer(msg.value - context.proverFee);
-        }
-
         _stats.avgPendingSize = _calcAverage(
             _stats.avgPendingSize,
             nextPendingId - lastFinalizedId - 1
@@ -231,6 +225,11 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         emit BlockProposed(nextPendingId, context);
 
         nextPendingId += 1;
+
+        require(msg.value >= context.proverFee, "insufficient fee");
+        if (msg.value > context.proverFee) {
+            payable(msg.sender).transfer(msg.value - context.proverFee);
+        }
     }
 
     // TODO: how to verify the zkp is associated with msg.sender?

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -201,7 +201,6 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         context.id = nextPendingId;
         context.proposedAt = block.timestamp.toUint64();
         context.txListHash = txList.hashTxList();
-
         context.proverFee = context.gasLimit * proverGasPrice + proverBaseFee;
 
         require(msg.value >= proverFee, "insufficient prover fee");

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -454,7 +454,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
         emit BlockFinalized(id, height, evidence);
 
-        // Delete the evidence to potentially avoid a sstore.
+        // Delete the evidence to potentially avoid 5 sstore ops.
         evidence.prover = address(0);
         evidence.proverFee = 0;
         evidence.proposedAt = 0;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -98,7 +98,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
     mapping(uint256 => mapping(bytes32 => Evidence)) public evidences;
 
-    KeyManager public keyManager;
+    address public keyManagerAddress;
     address public taikoL2Address;
     address public daoAddress;
 
@@ -147,7 +147,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
     function init(
         Snippet calldata genesis,
-        address keyManagerAddr,
+        address _keyManagerAddress,
         address _taikoL2Address,
         address _daoAddress,
         uint256 _proverBaseFee,
@@ -156,21 +156,21 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         ReentrancyGuardUpgradeable.__ReentrancyGuard_init();
 
         require(
-            !AddressUpgradeable.isContract(keyManagerAddr),
+            !AddressUpgradeable.isContract(_keyManagerAddress),
             "invalid keyManager"
         );
         require(_taikoL2Address != address(0), "invalid keyManager");
 
         proverBaseFee = _proverBaseFee;
         proverGasPrice = _proverGasPrice;
-        daoAddress = _daoAddress;
 
         finalizedBlocks[0] = genesis;
         nextPendingId = 1;
 
         genesisHeight = block.number.toUint64();
-        keyManager = KeyManager(keyManagerAddr);
+        keyManagerAddress = _keyManagerAddress;
         taikoL2Address = _taikoL2Address;
+        daoAddress = _daoAddress;
 
         Evidence memory evidence = Evidence({
             prover: address(0),
@@ -243,7 +243,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         bytes32 blockHash = header.hashBlockHeader();
 
         LibZKP.verify(
-            keyManager.getKey(ZKP_VKEY),
+            KeyManager(keyManagerAddress).getKey(ZKP_VKEY),
             header.parentHash,
             blockHash,
             context.txListHash,
@@ -308,7 +308,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         );
 
         LibZKP.verify(
-            keyManager.getKey(ZKP_VKEY),
+            KeyManager(keyManagerAddress).getKey(ZKP_VKEY),
             throwAwayHeader.parentHash,
             throwAwayHeader.hashBlockHeader(),
             throwAwayTxListHash,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -39,10 +39,10 @@ struct Snippet {
 }
 
 struct Evidence {
+    uint256 proverFee;
     address prover;
     uint64 proposedAt;
     uint64 provenAt;
-    uint256 proverFee;
     Snippet snippet;
 }
 
@@ -168,9 +168,9 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
         Evidence memory evidence = Evidence({
             prover: address(0),
+            proverFee: 0,
             proposedAt: 0,
             provenAt: 0,
-            proverFee: 0,
             snippet: genesis
         });
         emit BlockFinalized(0, 0, evidence);
@@ -257,9 +257,9 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
         Evidence memory evidence = Evidence({
             prover: msg.sender,
+            proverFee: context.proverFee,
             proposedAt: context.proposedAt,
             provenAt: block.timestamp.toUint64(),
-            proverFee: context.proverFee,
             snippet: Snippet({
                 blockHash: blockHash,
                 stateRoot: header.stateRoot
@@ -409,9 +409,9 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         );
         evidences[context.id][JUMP_MARKER] = Evidence({
             prover: msg.sender,
+            proverFee: context.proverFee,
             proposedAt: context.proposedAt,
             provenAt: block.timestamp.toUint64(),
-            proverFee: context.proverFee,
             snippet: Snippet({blockHash: 0x0, stateRoot: 0x0})
         });
         emit BlockProvenInvalid(context.id);
@@ -422,6 +422,8 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         uint64 height,
         Evidence storage evidence
     ) private {
+        payable(evidence.prover).transfer(evidence.proverFee);
+
         _stats.avgProvingDelay = _calcAverage(
             _stats.avgProvingDelay,
             evidence.provenAt - evidence.proposedAt
@@ -436,9 +438,9 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
         // Delete the evidence
         evidence.prover = address(0);
-        evidence.proposedAt = 0;
-        evidence.proposedAt = 0;
         evidence.proverFee = 0;
+        evidence.proposedAt = 0;
+        evidence.proposedAt = 0;
         delete evidence.snippet;
     }
 


### PR DESCRIPTION
This to 1) save gas, 2)  make sure L1 and L2 they only know each other's blockHash.