### PR TITLE
[protocol] use the official `smock` library

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -37,7 +37,7 @@
     "author": "Taiko Labs",
     "license": "MIT",
     "devDependencies": {
-        "@defi-wonderland/smock": "git+https://git@github.com/taikochain/smock.git#taiko",
+        "@defi-wonderland/smock": "^2.3.3",
         "@nomiclabs/hardhat-ethers": "^2.0.0",
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
         "@nomiclabs/hardhat-waffle": "^2.0.0",


### PR DESCRIPTION
The bug we fixed in our own forked `smock` library has been fixed in `smock 2.3.1`, and yesterday the `smock` team upgrade the library version [in npm](https://www.npmjs.com/package/@defi-wonderland/smock) from `2.3.0` to `2.3.3`, so right now i think we can use back the official `smock` library.

Ref: 
- https://github.com/defi-wonderland/smock/pull/115
- https://github.com/defi-wonderland/smock/issues/164