### PR TITLE
fix(relayer): Fix duplicate/0 signal events

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "packages/relayer/**"
+  pull_request:
+    paths:
+      - "packages/relayer/**"
 jobs:
   push-docker-image:
     name: Build and push docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
     paths:
       - "packages/relayer/**"
-  pull_request:
-    paths:
-      - "packages/relayer/**"
 jobs:
   push-docker-image:
     name: Build and push docker image

--- a/packages/relayer/indexer/filter_then_subscribe.go
+++ b/packages/relayer/indexer/filter_then_subscribe.go
@@ -82,8 +82,10 @@ func (svc *Service) FilterThenSubscribe(
 		group.SetLimit(svc.numGoroutines)
 
 		for {
+			event := events.Event
+
 			group.Go(func() error {
-				err := svc.handleEvent(groupCtx, chainID, events.Event)
+				err := svc.handleEvent(groupCtx, chainID, event)
 				if err != nil {
 					// log error but always return nil to keep other goroutines active
 					log.Error(err.Error())

--- a/packages/relayer/indexer/handle_event.go
+++ b/packages/relayer/indexer/handle_event.go
@@ -25,7 +25,7 @@ func (svc *Service) handleEvent(
 	// handle chain re-org by checking Removed property, no need to
 	// return error, just continue and do not process.
 	if raw.Removed {
-		log.Warn("event signal was removed: %v", common.Hash(event.Signal).Hex())
+		log.Warnf("event signal was removed: %v", common.Hash(event.Signal).Hex())
 		return nil
 	}
 

--- a/packages/relayer/indexer/handle_event.go
+++ b/packages/relayer/indexer/handle_event.go
@@ -20,9 +20,12 @@ func (svc *Service) handleEvent(
 ) error {
 	raw := event.Raw
 
+	log.Infof("event found for signal: %v", common.Hash(event.Signal).Hex())
+
 	// handle chain re-org by checking Removed property, no need to
 	// return error, just continue and do not process.
 	if raw.Removed {
+		log.Warn("event signal was removed: %v", common.Hash(event.Signal).Hex())
 		return nil
 	}
 
@@ -30,8 +33,6 @@ func (svc *Service) handleEvent(
 		log.Warn("Zero signal found. This is unexpected. Returning early")
 		return nil
 	}
-
-	log.Infof("event found for signal: %v", common.Hash(event.Signal).Hex())
 
 	eventStatus, err := svc.eventStatusFromSignal(ctx, event.Message.GasLimit, event.Signal)
 	if err != nil {


### PR DESCRIPTION
`event` needs to be captured toa  variable on each loop before the goroutine runs, or else it could have advanced before it runs or else there is a race condition. This leads to signals being represented as the ZeroHash, because the iterator has advanced and there is no next Event, or duplicate events being processed,which is a waste of gas.

In addition, some logs have been moved around to always log the event signal, even if it is Removed or the ZeroHash.