### PR TITLE
fix(protocol): Anyone can disable chains, disabling bridges.

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -99,14 +99,21 @@ contract Bridge is EssentialContract, IBridge {
             });
     }
 
-    function enableDestChain(
-        uint256 _chainId,
-        bool enabled
-    ) external nonReentrant {
+    function enableDestChain(uint256 _chainId) external nonReentrant {
         LibBridgeSend.enableDestChain({
             state: state,
             chainId: _chainId,
-            enabled: enabled
+            enabled: true
+        });
+    }
+
+    function disableDestChain(
+        uint256 _chainId
+    ) external onlyOwner nonReentrant {
+        LibBridgeSend.enableDestChain({
+            state: state,
+            chainId: _chainId,
+            enabled: false
         });
     }
 

--- a/packages/protocol/contracts/bridge/libs/LibBridgeSend.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeSend.sol
@@ -78,6 +78,7 @@ library LibBridgeSend {
         bool enabled
     ) internal {
         require(chainId > 0 && chainId != block.chainid, "B:chainId");
+        require(state.destChains[chainId] != enabled, "B:enabled");
         state.destChains[chainId] = enabled;
         emit LibBridgeData.DestChainEnabled(chainId, enabled);
     }

--- a/packages/protocol/test/L1/TaikoL1.test.ts
+++ b/packages/protocol/test/L1/TaikoL1.test.ts
@@ -169,7 +169,9 @@ describe("integration:TaikoL1", function () {
         );
 
         l2Signer = await l2Provider.getSigner(
-            (await l2Provider.listAccounts())[0]
+            (
+                await l2Provider.listAccounts()
+            )[0]
         );
 
         const addressManager = await (

--- a/packages/protocol/test/genesis/generate_genesis.test.ts
+++ b/packages/protocol/test/genesis/generate_genesis.test.ts
@@ -237,7 +237,7 @@ action("Generate Genesis", function () {
 
             expect(owner).to.be.equal(testConfig.contractOwner);
 
-            await expect(Bridge.enableDestChain(1, true)).not.to.reverted;
+            await expect(Bridge.enableDestChain(1)).not.to.reverted;
 
             await expect(
                 Bridge.processMessage(

--- a/packages/protocol/test/libs/LibTrieProof.test.ts
+++ b/packages/protocol/test/libs/LibTrieProof.test.ts
@@ -67,7 +67,7 @@ describe("integration:LibTrieProof", function () {
             const { chainId } = await ethers.provider.getNetwork();
             const srcChainId = chainId;
             const destChainId = srcChainId + 1;
-            await (await bridge.enableDestChain(destChainId, true)).wait();
+            await (await bridge.enableDestChain(destChainId)).wait();
 
             const message: Message = {
                 id: 1,


### PR DESCRIPTION
This PR separates enable and disable into two separate functions and adds test coverage.

Question: Instead of `onlyOwner`, do we want to say something like `only the person who enable the chainId, can disable it`?