### PR TITLE
Revert "[protocol] block.timestamp > parent.timestamp (#188)"

### DIFF
--- a/packages/protocol/contracts/L1/LibData.sol
+++ b/packages/protocol/contracts/L1/LibData.sol
@@ -43,13 +43,10 @@ library LibData {
         // block id => parent hash => fork choice
         mapping(uint256 => mapping(bytes32 => ForkChoice)) forkChoices;
         mapping(bytes32 => uint256) commits;
-        // TODO(daniel): optimize the order of these fields after
-        // tokenomics are implemented to reduce gas cost.
-        uint256 genesisHeight; // immutable after initial sstore
-        uint64 nextBlockId;
-        uint64 parentTimestamp;
+        uint64 genesisHeight;
         uint64 latestFinalizedHeight;
         uint64 latestFinalizedId;
+        uint64 nextBlockId;
     }
 
     function saveProposedBlock(
@@ -81,7 +78,7 @@ library LibData {
         internal
         view
         returns (
-            uint256 genesisHeight,
+            uint64 genesisHeight,
             uint64 latestFinalizedHeight,
             uint64 latestFinalizedId,
             uint64 nextBlockId

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -27,7 +27,7 @@ contract TaikoL1 is EssentialContract, IHeaderSync, V1Events {
     using SafeCastUpgradeable for uint256;
 
     LibData.State public state;
-    uint256[44] private __gap;
+    uint256[45] private __gap;
 
     function init(address _addressManager, bytes32 _genesisBlockHash)
         external
@@ -160,7 +160,7 @@ contract TaikoL1 is EssentialContract, IHeaderSync, V1Events {
         public
         view
         returns (
-            uint256, /*genesisHeight*/
+            uint64, /*genesisHeight*/
             uint64, /*latestFinalizedHeight*/
             uint64, /*latestFinalizedId*/
             uint64 /*nextBlockId*/

--- a/packages/protocol/contracts/L1/v1/V1Finalizing.sol
+++ b/packages/protocol/contracts/L1/v1/V1Finalizing.sol
@@ -24,10 +24,8 @@ library V1Finalizing {
 
     function init(LibData.State storage s, bytes32 _genesisBlockHash) public {
         s.l2Hashes[0] = _genesisBlockHash;
-        s.genesisHeight = block.number;
-
         s.nextBlockId = 1;
-        s.parentTimestamp = uint64(block.number);
+        s.genesisHeight = uint64(block.number);
 
         emit BlockFinalized(0, _genesisBlockHash);
         emit HeaderSynced(block.number, 0, _genesisBlockHash);

--- a/packages/protocol/contracts/L1/v1/V1Proposing.sol
+++ b/packages/protocol/contracts/L1/v1/V1Proposing.sol
@@ -70,14 +70,7 @@ library V1Proposing {
         meta.id = s.nextBlockId;
         meta.l1Height = block.number - 1;
         meta.l1Hash = blockhash(block.number - 1);
-
-        // enforce block.timestamp > parent.timestamp
-        if (block.timestamp > s.parentTimestamp) {
-            s.parentTimestamp = uint64(block.timestamp);
-        } else {
-            s.parentTimestamp += 1;
-        }
-        meta.timestamp = s.parentTimestamp;
+        meta.timestamp = uint64(block.timestamp);
 
         // if multiple L2 blocks included in the same L1 block,
         // their block.mixHash fields for randomness will be the same.


### PR DESCRIPTION
This reverts commit 7853a282c99b930bb1efc56d03a9c2c8325e308d.