### PR TITLE
feat(protocol): Bridge proof should only use storage proof

### DIFF
--- a/packages/protocol/contracts/bridge/libs/LibBridgeStatus.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeStatus.sol
@@ -79,6 +79,7 @@ library LibBridgeStatus {
             proof,
             (LibBridgeData.StatusProof)
         );
+
         bytes32 syncedHeaderHash = IXchainSync(resolver.resolve("taiko", false))
             .getXchainBlockHash(sp.header.height);
 
@@ -90,7 +91,7 @@ library LibBridgeStatus {
         }
 
         return
-            LibTrieProof.verify({
+            LibTrieProof.verifyWithAccountProof({
                 stateRoot: sp.header.stateRoot,
                 addr: resolver.resolve(destChainId, "bridge", false),
                 slot: getMessageStatusSlot(msgHash),

--- a/packages/protocol/contracts/libs/LibTrieProof.sol
+++ b/packages/protocol/contracts/libs/LibTrieProof.sol
@@ -27,18 +27,38 @@ library LibTrieProof {
      *********************/
 
     /**
-     * Verifies that the value of a slot in the storage tree of `addr`
-     * is `value`.
+     * Verifies that the value of a slot in the storage of an account is value.
      *
-     * @param stateRoot The merkle root of state tree.
-     * @param addr The contract address.
      * @param slot The slot in the contract.
      * @param value The value to be verified.
-     * @param mkproof The proof obtained by encoding state proof and storage
-     *        proof.
+     * @param storageProof The proof obtained by encoding storage proof.
+     * @param storageRoot The synced storage root for the given block.
      * @return verified The verification result.
      */
     function verify(
+        bytes32 slot,
+        bytes32 value,
+        bytes calldata storageProof,
+        bytes32 storageRoot
+    ) public pure returns (bool verified) {
+        verified = LibSecureMerkleTrie.verifyInclusionProof(
+            abi.encodePacked(slot),
+            LibRLPWriter.writeBytes32(value),
+            storageProof,
+            storageRoot
+        );
+    }
+
+    /**
+     * Verifies that the value of a slot in the storage of an account is value.
+     *
+     * @param stateRoot The merkle root of state tree..
+     * @param slot The slot in the contract.
+     * @param value The value to be verified.
+     * @param mkproof The proof obtained by encoding storage proof.
+     * @return verified The verification result.
+     */
+    function verifyWithAccountProof(
         bytes32 stateRoot,
         address addr,
         bytes32 slot,

--- a/packages/protocol/contracts/test/bridge/TestHeaderSync.sol
+++ b/packages/protocol/contracts/test/bridge/TestHeaderSync.sol
@@ -18,7 +18,7 @@ contract TestXchainSync is IXchainSync {
         _blockHash = blockHash;
     }
 
-    function seXchainSignalRoot(bytes32 signalRoot) external {
+    function setXchainSignalRoot(bytes32 signalRoot) external {
         _blockHash = signalRoot;
     }
 

--- a/packages/protocol/contracts/test/bridge/TestHeaderSync.sol
+++ b/packages/protocol/contracts/test/bridge/TestHeaderSync.sol
@@ -19,7 +19,7 @@ contract TestXchainSync is IXchainSync {
     }
 
     function setXchainSignalRoot(bytes32 signalRoot) external {
-        _blockHash = signalRoot;
+        _signalRoot = signalRoot;
     }
 
     function getXchainBlockHash(uint256) external view returns (bytes32) {

--- a/packages/protocol/contracts/test/libs/TestLibTrieProof.sol
+++ b/packages/protocol/contracts/test/libs/TestLibTrieProof.sol
@@ -16,12 +16,11 @@ contract TestLibTrieProof {
     }
 
     function verify(
-        bytes32 stateRoot,
-        address addr,
         bytes32 slot,
         bytes32 value,
-        bytes calldata mkproof
+        bytes calldata storageProof,
+        bytes32 storageRoot
     ) public pure returns (bool) {
-        return LibTrieProof.verify(stateRoot, addr, slot, value, mkproof);
+        return LibTrieProof.verify(slot, value, storageProof, storageRoot);
     }
 }

--- a/packages/protocol/hardhat.config.ts
+++ b/packages/protocol/hardhat.config.ts
@@ -14,122 +14,134 @@ import "./tasks/compile_yul";
 import "./tasks/deploy_L1";
 
 const hardhatMnemonic =
-  "test test test test test test test test test test test taik";
+    "test test test test test test test test test test test taik";
 const config: HardhatUserConfig = {
-  docgen: {
-    exclude: [
-      "bridge/libs/",
-      "L1/libs/",
-      "libs/",
-      "test/",
-      "thirdparty/",
-      "common/EssentialContract.sol",
-    ],
-    outputDir: "../website/pages/docs/reference/contract-documentation/",
-    pages: "files",
-    templates: "./solidity-docgen/templates",
-  },
+    docgen: {
+        exclude: [
+            "bridge/libs/",
+            "L1/libs/",
+            "libs/",
+            "test/",
+            "thirdparty/",
+            "common/EssentialContract.sol",
+        ],
+        outputDir: "../website/pages/docs/reference/contract-documentation/",
+        pages: "files",
+        templates: "./solidity-docgen/templates",
+    },
 
-  gasReporter: {
-    currency: "USD",
-    enabled: true,
-    gasPriceApi:
-      "https://api.etherscan.io/api?module=proxy&action=eth_gasPrice",
-    token: "ETH",
-  },
-  mocha: {
-    timeout: 300000,
-  },
-  networks: {
-    goerli: {
-      accounts:
-        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-      url: process.env.GOERLI_URL || "",
-    },
-    hardhat: {
-      accounts: {
-        mnemonic: hardhatMnemonic,
-      },
-      gas: 8000000,
-    },
-    mainnet: {
-      accounts:
-        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-      url: process.env.MAINNET_URL || "",
-    },
-    l1_test: {
-      accounts:
-        process.env.PRIVATE_KEY !== undefined
-          ? [process.env.PRIVATE_KEY]
-          : { mnemonic: hardhatMnemonic },
-      url: "http://127.0.0.1:18545" || "",
-    },
-    l2_test: {
-      accounts:
-        process.env.PRIVATE_KEY !== undefined
-          ? [process.env.PRIVATE_KEY]
-          : { mnemonic: hardhatMnemonic },
-      url: "http://127.0.0.1:28545" || "",
-    },
-    localhost: {
-      accounts:
-        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-      url: "http://127.0.0.1:8545" || "",
-    },
-    ropsten: {
-      accounts:
-        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-      url: process.env.ROPSTEN_URL || "",
-    },
-    internal_devnet_l1: {
-      url: "https://l1rpc.internal.taiko.xyz/",
-      accounts:
-        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-    },
-    internal_devnet_l2: {
-      url: "https://l2rpc.internal.taiko.xyz/",
-      accounts:
-        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-    },
-  },
-  etherscan: {
-    apiKey: {
-      internal_devnet_l1: "internal_devnet_l1_key",
-      internal_devnet_l2: "internal_devnet_l2_key",
-    },
-    customChains: [
-      {
-        network: "internal_devnet_l1",
-        chainId: 31336,
-        urls: {
-          apiURL: "https://l1explorer.internal.taiko.xyz/api",
-          browserURL: "https://l1explorer.internal.taiko.xyz",
-        },
-      },
-      {
-        network: "internal_devnet_l2",
-        chainId: 167001,
-        urls: {
-          apiURL: "https://l2explorer.internal.taiko.xyz/api",
-          browserURL: "https://l2explorer.internal.taiko.xyz",
-        },
-      },
-    ],
-  },
-  solidity: {
-    settings: {
-      optimizer: {
+    gasReporter: {
+        currency: "USD",
         enabled: true,
-        runs: 10000,
-      },
-      outputSelection: {
-        "*": {
-          "*": ["storageLayout"],
-        },
-      },
+        gasPriceApi:
+            "https://api.etherscan.io/api?module=proxy&action=eth_gasPrice",
+        token: "ETH",
     },
-    version: "0.8.18",
-  },
+    mocha: {
+        timeout: 300000,
+    },
+    networks: {
+        goerli: {
+            accounts:
+                process.env.PRIVATE_KEY !== undefined
+                    ? [process.env.PRIVATE_KEY]
+                    : [],
+            url: process.env.GOERLI_URL || "",
+        },
+        hardhat: {
+            accounts: {
+                mnemonic: hardhatMnemonic,
+            },
+            gas: 8000000,
+        },
+        mainnet: {
+            accounts:
+                process.env.PRIVATE_KEY !== undefined
+                    ? [process.env.PRIVATE_KEY]
+                    : [],
+            url: process.env.MAINNET_URL || "",
+        },
+        l1_test: {
+            accounts:
+                process.env.PRIVATE_KEY !== undefined
+                    ? [process.env.PRIVATE_KEY]
+                    : { mnemonic: hardhatMnemonic },
+            url: "http://127.0.0.1:18545" || "",
+        },
+        l2_test: {
+            accounts:
+                process.env.PRIVATE_KEY !== undefined
+                    ? [process.env.PRIVATE_KEY]
+                    : { mnemonic: hardhatMnemonic },
+            url: "http://127.0.0.1:28545" || "",
+        },
+        localhost: {
+            accounts:
+                process.env.PRIVATE_KEY !== undefined
+                    ? [process.env.PRIVATE_KEY]
+                    : [],
+            url: "http://127.0.0.1:8545" || "",
+        },
+        ropsten: {
+            accounts:
+                process.env.PRIVATE_KEY !== undefined
+                    ? [process.env.PRIVATE_KEY]
+                    : [],
+            url: process.env.ROPSTEN_URL || "",
+        },
+        internal_devnet_l1: {
+            url: "https://l1rpc.internal.taiko.xyz/",
+            accounts:
+                process.env.PRIVATE_KEY !== undefined
+                    ? [process.env.PRIVATE_KEY]
+                    : [],
+        },
+        internal_devnet_l2: {
+            url: "https://l2rpc.internal.taiko.xyz/",
+            accounts:
+                process.env.PRIVATE_KEY !== undefined
+                    ? [process.env.PRIVATE_KEY]
+                    : [],
+        },
+    },
+    etherscan: {
+        apiKey: {
+            internal_devnet_l1: "internal_devnet_l1_key",
+            internal_devnet_l2: "internal_devnet_l2_key",
+        },
+        customChains: [
+            {
+                network: "internal_devnet_l1",
+                chainId: 31336,
+                urls: {
+                    apiURL: "https://l1explorer.internal.taiko.xyz/api",
+                    browserURL: "https://l1explorer.internal.taiko.xyz",
+                },
+            },
+            {
+                network: "internal_devnet_l2",
+                chainId: 167001,
+                urls: {
+                    apiURL: "https://l2explorer.internal.taiko.xyz/api",
+                    browserURL: "https://l2explorer.internal.taiko.xyz",
+                },
+            },
+        ],
+    },
+    solidity: {
+        settings: {
+            optimizer: {
+                enabled: true,
+                runs: 10000,
+            },
+            outputSelection: {
+                "*": {
+                    "*": ["storageLayout"],
+                },
+            },
+        },
+        version: "0.8.18",
+    },
 };
 
 export default config;

--- a/packages/protocol/tasks/deploy_L1.ts
+++ b/packages/protocol/tasks/deploy_L1.ts
@@ -98,8 +98,6 @@ export async function deployContracts(hre: any) {
     const AddressManager = await utils.deployContract(hre, "AddressManager");
     await utils.waitTx(hre, await AddressManager.init());
 
-
-
     await utils.waitTx(
         hre,
         await AddressManager.setAddress(`${chainId}.dao_vault`, daoVault)

--- a/packages/protocol/test/L1/TaikoL1.integration.test.ts
+++ b/packages/protocol/test/L1/TaikoL1.integration.test.ts
@@ -1,13 +1,11 @@
 import { expect } from "chai";
 import { SimpleChannel } from "channel-ts";
-import { BigNumber, ethers as ethersLib } from "ethers";
+import { ethers as ethersLib } from "ethers";
 import { ethers } from "hardhat";
 import { TaikoL1, TestTaikoToken } from "../../typechain";
 import blockListener from "../utils/blockListener";
 import { BlockMetadata } from "../utils/block_metadata";
-import {
-    proposeLatestBlock,
-} from "../utils/commit";
+import { proposeLatestBlock } from "../utils/commit";
 import { encodeEvidence } from "../utils/encoding";
 import {
     readShouldRevertWithCustomError,
@@ -15,12 +13,11 @@ import {
 } from "../utils/errors";
 import Evidence from "../utils/evidence";
 import { initIntegrationFixture } from "../utils/fixture";
-import { buildProposeBlockInputs } from "../utils/propose";
 import Proposer from "../utils/proposer";
 import { buildProveBlockInputs, proveBlock } from "../utils/prove";
 import Prover from "../utils/prover";
 import { getBlockHeader } from "../utils/rpc";
-import { seedTko, sendTinyEtherToZeroAddress } from "../utils/seed";
+import { seedTko } from "../utils/seed";
 import { proposeProveAndVerify, verifyBlocks } from "../utils/verify";
 
 describe("integ-----disabled-----ration:TaikoL1", function () {
@@ -82,7 +79,7 @@ describe("integ-----disabled-----ration:TaikoL1", function () {
             const { proposedEvent } = await proposeLatestBlock(
                 taikoL1,
                 l1Signer,
-                l2Provider,
+                l2Provider
             );
             expect(proposedEvent).not.to.be.undefined;
 
@@ -141,9 +138,7 @@ describe("integ-----disabled-----ration:TaikoL1", function () {
             const block = await l2Provider.getBlock(blockNumber);
 
             // propose block, so our provers can prove it.
-            const { proposedEvent } = await proposer.proposeBlock(
-                block
-            );
+            const { proposedEvent } = await proposer.proposeBlock(block);
 
             await prover.prove(
                 proposedEvent.args.id.toNumber(),
@@ -221,9 +216,7 @@ describe("integ-----disabled-----ration:TaikoL1", function () {
                 const block = await l2Provider.getBlock(blockNumber);
 
                 // propose block, so our provers can prove it.
-                const { proposedEvent } = await proposer.proposeBlock(
-                    block
-                );
+                const { proposedEvent } = await proposer.proposeBlock(block);
 
                 const header = await getBlockHeader(l2Provider, blockNumber);
                 const inputs = buildProveBlockInputs(
@@ -268,9 +261,7 @@ describe("integ-----disabled-----ration:TaikoL1", function () {
                 const block = await l2Provider.getBlock(blockNumber);
 
                 // propose block, so our provers can prove it.
-                const { proposedEvent } = await proposer.proposeBlock(
-                    block
-                );
+                const { proposedEvent } = await proposer.proposeBlock(block);
 
                 const header = await getBlockHeader(l2Provider, blockNumber);
                 const inputs = [];

--- a/packages/protocol/test/bridge/Bridge.integration.test.ts
+++ b/packages/protocol/test/bridge/Bridge.integration.test.ts
@@ -25,7 +25,11 @@ import {
     getL2Provider,
 } from "../utils/provider";
 import { Block, getBlockHeader } from "../utils/rpc";
-import { deploySignalService, getSignalProof } from "../utils/signal";
+import {
+    deploySignalService,
+    getSignalProof,
+    getSignalProofWithAccountProof,
+} from "../utils/signal";
 
 describe("integrationbridge:Bridge", function () {
     let owner: SignerWithAddress;
@@ -247,7 +251,7 @@ describe("integrationbridge:Bridge", function () {
 
             await l2XchainSync.setXchainBlockHeader(ethers.constants.HashZero);
 
-            const signalProof = await getSignalProof(
+            const { signalProof } = await getSignalProof(
                 hre.ethers.provider,
                 l1SignalService.address,
                 await l1SignalService.getSignalSlot(l1Bridge.address, msgHash),
@@ -298,7 +302,7 @@ describe("integrationbridge:Bridge", function () {
                 "0x0000000000000000000000000000000000000000000000000000000000000001"
             );
 
-            const signalProof = await getSignalProof(
+            const { signalProof } = await getSignalProof(
                 hre.ethers.provider,
                 l1SignalService.address,
                 slot,
@@ -410,13 +414,15 @@ describe("integrationbridge:Bridge", function () {
                 "0x0000000000000000000000000000000000000000000000000000000000000001"
             );
 
-            const signalProof = await getSignalProof(
+            const { signalProof, signalRoot } = await getSignalProof(
                 hre.ethers.provider,
                 l1SignalService.address,
                 slot,
                 block.number,
                 blockHeader
             );
+
+            await l2XchainSync.setXchainSignalRoot(signalRoot);
 
             await expect(
                 l2Bridge.isMessageReceived(msgHash, srcChainId, signalProof)
@@ -447,13 +453,14 @@ describe("integrationbridge:Bridge", function () {
                 "0x0000000000000000000000000000000000000000000000000000000000000001"
             );
 
-            const signalProof = await getSignalProof(
+            const { signalProof, signalRoot } = await getSignalProof(
                 hre.ethers.provider,
                 l1SignalService.address,
                 slot,
                 block.number,
                 blockHeader
             );
+            await l2XchainSync.setXchainSignalRoot(signalRoot);
 
             expect(
                 await l2Bridge.isMessageReceived(
@@ -565,7 +572,7 @@ describe("integrationbridge:Bridge", function () {
 
             const slot = await l1Bridge.getMessageStatusSlot(msgHash);
 
-            const signalProof = await getSignalProof(
+            const { signalProof } = await getSignalProof(
                 l1Provider,
                 l1Bridge.address,
                 slot,
@@ -636,7 +643,7 @@ describe("integrationbridge:Bridge", function () {
 
             const slot = await l1Bridge.getMessageStatusSlot(msgHash);
 
-            const signalProof = await getSignalProof(
+            const signalProof = await getSignalProofWithAccountProof(
                 l1Provider,
                 l1Bridge.address,
                 slot,

--- a/packages/protocol/test/libs/LibTrieProof.test.ts
+++ b/packages/protocol/test/libs/LibTrieProof.test.ts
@@ -114,11 +114,14 @@ describe("integration:LibTrieProof", function () {
 
             // use this instead of ethers.provider.getBlock() beccause it doesnt have stateRoot
             // in the response
-            const block: { stateRoot: string; number: string; hash: string } =
-                await ethers.provider.send("eth_getBlockByNumber", [
-                    "latest",
-                    false,
-                ]);
+            const block: {
+                stateRoot: string;
+                number: string;
+                hash: string;
+            } = await ethers.provider.send("eth_getBlockByNumber", [
+                "latest",
+                false,
+            ]);
 
             // get storageValue for the slot
             const storageValue = await ethers.provider.getStorageAt(
@@ -136,23 +139,12 @@ describe("integration:LibTrieProof", function () {
                 [signalService.address, [slot], block.hash]
             );
 
-            const stateRoot = block.stateRoot;
-
-            // RLP encode the proof together for LibTrieProof to decode
-            const encodedProof = ethers.utils.defaultAbiCoder.encode(
-                ["bytes", "bytes"],
-                [
-                    RLP.encode(proof.accountProof),
-                    RLP.encode(proof.storageProof[0].proof),
-                ]
-            );
             // proof verifies the storageValue at slot is 1
             await testLibTrieProof.verify(
-                stateRoot,
-                signalService.address,
                 slot,
                 "0x0000000000000000000000000000000000000000000000000000000000000001",
-                encodedProof
+                RLP.encode(proof.storageProof[0].proof),
+                proof.storageHash
             );
         });
     });

--- a/packages/protocol/test/signal/SignalService.integration.test.ts
+++ b/packages/protocol/test/signal/SignalService.integration.test.ts
@@ -10,7 +10,7 @@ import {
     getL2Provider,
 } from "../utils/provider";
 
-describe.only("integration:SignalService", function () {
+describe("integration:SignalService", function () {
     async function deployIntegrationSignalService() {
         const [owner] = await ethers.getSigners();
 

--- a/packages/protocol/test/signal/SignalService.integration.test.ts
+++ b/packages/protocol/test/signal/SignalService.integration.test.ts
@@ -10,7 +10,7 @@ import {
     getL2Provider,
 } from "../utils/provider";
 
-describe("integration:SignalService", function () {
+describe.only("integration:SignalService", function () {
     async function deployIntegrationSignalService() {
         const [owner] = await ethers.getSigners();
 
@@ -110,7 +110,7 @@ describe("integration:SignalService", function () {
                 enabledDestChainId,
                 app,
                 signal,
-                signalProof
+                signalProof.signalProof
             )
         ).to.be.revertedWith("B_WRONG_CHAIN_ID()");
     });
@@ -149,7 +149,7 @@ describe("integration:SignalService", function () {
                 srcChainId,
                 app,
                 signal,
-                signalProof
+                signalProof.signalProof
             )
         ).to.be.revertedWith("B_NULL_APP_ADDR()");
     });
@@ -188,7 +188,7 @@ describe("integration:SignalService", function () {
                 srcChainId,
                 app,
                 ethers.constants.HashZero,
-                signalProof
+                signalProof.signalProof
             )
         ).to.be.revertedWith("B_ZERO_SIGNAL()");
     });
@@ -213,32 +213,18 @@ describe("integration:SignalService", function () {
 
         const { block, blockHeader } = await getBlockHeader(l1Provider);
 
-        const failProof = await getSignalProof(
-            l1Provider,
-            l1SignalService.address,
-            slot,
-            block.number,
-            blockHeader
-        );
-        // should return false since header has not been synced yet.
-        expect(
-            await l2SignalService.isSignalReceived(
-                srcChainId,
-                app,
-                signal,
-                failProof
-            )
-        ).to.be.equal(false);
-
+        console.log(blockHeader);
         await xchainSync.setXchainBlockHeader(block.hash);
 
-        const signalProof = await getSignalProof(
+        const { signalProof, signalRoot } = await getSignalProof(
             l1Provider,
             l1SignalService.address,
             slot,
             block.number,
             blockHeader
         );
+
+        await xchainSync.setXchainSignalRoot(signalRoot);
 
         expect(
             await l2SignalService.isSignalReceived(

--- a/packages/protocol/test/utils/bridge.ts
+++ b/packages/protocol/test/utils/bridge.ts
@@ -111,13 +111,15 @@ async function processMessage(
 
     await xchainSync.setXchainBlockHeader(block.hash);
 
-    const signalProof = await getSignalProof(
+    const { signalProof, signalRoot } = await getSignalProof(
         provider,
         l1SignalService.address,
         slot,
         block.number,
         blockHeader
     );
+
+    await xchainSync.setXchainSignalRoot(signalRoot);
 
     const tx = await l2Bridge.processMessage(message, signalProof);
     const receipt = await tx.wait(1);

--- a/packages/protocol/test/utils/commit.ts
+++ b/packages/protocol/test/utils/commit.ts
@@ -1,23 +1,19 @@
 import { ethers } from "ethers";
-import RLP from "rlp";
 import { TaikoL1 } from "../../typechain";
 import { BlockProposedEvent } from "../../typechain/LibProposing";
 import { proposeBlock } from "./propose";
-import { sendTinyEtherToZeroAddress } from "./seed";
-
 
 const proposeLatestBlock = async (
     taikoL1: TaikoL1,
     l1Signer: any,
-    l2Provider: ethers.providers.JsonRpcProvider,
+    l2Provider: ethers.providers.JsonRpcProvider
 ) => {
     const block = await l2Provider.getBlock("latest");
-
 
     const proposeReceipt = await proposeBlock(
         taikoL1.connect(l1Signer),
         block,
-        block.gasLimit,
+        block.gasLimit
     );
 
     const proposedEvent: BlockProposedEvent = (

--- a/packages/protocol/test/utils/fixture.ts
+++ b/packages/protocol/test/utils/fixture.ts
@@ -36,7 +36,7 @@ async function initIntegrationFixture(
         await Promise.all([l1Signer.unlock(""), l2Signer.unlock("")]);
     } catch (_) {}
 
-    const l2AddressManager = await deployAddressManager(l2Signer);
+    // const l2AddressManager = await deployAddressManager(l2Signer);
     const taikoL2 = await deployTaikoL2(
         l2Signer,
         5000000 // Note: need to explicitly set gasLimit here, otherwise the deployment transaction may fail.

--- a/packages/protocol/test/utils/propose.ts
+++ b/packages/protocol/test/utils/propose.ts
@@ -31,7 +31,7 @@ const proposeBlock = async (
         mixHash: ethers.constants.HashZero,
         extraData: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
         gasLimit: gasLimit,
-        timestamp: 0
+        timestamp: 0,
     };
 
     const inputs = buildProposeBlockInputs(block, meta);

--- a/packages/protocol/test/utils/proposer.ts
+++ b/packages/protocol/test/utils/proposer.ts
@@ -28,8 +28,6 @@ class Proposer {
         return this.signer;
     }
 
-
-
     async proposeBlock(block?: ethers.providers.Block) {
         try {
             while (this.proposingMutex) {

--- a/packages/protocol/test/utils/signal.ts
+++ b/packages/protocol/test/utils/signal.ts
@@ -37,7 +37,7 @@ async function deploySignalService(
     return { signalService };
 }
 
-async function getSignalProof(
+async function getSignalProofWithAccountProof(
     provider: ethers.providers.JsonRpcProvider,
     contractAddress: string,
     slot: string,
@@ -69,4 +69,30 @@ async function getSignalProof(
     return signalProof;
 }
 
-export { deploySignalService, getSignalProof };
+async function getSignalProof(
+    provider: ethers.providers.JsonRpcProvider,
+    contractAddress: string,
+    slot: string,
+    blockNumber: number,
+    blockHeader: BlockHeader
+) {
+    const proof: EthGetProofResponse = await provider.send("eth_getProof", [
+        contractAddress,
+        [slot],
+        blockNumber,
+    ]);
+
+    // RLP encode the proof together for LibTrieProof to decode
+    const encodedProof = RLP.encode(proof.storageProof[0].proof);
+    // encode the SignalProof struct from LibBridgeSignal
+    const signalProof = ethers.utils.defaultAbiCoder.encode(
+        [
+            "tuple(tuple(bytes32 parentHash, bytes32 ommersHash, address beneficiary, bytes32 stateRoot, bytes32 transactionsRoot, bytes32 receiptsRoot, bytes32[8] logsBloom, uint256 difficulty, uint128 height, uint64 gasLimit, uint64 gasUsed, uint64 timestamp, bytes extraData, bytes32 mixHash, uint64 nonce, uint256 baseFeePerGas, bytes32 withdrawalsRoot) header, bytes proof)",
+        ],
+        [{ header: blockHeader, proof: encodedProof }]
+    );
+
+    return { signalProof: signalProof, signalRoot: proof.storageHash };
+}
+
+export { deploySignalService, getSignalProof, getSignalProofWithAccountProof };

--- a/packages/protocol/test/utils/taikoL2.ts
+++ b/packages/protocol/test/utils/taikoL2.ts
@@ -1,16 +1,12 @@
 import { ethers } from "ethers";
 import { ethers as hardhatEthers } from "hardhat";
-import {  TaikoL2 } from "../../typechain";
+import { TaikoL2 } from "../../typechain";
 
 async function deployTaikoL2(
     signer: ethers.Signer,
     gasLimit: number | undefined = undefined
 ): Promise<TaikoL2> {
-    const taikoL2 = await (
-        await hardhatEthers.getContractFactory(
-                 "TaikoL2"
-        )
-    )
+    const taikoL2 = await (await hardhatEthers.getContractFactory("TaikoL2"))
         .connect(signer)
         .deploy({ gasLimit });
 

--- a/packages/protocol/test/utils/taikoToken.ts
+++ b/packages/protocol/test/utils/taikoToken.ts
@@ -7,9 +7,7 @@ const deployTaikoToken = async (
     addressManager: AddressManager,
     protoBroker: string
 ) => {
-    const token = await (
-        await hardhatEthers.getContractFactory("TaikoToken")
-    )
+    const token = await (await hardhatEthers.getContractFactory("TaikoToken"))
         .connect(signer)
         .deploy();
     await token.init(addressManager.address, "Taiko Token", "TKO");


### PR DESCRIPTION
Not sure if this is the correct way to do this, but I'd take a stab at it regardless. This is a large gas optimization for the bridge.
@dantaik because we sync the storageRoot, we can remove the account proof, and use the synced signal root instead. I'm not sure if I did it correctly, tests pass though. Please let me know if this is the appropriate way or if I missed some additional verification necessary, or removed too much.

`verifyWithAccountProof` is for `isMessageFailed`, which still requires an account proof, since it uses the Bridge's storage tree not the SignalService.