### PR TITLE
feat(protocol): re-implement bridge receive check

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -51,7 +51,7 @@ contract Bridge is EssentialContract, IBridge {
     receive() external payable {
         require(
             msg.sender == resolve("token_vault", true) ||
-                msg.sender == resolve("ether_valut", true) ||
+                msg.sender == resolve("ether_vault", true) ||
                 msg.sender == owner(),
             "B:receive"
         );

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -50,9 +50,9 @@ contract Bridge is EssentialContract, IBridge {
     /// Allow Bridge to receive ETH from the TokenVault or EtherVault.
     receive() external payable {
         require(
-            msg.sender == owner() ||
-                msg.sender == resolve("token_vault", true) ||
-                msg.sender == resolve("ether_valut", true),
+            msg.sender == resolve("token_vault", true) ||
+                msg.sender == resolve("ether_valut", true) ||
+                msg.sender == owner(),
             "B:receive"
         );
     }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -50,8 +50,9 @@ contract Bridge is EssentialContract, IBridge {
     /// Allow Bridge to receive ETH from the TokenVault or EtherVault.
     receive() external payable {
         require(
-            msg.sender != resolve("token_vault", true) &&
-                msg.sender != resolve("ether_valut", true),
+            msg.sender == owner() ||
+                msg.sender == resolve("token_vault", true) ||
+                msg.sender == resolve("ether_valut", true),
             "B:receive"
         );
     }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -49,7 +49,11 @@ contract Bridge is EssentialContract, IBridge {
 
     /// Allow Bridge to receive ETH from the TokenVault or EtherVault.
     receive() external payable {
-        // TODO(dave,PR#13110): require the sender is the TokenVault or EtherVault
+        require(
+            msg.sender != resolve("token_vault", true) &&
+                msg.sender != resolve("ether_valut", true),
+            "B:receive"
+        );
     }
 
     /// @dev Initializer to be called after being deployed behind a proxy.


### PR DESCRIPTION
This implementation is slightly different from the previous implementation in that we all the resolve to return empty values. It does't has security issues compared to the previous one.
I also allow the  owner() in the receive just in case.