### PR TITLE
feat(protocol): proposers must assert the header of new blocks.

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -54,6 +54,7 @@ library TaikoData {
         uint64 timestamp;
         uint64 commitHeight;
         uint64 commitSlot;
+        bytes32 assertedBlockHash;
     }
 
     // 3 slots
@@ -62,6 +63,7 @@ library TaikoData {
         uint256 deposit;
         address proposer;
         uint64 proposedAt;
+        bytes32 assertedBlockHash;
     }
 
     // 3 + n slots

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -40,6 +40,7 @@ library TaikoData {
         uint64 initialUncleDelay;
         bool enableTokenomics;
         bool enablePublicInputsCheck;
+        bool checkAssertedBlockHash;
     }
 
     struct BlockMetadata {

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -54,7 +54,7 @@ library TaikoData {
         uint64 timestamp;
         uint64 commitHeight;
         uint64 commitSlot;
-        bytes32 assertedBlockHash;
+        bytes32 assertedBlockHash; // TODO(daniel): remove this field.
     }
 
     // 3 slots
@@ -63,7 +63,7 @@ library TaikoData {
         uint256 deposit;
         address proposer;
         uint64 proposedAt;
-        bytes32 assertedBlockHash;
+        bytes32 assertedBlockHash; // TODO(daniel): remove this field.
     }
 
     // 3 + n slots

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -253,7 +253,12 @@ library LibProposing {
         require(meta.extraData.length <= 32, "L1:extraData");
 
         if (config.checkAssertedBlockHash) {
-            require(meta.assertedBlockHash != 0, "L1:assertedBlockHash");
+            require(
+                meta.assertedBlockHash != 0,
+                "L1:assertedBlockHash:nonZero"
+            );
+        } else {
+            require(meta.assertedBlockHash == 0, "L1:assertedBlockHash:zero");
         }
     }
 

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -251,6 +251,10 @@ library LibProposing {
 
         require(meta.gasLimit <= config.blockMaxGasLimit, "L1:gasLimit");
         require(meta.extraData.length <= 32, "L1:extraData");
+
+        if (config.checkAssertedBlockHash) {
+            require(meta.assertedBlockHash != 0, "L1:assertedBlockHash");
+        }
     }
 
     function _calculateCommitHash(

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -131,7 +131,8 @@ library LibProposing {
                 metaHash: meta.hashMetadata(),
                 deposit: deposit,
                 proposer: msg.sender,
-                proposedAt: meta.timestamp
+                proposedAt: meta.timestamp,
+                assertedBlockHash: meta.assertedBlockHash
             })
         );
 

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -373,7 +373,9 @@ library LibProving {
         );
         require(pb.metaHash == meta.hashMetadata(), "L1:metaHash");
         // TODO(daniel): remove the next line
-        require(pb.assertedBlockHash == blockHash, "L1:assertedBlockHash");
+        if (config.checkAssertedBlockHash) {
+            require(pb.assertedBlockHash == blockHash, "L1:assertedBlockHash");
+        }
     }
 
     function _validateHeaderForMetadata(

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -371,8 +371,9 @@ library LibProving {
             config.maxNumBlocks,
             meta.id
         );
-        require(pb.assertedBlockHash == blockHash, "L1:assertedBlockHash");
         require(pb.metaHash == meta.hashMetadata(), "L1:metaHash");
+        // TODO(daniel): remove the next line
+        require(pb.assertedBlockHash == blockHash, "L1:assertedBlockHash");
     }
 
     function _validateHeaderForMetadata(

--- a/packages/protocol/contracts/libs/LibSharedConfig.sol
+++ b/packages/protocol/contracts/libs/LibSharedConfig.sol
@@ -42,7 +42,8 @@ library LibSharedConfig {
                 bootstrapDiscountHalvingPeriod: 180 days,
                 initialUncleDelay: 60 minutes,
                 enableTokenomics: false,
-                enablePublicInputsCheck: true
+                enablePublicInputsCheck: true,
+                checkAssertedBlockHash: false
             });
     }
 }

--- a/packages/protocol/contracts/test/L1/TestTaikoL1.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL1.sol
@@ -49,6 +49,7 @@ contract TestTaikoL1 is TaikoL1, IProofVerifier {
         config.initialUncleDelay = 1 minutes;
         config.enableTokenomics = false;
         config.enablePublicInputsCheck = true;
+        config.checkAssertedBlockHash = false;
     }
 
     function verifyZKP(

--- a/packages/protocol/contracts/test/L1/TestTaikoL1EnableTokenomics.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL1EnableTokenomics.sol
@@ -49,6 +49,7 @@ contract TestTaikoL1EnableTokenomics is TaikoL1, IProofVerifier {
         config.initialUncleDelay = 1 seconds;
         config.enableTokenomics = true;
         config.enablePublicInputsCheck = false;
+        config.checkAssertedBlockHash = false;
     }
 
     function verifyZKP(

--- a/packages/protocol/contracts/test/L1/TestTaikoL2.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL2.sol
@@ -50,5 +50,6 @@ contract TestTaikoL2 is TaikoL2 {
         config.initialUncleDelay = 1 minutes;
         config.enableTokenomics = true;
         config.enablePublicInputsCheck = false;
+        config.checkAssertedBlockHash = false;
     }
 }

--- a/packages/protocol/contracts/test/L1/TestTaikoL2EnablePublicInputsCheck.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL2EnablePublicInputsCheck.sol
@@ -50,5 +50,6 @@ contract TestTaikoL2EnablePublicInputsCheck is TaikoL2 {
         config.initialUncleDelay = 1 minutes;
         config.enableTokenomics = true;
         config.enablePublicInputsCheck = true;
+        config.checkAssertedBlockHash = false;
     }
 }


### PR DESCRIPTION
This is a temporary feature for testnet alpha-2 to allow permissioned proposers and permissionless provers.

### Why we need this:
the current ZKP is comprehensive, a malicious prover may generate a variable ZKP with an incorrect block hash. The current approach is to allow trusted proposers to assert block hashes at the time of block proposal and force the protocol to reject all ZKP that asserts different block headers. When our circuits are more comprehensive, we can revert this change.