### PR TITLE
[protocol] introducing ProtoBroker

### DIFF
--- a/packages/protocol/contracts/L1/TaiToken.sol
+++ b/packages/protocol/contracts/L1/TaiToken.sol
@@ -31,6 +31,7 @@ contract TaiToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
      * Events            *
      *********************/
     event Mint(address account, uint256 amount);
+    event Burn(address account, uint256 amount);
 
     /*********************
      * External Functions*
@@ -74,10 +75,25 @@ contract TaiToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
      */
     function mint(address account, uint256 amount)
         public
-        onlyFromNamed("taiko_l1")
+        onlyFromNamed("proto_broker")
     {
         require(account != address(0), "TAI: invalid address");
         _mint(account, amount);
         emit Mint(account, amount);
+    }
+
+    /**
+     * @dev Burn tokens from the given address's balance. This will decrease
+     *      the circulating supply.
+     * @param account The address to burn the tokens from.
+     * @param amount The amount of tokens to burn.
+     */
+    function burn(address account, uint256 amount)
+        public
+        onlyFromNamed("proto_broker")
+    {
+        require(account != address(0), "TAI: invalid address");
+        _burn(account, amount);
+        emit Burn(account, amount);
     }
 }

--- a/packages/protocol/contracts/L1/broker/IProtoBroker.sol
+++ b/packages/protocol/contracts/L1/broker/IProtoBroker.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+//
+// ╭━━━━╮╱╱╭╮╱╱╱╱╱╭╮╱╱╱╱╱╭╮
+// ┃╭╮╭╮┃╱╱┃┃╱╱╱╱╱┃┃╱╱╱╱╱┃┃
+// ╰╯┃┃┣┻━┳┫┃╭┳━━╮┃┃╱╱╭━━┫╰━┳━━╮
+// ╱╱┃┃┃╭╮┣┫╰╯┫╭╮┃┃┃╱╭┫╭╮┃╭╮┃━━┫
+// ╱╱┃┃┃╭╮┃┃╭╮┫╰╯┃┃╰━╯┃╭╮┃╰╯┣━━┃
+// ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
+pragma solidity ^0.8.9;
+
+/// @author dantaik <dan@taiko.xyz>
+interface IProtoBroker {
+    function chargeProposer(
+        uint256 blockId,
+        address proposer,
+        uint128 gasLimit,
+        uint64 numUnprovenBlocks
+    ) external returns (uint128 proposerFee);
+
+    function payProver(
+        uint256 blockId,
+        address prover,
+        uint256 uncleId,
+        uint64 proposedAt,
+        uint64 provenAt,
+        uint128 proposerFee
+    ) external returns (uint128 proverFee);
+
+    function getProposerFee(uint128 gasLimit, uint64 numUnprovenBlocks)
+        external
+        view
+        returns (uint128 gasFee);
+}

--- a/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
+++ b/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
@@ -18,12 +18,12 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
 
     uint256[48] private __gap;
 
-    event FeeReceived(
+    event ProposerCharged(
         uint256 indexed blockId,
         address indexed account,
         uint256 amount
     );
-    event FeePaid(
+    event ProverPaid(
         uint256 indexed blockId,
         address indexed account,
         uint256 amount,
@@ -39,7 +39,7 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
         proposerFee = getProposerFee(gasLimit, numUnprovenBlocks);
 
         require(_chargeFee(proposer, proposerFee), "failed to charge");
-        emit FeeReceived(blockId, proposer, proposerFee);
+        emit ProposerCharged(blockId, proposer, proposerFee);
     }
 
     function payProver(
@@ -78,7 +78,7 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
             }
         }
 
-        emit FeePaid(blockId, prover, proverFee, uncleId);
+        emit ProverPaid(blockId, prover, proverFee, uncleId);
     }
 
     function getProposerFee(uint128 gasLimit, uint64 numUnprovenBlocks)

--- a/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
+++ b/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
@@ -55,6 +55,18 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
         proverFee /= uint128(uncleId + 1);
 
         if (proverFee > 0) {
+            address daoVault = resolve("dao_reserve");
+            if (uncleId == 0 && proverFee > proposerFee) {
+                uint128 mintAmount = proverFee - proposerFee;
+                if (!_payFee(daoVault, mintAmount)) {
+                    unsettledProverFee += mintAmount;
+                }
+            } else {
+                if (!_payFee(daoVault, proverFee)) {
+                    unsettledProverFee += proverFee;
+                }
+            }
+
             if (!_payFee(prover, proverFee)) {
                 unsettledProverFee += proverFee;
             }

--- a/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
+++ b/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
@@ -18,12 +18,12 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
 
     uint256[48] private __gap;
 
-    event ProposerCharged(
+    event FeeReceived(
         uint256 indexed blockId,
         address indexed account,
         uint256 amount
     );
-    event ProverPaid(
+    event FeePaid(
         uint256 indexed blockId,
         address indexed account,
         uint256 amount,
@@ -39,7 +39,7 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
         proposerFee = getProposerFee(gasLimit, numUnprovenBlocks);
 
         require(_chargeFee(proposer, proposerFee), "failed to charge");
-        emit ProposerCharged(blockId, proposer, proposerFee);
+        emit FeeReceived(blockId, proposer, proposerFee);
     }
 
     function payProver(
@@ -78,7 +78,7 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
             }
         }
 
-        emit ProverPaid(blockId, prover, proverFee, uncleId);
+        emit FeePaid(blockId, prover, proverFee, uncleId);
     }
 
     function getProposerFee(uint128 gasLimit, uint64 numUnprovenBlocks)

--- a/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
+++ b/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+//
+// ╭━━━━╮╱╱╭╮╱╱╱╱╱╭╮╱╱╱╱╱╭╮
+// ┃╭╮╭╮┃╱╱┃┃╱╱╱╱╱┃┃╱╱╱╱╱┃┃
+// ╰╯┃┃┣┻━┳┫┃╭┳━━╮┃┃╱╱╭━━┫╰━┳━━╮
+// ╱╱┃┃┃╭╮┣┫╰╯┫╭╮┃┃┃╱╭┫╭╮┃╭╮┃━━┫
+// ╱╱┃┃┃╭╮┃┃╭╮┫╰╯┃┃╰━╯┃╭╮┃╰╯┣━━┃
+// ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
+pragma solidity ^0.8.9;
+
+import "../../common/EssentialContract.sol";
+import "./IProtoBroker.sol";
+
+abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
+    uint128 public unsettledProverFeeThreshold;
+    uint128 public unsettledProverFee;
+    uint128 internal _suggestedGasPrice;
+
+    uint256[48] private __gap;
+
+    event FeeReceived(
+        uint256 indexed blockId,
+        address indexed account,
+        uint256 amount
+    );
+    event FeePaid(
+        uint256 indexed blockId,
+        address indexed account,
+        uint256 amount,
+        uint256 uncleId
+    );
+
+    function chargeProposer(
+        uint256 blockId,
+        address proposer,
+        uint128 gasLimit,
+        uint64 numUnprovenBlocks
+    ) public virtual override returns (uint128 proposerFee) {
+        proposerFee = getProposerFee(gasLimit, numUnprovenBlocks);
+
+        require(_chargeFee(proposer, proposerFee), "failed to charge");
+        emit FeeReceived(blockId, proposer, proposerFee);
+    }
+
+    function payProver(
+        uint256 blockId,
+        address prover,
+        uint256 uncleId,
+        uint64 proposedAt,
+        uint64 provenAt,
+        uint128 proposerFee
+    ) public virtual override returns (uint128 proverFee) {
+        proverFee = _getProverFee(proposerFee, provenAt - proposedAt);
+
+        proverFee /= uint128(uncleId + 1);
+
+        if (proverFee > 0) {
+            if (!_payFee(prover, proverFee)) {
+                unsettledProverFee += proverFee;
+            }
+
+            if (unsettledProverFee > unsettledProverFeeThreshold) {
+                if (_payFee(resolve("dao_vault"), unsettledProverFee - 1)) {
+                    unsettledProverFee = 1;
+                }
+            }
+        }
+
+        emit FeePaid(blockId, prover, proverFee, uncleId);
+    }
+
+    function getProposerFee(uint128 gasLimit, uint64 numUnprovenBlocks)
+        public
+        view
+        override
+        returns (uint128)
+    {
+        uint128 gasPrice = _getProposerGasPrice(numUnprovenBlocks);
+        return _calculateFee(gasPrice, gasLimit);
+    }
+
+    /// @dev Initializer to be called after being deployed behind a proxy.
+    function _init(
+        address _addressManager,
+        uint128 _unsettledProverFeeThreshold
+    ) internal virtual {
+        require(_unsettledProverFeeThreshold > 0, "threshold too small");
+        EssentialContract._init(_addressManager);
+        unsettledProverFeeThreshold = _unsettledProverFeeThreshold;
+    }
+
+    function _getProverFee(
+        uint128 proposerFee,
+        uint64 /*provingDelay*/
+    ) internal virtual returns (uint128) {
+        return proposerFee;
+    }
+
+    function _payFee(
+        address, /*recipient*/
+        uint256 /*amount*/
+    )
+        internal
+        virtual
+        returns (
+            bool /*success*/
+        );
+
+    function _chargeFee(
+        address, /*recipient*/
+        uint256 /*amount*/
+    )
+        internal
+        virtual
+        returns (
+            bool /*success*/
+        );
+
+    function _getProposerGasPrice(
+        uint64 /*numUnprovenBlocks*/
+    ) internal view virtual returns (uint128);
+
+    function _gasLimitBase() internal pure virtual returns (uint128);
+
+    function _calculateFee(uint128 gasPrice, uint128 gasLimit)
+        private
+        pure
+        returns (uint128)
+    {
+        return gasPrice * (gasLimit + _gasLimitBase());
+    }
+}

--- a/packages/protocol/contracts/L1/broker/ProtoBrokerWithDynamicFees.sol
+++ b/packages/protocol/contracts/L1/broker/ProtoBrokerWithDynamicFees.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+//
+// ╭━━━━╮╱╱╭╮╱╱╱╱╱╭╮╱╱╱╱╱╭╮
+// ┃╭╮╭╮┃╱╱┃┃╱╱╱╱╱┃┃╱╱╱╱╱┃┃
+// ╰╯┃┃┣┻━┳┫┃╭┳━━╮┃┃╱╱╭━━┫╰━┳━━╮
+// ╱╱┃┃┃╭╮┣┫╰╯┫╭╮┃┃┃╱╭┫╭╮┃╭╮┃━━┫
+// ╱╱┃┃┃╭╮┃┃╭╮┫╰╯┃┃╰━╯┃╭╮┃╰╯┣━━┃
+// ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
+
+import "../../libs/LibMath.sol";
+import "../../libs/Lib1559Math.sol";
+import "./ProtoBrokerBase.sol";
+
+abstract contract ProtoBrokerWithDynamicFees is ProtoBrokerBase {
+    using SafeCastUpgradeable for uint256;
+    using LibMath for uint256;
+
+    uint256 public constant STAT_AVERAGING_FACTOR = 2048;
+    uint256 internal constant TARGET_FEE_ROI = 1000000;
+    uint64 internal constant NANO_PER_SECOND = 1E9;
+
+    uint64 internal _avgNumUnprovenBlocks;
+    uint64 internal _avgProvingDelay;
+    uint128 public suggestedGasPrice;
+
+    uint256[49] private __gap;
+
+    function chargeProposer(
+        uint256 blockId,
+        address proposer,
+        uint128 gasLimit,
+        uint64 numUnprovenBlocks
+    )
+        public
+        virtual
+        override
+        onlyFromNamed("taiko_l1")
+        returns (uint128 proposerFee)
+    {
+        proposerFee = ProtoBrokerBase.chargeProposer(
+            blockId,
+            proposer,
+            gasLimit,
+            numUnprovenBlocks
+        );
+
+        _avgNumUnprovenBlocks = _calcAverage(
+            _avgNumUnprovenBlocks,
+            numUnprovenBlocks,
+            512
+        ).toUint64();
+    }
+
+    function payProver(
+        uint256 blockId,
+        address prover,
+        uint256 uncleId,
+        uint64 proposedAt,
+        uint64 provenAt,
+        uint128 proposerFee
+    ) public virtual override returns (uint128 proverFee) {
+        proverFee = ProtoBrokerBase.payProver(
+            blockId,
+            prover,
+            uncleId,
+            proposedAt,
+            provenAt,
+            proposerFee
+        );
+
+        if (uncleId == 0) {
+            _avgProvingDelay = _calcAverage(
+                _avgProvingDelay,
+                (provenAt - proposedAt) * NANO_PER_SECOND,
+                512
+            ).toUint64();
+
+            uint256 roiMeasured = (proposerFee * TARGET_FEE_ROI) / proverFee;
+
+            _suggestedGasPrice = Lib1559Math
+                .adjustTarget(
+                    _suggestedGasPrice,
+                    roiMeasured,
+                    TARGET_FEE_ROI,
+                    16
+                )
+                .toUint128();
+        }
+    }
+
+    function getStats()
+        public
+        view
+        returns (uint64 avgNumUnprovenBlocks, uint64 avgProvingDelay)
+    {
+        avgNumUnprovenBlocks = _avgNumUnprovenBlocks / NANO_PER_SECOND;
+        avgProvingDelay = _avgProvingDelay / NANO_PER_SECOND;
+    }
+
+    /// @dev Initializer to be called after being deployed behind a proxy.
+    function _init(
+        address _addressManager,
+        uint128 _unsettledProverFeeThreshold,
+        uint128 _suggestedGasPrice
+    ) internal virtual {
+        ProtoBrokerBase._init(_addressManager, _unsettledProverFeeThreshold);
+
+        suggestedGasPrice = _suggestedGasPrice;
+    }
+
+    function _getProverFee(uint128 proposerFee, uint64 provingDelay)
+        internal
+        virtual
+        override
+        returns (uint128)
+    {
+        uint64 threshold = _avgProvingDelay * 2;
+        uint64 provingDelayNano = provingDelay * NANO_PER_SECOND;
+
+        uint128 gasFeeAfterTax = (proposerFee * 95) / 100;
+
+        if (provingDelayNano < threshold) {
+            return gasFeeAfterTax;
+        }
+
+        uint256 fee = (uint256(gasFeeAfterTax) *
+            (provingDelayNano - threshold)) /
+            _avgProvingDelay +
+            gasFeeAfterTax;
+
+        return fee.toUint128();
+    }
+
+    function _getProposerGasPrice(uint64 numUnprovenBlocks)
+        internal
+        view
+        virtual
+        override
+        returns (uint128)
+    {
+        uint64 threshold = _avgNumUnprovenBlocks > 64
+            ? _avgNumUnprovenBlocks
+            : 64;
+
+        if (numUnprovenBlocks <= threshold) {
+            return suggestedGasPrice;
+        } else {
+            uint256 premeium = (10000 * numUnprovenBlocks) / (2 * threshold);
+            premeium = premeium.min(20000);
+            return (suggestedGasPrice * uint128(premeium)) / 10000;
+        }
+    }
+
+    function _calcAverage(
+        uint256 avg,
+        uint256 current,
+        uint256 factor
+    ) private pure returns (uint256) {
+        if (current == 0) return avg;
+        if (avg == 0) return current;
+
+        return ((factor - 1) * avg + current) / factor;
+    }
+}

--- a/packages/protocol/contracts/L1/broker/ProtoBrokerWithDynamicFees.sol
+++ b/packages/protocol/contracts/L1/broker/ProtoBrokerWithDynamicFees.sol
@@ -148,9 +148,9 @@ abstract contract ProtoBrokerWithDynamicFees is ProtoBrokerBase {
         if (numUnprovenBlocks <= threshold) {
             return suggestedGasPrice;
         } else {
-            uint256 premeium = (10000 * numUnprovenBlocks) / (2 * threshold);
-            premeium = premeium.min(20000);
-            return (suggestedGasPrice * uint128(premeium)) / 10000;
+            uint256 premium = (10000 * numUnprovenBlocks) / (2 * threshold);
+            premium = premium.min(40000);
+            return (suggestedGasPrice * uint128(premium)) / 10000;
         }
     }
 

--- a/packages/protocol/contracts/L1/broker/TaikoProtoBroker.sol
+++ b/packages/protocol/contracts/L1/broker/TaikoProtoBroker.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+//
+// ╭━━━━╮╱╱╭╮╱╱╱╱╱╭╮╱╱╱╱╱╭╮
+// ┃╭╮╭╮┃╱╱┃┃╱╱╱╱╱┃┃╱╱╱╱╱┃┃
+// ╰╯┃┃┣┻━┳┫┃╭┳━━╮┃┃╱╱╭━━┫╰━┳━━╮
+// ╱╱┃┃┃╭╮┣┫╰╯┫╭╮┃┃┃╱╭┫╭╮┃╭╮┃━━┫
+// ╱╱┃┃┃╭╮┃┃╭╮┫╰╯┃┃╰━╯┃╭╮┃╰╯┣━━┃
+// ╱╱╰╯╰╯╰┻┻╯╰┻━━╯╰━━━┻╯╰┻━━┻━━╯
+pragma solidity ^0.8.9;
+
+import "../../common/IMintableERC20.sol";
+import "./ProtoBrokerWithDynamicFees.sol";
+
+contract TaikoProtoBroker is ProtoBrokerWithDynamicFees {
+    uint256[50] private __gap;
+
+    /// @dev Initializer to be called after being deployed behind a proxy.
+    function init(
+        address _addressManager,
+        uint128 _gasPriceNow,
+        uint128 _unsettledProverFeeThreshold,
+        uint256 _amountMintToDAO,
+        uint256 _amountMintToTeam
+    ) external initializer {
+        ProtoBrokerWithDynamicFees._init(
+            _addressManager,
+            _gasPriceNow,
+            _unsettledProverFeeThreshold
+        );
+
+        IMintableERC20 taiToken = IMintableERC20(resolve("tai_token"));
+        taiToken.mint(resolve("dao_vault"), _amountMintToDAO);
+        taiToken.mint(resolve("team_vault"), _amountMintToTeam);
+    }
+
+    function feeToken() public view returns (address) {
+        return resolve("tai_token");
+    }
+
+    function _payFee(address recipient, uint256 amount)
+        internal
+        override
+        returns (bool success)
+    {
+        if (amount > 0) {
+            IMintableERC20(feeToken()).mint(recipient, amount);
+        }
+        return true;
+    }
+
+    function _chargeFee(address recipient, uint256 amount)
+        internal
+        override
+        returns (bool success)
+    {
+        if (amount > 0) {
+            IMintableERC20(feeToken()).burn(recipient, amount);
+        }
+        return true;
+    }
+
+    function _gasLimitBase() internal pure override returns (uint128) {
+        return 1000000;
+    }
+}

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -35,8 +35,8 @@ contract TaikoL2 is EssentialContract {
         bytes32 proofVal
     );
 
-    event EtherCredited(address receipient, uint256 amount);
-    event EtherReturned(address receipient, uint256 amount);
+    event EtherCredited(address recipient, uint256 amount);
+    event EtherReturned(address recipient, uint256 amount);
 
     /**********************
      * Modifiers          *
@@ -64,14 +64,14 @@ contract TaikoL2 is EssentialContract {
         EssentialContract._init(_addressManager);
     }
 
-    function creditEther(address receipient, uint256 amount)
+    function creditEther(address recipient, uint256 amount)
         external
         nonReentrant
         onlyFromNamed("eth_depositor")
     {
-        require(receipient != address(this), "L2:invalid address");
-        payable(receipient).transfer(amount);
-        emit EtherCredited(receipient, amount);
+        require(recipient != address(this), "L2:invalid address");
+        payable(recipient).transfer(amount);
+        emit EtherCredited(recipient, amount);
     }
 
     function anchor(uint256 anchorHeight, bytes32 anchorHash)

--- a/packages/protocol/contracts/common/IMintableERC20.sol
+++ b/packages/protocol/contracts/common/IMintableERC20.sol
@@ -12,4 +12,6 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
 interface IMintableERC20 is IERC20Upgradeable {
     function mint(address account, uint256 amount) external;
+
+    function burn(address account, uint256 amount) external;
 }


### PR DESCRIPTION
This PR implemented my idea that we can view block proposing-and-proving as a business among three actors, the propose, the proto-broker (or broker for short), and the prover. Here is how it works:

1. The proposer first enters an deal with the broker so he can pay the broker a fee, `Fa`, and **buys not only the block space, but a guarantee that his block will be eventually proven by a prover**.

1. The broker's goal is to break-even. Once a block is proposed by the proposer, the broker starts a time-based auction to hire a prover to prove this block. The initial prover fee offering is `Fb = Fa * 95%`. If there is a prover submitted a proof before the average proving delay `D`, then the actual amount the broker pays to the prover is `Fb`. In such a case, there is a profit of 5%.  If no prover is interested, then after proving delay `D`,  the prover fee offering `Fb` will linearly increase until at least one prover is willing to submit a prove. In such a case, the broker may have to pay a bigger fee and suffer a loss. But it's OK for the broker to take a lose -- he can simply mint more tokens out of the thin air.

1. Whenever a block is finalized (important: not when it is proven), the broker adjusts an internally maintained gasPrice `p` using the EIP1559 math. The broker's goal is very straightforward: being break even, i,e., `Fb/Fa ==> 1`.

## Proving time

We have no idea about the actual proving time in the near or far future,  we shouldn't use an imaged value in our fee adjustment as it will become very problematic. As long as the provers is interested in the broker's fee offering, then they wll compete to be the first one to submit the right ZKP to earn the fee. The proving time is a result of such competition, while the broker's offering is the reason for such competition.

## Fee Adjustment 
As the internal gasPrice `p` is only adjusted when a block is finalized, we have to adjust the fee more real-time based on the number of pending blocks yet to be proven. Otherwise, when the fee is low, many proposers will take the opportunity to propose a lot of blocks before another block is finalized. 

We adjusted the fee based on the number of average unproved blocks as follows in a function called `_getProposerGasPrice`. Using this function, we can charge as much as  `Fa * 400%` if there are many unproven blocks, even before another block is finalized. 

I think the math here doesn't have to be perfect, the EIP1559 style math will eventually converge.

## Proposer Fee not ETH

I don't think we have to use ETH as some fees here. Block proposers and provers are serious businesses, if provers can invest $$$ into expensive hardwares like GPU, block proposers can also invest in his own "infrastructure' by holding some TAI token.

> Also note that we can easily support a sub-contract of `ProtoBrokerWithDynamicFees` to enable the rollup to use any existing ERC20 tokens or Ether as the underlying proposal/prover fee. They just need to implement two functions: `_payFee` and `_chargeFee`.


