### PR TITLE
revert(protocol): revert whitelist changing

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -40,6 +40,8 @@ library TaikoData {
         uint64 initialUncleDelay;
         bool enableTokenomics;
         bool enablePublicInputsCheck;
+        bool whitelistProposers;
+        bool whitelistProvers;
     }
 
     struct BlockMetadata {
@@ -81,6 +83,8 @@ library TaikoData {
         mapping(uint256 => mapping(bytes32 => ForkChoice)) forkChoices;
         // proposer => commitSlot => hash(commitHash, commitHeight)
         mapping(address => mapping(uint256 => bytes32)) commits;
+        mapping(address => bool) proposers; // Whitelisted proposers
+        mapping(address => bool) provers; // Whitelisted provers
         // Never or rarely changed
         uint64 genesisHeight;
         uint64 genesisTimestamp;
@@ -101,15 +105,6 @@ library TaikoData {
         uint64 avgProofTime;
         uint64 __reservedC1;
         // Reserved
-        uint256[42] __gap;
-    }
-
-    struct TentativeState {
-        mapping(address => bool) proposers; // Whitelisted proposers
-        mapping(address => bool) provers; // Whitelisted provers
-        bool whitelistProposers;
-        bool whitelistProvers;
-        // // Reserved
-        uint256[46] __gap;
+        uint256[40] __gap;
     }
 }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -103,4 +103,13 @@ library TaikoData {
         // Reserved
         uint256[42] __gap;
     }
+
+    struct TentativeState {
+        mapping(address => bool) proposers; // Whitelisted proposers
+        mapping(address => bool) provers; // Whitelisted provers
+        bool whitelistProposers;
+        bool whitelistProvers;
+        // // Reserved
+        uint256[46] __gap;
+    }
 }

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -30,8 +30,6 @@ abstract contract TaikoEvents {
         address prover
     );
 
-    event WhitelistingEnabled(bool whitelistProposers, bool whitelistProvers);
-
     event ProposerWhitelisted(address indexed prover, bool whitelisted);
 
     event ProverWhitelisted(address indexed prover, bool whitelisted);

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -30,5 +30,11 @@ abstract contract TaikoEvents {
         address prover
     );
 
+    event WhitelistingEnabled(bool whitelistProposers, bool whitelistProvers);
+
+    event ProposerWhitelisted(address indexed prover, bool whitelisted);
+
+    event ProverWhitelisted(address indexed prover, bool whitelisted);
+
     event Halted(bool halted);
 }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -24,15 +24,6 @@ library LibProposing {
     );
     event BlockProposed(uint256 indexed id, TaikoData.BlockMetadata meta);
 
-    modifier onlyWhitelistedProposer(
-        TaikoData.TentativeState storage tentative
-    ) {
-        if (tentative.whitelistProposers) {
-            require(tentative.proposers[msg.sender], "L1:whitelist");
-        }
-        _;
-    }
-
     function commitBlock(
         TaikoData.State storage state,
         TaikoData.Config memory config,
@@ -60,10 +51,13 @@ library LibProposing {
     function proposeBlock(
         TaikoData.State storage state,
         TaikoData.Config memory config,
-        TaikoData.TentativeState storage tentative,
         AddressResolver resolver,
         bytes[] calldata inputs
-    ) public onlyWhitelistedProposer(tentative) {
+    ) public {
+        if (config.whitelistProposers) {
+            require(state.proposers[msg.sender], "L1:whitelist");
+        }
+
         assert(!LibUtils.isHalted(state));
 
         require(inputs.length == 2, "L1:inputs:size");

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -46,13 +46,21 @@ library LibProving {
         address prover
     );
 
+    modifier onlyWhitelistedProver(TaikoData.TentativeState storage tentative) {
+        if (tentative.whitelistProvers) {
+            require(tentative.provers[msg.sender], "L1:whitelist");
+        }
+        _;
+    }
+
     function proveBlock(
         TaikoData.State storage state,
+        TaikoData.TentativeState storage tentative,
         TaikoData.Config memory config,
         AddressResolver resolver,
         uint256 blockId,
         bytes[] calldata inputs
-    ) public {
+    ) public onlyWhitelistedProver(tentative) {
         assert(!LibUtils.isHalted(state));
 
         // Check and decode inputs
@@ -149,11 +157,12 @@ library LibProving {
 
     function proveBlockInvalid(
         TaikoData.State storage state,
+        TaikoData.TentativeState storage tentative,
         TaikoData.Config memory config,
         AddressResolver resolver,
         uint256 blockId,
         bytes[] calldata inputs
-    ) public {
+    ) public onlyWhitelistedProver(tentative) {
         assert(!LibUtils.isHalted(state));
 
         // Check and decode inputs

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -46,21 +46,17 @@ library LibProving {
         address prover
     );
 
-    modifier onlyWhitelistedProver(TaikoData.TentativeState storage tentative) {
-        if (tentative.whitelistProvers) {
-            require(tentative.provers[msg.sender], "L1:whitelist");
-        }
-        _;
-    }
-
     function proveBlock(
         TaikoData.State storage state,
-        TaikoData.TentativeState storage tentative,
         TaikoData.Config memory config,
         AddressResolver resolver,
         uint256 blockId,
         bytes[] calldata inputs
-    ) public onlyWhitelistedProver(tentative) {
+    ) public {
+        if (config.whitelistProvers) {
+            require(state.provers[msg.sender], "L1:whitelist");
+        }
+
         assert(!LibUtils.isHalted(state));
 
         // Check and decode inputs
@@ -160,12 +156,15 @@ library LibProving {
 
     function proveBlockInvalid(
         TaikoData.State storage state,
-        TaikoData.TentativeState storage tentative,
         TaikoData.Config memory config,
         AddressResolver resolver,
         uint256 blockId,
         bytes[] calldata inputs
-    ) public onlyWhitelistedProver(tentative) {
+    ) public {
+        if (config.whitelistProvers) {
+            require(state.provers[msg.sender], "L1:whitelist");
+        }
+
         assert(!LibUtils.isHalted(state));
 
         // Check and decode inputs

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -19,49 +19,39 @@ library LibUtils {
 
     bytes32 public constant BLOCK_DEADEND_HASH = bytes32(uint256(1));
 
-    event WhitelistingEnabled(bool whitelistProposers, bool whitelistProvers);
     event ProposerWhitelisted(address indexed proposer, bool whitelisted);
     event ProverWhitelisted(address indexed prover, bool whitelisted);
     event Halted(bool halted);
 
-    function enableWhitelisting(
-        TaikoData.TentativeState storage tentative,
-        bool whitelistProposers,
-        bool whitelistProvers
-    ) internal {
-        tentative.whitelistProposers = whitelistProvers;
-        tentative.whitelistProvers = whitelistProvers;
-        emit WhitelistingEnabled(whitelistProposers, whitelistProvers);
-    }
-
     function whitelistProposer(
-        TaikoData.TentativeState storage tentative,
+        TaikoData.State storage state,
+        TaikoData.Config memory config,
         address proposer,
         bool whitelisted
     ) internal {
-        assert(tentative.whitelistProposers);
+        assert(config.whitelistProposers);
         require(
-            proposer != address(0) &&
-                tentative.proposers[proposer] != whitelisted,
+            proposer != address(0) && state.proposers[proposer] != whitelisted,
             "L1:precondition"
         );
 
-        tentative.proposers[proposer] = whitelisted;
+        state.proposers[proposer] = whitelisted;
         emit ProposerWhitelisted(proposer, whitelisted);
     }
 
     function whitelistProver(
-        TaikoData.TentativeState storage tentative,
+        TaikoData.State storage state,
+        TaikoData.Config memory config,
         address prover,
         bool whitelisted
     ) internal {
-        assert(tentative.whitelistProvers);
+        assert(config.whitelistProvers);
         require(
-            prover != address(0) && tentative.provers[prover] != whitelisted,
+            prover != address(0) && state.provers[prover] != whitelisted,
             "L1:precondition"
         );
 
-        tentative.provers[prover] = whitelisted;
+        state.provers[prover] = whitelisted;
         emit ProverWhitelisted(prover, whitelisted);
     }
 
@@ -131,19 +121,21 @@ library LibUtils {
     }
 
     function isProposerWhitelisted(
-        TaikoData.TentativeState storage tentative,
+        TaikoData.State storage state,
+        TaikoData.Config memory config,
         address proposer
     ) internal view returns (bool) {
-        assert(tentative.whitelistProposers);
-        return tentative.proposers[proposer];
+        assert(config.whitelistProposers);
+        return state.proposers[proposer];
     }
 
     function isProverWhitelisted(
-        TaikoData.TentativeState storage tentative,
+        TaikoData.State storage state,
+        TaikoData.Config memory config,
         address prover
     ) internal view returns (bool) {
-        assert(tentative.whitelistProvers);
-        return tentative.provers[prover];
+        assert(config.whitelistProvers);
+        return state.provers[prover];
     }
 
     // Implement "Incentive Multipliers", see the whitepaper.

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -19,7 +19,51 @@ library LibUtils {
 
     bytes32 public constant BLOCK_DEADEND_HASH = bytes32(uint256(1));
 
+    event WhitelistingEnabled(bool whitelistProposers, bool whitelistProvers);
+    event ProposerWhitelisted(address indexed proposer, bool whitelisted);
+    event ProverWhitelisted(address indexed prover, bool whitelisted);
     event Halted(bool halted);
+
+    function enableWhitelisting(
+        TaikoData.TentativeState storage tentative,
+        bool whitelistProposers,
+        bool whitelistProvers
+    ) internal {
+        tentative.whitelistProposers = whitelistProvers;
+        tentative.whitelistProvers = whitelistProvers;
+        emit WhitelistingEnabled(whitelistProposers, whitelistProvers);
+    }
+
+    function whitelistProposer(
+        TaikoData.TentativeState storage tentative,
+        address proposer,
+        bool whitelisted
+    ) internal {
+        assert(tentative.whitelistProposers);
+        require(
+            proposer != address(0) &&
+                tentative.proposers[proposer] != whitelisted,
+            "L1:precondition"
+        );
+
+        tentative.proposers[proposer] = whitelisted;
+        emit ProposerWhitelisted(proposer, whitelisted);
+    }
+
+    function whitelistProver(
+        TaikoData.TentativeState storage tentative,
+        address prover,
+        bool whitelisted
+    ) internal {
+        assert(tentative.whitelistProvers);
+        require(
+            prover != address(0) && tentative.provers[prover] != whitelisted,
+            "L1:precondition"
+        );
+
+        tentative.provers[prover] = whitelisted;
+        emit ProverWhitelisted(prover, whitelisted);
+    }
 
     function halt(TaikoData.State storage state, bool toHalt) internal {
         require(isHalted(state) != toHalt, "L1:precondition");
@@ -84,6 +128,22 @@ library LibUtils {
         TaikoData.State storage state
     ) internal view returns (bool) {
         return isBitOne(state, MASK_HALT);
+    }
+
+    function isProposerWhitelisted(
+        TaikoData.TentativeState storage tentative,
+        address proposer
+    ) internal view returns (bool) {
+        assert(tentative.whitelistProposers);
+        return tentative.proposers[proposer];
+    }
+
+    function isProverWhitelisted(
+        TaikoData.TentativeState storage tentative,
+        address prover
+    ) internal view returns (bool) {
+        assert(tentative.whitelistProvers);
+        return tentative.provers[prover];
     }
 
     // Implement "Incentive Multipliers", see the whitepaper.

--- a/packages/protocol/contracts/libs/LibSharedConfig.sol
+++ b/packages/protocol/contracts/libs/LibSharedConfig.sol
@@ -42,7 +42,9 @@ library LibSharedConfig {
                 bootstrapDiscountHalvingPeriod: 180 days,
                 initialUncleDelay: 60 minutes,
                 enableTokenomics: false,
-                enablePublicInputsCheck: true
+                enablePublicInputsCheck: true,
+                whitelistProposers: true,
+                whitelistProvers: true
             });
     }
 }

--- a/packages/protocol/contracts/test/L1/TestTaikoL1.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL1.sol
@@ -49,6 +49,8 @@ contract TestTaikoL1 is TaikoL1, IProofVerifier {
         config.initialUncleDelay = 1 minutes;
         config.enableTokenomics = false;
         config.enablePublicInputsCheck = true;
+        config.whitelistProposers = false;
+        config.whitelistProvers = false;
     }
 
     function verifyZKP(

--- a/packages/protocol/contracts/test/L1/TestTaikoL1EnableTokenomics.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL1EnableTokenomics.sol
@@ -49,6 +49,8 @@ contract TestTaikoL1EnableTokenomics is TaikoL1, IProofVerifier {
         config.initialUncleDelay = 1 seconds;
         config.enableTokenomics = true;
         config.enablePublicInputsCheck = false;
+        config.whitelistProposers = false;
+        config.whitelistProvers = false;
     }
 
     function verifyZKP(

--- a/packages/protocol/contracts/test/L1/TestTaikoL2.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL2.sol
@@ -50,5 +50,7 @@ contract TestTaikoL2 is TaikoL2 {
         config.initialUncleDelay = 1 minutes;
         config.enableTokenomics = true;
         config.enablePublicInputsCheck = false;
+        config.whitelistProposers = false;
+        config.whitelistProvers = false;
     }
 }

--- a/packages/protocol/contracts/test/L1/TestTaikoL2EnablePublicInputsCheck.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL2EnablePublicInputsCheck.sol
@@ -50,5 +50,7 @@ contract TestTaikoL2EnablePublicInputsCheck is TaikoL2 {
         config.initialUncleDelay = 1 minutes;
         config.enableTokenomics = true;
         config.enablePublicInputsCheck = true;
+        config.whitelistProposers = false;
+        config.whitelistProvers = false;
     }
 }


### PR DESCRIPTION
After discussing with Shanghai team, we feel like for testnet alpha-2, we need to whitelist both provers and proposers.