### PR TITLE
[protocol] verify EIP-155 signature for legacy transactions

### DIFF
--- a/packages/protocol/contracts/libs/LibInvalidTxList.sol
+++ b/packages/protocol/contracts/libs/LibInvalidTxList.sol
@@ -133,6 +133,19 @@ library LibInvalidTxList {
             );
         }
 
+        if (transaction.txType == 0) {
+            // Legacy transactions
+            require(txRLPItems.length == 9, "invalid rlp items");
+        } else if (transaction.txType == 1) {
+            // EIP-2930 transactions
+            require(txRLPItems.length == 11, "invalid rlp items");
+        } else if (transaction.txType == 2) {
+            // EIP-1559 transactions
+            require(txRLPItems.length == 12, "invalid rlp items");
+        } else {
+            revert("invalid txType");
+        }
+
         // Signature values are always last three RLP items for all kinds of
         // transactions.
         bytes[] memory list = new bytes[](

--- a/packages/protocol/contracts/libs/LibTaikoConstants.sol
+++ b/packages/protocol/contracts/libs/LibTaikoConstants.sol
@@ -14,6 +14,7 @@ library LibTaikoConstants {
     uint256 public constant TAIKO_BLOCK_MAX_TXLIST_BYTES = 1000000; // TODO
     uint256 public constant TAIKO_TX_MIN_GAS_LIMIT = 10000; // TODO
     uint256 public constant TAIKO_ANCHOR_TX_GAS_LIMIT = 200000; // TODO
+    uint256 public constant TAIKO_CHAIN_ID = 1337; // TODO
 
     address public constant GOLD_FINGER_ADDRESS =
         0x0000777735367b36bC9B61C50022d9D0700dB4Ec;

--- a/packages/protocol/test/libs/LibInvalidTxList.test.ts
+++ b/packages/protocol/test/libs/LibInvalidTxList.test.ts
@@ -141,8 +141,15 @@ describe("LibInvalidTxList", function () {
             )
             const signature = signingKey.signDigest(expectedHash)
 
+            const randomV =
+                unsignedTx.type === 0
+                    ? Math.floor(Math.random() * Math.pow(2, 7)) +
+                      2 * chainId +
+                      35
+                    : Math.floor(Math.random() * Math.pow(2, 7))
+
             const randomSignature = {
-                v: Math.floor(Math.random() * Math.pow(2, 7)) + 2 * chainId + 8,
+                v: randomV,
                 r: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
                 s: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             }

--- a/packages/protocol/test/libs/LibInvalidTxList.test.ts
+++ b/packages/protocol/test/libs/LibInvalidTxList.test.ts
@@ -6,58 +6,18 @@ describe("LibInvalidTxList", function () {
     let libInvalidTxList: any
     let libRLPWriter: any
     let libRLPReader: any
-
-    const unsignedLegacyTx: UnsignedTransaction = {
-        type: 0,
-        nonce: Math.floor(Math.random() * 1024),
-        gasPrice: randomBigInt(),
-        gasLimit: randomBigInt(),
-        to: ethers.Wallet.createRandom().address,
-        value: randomBigInt(),
-        data: ethers.utils.randomBytes(32),
-    }
-
-    const unsigned2930Tx: UnsignedTransaction = {
-        type: 1,
-        chainId: Math.floor(Math.random() * 1024),
-        nonce: Math.floor(Math.random() * 1024),
-        gasPrice: randomBigInt(),
-        gasLimit: randomBigInt(),
-        to: ethers.Wallet.createRandom().address,
-        value: randomBigInt(),
-        accessList: [
-            [
-                ethers.Wallet.createRandom().address,
-                [ethers.utils.hexlify(ethers.utils.randomBytes(32))],
-            ],
-        ],
-        data: ethers.utils.randomBytes(32),
-    }
-
-    const unsigned1559Tx: UnsignedTransaction = {
-        type: 2,
-        chainId: Math.floor(Math.random() * 1024),
-        nonce: Math.floor(Math.random() * 1024),
-        maxPriorityFeePerGas: randomBigInt(),
-        maxFeePerGas: randomBigInt(),
-        gasLimit: randomBigInt(),
-        to: ethers.Wallet.createRandom().address,
-        value: randomBigInt(),
-        accessList: [
-            [
-                ethers.Wallet.createRandom().address,
-                [ethers.utils.hexlify(ethers.utils.randomBytes(32))],
-            ],
-        ],
-        data: ethers.utils.randomBytes(32),
-    }
-
-    const testUnsignedTxs = [unsignedLegacyTx, unsigned2930Tx, unsigned1559Tx]
+    let libTaikoConstants: any
+    let testUnsignedTxs: Array<UnsignedTransaction>
+    let chainId: any
 
     const signingKey = new ethers.utils.SigningKey(ethers.utils.randomBytes(32))
     const signerAddress = new ethers.Wallet(signingKey.privateKey).address
 
     before(async function () {
+        libTaikoConstants = await (
+            await ethers.getContractFactory("LibTaikoConstants")
+        ).deploy()
+
         libInvalidTxList = await (
             await ethers.getContractFactory("TestLibInvalidTxList")
         ).deploy()
@@ -69,6 +29,58 @@ describe("LibInvalidTxList", function () {
         libRLPWriter = await (
             await ethers.getContractFactory("TestLib_RLPWriter")
         ).deploy()
+
+        chainId = (await libTaikoConstants.TAIKO_CHAIN_ID()).toNumber()
+
+        const unsignedLegacyTx: UnsignedTransaction = {
+            type: 0,
+            // if chainId is defined, ether.js will automatically use EIP-155
+            // signature
+            chainId,
+            nonce: Math.floor(Math.random() * 1024),
+            gasPrice: randomBigInt(),
+            gasLimit: randomBigInt(),
+            to: ethers.Wallet.createRandom().address,
+            value: randomBigInt(),
+            data: ethers.utils.randomBytes(32),
+        }
+
+        const unsigned2930Tx: UnsignedTransaction = {
+            type: 1,
+            chainId,
+            nonce: Math.floor(Math.random() * 1024),
+            gasPrice: randomBigInt(),
+            gasLimit: randomBigInt(),
+            to: ethers.Wallet.createRandom().address,
+            value: randomBigInt(),
+            accessList: [
+                [
+                    ethers.Wallet.createRandom().address,
+                    [ethers.utils.hexlify(ethers.utils.randomBytes(32))],
+                ],
+            ],
+            data: ethers.utils.randomBytes(32),
+        }
+
+        const unsigned1559Tx: UnsignedTransaction = {
+            type: 2,
+            chainId,
+            nonce: Math.floor(Math.random() * 1024),
+            maxPriorityFeePerGas: randomBigInt(),
+            maxFeePerGas: randomBigInt(),
+            gasLimit: randomBigInt(),
+            to: ethers.Wallet.createRandom().address,
+            value: randomBigInt(),
+            accessList: [
+                [
+                    ethers.Wallet.createRandom().address,
+                    [ethers.utils.hexlify(ethers.utils.randomBytes(32))],
+                ],
+            ],
+            data: ethers.utils.randomBytes(32),
+        }
+
+        testUnsignedTxs = [unsignedLegacyTx, unsigned2930Tx, unsigned1559Tx]
     })
 
     it("should parse the recover payloads correctly", async function () {
@@ -130,7 +142,7 @@ describe("LibInvalidTxList", function () {
             const signature = signingKey.signDigest(expectedHash)
 
             const randomSignature = {
-                v: Math.floor(Math.random() * (Math.pow(2, 8) - 28)),
+                v: Math.floor(Math.random() * Math.pow(2, 7)) + 2 * chainId + 8,
                 r: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
                 s: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             }


### PR DESCRIPTION
Since L2 nodes enabled [EIP-155](https://eips.ethereum.org/EIPS/eip-155), we should verify EIP-155 signature for legacy transactions.