### PR TITLE
[protocol] Allow proving the same block more than once with different ZKPs

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -534,7 +534,6 @@ contract TaikoL1 is EssentialContract {
     }
 
     function _payProverFee(address prover, uint256 proverFee) private {
-        if (proverFee == 0) return;
         // Pay prover fee
         bool success;
         (success, ) = prover.call{value: proverFee}("");

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -120,7 +120,7 @@ contract TaikoL1 is EssentialContract {
 
     Stats private _stats; // 1 slot
 
-    uint256[42] private __gap;
+    uint256[43] private __gap;
 
     /**********************
      * Events             *
@@ -128,7 +128,7 @@ contract TaikoL1 is EssentialContract {
 
     event BlockProposed(uint256 indexed id, BlockContext context);
 
-    event BlockProven(
+    event BlockProvenValid(
         uint256 indexed id,
         bytes32 parentHash,
         Evidence evidence
@@ -285,7 +285,7 @@ contract TaikoL1 is EssentialContract {
             blockHash
         );
 
-        emit BlockProven(context.id, header.parentHash, evidence);
+        emit BlockProvenValid(context.id, header.parentHash, evidence);
     }
 
     // TODO: how to verify the zkp is associated with msg.sender?

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -89,7 +89,8 @@ contract TaikoL1 is EssentialContract {
     uint256 public constant MAX_PROOFS_PER_BLOCK = 5;
     string public constant ZKP_VKEY = "TAIKO_ZKP_VKEY";
 
-    bytes32 private constant JUMP_MARKER = bytes32(uint256(1));
+    bytes32 private constant PARENT_HASH_PLACEHOLDER = bytes32(uint256(1));
+    bytes32 private constant JUMP_MARKER = keccak256("JUMP_MARKER");
     uint256 private constant STAT_AVERAGING_FACTOR = 2048;
     uint64 private constant NANO_PER_SECOND = 1E9;
     uint64 private constant UTILIZATION_FEE_RATIO = 500; // 5x
@@ -452,6 +453,7 @@ contract TaikoL1 is EssentialContract {
 
         require(
             blk.parentHash == 0 ||
+                blk.parentHash == PARENT_HASH_PLACEHOLDER ||
                 (blk.parentHash == parentHash &&
                     blk.blockHash == blockHash &&
                     blk.evidences.length < MAX_PROOFS_PER_BLOCK),
@@ -566,8 +568,7 @@ contract TaikoL1 is EssentialContract {
     function _savePendingBlock(uint256 id, bytes32 contextHash) private {
         uint256 slot = id % MAX_PENDING_BLOCKS;
         pendingBlocks[slot].contextHash = contextHash;
-        pendingBlocks[slot].parentHash = 0; // TODO
-        pendingBlocks[slot].blockHash = 0;
+        pendingBlocks[slot].parentHash = PARENT_HASH_PLACEHOLDER;
 
         Evidence[] storage evidences = pendingBlocks[slot].evidences;
         assembly {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -131,17 +131,17 @@ contract TaikoL1 is EssentialContract {
         uint256 proverFee,
         uint256 reward
     );
-    event BlockProposed(uint256 indexed id, BlockContext context);
+    event BlockProposed(uint256 indexed blockId, BlockContext context);
 
     event BlockProven(
-        uint256 indexed id,
+        uint256 indexed blockId,
         Evidence evidence,
         bytes32 parentHash,
         bytes32 blockHash
     );
 
     event BlockFinalized(
-        uint256 indexed id,
+        uint256 indexed blockId,
         uint256 indexed height,
         bytes32 blockHash
     );

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -359,7 +359,6 @@ contract TaikoL1 is EssentialContract {
                 _finalizeBlock(id, fc);
             } else {
                 fc = forkChoices[id][SKIP_OVER_BLOCK_HASH];
-
                 if (fc.blockHash != 0) {
                     _finalizeBlock(id, fc);
                 } else {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -481,7 +481,7 @@ contract TaikoL1 is EssentialContract {
             _payProverFee(evidence.prover, proverFee);
 
             (uint256 blockReward, ) = _payBlockReward(
-                fc.evidences.length,
+                i,
                 evidence.prover,
                 evidence.provenAt - evidence.proposedAt
             );

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -102,7 +102,7 @@ contract TaikoL1 is EssentialContract {
     // block id => block context hash
     mapping(uint256 => bytes32) public pendingBlocks;
 
-    // block id => parent hash => for choice
+    // block id => parent hash => fork choice
     mapping(uint256 => mapping(bytes32 => ForkChoice)) public forkChoices;
 
     uint64 public genesisHeight;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -144,9 +144,7 @@ contract TaikoL1 is EssentialContract {
     event BlockFinalized(
         uint256 indexed id,
         uint256 indexed height,
-        bytes32 blockHash,
-        uint256 blockTaiReward,
-        uint256 daoReward
+        bytes32 blockHash
     );
 
     /**********************
@@ -181,7 +179,7 @@ contract TaikoL1 is EssentialContract {
 
         genesisHeight = block.number.toUint64();
 
-        emit BlockFinalized(0, 0, _genesisBlockHash, 0, 0);
+        emit BlockFinalized(0, 0, _genesisBlockHash);
 
         IMintableERC20 taiToken = IMintableERC20(resolve("tai_token"));
         if (_amountMintToDAO != 0) {
@@ -475,10 +473,6 @@ contract TaikoL1 is EssentialContract {
     }
 
     function _finalizeBlock(uint64 id, bytes32 blockHash) private {
-        uint256 totalBlockReward;
-        uint256 totalDaoReward;
-
-        // TODO: pay the first higher
         PendingBlock storage blk = _getPendingBlock(id);
         for (uint256 i = 0; i < blk.evidences.length; i++) {
             Evidence memory evidence = blk.evidences[i];
@@ -501,9 +495,6 @@ contract TaikoL1 is EssentialContract {
 
             emit ProverPaid(evidence.prover, id, proverFee, blockReward);
 
-            totalBlockReward += blockReward;
-            totalDaoReward += daoReward;
-
             // Update stats
             _stats.avgProvingDelay = _calcAverage(
                 _stats.avgProvingDelay,
@@ -511,13 +502,7 @@ contract TaikoL1 is EssentialContract {
             );
         }
 
-        emit BlockFinalized(
-            id,
-            lastFinalizedHeight,
-            blockHash,
-            totalBlockReward,
-            totalDaoReward
-        );
+        emit BlockFinalized(id, lastFinalizedHeight, blockHash);
     }
 
     function _chargeProposerFee(uint256 proverFee) private {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -357,11 +357,12 @@ contract TaikoL1 is EssentialContract {
 
         while (id < nextPendingId && processed <= MAX_FINALIZATION_PER_TX) {
             PendingBlock storage blk = _getPendingBlock(id);
+
             if (blk.parentHash == finalizedBlocks[lastFinalizedHeight]) {
                 finalizedBlocks[++lastFinalizedHeight] = blk.blockHash;
-                _finalizeBlock(id, blk.blockHash);
+                _finalizeBlock(id);
             } else if (blk.parentHash == JUMP_MARKER) {
-                _finalizeBlock(id, blk.blockHash);
+                _finalizeBlock(id);
             } else {
                 break;
             }
@@ -470,7 +471,7 @@ contract TaikoL1 is EssentialContract {
         blk.evidences.push(evidence);
     }
 
-    function _finalizeBlock(uint64 id, bytes32 blockHash) private {
+    function _finalizeBlock(uint64 id) private {
         PendingBlock storage blk = _getPendingBlock(id);
         for (uint256 i = 0; i < blk.evidences.length; i++) {
             Evidence memory evidence = blk.evidences[i];
@@ -500,7 +501,11 @@ contract TaikoL1 is EssentialContract {
             );
         }
 
-        emit BlockFinalized(id, lastFinalizedHeight, blockHash);
+        emit BlockFinalized(
+            id,
+            lastFinalizedHeight,
+            finalizedBlocks[lastFinalizedHeight]
+        );
     }
 
     function _chargeProposerFee(uint256 proverFee) private {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -128,14 +128,14 @@ contract TaikoL1 is EssentialContract {
 
     event ProverPaid(
         address indexed prover,
-        uint256 blockId,
+        uint256 id,
         uint256 proverFee,
         uint256 reward
     );
-    event BlockProposed(uint256 indexed blockId, BlockContext context);
+    event BlockProposed(uint256 indexed id, BlockContext context);
 
     event BlockProven(
-        uint256 indexed blockId,
+        uint256 indexed id,
         Evidence evidence,
         bytes32 parentHash,
         bytes32 blockHash,
@@ -143,7 +143,7 @@ contract TaikoL1 is EssentialContract {
     );
 
     event BlockFinalized(
-        uint256 indexed blockId,
+        uint256 indexed id,
         uint256 indexed height,
         bytes32 blockHash,
         uint256 proverFee

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -246,11 +246,17 @@ contract TaikoL1 is EssentialContract {
         _validateHeaderForContext(header, context);
         bytes32 blockHash = header.hashBlockHeader();
 
+        // We currently assume the public input has at least
+        // two parts: msg.sender, and txListHash.
+        // TODO(daniel): figure it out.
+        bytes32 publicInputHash = keccak256(
+            abi.encodePacked(msg.sender, context.txListHash)
+        );
         LibZKP.verify(
             ConfigManager(resolve("config_manager")).get(ZKP_VKEY),
             header.parentHash,
             blockHash,
-            context.txListHash,
+            publicInputHash,
             proofs[0]
         );
 

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -487,7 +487,7 @@ contract TaikoL1 is EssentialContract {
                 );
             }
 
-            (uint256 blockReward, uint256 daoReward) = _payBlockReward(
+            (uint256 blockReward, ) = _payBlockReward(
                 i,
                 evidence.prover,
                 evidence.provenAt - evidence.proposedAt

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -449,7 +449,6 @@ contract TaikoL1 is EssentialContract {
             fc.blockHash = blockHash;
         } else {
             require(fc.blockHash == blockHash, "conflicting proof");
-
             require(fc.evidences.length < maxNumProofs, "too many proofs");
 
             for (uint256 i = 0; i < fc.evidences.length; i++) {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -104,8 +104,6 @@ contract TaikoL1 is EssentialContract {
     // block id => block context hash
     mapping(uint256 => PendingBlock) public pendingBlocks;
 
-    // mapping(uint256 => mapping(bytes32 => Evidence)) public evidences;
-
     uint64 public genesisHeight;
     uint64 public lastFinalizedHeight;
     uint64 public lastFinalizedId;
@@ -131,6 +129,7 @@ contract TaikoL1 is EssentialContract {
     event BlockProvenValid(
         uint256 indexed id,
         bytes32 parentHash,
+        bytes32 blockHash,
         Evidence evidence
     );
 
@@ -176,15 +175,7 @@ contract TaikoL1 is EssentialContract {
 
         genesisHeight = block.number.toUint64();
 
-        Evidence[] memory evidences = new Evidence[](1);
-        evidences[0] = Evidence({
-            prover: address(0),
-            proverFee: 0,
-            proposedAt: 0,
-            provenAt: 0
-        });
-
-        emit BlockFinalized(0, 0, 0, 0, evidences);
+        emit BlockFinalized(0, 0, 0, 0, new Evidence[](0));
 
         IMintableERC20 taiToken = IMintableERC20(resolve("tai_token"));
         if (_amountMintToDAO != 0) {
@@ -285,7 +276,12 @@ contract TaikoL1 is EssentialContract {
             blockHash
         );
 
-        emit BlockProvenValid(context.id, header.parentHash, evidence);
+        emit BlockProvenValid(
+            context.id,
+            header.parentHash,
+            blockHash,
+            evidence
+        );
     }
 
     // TODO: how to verify the zkp is associated with msg.sender?

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -450,8 +450,12 @@ contract TaikoL1 is EssentialContract {
                 (blk.parentHash == parentHash &&
                     blk.blockHash == blockHash &&
                     blk.evidences.length < MAX_PROOFS_PER_BLOCK),
-            "cannot update block"
+            "proving failure"
         );
+
+        for (uint256 i = 0; i < blk.evidences.length; i++) {
+            require(blk.evidences[i].prover != msg.sender, "duplicate proof");
+        }
 
         blk.parentHash = parentHash;
         blk.blockHash = blockHash;
@@ -463,7 +467,6 @@ contract TaikoL1 is EssentialContract {
             provenAt: block.timestamp.toUint64()
         });
 
-        // TODO: dedup
         blk.evidences.push(evidence);
     }
 

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -246,17 +246,11 @@ contract TaikoL1 is EssentialContract {
         _validateHeaderForContext(header, context);
         bytes32 blockHash = header.hashBlockHeader();
 
-        // We currently assume the public input has at least
-        // two parts: msg.sender, and txListHash.
-        // TODO(daniel): figure it out.
-        bytes32 publicInputHash = keccak256(
-            abi.encodePacked(msg.sender, context.txListHash)
-        );
         LibZKP.verify(
             ConfigManager(resolve("config_manager")).get(ZKP_VKEY),
             header.parentHash,
             blockHash,
-            publicInputHash,
+            _computePublicInputHash(msg.sender, context.txListHash),
             proofs[0]
         );
 
@@ -314,7 +308,7 @@ contract TaikoL1 is EssentialContract {
             ConfigManager(resolve("config_manager")).get(ZKP_VKEY),
             throwAwayHeader.parentHash,
             throwAwayHeader.hashBlockHeader(),
-            throwAwayTxListHash,
+            _computePublicInputHash(msg.sender, throwAwayTxListHash),
             proofs[0]
         );
 
@@ -642,5 +636,16 @@ contract TaikoL1 is EssentialContract {
             current *
             NANO_PER_SECOND) / STAT_AVERAGING_FACTOR;
         return _avg.toUint64();
+    }
+
+    // We currently assume the public input has at least
+    // two parts: msg.sender, and txListHash.
+    // TODO(daniel): figure it out.
+    function _computePublicInputHash(address prover, bytes32 txListHash)
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(prover, txListHash));
     }
 }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -133,14 +133,12 @@ contract TaikoL1 is EssentialContract {
     );
     event BlockProposed(uint256 indexed id, BlockContext context);
 
-    event BlockProvenValid(
+    event BlockProven(
         uint256 indexed id,
+        Evidence evidence,
         bytes32 parentHash,
-        bytes32 blockHash,
-        Evidence evidence
+        bytes32 blockHash
     );
-
-    event BlockProvenInvalid(uint256 indexed id, Evidence evidence);
 
     event BlockFinalized(
         uint256 indexed id,
@@ -281,12 +279,7 @@ contract TaikoL1 is EssentialContract {
             blockHash
         );
 
-        emit BlockProvenValid(
-            context.id,
-            header.parentHash,
-            blockHash,
-            evidence
-        );
+        emit BlockProven(context.id, evidence, header.parentHash, blockHash);
     }
 
     // TODO: how to verify the zkp is associated with msg.sender?
@@ -336,7 +329,7 @@ contract TaikoL1 is EssentialContract {
             JUMP_MARKER,
             JUMP_MARKER
         );
-        emit BlockProvenInvalid(context.id, evidence);
+        emit BlockProven(context.id, evidence, 0, 0);
     }
 
     function verifyBlockInvalid(
@@ -351,7 +344,7 @@ contract TaikoL1 is EssentialContract {
             JUMP_MARKER,
             JUMP_MARKER
         );
-        emit BlockProvenInvalid(context.id, evidence);
+        emit BlockProven(context.id, evidence, 0, 0);
     }
 
     /**********************


### PR DESCRIPTION
This PR assume that different provers can generate different ZKPs that are associated with their addresses (`msg.sender`) to prove the very same block, meaning the tuple (pendingBlock, proverAddress) can be used to compute a unique ZKP.

Currently we allow up to 5 valid proofs to be used to prove a block. Only the first prover will receive the proving fee, but all validators will receive some Tai block reward, the *i-th* prover will receive `X/i` Tai: X, X/2, X/3...