### PR TITLE
ci(protocol): temporarily disable autocommit docs to unblock PRs

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -68,11 +68,11 @@ jobs:
         working-directory: ./packages/protocol
         run: pnpm export:docs
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        name: protocol - Auto Commit Solidity Docs
-        if: github.ref != 'refs/heads/main'
-        with:
-          commit_message: "chore(docs): auto commit solidity docs"
+      # - uses: stefanzweifel/git-auto-commit-action@v4
+      #   name: protocol - Auto Commit Solidity Docs
+      #   if: github.ref != 'refs/heads/main'
+      #   with:
+      #     commit_message: "chore(docs): auto commit solidity docs"
 
       - name: protocol - Deploy L1 Contracts
         working-directory: ./packages/protocol


### PR DESCRIPTION
## summary
this functionality is blocking PRs. specifically:

https://github.com/taikoxyz/taiko-mono/pull/7058
https://github.com/taikoxyz/taiko-mono/pull/7310

you can see that validate-pr-title job is waiting.. and not responding with a result:
<img width="759" alt="image" src="https://user-images.githubusercontent.com/13951458/210480442-518b7114-bbb6-48d0-957d-33f8f8bd9d4e.png">


## solution
let's disable this temporarily, and i will patch it tomorrow. i also would like to update this so it doesn't invade the PR diff (perhaps open the docs update in a separate PR). 

EDIT: also i think the problem is here: https://github.com/EndBug/add-and-commit/issues/188#issuecomment-833316583