### PR TITLE
[protocol] multiple tokenomics related improvements

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -471,16 +471,12 @@ contract TaikoL1 is EssentialContract {
             }
         }
 
-        uint64 provingDelay = (block.timestamp - context.proposedAt).toUint64();
-        uint128 reward = getBlockTaiReward(provingDelay) /
-            (fc.evidences.length + 1).toUint128();
-
         Evidence memory evidence = Evidence({
             prover: msg.sender,
             proverFee: 0,
             feeRebate: 0,
-            reward: reward,
-            provingDelay: provingDelay
+            reward: 0,
+            provingDelay: (block.timestamp - context.proposedAt).toUint64()
         });
 
         if (fc.evidences.length == 0) {
@@ -489,6 +485,11 @@ contract TaikoL1 is EssentialContract {
                 .min(context.feeReserve)
                 .toUint128();
             evidence.feeRebate = context.feeReserve - evidence.proverFee;
+            evidence.reward = getBlockTaiReward(evidence.provingDelay);
+        } else {
+            evidence.reward =
+                fc.evidences[0].reward /
+                (fc.evidences.length + 1).toUint128();
         }
 
         fc.evidences.push(evidence);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -190,13 +190,9 @@ contract TaikoL1 is EssentialContract {
         emit BlockFinalized(0, 0, _genesisBlockHash);
 
         IMintableERC20 taiToken = IMintableERC20(resolve("tai_token"));
-        if (_amountMintToDAO != 0) {
-            taiToken.mint(resolve("dao_vault"), _amountMintToDAO);
-        }
+        taiToken.mint(resolve("dao_vault"), _amountMintToDAO);
 
-        if (_amountMintToTeam != 0) {
-            taiToken.mint(resolve("team_vault"), _amountMintToTeam);
-        }
+        taiToken.mint(resolve("team_vault"), _amountMintToTeam);
     }
 
     /// @notice Propose a Taiko L2 block.
@@ -539,10 +535,7 @@ contract TaikoL1 is EssentialContract {
     }
 
     function _chargeProposer(uint256 proverFee) private {
-        address daoVault = resolve("dao_vault");
-        uint256 utilizationFee = daoVault == address(0)
-            ? 0
-            : (proverFee * getUtilizationFeeBips()) / 10000;
+        uint256 utilizationFee = (proverFee * getUtilizationFeeBips()) / 10000;
         uint256 totalFees = proverFee + utilizationFee;
 
         require(msg.value >= totalFees, "insufficient fee");
@@ -552,7 +545,7 @@ contract TaikoL1 is EssentialContract {
             payable(msg.sender).transfer(msg.value - totalFees);
         }
         if (utilizationFee > 0) {
-            payable(daoVault).transfer(utilizationFee);
+            payable(resolve("dao_vault")).transfer(utilizationFee);
         }
     }
 
@@ -569,13 +562,11 @@ contract TaikoL1 is EssentialContract {
             unsettledProverFee += evidence.feeRebate;
         }
 
-        address daoVault = resolve("dao_vault");
-
-        if (daoVault != address(0)) {
-            (success, ) = daoVault.call{value: unsettledProverFee - 1}("");
-            if (success) {
-                unsettledProverFee = 1;
-            }
+        (success, ) = resolve("dao_vault").call{value: unsettledProverFee - 1}(
+            ""
+        );
+        if (success) {
+            unsettledProverFee = 1;
         }
 
         if (evidence.blockReward != 0) {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -486,6 +486,8 @@ contract TaikoL1 is EssentialContract {
             evidence.feeRebate = context.feeReserve - evidence.proverFee;
             evidence.reward = getBlockTaiReward(evidence.provingDelay);
         } else {
+            // Uncle proof reward is now based on the first proof submitted,
+            // which avoid provers waiting for larger block rewards.
             evidence.reward =
                 fc.evidences[0].reward /
                 (fc.evidences.length + 1).toUint128();

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -122,13 +122,15 @@ contract TaikoL1 is EssentialContract {
     uint64 public nextPendingId;
 
     uint256 public unsettledProverFee;
-    uint256 public proverGasPrice; // TODO: auto-adjustable
 
-    uint256 public reservedProverFee;
+    // The following two variables are automiatically adjusted based on
+    // the latest finalized blocks.
+    uint128 public proverGasPrice; // TODO: auto-adjustable
+    uint128 public proverReward; // TODO: auto-adjustable
 
     Stats private _stats; // 1 slot
 
-    uint256[42] private __gap;
+    uint256[43] private __gap;
 
     /**********************
      * Events             *

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -487,7 +487,7 @@ contract TaikoL1 is EssentialContract {
         if (fc.evidences.length == 0) {
             evidence.proverFee = (proverGasPrice *
                 (context.gasLimit + blockGasBaseline))
-                .max(context.feeReserve)
+                .min(context.feeReserve)
                 .toUint128();
             evidence.feeRebate = context.feeReserve - evidence.proverFee;
         }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -230,7 +230,9 @@ contract TaikoL1 is EssentialContract {
         // Check fees
         context.feeReserve = (PROVER_FEE_RESERVE_RATIO *
             proverGasPrice *
-            (context.gasLimit + blockGasBaseline)).toUint128();
+            (context.gasLimit + blockGasBaseline))
+            .max(type(uint128).max)
+            .toUint128();
 
         _chargeProposer(context.feeReserve);
 
@@ -557,6 +559,7 @@ contract TaikoL1 is EssentialContract {
         if (!success) {
             unsettledProverFee += evidence.proverFee;
         }
+
         (success, ) = proposer.call{value: evidence.feeRebate}("");
         if (!success) {
             unsettledProverFee += evidence.feeRebate;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -270,7 +270,7 @@ contract TaikoL1 is EssentialContract {
             );
 
         if (!anchored) {
-            proofVal = 0x0;
+            proofVal = 0;
         }
 
         LibMerkleProof.verify(
@@ -386,8 +386,8 @@ contract TaikoL1 is EssentialContract {
     function validateContext(BlockContext memory context) public view {
         require(
             context.id == 0 &&
-                context.txListHash == 0x0 &&
-                context.mixHash == 0x0 &&
+                context.txListHash == 0 &&
+                context.mixHash == 0 &&
                 context.proposedAt == 0 &&
                 context.feeReserve == 0,
             "nonzero placeholder fields"
@@ -396,7 +396,7 @@ contract TaikoL1 is EssentialContract {
         require(
             block.number <= context.anchorHeight + MAX_ANCHOR_HEIGHT_DIFF &&
                 context.anchorHash == blockhash(context.anchorHeight) &&
-                context.anchorHash != 0x0,
+                context.anchorHash != 0,
             "invalid anchor"
         );
 
@@ -626,7 +626,7 @@ contract TaikoL1 is EssentialContract {
 
     function _validateHeader(BlockHeader calldata header) private pure {
         require(
-            header.parentHash != 0x0 &&
+            header.parentHash != 0 &&
                 header.gasLimit <= LibConstants.MAX_TAIKO_BLOCK_GAS_LIMIT &&
                 header.extraData.length <= 32 &&
                 header.difficulty == 0 &&

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -550,24 +550,30 @@ contract TaikoL1 is EssentialContract {
         address proposer = _getPendingBlock(id).proposer;
 
         bool success;
-        (success, ) = evidence.prover.call{value: evidence.proverFee}("");
-        if (!success) {
-            unsettledProverFee += evidence.proverFee;
+        if (evidence.proverFee > 0) {
+            (success, ) = evidence.prover.call{value: evidence.proverFee}("");
+            if (!success) {
+                unsettledProverFee += evidence.proverFee;
+            }
         }
 
-        (success, ) = proposer.call{value: evidence.feeRebate}("");
-        if (!success) {
-            unsettledProverFee += evidence.feeRebate;
+        if (evidence.feeRebate > 0) {
+            (success, ) = proposer.call{value: evidence.feeRebate}("");
+            if (!success) {
+                unsettledProverFee += evidence.feeRebate;
+            }
         }
 
-        (success, ) = resolve("dao_vault").call{value: unsettledProverFee - 1}(
-            ""
-        );
-        if (success) {
-            unsettledProverFee = 1;
+        if (unsettledProverFee > 1) {
+            (success, ) = resolve("dao_vault").call{
+                value: unsettledProverFee - 1
+            }("");
+            if (success) {
+                unsettledProverFee = 1;
+            }
         }
 
-        if (evidence.reward != 0) {
+        if (evidence.reward > 0) {
             IMintableERC20(resolve("tai_token")).mint(
                 evidence.prover,
                 evidence.reward

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -98,7 +98,7 @@ contract TaikoL1 is EssentialContract {
     uint256 public constant MIN_BLOCK_REWARD_BASE = 2E18; // 2 TAI
     uint256 public constant MAX_PROOFS_PER_BLOCK = 5;
     uint256 public constant PROVER_FEE_RESERVE_MULTIPLIER = 4; // 4X
-    uint256 public constant MAX_BLOCK_REWARD_MULTIPLIER = 16; // 16X
+    uint256 public constant MAX_BLOCK_REWARD_MULTIPLIER = 64; // 64X
     uint256 public constant BLOCK_GAS_LIMIT_EXTRA = 1000000; // TODO
     bytes32 public constant SKIP_OVER_BLOCK_HASH = bytes32(uint256(1));
     uint256 public constant STAT_AVERAGING_FACTOR = 2048;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -95,12 +95,11 @@ contract TaikoL1 is EssentialContract {
     uint256 public constant MAX_PROOFS_PER_BLOCK = 5;
     uint256 public constant PROVER_FEE_RESERVE_RATIO = 4; // 400%
     uint256 public constant BLOCK_GAS_LIMIT_EXTRA = 1000000; // TODO
+    bytes32 public constant SKIP_OVER_BLOCK_HASH = bytes32(uint256(1));
+    uint256 public constant STAT_AVERAGING_FACTOR = 2048;
     string public constant ZKP_VKEY = "TAIKO_ZKP_VKEY";
-
-    bytes32 private constant SKIP_OVER_BLOCK_HASH = bytes32(uint256(1));
-    uint256 private constant STAT_AVERAGING_FACTOR = 2048;
-    uint64 private constant NANO_PER_SECOND = 1E9;
-    uint64 private constant UTILIZATION_FEE_RATIO = 500; // 5x
+    uint64 public constant NANO_PER_SECOND = 1E9;
+    uint64 public constant UTILIZATION_FEE_RATIO = 500; // 5x
 
     /**********************
      * State Variables    *

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -116,6 +116,8 @@ contract TaikoL1 is EssentialContract {
     // block id => parent hash => fork choice
     mapping(uint256 => mapping(bytes32 => ForkChoice)) public forkChoices;
 
+    Stats private _stats; // 1 slot
+
     uint64 public genesisHeight;
     uint64 public lastFinalizedHeight;
     uint64 public lastFinalizedId;
@@ -127,8 +129,6 @@ contract TaikoL1 is EssentialContract {
     // the latest finalized blocks.
     uint128 public proverGasPrice; // TODO: auto-adjustable
     uint128 public proverReward; // TODO: auto-adjustable
-
-    Stats private _stats; // 1 slot
 
     uint256[43] private __gap;
 
@@ -491,7 +491,9 @@ contract TaikoL1 is EssentialContract {
                 .min(context.feeReserve)
                 .toUint128();
             evidence.feeRebate = context.feeReserve - evidence.proverFee;
-            evidence.reward = getBlockTaiReward(evidence.provedAt - evidence.proposedAt);
+            evidence.reward = getBlockTaiReward(
+                evidence.provedAt - evidence.proposedAt
+            );
         } else {
             // Uncle proof reward is now based on the first proof submitted,
             // which avoid provers waiting for larger block rewards.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -132,7 +132,7 @@ contract TaikoL1 is EssentialContract {
     // The following two variables are automiatically adjusted based on
     // the latest finalized blocks.
     uint128 public proverGasPrice; // TODO: auto-adjustable
-    uint128 public avgProverReward; // TODO: auto-adjustable
+    uint128 public avgProverReward;
 
     uint256[43] private __gap;
 
@@ -255,7 +255,6 @@ contract TaikoL1 is EssentialContract {
         );
     }
 
-    // TODO: how to verify the zkp is associated with msg.sender?
     function proveBlock(
         bool anchored,
         BlockHeader calldata header,
@@ -300,7 +299,6 @@ contract TaikoL1 is EssentialContract {
         );
     }
 
-    // TODO: how to verify the zkp is associated with msg.sender?
     function proveBlockInvalid(
         bytes32 throwAwayTxListHash, // hash of a txList that contains a verifyBlockInvalid tx on L2.
         BlockHeader calldata throwAwayHeader,
@@ -691,7 +689,8 @@ contract TaikoL1 is EssentialContract {
             header.beneficiary == context.beneficiary &&
                 header.gasLimit == context.gasLimit &&
                 header.timestamp == context.proposedAt &&
-                keccak256(header.extraData) == keccak256(context.extraData) && // TODO: direct compare
+                header.extraData.length == context.extraData.length &&
+                keccak256(header.extraData) == keccak256(context.extraData) &&
                 header.mixHash == context.mixHash,
             "header mismatch"
         );

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -45,7 +45,7 @@ struct Evidence {
     uint128 feeRebate;
     uint128 reward;
     uint64 proposedAt;
-    uint64 provedAt;
+    uint64 provenAt;
 }
 
 struct ForkChoice {
@@ -481,7 +481,7 @@ contract TaikoL1 is EssentialContract {
             feeRebate: 0,
             reward: reward,
             proposedAt: context.proposedAt,
-            provedAt: block.timestamp.toUint64()
+            provenAt: block.timestamp.toUint64()
         });
 
         if (fc.evidences.length == 0) {
@@ -492,7 +492,7 @@ contract TaikoL1 is EssentialContract {
                 .toUint128();
             evidence.feeRebate = context.feeReserve - evidence.proverFee;
             evidence.reward = getBlockTaiReward(
-                evidence.provedAt - evidence.proposedAt
+                evidence.provenAt - evidence.proposedAt
             );
         } else {
             // Uncle proof reward is now based on the first proof submitted,
@@ -528,13 +528,13 @@ contract TaikoL1 is EssentialContract {
 
                 _stats.avgProvingDelay = _calcAverage(
                     _stats.avgProvingDelay,
-                    evidence.provedAt - evidence.proposedAt
+                    evidence.provenAt - evidence.proposedAt
                 );
             }
 
             _stats.avgProvingDelayWithUncles = _calcAverage(
                 _stats.avgProvingDelayWithUncles,
-                evidence.provedAt - evidence.proposedAt
+                evidence.provenAt - evidence.proposedAt
             );
         }
 

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -102,6 +102,7 @@ contract TaikoL1 is EssentialContract {
     uint256 public constant BLOCK_GAS_LIMIT_EXTRA = 1000000; // TODO
     bytes32 public constant SKIP_OVER_BLOCK_HASH = bytes32(uint256(1));
     uint256 public constant STAT_AVERAGING_FACTOR = 2048;
+    uint256 public constant ETH_TRANSFER_GAS_LIMIT = 25000;
     uint64 public constant MAX_UTILIZATION_FEE_RATIO = 500; // 500%
     uint64 public constant NANO_PER_SECOND = 1E9;
     string public constant ZKP_VKEY = "TAIKO_ZKP_VKEY";
@@ -593,14 +594,20 @@ contract TaikoL1 is EssentialContract {
 
         bool success;
         if (evidence.proverFee > 0) {
-            (success, ) = evidence.prover.call{value: evidence.proverFee}("");
+            (success, ) = evidence.prover.call{
+                gas: ETH_TRANSFER_GAS_LIMIT,
+                value: evidence.proverFee
+            }("");
             if (!success) {
                 unsettledProverFee += evidence.proverFee;
             }
         }
 
         if (evidence.feeRebate > 0) {
-            (success, ) = proposer.call{value: evidence.feeRebate}("");
+            (success, ) = proposer.call{
+                gas: ETH_TRANSFER_GAS_LIMIT,
+                value: evidence.feeRebate
+            }("");
             if (!success) {
                 unsettledProverFee += evidence.feeRebate;
             }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -228,11 +228,11 @@ contract TaikoL1 is EssentialContract {
         context.mixHash = bytes32(block.difficulty);
 
         // Check fees
-        context.feeReserve = (PROVER_FEE_RESERVE_RATIO *
-            proverGasPrice *
-            (context.gasLimit + blockGasBaseline))
-            .max(type(uint128).max)
-            .toUint128();
+        context.feeReserve = uint128(
+            (PROVER_FEE_RESERVE_RATIO *
+                proverGasPrice *
+                (context.gasLimit + blockGasBaseline)).max(type(uint128).max)
+        );
 
         _chargeProposer(context.feeReserve);
 

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -711,7 +711,7 @@ contract TaikoL1 is EssentialContract {
             avg +
             current *
             NANO_PER_SECOND) / STAT_AVERAGING_FACTOR;
-        return _avg.max(max);
+        return _avg.min(max);
     }
 
     // We currently assume the public input has at least

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -479,6 +479,7 @@ contract TaikoL1 is EssentialContract {
         });
 
         if (fc.evidences.length == 0) {
+            // Only the first prover get the proverFee
             evidence.proverFee = (proverGasPrice *
                 (context.gasLimit + BLOCK_GAS_LIMIT_EXTRA))
                 .min(context.feeReserve)
@@ -490,7 +491,7 @@ contract TaikoL1 is EssentialContract {
             // which avoid provers waiting for larger block rewards.
             evidence.reward =
                 fc.evidences[0].reward /
-                (fc.evidences.length + 1).toUint128();
+                (fc.evidences.length + 2).toUint128();
         }
 
         fc.evidences.push(evidence);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -89,14 +89,16 @@ contract TaikoL1 is EssentialContract {
     /**********************
      * Constants   *
      **********************/
+
     uint256 public constant MAX_ANCHOR_HEIGHT_DIFF = 128;
     uint256 public constant MAX_PENDING_BLOCKS = 2048;
     uint256 public constant MAX_THROW_AWAY_PARENT_DIFF = 1024;
     uint256 public constant MAX_FINALIZATION_PER_TX = 5;
     uint256 public constant DAO_REWARD_RATIO = 100; // 100%
+    uint256 public constant MIN_BLOCK_REWARD_BASE = 2E18; // 2 TAI
     uint256 public constant MAX_PROOFS_PER_BLOCK = 5;
     uint256 public constant PROVER_FEE_RESERVE_MULTIPLIER = 4; // 4X
-    uint256 public constant MAX_BLOCK_REWARD_MULTIPLIER = 10; // 10X
+    uint256 public constant MAX_BLOCK_REWARD_MULTIPLIER = 16; // 16X
     uint256 public constant BLOCK_GAS_LIMIT_EXTRA = 1000000; // TODO
     bytes32 public constant SKIP_OVER_BLOCK_HASH = bytes32(uint256(1));
     uint256 public constant STAT_AVERAGING_FACTOR = 2048;
@@ -129,7 +131,7 @@ contract TaikoL1 is EssentialContract {
     // The following two variables are automiatically adjusted based on
     // the latest finalized blocks.
     uint128 public proverGasPrice; // TODO: auto-adjustable
-    uint128 public proverReward; // TODO: auto-adjustable
+    uint128 public avgProverReward; // TODO: auto-adjustable
 
     uint256[43] private __gap;
 
@@ -243,9 +245,12 @@ contract TaikoL1 is EssentialContract {
         emit BlockProposed(nextPendingId++, context);
 
         // Update stats first.
-        _stats.avgPendingSize = _calcAverage(
-            _stats.avgPendingSize,
-            nextPendingId - lastFinalizedId - 1
+        _stats.avgPendingSize = uint64(
+            _calcAverage(
+                _stats.avgPendingSize,
+                nextPendingId - lastFinalizedId - 1,
+                type(uint64).max
+            )
         );
     }
 
@@ -447,10 +452,10 @@ contract TaikoL1 is EssentialContract {
         view
         returns (uint128)
     {
-        uint256 reward = (proverReward * provingDelay * provingDelay) /
+        uint256 base = MIN_BLOCK_REWARD_BASE.max(avgProverReward);
+        uint256 reward = (base * provingDelay * provingDelay) /
             (_stats.avgProvingDelay * _stats.avgProvingDelay);
-        return
-            reward.min(proverReward * MAX_BLOCK_REWARD_MULTIPLIER).toUint128();
+        return reward.min(base * MAX_BLOCK_REWARD_MULTIPLIER).toUint128();
     }
 
     /**********************
@@ -527,20 +532,37 @@ contract TaikoL1 is EssentialContract {
 
             // Update stats
             if (i == 0) {
-                _stats.avgFinalizationDelay = _calcAverage(
-                    _stats.avgFinalizationDelay,
-                    uint64(block.timestamp - evidence.proposedAt)
+                _stats.avgFinalizationDelay = uint64(
+                    _calcAverage(
+                        _stats.avgFinalizationDelay,
+                        uint64(block.timestamp - evidence.proposedAt),
+                        type(uint64).max
+                    )
                 );
 
-                _stats.avgProvingDelay = _calcAverage(
-                    _stats.avgProvingDelay,
-                    evidence.provenAt - evidence.proposedAt
+                _stats.avgProvingDelay = uint64(
+                    _calcAverage(
+                        _stats.avgProvingDelay,
+                        evidence.provenAt - evidence.proposedAt,
+                        type(uint64).max
+                    )
+                );
+
+                avgProverReward = uint128(
+                    _calcAverage(
+                        avgProverReward,
+                        evidence.reward,
+                        type(uint128).max
+                    )
                 );
             }
 
-            _stats.avgProvingDelayWithUncles = _calcAverage(
-                _stats.avgProvingDelayWithUncles,
-                evidence.provenAt - evidence.proposedAt
+            _stats.avgProvingDelayWithUncles = uint64(
+                _calcAverage(
+                    _stats.avgProvingDelayWithUncles,
+                    evidence.provenAt - evidence.proposedAt,
+                    type(uint128).max
+                )
             );
         }
 
@@ -677,11 +699,11 @@ contract TaikoL1 is EssentialContract {
         return keccak256(abi.encode(context));
     }
 
-    function _calcAverage(uint64 avg, uint64 current)
-        private
-        pure
-        returns (uint64)
-    {
+    function _calcAverage(
+        uint256 avg,
+        uint256 current,
+        uint256 max
+    ) private pure returns (uint256) {
         if (current == 0) return avg;
         if (avg == 0) return current;
 
@@ -689,7 +711,7 @@ contract TaikoL1 is EssentialContract {
             avg +
             current *
             NANO_PER_SECOND) / STAT_AVERAGING_FACTOR;
-        return uint64(_avg.max(type(uint64).max));
+        return _avg.max(max);
     }
 
     // We currently assume the public input has at least

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -499,7 +499,6 @@ contract TaikoL1 is EssentialContract {
             evidence.proverFee = uint128(
                 (proverGasPrice * (context.gasLimit + BLOCK_GAS_LIMIT_EXTRA))
                     .min(context.feeReserve)
-                    .max(type(uint128).max)
             );
 
             evidence.feeRebate = context.feeReserve - evidence.proverFee;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -142,10 +142,9 @@ contract TaikoL1 is EssentialContract {
 
     event BlockProven(
         uint256 indexed id,
-        Evidence evidence,
         bytes32 parentHash,
         bytes32 blockHash,
-        uint256 provingDelay
+        Evidence evidence
     );
 
     event BlockFinalized(
@@ -494,13 +493,7 @@ contract TaikoL1 is EssentialContract {
 
         fc.evidences.push(evidence);
 
-        emit BlockProven(
-            context.id,
-            evidence,
-            parentHash,
-            blockHash,
-            evidence.provingDelay
-        );
+        emit BlockProven(context.id, parentHash, blockHash, evidence);
     }
 
     function _finalizeBlock(uint64 id, ForkChoice storage fc)

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -35,8 +35,8 @@ contract TaikoL2 is EssentialContract {
         bytes32 proofVal
     );
 
-    event TaiCredited(address receipient, uint256 amount);
-    event TaiReturned(address receipient, uint256 amount);
+    event EtherCredited(address receipient, uint256 amount);
+    event EtherReturned(address receipient, uint256 amount);
 
     /**********************
      * Modifiers          *
@@ -52,8 +52,8 @@ contract TaikoL2 is EssentialContract {
      * External Functions *
      **********************/
 
-    receive() external payable onlyFromNamed("tai_depositor") {
-        emit TaiReturned(msg.sender, msg.value);
+    receive() external payable onlyFromNamed("eth_depositor") {
+        emit EtherReturned(msg.sender, msg.value);
     }
 
     fallback() external payable {
@@ -64,14 +64,14 @@ contract TaikoL2 is EssentialContract {
         EssentialContract._init(_addressManager);
     }
 
-    function creditTaiToken(address receipient, uint256 amount)
+    function creditEther(address receipient, uint256 amount)
         external
         nonReentrant
-        onlyFromNamed("tai_depositor")
+        onlyFromNamed("eth_depositor")
     {
         require(receipient != address(this), "L2:invalid address");
         payable(receipient).transfer(amount);
-        emit TaiCredited(receipient, amount);
+        emit EtherCredited(receipient, amount);
     }
 
     function anchor(uint256 anchorHeight, bytes32 anchorHash)

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -78,9 +78,9 @@ contract TaikoL2 is EssentialContract {
         external
         onlyWhenNotAnchored
     {
-        require(anchorHeight != 0 && anchorHash != 0x0, "L2:invalid anchor");
+        require(anchorHeight != 0 && anchorHash != 0, "L2:invalid anchor");
 
-        if (anchorHashes[anchorHeight] == 0x0) {
+        if (anchorHashes[anchorHeight] == 0) {
             anchorHashes[anchorHeight] = anchorHash;
 
             (bytes32 proofKey, bytes32 proofVal) = LibStorageProof

--- a/packages/protocol/contracts/libs/LibBlockHeader.sol
+++ b/packages/protocol/contracts/libs/LibBlockHeader.sol
@@ -67,7 +67,7 @@ library LibBlockHeader {
         returns (bool)
     {
         return
-            header.parentHash != 0x0 &&
+            header.parentHash != 0 &&
             header.ommersHash == EMPTY_OMMERS_HASH &&
             header.gasLimit <= LibConstants.MAX_TAIKO_BLOCK_GAS_LIMIT &&
             header.extraData.length <= 32 &&


### PR DESCRIPTION
The following changes are applied:
### 1. Dynamic Prover Fee
When a block is proposed, we used the current `proverGasPrice` to estimate a prover fee reserve: 
```
feeReserve = 4 * proverGasPrice_at_proposing_time * (blockGasBaseline + block.gasLimit)
```
When the block is actually proven, we use the `proverGasPrice` at *the proving time* to recalculate the fee:
```
fee = proverGasPrice_at_proving_time * (blockGasBaseline + block.gasLimit)
```
then the prover charges `min(fee, feeReserve)` as the actual prover fee and rebate the remaining fee back to the proposer.

#### Why we need this change:?
`proverGasPrice` will be changing overtime (whenever a block is finalized), if we do not use its value for prover fee calculation **at proving time**, then when `proverGasPrice`'s value is small, many proposer will take the opportunity to propose many blocks to lock down their prover fees to game the system.


### 2. Block Reward Calculated at Proven Time
Now, block rewards are also calculated when a ZKP is submitted, not when a block is finalized.


### 3 Block Reward Determined by the first prover
Now the block rewards for all uncle proofs all depends on the first prover. It makes no more sense for uncle provers to wait for more block reward.

### 4 Implemented simple block reward math

The math is as below:
```
c = max(r, 2E18)
y= min(c*x^2/t^2, c*M)
```
where `y` is the block's TAI reward
`x` is the block's proving delay
`t` is the block proving delay moving average
`r` is the current block reward base which is adjustable
`M` is the max block reward multiplier, now it's 10 (will change to 64).

![WechatIMG236](https://user-images.githubusercontent.com/99078276/183041045-602c6fca-a36d-44c6-8e46-e59217b74a40.jpeg)


As show in the above image: it will take `sqrt(M)*` times the average proving delay for provers to receive the max rewards. 


This is way simpler than what's proposed https://github.com/taikochain/taiko-mono/issues/14#issuecomment-1204746881 but still effective because the first prover will set the block reward, regardless how late uncle proofs are generated. If the proverFee is too small or turns out to be not so competitive compared with other chains, the block prover can wait long enough for up to 64 times the average block reward.

### 5 ETH as L2 fee token
