### PR TITLE
[protocol] enable L2 block proposers to better handle MEV

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -36,6 +36,12 @@ import "./broker/IProtoBroker.sol";
 ///                 ZKP that's only valid if he transacts with this address. This is
 ///                 critical to ensure the ZKP will not be stolen by others
 ///
+/// - Assumption 6: Block data can be split into two parts, a txList that is a RLP-encoded
+///                 list of transactions without signature fields but with a 'sender' field;
+///                 a sigList that is a RLP-encoded list of signature fields. The prover shall
+///                 be able to handle the situation where txList and sigList has different length.
+///                 In such case, zero-padding shall apply to the shorter list.
+///
 /// This contract shall be deployed as the initial implementation of a
 /// https://docs.openzeppelin.com/contracts/4.x/api/proxy#UpgradeableBeacon contract,
 /// then a https://docs.openzeppelin.com/contracts/4.x/api/proxy#BeaconProxy contract

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -147,13 +147,13 @@ contract TaikoL1 is EssentialContract {
     /**********************
      * Modifiers          *
      **********************/
-    modifier whenBlockIsProposed(BlockContext calldata context) {
+    modifier ifBlockIsProposed(BlockContext calldata context) {
         _checkBlockIsProposed(context);
         _;
         finalizeBlocks();
     }
 
-    modifier whenBlockIsProvable(BlockContext calldata context) {
+    modifier ifBlockIsProvable(BlockContext calldata context) {
         _checkBlockIsProvable(context);
         _;
         finalizeBlocks();
@@ -250,7 +250,7 @@ contract TaikoL1 is EssentialContract {
     function revealTxList(BlockContext calldata context, bytes calldata txList)
         external
         nonReentrant
-        whenBlockIsProposed(context)
+        ifBlockIsProposed(context)
     {
         require(
             txList.length > 0 && context.txListHash == txList.hashTxList(),
@@ -267,7 +267,7 @@ contract TaikoL1 is EssentialContract {
         BlockHeader calldata header,
         BlockContext calldata context,
         bytes[2] calldata proofs
-    ) external nonReentrant whenBlockIsProvable(context) {
+    ) external nonReentrant ifBlockIsProvable(context) {
         _validateHeaderForContext(header, context);
         bytes32 blockHash = header.hashBlockHeader();
 
@@ -311,7 +311,7 @@ contract TaikoL1 is EssentialContract {
         BlockHeader calldata throwAwayHeader,
         BlockContext calldata context,
         bytes[2] calldata proofs
-    ) external nonReentrant whenBlockIsProvable(context) {
+    ) external nonReentrant ifBlockIsProvable(context) {
         require(
             throwAwayHeader.isPartiallyValidForTaiko(),
             "L1:throwAwayHeader invalid"
@@ -358,7 +358,7 @@ contract TaikoL1 is EssentialContract {
     function verifyBlockInvalid(
         BlockContext calldata context,
         bytes calldata txList
-    ) external nonReentrant whenBlockIsProvable(context) {
+    ) external nonReentrant ifBlockIsProvable(context) {
         require(
             txList.hashTxList() == context.txListHash,
             "L1:txList mismatch"

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -151,16 +151,15 @@ contract TaikoL1 is EssentialContract {
     /**********************
      * Modifiers          *
      **********************/
+    modifier whenBlockIsProposed(BlockContext calldata context) {
+        _checkBlockIsProposed(context);
+        _;
+    }
 
     modifier whenBlockIsProvable(BlockContext calldata context) {
         _checkBlockIsProvable(context);
         _;
         finalizeBlocks();
-    }
-
-    modifier whenBlockIsProposed(BlockContext calldata context) {
-        _checkBlockIsProposed(context);
-        _;
     }
 
     /**********************

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -384,7 +384,8 @@ contract TaikoL1 is EssentialContract {
         bytes calldata sigList
     ) external nonReentrant ifBlockIsProvable(context) {
         require(
-            txList.hashTxList() == context.txListHash,
+            txList.hashTxList() == context.txListHash &&
+                sigList.hashSigList() == context.sigListHash,
             "L1:txList mismatch"
         );
         require(

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -325,7 +325,7 @@ contract TaikoL1 is EssentialContract {
     }
 
     function proveBlockInvalid(
-        bytes32 throwAwayTxListHash, // hash of a txList that contains a verifyBlockInvalid tx on L2.
+        bytes32 throwAwayTxListHash,
         bytes32 throwAwaySigListHash,
         BlockHeader calldata throwAwayHeader,
         BlockContext calldata context,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -247,7 +247,7 @@ contract TaikoL1 is EssentialContract {
         );
     }
 
-    function reviewBlock(BlockContext calldata context, bytes calldata txList)
+    function revealBlock(BlockContext calldata context, bytes calldata txList)
         external
         nonReentrant
         whenBlockIsProposed(context)

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -128,7 +128,7 @@ contract TaikoL1 is EssentialContract {
     event BlockProposed(
         uint256 indexed id,
         BlockContext context,
-        bool revealed
+        bool txListRevealed
     );
 
     event BlockRevealed(uint256 indexed id);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -247,14 +247,21 @@ contract TaikoL1 is EssentialContract {
         );
     }
 
-    function revealBlock(BlockContext calldata context, bytes calldata txList)
+    /// @notice Reveal a Taiko L2 block's txList.
+    /// @param context The block's context.
+    /// @param txList A list of transactions in this block, encoded with RLP.
+    function revealTxList(BlockContext calldata context, bytes calldata txList)
         external
         nonReentrant
         whenBlockIsProposed(context)
     {
-        require(context.txListHash == txList.hashTxList(), "invalid blockHash");
-        PendingBlock storage blk = _getPendingBlock(context.id);
-        blk.status = uint8(PendingBlockStatus.REVEALED);
+        require(
+            txList.length > 0 && context.txListHash == txList.hashTxList(),
+            "invalid blockHash"
+        );
+        _getPendingBlock(context.id).status = uint8(
+            PendingBlockStatus.REVEALED
+        );
         emit BlockRevealed(context.id);
     }
 

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -247,7 +247,7 @@ contract TaikoL1 is EssentialContract {
     /// @notice Reveal a Taiko L2 block's txList.
     /// @param context The block's context.
     /// @param txList A list of transactions in this block, encoded with RLP.
-    function revealTxList(BlockContext calldata context, bytes calldata txList)
+    function revealBlock(BlockContext calldata context, bytes calldata txList)
         external
         nonReentrant
         ifBlockIsProposed(context)

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -152,14 +152,14 @@ contract TaikoL1 is EssentialContract {
      * Modifiers          *
      **********************/
 
-    modifier whenBlockProvable(BlockContext calldata context) {
-        _checkBlockProvable(context);
+    modifier whenBlockIsProvable(BlockContext calldata context) {
+        _checkBlockIsProvable(context);
         _;
         finalizeBlocks();
     }
 
-    modifier whenBlockPublishable(BlockContext calldata context) {
-        _checkBlockUnrevealed(context);
+    modifier whenBlockIsProposed(BlockContext calldata context) {
+        _checkBlockIsProposed(context);
         _;
         finalizeBlocks();
     }
@@ -252,7 +252,7 @@ contract TaikoL1 is EssentialContract {
     function reviewBlock(BlockContext calldata context, bytes calldata txList)
         external
         nonReentrant
-        whenBlockPublishable(context)
+        whenBlockIsProposed(context)
     {
         require(context.txListHash == txList.hashTxList(), "invalid blockHash");
         PendingBlock storage blk = _getPendingBlock(context.id);
@@ -265,7 +265,7 @@ contract TaikoL1 is EssentialContract {
         BlockHeader calldata header,
         BlockContext calldata context,
         bytes[2] calldata proofs
-    ) external nonReentrant whenBlockProvable(context) {
+    ) external nonReentrant whenBlockIsProvable(context) {
         _validateHeaderForContext(header, context);
         bytes32 blockHash = header.hashBlockHeader();
 
@@ -309,7 +309,7 @@ contract TaikoL1 is EssentialContract {
         BlockHeader calldata throwAwayHeader,
         BlockContext calldata context,
         bytes[2] calldata proofs
-    ) external nonReentrant whenBlockProvable(context) {
+    ) external nonReentrant whenBlockIsProvable(context) {
         require(
             throwAwayHeader.isPartiallyValidForTaiko(),
             "throwAwayHeader invalid"
@@ -356,7 +356,7 @@ contract TaikoL1 is EssentialContract {
     function verifyBlockInvalid(
         BlockContext calldata context,
         bytes calldata txList
-    ) external nonReentrant whenBlockProvable(context) {
+    ) external nonReentrant whenBlockIsProvable(context) {
         require(txList.hashTxList() == context.txListHash, "txList mismatch");
         require(!txList.isTxListValid(), "txList is valid");
 
@@ -522,7 +522,7 @@ contract TaikoL1 is EssentialContract {
         return pendingBlocks[id % MAX_PENDING_BLOCKS];
     }
 
-    function _checkBlockProvable(BlockContext calldata context) private view {
+    function _checkBlockIsProvable(BlockContext calldata context) private view {
         PendingBlock storage blk = _checkBlockPending(context);
         require(
             blk.status == uint8(PendingBlockStatus.REVEALED) ||
@@ -531,7 +531,7 @@ contract TaikoL1 is EssentialContract {
         );
     }
 
-    function _checkBlockUnrevealed(BlockContext calldata context) private view {
+    function _checkBlockIsProposed(BlockContext calldata context) private view {
         PendingBlock storage blk = _checkBlockPending(context);
         require(blk.status == uint8(PendingBlockStatus.PROPOSED), "revealed");
         require(

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -97,7 +97,7 @@ contract TaikoL1 is EssentialContract {
     uint256 public constant MAX_THROW_AWAY_PARENT_DIFF = 1024;
     uint256 public constant MAX_FINALIZATION_PER_TX = 5;
     uint256 public constant MAX_PROOFS_PER_BLOCK = 5;
-    uint256 public constant TXLIST_REVEAL_WINDOW = 120; // 120 seconds
+    uint256 public constant BLOCK_REVEAL_TIMEOUT = 120; // 120 seconds
     bytes32 public constant SKIP_OVER_BLOCK_HASH = bytes32(uint256(1));
     string public constant ZKP_VKEY = "TAIKO_ZKP_VKEY";
 
@@ -422,7 +422,7 @@ contract TaikoL1 is EssentialContract {
                 }
             } else if (
                 blk.status == uint8(PendingBlockStatus.PROPOSED) &&
-                block.timestamp > blk.proposedAt + TXLIST_REVEAL_WINDOW
+                block.timestamp > blk.proposedAt + BLOCK_REVEAL_TIMEOUT
             ) {
                 _finalizeExpiredBlock(broker, id, blk.proposerFee);
             } else {
@@ -574,7 +574,7 @@ contract TaikoL1 is EssentialContract {
             "L1:revealed"
         );
         require(
-            block.timestamp <= blk.proposedAt + TXLIST_REVEAL_WINDOW,
+            block.timestamp <= blk.proposedAt + BLOCK_REVEAL_TIMEOUT,
             "L1:too late"
         );
     }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -540,7 +540,7 @@ contract TaikoL1 is EssentialContract {
     }
 
     function _checkBlockIsProvable(BlockContext calldata context) private view {
-        PendingBlock storage blk = _checkBlockPending(context);
+        PendingBlock storage blk = _checkBlockIsPending(context);
         require(
             blk.status == uint8(PendingBlockStatus.REVEALED) ||
                 blk.status == uint8(PendingBlockStatus.PROVEN),
@@ -549,7 +549,7 @@ contract TaikoL1 is EssentialContract {
     }
 
     function _checkBlockIsProposed(BlockContext calldata context) private view {
-        PendingBlock storage blk = _checkBlockPending(context);
+        PendingBlock storage blk = _checkBlockIsPending(context);
         require(blk.status == uint8(PendingBlockStatus.PROPOSED), "revealed");
         require(
             block.timestamp <= blk.proposedAt + TXLIST_REVEAL_WINDOW,
@@ -557,7 +557,7 @@ contract TaikoL1 is EssentialContract {
         );
     }
 
-    function _checkBlockPending(BlockContext calldata context)
+    function _checkBlockIsPending(BlockContext calldata context)
         private
         view
         returns (PendingBlock storage blk)

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -150,6 +150,7 @@ contract TaikoL1 is EssentialContract {
     modifier whenBlockIsProposed(BlockContext calldata context) {
         _checkBlockIsProposed(context);
         _;
+        finalizeBlocks();
     }
 
     modifier whenBlockIsProvable(BlockContext calldata context) {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -125,11 +125,7 @@ contract TaikoL1 is EssentialContract {
      * Events             *
      **********************/
 
-    event BlockProposed(
-        uint256 indexed id,
-        BlockContext context,
-        bool txListRevealed
-    );
+    event BlockProposed(uint256 indexed id, BlockContext context);
 
     event BlockRevealed(uint256 indexed id);
 
@@ -238,11 +234,13 @@ contract TaikoL1 is EssentialContract {
 
         numUnprovenBlocks += 1;
 
-        emit BlockProposed(
-            nextPendingId++,
-            context,
-            status == PendingBlockStatus.REVEALED
-        );
+        emit BlockProposed(nextPendingId, context);
+
+        if (status == PendingBlockStatus.REVEALED) {
+            emit BlockRevealed(nextPendingId);
+        }
+
+        nextPendingId++;
     }
 
     /// @notice Reveal a Taiko L2 block's txList.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -92,7 +92,7 @@ contract TaikoL1 is EssentialContract {
      **********************/
 
     uint256 public constant MAX_ANCHOR_HEIGHT_DIFF = 128;
-    uint256 public constant MAX_BLOCKS = 2048;
+    uint256 public constant MAX_PENDING_BLOCKS = 2048;
     uint256 public constant MAX_THROW_AWAY_PARENT_DIFF = 1024;
     uint256 public constant MAX_FINALIZATION_PER_TX = 5;
     uint256 public constant MAX_PROOFS_PER_BLOCK = 5;
@@ -201,7 +201,7 @@ contract TaikoL1 is EssentialContract {
 
         require(txList.length >= 32, "invalid txList");
         require(
-            nextPendingId <= lastFinalizedId + MAX_BLOCKS,
+            nextPendingId <= lastFinalizedId + MAX_PENDING_BLOCKS,
             "too many pending blocks"
         );
         validateContext(context);
@@ -511,7 +511,7 @@ contract TaikoL1 is EssentialContract {
     }
 
     function _savePendingBlock(uint256 id, PendingBlock memory blk) private {
-        pendingBlocks[id % MAX_BLOCKS] = blk;
+        pendingBlocks[id % MAX_PENDING_BLOCKS] = blk;
     }
 
     function _getPendingBlock(uint256 id)
@@ -519,7 +519,7 @@ contract TaikoL1 is EssentialContract {
         view
         returns (PendingBlock storage)
     {
-        return pendingBlocks[id % MAX_BLOCKS];
+        return pendingBlocks[id % MAX_PENDING_BLOCKS];
     }
 
     function _checkBlockProvable(BlockContext calldata context) private view {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -161,7 +161,6 @@ contract TaikoL1 is EssentialContract {
     modifier whenBlockIsProposed(BlockContext calldata context) {
         _checkBlockIsProposed(context);
         _;
-        finalizeBlocks();
     }
 
     /**********************

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -50,7 +50,6 @@ contract TaikoL1 is EssentialContract {
     using SafeCastUpgradeable for uint256;
     using LibBlockHeader for BlockHeader;
     using LibTxListDecoder for bytes;
-    using LibTxListValidator for bytes;
 
     /**********************
      * Enums              *
@@ -381,13 +380,17 @@ contract TaikoL1 is EssentialContract {
 
     function verifyBlockInvalid(
         BlockContext calldata context,
-        bytes calldata txList
+        bytes calldata txList,
+        bytes calldata sigList
     ) external nonReentrant ifBlockIsProvable(context) {
         require(
             txList.hashTxList() == context.txListHash,
             "L1:txList mismatch"
         );
-        require(!txList.isTxListValid(), "L1:txList is valid");
+        require(
+            !LibTxListValidator.isTxListValid(txList, sigList),
+            "L1:txList is valid"
+        );
 
         _proveBlock(
             1, // no uncles

--- a/packages/protocol/contracts/L1/broker/IProtoBroker.sol
+++ b/packages/protocol/contracts/L1/broker/IProtoBroker.sol
@@ -25,6 +25,10 @@ interface IProtoBroker {
         address[] memory provers
     ) external returns (uint256 totalProverFees);
 
+    function payFee(address recipient, uint256 amount)
+        external
+        returns (bool success);
+
     function getProposerFee(uint256 gasLimit, uint256 numUnprovenBlocks)
         external
         view

--- a/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
+++ b/packages/protocol/contracts/L1/broker/ProtoBrokerBase.sol
@@ -82,11 +82,17 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
 
         if (
             amountToMintToDAO > amountToMintToDAOThreshold &&
-            payFee(resolve("dao_reserve"), amountToMintToDAO - 1)
+            payFee(resolve("dao_vault"), amountToMintToDAO - 1)
         ) {
             amountToMintToDAO = 1;
         }
     }
+
+    function payFee(address recipient, uint256 amount)
+        public
+        virtual
+        override
+        returns (bool success);
 
     function getProposerFee(uint256 gasLimit, uint256 numUnprovenBlocks)
         public
@@ -118,16 +124,6 @@ abstract contract ProtoBrokerBase is IProtoBroker, EssentialContract {
         uint256, /*provingDelay*/
         address[] memory provers
     ) internal virtual returns (uint256[] memory fees, uint256 totalFees);
-
-    function payFee(
-        address, /*recipient*/
-        uint256 /*amount*/
-    )
-        internal
-        virtual
-        returns (
-            bool /*success*/
-        );
 
     function chargeFee(
         address, /*recipient*/

--- a/packages/protocol/contracts/L1/broker/TaikoProtoBroker.sol
+++ b/packages/protocol/contracts/L1/broker/TaikoProtoBroker.sol
@@ -33,12 +33,8 @@ contract TaikoProtoBroker is ProtoBrokerWithDynamicFees {
         taiToken.mint(resolve("team_vault"), _amountMintToTeam);
     }
 
-    function feeToken() public view returns (address) {
-        return resolve("tai_token");
-    }
-
     function payFee(address recipient, uint256 amount)
-        internal
+        public
         override
         returns (bool success)
     {
@@ -46,6 +42,10 @@ contract TaikoProtoBroker is ProtoBrokerWithDynamicFees {
             IMintableERC20(feeToken()).mint(recipient, amount);
         }
         return true;
+    }
+
+    function feeToken() public view returns (address) {
+        return resolve("tai_token");
     }
 
     function chargeFee(address recipient, uint256 amount)

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -97,9 +97,11 @@ contract TaikoL2 is EssentialContract {
         }
     }
 
-    function verifyBlockInvalid(bytes calldata txList) external {
+    function verifyBlockInvalid(bytes calldata txList, bytes calldata sigList)
+        external
+    {
         require(
-            !LibTxListValidator.isTxListValid(txList),
+            !LibTxListValidator.isTxListValid(txList, sigList),
             "L2:txList is valid"
         );
 

--- a/packages/protocol/contracts/libs/LibTxListDecoder.sol
+++ b/packages/protocol/contracts/libs/LibTxListDecoder.sol
@@ -68,12 +68,15 @@ struct TxList {
 }
 
 library LibTxListDecoder {
-    function decodeTxList(bytes calldata encoded)
-        public
-        pure
-        returns (TxList memory txList)
-    {
-        Lib_RLPReader.RLPItem[] memory txs = Lib_RLPReader.readList(encoded);
+    // TODO: support sigList
+    // throw if the number of items in the two array differ.
+    function decodeTxList(
+        bytes calldata txListEncoded,
+        bytes calldata sigListEncoded
+    ) public pure returns (TxList memory txList) {
+        Lib_RLPReader.RLPItem[] memory txs = Lib_RLPReader.readList(
+            txListEncoded
+        );
         require(txs.length > 0, "empty txList");
 
         Tx[] memory _txList = new Tx[](txs.length);

--- a/packages/protocol/contracts/libs/LibTxListDecoder.sol
+++ b/packages/protocol/contracts/libs/LibTxListDecoder.sol
@@ -94,6 +94,14 @@ library LibTxListDecoder {
         return keccak256(encoded);
     }
 
+    function hashSigList(bytes calldata encoded)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(encoded);
+    }
+
     function decodeTx(bytes memory txBytes)
         internal
         pure

--- a/packages/protocol/contracts/libs/LibTxListDecoder.sol
+++ b/packages/protocol/contracts/libs/LibTxListDecoder.sol
@@ -21,6 +21,7 @@ struct TransactionLegacy {
     uint8 v;
     uint256 r;
     uint256 s;
+    address sender;
 }
 
 struct Transaction2930 {
@@ -35,6 +36,7 @@ struct Transaction2930 {
     uint8 signatureYParity;
     uint256 signatureR;
     uint256 signatureS;
+    address sender;
 }
 
 struct Transaction1559 {
@@ -50,6 +52,7 @@ struct Transaction1559 {
     uint8 signatureYParity;
     uint256 signatureR;
     uint256 signatureS;
+    address sender;
 }
 
 struct AccessItem {

--- a/packages/protocol/contracts/libs/LibTxListDecoder.sol
+++ b/packages/protocol/contracts/libs/LibTxListDecoder.sol
@@ -68,7 +68,7 @@ struct TxList {
 }
 
 library LibTxListDecoder {
-    // TODO: support sigList
+    // TODO(kongliang): support sigList
     // throw if the number of items in the two array differ.
     function decodeTxList(
         bytes calldata txListEncoded,

--- a/packages/protocol/contracts/libs/LibTxListValidator.sol
+++ b/packages/protocol/contracts/libs/LibTxListValidator.sol
@@ -14,14 +14,13 @@ library LibTxListValidator {
     uint256 public constant MAX_TAIKO_BLOCK_GAS_LIMIT = 5000000;
     uint256 public constant MAX_TAIKO_BLOCK_NUM_TXS = 20;
 
-    function isTxListValid(bytes calldata encoded)
-        internal
-        pure
-        returns (bool)
-    {
-        try LibTxListDecoder.decodeTxList(encoded) returns (
-            TxList memory txList
-        ) {
+    function isTxListValid(
+        bytes calldata txListEncoded,
+        bytes calldata sigListEncoded
+    ) internal pure returns (bool) {
+        try
+            LibTxListDecoder.decodeTxList(txListEncoded, sigListEncoded)
+        returns (TxList memory txList) {
             return
                 txList.items.length <= MAX_TAIKO_BLOCK_NUM_TXS &&
                 LibTxListDecoder.sumGasLimit(txList) <=


### PR DESCRIPTION
This PR allows block proposers to propose a block without the actual block content (txList), then use a `reviewTxList` transaction to submit the txList after the `proposeBlock` transaction has a few confirmations on L1. With this approach, transactions in the txList will less likely to be stolen by the Ethereum miners.

If the block proposer does not reveal the corresponding txList within 120 seconds, then this block is considered as "expired" and can be finalized without affecting the L2 world state -- the L2 node doesn't create actual blocks for such expired blocks.

Note that expired blocks do not need to be proven at all, therefore, the prepaid proving fees will be donated to the DAO once these blocks are finalized.

@davidtaikocha  With this PR, the go-taiko node needs to handle chain reorg for up to 120 seconds.

The unknown: we don't know when there is a block without txList (unrevealed block), whether other proposers are willing to keep proposing new blocks, or they will choose to wait. Proposing new blocks after a unrevealed block  is more risky as the pre-state is actually unknown.

A work around is the split the txList into two lists:
- txList: a list of transactions without signatures but with a new field for msgSender
- sigList: a list of transaction signatures.

Code demo here: https://github.com/taikochain/taiko-mono/pull/79

When a block is proposed, txList must be attached, and sigList can be published later. With this approach, we can make sure even without the sigList, the post-state for a unrevealed block is still deterministic.

To ensure sigList is attached later, we can ask proposer to pay a higher fee first then refund the extra fee when the sigList is published. @Brechtpd Do you think this is possible with zkEVM?


