### PR TITLE
fix(protocol): fix workflow errors in #13293

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -93,7 +93,7 @@ library LibUtils {
             uint256 grace = (config.feeGracePeriodPctg * _tAvg) / 100;
             uint256 max = (config.feeMaxPeriodPctg * _tAvg) / 100;
             uint256 t = uint256(tNow - tLast).max(grace).min(max);
-            tRelBp = (t * 10000) / (max - grace); // [0 - 10000]
+            tRelBp = ((t - grace) * 10000) / (max - grace); // [0 - 10000]
             uint256 alpha = 10000 +
                 ((config.rewardMultiplierPctg - 100) * tRelBp) /
                 100;

--- a/packages/protocol/test/tokenomics/blockFee.test.ts
+++ b/packages/protocol/test/tokenomics/blockFee.test.ts
@@ -67,8 +67,7 @@ describe("tokenomics: blockFee", function () {
     });
 
     it(
-        "proposes blocks on interval, blockFee should increase, " +
-            "proposer's balance for TkoToken should decrease as it pays proposer fee, " +
+        "proposes blocks on interval, proposer's balance for TkoToken should decrease as it pays proposer fee, " +
             "proofReward should increase since more slots are used and " +
             "no proofs have been submitted",
         async function () {
@@ -76,17 +75,6 @@ describe("tokenomics: blockFee", function () {
             let lastProposerBalance = await taikoTokenL1.balanceOf(
                 await proposerSigner.getAddress()
             );
-
-            // do the same for the blockFee, which should increase every block proposal
-            // with proofs not being submitted.
-            // we want to wait for enough blocks until the blockFee is no longer 0, then run our
-            // tests.
-            let lastBlockFee = await taikoL1.getBlockFee();
-
-            while (lastBlockFee.eq(0)) {
-                await sleep(500);
-                lastBlockFee = await taikoL1.getBlockFee();
-            }
 
             let lastProofReward = BigNumber.from(0);
 
@@ -99,7 +87,7 @@ describe("tokenomics: blockFee", function () {
                 ) {
                     break;
                 }
-                const { newProposerBalance, newBlockFee, newProofReward } =
+                const { newProposerBalance, newProofReward } =
                     await onNewL2Block(
                         l2Provider,
                         blockNumber,
@@ -114,16 +102,10 @@ describe("tokenomics: blockFee", function () {
 
                 expect(newProposerBalance).to.be.lt(lastProposerBalance);
 
-                console.log("lastBlockFee", lastBlockFee);
-                console.log("newBlockFee", newBlockFee);
-
-                expect(newBlockFee).to.be.gt(lastBlockFee);
-
                 console.log("lastProofReward", lastProofReward);
                 console.log("newProofReward", newProofReward);
                 expect(newProofReward).to.be.gt(lastProofReward);
 
-                lastBlockFee = newBlockFee;
                 lastProofReward = newProofReward;
                 lastProposerBalance = newProposerBalance;
             }

--- a/packages/protocol/test/tokenomics/blockFee.test.ts
+++ b/packages/protocol/test/tokenomics/blockFee.test.ts
@@ -78,6 +78,10 @@ describe("tokenomics: blockFee", function () {
 
             let lastProofReward = BigNumber.from(0);
 
+            while ((await taikoL1.getBlockFee()).eq(0)) {
+                await sleep(500);
+            }
+
             l2Provider.on("block", blockListener(chan, genesisHeight));
             /* eslint-disable-next-line */
             for await (const blockNumber of chan) {

--- a/packages/protocol/test/tokenomics/blockFee.test.ts
+++ b/packages/protocol/test/tokenomics/blockFee.test.ts
@@ -78,6 +78,8 @@ describe("tokenomics: blockFee", function () {
 
             let lastProofReward = BigNumber.from(0);
 
+            // we want to wait for enough blocks until the blockFee is no longer 0, then run our
+            // tests.
             while ((await taikoL1.getBlockFee()).eq(0)) {
                 await sleep(500);
             }

--- a/packages/protocol/test/utils/onNewL2Block.ts
+++ b/packages/protocol/test/utils/onNewL2Block.ts
@@ -31,7 +31,7 @@ async function onNewL2Block(
     const { enableTokenomics } = await taikoL1.getConfig();
 
     const newProofReward = await taikoL1.getProofReward(
-        new Date().getMilliseconds(),
+        new Date().getTime(),
         meta.timestamp
     );
 


### PR DESCRIPTION
- fix a `tRelBp` calculation error
- fix a `getProofReward` parameter(`provenAt`) error in tests (`new Date().getMilliseconds()` => `new Date().getTime()`)
- fix an occasional error in `blockFee.test.ts` (`blockFee` is not promised to be increased in the test, especially the first comparison: `expect(initFee).to.be.lt.(feeAfterFirstProposal)` )