### PR TITLE
chore(protocol): update `TaikoConfig.anchorTxGasLimit` due to changes in #13254

### DIFF
--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -36,7 +36,7 @@ library TaikoConfig {
                 maxTransactionsPerBlock: 79, //  owner:david. Set it to 79  (+1 TaikoL2.anchor transaction = 80), and 80 is the upper limit of the Alpha-2 testnet's circuits.
                 maxBytesPerTxList: 120000, // owner:david. Set it to 120KB, since 128KB is the upper size limit of a geth transaction, so using 120KB for the proposed transactions list calldata, 8K for the remaining tx fields.
                 minTxGasLimit: 21000, // owner:david
-                anchorTxGasLimit: 250000, // owner:david
+                anchorTxGasLimit: 260000, // owner:david
                 slotSmoothingFactor: 16789, // owner:daniel
                 rewardBurnBips: 100, // owner:daniel. 100 basis points or 1%
                 proposerDepositPctg: 25, // owner:daniel - 25%

--- a/packages/protocol/test/genesis/generate_genesis.test.ts
+++ b/packages/protocol/test/genesis/generate_genesis.test.ts
@@ -142,6 +142,37 @@ action("Generate Genesis", function () {
             );
         });
 
+        it("TaikoL2", async function () {
+            const TaikoL2Alloc = getContractAlloc("TaikoL2");
+
+            const TaikoL2 = new hre.ethers.Contract(
+                TaikoL2Alloc.address,
+                require("../../artifacts/contracts/L2/TaikoL2.sol/TaikoL2.json").abi,
+                signer
+            );
+
+            let latestL1Height = 1;
+            for (let i = 0; i < 300; i++) {
+                const tx = await TaikoL2.anchor(
+                    latestL1Height++,
+                    ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+                    ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+                    { gasLimit: 1000000 }
+                );
+
+                const receipt = await tx.wait();
+
+                expect(receipt.status).to.be.equal(1);
+
+                if (i === 299) {
+                    console.log({
+                        message: "TaikoL2.anchor gas cost after 256 L2 blocks",
+                        gasUsed: receipt.gasUsed,
+                    });
+                }
+            }
+        });
+
         it("Bridge", async function () {
             const BridgeAlloc = getContractAlloc("Bridge");
             const Bridge = new hre.ethers.Contract(


### PR DESCRIPTION
Due to changes in #13254, `TaikoL2.anchor` will use more gas to execute than before, so the consensus `gasLimit` for `TaikoL2.anchor` needs to be updated:

```
{
  message: 'TaikoL2.anchor gas cost after 256 L2 blocks',
  gasUsed: BigNumber { value: "256376" }
}
```