### PR TITLE
[protocol] Allow more blocks to be finalized in 1 transaction

### DIFF
--- a/packages/protocol/contracts/libs/LibConstants.sol
+++ b/packages/protocol/contracts/libs/LibConstants.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.9;
 library LibConstants {
     uint256 public constant TAIKO_CHAIN_ID = 1337; // TODO
     uint256 public constant TAIKO_MAX_PENDING_BLOCKS = 2048;
-    uint256 public constant TAIKO_MAX_FINALIZATIONS_PER_TX = 5;
+    uint256 public constant TAIKO_MAX_FINALIZATIONS_PER_TX = 20;
     uint256 public constant TAIKO_COMMIT_DELAY_CONFIRMATIONS = 4;
     uint256 public constant TAIKO_MAX_PROOFS_PER_FORK_CHOICE = 5;
     uint256 public constant TAIKO_BLOCK_MAX_GAS_LIMIT = 5000000; // TODO


### PR DESCRIPTION
We can do this because we only sync the last finalized block hash, so the writes are not O(n), it's now O(1).