### PR TITLE
feat(protocol): add `TaikoL1.getBlockProvers`

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -229,6 +229,14 @@ contract TaikoL1 is EssentialContract, IHeaderSync, V1Events {
         return LibAnchorSignature.signTransaction(hash, k);
     }
 
+    function getBlockProvers(uint256 id, bytes32 parentHash)
+        public
+        view
+        returns (address[] memory)
+    {
+        return state.forkChoices[id][parentHash].provers;
+    }
+
     function getConstants()
         public
         pure

--- a/packages/protocol/test/L1/TaikoL1.test.ts
+++ b/packages/protocol/test/L1/TaikoL1.test.ts
@@ -94,6 +94,19 @@ describe("TaikoL1", function () {
             expect(hash).to.be.eq(genesisHash)
         })
     })
+
+    describe("getBlockProvers()", async function () {
+        it("should return empty list when there is no proof for that block", async function () {
+            const { taikoL1 } = await deployTaikoL1Fixture()
+
+            const provers = await taikoL1.getBlockProvers(
+                Math.ceil(Math.random() * 1024),
+                randomBytes32()
+            )
+
+            expect(provers).to.be.empty
+        })
+    })
 })
 
 function randomBytes32() {


### PR DESCRIPTION
Provers may need to know how many proofs have been submitted for a pending block, and check whether it exceeds `TAIKO_MAX_PROOFS_PER_FORK_CHOICE`, before submitting the proof.