### PR TITLE
[protocol] fix `LibMerkleTrie` test cases failing occasionally

### DIFF
--- a/packages/protocol/test/thirdparty/LibMerkleTrie.test.ts
+++ b/packages/protocol/test/thirdparty/LibMerkleTrie.test.ts
@@ -83,7 +83,7 @@ describe("LibMerkleTrie", function () {
                 defaultMerkleTrie.nodes[0].key
             )
 
-            const key = Buffer.allocUnsafe(defaultNodeLength)
+            const key = Buffer.alloc(defaultNodeLength, 1)
             const isIncluded = await libMerkleTrie.get(
                 key,
                 t.proof.proof,

--- a/packages/protocol/test/thirdparty/LibSecureMerkleTrie.test.ts
+++ b/packages/protocol/test/thirdparty/LibSecureMerkleTrie.test.ts
@@ -87,7 +87,7 @@ describe("LibSecureMerkleTrie", function () {
                 defaultSecureMerkleTrie.nodes[0].key
             )
 
-            const key = Buffer.allocUnsafe(defaultNodeLength)
+            const key = Buffer.alloc(defaultNodeLength, 1)
             const isIncluded = await libSecureMerkleTrie.get(
                 key,
                 t.proof.proof,


### PR DESCRIPTION
Some failed actions after #179 : 
- https://github.com/taikochain/taiko-mono/actions/runs/3318264699/jobs/5482017008
- https://github.com/taikochain/taiko-mono/actions/runs/3316742221/jobs/5478881491

Looks like if `Buffer.allocUnsafe` creates a not-pre-filled buffer that unluckily contains an existed key in test trie, then this test case will fail:

```
This method differs from the `Buffer.alloc()` method because it creates a not-pre-filled buffer,
and it may contain information from older buffers. That is why it is called unsafe.
```
So this PR tries to fix this by creating a pre-filled buffer.