### PR TITLE
fix(website): fix link to the contract addresses

### DIFF
--- a/packages/website/pages/docs/testnet-guide/use-the-bridge.md
+++ b/packages/website/pages/docs/testnet-guide/use-the-bridge.md
@@ -1,6 +1,6 @@
 # Use the bridge
 
-These steps will help you to use the bridge to transfer assets between Ethereum A1 and Taiko A1. All the bridge contracts can be found [here](/docs/reference/testnet/contract-addresses).
+These steps will help you to use the bridge to transfer assets between Ethereum A1 and Taiko A1. All the bridge contracts can be found [here](/docs/reference/contract-addresses).
 
 ## Prerequisites
 


### PR DESCRIPTION
There is a broken link on the page https://taiko.xyz/docs/testnet-guide/use-the-bridge in the sentence All the bridge contracts can be found [here](https://taiko.xyz/docs/reference/testnet/contract-addresses). 
Changed with the correct one - https://taiko.xyz/docs/reference/contract-addresses