### PR TITLE
[protocol] Allow a bridge helper contract to handle TaiToken deposit to L2

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -8,7 +8,6 @@
 // ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "../common/EssentialContract.sol";
@@ -16,7 +15,6 @@ import "../libs/LibStorageProof.sol";
 import "../libs/LibTxList.sol";
 
 contract TaikoL2 is EssentialContract {
-    using AddressUpgradeable for address;
     /**********************
      * State Variables    *
      **********************/
@@ -54,8 +52,7 @@ contract TaikoL2 is EssentialContract {
      * External Functions *
      **********************/
 
-    receive() external payable {
-        require(msg.sender.isContract(), "L2:not contract");
+    receive() external payable onlyFromNamed("bridge_helper") {
         emit EtherReturned(msg.sender, msg.value);
     }
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -8,6 +8,7 @@
 // ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
 pragma solidity ^0.8.9;
 
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "../common/EssentialContract.sol";
@@ -15,6 +16,7 @@ import "../libs/LibStorageProof.sol";
 import "../libs/LibTxList.sol";
 
 contract TaikoL2 is EssentialContract {
+    using AddressUpgradeable for address;
     /**********************
      * State Variables    *
      **********************/
@@ -53,6 +55,7 @@ contract TaikoL2 is EssentialContract {
      **********************/
 
     receive() external payable {
+        require(msg.sender.isContract(), "L2:not contract");
         emit EtherReturned(msg.sender, msg.value);
     }
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -35,8 +35,8 @@ contract TaikoL2 is EssentialContract {
         bytes32 proofVal
     );
 
-    event EtherCredited(address receipient, uint256 amount);
-    event EtherReturned(address receipient, uint256 amount);
+    event TaiCredited(address receipient, uint256 amount);
+    event TaiReturned(address receipient, uint256 amount);
 
     /**********************
      * Modifiers          *
@@ -53,7 +53,7 @@ contract TaikoL2 is EssentialContract {
      **********************/
 
     receive() external payable onlyFromNamed("bridge_helper") {
-        emit EtherReturned(msg.sender, msg.value);
+        emit TaiReturned(msg.sender, msg.value);
     }
 
     fallback() external payable {
@@ -64,14 +64,14 @@ contract TaikoL2 is EssentialContract {
         EssentialContract._init(_addressManager);
     }
 
-    function creditEther(address receipient, uint256 amount)
+    function creditTaiToken(address receipient, uint256 amount)
         external
         nonReentrant
         onlyFromNamed("bridge_helper")
     {
         require(receipient != address(this), "L2:invalid address");
         payable(receipient).transfer(amount);
-        emit EtherCredited(receipient, amount);
+        emit TaiCredited(receipient, amount);
     }
 
     function anchor(uint256 anchorHeight, bytes32 anchorHash)

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -56,6 +56,10 @@ contract TaikoL2 is EssentialContract {
         emit EtherReturned(msg.sender, msg.value);
     }
 
+    fallback() external payable {
+        revert("L2:not allowed");
+    }
+
     function init(address _addressManager) external initializer {
         EssentialContract._init(_addressManager);
     }

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -44,7 +44,7 @@ contract TaikoL2 is EssentialContract {
      * Modifiers          *
      **********************/
 
-    modifier whenAnchoreAllowed() {
+    modifier onlyWhenNotAnchored() {
         require(lastAnchorHeight < block.number, "L2:anchored already");
         lastAnchorHeight = block.number;
         _;
@@ -75,7 +75,7 @@ contract TaikoL2 is EssentialContract {
 
     function anchor(uint256 anchorHeight, bytes32 anchorHash)
         external
-        whenAnchoreAllowed
+        onlyWhenNotAnchored
     {
         require(anchorHeight != 0 && anchorHash != 0x0, "L2:invalid anchor");
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -52,7 +52,7 @@ contract TaikoL2 is EssentialContract {
      * External Functions *
      **********************/
 
-    receive() external payable onlyFromNamed("bridge_helper") {
+    receive() external payable onlyFromNamed("tai_depositor") {
         emit TaiReturned(msg.sender, msg.value);
     }
 
@@ -67,7 +67,7 @@ contract TaikoL2 is EssentialContract {
     function creditTaiToken(address receipient, uint256 amount)
         external
         nonReentrant
-        onlyFromNamed("bridge_helper")
+        onlyFromNamed("tai_depositor")
     {
         require(receipient != address(this), "L2:invalid address");
         payable(receipient).transfer(amount);


### PR DESCRIPTION
Previously, we assume TAI  tokens, once deposited on L2, will be received on L2 as an ERC20 token first, then such a token can be "unwrapped" into Ether on L2 to be used as gas fees. 

This implementation remove that assumption and let a "bridge helper" to assist bridges to credit Ether to users.