### PR TITLE
feat(protocol): improve sync header storage on L2

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -27,7 +27,7 @@ contract TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
     mapping(uint256 => bytes32) private l2Hashes;
     mapping(uint256 => bytes32) private l1Hashes;
     bytes32 public publicInputHash;
-    bytes32 public latestSyncedHeader;
+    bytes32 public latestSyncedL1Height;
 
     uint256[46] private __gap;
 
@@ -79,8 +79,8 @@ contract TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
             _checkPublicInputs();
         }
 
+        latestSyncedL1Height = l1Height;
         l1Hashes[l1Height] = l1Hash;
-        latestSyncedHeader = l1Hash;
         emit HeaderSynced(block.number, l1Height, l1Hash);
     }
 
@@ -140,7 +140,7 @@ contract TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
     }
 
     function getLatestSyncedHeader() public view override returns (bytes32) {
-        return latestSyncedHeader;
+        return l1Hashes[latestSyncedL1Height];
     }
 
     function getBlockHash(uint256 number) public view returns (bytes32) {

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -27,7 +27,7 @@ contract TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
     mapping(uint256 => bytes32) private l2Hashes;
     mapping(uint256 => bytes32) private l1Hashes;
     bytes32 public publicInputHash;
-    bytes32 public latestSyncedL1Height;
+    uint256 public latestSyncedL1Height;
 
     uint256[46] private __gap;
 


### PR DESCRIPTION
Now both the height and the hash of latest synced L1 block is known.