### PR TITLE
fix abi.encodePacked hash bug

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -142,7 +142,7 @@ contract TaikoL1 is EssentialContract {
         validateContext(context);
 
         bytes32 hash = keccak256(
-            abi.encodePacked(context.beneficiary, context.txListHash)
+            abi.encode(context.beneficiary, context.txListHash)
         );
         require(isCommitValid(hash), "L1:invalid commit");
         delete commits[hash];


### PR DESCRIPTION
- The main use case of abi.encodePacked is for contract to be able to assemble data for hashing. It is not for exchanging data. 
- more detail: https://github.com/ethereum/go-ethereum/pull/22273