### PR TITLE
feat(protocol): add `proto_broker` / `oracle_prover` addresses into `AddressManager` in deploy_L1 script

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,7 +18,7 @@
     "test:genesis": "./test/genesis/generate_genesis.test.sh",
     "test:integration": "TEST_TYPE=integration ./test/test_integration.sh",
     "test:tokenomics": "TEST_TYPE=tokenomics ./test/test_integration.sh",
-    "deploy:hardhat": "./scripts/download_solc.sh && LOG_LEVEL=debug pnpm hardhat deploy_L1 --network hardhat --dao-vault 0xdf08f82de32b8d460adbe8d72043e3a7e25a3b39 --team-vault 0xdf08f82de32b8d460adbe8d72043e3a7e25a3b39 --l2-genesis-block-hash 0xee1950562d42f0da28bd4550d88886bc90894c77c9c9eaefef775d4c8223f259 --bridge-funder-private-key ddbf12f72c946bb1e6de5eaf580c51db51828ba198d9b0dba9c7d48ec748dc04 --bridge-fund 0xff --confirmations 1",
+    "deploy:hardhat": "./scripts/download_solc.sh && LOG_LEVEL=debug pnpm hardhat deploy_L1 --network hardhat --dao-vault 0xdf08f82de32b8d460adbe8d72043e3a7e25a3b39 --team-vault 0xdf08f82de32b8d460adbe8d72043e3a7e25a3b39 --l2-genesis-block-hash 0xee1950562d42f0da28bd4550d88886bc90894c77c9c9eaefef775d4c8223f259 --bridge-funder-private-key ddbf12f72c946bb1e6de5eaf580c51db51828ba198d9b0dba9c7d48ec748dc04 --bridge-fund 0xff --oracle-prover 0xdf08f82de32b8d460adbe8d72043e3a7e25a3b39 --confirmations 1",
     "lint-staged": "lint-staged --allow-empty"
   },
   "lint-staged": {

--- a/packages/protocol/tasks/deploy_L1.ts
+++ b/packages/protocol/tasks/deploy_L1.ts
@@ -137,6 +137,15 @@ export async function deployContracts(hre: any) {
         await AddressManager.setAddress(`${chainId}.taiko`, TaikoL1.address)
     );
 
+    // Used by TkoToken
+    await utils.waitTx(
+        hre,
+        await AddressManager.setAddress(
+            `${chainId}.proto_broker`,
+            TaikoL1.address
+        )
+    );
+
     // Bridge
     const Bridge = await deployBridge(hre, AddressManager.address);
 

--- a/packages/protocol/tasks/deploy_L1.ts
+++ b/packages/protocol/tasks/deploy_L1.ts
@@ -32,6 +32,12 @@ task("deploy_L1")
         types.string
     )
     .addOptionalParam(
+        "oracleProver",
+        "Address of the oracle prover",
+        "",
+        types.string
+    )
+    .addOptionalParam(
         "confirmations",
         "Number of confirmations to wait for deploy transaction.",
         config.K_DEPLOY_CONFIRMATIONS,
@@ -65,6 +71,7 @@ export async function deployContracts(hre: any) {
     const l2ChainId = hre.args.l2ChainId;
     const bridgeFunderPrivateKey = hre.args.bridgeFunderPrivateKey;
     const bridgeFund = hre.args.bridgeFund;
+    const oracleProver = hre.args.oracleProver;
 
     log.debug(`network: ${network}`);
     log.debug(`chainId: ${chainId}`);
@@ -75,6 +82,7 @@ export async function deployContracts(hre: any) {
     log.debug(`l2ChainId: ${l2ChainId}`);
     log.debug(`bridgeFunderPrivateKey: ${bridgeFunderPrivateKey}`);
     log.debug(`bridgeFund: ${bridgeFund}`);
+    log.debug(`oracleProver: ${oracleProver}`);
     log.debug(`confirmations: ${hre.args.confirmations}`);
     log.debug();
 
@@ -214,6 +222,16 @@ export async function deployContracts(hre: any) {
             PlonkVerifier.address
         )
     );
+
+    if (ethers.utils.isAddress(oracleProver)) {
+        await utils.waitTx(
+            hre,
+            await AddressManager.setAddress(
+                `${chainId}.oracle_prover`,
+                oracleProver
+            )
+        );
+    }
 
     // save deployments
     const deployments = {


### PR DESCRIPTION
`proto_broker` address is used by `TkoToken`: https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/contracts/L1/TkoToken.sol#L80