### PR TITLE
[protocol] fix another occasional test error and remove some unused variables

### DIFF
--- a/packages/protocol/test/libs/LibTxDecoder.test.ts
+++ b/packages/protocol/test/libs/LibTxDecoder.test.ts
@@ -42,9 +42,9 @@ describe("LibTxDecoder", function () {
             const randomBytes = ethers.utils.hexlify(
                 ethers.utils.randomBytes(73)
             )
-            await expect(
-                libTxDecoder.callStatic.decodeTxList(randomBytes)
-            ).to.be.revertedWith("Invalid RLP")
+
+            await expect(libTxDecoder.callStatic.decodeTxList(randomBytes)).to
+                .be.reverted
         })
 
         it("can decode txList with legacy transaction", async function () {

--- a/packages/protocol/utils/generate_genesis/interface.ts
+++ b/packages/protocol/utils/generate_genesis/interface.ts
@@ -1,6 +1,5 @@
 export interface Config {
     contractOwner: string
-    ethDepositor: string
     chainId: number
     seedAccounts: Array<{
         [key: string]: number

--- a/packages/protocol/utils/generate_genesis/v1TaikoL2.ts
+++ b/packages/protocol/utils/generate_genesis/v1TaikoL2.ts
@@ -14,7 +14,7 @@ export async function deployV1TaikoL2(
     config: Config,
     result: Result
 ): Promise<Result> {
-    const { contractOwner, chainId, seedAccounts, ethDepositor } = config
+    const { contractOwner, chainId, seedAccounts } = config
 
     const alloc: any = {}
 
@@ -39,8 +39,7 @@ export async function deployV1TaikoL2(
 
     const contractConfigs: any = await generateContractConfigs(
         contractOwner,
-        chainId,
-        ethDepositor
+        chainId
     )
 
     const storageLayouts: any = {}
@@ -89,8 +88,7 @@ export async function deployV1TaikoL2(
 // and initialized variables.
 async function generateContractConfigs(
     contractOwner: string,
-    chainId: number,
-    ethDepositor: string
+    chainId: number
 ): Promise<any> {
     const contractArtifacts: any = {
         // Libraries


### PR DESCRIPTION
That `libTxDecoder` test case wont always revert with `"Invalid RLP"`, some random bytes will let it revert with `"RLP item cannot be null."`, so we only need to assert the reversion and ignore the reason is OK here.