### PR TITLE
[protocol] adjust the calculation of uncle proof reward

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -471,16 +471,12 @@ contract TaikoL1 is EssentialContract {
             }
         }
 
-        uint64 provingDelay = (block.timestamp - context.proposedAt).toUint64();
-        uint128 reward = getBlockTaiReward(provingDelay) /
-            (fc.evidences.length + 1).toUint128();
-
         Evidence memory evidence = Evidence({
             prover: msg.sender,
             proverFee: 0,
             feeRebate: 0,
-            reward: reward,
-            provingDelay: provingDelay
+            reward: 0,
+            provingDelay: (block.timestamp - context.proposedAt).toUint64()
         });
 
         if (fc.evidences.length == 0) {
@@ -489,6 +485,11 @@ contract TaikoL1 is EssentialContract {
                 .min(context.feeReserve)
                 .toUint128();
             evidence.feeRebate = context.feeReserve - evidence.proverFee;
+            evidence.reward = getBlockTaiReward(evidence.provingDelay);
+        } else {
+            evidence.reward =
+                fc.evidences[0].reward /
+                (fc.evidences.length + 1).toUint128();
         }
 
         fc.evidences.push(evidence);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -486,6 +486,8 @@ contract TaikoL1 is EssentialContract {
             evidence.feeRebate = context.feeReserve - evidence.proverFee;
             evidence.reward = getBlockTaiReward(evidence.provingDelay);
         } else {
+            // Uncle proof reward is now based on the first proof submitted,
+            // which avoid provers waiting for larger block rewards.
             evidence.reward =
                 fc.evidences[0].reward /
                 (fc.evidences.length + 1).toUint128();

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -270,7 +270,7 @@ contract TaikoL1 is EssentialContract {
             );
 
         if (!anchored) {
-            proofVal = 0x0;
+            proofVal = 0;
         }
 
         LibMerkleProof.verify(
@@ -386,8 +386,8 @@ contract TaikoL1 is EssentialContract {
     function validateContext(BlockContext memory context) public view {
         require(
             context.id == 0 &&
-                context.txListHash == 0x0 &&
-                context.mixHash == 0x0 &&
+                context.txListHash == 0 &&
+                context.mixHash == 0 &&
                 context.proposedAt == 0 &&
                 context.feeReserve == 0,
             "nonzero placeholder fields"
@@ -396,7 +396,7 @@ contract TaikoL1 is EssentialContract {
         require(
             block.number <= context.anchorHeight + MAX_ANCHOR_HEIGHT_DIFF &&
                 context.anchorHash == blockhash(context.anchorHeight) &&
-                context.anchorHash != 0x0,
+                context.anchorHash != 0,
             "invalid anchor"
         );
 
@@ -626,7 +626,7 @@ contract TaikoL1 is EssentialContract {
 
     function _validateHeader(BlockHeader calldata header) private pure {
         require(
-            header.parentHash != 0x0 &&
+            header.parentHash != 0 &&
                 header.gasLimit <= LibConstants.MAX_TAIKO_BLOCK_GAS_LIMIT &&
                 header.extraData.length <= 32 &&
                 header.difficulty == 0 &&

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -550,24 +550,30 @@ contract TaikoL1 is EssentialContract {
         address proposer = _getPendingBlock(id).proposer;
 
         bool success;
-        (success, ) = evidence.prover.call{value: evidence.proverFee}("");
-        if (!success) {
-            unsettledProverFee += evidence.proverFee;
+        if (evidence.proverFee > 0) {
+            (success, ) = evidence.prover.call{value: evidence.proverFee}("");
+            if (!success) {
+                unsettledProverFee += evidence.proverFee;
+            }
         }
 
-        (success, ) = proposer.call{value: evidence.feeRebate}("");
-        if (!success) {
-            unsettledProverFee += evidence.feeRebate;
+        if (evidence.feeRebate > 0) {
+            (success, ) = proposer.call{value: evidence.feeRebate}("");
+            if (!success) {
+                unsettledProverFee += evidence.feeRebate;
+            }
         }
 
-        (success, ) = resolve("dao_vault").call{value: unsettledProverFee - 1}(
-            ""
-        );
-        if (success) {
-            unsettledProverFee = 1;
+        if (unsettledProverFee > 1) {
+            (success, ) = resolve("dao_vault").call{
+                value: unsettledProverFee - 1
+            }("");
+            if (success) {
+                unsettledProverFee = 1;
+            }
         }
 
-        if (evidence.reward != 0) {
+        if (evidence.reward > 0) {
             IMintableERC20(resolve("tai_token")).mint(
                 evidence.prover,
                 evidence.reward

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -479,6 +479,7 @@ contract TaikoL1 is EssentialContract {
         });
 
         if (fc.evidences.length == 0) {
+            // Only the first prover get the proverFee
             evidence.proverFee = (proverGasPrice *
                 (context.gasLimit + BLOCK_GAS_LIMIT_EXTRA))
                 .min(context.feeReserve)
@@ -490,7 +491,7 @@ contract TaikoL1 is EssentialContract {
             // which avoid provers waiting for larger block rewards.
             evidence.reward =
                 fc.evidences[0].reward /
-                (fc.evidences.length + 1).toUint128();
+                (fc.evidences.length + 2).toUint128();
         }
 
         fc.evidences.push(evidence);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -142,10 +142,9 @@ contract TaikoL1 is EssentialContract {
 
     event BlockProven(
         uint256 indexed id,
-        Evidence evidence,
         bytes32 parentHash,
         bytes32 blockHash,
-        uint256 provingDelay
+        Evidence evidence
     );
 
     event BlockFinalized(
@@ -494,13 +493,7 @@ contract TaikoL1 is EssentialContract {
 
         fc.evidences.push(evidence);
 
-        emit BlockProven(
-            context.id,
-            evidence,
-            parentHash,
-            blockHash,
-            evidence.provingDelay
-        );
+        emit BlockProven(context.id, parentHash, blockHash, evidence);
     }
 
     function _finalizeBlock(uint64 id, ForkChoice storage fc)

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -78,9 +78,9 @@ contract TaikoL2 is EssentialContract {
         external
         onlyWhenNotAnchored
     {
-        require(anchorHeight != 0 && anchorHash != 0x0, "L2:invalid anchor");
+        require(anchorHeight != 0 && anchorHash != 0, "L2:invalid anchor");
 
-        if (anchorHashes[anchorHeight] == 0x0) {
+        if (anchorHashes[anchorHeight] == 0) {
             anchorHashes[anchorHeight] = anchorHash;
 
             (bytes32 proofKey, bytes32 proofVal) = LibStorageProof

--- a/packages/protocol/contracts/libs/LibBlockHeader.sol
+++ b/packages/protocol/contracts/libs/LibBlockHeader.sol
@@ -67,7 +67,7 @@ library LibBlockHeader {
         returns (bool)
     {
         return
-            header.parentHash != 0x0 &&
+            header.parentHash != 0 &&
             header.ommersHash == EMPTY_OMMERS_HASH &&
             header.gasLimit <= LibConstants.MAX_TAIKO_BLOCK_GAS_LIMIT &&
             header.extraData.length <= 32 &&


### PR DESCRIPTION
With this change, TAI rewards for uncle proofs won't increase over time once the first proof is submitted. This is very necessary to prevent provers from waiting long enough to receive more rewards.