### PR TITLE
[protocol] Change the tokenomics math

### DIFF
--- a/packages/protocol/TOKENOMICS.md
+++ b/packages/protocol/TOKENOMICS.md
@@ -32,12 +32,13 @@ $$F_i = \hat{g_{i-1}} (B+L_i) $$
 
 - $R_i(t)$: The prover fee for the *i*-th block if the block is proven with a delay of $t$.
 
-    - if $t <= 1.5A_{i-1}$ then $R_i(t)=\hat{F_i}$
-    - else $R_i(t)=       {t \over A_{i-1}} \hat{F_i}    $
+    - if $t <= A_{i-1}$ then $R_i(t)=\hat{F_i}$
+    - else $R_i(t)=     ({1 \over 2}  + {t \over A_{i-1}})\hat{F_i}  $
 
 
-<img width="865" alt="Screenshot 2022-08-07 at 22 44 45" src="https://user-images.githubusercontent.com/99078276/183296568-0de10279-daab-46ad-8b68-57e7e9714b18.png">
 
+
+<img width="80%" alt="Screenshot 2022-08-09 at 19 29 51" src="https://user-images.githubusercontent.com/99078276/183636828-1e61f975-8b9d-4fe3-b014-90f90e25a283.png">
 
 
 Currently we allow up to 5 proofs per block. If the first proof was submitted with delay $D^1$, all the other *uncle proofs* must be submitted within a time window of $D^1 \over 2$.

--- a/packages/protocol/TOKENOMICS.md
+++ b/packages/protocol/TOKENOMICS.md
@@ -33,7 +33,7 @@ $$F_i = \hat{g_{i-1}} (B+L_i) $$
 - $R_i(t)$: The prover fee for the *i*-th block if the block is proven with a delay of $t$.
 
     - if $t <= A_{i-1}$ then $R_i(t)=\hat{F_i}$
-    - else $R_i(t)=     ({1 \over 2}  + {t \over A_{i-1}})\hat{F_i}  $
+    - else $R_i(t)=   max( 100 * \hat{F_i},   ({1 \over 2}  + {t \over A_{i-1}})\hat{F_i} ) $
 
 
 

--- a/packages/protocol/contracts/L1/broker/ProtoBrokerWithDynamicFees.sol
+++ b/packages/protocol/contracts/L1/broker/ProtoBrokerWithDynamicFees.sol
@@ -25,6 +25,7 @@ abstract contract ProtoBrokerWithDynamicFees is ProtoBrokerBase {
     uint256 public constant FEE_ADJUSTMENT_FACTOR = 32;
     uint256 public constant PROVING_DELAY_AVERAGING_FACTOR = 64;
     uint256 public constant FEE_PREMIUM_MAX_MUTIPLIER = 4;
+    uint256 public constant FEE_TOTAL_MAX_MULTIPLIER = 100;
     uint256 public constant FEE_BIPS = 500; // 5%
     uint64 internal constant MILIS_PER_SECOND = 1E3;
 
@@ -173,11 +174,11 @@ abstract contract ProtoBrokerWithDynamicFees is ProtoBrokerBase {
         view
         returns (uint256)
     {
-        // start to paying additional rewards above 150% of average proving delay
-        uint256 t = (_avgProvingDelay * 150) / 100; // threshold
-        uint256 x = provingDelay * MILIS_PER_SECOND;
-        uint256 b = (proposerFee * (10_000 - FEE_BIPS)) / 10_000; // feeBaseline
-        return x > t ? (b * (x - t)) / t + b : b;
+        uint256 a = _avgProvingDelay; // threshold
+        uint256 t = provingDelay * MILIS_PER_SECOND;
+        uint256 f = (proposerFee * (10_000 - FEE_BIPS)) / 10_000; // feeBaseline
+        return
+            t > a ? ((f * t) / a + f / 2).min(FEE_TOTAL_MAX_MULTIPLIER * f) : f;
     }
 
     function _updateAverage(


### PR DESCRIPTION
This should be merged only if the current one is proven wrong after simulation.