### PR TITLE
fix(protocol): fix `TokenVault.sendERC20`

### DIFF
--- a/packages/protocol/contracts/bridge/TokenVault.sol
+++ b/packages/protocol/contracts/bridge/TokenVault.sol
@@ -220,7 +220,7 @@ contract TokenVault is EssentialContract {
 
         message.gasLimit = gasLimit;
         message.processingFee = processingFee;
-        message.depositValue = msg.value;
+        message.depositValue = msg.value - processingFee;
         message.refundAddress = refundAddress;
         message.memo = memo;
 


### PR DESCRIPTION
When I re-read bridge's protocol today, i thought the `depositValue` when sending ERC-20 tokens should be `msg.value - processingFee`, otherwise, this message can not be sent unless the `processingFee` is `0`?  Because of the following check in `LibBridgeSend.sendMessage`:
```solidity
uint256 expectedAmount = message.depositValue +
            message.callValue +
            message.processingFee;
require(expectedAmount == msg.value, "B:value");
```