### PR TITLE
Implement a linear network utilization fee

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -455,6 +455,8 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         Evidence storage evidence
     ) private {
         bool success;
+
+        // Pay the prover fee
         (success, ) = evidence.prover.call{value: evidence.proverFee}("");
 
         if (!success && daoAddress != address(0)) {
@@ -471,7 +473,6 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
             block.timestamp.toUint64() - evidence.proposedAt
         );
 
-        payable(msg.sender).transfer(evidence.proverFee);
         emit BlockFinalized(id, _lastFinalizedHeight, evidence);
 
         // Delete the evidence to potentially avoid 4 sstore ops.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -85,7 +85,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
     bytes32 private constant JUMP_MARKER = bytes32(uint256(1));
     uint256 private constant STAT_AVERAGING_FACTOR = 2048;
     uint64 private constant NANO_PER_SECOND = 1E9;
-    uint64 private constant UTILIZATION_FEE_RATIO = 50; // 50%
+    uint64 private constant UTILIZATION_FEE_RATIO = 500; // 5x
 
     /**********************
      * State Variables    *

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -462,7 +462,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         if (!success && daoAddress != address(0)) {
             (success, ) = daoAddress.call{value: evidence.proverFee}("");
         }
-
+        // update Stats
         _stats.avgProvingDelay = _calcAverage(
             _stats.avgProvingDelay,
             evidence.provenAt - evidence.proposedAt

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -360,9 +360,9 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
             if (evidence.prover != address(0)) {
                 finalizedBlocks[++lastFinalizedHeight] = evidence.blockHash;
-                _processBlock(id, lastFinalizedHeight, evidence);
+                _finalizeBlock(id, lastFinalizedHeight, evidence);
             } else if (evidences[id][JUMP_MARKER].prover != address(0)) {
-                _processBlock(
+                _finalizeBlock(
                     id,
                     lastFinalizedHeight,
                     evidences[id][JUMP_MARKER]
@@ -449,7 +449,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         emit BlockProvenInvalid(context.id);
     }
 
-    function _processBlock(
+    function _finalizeBlock(
         uint64 id,
         uint64 _lastFinalizedHeight,
         Evidence storage evidence

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -463,7 +463,6 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
             (success, ) = daoAddress.call{value: evidence.proverFee}("");
         }
         // Update stats
-
         _stats.avgPendingSize = _calcAverage(
             _stats.avgPendingSize,
             nextPendingId - lastFinalizedId - 1

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -479,7 +479,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
             block.timestamp.toUint64() - evidence.proposedAt
         );
 
-        emit BlockFinalized(id, height, evidence);
+        payable(msg.sender).transfer(evidence.proverFee);
 
         // Delete the evidence to potentially avoid 4 sstore ops.
         evidence.prover = address(0);
@@ -487,6 +487,8 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         evidence.proposedAt = 0;
         evidence.proposedAt = 0;
         evidence.blockHash = 0x0;
+
+        emit BlockFinalized(id, height, evidence);
     }
 
     function _savePendingBlock(uint256 id, bytes32 contextHash)

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -85,7 +85,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
     bytes32 private constant JUMP_MARKER = bytes32(uint256(1));
     uint256 private constant STAT_AVERAGING_FACTOR = 2048;
     uint64 private constant NANO_PER_SECOND = 1E9;
-    uint64 private constant UTILIZATION_FEE_RATIO = 50; // 20%
+    uint64 private constant UTILIZATION_FEE_RATIO = 50; // 50%
 
     /**********************
      * State Variables    *

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -454,9 +454,8 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         uint64 _lastFinalizedHeight,
         Evidence storage evidence
     ) private {
-        bool success;
-
         // Pay prover fee
+        bool success;
         (success, ) = evidence.prover.call{value: evidence.proverFee}("");
 
         if (!success && daoAddress != address(0)) {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -226,8 +226,8 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
 
         nextPendingId += 1;
 
-        uint256 utilizationFee = (context.proverFee *
-            getUtilizationFeeRatio()) / 10000;
+        uint256 utilizationFee = (context.proverFee * getUtilizationFeeBips()) /
+            10000;
 
         uint256 totalFees = context.proverFee + utilizationFee;
         require(msg.value >= totalFees, "insufficient fee");
@@ -419,7 +419,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         stats.avgFinalizationDelay /= NANO_PER_SECOND;
     }
 
-    function getUtilizationFeeRatio()
+    function getUtilizationFeeBips()
         public
         view
         returns (
@@ -430,10 +430,9 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         if (numPendingBlocks <= MAX_PENDING_BLOCKS / 2) return 0;
 
         return
-            (UTILIZATION_FEE_RATIO *
+            ((2 * numPendingBlocks - MAX_PENDING_BLOCKS) *
                 100 *
-                (2 * numPendingBlocks - MAX_PENDING_BLOCKS)) /
-            MAX_PENDING_BLOCKS;
+                UTILIZATION_FEE_RATIO) / MAX_PENDING_BLOCKS;
     }
 
     /**********************

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -76,7 +76,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
      * Constants   *
      **********************/
     uint256 public constant MAX_ANCHOR_HEIGHT_DIFF = 128;
-    uint256 public constant MAX_PENDING_BLOCKS = 1024;
+    uint256 public constant MAX_PENDING_BLOCKS = 2048;
     uint256 public constant MAX_THROW_AWAY_PARENT_DIFF = 1024;
     uint256 public constant MAX_FINALIZATION_WRITES_PER_TX = 5;
     uint256 public constant MAX_FINALIZATION_READS_PER_TX = 50;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -228,7 +228,6 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         );
 
         _savePendingBlock(nextPendingId, _hashContext(context));
-        nextPendingId += 1;
 
         // Refund
         if (msg.value > totalFees) {
@@ -238,7 +237,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
             payable(daoAddress).transfer(utilizationFee);
         }
 
-        emit BlockProposed(nextPendingId, context);
+        emit BlockProposed(nextPendingId++, context);
     }
 
     // TODO: how to verify the zkp is associated with msg.sender?

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -424,8 +424,13 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
             uint256 /*basisPoints*/
         )
     {
+        // TODO(daniel): optimize the math. Maybe also include `proverGasPrice` in the
+        // calculation.
         uint256 numPendingBlocks = nextPendingId - lastFinalizedId;
-        uint256 threshold = MAX_PENDING_BLOCKS / 2;
+
+        // threshold is the middle point of MAX_PENDING_BLOCKS/2 and
+        // _stats.avgPendingSize
+        uint256 threshold = MAX_PENDING_BLOCKS / 4 + _stats.avgPendingSize / 2;
         if (numPendingBlocks <= threshold) return 0;
 
         return

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -480,6 +480,7 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         );
 
         payable(msg.sender).transfer(evidence.proverFee);
+        emit BlockFinalized(id, height, evidence);
 
         // Delete the evidence to potentially avoid 4 sstore ops.
         evidence.prover = address(0);
@@ -487,8 +488,6 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         evidence.proposedAt = 0;
         evidence.proposedAt = 0;
         evidence.blockHash = 0x0;
-
-        emit BlockFinalized(id, height, evidence);
     }
 
     function _savePendingBlock(uint256 id, bytes32 contextHash)

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -456,13 +456,19 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
     ) private {
         bool success;
 
-        // Pay the prover fee
+        // Pay prover fee
         (success, ) = evidence.prover.call{value: evidence.proverFee}("");
 
         if (!success && daoAddress != address(0)) {
             (success, ) = daoAddress.call{value: evidence.proverFee}("");
         }
-        // update Stats
+        // Update stats
+
+        _stats.avgPendingSize = _calcAverage(
+            _stats.avgPendingSize,
+            nextPendingId - lastFinalizedId - 1
+        );
+
         _stats.avgProvingDelay = _calcAverage(
             _stats.avgProvingDelay,
             evidence.provenAt - evidence.proposedAt

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -425,12 +425,12 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         )
     {
         uint256 numPendingBlocks = nextPendingId - lastFinalizedId;
-        if (numPendingBlocks <= MAX_PENDING_BLOCKS / 2) return 0;
+        uint256 threshold = MAX_PENDING_BLOCKS / 2;
+        if (numPendingBlocks <= threshold) return 0;
 
         return
-            ((2 * numPendingBlocks - MAX_PENDING_BLOCKS) *
-                100 *
-                UTILIZATION_FEE_RATIO) / MAX_PENDING_BLOCKS;
+            (UTILIZATION_FEE_RATIO * 100 * (numPendingBlocks - threshold)) /
+            (MAX_PENDING_BLOCKS - threshold);
     }
 
     /**********************

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -459,11 +459,6 @@ contract TaikoL1 is ReentrancyGuardUpgradeable {
         _payProverFee(evidence.prover, evidence.proverFee);
 
         // Update stats
-        _stats.avgPendingSize = _calcAverage(
-            _stats.avgPendingSize,
-            nextPendingId - lastFinalizedId - 1
-        );
-
         _stats.avgProvingDelay = _calcAverage(
             _stats.avgProvingDelay,
             evidence.provenAt - evidence.proposedAt


### PR DESCRIPTION
This PR implements a network utilization fee that is linear to the number of pending blocks when a block is proposed. Such a fee will only be non-zero if the pending block is greater than MAX_PENDING_BLOCKS, the max utilization fee is now implemented as 50% of the block's prover fee.

I'm not convinced an 1995 style is better. But maybe I'm wrong.