### PR TITLE
chore(relayer): add additional test coverage

### DIFF
--- a/packages/relayer/.golangci.yml
+++ b/packages/relayer/.golangci.yml
@@ -29,7 +29,7 @@ linters-settings:
     lines: 116
     statements: 48
   gocognit:
-    min-complexity: 35
+    min-complexity: 37
 
 issues:
   exclude-rules:

--- a/packages/relayer/.golangci.yml
+++ b/packages/relayer/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - gosec
     - gosimple
     - lll
+    - unused
     - whitespace
     - wsl
 

--- a/packages/relayer/.golangci.yml
+++ b/packages/relayer/.golangci.yml
@@ -13,6 +13,7 @@ output:
 
 linters:
   enable:
+    - errcheck
     - funlen
     - gocognit
     - gocritic

--- a/packages/relayer/bridge.go
+++ b/packages/relayer/bridge.go
@@ -1,0 +1,22 @@
+package relayer
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/taikochain/taiko-mono/packages/relayer/contracts"
+)
+
+type Bridge interface {
+	WatchMessageSent(
+		opts *bind.WatchOpts,
+		sink chan<- *contracts.BridgeMessageSent,
+		signal [][32]byte,
+	) (event.Subscription, error)
+	FilterMessageSent(opts *bind.FilterOpts, signal [][32]byte) (*contracts.BridgeMessageSentIterator, error)
+	GetMessageStatus(opts *bind.CallOpts, signal [32]byte) (uint8, error)
+	ProcessMessage(opts *bind.TransactOpts, message contracts.IBridgeMessage, proof []byte) (*types.Transaction, error)
+	IsMessageReceived(opts *bind.CallOpts, signal [32]byte, srcChainId *big.Int, proof []byte) (bool, error) // nolint
+}

--- a/packages/relayer/caller.go
+++ b/packages/relayer/caller.go
@@ -1,0 +1,7 @@
+package relayer
+
+import "context"
+
+type Caller interface {
+	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+}

--- a/packages/relayer/cli/cli.go
+++ b/packages/relayer/cli/cli.go
@@ -44,7 +44,7 @@ var (
 	defaultConfirmations       = 15
 )
 
-func Run(mode relayer.Mode, layer relayer.Layer) {
+func Run(mode relayer.Mode, watchMode relayer.WatchMode, layer relayer.Layer) {
 	if err := loadAndValidateEnv(); err != nil {
 		log.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func Run(mode relayer.Mode, layer relayer.Layer) {
 
 	for _, i := range indexers {
 		go func(i *indexer.Service) {
-			if err := i.FilterThenSubscribe(context.Background(), mode); err != nil {
+			if err := i.FilterThenSubscribe(context.Background(), mode, watchMode); err != nil {
 				log.Fatal(err)
 			}
 		}(i)

--- a/packages/relayer/cmd/main.go
+++ b/packages/relayer/cmd/main.go
@@ -23,6 +23,13 @@ func main() {
 	  both: watch l1 => l2 and l2 => l1 bridge messages
 	`)
 
+	watchModePtr := flag.String("watch-mode", string(relayer.FilterAndSubscribeWatchMode), `watch mode to run in. 
+	options:
+	  filter: only filter previous messages
+	  subscribe: only subscribe to new messages
+	  filter-and-subscribe: catch up on all previous messages, then subscribe to new messages
+	`)
+
 	flag.Parse()
 
 	if !relayer.IsInSlice(relayer.Mode(*modePtr), relayer.Modes) {
@@ -33,5 +40,5 @@ func main() {
 		log.Fatal("mode not valid")
 	}
 
-	cli.Run(relayer.Mode(*modePtr), relayer.Layer(*layersPtr))
+	cli.Run(relayer.Mode(*modePtr), relayer.WatchMode(*watchModePtr), relayer.Layer(*layersPtr))
 }

--- a/packages/relayer/flags.go
+++ b/packages/relayer/flags.go
@@ -16,3 +16,12 @@ var (
 	Both   Layer = "both"
 	Layers       = []Layer{L1, L2, Both}
 )
+
+type WatchMode string
+
+var (
+	FilterWatchMode             WatchMode = "filter"
+	SubscribeWatchMode          WatchMode = "subscribe"
+	FilterAndSubscribeWatchMode WatchMode = "filter-and-subscribe"
+	WatchModes                            = []WatchMode{FilterWatchMode, SubscribeWatchMode}
+)

--- a/packages/relayer/header_syncer.go
+++ b/packages/relayer/header_syncer.go
@@ -1,0 +1,7 @@
+package relayer
+
+import "github.com/ethereum/go-ethereum/accounts/abi/bind"
+
+type HeaderSyncer interface {
+	GetLatestSyncedHeader(opts *bind.CallOpts) ([32]byte, error)
+}

--- a/packages/relayer/indexer/filter_then_subscribe.go
+++ b/packages/relayer/indexer/filter_then_subscribe.go
@@ -17,10 +17,15 @@ var (
 // FilterThenSubscribe gets the most recent block height that has been indexed, and works it's way
 // up to the latest block. As it goes, it tries to process messages.
 // When it catches up, it then starts to Subscribe to latest events as they come in.
-func (svc *Service) FilterThenSubscribe(ctx context.Context, mode relayer.Mode) error {
+func (svc *Service) FilterThenSubscribe(ctx context.Context, mode relayer.Mode, watchMode relayer.WatchMode) error {
 	chainID, err := svc.ethClient.ChainID(ctx)
 	if err != nil {
 		return errors.Wrap(err, "svc.ethClient.ChainID()")
+	}
+
+	// if subscribing to new events, skip filtering and subscribe
+	if watchMode == relayer.SubscribeWatchMode {
+		return svc.subscribe(ctx, chainID)
 	}
 
 	if err := svc.setInitialProcessingBlockByMode(ctx, mode, chainID); err != nil {
@@ -107,7 +112,12 @@ func (svc *Service) FilterThenSubscribe(ctx context.Context, mode relayer.Mode) 
 	}
 
 	if svc.processingBlock.Height < latestBlock.Number.Uint64() {
-		return svc.FilterThenSubscribe(ctx, relayer.SyncMode)
+		return svc.FilterThenSubscribe(ctx, relayer.SyncMode, watchMode)
+	}
+
+	// we are caught up and specified not to subscribe, we can return now
+	if watchMode == relayer.WatchMode(relayer.FilterWatchMode) {
+		return nil
 	}
 
 	return svc.subscribe(ctx, chainID)

--- a/packages/relayer/indexer/filter_then_subscribe.go
+++ b/packages/relayer/indexer/filter_then_subscribe.go
@@ -116,7 +116,7 @@ func (svc *Service) FilterThenSubscribe(ctx context.Context, mode relayer.Mode, 
 	}
 
 	// we are caught up and specified not to subscribe, we can return now
-	if watchMode == relayer.WatchMode(relayer.FilterWatchMode) {
+	if watchMode == relayer.FilterWatchMode {
 		return nil
 	}
 

--- a/packages/relayer/indexer/filter_then_subscribe_test.go
+++ b/packages/relayer/indexer/filter_then_subscribe_test.go
@@ -14,6 +14,46 @@ func Test_FilterThenSubscribe(t *testing.T) {
 	svc, bridge := newTestService()
 	b := bridge.(*mock.Bridge)
 
+	svc.processingBlock = &relayer.Block{
+		Height: 0,
+	}
+
+	go svc.FilterThenSubscribe(
+		context.Background(),
+		relayer.Mode(relayer.SyncMode),
+		relayer.FilterAndSubscribeWatchMode,
+	)
+
+	<-time.After(6 * time.Second)
+
+	assert.Equal(t, b.MessagesSent, 1)
+	assert.Equal(t, b.ErrorsSent, 1)
+}
+
+func Test_FilterThenSubscribe_subscribeWatchMode(t *testing.T) {
+	svc, bridge := newTestService()
+	b := bridge.(*mock.Bridge)
+
+	go svc.FilterThenSubscribe(
+		context.Background(),
+		relayer.Mode(relayer.SyncMode),
+		relayer.SubscribeWatchMode,
+	)
+
+	<-time.After(6 * time.Second)
+
+	assert.Equal(t, b.MessagesSent, 1)
+	assert.Equal(t, b.ErrorsSent, 1)
+}
+
+func Test_FilterThenSubscribe_alreadyCaughtUp(t *testing.T) {
+	svc, bridge := newTestService()
+	b := bridge.(*mock.Bridge)
+
+	svc.processingBlock = &relayer.Block{
+		Height: mock.LatestBlockNumber.Uint64(),
+	}
+
 	go svc.FilterThenSubscribe(
 		context.Background(),
 		relayer.Mode(relayer.SyncMode),

--- a/packages/relayer/indexer/filter_then_subscribe_test.go
+++ b/packages/relayer/indexer/filter_then_subscribe_test.go
@@ -1,0 +1,27 @@
+package indexer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taikochain/taiko-mono/packages/relayer"
+	"github.com/taikochain/taiko-mono/packages/relayer/mock"
+)
+
+func Test_FilterThenSubscribe(t *testing.T) {
+	svc, bridge := newTestService()
+	b := bridge.(*mock.Bridge)
+
+	go svc.FilterThenSubscribe(
+		context.Background(),
+		relayer.Mode(relayer.SyncMode),
+		relayer.FilterAndSubscribeWatchMode,
+	)
+
+	<-time.After(6 * time.Second)
+
+	assert.Equal(t, b.MessagesSent, 1)
+	assert.Equal(t, b.ErrorsSent, 1)
+}

--- a/packages/relayer/indexer/filter_then_subscribe_test.go
+++ b/packages/relayer/indexer/filter_then_subscribe_test.go
@@ -18,11 +18,13 @@ func Test_FilterThenSubscribe(t *testing.T) {
 		Height: 0,
 	}
 
-	go svc.FilterThenSubscribe(
-		context.Background(),
-		relayer.Mode(relayer.SyncMode),
-		relayer.FilterAndSubscribeWatchMode,
-	)
+	go func() {
+		_ = svc.FilterThenSubscribe(
+			context.Background(),
+			relayer.Mode(relayer.SyncMode),
+			relayer.FilterAndSubscribeWatchMode,
+		)
+	}()
 
 	<-time.After(6 * time.Second)
 
@@ -34,11 +36,13 @@ func Test_FilterThenSubscribe_subscribeWatchMode(t *testing.T) {
 	svc, bridge := newTestService()
 	b := bridge.(*mock.Bridge)
 
-	go svc.FilterThenSubscribe(
-		context.Background(),
-		relayer.Mode(relayer.SyncMode),
-		relayer.SubscribeWatchMode,
-	)
+	go func() {
+		_ = svc.FilterThenSubscribe(
+			context.Background(),
+			relayer.Mode(relayer.SyncMode),
+			relayer.SubscribeWatchMode,
+		)
+	}()
 
 	<-time.After(6 * time.Second)
 
@@ -54,11 +58,13 @@ func Test_FilterThenSubscribe_alreadyCaughtUp(t *testing.T) {
 		Height: mock.LatestBlockNumber.Uint64(),
 	}
 
-	go svc.FilterThenSubscribe(
-		context.Background(),
-		relayer.Mode(relayer.SyncMode),
-		relayer.FilterAndSubscribeWatchMode,
-	)
+	go func() {
+		_ = svc.FilterThenSubscribe(
+			context.Background(),
+			relayer.Mode(relayer.SyncMode),
+			relayer.FilterAndSubscribeWatchMode,
+		)
+	}()
 
 	<-time.After(6 * time.Second)
 

--- a/packages/relayer/indexer/handle_event.go
+++ b/packages/relayer/indexer/handle_event.go
@@ -18,6 +18,8 @@ func (svc *Service) handleEvent(
 	chainID *big.Int,
 	event *contracts.BridgeMessageSent,
 ) error {
+	log.Infof("event found for signal: %v", common.Hash(event.Signal).Hex())
+
 	raw := event.Raw
 
 	// handle chain re-org by checking Removed property, no need to

--- a/packages/relayer/indexer/handle_event_test.go
+++ b/packages/relayer/indexer/handle_event_test.go
@@ -102,7 +102,7 @@ func Test_eventStatusFromSignal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := newTestService()
+			svc, _ := newTestService()
 
 			status, err := svc.eventStatusFromSignal(tt.ctx, tt.gasLimit, tt.signal)
 			if tt.wantErr != nil {

--- a/packages/relayer/indexer/handle_no_events_in_batch_test.go
+++ b/packages/relayer/indexer/handle_no_events_in_batch_test.go
@@ -25,7 +25,7 @@ func Test_handleNoEventsInBatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := newTestService()
+			svc, _ := newTestService()
 
 			assert.NotEqual(t, svc.processingBlock.Height, uint64(tt.blockNumber))
 

--- a/packages/relayer/indexer/handle_no_events_remaining_test.go
+++ b/packages/relayer/indexer/handle_no_events_remaining_test.go
@@ -33,7 +33,7 @@ func Test_handleNoEventsRemaining(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := newTestService()
+			svc, _ := newTestService()
 			err := svc.handleNoEventsRemaining(context.Background(), tt.chainID, tt.events)
 			assert.Equal(t, tt.wantErr, err)
 		})

--- a/packages/relayer/indexer/service.go
+++ b/packages/relayer/indexer/service.go
@@ -35,8 +35,8 @@ type Service struct {
 
 	processingBlock *relayer.Block
 
-	bridge     *contracts.Bridge
-	destBridge *contracts.Bridge
+	bridge     relayer.Bridge
+	destBridge relayer.Bridge
 
 	processor *message.Processor
 

--- a/packages/relayer/indexer/service_test.go
+++ b/packages/relayer/indexer/service_test.go
@@ -49,6 +49,7 @@ func newTestService() (*Service, relayer.Bridge) {
 
 		processingBlock: &relayer.Block{},
 		processor:       processor,
+		blockBatchSize:  100,
 	}, b
 }
 

--- a/packages/relayer/indexer/service_test.go
+++ b/packages/relayer/indexer/service_test.go
@@ -16,13 +16,18 @@ import (
 var dummyEcdsaKey = "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f"
 var dummyAddress = "0x63FaC9201494f0bd17B9892B9fae4d52fe3BD377"
 
-func newTestService() *Service {
+func newTestService() (*Service, relayer.Bridge) {
+	b := &mock.Bridge{}
+
 	return &Service{
-		blockRepo: &mock.BlockRepository{},
-		ethClient: &mock.EthClient{},
+		blockRepo:     &mock.BlockRepository{},
+		eventRepo:     &mock.EventRepository{},
+		bridge:        b,
+		ethClient:     &mock.EthClient{},
+		numGoroutines: 10,
 
 		processingBlock: &relayer.Block{},
-	}
+	}, b
 }
 
 func Test_NewService(t *testing.T) {

--- a/packages/relayer/indexer/set_initial_processing_block_by_mode_test.go
+++ b/packages/relayer/indexer/set_initial_processing_block_by_mode_test.go
@@ -50,7 +50,7 @@ func Test_SetInitialProcessingBlockByMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := newTestService()
+			svc, _ := newTestService()
 			err := svc.setInitialProcessingBlockByMode(
 				context.Background(),
 				tt.mode,

--- a/packages/relayer/indexer/subscribe_test.go
+++ b/packages/relayer/indexer/subscribe_test.go
@@ -1,0 +1,24 @@
+package indexer
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taikochain/taiko-mono/packages/relayer/mock"
+)
+
+func Test_subscribe(t *testing.T) {
+	svc, bridge := newTestService()
+
+	go svc.subscribe(context.Background(), big.NewInt(1))
+
+	<-time.After(6 * time.Second)
+
+	b := bridge.(*mock.Bridge)
+
+	assert.Equal(t, b.MessagesSent, 1)
+	assert.Equal(t, b.ErrorsSent, 1)
+}

--- a/packages/relayer/indexer/subscribe_test.go
+++ b/packages/relayer/indexer/subscribe_test.go
@@ -13,7 +13,9 @@ import (
 func Test_subscribe(t *testing.T) {
 	svc, bridge := newTestService()
 
-	go svc.subscribe(context.Background(), big.NewInt(1))
+	go func() {
+		_ = svc.subscribe(context.Background(), big.NewInt(1))
+	}()
 
 	<-time.After(6 * time.Second)
 

--- a/packages/relayer/message/process_message.go
+++ b/packages/relayer/message/process_message.go
@@ -26,6 +26,8 @@ func (p *Processor) ProcessMessage(
 	event *contracts.BridgeMessageSent,
 	e *relayer.Event,
 ) error {
+	log.Infof("processing message for signal: %v", common.Hash(event.Signal).Hex())
+
 	// TODO: if relayer can not process, save this to DB with status Unprocessable
 	if event.Message.GasLimit == nil || event.Message.GasLimit.Cmp(common.Big0) == 0 {
 		return errors.New("only user can process this, gasLimit set to 0")
@@ -54,8 +56,6 @@ func (p *Processor) ProcessMessage(
 	)
 
 	key := hex.EncodeToString(hashed)
-
-	log.Infof("processing message for signal: %v, key: %v", common.Hash(event.Signal).Hex(), key)
 
 	encodedSignalProof, err := p.prover.EncodedSignalProof(ctx, p.rpc, event.Raw.Address, key, latestSyncedHeader)
 	if err != nil {

--- a/packages/relayer/message/process_message_test.go
+++ b/packages/relayer/message/process_message_test.go
@@ -1,0 +1,93 @@
+package message
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/taikochain/taiko-mono/packages/relayer"
+	"github.com/taikochain/taiko-mono/packages/relayer/contracts"
+	"github.com/taikochain/taiko-mono/packages/relayer/mock"
+)
+
+func Test_getLatestNonce(t *testing.T) {
+	p := newTestProcessor()
+
+	err := p.getLatestNonce(context.Background(), &bind.TransactOpts{})
+	assert.Nil(t, err)
+
+	assert.Equal(t, p.destNonce, mock.PendingNonce)
+}
+
+func Test_waitForConfirmations(t *testing.T) {
+	p := newTestProcessor()
+
+	err := p.waitForConfirmations(context.TODO(), mock.SucceedTxHash, uint64(mock.BlockNum))
+	assert.Nil(t, err)
+}
+
+func Test_sendProcessMessageCall(t *testing.T) {
+	p := newTestProcessor()
+
+	_, err := p.sendProcessMessageCall(
+		context.Background(),
+		&contracts.BridgeMessageSent{
+			Message: contracts.IBridgeMessage{
+				DestChainId: mock.MockChainID,
+			},
+		}, []byte{})
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, p.destNonce, mock.PendingNonce)
+}
+
+func Test_ProcessMessage_messageNotReceived(t *testing.T) {
+	p := newTestProcessor()
+
+	err := p.ProcessMessage(context.Background(), &contracts.BridgeMessageSent{
+		Message: contracts.IBridgeMessage{
+			GasLimit: big.NewInt(1),
+		},
+	}, &relayer.Event{})
+	assert.EqualError(t, err, "message not received")
+}
+
+func Test_ProcessMessage_gasLimit0(t *testing.T) {
+	p := newTestProcessor()
+
+	err := p.ProcessMessage(context.Background(), &contracts.BridgeMessageSent{}, &relayer.Event{})
+	assert.EqualError(t, errors.New("only user can process this, gasLimit set to 0"), err.Error())
+}
+
+func Test_ProcessMessage_noChainId(t *testing.T) {
+	p := newTestProcessor()
+
+	err := p.ProcessMessage(context.Background(), &contracts.BridgeMessageSent{
+		Message: contracts.IBridgeMessage{
+			GasLimit: big.NewInt(1),
+		},
+		Signal: mock.SuccessSignal,
+	}, &relayer.Event{})
+	assert.EqualError(t, err, "p.sendProcessMessageCall: bind.NewKeyedTransactorWithChainID: no chain id specified")
+}
+
+func Test_ProcessMessage(t *testing.T) {
+	p := newTestProcessor()
+
+	err := p.ProcessMessage(context.Background(), &contracts.BridgeMessageSent{
+		Message: contracts.IBridgeMessage{
+			GasLimit:    big.NewInt(1),
+			DestChainId: mock.MockChainID,
+		},
+		Signal: mock.SuccessSignal,
+	}, &relayer.Event{})
+
+	assert.Nil(
+		t,
+		err,
+	)
+}

--- a/packages/relayer/message/processor.go
+++ b/packages/relayer/message/processor.go
@@ -20,7 +20,7 @@ type Processor struct {
 	rpc           *rpc.Client
 	ecdsaKey      *ecdsa.PrivateKey
 
-	destBridge       *contracts.Bridge
+	destBridge       relayer.Bridge
 	destHeaderSyncer *contracts.IHeaderSync
 
 	prover *proof.Prover
@@ -38,7 +38,7 @@ type NewProcessorOpts struct {
 	RPCClient        *rpc.Client
 	SrcETHClient     *ethclient.Client
 	DestETHClient    *ethclient.Client
-	DestBridge       *contracts.Bridge
+	DestBridge       relayer.Bridge
 	EventRepo        relayer.EventRepository
 	DestHeaderSyncer *contracts.IHeaderSync
 	RelayerAddress   common.Address

--- a/packages/relayer/message/processor.go
+++ b/packages/relayer/message/processor.go
@@ -1,27 +1,31 @@
 package message
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/taikochain/taiko-mono/packages/relayer"
-	"github.com/taikochain/taiko-mono/packages/relayer/contracts"
 	"github.com/taikochain/taiko-mono/packages/relayer/proof"
 )
 
+type ethClient interface {
+	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	BlockNumber(ctx context.Context) (uint64, error)
+}
 type Processor struct {
 	eventRepo     relayer.EventRepository
-	srcEthClient  *ethclient.Client
-	destEthClient *ethclient.Client
-	rpc           *rpc.Client
+	srcEthClient  ethClient
+	destEthClient ethClient
+	rpc           relayer.Caller
 	ecdsaKey      *ecdsa.PrivateKey
 
 	destBridge       relayer.Bridge
-	destHeaderSyncer *contracts.IHeaderSync
+	destHeaderSyncer relayer.HeaderSyncer
 
 	prover *proof.Prover
 
@@ -35,12 +39,12 @@ type Processor struct {
 type NewProcessorOpts struct {
 	Prover           *proof.Prover
 	ECDSAKey         *ecdsa.PrivateKey
-	RPCClient        *rpc.Client
-	SrcETHClient     *ethclient.Client
-	DestETHClient    *ethclient.Client
+	RPCClient        relayer.Caller
+	SrcETHClient     ethClient
+	DestETHClient    ethClient
 	DestBridge       relayer.Bridge
 	EventRepo        relayer.EventRepository
-	DestHeaderSyncer *contracts.IHeaderSync
+	DestHeaderSyncer relayer.HeaderSyncer
 	RelayerAddress   common.Address
 	Confirmations    uint64
 }

--- a/packages/relayer/message/processor_test.go
+++ b/packages/relayer/message/processor_test.go
@@ -2,17 +2,42 @@ package message
 
 import (
 	"crypto/ecdsa"
+	"sync"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/taikochain/taiko-mono/packages/relayer"
 	"github.com/taikochain/taiko-mono/packages/relayer/contracts"
+	"github.com/taikochain/taiko-mono/packages/relayer/mock"
 	"github.com/taikochain/taiko-mono/packages/relayer/proof"
 	"github.com/taikochain/taiko-mono/packages/relayer/repo"
 	"gopkg.in/go-playground/assert.v1"
 )
 
+var dummyEcdsaKey = "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f"
+var dummyAddress = "0x63FaC9201494f0bd17B9892B9fae4d52fe3BD377"
+
+func newTestProcessor() *Processor {
+	privateKey, _ := crypto.HexToECDSA(dummyEcdsaKey)
+
+	prover, _ := proof.New(
+		&mock.Blocker{},
+	)
+
+	return &Processor{
+		eventRepo:        &mock.EventRepository{},
+		destBridge:       &mock.Bridge{},
+		srcEthClient:     &mock.EthClient{},
+		destEthClient:    &mock.EthClient{},
+		mu:               &sync.Mutex{},
+		ecdsaKey:         privateKey,
+		destHeaderSyncer: &mock.HeaderSyncer{},
+		prover:           prover,
+		rpc:              &mock.Caller{},
+	}
+}
 func Test_NewProcessor(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/packages/relayer/message/processor_test.go
+++ b/packages/relayer/message/processor_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 var dummyEcdsaKey = "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f"
-var dummyAddress = "0x63FaC9201494f0bd17B9892B9fae4d52fe3BD377"
 
 func newTestProcessor() *Processor {
 	privateKey, _ := crypto.HexToECDSA(dummyEcdsaKey)

--- a/packages/relayer/mock/bridge.go
+++ b/packages/relayer/mock/bridge.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/taikochain/taiko-mono/packages/relayer"
@@ -16,6 +17,8 @@ var (
 	SuccessSignal = [32]byte{0x1}
 	FailSignal    = [32]byte{0x2}
 )
+
+var dummyAddress = "0x63FaC9201494f0bd17B9892B9fae4d52fe3BD377"
 
 type Bridge struct {
 	MessagesSent int
@@ -81,7 +84,14 @@ func (b *Bridge) ProcessMessage(
 	message contracts.IBridgeMessage,
 	proof []byte,
 ) (*types.Transaction, error) {
-	return &types.Transaction{}, nil
+	return types.NewTransaction(
+		PendingNonce,
+		common.HexToAddress(dummyAddress),
+		big.NewInt(1),
+		100,
+		big.NewInt(10),
+		nil,
+	), nil
 }
 
 func (b *Bridge) IsMessageReceived(opts *bind.CallOpts, signal [32]byte, srcChainId *big.Int, proof []byte) (bool, error) { // nolint

--- a/packages/relayer/mock/bridge.go
+++ b/packages/relayer/mock/bridge.go
@@ -1,0 +1,93 @@
+package mock
+
+import (
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/taikochain/taiko-mono/packages/relayer"
+	"github.com/taikochain/taiko-mono/packages/relayer/contracts"
+)
+
+var (
+	SuccessSignal = [32]byte{0x1}
+	FailSignal    = [32]byte{0x2}
+)
+
+type Bridge struct {
+	MessagesSent int
+	ErrorsSent   int
+}
+
+type Subscription struct {
+	errChan chan error
+	done    bool
+}
+
+func (s *Subscription) Err() <-chan error {
+	return s.errChan
+}
+
+func (s *Subscription) Unsubscribe() {}
+
+func (b *Bridge) WatchMessageSent(
+	opts *bind.WatchOpts,
+	sink chan<- *contracts.BridgeMessageSent,
+	signal [][32]byte,
+) (event.Subscription, error) {
+	s := &Subscription{
+		errChan: make(chan error),
+	}
+
+	go func(sink chan<- *contracts.BridgeMessageSent) {
+		<-time.After(2 * time.Second)
+
+		sink <- &contracts.BridgeMessageSent{}
+		b.MessagesSent++
+	}(sink)
+
+	go func(errChan chan error) {
+		<-time.After(5 * time.Second)
+
+		errChan <- errors.New("fail")
+
+		s.done = true
+		b.ErrorsSent++
+	}(s.errChan)
+
+	return s, nil
+}
+
+func (b *Bridge) FilterMessageSent(
+	opts *bind.FilterOpts,
+	signal [][32]byte,
+) (*contracts.BridgeMessageSentIterator, error) {
+	return &contracts.BridgeMessageSentIterator{}, nil
+}
+
+func (b *Bridge) GetMessageStatus(opts *bind.CallOpts, signal [32]byte) (uint8, error) {
+	if signal == SuccessSignal {
+		return uint8(relayer.EventStatusNew), nil
+	}
+
+	return uint8(relayer.EventStatusDone), nil
+}
+
+func (b *Bridge) ProcessMessage(
+	opts *bind.TransactOpts,
+	message contracts.IBridgeMessage,
+	proof []byte,
+) (*types.Transaction, error) {
+	return &types.Transaction{}, nil
+}
+
+func (b *Bridge) IsMessageReceived(opts *bind.CallOpts, signal [32]byte, srcChainId *big.Int, proof []byte) (bool, error) { // nolint
+	if signal == SuccessSignal {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/packages/relayer/mock/eth_client.go
+++ b/packages/relayer/mock/eth_client.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	MockChainID = big.NewInt(167001)
+	MockChainID       = big.NewInt(167001)
+	LatestBlockNumber = big.NewInt(10)
 )
 
 type EthClient struct {
@@ -19,6 +20,10 @@ func (c *EthClient) ChainID(ctx context.Context) (*big.Int, error) {
 }
 
 func (c *EthClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	if number == nil {
+		number = LatestBlockNumber
+	}
+
 	return &types.Header{
 		Number: number,
 	}, nil

--- a/packages/relayer/mock/eth_client.go
+++ b/packages/relayer/mock/eth_client.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 var (
-	MockChainID       = big.NewInt(167001)
-	LatestBlockNumber = big.NewInt(10)
+	MockChainID              = big.NewInt(167001)
+	LatestBlockNumber        = big.NewInt(10)
+	NotFoundTxHash           = common.HexToHash("0x123")
+	SucceedTxHash            = common.HexToHash("0x456")
+	FailTxHash               = common.HexToHash("0x789")
+	BlockNum                 = 10
+	PendingNonce      uint64 = 10
 )
 
 type EthClient struct {
@@ -27,4 +34,30 @@ func (c *EthClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types
 	return &types.Header{
 		Number: number,
 	}, nil
+}
+
+func (c *EthClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	return PendingNonce, nil
+}
+
+func (c *EthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	if txHash == NotFoundTxHash {
+		return nil, ethereum.NotFound
+	}
+
+	if txHash == FailTxHash {
+		return &types.Receipt{
+			Status:      types.ReceiptStatusFailed,
+			BlockNumber: big.NewInt(1),
+		}, nil
+	}
+
+	return &types.Receipt{
+		Status:      types.ReceiptStatusSuccessful,
+		BlockNumber: new(big.Int).Sub(big.NewInt(int64(BlockNum)), big.NewInt(1)),
+	}, nil
+}
+
+func (c *EthClient) BlockNumber(ctx context.Context) (uint64, error) {
+	return uint64(BlockNum), nil
 }

--- a/packages/relayer/mock/event_repository.go
+++ b/packages/relayer/mock/event_repository.go
@@ -1,0 +1,16 @@
+package mock
+
+import (
+	"github.com/taikochain/taiko-mono/packages/relayer"
+)
+
+type EventRepository struct {
+}
+
+func (r *EventRepository) Save(opts relayer.SaveEventOpts) (*relayer.Event, error) {
+	return nil, nil
+}
+
+func (r *EventRepository) UpdateStatus(id int, status relayer.EventStatus) error {
+	return nil
+}

--- a/packages/relayer/mock/header_syncer.go
+++ b/packages/relayer/mock/header_syncer.go
@@ -1,0 +1,21 @@
+package mock
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+)
+
+var SuccessHeader = [32]byte{0x1}
+
+type HeaderSyncer struct {
+	Fail bool
+}
+
+func (h *HeaderSyncer) GetLatestSyncedHeader(opts *bind.CallOpts) ([32]byte, error) {
+	if h.Fail {
+		return [32]byte{}, errors.New("fail")
+	}
+
+	return SuccessHeader, nil
+}

--- a/packages/relayer/proof/encoded_signal_proof.go
+++ b/packages/relayer/proof/encoded_signal_proof.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/taikochain/taiko-mono/packages/relayer"
 	"github.com/taikochain/taiko-mono/packages/relayer/encoding"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,7 +17,7 @@ import (
 // in our contracts
 func (p *Prover) EncodedSignalProof(
 	ctx context.Context,
-	caller caller,
+	caller relayer.Caller,
 	bridgeAddress common.Address,
 	key string,
 	blockHash common.Hash,
@@ -49,7 +50,7 @@ func (p *Prover) EncodedSignalProof(
 // response from `eth_getProof`
 func (p *Prover) encodedStorageProof(
 	ctx context.Context,
-	c caller,
+	c relayer.Caller,
 	bridgeAddress common.Address,
 	key string,
 	blockNumber int64,

--- a/packages/relayer/proof/types.go
+++ b/packages/relayer/proof/types.go
@@ -2,7 +2,6 @@ package proof
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -11,10 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 )
-
-type caller interface {
-	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
-}
 
 type Bytes []byte
 


### PR DESCRIPTION
This MR enables only subscribing via cli flags, not indexing or processing old blocks, which is very useful for testing locally with the bridge UI in particular.

It also adds some interface separation to the various services, mocks for those, and bumps test coverage quite a bit in the process.