### PR TITLE
chore(protocol): update `maxNumBlocks` to `2048`

### DIFF
--- a/packages/protocol/contracts/libs/LibSharedConfig.sol
+++ b/packages/protocol/contracts/libs/LibSharedConfig.sol
@@ -29,7 +29,7 @@ library LibSharedConfig {
         return
             TaikoData.Config({
                 chainId: 167,
-                maxNumBlocks: 61, // owner:daniel
+                maxNumBlocks: 2048, // owner:daniel
                 blockHashHistory: 40, // owner:daniel
                 maxVerificationsPerTx: 10, //owner:david. Each time one more block is verified, there will be ~20k more gas cost.
                 commitConfirmations: 0, // owner:daniel


### PR DESCRIPTION
After a talk with @smtmfft , for the next testnet, we might want to increase the `maxNumBlocks` to a larger number. Then if we find a critical bug in circuits after the launch, @smtmfft will still have enough time to fix this without letting the chain look like halted.