### PR TITLE
feat(protocol): disable contracts as msg.sender

### DIFF
--- a/packages/protocol/contracts/L1/TaikoCustomErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoCustomErrors.sol
@@ -27,6 +27,7 @@ abstract contract TaikoCustomErrors {
     error L1_CIRCUIT_LENGTH();
     error L1_COMMITTED();
     error L1_CONFLICT_PROOF();
+    error L1_CONTRACT_NOT_ALLOWED();
     error L1_DUP_PROVERS();
     error L1_EXTRA_DATA();
     error L1_GAS_LIMIT();
@@ -34,6 +35,7 @@ abstract contract TaikoCustomErrors {
     error L1_HALT_CONDITION();
     error L1_ID();
     error L1_INPUT_SIZE();
+    error L1_INVALID_PARAM();
     error L1_METADATA_FIELD();
     error L1_META_MISMATCH();
     error L1_NOT_COMMITTED();

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -30,7 +30,10 @@ contract TaikoL1 is
     TaikoData.State public state;
     uint256[100] private __gap;
 
-    error L1_INVALID_PARAM();
+    modifier onlyFromEOA() {
+        if (msg.sender != tx.origin) revert L1_CONTRACT_NOT_ALLOWED();
+        _;
+    }
 
     function init(
         address _addressManager,
@@ -83,7 +86,9 @@ contract TaikoL1 is
      *          n transactions in `txList`, then there will be up to n+1
      *          transactions in the L2 block.
      */
-    function proposeBlock(bytes[] calldata inputs) external nonReentrant {
+    function proposeBlock(
+        bytes[] calldata inputs
+    ) external onlyFromEOA nonReentrant {
         TaikoData.Config memory config = getConfig();
         LibProposing.proposeBlock({
             state: state,
@@ -118,7 +123,7 @@ contract TaikoL1 is
     function proveBlock(
         uint256 blockId,
         bytes[] calldata inputs
-    ) external nonReentrant {
+    ) external onlyFromEOA nonReentrant {
         TaikoData.Config memory config = getConfig();
         LibProving.proveBlock({
             state: state,
@@ -153,7 +158,7 @@ contract TaikoL1 is
     function proveBlockInvalid(
         uint256 blockId,
         bytes[] calldata inputs
-    ) external nonReentrant {
+    ) external onlyFromEOA nonReentrant {
         TaikoData.Config memory config = getConfig();
 
         LibProving.proveBlockInvalid({
@@ -176,7 +181,7 @@ contract TaikoL1 is
      * Verify up to N blocks.
      * @param maxBlocks Max number of blocks to verify.
      */
-    function verifyBlocks(uint256 maxBlocks) external nonReentrant {
+    function verifyBlocks(uint256 maxBlocks) external onlyFromEOA nonReentrant {
         if (maxBlocks == 0) revert L1_INVALID_PARAM();
         LibVerifying.verifyBlocks({
             state: state,


### PR DESCRIPTION
I'm being cautious here as many hacks are done by creating a msg-sending contract to interact with the target contract. 

This PR enforce all msg.senders for proposeBlock, proveBlock, and verifyBlocks must be EOA, but doesn't prevent prover address to be contracts to receive rewards.