### PR TITLE
[protocol] block.timestamp > parent.timestamp

### DIFF
--- a/packages/protocol/contracts/L1/LibData.sol
+++ b/packages/protocol/contracts/L1/LibData.sol
@@ -47,6 +47,7 @@ library LibData {
         uint64 latestFinalizedHeight;
         uint64 latestFinalizedId;
         uint64 nextBlockId;
+        uint64 parentTimestamp;
     }
 
     function saveProposedBlock(

--- a/packages/protocol/contracts/L1/LibData.sol
+++ b/packages/protocol/contracts/L1/LibData.sol
@@ -43,11 +43,13 @@ library LibData {
         // block id => parent hash => fork choice
         mapping(uint256 => mapping(bytes32 => ForkChoice)) forkChoices;
         mapping(bytes32 => uint256) commits;
-        uint64 genesisHeight;
-        uint64 latestFinalizedHeight;
-        uint64 latestFinalizedId;
+        // TODO(daniel): optimize the order of these fields after
+        // tokenomics are implemented to reduce gas cost.
+        uint256 genesisHeight; // immutable after initial sstore
         uint64 nextBlockId;
         uint64 parentTimestamp;
+        uint64 latestFinalizedHeight;
+        uint64 latestFinalizedId;
     }
 
     function saveProposedBlock(
@@ -79,7 +81,7 @@ library LibData {
         internal
         view
         returns (
-            uint64 genesisHeight,
+            uint256 genesisHeight,
             uint64 latestFinalizedHeight,
             uint64 latestFinalizedId,
             uint64 nextBlockId

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -27,7 +27,7 @@ contract TaikoL1 is EssentialContract, IHeaderSync, V1Events {
     using SafeCastUpgradeable for uint256;
 
     LibData.State public state;
-    uint256[45] private __gap;
+    uint256[44] private __gap;
 
     function init(address _addressManager, bytes32 _genesisBlockHash)
         external

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -160,7 +160,7 @@ contract TaikoL1 is EssentialContract, IHeaderSync, V1Events {
         public
         view
         returns (
-            uint64, /*genesisHeight*/
+            uint256, /*genesisHeight*/
             uint64, /*latestFinalizedHeight*/
             uint64, /*latestFinalizedId*/
             uint64 /*nextBlockId*/

--- a/packages/protocol/contracts/L1/v1/V1Finalizing.sol
+++ b/packages/protocol/contracts/L1/v1/V1Finalizing.sol
@@ -24,8 +24,10 @@ library V1Finalizing {
 
     function init(LibData.State storage s, bytes32 _genesisBlockHash) public {
         s.l2Hashes[0] = _genesisBlockHash;
+        s.genesisHeight = block.number;
+
         s.nextBlockId = 1;
-        s.genesisHeight = uint64(block.number);
+        s.parentTimestamp = uint64(block.number);
 
         emit BlockFinalized(0, _genesisBlockHash);
         emit HeaderSynced(block.number, 0, _genesisBlockHash);

--- a/packages/protocol/contracts/L1/v1/V1Proposing.sol
+++ b/packages/protocol/contracts/L1/v1/V1Proposing.sol
@@ -73,11 +73,11 @@ library V1Proposing {
 
         // enforce block.timestamp > parent.timestamp
         if (block.timestamp > s.parentTimestamp) {
-            meta.timestamp = uint64(block.timestamp);
             s.parentTimestamp = uint64(block.timestamp);
         } else {
-            meta.timestamp = ++s.parentTimestamp;
+            s.parentTimestamp += 1;
         }
+        meta.timestamp = s.parentTimestamp;
 
         // if multiple L2 blocks included in the same L1 block,
         // their block.mixHash fields for randomness will be the same.

--- a/packages/protocol/contracts/L1/v1/V1Proposing.sol
+++ b/packages/protocol/contracts/L1/v1/V1Proposing.sol
@@ -70,7 +70,14 @@ library V1Proposing {
         meta.id = s.nextBlockId;
         meta.l1Height = block.number - 1;
         meta.l1Hash = blockhash(block.number - 1);
-        meta.timestamp = uint64(block.timestamp);
+
+        // enforce block.timestamp > parent.timestamp
+        if (block.timestamp > s.parentTimestamp) {
+            meta.timestamp = uint64(block.timestamp);
+            s.parentTimestamp = uint64(block.timestamp);
+        } else {
+            meta.timestamp = ++s.parentTimestamp;
+        }
 
         // if multiple L2 blocks included in the same L1 block,
         // their block.mixHash fields for randomness will be the same.


### PR DESCRIPTION
Before this change, we have `block.timestamp >= parent.timestamp` which is incompatible with Ethereum client specs. Now we can get rid of this incompatibility. @davidtaikocha 