### PR TITLE
fix(bridge-ui): changed faucet address to correct

### DIFF
--- a/packages/bridge-ui/src/components/HeaderAnnouncement.svelte
+++ b/packages/bridge-ui/src/components/HeaderAnnouncement.svelte
@@ -4,7 +4,7 @@
       <p class="font-medium text-white">
         <span class="md:inline"
           >Receive some tokens for bridging with our <a
-            href="https://taiko.xyz/docs/alpha-1-testnet-guide/request-from-faucet"
+            href="https://taiko.xyz/docs/testnet-guide/request-from-faucet"
             target="_blank"
             rel="noopener noreferrer"
             class="font-bold text-white underline">faucet</a


### PR DESCRIPTION
Popup message had a broken link, changed to correct one