### PR TITLE
docs(whitepaper): fix typo, changing adaptors to adopters

### DIFF
--- a/packages/whitepaper/main.tex
+++ b/packages/whitepaper/main.tex
@@ -443,7 +443,7 @@ We design price dynamics that evolve with respect to a number of different facto
 % % prevent slots from being over-sold 
 % -- this is due to the asynchronous nature of proposals and proofs, therefore, the adjustment of fees and rewards doesn't happen after each block proposal or proof.
 
-\item A system that benefits early-adaptors, working as base discounts for proposal fees that diminish over time, as proposers may be more vulnerable at the initial stages of the protocol compared to provers.
+\item A system that benefits early adopter, working as base discounts for proposal fees that diminish over time, as proposers may be more vulnerable at the initial stages of the protocol compared to provers.
 \end{enumerate}
 
 % Our overall fees for proposers and rewards for provers will be a summation of these four components. In this section, we will focus on the last three building blocks.

--- a/packages/whitepaper/main.tex
+++ b/packages/whitepaper/main.tex
@@ -443,7 +443,7 @@ We design price dynamics that evolve with respect to a number of different facto
 % % prevent slots from being over-sold 
 % -- this is due to the asynchronous nature of proposals and proofs, therefore, the adjustment of fees and rewards doesn't happen after each block proposal or proof.
 
-\item A system that benefits early adopter, working as base discounts for proposal fees that diminish over time, as proposers may be more vulnerable at the initial stages of the protocol compared to provers.
+\item A system that benefits early adopters, working as base discounts for proposal fees that diminish over time, as proposers may be more vulnerable at the initial stages of the protocol compared to provers.
 \end{enumerate}
 
 % Our overall fees for proposers and rewards for provers will be a summation of these four components. In this section, we will focus on the last three building blocks.


### PR DESCRIPTION
Change "early-adaptors" to "early adopters"