### PR TITLE
[protocol] fix LibTxUtils test cases occasional workflow errors

### DIFF
--- a/packages/protocol/test/libs/LibTxUtils.test.ts
+++ b/packages/protocol/test/libs/LibTxUtils.test.ts
@@ -142,9 +142,9 @@ describe("LibTxUtils", function () {
             const signature = signingKey.signDigest(expectedHash)
 
             const randomSignature = {
-                v: Math.floor(Math.random() * Math.pow(2, 7)),
-                r: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
-                s: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+                v: 75,
+                r: "0xb14e3f5eab11cd2c459b04a91a9db8bd6f5acccfbd830c9693c84f8d21187eef",
+                s: "0x5cf4b3b2b3957e7016366d180493c2c226ea8ad12aed7faddbc0ce3a6789256d",
             }
 
             const txData = await changeSignature(

--- a/packages/protocol/test/libs/LibTxUtils.test.ts
+++ b/packages/protocol/test/libs/LibTxUtils.test.ts
@@ -141,7 +141,7 @@ describe("LibTxUtils", function () {
             )
             const signature = signingKey.signDigest(expectedHash)
 
-            const randomSignature = {
+            const invalidSignature = {
                 v: 75,
                 r: "0xb14e3f5eab11cd2c459b04a91a9db8bd6f5acccfbd830c9693c84f8d21187eef",
                 s: "0x5cf4b3b2b3957e7016366d180493c2c226ea8ad12aed7faddbc0ce3a6789256d",
@@ -152,7 +152,7 @@ describe("LibTxUtils", function () {
                 ethers.utils.arrayify(
                     ethers.utils.serializeTransaction(unsignedTx, signature)
                 ),
-                randomSignature
+                invalidSignature
             )
 
             expect(
@@ -161,9 +161,9 @@ describe("LibTxUtils", function () {
                     destination: unsignedTx.to,
                     data: unsignedTx.data,
                     gasLimit: unsignedTx.gasLimit,
-                    v: randomSignature.v,
-                    r: randomSignature.r,
-                    s: randomSignature.s,
+                    v: invalidSignature.v,
+                    r: invalidSignature.r,
+                    s: invalidSignature.s,
                     txData,
                 })
             ).to.be.equal(ethers.constants.AddressZero)


### PR DESCRIPTION
According to the output:
```
1) LibTxUtils
       should verify invalid transaction signatures:

      AssertionError: expected '0x1127Bf5f01a23266A2af0A3B2034DC98242…' to equal '0x00000000000000000000000000000000000…'
      + expected - actual

      -0x1127Bf5f01a23266A2af0A3B2034DC9824205D64
      +0x0000000000000000000000000000000000000000
      
      at Context.<anonymous> (test/libs/LibTxUtils.test.ts:169:21)
```

That failed test case uses valid random numbers as v,r,s to recover sender, looks like sometimes the random number combination becomes a valid signature that can be recovered... This PR is to fix it by using a fixed "random invalid signature".