### PR TITLE
fix(protocol): make download solc script can run outside the protocol dir

### DIFF
--- a/packages/protocol/scripts/download_solc.sh
+++ b/packages/protocol/scripts/download_solc.sh
@@ -2,11 +2,14 @@
 
 set -e
 
-mkdir -p bin && cd bin
+protocol_dir=$(realpath "$(dirname $0)/..")
+solc_bin=${protocol_dir}/bin/solc
 
-if [ -f "solc" ]; then
+if [ -f "${solc_bin}" ]; then
   exit 0
 fi
+
+mkdir -p "$(dirname ${solc_bin})"
 
 VERSION=v0.8.18
 
@@ -19,6 +22,6 @@ else
   exit 1
 fi
 
-wget -O solc https://github.com/ethereum/solidity/releases/download/$VERSION/$SOLC_FILE_NAME
+wget -O "${solc_bin}" https://github.com/ethereum/solidity/releases/download/$VERSION/$SOLC_FILE_NAME
 
-chmod +x solc
+chmod +x "${solc_bin}"


### PR DESCRIPTION
Make the script run outside the protocol directory, which is used in CI scripts, so we don't have to go into the protocol directory (`cd taiko-mono/package/protocol`) and then exit (`cd -`)