### PR TITLE
feat: implement release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          command: manifest

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,11 @@
+{
+  ".": "0.3.0",
+  "packages/branding": "0.0.0",
+  "packages/bridge-ui": "0.0.0",
+  "packages/protocol": "0.0.0",
+  "packages/relayer": "0.0.0",
+  "packages/status-page": "0.0.0",
+  "packages/tokenomics": "0.0.0",
+  "packages/website": "0.0.0",
+  "packages/whitepaper": "1.2.2"
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2022 Taiko Labs
+Copyright 2023 Taiko Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,10 @@
 {
   "name": "taiko-mono",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "version": "0.0.0",
+  "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "husky install"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
     "husky": "^8.0.3"
   }

--- a/packages/branding/package.json
+++ b/packages/branding/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@taiko/branding",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@taiko/relayer",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/tokenomics/package.json
+++ b/packages/tokenomics/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@taiko/tokenomics",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/whitepaper/package.json
+++ b/packages/whitepaper/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@taiko/whitepaper",
+  "version": "1.2.2",
+  "private": true
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,13 @@
+{
+  "packages": {
+    ".": {},
+    "packages/branding": {},
+    "packages/bridge-ui": {},
+    "packages/protocol": {},
+    "packages/relayer": {},
+    "packages/status-page": {},
+    "packages/tokenomics": {},
+    "packages/website": {},
+    "packages/whitepaper": {}
+  }
+}


### PR DESCRIPTION
## summary of changes
This PR will implement [release-please](https://github.com/googleapis/release-please). git-cliff was not good enough for publishing release-notes, and changesets added unnecessary complexity imo by requiring devs to add a changeset -- this solution will work with our conventional commits standard. I tested it out on my taiko-mono fork, and it works awesome.

I am giving every package, including the root, a `package.json` to declare the version. As we make conventional commits throughout our work iteration, the github-action will update a release PR.

We can merge this release PR at a cadence, and it will bump / release packages for those that have changes in the git diff that matches that sub-package path. It will push some tags: `<packageName>-vx.y.z` for each each sub-package release as well.