### PR TITLE
[protocol] Move parent hash into BlockHeader

### DIFF
--- a/packages/protocol/contracts/L1/v1/V1Proving.sol
+++ b/packages/protocol/contracts/L1/v1/V1Proving.sol
@@ -34,7 +34,6 @@ library V1Proving {
         LibData.BlockMetadata meta;
         BlockHeader header;
         address prover;
-        bytes32 parentHash;
         bytes[] proofs;
     }
 
@@ -194,9 +193,7 @@ library V1Proving {
         _checkMetadataPending(s, target);
         _validateHeaderForMetadata(evidence.header, evidence.meta);
 
-        bytes32 blockHash = evidence.header.hashBlockHeader(
-            evidence.parentHash
-        );
+        bytes32 blockHash = evidence.header.hashBlockHeader();
 
         LibZKP.verify(
             ConfigManager(resolver.resolve("config_manager")).getValue(
@@ -212,7 +209,7 @@ library V1Proving {
             s,
             evidence.prover,
             target,
-            evidence.parentHash,
+            evidence.header.parentHash,
             blockHashOverride == 0 ? blockHash : blockHashOverride
         );
     }
@@ -307,7 +304,8 @@ library V1Proving {
         LibData.BlockMetadata memory meta
     ) private pure {
         require(
-            header.beneficiary == meta.beneficiary &&
+            header.parentHash != 0 &&
+                header.beneficiary == meta.beneficiary &&
                 header.difficulty == 0 &&
                 header.gasLimit ==
                 meta.gasLimit + LibConstants.V1_ANCHOR_TX_GAS_LIMIT &&

--- a/packages/protocol/contracts/libs/LibBlockHeader.sol
+++ b/packages/protocol/contracts/libs/LibBlockHeader.sol
@@ -13,6 +13,7 @@ import "./LibConstants.sol";
 
 /// @author david <david@taiko.xyz>
 struct BlockHeader {
+    bytes32 parentHash;
     bytes32 ommersHash;
     address beneficiary;
     bytes32 stateRoot;
@@ -33,14 +34,13 @@ library LibBlockHeader {
     bytes32 private constant EMPTY_OMMERS_HASH =
         0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347;
 
-    function hashBlockHeader(BlockHeader memory header, bytes32 parentHash)
+    function hashBlockHeader(BlockHeader memory header)
         internal
         pure
         returns (bytes32)
     {
-        // require(parentHash != 0, "invalid parentHash");
         bytes[] memory list = new bytes[](15);
-        list[0] = Lib_RLPWriter.writeHash(parentHash);
+        list[0] = Lib_RLPWriter.writeHash(header.parentHash);
         list[1] = Lib_RLPWriter.writeHash(header.ommersHash);
         list[2] = Lib_RLPWriter.writeAddress(header.beneficiary);
         list[3] = Lib_RLPWriter.writeHash(header.stateRoot);
@@ -68,6 +68,7 @@ library LibBlockHeader {
         returns (bool)
     {
         return
+            header.parentHash != 0 &&
             header.ommersHash == EMPTY_OMMERS_HASH &&
             header.gasLimit <= LibConstants.TAIKO_BLOCK_MAX_GAS_LIMIT &&
             header.extraData.length <= 32 &&

--- a/packages/protocol/contracts/test/TestLibBlockHeader.sol
+++ b/packages/protocol/contracts/test/TestLibBlockHeader.sol
@@ -11,22 +11,21 @@ pragma solidity ^0.8.9;
 import "../libs/LibBlockHeader.sol";
 
 contract TestLibBlockHeader {
-    function hashBlockHeader(BlockHeader calldata header, bytes32 parentHash)
+    function hashBlockHeader(BlockHeader calldata header)
         public
         pure
         returns (bytes32)
     {
-        return LibBlockHeader.hashBlockHeader(header, parentHash);
+        return LibBlockHeader.hashBlockHeader(header);
     }
 
-    function rlpBlockHeader(BlockHeader calldata header, bytes32 parentHash)
+    function rlpBlockHeader(BlockHeader calldata header)
         public
         pure
         returns (bytes memory)
     {
-        // require(parentHash != 0, "invalid parentHash");
         bytes[] memory list = new bytes[](15);
-        list[0] = Lib_RLPWriter.writeHash(parentHash);
+        list[0] = Lib_RLPWriter.writeHash(header.parentHash);
         list[1] = Lib_RLPWriter.writeHash(header.ommersHash);
         list[2] = Lib_RLPWriter.writeAddress(header.beneficiary);
         list[3] = Lib_RLPWriter.writeHash(header.stateRoot);

--- a/packages/protocol/test/libs/LibBlockHeader.test.ts
+++ b/packages/protocol/test/libs/LibBlockHeader.test.ts
@@ -17,7 +17,12 @@ describe("LibBlockHeader tests", function () {
         const blockHash =
             "0xc0528bca43a7316776dddb92380cc3a5d9e717bc948ce71f6f1605d7281a4fe8"
         // block 0xc0528bca43a7316776dddb92380cc3a5d9e717bc948ce71f6f1605d7281a4fe8 on Ethereum mainnet
+
+        const parentHash =
+            "0xa7881266ca0a344c43cb24175d9dbd243b58d45d6ae6ad71310a273a3d1d3afb"
+
         const l2BlockHeader: any = {
+            parentHash: parentHash,
             ommersHash:
                 "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
             beneficiary: "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
@@ -42,12 +47,8 @@ describe("LibBlockHeader tests", function () {
             nonce: EBN.from("0x738b7e38476abe98"),
         }
 
-        const parentHash =
-            "0xa7881266ca0a344c43cb24175d9dbd243b58d45d6ae6ad71310a273a3d1d3afb"
-
         const headerComputed = await libBlockHeader.hashBlockHeader(
-            l2BlockHeader,
-            parentHash
+            l2BlockHeader
         )
         log.debug("headerComputed:", headerComputed)
 
@@ -61,6 +62,7 @@ describe("LibBlockHeader tests", function () {
         // https://rinkeby.etherscan.io/block/0
 
         const blockHeader: any = {
+            parentHash: ethers.constants.HashZero,
             ommersHash:
                 "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
             beneficiary: ethers.constants.AddressZero,
@@ -85,11 +87,7 @@ describe("LibBlockHeader tests", function () {
             nonce: EBN.from("0x0"),
         }
 
-        const parentHash = ethers.constants.HashZero
-        const headerComputed = await libBlockHeader.hashBlockHeader(
-            blockHeader,
-            parentHash
-        )
+        const headerComputed = await libBlockHeader.hashBlockHeader(blockHeader)
 
         expect(headerComputed).to.equal(blockHash)
     })

--- a/packages/protocol/test/thirdparty/Lib_BlockHeaderDecoder.test.ts
+++ b/packages/protocol/test/thirdparty/Lib_BlockHeaderDecoder.test.ts
@@ -31,7 +31,10 @@ describe("Lib_BlockHeaderDecoder", async function () {
     })
 
     it("Decode should return stateRoot and timeStamp", async function () {
+        const parentHash =
+            "0xa7881266ca0a344c43cb24175d9dbd243b58d45d6ae6ad71310a273a3d1d3afb"
         const blockHeader: any = {
+            parentHash: parentHash,
             ommersHash:
                 "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
             beneficiary: "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
@@ -56,11 +59,8 @@ describe("Lib_BlockHeaderDecoder", async function () {
             nonce: EBN.from("0x738b7e38476abe98"),
         }
 
-        const parentHash =
-            "0xa7881266ca0a344c43cb24175d9dbd243b58d45d6ae6ad71310a273a3d1d3afb"
         const encodedBlockHeader = await hashBlockHeader.rlpBlockHeader(
-            blockHeader,
-            parentHash
+            blockHeader
         )
 
         const [_stateRoot, _timeStamp, _transactionsRoot, _receiptsRoot] =
@@ -83,6 +83,7 @@ describe("Lib_BlockHeaderDecoder", async function () {
         ])
         const logsBloom = block.logsBloom.toString().substring(2)
         const blockHeader = {
+            parentHash: block.parentHash,
             ommersHash: block.sha3Uncles,
             beneficiary: block.miner,
             stateRoot: block.stateRoot,
@@ -101,8 +102,7 @@ describe("Lib_BlockHeaderDecoder", async function () {
             nonce: block.nonce,
         }
         const encodedBlockHeader = await hashBlockHeader.rlpBlockHeader(
-            blockHeader,
-            block.parentHash
+            blockHeader
         )
 
         const [_stateRoot, _timeStamp, _transactionsRoot, _receiptsRoot] =
@@ -125,6 +125,7 @@ describe("Lib_BlockHeaderDecoder", async function () {
         ])
         const logsBloom = block.logsBloom.toString().substring(2)
         const blockHeader = {
+            parentHash: block.parentHash,
             ommersHash: block.sha3Uncles,
             beneficiary: block.miner,
             stateRoot: block.stateRoot,
@@ -143,8 +144,7 @@ describe("Lib_BlockHeaderDecoder", async function () {
             nonce: block.nonce,
         }
         const encodedBlockHeader = await hashBlockHeader.rlpBlockHeader(
-            blockHeader,
-            block.parentHash
+            blockHeader
         )
 
         const [_stateRoot, _timeStamp, _transactionsRoot, _receiptsRoot] =


### PR DESCRIPTION
@alexshliu @johntaiko @davidtaikocha Breaking change for backend:

`parentHash` was moved from `Evidence` to `BlockHeader`.