### PR TITLE
fix(bridge): use metamask wagmi connector

### DIFF
--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -7,12 +7,12 @@
   import {
     configureChains,
     createClient,
-    InjectedConnector,
   } from "@wagmi/core";
   import { publicProvider } from "@wagmi/core/providers/public";
   import { jsonRpcProvider } from "@wagmi/core/providers/jsonRpc";
   import { CoinbaseWalletConnector } from "@wagmi/core/connectors/coinbaseWallet";
   import { WalletConnectConnector } from "@wagmi/core/connectors/walletConnect";
+  import { MetaMaskConnector } from '@wagmi/core/connectors/metaMask'
 
   import Home from "./pages/home/Home.svelte";
   import { setupI18n } from "./i18n";
@@ -85,7 +85,7 @@
   $wagmiClient = createClient({
     provider,
     connectors: [
-      new InjectedConnector({
+      new MetaMaskConnector({
         chains: wagmiChains,
       }),
       new CoinbaseWalletConnector({

--- a/packages/bridge-ui/src/components/buttons/Connect.svelte
+++ b/packages/bridge-ui/src/components/buttons/Connect.svelte
@@ -49,7 +49,6 @@
 
   async function connectWithConnector(connector: Connector) {
     try {
-
       const { chain } = await wagmiConnect({ connector });
       await setSigner();
       await changeChain(chain.id);


### PR DESCRIPTION
Fixes issues with multiple wallets of same name showing up or connect wallet flow not highlighting if a wallet is not installed.