### PR TITLE
feat(bridge-ui): remove right padding on mobile view banner

### DIFF
--- a/packages/bridge-ui/src/components/HeaderAnnouncement.svelte
+++ b/packages/bridge-ui/src/components/HeaderAnnouncement.svelte
@@ -1,12 +1,17 @@
 <div class="relative bg-[#fc0fc0]">
   <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
-    <div class="pr-16 sm:px-16 text-center">
+    <div class="sm:px-16 text-center">
       <p class="font-medium text-white">
-        <span class="md:inline">Hello! At Taiko, we develop in open-source, so this URL, and others, are
-            publicly available. However, it is not ready to be used. We will make an
-            announcement when our public testnet is ready!</span>
-        <span class="block sm:ml-2 sm:inline-block">
-          <a href="https://twitter.com/taikoxyz" class="font-bold text-white underline">
+        <span class="md:inline"
+          >Hello! At Taiko, we develop in open-source, so this URL, and others,
+          are publicly available. However, it is not ready to be used. We will
+          make an announcement when our public testnet is ready!</span
+        >
+        <span class="block sm:inline-block">
+          <a
+            href="https://twitter.com/taikoxyz"
+            class="font-bold text-white underline"
+          >
             Follow @taikoxyz on Twitter
             <span aria-hidden="true"> &rarr;</span>
           </a>


### PR DESCRIPTION
center align text properly.