### PR TITLE
docs(website): fix markdown link

### DIFF
--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -16,4 +16,4 @@ pnpm start
 
 ## Contributing
 
-Refer to [CONTRIBUTING.md](./CONTRIBUTING.md).
+Refer to [CONTRIBUTING.md](../../CONTRIBUTING.md).


### PR DESCRIPTION
Fixes the [CONTRIBUTING.md](https://github.com/taikoxyz/taiko-mono/blob/main/CONTRIBUTING.md) link within the [README.md](https://github.com/taikoxyz/taiko-mono/blob/main/packages/website/README.md) of the `website` package (which currently points [to nowhere](https://github.com/taikoxyz/taiko-mono/blob/main/packages/website/CONTRIBUTING.md)).