### PR TITLE
fix(protocol): allow resolver to return zero address for EtherVault

### DIFF
--- a/packages/protocol/contracts/bridge/libs/LibBridgeProcess.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeProcess.sol
@@ -77,7 +77,7 @@ library LibBridgeProcess {
         );
 
         // We retrieve the necessary ether from EtherVault
-        address ethVault = resolver.resolve("ether_vault", false);
+        address ethVault = resolver.resolve("ether_vault", true);
         if (ethVault != address(0)) {
             EtherVault(payable(ethVault)).releaseEther(
                 message.depositValue + message.callValue + message.processingFee


### PR DESCRIPTION
this is already checked by the addressResolved because we pass in `false` to the function. this makes sure it cannot return the zero address.