### PR TITLE
[protocol] fix gas limit checking for throwaway block && update `libConstants.V1_ANCHOR_TX_GAS_LIMIT`

### DIFF
--- a/packages/protocol/contracts/L1/v1/V1Proving.sol
+++ b/packages/protocol/contracts/L1/v1/V1Proving.sol
@@ -191,7 +191,11 @@ library V1Proving {
         require(evidence.prover != address(0), "L1:prover");
 
         _checkMetadataPending(s, target);
-        _validateHeaderForMetadata(evidence.header, evidence.meta);
+        _validateHeaderForMetadata(
+            evidence.header,
+            evidence.meta,
+            blockHashOverride
+        );
 
         bytes32 blockHash = evidence.header.hashBlockHeader();
 
@@ -301,14 +305,19 @@ library V1Proving {
 
     function _validateHeaderForMetadata(
         BlockHeader memory header,
-        LibData.BlockMetadata memory meta
+        LibData.BlockMetadata memory meta,
+        bytes32 blockHashOverride
     ) private pure {
         require(
             header.parentHash != 0 &&
                 header.beneficiary == meta.beneficiary &&
                 header.difficulty == 0 &&
                 header.gasLimit ==
-                meta.gasLimit + LibConstants.V1_ANCHOR_TX_GAS_LIMIT &&
+                (
+                    blockHashOverride == 0
+                        ? meta.gasLimit + LibConstants.V1_ANCHOR_TX_GAS_LIMIT
+                        : meta.gasLimit
+                ) &&
                 header.gasUsed > 0 &&
                 header.timestamp == meta.proposedAt &&
                 header.extraData.length == meta.extraData.length &&

--- a/packages/protocol/contracts/libs/LibConstants.sol
+++ b/packages/protocol/contracts/libs/LibConstants.sol
@@ -23,7 +23,7 @@ library LibConstants {
     uint256 public constant TAIKO_TX_MIN_GAS_LIMIT = 21000; // TODO
 
     // Taiko L2 releated constants
-    uint256 public constant V1_ANCHOR_TX_GAS_LIMIT = 100000; // TODO
+    uint256 public constant V1_ANCHOR_TX_GAS_LIMIT = 1000000; // TODO
 
     bytes4 public constant V1_ANCHOR_TX_SELECTOR =
         bytes4(keccak256("anchor(uint256,bytes32)"));

--- a/packages/protocol/contracts/libs/LibConstants.sol
+++ b/packages/protocol/contracts/libs/LibConstants.sol
@@ -23,7 +23,9 @@ library LibConstants {
     uint256 public constant TAIKO_TX_MIN_GAS_LIMIT = 21000; // TODO
 
     // Taiko L2 releated constants
-    uint256 public constant V1_ANCHOR_TX_GAS_LIMIT = 1000000; // TODO
+    // A V1TaikoL2.anchor transaction that checking all 256 ancestor blocks,
+    // will cost ~70K gas.
+    uint256 public constant V1_ANCHOR_TX_GAS_LIMIT = 1000000;
 
     bytes4 public constant V1_ANCHOR_TX_SELECTOR =
         bytes4(keccak256("anchor(uint256,bytes32)"));


### PR DESCRIPTION
- When checking `proveBlockInvalid()` throwaway header's gas limit, not add `LibConstants.V1_ANCHOR_TX_GAS_LIMIT`
- According to tests, a `TaikoL2.anchor` transaction that checking all 256 ancestor blocks, will cost ~70K gas, so update `libConstants.V1_ANCHOR_TX_GAS_LIMIT` to 1M.
![image](https://user-images.githubusercontent.com/104078303/190884273-de2d3a36-197f-48bd-90f5-7d639ac118b3.png)
