### PR TITLE
[protocol] read constants defined in `LibConstants` from `TaikoL1`

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -159,6 +159,18 @@ contract TaikoL1 is EssentialContract, V1Events {
         return state.getStateVariables();
     }
 
+    function signWithGoldFinger(bytes32 hash, uint8 k)
+        public
+        view
+        returns (
+            uint8 v,
+            uint256 r,
+            uint256 s
+        )
+    {
+        return LibAnchorSignature.signTransaction(hash, k);
+    }
+
     function getConstants()
         public
         pure
@@ -193,17 +205,5 @@ contract TaikoL1 is EssentialContract, V1Events {
             LibConstants.V1_ANCHOR_TX_SELECTOR,
             LibConstants.V1_INVALIDATE_BLOCK_LOG_TOPIC
         );
-    }
-
-    function signWithGoldFinger(bytes32 hash, uint8 k)
-        public
-        view
-        returns (
-            uint8 v,
-            uint256 r,
-            uint256 s
-        )
-    {
-        return LibAnchorSignature.signTransaction(hash, k);
     }
 }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -159,6 +159,42 @@ contract TaikoL1 is EssentialContract, V1Events {
         return state.getStateVariables();
     }
 
+    function getConstants()
+        public
+        pure
+        returns (
+            uint256, // TAIKO_CHAIN_ID
+            uint256, // TAIKO_MAX_PENDING_BLOCKS
+            uint256, // TAIKO_MAX_FINALIZATIONS_PER_TX
+            uint256, // TAIKO_COMMIT_DELAY_CONFIRMATIONS
+            uint256, // TAIKO_MAX_PROOFS_PER_FORK_CHOICE
+            uint256, // TAIKO_BLOCK_MAX_GAS_LIMIT
+            uint256, // TAIKO_BLOCK_MAX_TXS
+            bytes32, // TAIKO_BLOCK_DEADEND_HASH
+            uint256, // TAIKO_TXLIST_MAX_BYTES
+            uint256, // TAIKO_TX_MIN_GAS_LIMIT
+            uint256, // V1_ANCHOR_TX_GAS_LIMIT
+            bytes4, // V1_ANCHOR_TX_SELECTOR
+            bytes32 // V1_INVALIDATE_BLOCK_LOG_TOPIC
+        )
+    {
+        return (
+            LibConstants.TAIKO_CHAIN_ID,
+            LibConstants.TAIKO_MAX_PENDING_BLOCKS,
+            LibConstants.TAIKO_MAX_FINALIZATIONS_PER_TX,
+            LibConstants.TAIKO_COMMIT_DELAY_CONFIRMATIONS,
+            LibConstants.TAIKO_MAX_PROOFS_PER_FORK_CHOICE,
+            LibConstants.TAIKO_BLOCK_MAX_GAS_LIMIT,
+            LibConstants.TAIKO_BLOCK_MAX_TXS,
+            LibConstants.TAIKO_BLOCK_DEADEND_HASH,
+            LibConstants.TAIKO_TXLIST_MAX_BYTES,
+            LibConstants.TAIKO_TX_MIN_GAS_LIMIT,
+            LibConstants.V1_ANCHOR_TX_GAS_LIMIT,
+            LibConstants.V1_ANCHOR_TX_SELECTOR,
+            LibConstants.V1_INVALIDATE_BLOCK_LOG_TOPIC
+        );
+    }
+
     function signWithGoldFinger(bytes32 hash, uint8 k)
         public
         view

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -135,6 +135,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard {
     /**********************
      * Public Functions   *
      **********************/
+
     function getL1BlockHash(uint256 number) public view returns (bytes32) {
         require(number <= latestL1Height, "L2:number");
         return l1Hashes[number];

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -135,7 +135,6 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard {
     /**********************
      * Public Functions   *
      **********************/
-
     function getL1BlockHash(uint256 number) public view returns (bytes32) {
         require(number <= latestL1Height, "L2:number");
         return l1Hashes[number];

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -145,6 +145,42 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard {
      * Private Functions  *
      **********************/
 
+    function getConstants()
+        public
+        pure
+        returns (
+            uint256, // TAIKO_CHAIN_ID
+            uint256, // TAIKO_MAX_PENDING_BLOCKS
+            uint256, // TAIKO_MAX_FINALIZATIONS_PER_TX
+            uint256, // TAIKO_COMMIT_DELAY_CONFIRMATIONS
+            uint256, // TAIKO_MAX_PROOFS_PER_FORK_CHOICE
+            uint256, // TAIKO_BLOCK_MAX_GAS_LIMIT
+            uint256, // TAIKO_BLOCK_MAX_TXS
+            bytes32, // TAIKO_BLOCK_DEADEND_HASH
+            uint256, // TAIKO_TXLIST_MAX_BYTES
+            uint256, // TAIKO_TX_MIN_GAS_LIMIT
+            uint256, // V1_ANCHOR_TX_GAS_LIMIT
+            bytes4, // V1_ANCHOR_TX_SELECTOR
+            bytes32 // V1_INVALIDATE_BLOCK_LOG_TOPIC
+        )
+    {
+        return (
+            LibConstants.TAIKO_CHAIN_ID,
+            LibConstants.TAIKO_MAX_PENDING_BLOCKS,
+            LibConstants.TAIKO_MAX_FINALIZATIONS_PER_TX,
+            LibConstants.TAIKO_COMMIT_DELAY_CONFIRMATIONS,
+            LibConstants.TAIKO_MAX_PROOFS_PER_FORK_CHOICE,
+            LibConstants.TAIKO_BLOCK_MAX_GAS_LIMIT,
+            LibConstants.TAIKO_BLOCK_MAX_TXS,
+            LibConstants.TAIKO_BLOCK_DEADEND_HASH,
+            LibConstants.TAIKO_TXLIST_MAX_BYTES,
+            LibConstants.TAIKO_TX_MIN_GAS_LIMIT,
+            LibConstants.V1_ANCHOR_TX_GAS_LIMIT,
+            LibConstants.V1_ANCHOR_TX_SELECTOR,
+            LibConstants.V1_INVALIDATE_BLOCK_LOG_TOPIC
+        );
+    }
+
     function _checkGlobalVariables() private {
         // Check chainid
         require(block.chainid == chainId, "L2:chainId");


### PR DESCRIPTION
Currently `LibConstants` dose not deployed as an independent library but a part of `TaikoL1`'s byte code, so it dose not have an address. But we need a way to read all the constants defined in it.