### PR TITLE
[protocol] add `TaikoL1.getCommitHeight` method

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -135,6 +135,10 @@ contract TaikoL1 is EssentialContract, IHeaderSync, V1Events {
         return V1Proposing.isCommitValid(state, hash);
     }
 
+    function getCommitHeight(bytes32 commitHash) public view returns (uint256) {
+        return state.commits[commitHash];
+    }
+
     function getPendingBlock(uint256 id)
         public
         view

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -137,11 +137,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
         return l1Hashes[number];
     }
 
-    function getBlockHash(uint256 number)
-        public
-        view
-        returns (bytes32)
-    {
+    function getBlockHash(uint256 number) public view returns (bytes32) {
         if (number >= block.number) {
             return 0;
         } else if (number < block.number && number >= block.number - 256) {
@@ -201,7 +197,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
             ancestors[(number - i) % 255] = blockhash(number - i);
         }
 
-        uint parentHeight = number - 1;
+        uint256 parentHeight = number - 1;
         bytes32 parentHash = blockhash(parentHeight);
 
         require(
@@ -209,7 +205,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
                 _hashPublicInputHash(chainId, parentHeight, 0, ancestors),
             "L2:publicInputHash"
         );
-        
+
         ancestors[parentHeight % 255] = parentHash;
         publicInputHash = _hashPublicInputHash(chainId, number, 0, ancestors);
 


### PR DESCRIPTION
This PR is to add a `TaikoL1.getCommitHeight` method to tell the client whether the given `commitHash` was committed before and its corresponding L1 height.