### PR TITLE
ci: fix release please initial version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,11 @@
 {
   ".": "0.3.0",
-  "packages/branding": "0.1.0",
-  "packages/bridge-ui": "0.1.0",
-  "packages/protocol": "0.1.0",
-  "packages/relayer": "0.1.0",
-  "packages/status-page": "0.1.0",
-  "packages/tokenomics": "0.1.0",
-  "packages/website": "0.1.0",
+  "packages/branding": "0.0.1",
+  "packages/bridge-ui": "0.0.1",
+  "packages/protocol": "0.0.1",
+  "packages/relayer": "0.0.1",
+  "packages/status-page": "0.0.1",
+  "packages/tokenomics": "0.0.1",
+  "packages/website": "0.0.1",
   "packages/whitepaper": "1.2.2"
 }


### PR DESCRIPTION
I believe this will work to properly set initial version `0.1.0`, after this it should be automatic. If this doesn't work, I have one more option, but let's try this first.