### PR TITLE
[protocol] Persist all L2 block hashes to trie

### DIFF
--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -26,7 +26,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
      * State Variables    *
      **********************/
 
-     mapping(uint256 => bytes32) public blockhashes;
+     mapping(uint256 => bytes32) private l2Hashes;
     mapping(uint256 => bytes32) private l1Hashes;
     bytes32 public publicInputHash;
 
@@ -137,6 +137,16 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
         return l1Hashes[number];
     }
 
+    function getBlockHash(uint256 number) {
+        if (number >=  block.number -256 && number < block.number) {
+            return blockhash(nummber);
+        } else if (number >= block.number) {
+            return 0;
+        } else {
+            return l2Hashes[number];
+        }
+    }
+
     /**********************
      * Private Functions  *
      **********************/
@@ -198,8 +208,8 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
         
         ancestors[parentHeight % 255] = parentHash;
         publicInputHash = _hashPublicInputHash(chainId, number, 0, ancestors);
-        
-        blockhashes[parentHeight] = parentHash;
+
+        l2Hashes[parentHeight] = parentHash;
     }
 
     function _hashPublicInputHash(

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -145,7 +145,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
         if (number >= block.number) {
             return 0;
         } else if (number < block.number && number >= block.number - 256) {
-            return blockhash(nummber);
+            return blockhash(number);
         } else {
             return l2Hashes[number];
         }

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -26,7 +26,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
      * State Variables    *
      **********************/
 
-     mapping(uint256 => bytes32) private l2Hashes;
+    mapping(uint256 => bytes32) private l2Hashes;
     mapping(uint256 => bytes32) private l1Hashes;
     bytes32 public publicInputHash;
 
@@ -137,11 +137,15 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
         return l1Hashes[number];
     }
 
-    function getBlockHash(uint256 number) {
-        if (number >=  block.number -256 && number < block.number) {
-            return blockhash(nummber);
-        } else if (number >= block.number) {
+    function getBlockHash(uint256 number)
+        public
+        view
+        returns (bytes32)
+    {
+        if (number >= block.number) {
             return 0;
+        } else if (number < block.number && number >= block.number - 256) {
+            return blockhash(nummber);
         } else {
             return l2Hashes[number];
         }

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -26,10 +26,11 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
      * State Variables    *
      **********************/
 
+     mapping(uint256 => bytes32) public blockhashes;
     mapping(uint256 => bytes32) private l1Hashes;
     bytes32 public publicInputHash;
 
-    uint256[48] private __gap;
+    uint256[47] private __gap;
 
     /**********************
      * Events             *
@@ -186,14 +187,19 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
             ancestors[(number - i) % 255] = blockhash(number - i);
         }
 
+        uint parentHeight = number - 1;
+        bytes32 parentHash = blockhash(parentHeight);
+
         require(
             publicInputHash ==
-                _hashPublicInputHash(chainId, number - 1, 0, ancestors),
+                _hashPublicInputHash(chainId, parentHeight, 0, ancestors),
             "L2:publicInputHash"
         );
-
-        ancestors[(number - 1) % 255] = blockhash(number - 1);
+        
+        ancestors[parentHeight % 255] = parentHash;
         publicInputHash = _hashPublicInputHash(chainId, number, 0, ancestors);
+        
+        blockhashes[parentHeight] = parentHash;
     }
 
     function _hashPublicInputHash(


### PR DESCRIPTION
This change is based on Brecht's suggestion:
> The more I think about it the more I think we actually require all L2 block hashes to be available somewhere. On Ethereum you can kind of get away with just having the latest 256 because block times are fixed and 256*12 seconds = 50 minutes. So a transaction containing a Merkle proof for a certain block hash can remain valid up to 50 minutes in the best case. Then the block hash is gone and the merkle proof will be invalid in the transaction. Certainly not great because it puts a hard limit on how quickly these transactions need to be settled before users waste gas on a useless transaction, but you can say it's acceptable. On L2 however we don't have fixed block times. Even worse, the network may prefer smaller blocks, but a lot of them because that's more efficient to prove and we of course want high throughput. That means only having the last 256 L2 block hashes available on L2 doesn't really have a lower limit on how long these block hashes are available, it depends on other network parameters as well. In the worst case somebody creates a tx with a Merkle proof against the latest known L2 blockhash, submits a transaction, but 256 blocks are proposed before the transaction gets included. Theoretically this can happen immediately in times of high demand, but of course more realistically that will still take some time, but there's no guaranteed time it remains valid. Even if  users do everything right their transaction can be made useless at any time. So I would err on the side of caution and eat the relatively small cost to just keep a full history of L2 block hashes (on L1 and L2) and all the L1 block hashes we have on L2.