### PR TITLE
Improve contract upgradability

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -10,13 +10,14 @@ pragma solidity ^0.8.9;
 
 import "hardhat/console.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-import "../common/EssentialContract.sol";
+import "../common/AddressResolver.sol";
 import "../libs/LibInvalidTxList.sol";
 import "../libs/LibConstants.sol";
 import "../libs/LibTxDecoder.sol";
 
-contract TaikoL2 is EssentialContract {
+contract TaikoL2 is AddressResolver, ReentrancyGuard {
     using LibTxDecoder for bytes;
 
     /**********************
@@ -55,6 +56,15 @@ contract TaikoL2 is EssentialContract {
     }
 
     /**********************
+     * Constructor         *
+     **********************/
+
+    constructor(address _addressManager, uint256 _chainId) {
+        AddressResolver._init(_addressManager);
+        chainId = _chainId;
+    }
+
+    /**********************
      * External Functions *
      **********************/
 
@@ -64,14 +74,6 @@ contract TaikoL2 is EssentialContract {
 
     fallback() external payable {
         revert("L2:prohibited");
-    }
-
-    function init(address _addressManager, uint256 _chainId)
-        external
-        initializer
-    {
-        EssentialContract._init(_addressManager);
-        chainId = _chainId;
     }
 
     function creditEther(address recipient, uint256 amount)

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -59,7 +59,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard {
      * Constructor         *
      **********************/
 
-    constructor(address _addressManager, uint256 _chainId) {
+    constructor(address _addressManager, uint256 _chainId) initializer {
         AddressResolver._init(_addressManager);
         chainId = _chainId;
     }

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -17,7 +17,7 @@ import "../libs/LibInvalidTxList.sol";
 import "../libs/LibConstants.sol";
 import "../libs/LibTxDecoder.sol";
 
-contract TaikoL2 is AddressResolver, ReentrancyGuard {
+contract V1TaikoL2 is AddressResolver, ReentrancyGuard {
     using LibTxDecoder for bytes;
 
     /**********************

--- a/packages/protocol/tasks/deploy_L1.ts
+++ b/packages/protocol/tasks/deploy_L1.ts
@@ -9,8 +9,8 @@ task("deploy_L1")
     .addParam("daoVault", "The DAO vault address")
     .addParam("teamVault", "The team vault address")
     .addOptionalParam(
-        "taikoL2",
-        "The TaikoL2 address",
+        "v1TaikoL2",
+        "The V1TaikoL2 address",
         ethers.constants.AddressZero
     )
     .addOptionalParam(
@@ -48,14 +48,14 @@ export async function deployContracts(hre: any) {
     const daoVault = hre.args.daoVault
     const teamVault = hre.args.teamVault
     const l2GenesisBlockHash = hre.args.l2GenesisBlockHash
-    const taikoL2Address = hre.args.taikoL2
+    const v1TaikoL2Address = hre.args.v1TaikoL2
 
     log.debug(`network: ${network}`)
     log.debug(`chainId: ${chainId}`)
     log.debug(`deployer: ${deployer}`)
     log.debug(`daoVault: ${daoVault}`)
     log.debug(`l2GenesisBlockHash: ${l2GenesisBlockHash}`)
-    log.debug(`taikoL2Address: ${taikoL2Address}`)
+    log.debug(`v1TaikoL2Address: ${v1TaikoL2Address}`)
     log.debug(`confirmations: ${hre.args.confirmations}`)
     log.debug()
 
@@ -72,7 +72,7 @@ export async function deployContracts(hre: any) {
     )
     await utils.waitTx(
         hre,
-        await AddressManager.setAddress("v1_taiko_l2", taikoL2Address)
+        await AddressManager.setAddress("v1_taiko_l2", v1TaikoL2Address)
     )
 
     // TaiToken

--- a/packages/protocol/test/TaikoL2.test.ts
+++ b/packages/protocol/test/TaikoL2.test.ts
@@ -2,8 +2,8 @@ import { expect } from "chai"
 const hre = require("hardhat")
 const ethers = hre.ethers
 
-describe("TaikoL2", function () {
-    let taikoL2: any
+describe("V1TaikoL2", function () {
+    let v1TaikoL2: any
     let addressManager: any
     let signers: any
 
@@ -18,21 +18,21 @@ describe("TaikoL2", function () {
         ).deploy()
         await addressManager.init()
 
-        // Deploying TaikoL2 Contract linked with LibTxDecoder (throws error otherwise)
+        // Deploying V1TaikoL2 Contract linked with LibTxDecoder (throws error otherwise)
         const libTxDecoder = await (
             await ethers.getContractFactory("LibTxDecoder")
         ).deploy()
 
         const { chainId } = await hre.ethers.provider.getNetwork()
 
-        const taikoL2Factory = await ethers.getContractFactory("TaikoL2", {
+        const v1TaikoL2Factory = await ethers.getContractFactory("V1TaikoL2", {
             _addressManager: addressManager.address,
             _chainId: chainId,
             libraries: {
                 LibTxDecoder: libTxDecoder.address,
             },
         })
-        taikoL2 = await taikoL2Factory.deploy()
+        v1TaikoL2 = await v1TaikoL2Factory.deploy()
 
         signers = await ethers.getSigners()
         await addressManager.setAddress(
@@ -44,30 +44,30 @@ describe("TaikoL2", function () {
     it("should emit EtherReturned event when receiving ether", async function () {
         expect(
             await signers[0].sendTransaction({
-                to: taikoL2.address,
+                to: v1TaikoL2.address,
                 value: ethers.utils.parseEther("150.0"),
             })
-        ).to.emit(taikoL2, "EtherReturned")
+        ).to.emit(v1TaikoL2, "EtherReturned")
     })
 
     describe("creditEther()", async function () {
-        it("should throw if recipient address is taikoL2.address", async function () {
-            await expect(taikoL2.creditEther(taikoL2.address, "1000")).to
+        it("should throw if recipient address is v1TaikoL2.address", async function () {
+            await expect(v1TaikoL2.creditEther(v1TaikoL2.address, "1000")).to
                 .reverted
         })
 
         it('should revert if not from named "eth_depositor"', async function () {
             const randWallet = ethers.Wallet.createRandom().address
             await expect(
-                taikoL2.connect(randWallet).creditEther(randWallet, "1000")
+                v1TaikoL2.connect(randWallet).creditEther(randWallet, "1000")
             ).to.reverted
         })
 
         it("should emit EtherCredited when crediting Ether to recipient and balance of reciever should be ether credited", async function () {
             const recieverWallet = ethers.Wallet.createRandom().address
             const amount = "10000"
-            expect(await taikoL2.creditEther(recieverWallet, amount)).to.emit(
-                taikoL2,
+            expect(await v1TaikoL2.creditEther(recieverWallet, amount)).to.emit(
+                v1TaikoL2,
                 "EtherCredited"
             )
             expect(await ethers.provider.getBalance(recieverWallet)).to.equal(
@@ -79,7 +79,7 @@ describe("TaikoL2", function () {
     describe("anchor()", async function () {
         it("should revert since ancestor hashes not written", async function () {
             const randomHash = randomBytes32()
-            await expect(taikoL2.anchor(10, randomHash)).to.be.revertedWith(
+            await expect(v1TaikoL2.anchor(10, randomHash)).to.be.revertedWith(
                 "L2:anchored"
             )
         })

--- a/packages/protocol/test/TaikoL2.test.ts
+++ b/packages/protocol/test/TaikoL2.test.ts
@@ -23,15 +23,16 @@ describe("TaikoL2", function () {
             await ethers.getContractFactory("LibTxDecoder")
         ).deploy()
 
+        const { chainId } = await hre.ethers.provider.getNetwork()
+
         const taikoL2Factory = await ethers.getContractFactory("TaikoL2", {
+            _addressManager: addressManager.address,
+            _chainId: chainId,
             libraries: {
                 LibTxDecoder: libTxDecoder.address,
             },
         })
         taikoL2 = await taikoL2Factory.deploy()
-
-        const { chainId } = await hre.ethers.provider.getNetwork()
-        await taikoL2.init(addressManager.address, chainId)
 
         signers = await ethers.getSigners()
         await addressManager.setAddress(

--- a/packages/protocol/test/TaikoL2.test.ts
+++ b/packages/protocol/test/TaikoL2.test.ts
@@ -26,13 +26,14 @@ describe("V1TaikoL2", function () {
         const { chainId } = await hre.ethers.provider.getNetwork()
 
         const v1TaikoL2Factory = await ethers.getContractFactory("V1TaikoL2", {
-            _addressManager: addressManager.address,
-            _chainId: chainId,
             libraries: {
                 LibTxDecoder: libTxDecoder.address,
             },
         })
-        v1TaikoL2 = await v1TaikoL2Factory.deploy()
+        v1TaikoL2 = await v1TaikoL2Factory.deploy(
+            addressManager.address,
+            chainId
+        )
 
         signers = await ethers.getSigners()
         await addressManager.setAddress(

--- a/packages/protocol/test/genesis/generate_genesis.test.ts
+++ b/packages/protocol/test/genesis/generate_genesis.test.ts
@@ -78,8 +78,8 @@ action("Generate Genesis", function () {
         }
 
         // NOTE: since L2 bridge contract hasn't finished yet, temporarily move
-        // L2 bridge's balance to TaikoL2 contract address.
-        const bridgeAddress = getContractAlloc("TaikoL2").address
+        // L2 bridge's balance to V1TaikoL2 contract address.
+        const bridgeAddress = getContractAlloc("V1TaikoL2").address
 
         expect(await provider.getBalance(bridgeAddress)).to.be.equal(
             bridgeBalance.toHexString()
@@ -121,12 +121,12 @@ action("Generate Genesis", function () {
             ).to.be.revertedWith("empty txList")
         })
 
-        it("TaikoL2", async function () {
-            const TaikoL2Alloc = getContractAlloc("TaikoL2")
+        it("V1TaikoL2", async function () {
+            const V1TaikoL2Alloc = getContractAlloc("V1TaikoL2")
 
-            const TaikoL2 = new hre.ethers.Contract(
-                TaikoL2Alloc.address,
-                require("../../artifacts/contracts/L2/TaikoL2.sol/TaikoL2.json").abi,
+            const V1TaikoL2 = new hre.ethers.Contract(
+                V1TaikoL2Alloc.address,
+                require("../../artifacts/contracts/L2/V1TaikoL2.sol/V1TaikoL2.json").abi,
                 signer
             )
 
@@ -135,18 +135,18 @@ action("Generate Genesis", function () {
                 ethers.utils.randomBytes(32)
             )
 
-            expect(await TaikoL2.chainId()).to.be.equal(testConfig.chainId)
+            expect(await V1TaikoL2.chainId()).to.be.equal(testConfig.chainId)
 
             await expect(
-                TaikoL2.anchor(anchorHeight, anchorHash)
+                V1TaikoL2.anchor(anchorHeight, anchorHash)
             ).not.to.reverted
 
             await expect(
-                TaikoL2.creditEther(
+                V1TaikoL2.creditEther(
                     hre.ethers.Wallet.createRandom().address,
                     1024
                 )
-            ).to.emit(TaikoL2, "EtherCredited")
+            ).to.emit(V1TaikoL2, "EtherCredited")
         })
     })
 

--- a/packages/protocol/utils/generate_genesis.ts
+++ b/packages/protocol/utils/generate_genesis.ts
@@ -102,9 +102,9 @@ async function generateL2Genesis(
 
         // pre-mint ETHs for Bridge contract
         // NOTE: since L2 bridge contract hasn't finished yet, temporarily move
-        // L2 bridge's balance to TaikoL2 contract address.
+        // L2 bridge's balance to V1TaikoL2 contract address.
         alloc[contractConfig.address].balance =
-            contractName === "TaikoL2" ? bridgeBalance.toHexString() : "0x0"
+            contractName === "V1TaikoL2" ? bridgeBalance.toHexString() : "0x0"
 
         // since we enable storageLayout compiler output in hardhat.config.ts,
         // rollup/artifacts/build-info will contain storage layouts, here
@@ -157,9 +157,9 @@ async function generateContractConfigs(
             ARTIFACTS_PATH,
             "./libs/LibTxDecoder.sol/LibTxDecoder.json"
         )),
-        TaikoL2: require(path.join(
+        V1TaikoL2: require(path.join(
             ARTIFACTS_PATH,
-            "./L2/TaikoL2.sol/TaikoL2.json"
+            "./L2/V1TaikoL2.sol/V1TaikoL2.json"
         )),
     }
 
@@ -168,12 +168,12 @@ async function generateContractConfigs(
     for (const [contractName, artifact] of Object.entries(contractArtifacts)) {
         let bytecode = (artifact as any).bytecode
 
-        if (contractName === "TaikoL2") {
+        if (contractName === "V1TaikoL2") {
             if (!addressMap.LibTxDecoder) {
                 throw new Error("LibTxDecoder not initialized")
             }
 
-            bytecode = linkTaikoL2Bytecode(bytecode, addressMap)
+            bytecode = linkV1TaikoL2Bytecode(bytecode, addressMap)
         }
 
         addressMap[contractName] = ethers.utils.getCreate2Address(
@@ -213,10 +213,10 @@ async function generateContractConfigs(
             deployedBytecode: contractArtifacts.LibTxDecoder.deployedBytecode,
             variables: {},
         },
-        TaikoL2: {
-            address: addressMap.TaikoL2,
-            deployedBytecode: linkTaikoL2Bytecode(
-                contractArtifacts.TaikoL2.deployedBytecode,
+        V1TaikoL2: {
+            address: addressMap.V1TaikoL2,
+            deployedBytecode: linkV1TaikoL2Bytecode(
+                contractArtifacts.V1TaikoL2.deployedBytecode,
                 addressMap
             ),
             variables: {
@@ -235,9 +235,9 @@ async function generateContractConfigs(
     }
 }
 
-// linkL2RollupBytecode tries to link TaikoL2 deployedBytecode to its library.
+// linkL2RollupBytecode tries to link V1TaikoL2 deployedBytecode to its library.
 // Ref: https://docs.soliditylang.org/en/latest/using-the-compiler.html#library-linking
-function linkTaikoL2Bytecode(byteCode: string, addressMap: any): string {
+function linkV1TaikoL2Bytecode(byteCode: string, addressMap: any): string {
     const refs = linker.findLinkReferences(byteCode)
 
     if (Object.keys(refs).length !== 1) {

--- a/packages/protocol/utils/generate_genesis.ts
+++ b/packages/protocol/utils/generate_genesis.ts
@@ -225,8 +225,6 @@ async function generateContractConfigs(
                 _initializing: false,
                 // ReentrancyGuardUpgradeable
                 _status: 1, // _NOT_ENTERED
-                // OwnableUpgradeable
-                _owner: contractOwner,
                 // AddressResolver
                 _addressManager: addressMap.AddressManager,
                 chainId: config.chainId,


### PR DESCRIPTION
The L2 contract doesn't have to be upgradable, we can deploy V1TaikoL2 and V2TaikoL2, they don't have to be compatible. In L1 contracts, we use these two different contracts by resolving "v1_taiko_l2" and "v2_taiko_l2" addresses. 