### PR TITLE
Allow on L2 to unwrap a "WETH" token into ETH. 

### DIFF
--- a/packages/protocol/contracts/L1/TaiToken.sol
+++ b/packages/protocol/contracts/L1/TaiToken.sol
@@ -75,7 +75,7 @@ contract TaiToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
      */
     function mint(address account, uint256 amount)
         public
-        onlyFromNamedEither("rollup", "erc20_vault")
+        onlyFromNamed("taiko_l1")
     {
         _mint(account, amount);
         emit Mint(account, amount, false);

--- a/packages/protocol/contracts/L1/TaiToken.sol
+++ b/packages/protocol/contracts/L1/TaiToken.sol
@@ -40,24 +40,9 @@ contract TaiToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
     /// @dev Initializer to be called after being deployed behind a proxy.
     ///      Based on our simulation in simulate/tokenomics/index.js, both
     ///      amountMintToDAO and amountMintToDev shall be set to ~150,000,000.
-    function init(
-        address _addressManager,
-        uint256 amountMintToDAO,
-        uint256 amountMintToDev
-    ) external initializer {
+    function init(address _addressManager) external initializer {
         EssentialContract._init(_addressManager);
         ERC20Upgradeable.__ERC20_init("Taiko Token", "TAI", 18);
-
-        address daoVault = resolve("dao_vault");
-        address devVault = resolve("dev_vault");
-
-        require(
-            daoVault != address(0) && devVault != address(0),
-            "TAI:zero address"
-        );
-
-        _mint(daoVault, amountMintToDAO);
-        _mint(devVault, amountMintToDev);
     }
 
     /*********************

--- a/packages/protocol/contracts/L1/TaiToken.sol
+++ b/packages/protocol/contracts/L1/TaiToken.sol
@@ -66,7 +66,7 @@ contract TaiToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
 
     function transfer(address to, uint256 amount)
         public
-        override
+        override(ERC20Upgradeable, IERC20Upgradeable)
         returns (bool)
     {
         require(to != address(this), "TAI: invalid to");
@@ -77,7 +77,7 @@ contract TaiToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
         address from,
         address to,
         uint256 amount
-    ) public override returns (bool) {
+    ) public override(ERC20Upgradeable, IERC20Upgradeable) returns (bool) {
         require(to != address(this), "TAI: invalid to");
         return ERC20Upgradeable.transferFrom(from, to, amount);
     }

--- a/packages/protocol/contracts/L1/TaiToken.sol
+++ b/packages/protocol/contracts/L1/TaiToken.sol
@@ -30,8 +30,8 @@ contract TaiToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
     /*********************
      * Events            *
      *********************/
-    event Burn(address account, uint256 amount, bool fromStaking);
-    event Mint(address account, uint256 amount, bool toStaking);
+    event Burn(address account, uint256 amount);
+    event Mint(address account, uint256 amount);
 
     /*********************
      * External Functions*
@@ -77,7 +77,8 @@ contract TaiToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
         public
         onlyFromNamed("taiko_l1")
     {
+        require(account != address(0), "TAI: invalid address");
         _mint(account, amount);
-        emit Mint(account, amount, false);
+        emit Mint(account, amount);
     }
 }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -151,8 +151,8 @@ contract TaikoL1 is EssentialContract {
         bytes32 _genesisBlockHash,
         uint256 _proverBaseFee,
         uint256 _proverGasPrice,
-        uint256 _ethAmountToConvert,
-        address _ethReceiver
+        uint256 amountMintToDAO,
+        uint256 amountMintToTeam
     ) external initializer {
         EssentialContract._init(_addressManager);
 
@@ -171,12 +171,24 @@ contract TaikoL1 is EssentialContract {
             provenAt: 0,
             blockHash: _genesisBlockHash
         });
-        emit BlockFinalized(0, 0, evidence, 0, 0);
 
-        if (_ethAmountToConvert != 0) {
-            require(_ethReceiver != address(0), "invalid eth receiver");
-            payable(_ethReceiver).transfer(_ethAmountToConvert);
+        if (amountMintToDAO != 0) {
+            require(resolve("dao_vault") != address(0), "invalid dao vault");
+            IMintableERC20(resolve("proto_token")).mint(
+                resolve("dao_vault"),
+                amountMintToDAO
+            );
         }
+
+        if (amountMintToTeam != 0) {
+            require(resolve("team_vault") != address(0), "invalid team vault");
+            IMintableERC20(resolve("proto_token")).mint(
+                resolve("team_vault"),
+                amountMintToTeam
+            );
+        }
+
+        emit BlockFinalized(0, 0, evidence, 0, 0);
     }
 
     /// @notice Propose a Taiko L2 block.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -150,7 +150,9 @@ contract TaikoL1 is EssentialContract {
         address _addressManager,
         bytes32 _genesisBlockHash,
         uint256 _proverBaseFee,
-        uint256 _proverGasPrice
+        uint256 _proverGasPrice,
+        uint256 _ethAmountToConvert,
+        address _ethReceiver
     ) external initializer {
         EssentialContract._init(_addressManager);
 
@@ -170,6 +172,11 @@ contract TaikoL1 is EssentialContract {
             blockHash: _genesisBlockHash
         });
         emit BlockFinalized(0, 0, evidence, 0, 0);
+
+        if (_ethAmountToConvert != 0) {
+            require(_ethReceiver != address(0), "invalid eth receiver");
+            payable(_ethReceiver).transfer(_ethAmountToConvert);
+        }
     }
 
     /// @notice Propose a Taiko L2 block.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -151,8 +151,8 @@ contract TaikoL1 is EssentialContract {
         bytes32 _genesisBlockHash,
         uint256 _proverBaseFee,
         uint256 _proverGasPrice,
-        uint256 amountMintToDAO,
-        uint256 amountMintToTeam
+        uint256 _amountMintToDAO,
+        uint256 _amountMintToTeam
     ) external initializer {
         EssentialContract._init(_addressManager);
 
@@ -172,20 +172,13 @@ contract TaikoL1 is EssentialContract {
             blockHash: _genesisBlockHash
         });
 
-        if (amountMintToDAO != 0) {
-            require(resolve("dao_vault") != address(0), "invalid dao vault");
-            IMintableERC20(resolve("proto_token")).mint(
-                resolve("dao_vault"),
-                amountMintToDAO
-            );
+        IMintableERC20 protoToken = IMintableERC20(resolve("proto_token"));
+        if (_amountMintToDAO != 0) {
+            protoToken.mint(resolve("dao_vault"), _amountMintToDAO);
         }
 
-        if (amountMintToTeam != 0) {
-            require(resolve("team_vault") != address(0), "invalid team vault");
-            IMintableERC20(resolve("proto_token")).mint(
-                resolve("team_vault"),
-                amountMintToTeam
-            );
+        if (_amountMintToTeam != 0) {
+            protoToken.mint(resolve("team_vault"), _amountMintToTeam);
         }
 
         emit BlockFinalized(0, 0, evidence, 0, 0);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -172,13 +172,13 @@ contract TaikoL1 is EssentialContract {
             blockHash: _genesisBlockHash
         });
 
-        IMintableERC20 protoToken = IMintableERC20(resolve("proto_token"));
+        IMintableERC20 taiToken = IMintableERC20(resolve("dai_token"));
         if (_amountMintToDAO != 0) {
-            protoToken.mint(resolve("dao_vault"), _amountMintToDAO);
+            taiToken.mint(resolve("dao_vault"), _amountMintToDAO);
         }
 
         if (_amountMintToTeam != 0) {
-            protoToken.mint(resolve("team_vault"), _amountMintToTeam);
+            taiToken.mint(resolve("team_vault"), _amountMintToTeam);
         }
 
         emit BlockFinalized(0, 0, evidence, 0, 0);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -174,7 +174,7 @@ contract TaikoL1 is EssentialContract {
             blockHash: _genesisBlockHash
         });
 
-        IMintableERC20 taiToken = IMintableERC20(resolve("dai_token"));
+        IMintableERC20 taiToken = IMintableERC20(resolve("tai_token"));
         if (_amountMintToDAO != 0) {
             taiToken.mint(resolve("dao_vault"), _amountMintToDAO);
         }

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -8,14 +8,23 @@
 // ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
 pragma solidity ^0.8.9;
 
+import "../common/EssentialContract.sol";
 import "../libs/LibStorageProof.sol";
 import "../libs/LibTxList.sol";
 
-contract TaikoL2 {
+contract TaikoL2 is EssentialContract {
+    /**********************
+     * State Variables    *
+     **********************/
+
     mapping(uint256 => bytes32) public anchorHashes;
     uint256 public lastAnchorHeight;
 
     uint256[48] private __gap;
+
+    /**********************
+     * Events             *
+     **********************/
 
     event Anchored(
         uint256 anchorHeight,
@@ -24,10 +33,31 @@ contract TaikoL2 {
         bytes32 proofVal
     );
 
+    /**********************
+     * Modifiers          *
+     **********************/
+
     modifier whenAnchoreAllowed() {
         require(lastAnchorHeight < block.number, "anchored already");
         lastAnchorHeight = block.number;
         _;
+    }
+
+    /**********************
+     * External Functions *
+     **********************/
+
+    function init(address _addressManager) external initializer {
+        EssentialContract._init(_addressManager);
+    }
+
+    /// @dev Transfers Ether out of this contract to an recipient. We expect
+    ///      this method will be called by a Bridge on L2.
+    function transferEther(address receipient, uint256 amount)
+        external
+        onlyFromNamed("authorized_bridge")
+    {
+        payable(receipient).transfer(amount);
     }
 
     function anchor(uint256 anchorHeight, bytes32 anchorHash)

--- a/packages/protocol/contracts/common/IMintableERC20.sol
+++ b/packages/protocol/contracts/common/IMintableERC20.sol
@@ -8,6 +8,8 @@
 // ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
 pragma solidity ^0.8.9;
 
-interface IMintableERC20 {
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+
+interface IMintableERC20 is IERC20Upgradeable {
     function mint(address account, uint256 amount) external;
 }

--- a/packages/protocol/contracts/test/TestLibBlockHeader.sol
+++ b/packages/protocol/contracts/test/TestLibBlockHeader.sol
@@ -8,7 +8,7 @@
 // ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
 pragma solidity ^0.8.9;
 
-import "../L1/LibBlockHeader.sol";
+import "../libs/LibBlockHeader.sol";
 
 contract TestLibBlockHeader {
     function hashBlockHeader(BlockHeader calldata header)


### PR DESCRIPTION
This WETH token can be a mirroring token of the L1 TaiToken. Third party bridges can also accept TaiToken deposit then credit user L2 account by minting new WETH tokens.