### PR TITLE
[protocol] change constants before compiling by hardhat-preprocessor

### DIFF
--- a/packages/protocol/hardhat.config.ts
+++ b/packages/protocol/hardhat.config.ts
@@ -5,6 +5,7 @@ import "@primitivefi/hardhat-dodoc"
 import "@typechain/hardhat"
 import "hardhat-abi-exporter"
 import "hardhat-gas-reporter"
+import "hardhat-preprocessor"
 import { HardhatUserConfig, task } from "hardhat/config"
 import "solidity-coverage"
 import "./tasks/deploy_L1"
@@ -92,6 +93,34 @@ const config: HardhatUserConfig = {
     gasReporter: {
         enabled: process.env.REPORT_GAS === "true",
         currency: "USD",
+    },
+    preprocess: {
+        eachLine: () => ({
+            transform: (line) => {
+                if (
+                    process.env.CHAIN_ID &&
+                    line.includes("uint256 public constant TAIKO_CHAIN_ID")
+                ) {
+                    line = `${line.slice(0, line.indexOf("="))}= ${
+                        process.env.CHAIN_ID
+                    };`
+                }
+
+                if (
+                    process.env.COMMIT_DELAY_CONFIRMATIONS &&
+                    line.includes(
+                        "uint256 public constant TAIKO_COMMIT_DELAY_CONFIRMATIONS"
+                    )
+                ) {
+                    line = `${line.slice(0, line.indexOf("="))}= ${
+                        process.env.COMMIT_DELAY_CONFIRMATIONS
+                    };`
+                }
+
+                return line
+            },
+            files: "libs/LibConstants.sol",
+        }),
     },
     mocha: {
         timeout: 300000,

--- a/packages/protocol/hardhat.config.ts
+++ b/packages/protocol/hardhat.config.ts
@@ -101,7 +101,7 @@ const config: HardhatUserConfig = {
                     process.env.CHAIN_ID &&
                     line.includes("uint256 public constant TAIKO_CHAIN_ID")
                 ) {
-                    line = `${line.slice(0, line.indexOf("="))}= ${
+                    return `${line.slice(0, line.indexOf(" ="))} = ${
                         process.env.CHAIN_ID
                     };`
                 }
@@ -112,7 +112,7 @@ const config: HardhatUserConfig = {
                         "uint256 public constant TAIKO_COMMIT_DELAY_CONFIRMATIONS"
                     )
                 ) {
-                    line = `${line.slice(0, line.indexOf("="))}= ${
+                    return `${line.slice(0, line.indexOf(" ="))} = ${
                         process.env.COMMIT_DELAY_CONFIRMATIONS
                     };`
                 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Taiko L2 Protocol",
     "scripts": {
-        "compile": "npx hardhat compile",
+        "compile": "npx hardhat preprocess && npx hardhat compile",
         "export:abi": "npx hardhat clear-abi && npx hardhat export-abi",
         "clean": "rm -rf abis cache && npx hardhat clean",
         "lint:sol": "npx prettier '**/*.sol' --write && npx solhint 'contracts/**/*.sol' --fix",
@@ -66,6 +66,7 @@
         "hardhat-abi-exporter": "^2.10.0",
         "hardhat-docgen": "^1.3.0",
         "hardhat-gas-reporter": "^1.0.7",
+        "hardhat-preprocessor": "^0.1.5",
         "husky": "^4.3.8",
         "lint-staged": "^12.3.4",
         "merkle-patricia-tree": "^4.2.4",


### PR DESCRIPTION
This PR aims to change constants before compiling by using [hardhat-preprocessor](https://www.npmjs.com/package/hardhat-preprocessor) plugin, if we want to compile contracts with different chain id and commit delay confirmations, we can:
```
CHAIN_ID=167001 COMMIT_DELAY_CONFIRMATIONS=1 yarn compile
```
Since this command **will still overwrite the original file**, I'm not sure this is the best approach, I think its just an approach without manually modifying the source code we can use so far...