### PR TITLE
[protocol] update `V1_ANCHOR_TX_GAS_LIMIT`

### DIFF
--- a/packages/protocol/contracts/libs/LibConstants.sol
+++ b/packages/protocol/contracts/libs/LibConstants.sol
@@ -23,7 +23,7 @@ library LibConstants {
     uint256 public constant TAIKO_TX_MIN_GAS_LIMIT = 21000; // TODO
 
     // Taiko L2 releated constants
-    uint256 public constant V1_ANCHOR_TX_GAS_LIMIT = 210000;
+    uint256 public constant V1_ANCHOR_TX_GAS_LIMIT = 250000;
 
     bytes4 public constant V1_ANCHOR_TX_SELECTOR =
         bytes4(keccak256("anchor(uint256,bytes32)"));


### PR DESCRIPTION
Since after https://github.com/taikochain/taiko-mono/pull/154 we also start saving `l2hash` in `V1TaikoL2.anchor` , the actual gas cost has been increased to ~225000 according to the output in `test:genesis`:
```
{
  message: 'V1TaikoL2.anchor gas cost after 256 L2 blocks',
  gasUsed: BigNumber { value: "225945" }
}
```
This PR is to increase its gas limit to `250000`.