### PR TITLE
feat(protocol): sync signal service storage roots

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -70,7 +70,7 @@ library TaikoData {
 
     // 3 + n slots
     struct ForkChoice {
-        bytes32 blockHash;
+        IHeaderSync.SyncData l2SyncData;
         uint64 provenAt;
         address[] provers;
     }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -6,7 +6,8 @@
 
 pragma solidity ^0.8.18;
 
-import {IHeaderSync} from "../common/IHeaderSync.sol";
+import {SyncData} from "../common/IHeaderSync.sol";
+import {BlockHeader} from "../libs/LibBlockHeader.sol";
 
 library TaikoData {
     struct Config {
@@ -44,11 +45,10 @@ library TaikoData {
         bool enablePublicInputsCheck;
         bool enableOracleProver;
     }
-
     struct BlockMetadata {
         uint256 id;
         uint256 l1Height;
-        IHeaderSync.SyncData l1SyncData;
+        SyncData l1SyncData;
         address beneficiary;
         bytes32 txListHash;
         bytes32 txListProofHash;
@@ -70,16 +70,26 @@ library TaikoData {
 
     // 3 + n slots
     struct ForkChoice {
-        IHeaderSync.SyncData l2SyncData;
+        SyncData l2SyncData;
         uint64 provenAt;
         address[] provers;
+    }
+
+    struct Evidence {
+        TaikoData.BlockMetadata meta;
+        BlockHeader header;
+        bytes32 l2SignalServiceStorageRoot;
+        address prover;
+        bytes[] proofs; // The first zkProofsPerBlock are ZKPs,
+        // followed by MKPs.
+        uint16[] circuits; // The circuits IDs (size === zkProofsPerBlock)
     }
 
     // This struct takes 9 slots.
     struct State {
         // some blocks' hashes won't be persisted,
         // only the latest one if verified in a batch
-        mapping(uint256 blockId => IHeaderSync.SyncData) l2SyncData;
+        mapping(uint256 blockId => SyncData) l2SyncData;
         mapping(uint256 blockId => ProposedBlock proposedBlock) proposedBlocks;
         // solhint-disable-next-line max-line-length
         mapping(uint256 blockId => mapping(bytes32 parentHash => ForkChoice)) forkChoices;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -49,8 +49,7 @@ library TaikoData {
     struct BlockMetadata {
         uint256 id;
         uint256 l1Height;
-        bytes32 l1Hash;
-        bytes32 l1SignalServiceStorageRoot;
+        IHeaderSync.SyncData l1SyncData;
         address beneficiary;
         bytes32 txListHash;
         bytes32 mixHash;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -6,6 +6,8 @@
 
 pragma solidity ^0.8.18;
 
+import {IHeaderSync} from "../common/IHeaderSync.sol";
+
 library TaikoData {
     struct Config {
         uint256 chainId;
@@ -48,6 +50,7 @@ library TaikoData {
         uint256 id;
         uint256 l1Height;
         bytes32 l1Hash;
+        bytes32 l1SignalServiceStorageRoot;
         address beneficiary;
         bytes32 txListHash;
         bytes32 mixHash;
@@ -77,7 +80,7 @@ library TaikoData {
     struct State {
         // some blocks' hashes won't be persisted,
         // only the latest one if verified in a batch
-        mapping(uint256 blockId => bytes32 blockHash) l2Hashes;
+        mapping(uint256 blockId => IHeaderSync.SyncData) l2SyncData;
         mapping(uint256 blockId => ProposedBlock proposedBlock) proposedBlocks;
         // solhint-disable-next-line max-line-length
         mapping(uint256 blockId => mapping(bytes32 parentHash => ForkChoice forkChoice)) forkChoices;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -82,7 +82,7 @@ library TaikoData {
         mapping(uint256 blockId => IHeaderSync.SyncData) l2SyncData;
         mapping(uint256 blockId => ProposedBlock proposedBlock) proposedBlocks;
         // solhint-disable-next-line max-line-length
-        mapping(uint256 blockId => mapping(bytes32 parentHash => ForkChoice forkChoice)) forkChoices;
+        mapping(uint256 blockId => mapping(bytes32 parentHash => ForkChoice)) forkChoices;
         // solhint-disable-next-line max-line-length
         mapping(address proposerAddress => mapping(uint256 commitSlot => bytes32 commitHash)) commits;
         // Never or rarely changed

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -6,12 +6,12 @@
 
 pragma solidity ^0.8.18;
 
-import {IHeaderSync} from "../common/IHeaderSync.sol";
+import {SyncData} from "../common/IHeaderSync.sol";
 import {TaikoData} from "./TaikoData.sol";
 
 abstract contract TaikoEvents {
     // The following events must match the definitions in other V1 libraries.
-    event BlockVerified(uint256 indexed id, IHeaderSync.SyncData syncData);
+    event BlockVerified(uint256 indexed id, SyncData syncData);
 
     event BlockCommitted(uint64 commitSlot, bytes32 commitHash);
 

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -6,11 +6,12 @@
 
 pragma solidity ^0.8.18;
 
+import {IHeaderSync} from "../common/IHeaderSync.sol";
 import {TaikoData} from "./TaikoData.sol";
 
 abstract contract TaikoEvents {
     // The following events must match the definitions in other V1 libraries.
-    event BlockVerified(uint256 indexed id, bytes32 blockHash);
+    event BlockVerified(uint256 indexed id, IHeaderSync.SyncData syncData);
 
     event BlockCommitted(uint64 commitSlot, bytes32 commitHash);
 

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -7,7 +7,7 @@
 pragma solidity ^0.8.18;
 
 import {EssentialContract} from "../common/EssentialContract.sol";
-import {IHeaderSync} from "../common/IHeaderSync.sol";
+import {IHeaderSync, SyncData} from "../common/IHeaderSync.sol";
 import {LibAnchorSignature} from "../libs/LibAnchorSignature.sol";
 import {LibSharedConfig} from "../libs/LibSharedConfig.sol";
 import {TaikoData} from "./TaikoData.sol";
@@ -256,7 +256,7 @@ contract TaikoL1 is
 
     function getSyncData(
         uint256 number
-    ) public view override returns (IHeaderSync.SyncData memory) {
+    ) public view override returns (SyncData memory) {
         return state.getL2BlockHash(number, getConfig().blockHashHistory);
     }
 
@@ -264,7 +264,7 @@ contract TaikoL1 is
         public
         view
         override
-        returns (IHeaderSync.SyncData memory)
+        returns (SyncData memory)
     {
         return
             state.getL2BlockHash(

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -251,13 +251,18 @@ contract TaikoL1 is
             LibProposing.getProposedBlock(state, getConfig().maxNumBlocks, id);
     }
 
-    function getSyncedHeader(
+    function getSyncData(
         uint256 number
-    ) public view override returns (bytes32) {
+    ) public view override returns (IHeaderSync.SyncData memory) {
         return state.getL2BlockHash(number, getConfig().blockHashHistory);
     }
 
-    function getLatestSyncedHeader() public view override returns (bytes32) {
+    function getLatestSyncData()
+        public
+        view
+        override
+        returns (IHeaderSync.SyncData memory)
+    {
         return
             state.getL2BlockHash(
                 state.latestVerifiedHeight,

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -15,6 +15,7 @@ import {TaikoToken} from "../TaikoToken.sol";
 import {LibUtils} from "./LibUtils.sol";
 import {TaikoData} from "../TaikoData.sol";
 import {AddressResolver} from "../../common/AddressResolver.sol";
+import {IHeaderSync} from "../../common/IHeaderSync.sol";
 import {ISignalService} from "../../signal/ISignalService.sol";
 
 library LibProposing {
@@ -104,10 +105,12 @@ library LibProposing {
 
             meta.id = state.nextBlockId;
             meta.l1Height = block.number - 1;
-            meta.l1Hash = blockhash(block.number - 1);
-            meta.l1SignalServiceStorageRoot = ISignalService(
-                resolver.resolve("signal_service", false)
-            ).getStorageRoot();
+            meta.l1SyncData = IHeaderSync.SyncData({
+                blockHash: blockhash(block.number - 1),
+                signalServiceStorageRoot: ISignalService(
+                    resolver.resolve("signal_service", false)
+                ).getStorageRoot()
+            });
 
             meta.timestamp = uint64(block.timestamp);
 
@@ -251,8 +254,8 @@ library LibProposing {
         if (
             meta.id != 0 ||
             meta.l1Height != 0 ||
-            meta.l1Hash != 0 ||
-            meta.l1SignalServiceStorageRoot != 0 ||
+            meta.l1SyncData.blockHash != 0 ||
+            meta.l1SyncData.signalServiceStorageRoot != 0 ||
             meta.mixHash != 0 ||
             meta.timestamp != 0 ||
             meta.beneficiary == address(0) ||

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -15,7 +15,7 @@ import {TaikoToken} from "../TaikoToken.sol";
 import {LibUtils} from "./LibUtils.sol";
 import {TaikoData} from "../TaikoData.sol";
 import {AddressResolver} from "../../common/AddressResolver.sol";
-import {IHeaderSync} from "../../common/IHeaderSync.sol";
+import {SyncData} from "../../common/IHeaderSync.sol";
 import {ISignalService} from "../../signal/ISignalService.sol";
 
 library LibProposing {
@@ -108,7 +108,7 @@ library LibProposing {
 
             meta.id = state.nextBlockId;
             meta.l1Height = block.number - 1;
-            meta.l1SyncData = IHeaderSync.SyncData({
+            meta.l1SyncData = SyncData({
                 blockHash: blockhash(block.number - 1),
                 signalServiceStorageRoot: ISignalService(
                     resolver.resolve("signal_service", false)

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -15,6 +15,7 @@ import {TaikoToken} from "../TaikoToken.sol";
 import {LibUtils} from "./LibUtils.sol";
 import {TaikoData} from "../TaikoData.sol";
 import {AddressResolver} from "../../common/AddressResolver.sol";
+import {ISignalService} from "../../signal/ISignalService.sol";
 
 library LibProposing {
     using LibTxDecoder for bytes;
@@ -104,6 +105,10 @@ library LibProposing {
             meta.id = state.nextBlockId;
             meta.l1Height = block.number - 1;
             meta.l1Hash = blockhash(block.number - 1);
+            meta.l1SignalServiceStorageRoot = ISignalService(
+                resolver.resolve("signal_service", false)
+            ).getStorageRoot();
+
             meta.timestamp = uint64(block.timestamp);
 
             // After The Merge, L1 mixHash contains the prevrandao
@@ -247,6 +252,7 @@ library LibProposing {
             meta.id != 0 ||
             meta.l1Height != 0 ||
             meta.l1Hash != 0 ||
+            meta.l1SignalServiceStorageRoot != 0 ||
             meta.mixHash != 0 ||
             meta.timestamp != 0 ||
             meta.beneficiary == address(0) ||

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -342,8 +342,8 @@ library LibProving {
                 bytes.concat(
                     ANCHOR_TX_SELECTOR,
                     bytes32(evidence.meta.l1Height),
-                    evidence.meta.l1Hash,
-                    evidence.meta.l1SignalServiceStorageRoot
+                    evidence.meta.l1SyncData.blockHash,
+                    evidence.meta.l1SyncData.signalServiceStorageRoot
                 )
             )
         ) revert L1_ANCHOR_CALLDATA();

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -227,7 +227,7 @@ library LibProving {
 
         SyncData memory l2SyncData = SyncData({
             blockHash: blockHash,
-            signalServiceStorageRoot: 0
+            signalServiceStorageRoot: 0 // TODO: read this value
         });
 
         _markBlockProven({

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -10,6 +10,7 @@ import {
     SafeCastUpgradeable
 } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 
+import {IHeaderSync} from "../../common/IHeaderSync.sol";
 import {LibMath} from "../../libs/LibMath.sol";
 import {TaikoData} from "../TaikoData.sol";
 
@@ -55,13 +56,13 @@ library LibUtils {
         TaikoData.State storage state,
         uint256 number,
         uint256 blockHashHistory
-    ) internal view returns (bytes32) {
+    ) internal view returns (IHeaderSync.SyncData memory) {
         if (
             number + blockHashHistory <= state.latestVerifiedHeight ||
             number > state.latestVerifiedHeight
         ) revert L1_BLOCK_NUMBER();
 
-        return state.l2Hashes[number % blockHashHistory];
+        return state.l2SyncData[number % blockHashHistory];
     }
 
     function getStateVariables(

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -10,7 +10,7 @@ import {
     SafeCastUpgradeable
 } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 
-import {IHeaderSync} from "../../common/IHeaderSync.sol";
+import {SyncData} from "../../common/IHeaderSync.sol";
 import {LibMath} from "../../libs/LibMath.sol";
 import {TaikoData} from "../TaikoData.sol";
 
@@ -56,7 +56,7 @@ library LibUtils {
         TaikoData.State storage state,
         uint256 number,
         uint256 blockHashHistory
-    ) internal view returns (IHeaderSync.SyncData memory) {
+    ) internal view returns (SyncData memory) {
         if (
             number + blockHashHistory <= state.latestVerifiedHeight ||
             number > state.latestVerifiedHeight

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -11,7 +11,7 @@ import {
 } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 
 import {AddressResolver} from "../../common/AddressResolver.sol";
-import {IHeaderSync} from "../../common/IHeaderSync.sol";
+import {SyncData} from "../../common/IHeaderSync.sol";
 import {TaikoToken} from "../TaikoToken.sol";
 import {LibUtils} from "./LibUtils.sol";
 import {TaikoData} from "../../L1/TaikoData.sol";
@@ -23,12 +23,9 @@ library LibVerifying {
     using SafeCastUpgradeable for uint256;
     using LibUtils for TaikoData.State;
 
-    event BlockVerified(uint256 indexed id, IHeaderSync.SyncData syncData);
+    event BlockVerified(uint256 indexed id, SyncData syncData);
 
-    event HeaderSynced(
-        uint256 indexed srcHeight,
-        IHeaderSync.SyncData syncData
-    );
+    event HeaderSynced(uint256 indexed srcHeight, SyncData syncData);
 
     error L1_HALTED();
     error L1_0_FEE_BASE();
@@ -45,7 +42,7 @@ library LibVerifying {
         state.feeBase = feeBase;
         state.nextBlockId = 1;
         state.lastProposedAt = uint64(block.timestamp);
-        state.l2SyncData[0] = IHeaderSync.SyncData({
+        state.l2SyncData[0] = SyncData({
             blockHash: genesisBlockHash,
             signalServiceStorageRoot: 0
         });
@@ -124,7 +121,7 @@ library LibVerifying {
                 // verified one in a batch. This is sufficient because the last
                 // verified hash is the only one needed checking the existence
                 // of a cross-chain message with a merkle proof.
-                IHeaderSync.SyncData memory syncData = IHeaderSync.SyncData({
+                SyncData memory syncData = SyncData({
                     blockHash: latestL2Hash,
                     signalServiceStorageRoot: 0x0 // TODO: fc.l2SyncData.signalServiceStorageRoot
                 });

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -126,7 +126,7 @@ library LibVerifying {
                 // of a cross-chain message with a merkle proof.
                 IHeaderSync.SyncData memory syncData = IHeaderSync.SyncData({
                     blockHash: latestL2Hash,
-                    signalServiceStorageRoot: 0x0 // TODO
+                    signalServiceStorageRoot: 0x0 // TODO: fc.l2SyncData.signalServiceStorageRoot
                 });
                 state.l2SyncData[
                     latestL2Height % config.blockHashHistory

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -12,7 +12,7 @@ import {
 } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 import {AddressResolver} from "../common/AddressResolver.sol";
-import {IHeaderSync} from "../common/IHeaderSync.sol";
+import {IHeaderSync, SyncData} from "../common/IHeaderSync.sol";
 import {LibAnchorSignature} from "../libs/LibAnchorSignature.sol";
 import {LibInvalidTxList} from "../libs/LibInvalidTxList.sol";
 import {LibSharedConfig} from "../libs/LibSharedConfig.sol";

--- a/packages/protocol/contracts/bridge/libs/LibBridgeStatus.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeStatus.sol
@@ -73,7 +73,8 @@ library LibBridgeStatus {
             (LibBridgeData.StatusProof)
         );
         bytes32 syncedHeaderHash = IHeaderSync(resolver.resolve("taiko", false))
-            .getSyncedHeader(sp.header.height);
+            .getSyncData(sp.header.height)
+            .blockHash;
 
         if (
             syncedHeaderHash == 0 ||

--- a/packages/protocol/contracts/common/IHeaderSync.sol
+++ b/packages/protocol/contracts/common/IHeaderSync.sol
@@ -6,16 +6,16 @@
 
 pragma solidity ^0.8.18;
 
+struct SyncData {
+    bytes32 blockHash;
+    bytes32 signalServiceStorageRoot;
+}
+
 /**
  * Interface implemented by both the TaikoL1 and TaikoL2 contracts. It exposes
  * the methods needed to access the block hashes of the other chain.
  */
 interface IHeaderSync {
-    struct SyncData {
-        bytes32 blockHash;
-        bytes32 signalServiceStorageRoot;
-    }
-
     event HeaderSynced(uint256 indexed srcHeight, SyncData syncData);
 
     function getSyncData(

--- a/packages/protocol/contracts/common/IHeaderSync.sol
+++ b/packages/protocol/contracts/common/IHeaderSync.sol
@@ -11,9 +11,16 @@ pragma solidity ^0.8.18;
  * the methods needed to access the block hashes of the other chain.
  */
 interface IHeaderSync {
-    event HeaderSynced(uint256 indexed srcHeight, bytes32 srcHash);
+    struct SyncData {
+        bytes32 blockHash;
+        bytes32 signalServiceStorageRoot;
+    }
 
-    function getSyncedHeader(uint256 number) external view returns (bytes32);
+    event HeaderSynced(uint256 indexed srcHeight, SyncData syncData);
 
-    function getLatestSyncedHeader() external view returns (bytes32);
+    function getSyncData(
+        uint256 number
+    ) external view returns (SyncData memory);
+
+    function getLatestSyncData() external view returns (SyncData memory);
 }

--- a/packages/protocol/contracts/libs/LibBlockHeader.sol
+++ b/packages/protocol/contracts/libs/LibBlockHeader.sol
@@ -34,21 +34,22 @@ library LibBlockHeader {
     function hashBlockHeader(
         BlockHeader memory header
     ) internal pure returns (bytes32) {
-        bytes memory rlpHeader = LibRLPWriter.writeList(
-            getBlockHeaderRLPItemsList(header)
-        );
-        return keccak256(rlpHeader);
+        (bytes[] memory items, ) = getBlockHeaderRLPItemsList(header, 0);
+        return keccak256(LibRLPWriter.writeList(items));
     }
 
     function getBlockHeaderRLPItemsList(
-        BlockHeader memory header
-    ) internal pure returns (bytes[] memory list) {
+        BlockHeader memory header,
+        uint256 extraSize
+    ) internal pure returns (bytes[] memory list, uint256 filledCount) {
         if (header.baseFeePerGas == 0) {
             // non-EIP11559 transaction
-            list = new bytes[](15);
+            filledCount = 15;
+            list = new bytes[](15 + extraSize);
         } else {
             // EIP1159 transaction
-            list = new bytes[](16);
+            filledCount = 16;
+            list = new bytes[](16 + extraSize);
         }
         list[0] = LibRLPWriter.writeHash(header.parentHash);
         list[1] = LibRLPWriter.writeHash(header.ommersHash);

--- a/packages/protocol/contracts/signal/ISignalService.sol
+++ b/packages/protocol/contracts/signal/ISignalService.sol
@@ -40,4 +40,9 @@ interface ISignalService {
         bytes32 signal,
         bytes calldata proof
     ) external view returns (bool);
+
+    /**
+     * Return the storage root of this contract.
+     */
+    function getStorageRoot() external view returns (bytes32 storageRoot);
 }

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -62,7 +62,8 @@ contract SignalService is ISignalService, EssentialContract {
         SignalProof memory sp = abi.decode(proof, (SignalProof));
         // Resolve the TaikoL1 or TaikoL2 contract if on Ethereum or Taiko.
         bytes32 syncedHeaderHash = IHeaderSync(resolve("taiko", false))
-            .getSyncedHeader(sp.header.height);
+            .getSyncData(sp.header.height)
+            .blockHash;
 
         return
             syncedHeaderHash != 0 &&
@@ -74,6 +75,12 @@ contract SignalService is ISignalService, EssentialContract {
                 value: bytes32(uint256(1)),
                 mkproof: sp.proof
             });
+    }
+
+    function getStorageRoot() public view returns (bytes32 root) {
+        assembly {
+            root := sload(0)
+        }
     }
 
     /**

--- a/packages/protocol/contracts/test/bridge/TestHeaderSync.sol
+++ b/packages/protocol/contracts/test/bridge/TestHeaderSync.sol
@@ -11,18 +11,23 @@ import {IHeaderSync} from "../../common/IHeaderSync.sol";
 // TODO(roger): remove this file. If you need extra functionality in
 // the Bridge contract, create a TestBridge.sol contract instead.
 contract TestHeaderSync is IHeaderSync {
-    bytes32 public headerHash;
+    SyncData public syncData;
 
-    function setSyncedHeader(bytes32 header) external {
-        headerHash = header;
+    function setSyncedHeader(
+        bytes32 blockHash,
+        bytes32 signalServiceStorageRoot
+    ) external {
+        syncData.blockHash = blockHash;
+        syncData.signalServiceStorageRoot = signalServiceStorageRoot;
     }
 
-    function getSyncedHeader(uint256 number) external view returns (bytes32) {
-        number;
-        return headerHash;
+    function getSyncData(
+        uint256 /*number*/
+    ) external view returns (SyncData memory) {
+        return syncData;
     }
 
-    function getLatestSyncedHeader() external view returns (bytes32) {
-        return headerHash;
+    function getLatestSyncData() external view returns (SyncData memory) {
+        return syncData;
     }
 }

--- a/packages/protocol/contracts/test/bridge/TestHeaderSync.sol
+++ b/packages/protocol/contracts/test/bridge/TestHeaderSync.sol
@@ -6,7 +6,7 @@
 
 pragma solidity ^0.8.18;
 
-import {IHeaderSync} from "../../common/IHeaderSync.sol";
+import {IHeaderSync, SyncData} from "../../common/IHeaderSync.sol";
 
 // TODO(roger): remove this file. If you need extra functionality in
 // the Bridge contract, create a TestBridge.sol contract instead.

--- a/packages/protocol/contracts/test/libs/TestLibProving.sol
+++ b/packages/protocol/contracts/test/libs/TestLibProving.sol
@@ -358,7 +358,7 @@ library TestLibProving {
                 bytes.concat(
                     ANCHOR_TX_SELECTOR,
                     bytes32(evidence.meta.l1Height),
-                    evidence.meta.l1Hash
+                    evidence.meta.l1SyncData.blockHash
                 )
             )
         ) revert L1_ANCHOR_CALLDATA();

--- a/packages/protocol/contracts/test/libs/TestLibProving.sol
+++ b/packages/protocol/contracts/test/libs/TestLibProving.sol
@@ -35,6 +35,7 @@ library TestLibProving {
     struct Evidence {
         TaikoData.BlockMetadata meta;
         BlockHeader header;
+        bytes32 l2SignalServiceStorageRoot;
         address prover;
         bytes[] proofs; // The first zkProofsPerBlock are ZKPs,
         // followed by MKPs.
@@ -210,7 +211,9 @@ library TestLibProving {
         // TODO(daniel): remove this special address.
         if (config.enableOracleProver) {
             bytes32 _blockHash = state
-            .forkChoices[target.id][evidence.header.parentHash].blockHash;
+                .forkChoices[target.id][evidence.header.parentHash]
+                .l2SyncData
+                .blockHash;
 
             if (msg.sender == resolver.resolve("oracle_prover", false)) {
                 if (_blockHash != 0) revert L1_NOT_FIRST_PROVER();
@@ -224,14 +227,6 @@ library TestLibProving {
 
         if (!skipZKPVerification) {
             for (uint256 i; i < config.zkProofsPerBlock; ++i) {
-                bytes32 instance = keccak256(
-                    abi.encode(
-                        blockHash,
-                        evidence.prover,
-                        evidence.meta.txListHash
-                    )
-                );
-
                 if (
                     !proofVerifier.verifyZKP({
                         verifierId: string(
@@ -243,7 +238,7 @@ library TestLibProving {
                             )
                         ),
                         zkproof: evidence.proofs[i],
-                        instance: instance
+                        instance: _getInstance(evidence)
                     })
                 ) revert L1_ZKP();
             }
@@ -255,7 +250,10 @@ library TestLibProving {
             prover: evidence.prover,
             target: target,
             parentHash: evidence.header.parentHash,
-            blockHash: blockHashOverride == 0 ? blockHash : blockHashOverride
+            blockHash: blockHashOverride == 0 ? blockHash : blockHashOverride,
+            signalServiceStorageRoot: blockHashOverride == 0
+                ? evidence.l2SignalServiceStorageRoot
+                : bytes32(0)
         });
     }
 
@@ -265,15 +263,17 @@ library TestLibProving {
         address prover,
         TaikoData.BlockMetadata memory target,
         bytes32 parentHash,
-        bytes32 blockHash
+        bytes32 blockHash,
+        bytes32 signalServiceStorageRoot
     ) private {
         TaikoData.ForkChoice storage fc = state.forkChoices[target.id][
             parentHash
         ];
 
-        if (fc.blockHash == 0) {
+        if (fc.l2SyncData.blockHash == 0) {
             // This is the first proof for this block.
-            fc.blockHash = blockHash;
+            fc.l2SyncData.blockHash = blockHash;
+            fc.l2SyncData.signalServiceStorageRoot = signalServiceStorageRoot;
 
             if (!config.enableOracleProver) {
                 // If the oracle prover is not enabled
@@ -301,7 +301,7 @@ library TestLibProving {
                 if (fc.provers[i] == prover) revert L1_DUP_PROVERS();
             }
 
-            if (fc.blockHash != blockHash) {
+            if (fc.l2SyncData.blockHash != blockHash) {
                 // We have a problem here: two proofs are both valid but claims
                 // the new block has different hashes.
                 if (config.enableOracleProver) {
@@ -358,7 +358,8 @@ library TestLibProving {
                 bytes.concat(
                     ANCHOR_TX_SELECTOR,
                     bytes32(evidence.meta.l1Height),
-                    evidence.meta.l1SyncData.blockHash
+                    evidence.meta.l1SyncData.blockHash,
+                    evidence.meta.l1SyncData.signalServiceStorageRoot
                 )
             )
         ) revert L1_ANCHOR_CALLDATA();
@@ -438,4 +439,27 @@ library TestLibProving {
         BlockHeader memory header,
         TaikoData.BlockMetadata memory meta
     ) private pure {}
+
+    function _getInstance(
+        Evidence memory evidence
+    ) internal pure returns (bytes32 instance) {
+        bytes[] memory headerRLPItemsList = LibBlockHeader
+            .getBlockHeaderRLPItemsList(evidence.header);
+
+        uint256 len = headerRLPItemsList.length;
+        bytes[] memory instanceRLPItemsList = new bytes[](len + 3);
+
+        for (uint256 i; i < len; ++i) {
+            instanceRLPItemsList[i] = headerRLPItemsList[i];
+        }
+        instanceRLPItemsList[len] = LibRLPWriter.writeAddress(evidence.prover);
+        instanceRLPItemsList[len + 1] = LibRLPWriter.writeHash(
+            evidence.meta.txListHash
+        );
+        instanceRLPItemsList[len + 2] = LibRLPWriter.writeHash(
+            evidence.l2SignalServiceStorageRoot
+        );
+
+        instance = keccak256(LibRLPWriter.writeList(instanceRLPItemsList));
+    }
 }

--- a/packages/protocol/test/L1/TaikoL1.integration.test.ts
+++ b/packages/protocol/test/L1/TaikoL1.integration.test.ts
@@ -414,7 +414,7 @@ describe("integration:TaikoL1", function () {
         });
     });
 
-    describe("getLatestSyncedHeader", function () {
+    describe("getLatestSyncData", function () {
         it("iterates through blockHashHistory length and asserts getLatestsyncedHeader returns correct value", async function () {
             l2Provider.on("block", blockListener(chan, genesisHeight));
 
@@ -440,7 +440,7 @@ describe("integration:TaikoL1", function () {
 
                 expect(verifyEvent).not.to.be.undefined;
 
-                const header = await taikoL1.getLatestSyncedHeader();
+                const header = await taikoL1.getLatestSyncData();
                 expect(header).to.be.eq(verifyEvent.args.blockHash);
                 blocks++;
             }

--- a/packages/protocol/test/L1/TaikoL1.test.ts
+++ b/packages/protocol/test/L1/TaikoL1.test.ts
@@ -16,22 +16,22 @@ describe("TaikoL1", function () {
         taikoL1 = await deployTaikoL1(addressManager, genesisHash, false);
     });
 
-    describe("getLatestSyncedHeader()", async function () {
+    describe("getLatestSyncData()", async function () {
         it("should be genesisHash because no headers have been synced", async function () {
-            const hash = await taikoL1.getLatestSyncedHeader();
+            const hash = await taikoL1.getLatestSyncData();
             expect(hash).to.be.eq(genesisHash);
         });
     });
 
-    describe("getSyncedHeader()", async function () {
+    describe("getSyncData()", async function () {
         it("should revert because header number has not been synced", async function () {
-            await expect(taikoL1.getSyncedHeader(1)).to.be.revertedWith(
+            await expect(taikoL1.getSyncData(1)).to.be.revertedWith(
                 "L1_BLOCK_NUMBER()"
             );
         });
 
         it("should return appropraite hash for header", async function () {
-            const hash = await taikoL1.getSyncedHeader(0);
+            const hash = await taikoL1.getSyncData(0);
             expect(hash).to.be.eq(genesisHash);
         });
     });

--- a/packages/protocol/test/L2/TaikoL2.test.ts
+++ b/packages/protocol/test/L2/TaikoL2.test.ts
@@ -22,16 +22,16 @@ describe("TaikoL2", function () {
         });
     });
 
-    describe("getLatestSyncedHeader()", async function () {
+    describe("getLatestSyncData()", async function () {
         it("should be 0 because no headers have been synced", async function () {
-            const hash = await taikoL2.getLatestSyncedHeader();
+            const hash = await taikoL2.getLatestSyncData();
             expect(hash).to.be.eq(ethers.constants.HashZero);
         });
     });
 
-    describe("getSyncedHeader()", async function () {
+    describe("getSyncData()", async function () {
         it("should be 0 because header number has not been synced", async function () {
-            const hash = await taikoL2.getSyncedHeader(1);
+            const hash = await taikoL2.getSyncData(1);
             expect(hash).to.be.eq(ethers.constants.HashZero);
         });
     });

--- a/packages/protocol/test/utils/verify.ts
+++ b/packages/protocol/test/utils/verify.ts
@@ -91,7 +91,7 @@ async function verifyBlockAndAssert(
     }
 
     // latest synced header should be our just-verified block hash.
-    const latestHash = await taikoL1.getLatestSyncedHeader();
+    const latestHash = await taikoL1.getLatestSyncData();
     expect(latestHash).to.be.eq(block.blockHash);
 
     // fork choice should be nullified via _cleanUp in LibVerifying


### PR DESCRIPTION
@Brechtpd @cyberhorsey 

This is a very immature PR that shows the idea of synchronising not only block hash across L1/L2, but also the storageRoot of the signal service.

### The benefits
- Now the signal proof can be shorter as the account proof can be skipped entirely.

### The downsides
- One extra bytes32 needed to prove a block ,and one extra SSTORE needed when a block is proven; one extra SSTORE when one or multiple blocks are proven.
- The new anchor circuit will also need to prove the signal service storage root based on the parent block's block hash.

### Assumptions
I assume the following code can read the storage roof of an account -- from ChatGPT:):
```solidity
function getStorageRoot() public view returns (bytes32 root) {
    assembly {
        root := sload(0)
    }
}
```

@Brechtpd @cyberhorsey please let me know what you think.