### PR TITLE
feat(protocol): add special logics for alpha-2 testnet

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -80,17 +80,6 @@ contract TaikoL1 is EssentialContract, IHeaderSync, TaikoEvents {
      *          transactions in the L2 block.
      */
     function proposeBlock(bytes[] calldata inputs) external nonReentrant {
-        // For alpha-2 testnet, he network only allows an special address
-        // to propose but anyone to prove. This is the first step of testing
-        // the tokenomics.
-
-        // TODO(daniel): remove this special address.
-        address authorized = resolve("proposer");
-        require(
-            authorized == address(0) || authorized == msg.sender,
-            "L1:unauthorized"
-        );
-
         TaikoData.Config memory config = getConfig();
         LibProposing.proposeBlock({
             state: state,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -80,6 +80,17 @@ contract TaikoL1 is EssentialContract, IHeaderSync, TaikoEvents {
      *          transactions in the L2 block.
      */
     function proposeBlock(bytes[] calldata inputs) external nonReentrant {
+        // For alpha-2 testnet, he network only allows an special address
+        // to propose but anyone to prove. This is the first step of testing
+        // the tokenomics.
+
+        // TODO(daniel): remove this special address.
+        address authorized = resolve("proposer");
+        require(
+            authorized == address(0) || authorized == msg.sender,
+            "L1:unauthorized"
+        );
+
         TaikoData.Config memory config = getConfig();
         LibProposing.proposeBlock({
             state: state,

--- a/packages/protocol/contracts/L1/TkoToken.sol
+++ b/packages/protocol/contracts/L1/TkoToken.sol
@@ -45,7 +45,7 @@ contract TkoToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
         ERC20Upgradeable.__ERC20_init({
             name_: "Taiko USD Stablecoin Token",
             symbol_: "tkUSD",
-            decimals_: 18
+            decimals_: 6
         });
     }
 

--- a/packages/protocol/contracts/L1/TkoToken.sol
+++ b/packages/protocol/contracts/L1/TkoToken.sol
@@ -43,8 +43,8 @@ contract TkoToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
     function init(address _addressManager) external initializer {
         EssentialContract._init(_addressManager);
         ERC20Upgradeable.__ERC20_init({
-            name_: "Taiko Test Token",
-            symbol_: "tTKO",
+            name_: "Taiko USD Stablecoin Token",
+            symbol_: "tkUSD",
             decimals_: 18
         });
     }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -57,7 +57,7 @@ library LibProposing {
         AddressResolver resolver,
         bytes[] calldata inputs
     ) public {
-        // For alpha-2 testnet, he network only allows an special address
+        // For alpha-2 testnet, the network only allows an special address
         // to propose but anyone to prove. This is the first step of testing
         // the tokenomics.
 

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -57,6 +57,17 @@ library LibProposing {
         AddressResolver resolver,
         bytes[] calldata inputs
     ) public {
+        // For alpha-2 testnet, he network only allows an special address
+        // to propose but anyone to prove. This is the first step of testing
+        // the tokenomics.
+
+        // TODO(daniel): remove this special address.
+        address specialProposer = resolver.resolve("special_proposer");
+        require(
+            specialProposer == address(0) || specialProposer == msg.sender,
+            "L1:specialProposer"
+        );
+
         assert(!LibUtils.isHalted(state));
 
         require(inputs.length == 2, "L1:inputs:size");

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -62,7 +62,7 @@ library LibProposing {
         // the tokenomics.
 
         // TODO(daniel): remove this special address.
-        address specialProposer = resolver.resolve("special_proposer");
+        address specialProposer = resolver.resolve("special_proposer", true);
         require(
             specialProposer == address(0) || specialProposer == msg.sender,
             "L1:specialProposer"

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -246,11 +246,15 @@ library LibProving {
 
         bytes32 blockHash = evidence.header.hashBlockHeader();
 
+        // For alpha-2 testnet, the network allows any address to submit ZKP,
+        // but a special prover can skip ZKP verification if the ZKP is empty.
+
+        // TODO(daniel): remove this special address.
         address specialProver = resolve.resolve("special_prover");
 
         for (uint256 i = 0; i < config.zkProofsPerBlock; ++i) {
             if (msg.sender == specialProver && evidence.proofs[i].length == 0) {
-                // The special prover can skip a ZKP verification if the proof is empty.
+                // Skip ZKP verification
             } else {
                 require(
                     proofVerifier.verifyZKP({

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -250,7 +250,7 @@ library LibProving {
         // but a special prover can skip ZKP verification if the ZKP is empty.
 
         // TODO(daniel): remove this special address.
-        address specialProver = resolve.resolve("special_prover");
+        address specialProver = resolver.resolve("special_prover", true);
 
         for (uint256 i = 0; i < config.zkProofsPerBlock; ++i) {
             if (msg.sender == specialProver && evidence.proofs[i].length == 0) {


### PR DESCRIPTION
For alpha-2 testnet, the network only allows an special address to propose but anyone to prove. This is the first step of testing the tokenomics. In this PR, a special prover can skip ZKP verification if the ZKP is empty which is to handle unexpected ZKP circuit bugs.

I also rebranded TkoToken as a Taiko USD stablecoin token, so we don't have to create a marketplace for it and can incentivize people with 1tkUSD == 1 USDT/USDC.

This PR shall be reverted once alpha-2 is shutdown.