### PR TITLE
refactor(protocol): unify proveBlock and proveBlockInvalid [step 3]

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -6,7 +6,6 @@
 
 pragma solidity ^0.8.18;
 
-import {BlockHeader} from "../libs/LibBlockHeader.sol";
 import {Snippet} from "../common/IXchainSync.sol";
 
 library TaikoData {
@@ -45,6 +44,25 @@ library TaikoData {
         bytes32 txListHash;
     }
 
+    struct BlockHeader {
+        bytes32 parentHash;
+        // bytes32 ommersHash;
+        address beneficiary;
+        bytes32 stateRoot;
+        bytes32 transactionsRoot;
+        bytes32 receiptsRoot;
+        // bytes32[8] logsBloom; // must be 0s.
+        // uint256 difficulty; // must be 0
+        uint128 height;
+        uint64 gasLimit;
+        uint64 gasUsed;
+        uint64 timestamp;
+        // bytes extraData; // must be `new bytes(0)`
+        bytes32 mixHash;
+        // uint64 nonce; // must be 0
+        uint256 baseFeePerGas;
+    }
+
     struct BlockMetadata {
         uint256 id;
         uint256 l1Height;
@@ -61,19 +79,13 @@ library TaikoData {
         uint256 circuitId;
     }
 
-    struct ValidBlockEvidence {
+    struct BlockEvidence {
         TaikoData.BlockMetadata meta;
-        ZKProof zkproof; // The block proof
-        address prover;
-        BlockHeader header;
-        bytes32 signalRoot;
-    }
-
-    struct InvalidBlockEvidence {
-        TaikoData.BlockMetadata meta;
-        ZKProof zkproof; // The txListProof
+        ZKProof zkproof;
         address prover;
         bytes32 parentHash;
+        bytes32 blockHash;
+        bytes32 signalRoot;
     }
 
     // 3 slots

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -82,10 +82,10 @@ library TaikoData {
     struct BlockEvidence {
         TaikoData.BlockMetadata meta;
         ZKProof zkproof;
-        address prover;
         bytes32 parentHash;
         bytes32 blockHash;
         bytes32 signalRoot;
+        address prover;
     }
 
     // 3 slots

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -39,18 +39,18 @@ library TaikoData {
     }
 
     struct BlockMetadataInput {
+        bytes32 txListHash;
         address beneficiary;
         uint64 gasLimit;
-        bytes32 txListHash;
     }
 
     struct BlockMetadata {
         uint256 id;
         uint256 l1Height;
         bytes32 l1Hash;
-        address beneficiary;
-        bytes32 txListHash;
         uint256 mixHash;
+        bytes32 txListHash;
+        address beneficiary;
         uint64 gasLimit;
         uint64 timestamp;
     }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -44,25 +44,6 @@ library TaikoData {
         bytes32 txListHash;
     }
 
-    struct BlockHeader {
-        bytes32 parentHash;
-        // bytes32 ommersHash;
-        address beneficiary;
-        bytes32 stateRoot;
-        bytes32 transactionsRoot;
-        bytes32 receiptsRoot;
-        // bytes32[8] logsBloom; // must be 0s.
-        // uint256 difficulty; // must be 0
-        uint128 height;
-        uint64 gasLimit;
-        uint64 gasUsed;
-        uint64 timestamp;
-        // bytes extraData; // must be `new bytes(0)`
-        bytes32 mixHash;
-        // uint64 nonce; // must be 0
-        uint256 baseFeePerGas;
-    }
-
     struct BlockMetadata {
         uint256 id;
         uint256 l1Height;

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -22,6 +22,7 @@ abstract contract TaikoErrors {
     error L1_INVALID_PARAM();
     error L1_INVALID_PROOF();
     error L1_METADATA_FIELD();
+    error L1_NONZERO_SIGNAL_ROOT();
     error L1_NOT_ORACLE_PROVER();
     error L1_SOLO_PROPOSER();
     error L1_TOO_MANY_BLOCKS();

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -91,38 +91,10 @@ contract TaikoL1 is EssentialContract, IXchainSync, TaikoEvents, TaikoErrors {
 
     function proveBlock(
         uint256 blockId,
-        TaikoData.ValidBlockEvidence calldata evidence
+        TaikoData.BlockEvidence calldata evidence
     ) external onlyFromEOA nonReentrant {
         TaikoData.Config memory config = getConfig();
         LibProving.proveBlock({
-            state: state,
-            config: config,
-            resolver: AddressResolver(this),
-            blockId: blockId,
-            evidence: evidence
-        });
-        LibVerifying.verifyBlocks({
-            state: state,
-            config: config,
-            maxBlocks: config.maxVerificationsPerTx
-        });
-    }
-
-    /**
-     * Prove a block is invalid with a zero-knowledge proof and a receipt
-     * merkel proof.
-     *
-     * @param blockId The index of the block to prove. This is also used to
-     *        select the right implementation version.
-     * @param evidence An abi-encoded TaikoData.InvalidBlockEvidence object.
-     */
-    function proveBlockInvalid(
-        uint256 blockId,
-        TaikoData.InvalidBlockEvidence calldata evidence
-    ) external onlyFromEOA nonReentrant {
-        TaikoData.Config memory config = getConfig();
-
-        LibProving.proveBlockInvalid({
             state: state,
             config: config,
             resolver: AddressResolver(this),

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -16,9 +16,9 @@ import {TaikoData} from "../../L1/TaikoData.sol";
 library LibProving {
     using LibUtils for TaikoData.State;
 
-
-    bytes32 public constant  VERIFIER_OK =  // keccak256("Taiko")
-    0xc6baa0f809cf694efa91aff0be8930f6986b3b4037ae3a94e302aeff2f794039;
+    // keccak256("Taiko")
+    bytes32 public constant VERIFIER_OK =
+        0xc6baa0f809cf694efa91aff0be8930f6986b3b4037ae3a94e302aeff2f794039;
 
     event BlockProven(
         uint256 indexed id,
@@ -139,7 +139,8 @@ library LibProving {
                 )
             );
 
-            if (!verified || ret.length != 32 || bytes32(ret) != VERIFIER_OK) revert L1_INVALID_PROOF();
+            if (!verified || ret.length != 32 || bytes32(ret) != VERIFIER_OK)
+                revert L1_INVALID_PROOF();
         }
 
         emit BlockProven({

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -18,7 +18,7 @@ library LibProving {
 
     // keccak256("taiko")
     bytes32 public constant VERIFIER_OK =
-        93ac8fdbfc0b0608f9195474a0dd6242f019f5abc3c4e26ad51fefb059cc0177;
+        0x93ac8fdbfc0b0608f9195474a0dd6242f019f5abc3c4e26ad51fefb059cc0177;
 
     event BlockProven(
         uint256 indexed id,

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -16,9 +16,9 @@ import {TaikoData} from "../../L1/TaikoData.sol";
 library LibProving {
     using LibUtils for TaikoData.State;
 
-    // keccak256("Taiko")
+    // keccak256("taiko")
     bytes32 public constant VERIFIER_OK =
-        0xc6baa0f809cf694efa91aff0be8930f6986b3b4037ae3a94e302aeff2f794039;
+        93ac8fdbfc0b0608f9195474a0dd6242f019f5abc3c4e26ad51fefb059cc0177;
 
     event BlockProven(
         uint256 indexed id,

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -52,8 +52,10 @@ library LibProving {
 
             instance = keccak256(
                 bytes.concat(
-                    bytes32(uint256(uint160(l1SignalService))), // for checking anchor tx
-                    bytes32(uint256(uint160(l2SignalService))), // for checking signalRoot
+                    // for checking anchor tx
+                    bytes32(uint256(uint160(l1SignalService))),
+                    // for checking signalRoot
+                    bytes32(uint256(uint160(l2SignalService))),
                     evidence.blockHash,
                     evidence.signalRoot,
                     bytes32(uint256(uint160(evidence.prover))),

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -52,9 +52,8 @@ library LibProving {
 
             instance = keccak256(
                 bytes.concat(
-                    bytes32(uint256(uint160(l1SignalService))),
-                    bytes32(uint256(uint160(l2SignalService))),
-                    evidence.parentHash,
+                    bytes32(uint256(uint160(l1SignalService))), // for checking anchor tx
+                    bytes32(uint256(uint160(l2SignalService))), // for checking signalRoot
                     evidence.blockHash,
                     evidence.signalRoot,
                     bytes32(uint256(uint160(evidence.prover))),

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -16,6 +16,10 @@ import {TaikoData} from "../../L1/TaikoData.sol";
 library LibProving {
     using LibUtils for TaikoData.State;
 
+
+    bytes32 public constant  VERIFIER_OK =  // keccak256("Taiko")
+    0xc6baa0f809cf694efa91aff0be8930f6986b3b4037ae3a94e302aeff2f794039;
+
     event BlockProven(
         uint256 indexed id,
         bytes32 parentHash,
@@ -125,7 +129,7 @@ library LibProving {
                 );
             }
 
-            (bool verified, ) = verifier.staticcall(
+            (bool verified, bytes memory ret) = verifier.staticcall(
                 bytes.concat(
                     bytes16(0),
                     bytes16(instance), // left 16 bytes of the given instance
@@ -135,7 +139,7 @@ library LibProving {
                 )
             );
 
-            if (!verified) revert L1_INVALID_PROOF();
+            if (!verified || ret.length != 32 || bytes32(ret) != VERIFIER_OK) revert L1_INVALID_PROOF();
         }
 
         emit BlockProven({

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -7,8 +7,6 @@
 pragma solidity ^0.8.18;
 
 import {AddressResolver} from "../../common/AddressResolver.sol";
-import {BlockHeader, LibBlockHeader} from "../../libs/LibBlockHeader.sol";
-import {LibRLPWriter} from "../../thirdparty/LibRLPWriter.sol";
 import {LibTokenomics} from "./LibTokenomics.sol";
 import {LibUtils} from "./LibUtils.sol";
 import {Snippet} from "../../common/IXchainSync.sol";
@@ -16,7 +14,6 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {TaikoData} from "../../L1/TaikoData.sol";
 
 library LibProving {
-    using LibBlockHeader for BlockHeader;
     using LibUtils for TaikoData.State;
 
     event BlockProven(
@@ -29,7 +26,6 @@ library LibProving {
     error L1_CONFLICT_PROOF(Snippet snippet);
     error L1_EVIDENCE_MISMATCH();
     error L1_ID();
-    error L1_INVALID_EVIDENCE();
     error L1_INVALID_PROOF();
     error L1_NOT_ORACLE_PROVER();
 
@@ -38,77 +34,42 @@ library LibProving {
         TaikoData.Config memory config,
         AddressResolver resolver,
         uint256 blockId,
-        TaikoData.ValidBlockEvidence calldata evidence
+        TaikoData.BlockEvidence calldata evidence
     ) internal {
         TaikoData.BlockMetadata calldata meta = evidence.meta;
+        bytes32 instance;
+        string memory verifierPrefix;
+        if (evidence.blockHash == LibUtils.BLOCK_DEADEND_HASH) {
+            require(evidence.signalRoot == 0);
 
-        BlockHeader memory header = evidence.header;
-        if (
-            evidence.signalRoot == 0 ||
-            evidence.prover == address(0) ||
-            header.parentHash == 0 ||
-            header.gasUsed == 0 ||
-            header.beneficiary != meta.beneficiary ||
-            header.difficulty != 0 ||
-            header.gasLimit != meta.gasLimit + config.anchorTxGasLimit ||
-            header.timestamp != meta.timestamp ||
-            header.extraData.length != 0 ||
-            header.mixHash != bytes32(meta.mixHash)
-        ) revert L1_INVALID_EVIDENCE();
+            verifierPrefix = "vib";
+            instance = evidence.meta.txListHash;
+        } else {
+            verifierPrefix = "vb";
 
-        bytes32 instance = _getInstance(
-            evidence,
-            resolver.resolve("signal_service", false),
-            resolver.resolve(config.chainId, "signal_service", false)
-        );
+            address signalServiceL1 = resolver.resolve("signal_service", false);
+            address signalServiceL2 = resolver.resolve(
+                config.chainId,
+                "signal_service",
+                false
+            );
 
-        _proveBlock({
-            state: state,
-            config: config,
-            resolver: resolver,
-            blockId: blockId,
-            meta: meta,
-            parentHash: header.parentHash,
-            snippet: Snippet(header.hashBlockHeader(), evidence.signalRoot),
-            prover: evidence.prover,
-            zkproof: evidence.zkproof,
-            instance: instance
-        });
-    }
+            instance = keccak256(
+                bytes.concat(
+                    bytes32(uint256(uint160(signalServiceL1))),
+                    bytes32(uint256(uint160(signalServiceL2))),
+                    evidence.parentHash,
+                    evidence.blockHash,
+                    evidence.signalRoot,
+                    bytes32(uint256(uint160(evidence.prover))),
+                    bytes32(uint256(evidence.meta.id)),
+                    bytes32(evidence.meta.l1Height),
+                    evidence.meta.l1Hash,
+                    evidence.meta.txListHash
+                )
+            );
+        }
 
-    function proveBlockInvalid(
-        TaikoData.State storage state,
-        TaikoData.Config memory config,
-        AddressResolver resolver,
-        uint256 blockId,
-        TaikoData.InvalidBlockEvidence calldata evidence
-    ) internal {
-        _proveBlock({
-            state: state,
-            config: config,
-            resolver: resolver,
-            blockId: blockId,
-            meta: evidence.meta,
-            parentHash: evidence.parentHash,
-            snippet: Snippet(LibUtils.BLOCK_DEADEND_HASH, 0),
-            prover: evidence.prover,
-            zkproof: evidence.zkproof,
-            instance: evidence.meta.txListHash
-        });
-    }
-
-    function _proveBlock(
-        TaikoData.State storage state,
-        TaikoData.Config memory config,
-        AddressResolver resolver,
-        uint256 blockId,
-        TaikoData.BlockMetadata calldata meta,
-        bytes32 parentHash,
-        Snippet memory snippet,
-        address prover,
-        TaikoData.ZKProof calldata zkproof,
-        bytes32 instance
-    ) private {
         if (meta.id != blockId) revert L1_ID();
 
         if (meta.id <= state.latestVerifiedId || meta.id >= state.nextBlockId)
@@ -120,7 +81,7 @@ library LibProving {
 
         bool oracleProving;
         TaikoData.ForkChoice storage fc = state.forkChoices[blockId][
-            parentHash
+            evidence.parentHash
         ];
 
         if (fc.snippet.blockHash == 0) {
@@ -129,14 +90,14 @@ library LibProving {
                 oracleProving = true;
             } else {
                 if (oracleProver != address(0)) revert L1_NOT_ORACLE_PROVER();
-                fc.prover = prover;
+                fc.prover = evidence.prover;
                 fc.provenAt = uint64(block.timestamp);
             }
-            fc.snippet = snippet;
+            fc.snippet = Snippet(evidence.blockHash, evidence.signalRoot);
         } else {
             if (
-                fc.snippet.blockHash != snippet.blockHash ||
-                fc.snippet.signalRoot != snippet.signalRoot
+                fc.snippet.blockHash != evidence.blockHash ||
+                fc.snippet.signalRoot != evidence.signalRoot
             ) {
                 // TODO(daniel): we may allow TaikoToken holders to stake
                 // to build an insurance fund. Then once there is a conflicting
@@ -148,7 +109,7 @@ library LibProving {
 
             if (fc.prover != address(0)) revert L1_ALREADY_PROVEN();
 
-            fc.prover = prover;
+            fc.prover = evidence.prover;
             fc.provenAt = uint64(block.timestamp);
         }
 
@@ -156,10 +117,8 @@ library LibProving {
             // Do not revert when circuitId is invalid.
             address verifier = resolver.resolve(
                 string.concat(
-                    snippet.blockHash == LibUtils.BLOCK_DEADEND_HASH
-                        ? "vib" // verifier for invalid blocks
-                        : "vb", // verifier for valid blocks
-                    Strings.toString(zkproof.circuitId)
+                    verifierPrefix,
+                    Strings.toString(evidence.zkproof.circuitId)
                 ),
                 true
             );
@@ -171,47 +130,17 @@ library LibProving {
                     bytes16(instance), // left 16 bytes of the given instance
                     bytes16(0),
                     bytes16(uint128(uint256(instance))), // right 16 bytes of the given instance
-                    zkproof.data
+                    evidence.zkproof.data
                 )
             );
 
             if (!verified) revert L1_INVALID_PROOF();
         }
 
-        emit BlockProven({id: blockId, parentHash: parentHash, forkChoice: fc});
-    }
-
-    function _getInstance(
-        TaikoData.ValidBlockEvidence calldata evidence,
-        address l1SignalServiceAddress,
-        address l2SignalServiceAddress
-    ) private pure returns (bytes32) {
-        bytes[] memory list = LibBlockHeader.getBlockHeaderRLPItemsList(
-            evidence.header,
-            7
-        );
-
-        uint256 i = list.length;
-
-        unchecked {
-            // All L2 related inputs
-            list[--i] = LibRLPWriter.writeHash(evidence.meta.txListHash);
-            list[--i] = LibRLPWriter.writeHash(
-                bytes32(uint256(uint160(l2SignalServiceAddress)))
-            );
-            list[--i] = LibRLPWriter.writeHash(evidence.signalRoot);
-
-            // All L1 related inputs
-            list[--i] = LibRLPWriter.writeHash(bytes32(evidence.meta.l1Height));
-            list[--i] = LibRLPWriter.writeHash(evidence.meta.l1Hash);
-            list[--i] = LibRLPWriter.writeHash(
-                bytes32(uint256(uint160(l1SignalServiceAddress)))
-            );
-
-            // Other inputs
-            list[--i] = LibRLPWriter.writeAddress(evidence.prover);
-        }
-
-        return keccak256(LibRLPWriter.writeList(list));
+        emit BlockProven({
+            id: blockId,
+            parentHash: evidence.parentHash,
+            forkChoice: fc
+        });
     }
 }


### PR DESCRIPTION
I realized that RLP handling on L1 is really expensive (@cyberhorsey the bridge code may also have to be optimized), more expensive than the protocol can afford. Then I tried, in this PR, to remove all RLP logics in the core protocol, and ended up with something Brecht has suggested before -- unifying proveBlock and probeBlockInvalid.

Previously, to prove a block is valid, we ask the prover to provide a BlockHeader, then hash the BlockHeader to get the L2 block's blockhash. 

Now the L2 block's blockhash is provided directly by the prover, then we need to hash all non-default BlockHeader fileds (available in the BlockMetadata) into plonk verifier's instance.  To avoid using RPL encoding which is super expensive, all these fields are converted to bytes32 then concatenated into a long byte array to be keccaked.