### PR TITLE
fix(relayer): estimate gas, now that gas estimation works again

### DIFF
--- a/packages/relayer/message/process_message.go
+++ b/packages/relayer/message/process_message.go
@@ -128,20 +128,18 @@ func (p *Processor) sendProcessMessageCall(
 		return nil, errors.New("p.getLatestNonce")
 	}
 
-	// profitable, gas, err := p.isProfitable(ctx, event.Message, proof)
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "p.isProfitable")
-	// }
+	profitable, gas, err := p.isProfitable(ctx, event.Message, proof)
+	if err != nil {
+		return nil, errors.Wrap(err, "p.isProfitable")
+	}
 
-	// if bool(p.profitableOnly) && !profitable {
-	// 	return nil, relayer.ErrUnprofitable
-	// }
+	if bool(p.profitableOnly) && !profitable {
+		return nil, relayer.ErrUnprofitable
+	}
 
-	// if gas != 0 {
-	// 	auth.GasLimit = gas
-	// 	log.Infof("gasLimit: %v", gas)
-	// }
-	auth.GasLimit = 1200000
+	if gas != 0 {
+		auth.GasLimit = gas
+	}
 
 	// process the message on the destination bridge.
 	tx, err := p.destBridge.ProcessMessage(auth, event.Message, proof)


### PR DESCRIPTION
Gas estimation was having an issue before, we hardcoded gas amount. It now works again, so we can re-enable the gas estimation, as well as the relayer determining if a tx is profitable. This will fix some relayer revert transactions.