### PR TITLE
chore(protocol): improve gas

### DIFF
--- a/packages/protocol/contracts/L1/v1/V1Proving.sol
+++ b/packages/protocol/contracts/L1/v1/V1Proving.sol
@@ -243,7 +243,7 @@ library V1Proving {
 
         bytes32 blockHash = evidence.header.hashBlockHeader();
 
-        for (uint256 i = 0; i < LibConstants.K_ZKPROOFS_PER_BLOCK; i++) {
+        for (uint256 i; i < LibConstants.K_ZKPROOFS_PER_BLOCK; i++) {
             LibZKP.verify({
                 verificationKey: ConfigManager(
                     resolver.resolve("config_manager")
@@ -296,7 +296,7 @@ library V1Proving {
                 "L1:tooLate"
             );
 
-            for (uint256 i = 0; i < fc.provers.length; i++) {
+            for (uint256 i; i < fc.provers.length; i++) {
                 require(fc.provers[i] != prover, "L1:prover:dup");
             }
         }

--- a/packages/protocol/contracts/L1/v1/V1Verifying.sol
+++ b/packages/protocol/contracts/L1/v1/V1Verifying.sol
@@ -57,7 +57,7 @@ library V1Verifying {
 
         uint64 latestL2Height = state.latestVerifiedHeight;
         bytes32 latestL2Hash = state.l2Hashes[latestL2Height];
-        uint64 processed = 0;
+        uint64 processed;
         TkoToken tkoToken;
 
         for (
@@ -155,7 +155,7 @@ library V1Verifying {
         TkoToken tkoToken
     ) private {
         uint sum = 2 ** fc.provers.length - 1;
-        for (uint i = 0; i < fc.provers.length; i++) {
+        for (uint i; i < fc.provers.length; i++) {
             uint weight = (1 << (fc.provers.length - i - 1));
             uint proverReward = (premiumReward * weight) / sum;
 
@@ -170,7 +170,7 @@ library V1Verifying {
     function _cleanUp(LibData.ForkChoice storage fc) private {
         fc.blockHash = 0;
         fc.provenAt = 0;
-        for (uint i = 0; i < fc.provers.length; i++) {
+        for (uint i; i < fc.provers.length; i++) {
             fc.provers[i] = address(0);
         }
         delete fc.provers;

--- a/packages/protocol/contracts/L2/V1TaikoL2.sol
+++ b/packages/protocol/contracts/L2/V1TaikoL2.sol
@@ -49,7 +49,7 @@ contract V1TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
 
         bytes32[255] memory ancestors;
         uint256 number = block.number;
-        for (uint256 i = 0; i < 255 && number >= i + 2; i++) {
+        for (uint256 i; i < 255 && number >= i + 2; i++) {
             ancestors[i] = blockhash(number - i - 2);
         }
 

--- a/packages/protocol/contracts/libs/LibReceiptDecoder.sol
+++ b/packages/protocol/contracts/libs/LibReceiptDecoder.sol
@@ -62,7 +62,7 @@ library LibReceiptDecoder {
     ) internal pure returns (Log[] memory) {
         Log[] memory logs = new Log[](logsRlp.length);
 
-        for (uint256 i = 0; i < logsRlp.length; i++) {
+        for (uint256 i; i < logsRlp.length; i++) {
             LibRLPReader.RLPItem[] memory rlpItems = LibRLPReader.readList(
                 logsRlp[i]
             );
@@ -79,7 +79,7 @@ library LibReceiptDecoder {
     ) internal pure returns (bytes32[] memory) {
         bytes32[] memory topics = new bytes32[](topicsRlp.length);
 
-        for (uint256 i = 0; i < topicsRlp.length; i++) {
+        for (uint256 i; i < topicsRlp.length; i++) {
             topics[i] = LibRLPReader.readBytes32(topicsRlp[i]);
         }
 

--- a/packages/protocol/contracts/libs/LibTxDecoder.sol
+++ b/packages/protocol/contracts/libs/LibTxDecoder.sol
@@ -82,7 +82,7 @@ library LibTxDecoder {
         require(txs.length > 0, "empty txList");
 
         Tx[] memory _txList = new Tx[](txs.length);
-        for (uint256 i = 0; i < txs.length; i++) {
+        for (uint256 i; i < txs.length; i++) {
             _txList[i] = decodeTx(LibRLPReader.readBytes(txs[i]));
         }
 
@@ -209,7 +209,7 @@ library LibTxDecoder {
         LibRLPReader.RLPItem[] memory accessListRLP
     ) internal pure returns (AccessItem[] memory accessList) {
         accessList = new AccessItem[](accessListRLP.length);
-        for (uint256 i = 0; i < accessListRLP.length; i++) {
+        for (uint256 i; i < accessListRLP.length; i++) {
             LibRLPReader.RLPItem[] memory items = LibRLPReader.readList(
                 accessListRLP[i]
             );
@@ -218,7 +218,7 @@ library LibTxDecoder {
                 items[1]
             );
             bytes32[] memory slots = new bytes32[](slotListRLP.length);
-            for (uint256 j = 0; j < slotListRLP.length; j++) {
+            for (uint256 j; j < slotListRLP.length; j++) {
                 slots[j] = LibRLPReader.readBytes32(slotListRLP[j]);
             }
             accessList[i] = AccessItem(addr, slots);
@@ -229,7 +229,7 @@ library LibTxDecoder {
         TxList memory txList
     ) internal pure returns (uint256 sum) {
         Tx[] memory items = txList.items;
-        for (uint256 i = 0; i < items.length; i++) {
+        for (uint256 i; i < items.length; i++) {
             sum += items[i].gasLimit;
         }
     }

--- a/packages/protocol/contracts/libs/LibTxUtils.sol
+++ b/packages/protocol/contracts/libs/LibTxUtils.sol
@@ -57,7 +57,7 @@ library LibTxUtils {
             transaction.txType == 0 ? txRLPItems.length : txRLPItems.length - 3
         );
 
-        for (uint256 i = 0; i < list.length; i++) {
+        for (uint256 i; i < list.length; i++) {
             // For Non-legacy transactions, accessList is always the
             // fourth to last item.
             if (transaction.txType != 0 && i == list.length - 1) {

--- a/packages/protocol/contracts/test/thirdparty/TestLibRLPReader.sol
+++ b/packages/protocol/contracts/test/thirdparty/TestLibRLPReader.sol
@@ -10,7 +10,7 @@ contract TestLibRLPReader {
     function readList(bytes memory _in) public pure returns (bytes[] memory) {
         LibRLPReader.RLPItem[] memory decoded = LibRLPReader.readList(_in);
         bytes[] memory out = new bytes[](decoded.length);
-        for (uint256 i = 0; i < out.length; i++) {
+        for (uint256 i; i < out.length; i++) {
             out[i] = LibRLPReader.readRawBytes(decoded[i]);
         }
         return out;

--- a/packages/protocol/contracts/thirdparty/LibBytesUtils.sol
+++ b/packages/protocol/contracts/thirdparty/LibBytesUtils.sol
@@ -119,7 +119,7 @@ library LibBytesUtils {
     ) internal pure returns (bytes memory) {
         bytes memory nibbles = new bytes(_bytes.length * 2);
 
-        for (uint256 i = 0; i < _bytes.length; i++) {
+        for (uint256 i; i < _bytes.length; i++) {
             nibbles[i * 2] = _bytes[i] >> 4;
             nibbles[i * 2 + 1] = bytes1(uint8(_bytes[i]) % 16);
         }
@@ -132,7 +132,7 @@ library LibBytesUtils {
     ) internal pure returns (bytes memory) {
         bytes memory ret = new bytes(_bytes.length / 2);
 
-        for (uint256 i = 0; i < ret.length; i++) {
+        for (uint256 i; i < ret.length; i++) {
             ret[i] = (_bytes[i * 2] << 4) | (_bytes[i * 2 + 1]);
         }
 

--- a/packages/protocol/contracts/thirdparty/LibMerkleTrie.sol
+++ b/packages/protocol/contracts/thirdparty/LibMerkleTrie.sol
@@ -135,16 +135,16 @@ library LibMerkleTrie {
             bool _isFinalNode
         )
     {
-        uint256 pathLength = 0;
+        uint256 pathLength;
         bytes memory key = LibBytesUtils.toNibbles(_key);
 
         bytes32 currentNodeID = _root;
-        uint256 currentKeyIndex = 0;
-        uint256 currentKeyIncrement = 0;
+        uint256 currentKeyIndex;
+        uint256 currentKeyIncrement;
         TrieNode memory currentNode;
 
         // Proof is top-down, so we start at the first element (root).
-        for (uint256 i = 0; i < _proof.length; i++) {
+        for (uint256 i; i < _proof.length; i++) {
             currentNode = _proof[i];
             currentKeyIndex += currentKeyIncrement;
 
@@ -263,7 +263,7 @@ library LibMerkleTrie {
         LibRLPReader.RLPItem[] memory nodes = LibRLPReader.readList(_proof);
         TrieNode[] memory proof = new TrieNode[](nodes.length);
 
-        for (uint256 i = 0; i < nodes.length; i++) {
+        for (uint256 i; i < nodes.length; i++) {
             bytes memory encoded = LibRLPReader.readBytes(nodes[i]);
             proof[i] = TrieNode({
                 encoded: encoded,
@@ -331,7 +331,7 @@ library LibMerkleTrie {
         bytes memory _a,
         bytes memory _b
     ) private pure returns (uint256 _shared) {
-        uint256 i = 0;
+        uint256 i;
         while (_a.length > i && _b.length > i && _a[i] == _b[i]) {
             i++;
         }

--- a/packages/protocol/contracts/thirdparty/LibRLPReader.sol
+++ b/packages/protocol/contracts/thirdparty/LibRLPReader.sol
@@ -70,7 +70,7 @@ library LibRLPReader {
         // simply set a reasonable maximum list length and decrease the size before we finish.
         RLPItem[] memory out = new RLPItem[](MAX_LIST_LENGTH);
 
-        uint256 itemCount = 0;
+        uint256 itemCount;
         uint256 offset = listOffset;
         while (offset < _in.length) {
             require(
@@ -401,7 +401,7 @@ library LibRLPReader {
         }
 
         // Copy over as many complete words as we can.
-        for (uint256 i = 0; i < _length / 32; i++) {
+        for (uint256 i; i < _length / 32; i++) {
             assembly {
                 mstore(dest, mload(src))
             }

--- a/packages/protocol/contracts/thirdparty/LibRLPWriter.sol
+++ b/packages/protocol/contracts/thirdparty/LibRLPWriter.sol
@@ -149,7 +149,7 @@ library LibRLPWriter {
     function _toBinary(uint256 _x) private pure returns (bytes memory) {
         bytes memory b = abi.encodePacked(_x);
 
-        uint256 i = 0;
+        uint256 i;
         for (; i < 32; i++) {
             if (b[i] != 0) {
                 break;
@@ -157,7 +157,7 @@ library LibRLPWriter {
         }
 
         bytes memory res = new bytes(32 - i);
-        for (uint256 j = 0; j < res.length; j++) {
+        for (uint256 j; j < res.length; j++) {
             res[j] = b[i++];
         }
 
@@ -175,10 +175,10 @@ library LibRLPWriter {
     ) private pure returns (bytes memory) {
         bytes memory b = abi.encodePacked(_x);
 
-        uint256 i = 0;
+        uint256 i;
 
         bytes memory res = new bytes(32);
-        for (uint256 j = 0; j < res.length; j++) {
+        for (uint256 j; j < res.length; j++) {
             res[j] = b[i++];
         }
 
@@ -230,7 +230,7 @@ library LibRLPWriter {
         }
 
         uint256 len;
-        uint256 i = 0;
+        uint256 i;
         for (; i < _list.length; i++) {
             len += _list[i].length;
         }


### PR DESCRIPTION
According to: https://blog.tenderly.co/how-to-reduce-smart-contract-gas-usage/

> Default value: When variables are initialized, it’s a good practice to set their values, but this uses gas. In Solidity, all variables are set to 0 by default. Therefore, if a variable's default value is 0, don't explicitly set it to that value.

This PR remove useless initialization to zero.