### PR TITLE
fix(test): fix two occasional errors when running bridge tests

### DIFF
--- a/packages/protocol/test/bridge/Bridge.test.ts
+++ b/packages/protocol/test/bridge/Bridge.test.ts
@@ -1,12 +1,10 @@
 import { expect } from "chai"
 import { BigNumber, Signer } from "ethers"
 import { ethers } from "hardhat"
+import RLP from "rlp"
 import { AddressManager, Bridge, EtherVault } from "../../typechain"
 import { Message } from "../utils/message"
 import { Block, BlockHeader, EthGetProofResponse } from "../utils/rpc"
-// import { getSlot, MessageStatus } from "../../tasks/utils"
-import RLP from "rlp"
-// const helpers = require("@nomicfoundation/hardhat-network-helpers")
 
 async function deployBridge(
     signer: Signer,

--- a/packages/protocol/test/bridge/Bridge.test.ts
+++ b/packages/protocol/test/bridge/Bridge.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
-import { AddressManager, Bridge, EtherVault } from "../../typechain"
-import { ethers } from "hardhat"
 import { BigNumber, Signer } from "ethers"
+import { ethers } from "hardhat"
+import { AddressManager, Bridge, EtherVault } from "../../typechain"
 import { Message } from "../utils/message"
 import { Block, BlockHeader, EthGetProofResponse } from "../utils/rpc"
 // import { getSlot, MessageStatus } from "../../tasks/utils"
@@ -860,7 +860,7 @@ describe("integration:Bridge", function () {
             const storageValue = await ethers.provider.getStorageAt(
                 l1Bridge.address,
                 key,
-                block.hash
+                block.number
             )
             // make sure it equals 1 so our proof will pass
             expect(storageValue).to.be.eq(
@@ -984,7 +984,7 @@ describe("integration:Bridge", function () {
             const storageValue = await ethers.provider.getStorageAt(
                 l1Bridge.address,
                 key,
-                block.hash
+                block.number
             )
             // make sure it equals 1 so our proof will pass
             expect(storageValue).to.be.eq(

--- a/packages/protocol/test/bridge/libs/LibBridgeInvoke.test.ts
+++ b/packages/protocol/test/bridge/libs/LibBridgeInvoke.test.ts
@@ -1,4 +1,3 @@
-// import { expect } from "chai"
 import { expect } from "chai"
 import { ethers } from "hardhat"
 import { Message } from "../../utils/message"

--- a/packages/protocol/test/bridge/libs/LibBridgeProcess.test.ts
+++ b/packages/protocol/test/bridge/libs/LibBridgeProcess.test.ts
@@ -1,11 +1,11 @@
+import * as helpers from "@nomicfoundation/hardhat-network-helpers"
 import { expect } from "chai"
-import hre, { ethers } from "hardhat"
-import { Message } from "../../utils/message"
-import { AddressManager, Bridge } from "../../../typechain"
-import { getSlot } from "../../../tasks/utils"
 import * as fs from "fs"
+import hre, { ethers } from "hardhat"
 import * as path from "path"
-const helpers = require("@nomicfoundation/hardhat-network-helpers")
+import { getSlot } from "../../../tasks/utils"
+import { AddressManager, Bridge } from "../../../typechain"
+import { Message } from "../../utils/message"
 
 describe("LibBridgeProcess", function () {
     function getStateSlot() {

--- a/packages/protocol/test/bridge/libs/LibBridgeRetry.test.ts
+++ b/packages/protocol/test/bridge/libs/LibBridgeRetry.test.ts
@@ -1,8 +1,8 @@
+import * as helpers from "@nomicfoundation/hardhat-network-helpers"
 import { expect } from "chai"
 import hre, { ethers } from "hardhat"
+import { decode, getSlot } from "../../../tasks/utils"
 import { Message } from "../../utils/message"
-import { getSlot, decode } from "../../../tasks/utils"
-const helpers = require("@nomicfoundation/hardhat-network-helpers")
 
 describe("LibBridgeRetry", function () {
     async function deployLibBridgeRetryFixture() {


### PR DESCRIPTION
Error message:
```
  10 passing (15s)
  1 failing

  1) integration:Bridge
       processMessage()
         should throw if message has not been received:
     ProviderError: invalid argument 2: hex number > 64 bits
      at HttpProvider.request (node_modules/hardhat/src/internal/core/providers/http.ts:78:19)
      at LocalAccountsProvider.request (node_modules/hardhat/src/internal/core/providers/accounts.ts:188:34)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async EthersProviderWrapper.send (node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
```

Its because [the last parameter in the eth_getStorageAt call](https://www.quicknode.com/docs/ethereum/eth_getStorageAt) here should be a block number but not a block hash:
```
quantity | tag - Integer block number, or the string 'latest, 'earliest' or 'pending.
```