### PR TITLE
fix(protocol): Unnecessary require in TaikoL2

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -110,7 +110,6 @@ contract TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
             hint: hint,
             txIdx: txIdx
         });
-        require(reason != LibInvalidTxList.Reason.OK, "L2:reason");
 
         if (config.enablePublicInputsCheck) {
             _checkPublicInputs();

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -104,7 +104,7 @@ contract TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
         require(tx.gasprice == 0, "L2:gasPrice");
 
         TaikoData.Config memory config = getConfig();
-        LibInvalidTxList.Reason reason = LibInvalidTxList.isTxListInvalid({
+        LibInvalidTxList.isTxListInvalid({
             config: config,
             encoded: txList,
             hint: hint,

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -104,7 +104,7 @@ contract TaikoL2 is AddressResolver, ReentrancyGuard, IHeaderSync {
         require(tx.gasprice == 0, "L2:gasPrice");
 
         TaikoData.Config memory config = getConfig();
-        LibInvalidTxList.isTxListInvalid({
+        LibInvalidTxList.assertTxListInvalid({
             config: config,
             encoded: txList,
             hint: hint,

--- a/packages/protocol/contracts/libs/LibInvalidTxList.sol
+++ b/packages/protocol/contracts/libs/LibInvalidTxList.sol
@@ -47,7 +47,7 @@ library LibInvalidTxList {
         TX_GAS_LIMIT_TOO_SMALL
     }
 
-    function isTxListInvalid(
+    function assertTxListInvalid(
         TaikoData.Config memory config,
         bytes calldata encoded,
         Reason hint,


### PR DESCRIPTION
we dont need to check the reason from `isTxListInvalid`, we can actually just call the function and save on gas. It will either provide a valid reason, which we dont care about because the function is incapable of returning `Reason.OK`, so any reason is fine, the function reverts being unable to prove that it's invalid.

@dantaik i may be wrong here?