### PR TITLE
fix(protocol): Wrong calculation when minting ERC20 tokens

### DIFF
--- a/packages/protocol/contracts/test/erc20/FreeMintERC20.sol
+++ b/packages/protocol/contracts/test/erc20/FreeMintERC20.sol
@@ -14,6 +14,6 @@ contract FreeMintERC20 is ERC20 {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 
     function mint(address to) public {
-        _mint(to, 5 ** decimals());
+        _mint(to, 5 * (10 ** decimals()));
     }
 }

--- a/packages/protocol/contracts/test/erc20/MayFailFreeMintERC20.sol
+++ b/packages/protocol/contracts/test/erc20/MayFailFreeMintERC20.sol
@@ -15,7 +15,7 @@ contract MayFailFreeMintERC20 is ERC20 {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 
     function mint(address to) public {
-        _mint(to, 5 ** decimals());
+        _mint(to, 5 * (10 ** decimals()));
     }
 
     function transfer(


### PR DESCRIPTION
There was a small mistake in the calculation of the amount to mint. The number of tokens should be multiplied by 10^decimals