### PR TITLE
chore(bridge-ui): reduce logic and remove some store variables

### DIFF
--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -53,7 +53,9 @@
     import.meta.env.VITE_RELAYER_URL,
   );
 
-  const tokenStore: TokenService = new CustomTokenService(window.localStorage);
+  const tokenStore: TokenService = new CustomTokenService(
+    globalThis.localStorage,
+  );
 
   tokenService.set(tokenStore);
 

--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -7,10 +7,7 @@
 
   import Home from './pages/home/Home.svelte';
   import { setupI18n } from './i18n';
-  import { BridgeType } from './domain/bridge';
-  import ETHBridge from './eth/bridge';
-  import { bridges, chainIdToTokenVaultAddress } from './store/bridge';
-  import ERC20Bridge from './erc20/bridge';
+  import { chainIdToTokenVaultAddress } from './store/bridge';
   import {
     pendingTransactions,
     transactioner,
@@ -24,9 +21,7 @@
   import { chains, CHAIN_MAINNET, CHAIN_TKO } from './domain/chain';
   import { providers } from './domain/provider';
   import SwitchEthereumChainModal from './components/modals/SwitchEthereumChainModal.svelte';
-  import { ProofService } from './proof/service';
   import { ethers } from 'ethers';
-  import type { Prover } from './domain/proof';
   import { successToast } from './utils/toast';
   import { StorageService } from './storage/service';
   import { MessageStatus } from './domain/message';
@@ -38,17 +33,6 @@
   import RelayerAPIService from './relayer-api/service';
   import type { RelayerAPI } from './domain/relayerApi';
   import { relayerApi, relayerBlockInfoMap } from './store/relayerApi';
-
-  const prover: Prover = new ProofService(providers);
-
-  const ethBridge = new ETHBridge(prover);
-  const erc20Bridge = new ERC20Bridge(prover);
-
-  bridges.update((store) => {
-    store.set(BridgeType.ETH, ethBridge);
-    store.set(BridgeType.ERC20, erc20Bridge);
-    return store;
-  });
 
   chainIdToTokenVaultAddress.update((store) => {
     store.set(CHAIN_TKO.id, import.meta.env.VITE_TAIKO_TOKEN_VAULT_ADDRESS);

--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -4,12 +4,6 @@
   import Router from 'svelte-spa-router';
   import { SvelteToast } from '@zerodevx/svelte-toast';
   import type { SvelteToastOptions } from '@zerodevx/svelte-toast';
-  import { configureChains, createClient } from '@wagmi/core';
-  import { publicProvider } from '@wagmi/core/providers/public';
-  import { jsonRpcProvider } from '@wagmi/core/providers/jsonRpc';
-  import { CoinbaseWalletConnector } from '@wagmi/core/connectors/coinbaseWallet';
-  import { WalletConnectConnector } from '@wagmi/core/connectors/walletConnect';
-  import { MetaMaskConnector } from '@wagmi/core/connectors/metaMask';
 
   import Home from './pages/home/Home.svelte';
   import { setupI18n } from './i18n';
@@ -25,17 +19,10 @@
   import Navbar from './components/Navbar.svelte';
   import { signer } from './store/signer';
   import type { BridgeTransaction, Transactioner } from './domain/transactions';
-  import { wagmiClient } from './store/wagmi';
 
   setupI18n({ withLocale: 'en' });
-  import {
-    chains,
-    providers,
-    CHAIN_MAINNET,
-    CHAIN_TKO,
-    mainnet,
-    taiko,
-  } from './domain/chain';
+  import { chains, CHAIN_MAINNET, CHAIN_TKO } from './domain/chain';
+  import { providers } from './domain/provider';
   import SwitchEthereumChainModal from './components/modals/SwitchEthereumChainModal.svelte';
   import { ProofService } from './proof/service';
   import { ethers } from 'ethers';

--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -19,7 +19,7 @@
 
   setupI18n({ withLocale: 'en' });
   import { chains, CHAIN_MAINNET, CHAIN_TKO } from './domain/chain';
-  import { providers } from './domain/provider';
+  import { providersMap } from './providers/map';
   import SwitchEthereumChainModal from './components/modals/SwitchEthereumChainModal.svelte';
   import { ethers } from 'ethers';
   import { successToast } from './utils/toast';
@@ -45,11 +45,11 @@
 
   const storageTransactioner: Transactioner = new StorageService(
     globalThis.localStorage,
-    providers,
+    providersMap,
   );
 
   const relayerApiService: RelayerAPI = new RelayerAPIService(
-    providers,
+    providersMap,
     import.meta.env.VITE_RELAYER_URL,
   );
 
@@ -130,7 +130,7 @@
         }
 
         if (tx.status === MessageStatus.New) {
-          const provider = providers.get(tx.toChainId);
+          const provider = providersMap.get(tx.toChainId);
 
           const interval = setInterval(async () => {
             const txInterval = transactionToIntervalMap.get(tx.hash);

--- a/packages/bridge-ui/src/bridges/map.ts
+++ b/packages/bridge-ui/src/bridges/map.ts
@@ -1,0 +1,15 @@
+import ERC20Bridge from '../erc20/bridge';
+import ETHBridge from '../eth/bridge';
+import { ProofService } from '../proof/service';
+import type { Prover } from '../domain/proof';
+import { providersMap } from '../providers/map';
+import { type Bridge, BridgeType } from '../domain/bridge';
+
+const prover: Prover = new ProofService(providersMap);
+const ethBridge = new ETHBridge(prover);
+const erc20Bridge = new ERC20Bridge(prover);
+
+export const bridgesMap = new Map<BridgeType, Bridge>([
+  [BridgeType.ETH, ethBridge],
+  [BridgeType.ERC20, erc20Bridge],
+]);

--- a/packages/bridge-ui/src/components/AddressDropdown.svelte
+++ b/packages/bridge-ui/src/components/AddressDropdown.svelte
@@ -60,7 +60,8 @@
 </script>
 
 <div class="dropdown dropdown-bottom dropdown-end">
-  <label tabindex="0" class="btn btn-md justify-around">
+  <!-- svelte-ignore a11y-label-has-associated-control -->
+  <label role="button" tabindex="0" class="btn btn-md justify-around">
     <span class="font-normal flex-1 text-left flex items-center">
       {#if $pendingTransactions && $pendingTransactions.length}
         <span>{$pendingTransactions.length} Pending</span>
@@ -92,6 +93,7 @@
     <ChevronDown size="20" />
   </label>
   <ul
+    role="listbox"
     tabindex="0"
     class="dropdown-content address-dropdown-content menu shadow bg-dark-2 rounded-sm w-48 mt-2 pb-2 text-sm">
     <div class="p-5 pb-0 flex flex-col items-center" transition:slide>
@@ -116,16 +118,16 @@
         alt="avatar" />
       {addressSubsection(address)}
     </div>
-    <div
+    <button
       class="cursor-pointer flex hover:bg-dark-5 items-center py-2 px-4 mx-2 rounded-md"
       on:click={async () => await copyToClipboard(address)}>
       <ClipboardDocument class="mr-2" />
       Copy Address
-    </div>
-    <div
+    </button>
+    <button
       class="cursor-pointer flex hover:bg-dark-5 items-center py-2 px-4 mx-2 rounded-md"
       on:click={async () => await disconnect()}>
       <Power class="mr-2" /> Disconnect
-    </div>
+    </button>
   </ul>
 </div>

--- a/packages/bridge-ui/src/components/ChainDropdown.svelte
+++ b/packages/bridge-ui/src/components/ChainDropdown.svelte
@@ -25,7 +25,11 @@
 </script>
 
 <div class="dropdown dropdown-end mr-4">
-  <label tabindex="0" class="btn btn-md justify-around md:w-[194px]">
+  <!-- svelte-ignore a11y-label-has-associated-control -->
+  <label
+    role="button"
+    tabindex="0"
+    class="btn btn-md justify-around md:w-[194px]">
     <span class="font-normal flex-1 text-left mr-2">
       {#if $fromChain}
         <svelte:component this={$fromChain.icon} />
@@ -40,6 +44,7 @@
     <ChevronDown size="20" />
   </label>
   <ul
+    role="listbox"
     tabindex="0"
     class="dropdown-content address-dropdown-content flex my-2 menu p-2 shadow bg-dark-2 rounded-sm w-[194px]">
     <li>

--- a/packages/bridge-ui/src/components/MessageStatusTooltip.svelte
+++ b/packages/bridge-ui/src/components/MessageStatusTooltip.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import TooltipModal from './modals/TooltipModal.svelte';
-  import { showMessageStatusTooltip } from '../store/transactions';
+
+  export let show: boolean;
 </script>
 
-<TooltipModal title="Message Status" bind:isOpen={$showMessageStatusTooltip}>
+<TooltipModal title="Message Status" bind:isOpen={show}>
   <span slot="body">
     <div class="text-left">
       A bridge message will pass through various states:

--- a/packages/bridge-ui/src/components/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transaction.svelte
@@ -6,7 +6,7 @@
   import { ArrowTopRightOnSquare } from 'svelte-heros-v2';
   import { MessageStatus } from '../domain/message';
   import { Contract, ethers } from 'ethers';
-  import { bridges, chainIdToTokenVaultAddress } from '../store/bridge';
+  import { chainIdToTokenVaultAddress } from '../store/bridge';
   import { signer } from '../store/signer';
   import {
     pendingTransactions,
@@ -19,7 +19,7 @@
     fromChain as fromChainStore,
     toChain as toChainStore,
   } from '../store/chain';
-  import { BridgeType } from '../domain/bridge';
+  import { bridges, BridgeType } from '../domain/bridge';
   import { onMount } from 'svelte';
 
   import { LottiePlayer } from '@lottiefiles/svelte-lottie-player';
@@ -67,7 +67,7 @@
         const chain = chains[bridgeTx.message.destChainId.toNumber()];
         await switchChainAndSetSigner(chain);
       }
-      const tx = await $bridges
+      const tx = await bridges
         .get(bridgeTx.message.data === '0x' ? BridgeType.ETH : BridgeType.ERC20)
         .Claim({
           signer: $signer,
@@ -100,7 +100,7 @@
         const chain = chains[bridgeTx.message.srcChainId.toNumber()];
         await switchChainAndSetSigner(chain);
       }
-      const tx = await $bridges
+      const tx = await bridges
         .get(bridgeTx.message.data === '0x' ? BridgeType.ETH : BridgeType.ERC20)
         .ReleaseTokens({
           signer: $signer,

--- a/packages/bridge-ui/src/components/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transaction.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { BridgeTransaction } from '../domain/transactions';
   import { chains, CHAIN_MAINNET, CHAIN_TKO } from '../domain/chain';
-  import { type Chain, providers } from '../domain/chain';
+  import type { Chain } from '../domain/chain';
+  import { providers } from '../domain/provider';
   import { ArrowTopRightOnSquare } from 'svelte-heros-v2';
   import { MessageStatus } from '../domain/message';
   import { Contract, ethers } from 'ethers';

--- a/packages/bridge-ui/src/components/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transaction.svelte
@@ -8,11 +8,7 @@
   import { Contract, ethers } from 'ethers';
   import { chainIdToTokenVaultAddress } from '../store/bridge';
   import { signer } from '../store/signer';
-  import {
-    pendingTransactions,
-    showTransactionDetails,
-    showMessageStatusTooltip,
-  } from '../store/transactions';
+  import { pendingTransactions } from '../store/transactions';
   import { errorToast, successToast } from '../utils/toast';
   import { _ } from 'svelte-i18n';
   import {
@@ -32,16 +28,14 @@
   export let transaction: BridgeTransaction;
   export let fromChain: Chain;
   export let toChain: Chain;
+  export let onTooltipClick: () => void;
+  export let onShowTransactionDetailsClick: () => void;
 
   let loading: boolean = false;
   let processable: boolean = false;
 
   let srcChain = chains[transaction.message.srcChainId.toNumber()];
   let destChain = chains[transaction.message.destChainId.toNumber()];
-
-  onMount(async () => {
-    processable = await isProcessable();
-  });
 
   async function switchChainAndSetSigner(chain: Chain) {
     await switchNetwork({
@@ -188,6 +182,10 @@
     transaction = transaction;
     if (transaction.status === MessageStatus.Done) clearInterval(interval);
   }, 20 * 1000);
+
+  onMount(async () => {
+    processable = await isProcessable();
+  });
 </script>
 
 <tr class="text-transaction-table">
@@ -207,7 +205,7 @@
   </td>
 
   <td>
-    <ButtonWithTooltip onClick={() => ($showMessageStatusTooltip = true)}>
+    <ButtonWithTooltip onClick={onTooltipClick}>
       <span slot="buttonText">
         {#if !processable}
           Pending
@@ -253,11 +251,9 @@
   </td>
 
   <td>
-    <span
-      class="cursor-pointer inline-block"
-      on:click={() => ($showTransactionDetails = transaction)}>
+    <button on:click={onShowTransactionDetailsClick}>
       <ArrowTopRightOnSquare />
-    </span>
+    </button>
   </td>
 </tr>
 

--- a/packages/bridge-ui/src/components/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transaction.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { BridgeTransaction } from '../domain/transactions';
   import { chains, CHAIN_MAINNET, CHAIN_TKO } from '../domain/chain';
-  import { Chain, providers } from '../domain/chain';
+  import { type Chain, providers } from '../domain/chain';
   import { ArrowTopRightOnSquare } from 'svelte-heros-v2';
   import { MessageStatus } from '../domain/message';
   import { Contract, ethers } from 'ethers';

--- a/packages/bridge-ui/src/components/TransactionDetail.svelte
+++ b/packages/bridge-ui/src/components/TransactionDetail.svelte
@@ -4,14 +4,15 @@
   import { truncateString } from '../utils/truncateString';
   import Modal from './modals/Modal.svelte';
   import { chains } from '../domain/chain';
-  import { showTransactionDetails } from '../store/transactions';
-  export let transaction;
+  import type { BridgeTransaction } from '../domain/transactions';
+
+  // TODO: can we always guarantee that this object isn't null or undefined?
+  //   in which case we need to guard => transaction?.prop
+  export let transaction: BridgeTransaction;
+  export let onClose: () => void;
 </script>
 
-<Modal
-  onClose={() => ($showTransactionDetails = null)}
-  isOpen={!!transaction}
-  title="Transaction Details">
+<Modal {onClose} isOpen={!!transaction} title="Transaction Details">
   <table
     class="table table-normal w-full md:w-2/3 m-auto table-fixed border-spacing-0 text-sm md:text-base">
     <tr>

--- a/packages/bridge-ui/src/components/Transactions.svelte
+++ b/packages/bridge-ui/src/components/Transactions.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { chains } from '../domain/chain';
-  import {
-    transactions,
-    showTransactionDetails,
-    showMessageStatusTooltip,
-  } from '../store/transactions';
+  import { transactions } from '../store/transactions';
   import Transaction from './Transaction.svelte';
   import TransactionDetail from './TransactionDetail.svelte';
   import MessageStatusTooltip from './MessageStatusTooltip.svelte';
+  import type { BridgeTransaction } from '../domain/transactions';
+
+  let selectedTransaction: BridgeTransaction;
+  let showMessageStatusTooltip: boolean;
 </script>
 
 <div class="my-4 md:px-4">
@@ -25,6 +25,10 @@
       <tbody class="text-sm md:text-base">
         {#each $transactions as transaction}
           <Transaction
+            onTooltipClick={() => (showMessageStatusTooltip = true)}
+            onShowTransactionDetailsClick={() => {
+              selectedTransaction = transaction;
+            }}
             toChain={chains[transaction.toChainId]}
             fromChain={chains[transaction.fromChainId]}
             {transaction} />
@@ -35,11 +39,11 @@
     No transactions
   {/if}
 
-  {#if $showTransactionDetails}
-    <TransactionDetail transaction={$showTransactionDetails} />
+  {#if selectedTransaction}
+    <TransactionDetail
+      transaction={selectedTransaction}
+      onClose={() => (selectedTransaction = null)} />
   {/if}
 
-  {#if $showMessageStatusTooltip}
-    <MessageStatusTooltip />
-  {/if}
+  <MessageStatusTooltip show={showMessageStatusTooltip} />
 </div>

--- a/packages/bridge-ui/src/components/buttons/Connect.svelte
+++ b/packages/bridge-ui/src/components/buttons/Connect.svelte
@@ -24,16 +24,15 @@
   import { CHAIN_MAINNET, CHAIN_TKO, mainnet, taiko } from '../../domain/chain';
   import { providersMap } from '../../providers/map';
   import { fromChain, toChain } from '../../store/chain';
-  import {
-    isSwitchEthereumChainModalOpen,
-    isConnectWalletModalOpen,
-  } from '../../store/modal';
+  import { isSwitchEthereumChainModalOpen } from '../../store/modal';
   import { errorToast, successToast } from '../../utils/toast';
   import Modal from '../modals/Modal.svelte';
   import MetaMask from '../icons/MetaMask.svelte';
   import WalletConnect from '../icons/WalletConnect.svelte';
   import CoinbaseWallet from '../icons/CoinbaseWallet.svelte';
   import { transactioner, transactions } from '../../store/transactions';
+
+  let isConnectWalletModalOpen = false;
 
   const iconMap = {
     metamask: MetaMask,
@@ -129,13 +128,14 @@
   });
 </script>
 
-<button class="btn btn-md" on:click={() => ($isConnectWalletModalOpen = true)}
-  >{$_('nav.connect')}</button>
+<button class="btn btn-md" on:click={() => (isConnectWalletModalOpen = true)}>
+  {$_('nav.connect')}
+</button>
 
 <Modal
   title={$_('connectModal.title')}
-  isOpen={$isConnectWalletModalOpen}
-  onClose={() => ($isConnectWalletModalOpen = false)}>
+  isOpen={isConnectWalletModalOpen}
+  onClose={() => (isConnectWalletModalOpen = false)}>
   <div class="flex flex-col items-center space-y-4 space-x-0 p-8">
     {#each wagmiClient.connectors as connector}
       <button

--- a/packages/bridge-ui/src/components/buttons/Connect.svelte
+++ b/packages/bridge-ui/src/components/buttons/Connect.svelte
@@ -22,7 +22,7 @@
 
   import { signer } from '../../store/signer';
   import { CHAIN_MAINNET, CHAIN_TKO, mainnet, taiko } from '../../domain/chain';
-  import { providers } from '../../domain/provider';
+  import { providersMap } from '../../providers/map';
   import { fromChain, toChain } from '../../store/chain';
   import {
     isSwitchEthereumChainModalOpen,
@@ -47,7 +47,7 @@
       publicProvider(),
       jsonRpcProvider({
         rpc: (chain) => ({
-          http: providers.get(chain.id).connection.url,
+          http: providersMap.get(chain.id).connection.url,
         }),
       }),
     ],

--- a/packages/bridge-ui/src/components/buttons/Connect.svelte
+++ b/packages/bridge-ui/src/components/buttons/Connect.svelte
@@ -21,13 +21,8 @@
   import { jsonRpcProvider } from '@wagmi/core/providers/jsonRpc';
 
   import { signer } from '../../store/signer';
-  import {
-    CHAIN_MAINNET,
-    CHAIN_TKO,
-    mainnet,
-    taiko,
-    providers,
-  } from '../../domain/chain';
+  import { CHAIN_MAINNET, CHAIN_TKO, mainnet, taiko } from '../../domain/chain';
+  import { providers } from '../../domain/provider';
   import { fromChain, toChain } from '../../store/chain';
   import {
     isSwitchEthereumChainModalOpen,

--- a/packages/bridge-ui/src/components/form/BridgeForm.svelte
+++ b/packages/bridge-ui/src/components/form/BridgeForm.svelte
@@ -19,7 +19,7 @@
   import type { Token } from '../../domain/token';
   import type { BridgeOpts, BridgeType } from '../../domain/bridge';
   import { chains } from '../../domain/chain';
-  import { providers } from '../../domain/provider';
+  import { providersMap } from '../../providers/map';
 
   import type { Chain } from '../../domain/chain';
   import { truncateString } from '../../utils/truncateString';
@@ -230,7 +230,7 @@
 
       const amountInWei = ethers.utils.parseUnits(amount, $token.decimals);
 
-      const provider = providers.get($toChain.id);
+      const provider = providersMap.get($toChain.id);
       const destTokenVaultAddress = $chainIdToTokenVaultAddress.get(
         $toChain.id,
       );

--- a/packages/bridge-ui/src/components/form/BridgeForm.svelte
+++ b/packages/bridge-ui/src/components/form/BridgeForm.svelte
@@ -18,7 +18,8 @@
 
   import type { Token } from '../../domain/token';
   import type { BridgeOpts, BridgeType } from '../../domain/bridge';
-  import { chains, providers } from '../../domain/chain';
+  import { chains } from '../../domain/chain';
+  import { providers } from '../../domain/provider';
 
   import type { Chain } from '../../domain/chain';
   import { truncateString } from '../../utils/truncateString';

--- a/packages/bridge-ui/src/components/form/BridgeForm.svelte
+++ b/packages/bridge-ui/src/components/form/BridgeForm.svelte
@@ -18,7 +18,7 @@
 
   import type { Token } from '../../domain/token';
   import type { BridgeOpts, BridgeType } from '../../domain/bridge';
-  import { chains } from '../../domain/chain';
+  import { chains, providers } from '../../domain/chain';
 
   import type { Chain } from '../../domain/chain';
   import { truncateString } from '../../utils/truncateString';
@@ -36,7 +36,6 @@
   import { Funnel } from 'svelte-heros-v2';
   import FaucetModal from '../modals/FaucetModal.svelte';
   import { fetchFeeData } from '@wagmi/core';
-  import { providers } from '../../store/providers';
   import { checkIfTokenIsDeployedCrossChain } from '../../utils/checkIfTokenIsDeployedCrossChain';
   import To from './To.svelte';
 
@@ -230,7 +229,7 @@
 
       const amountInWei = ethers.utils.parseUnits(amount, $token.decimals);
 
-      const provider = $providers.get($toChain.id);
+      const provider = providers.get($toChain.id);
       const destTokenVaultAddress = $chainIdToTokenVaultAddress.get(
         $toChain.id,
       );

--- a/packages/bridge-ui/src/components/modals/SwitchEthereumChainModal.svelte
+++ b/packages/bridge-ui/src/components/modals/SwitchEthereumChainModal.svelte
@@ -36,16 +36,16 @@
         on:click={async () => {
           await switchChain(CHAIN_MAINNET);
         }}>
-        <svelte:component this={CHAIN_MAINNET.icon} /><span class="ml-2"
-          >{CHAIN_MAINNET.name}</span>
+        <svelte:component this={CHAIN_MAINNET.icon} />
+        <span class="ml-2">{CHAIN_MAINNET.name}</span>
       </button>
       <button
         class="btn btn-dark-5 h-[60px] text-base"
         on:click={async () => {
           await switchChain(CHAIN_TKO);
         }}>
-        <svelte:component this={CHAIN_TKO.icon} /><span class="ml-2"
-          >{CHAIN_TKO.name}</span>
+        <svelte:component this={CHAIN_TKO.icon} />
+        <span class="ml-2">{CHAIN_TKO.name}</span>
       </button>
     </div>
   </div>

--- a/packages/bridge-ui/src/domain/bridge.ts
+++ b/packages/bridge-ui/src/domain/bridge.ts
@@ -1,10 +1,5 @@
 import type { BigNumber, ethers, Transaction } from 'ethers';
-import ERC20Bridge from '../erc20/bridge';
-import ETHBridge from '../eth/bridge';
-import { ProofService } from '../proof/service';
 import type { Message } from './message';
-import type { Prover } from './proof';
-import { providers } from './provider';
 
 enum BridgeType {
   ERC20 = 'ERC20',
@@ -65,15 +60,6 @@ interface HTMLBridgeForm extends HTMLFormElement {
   customTokenAddress: HTMLInputElement;
 }
 
-const prover: Prover = new ProofService(providers);
-const ethBridge = new ETHBridge(prover);
-const erc20Bridge = new ERC20Bridge(prover);
-
-const bridges = new Map<BridgeType, Bridge>([
-  [BridgeType.ETH, ethBridge],
-  [BridgeType.ERC20, erc20Bridge],
-]);
-
 export {
   ApproveOpts,
   BridgeOpts,
@@ -82,5 +68,4 @@ export {
   ClaimOpts,
   ReleaseOpts,
   HTMLBridgeForm,
-  bridges,
 };

--- a/packages/bridge-ui/src/domain/bridge.ts
+++ b/packages/bridge-ui/src/domain/bridge.ts
@@ -1,5 +1,10 @@
 import type { BigNumber, ethers, Transaction } from 'ethers';
+import ERC20Bridge from '../erc20/bridge';
+import ETHBridge from '../eth/bridge';
+import { ProofService } from '../proof/service';
 import type { Message } from './message';
+import type { Prover } from './proof';
+import { providers } from './provider';
 
 enum BridgeType {
   ERC20 = 'ERC20',
@@ -60,6 +65,15 @@ interface HTMLBridgeForm extends HTMLFormElement {
   customTokenAddress: HTMLInputElement;
 }
 
+const prover: Prover = new ProofService(providers);
+const ethBridge = new ETHBridge(prover);
+const erc20Bridge = new ERC20Bridge(prover);
+
+const bridges = new Map<BridgeType, Bridge>([
+  [BridgeType.ETH, ethBridge],
+  [BridgeType.ERC20, erc20Bridge],
+]);
+
 export {
   ApproveOpts,
   BridgeOpts,
@@ -68,4 +82,5 @@ export {
   ClaimOpts,
   ReleaseOpts,
   HTMLBridgeForm,
+  bridges,
 };

--- a/packages/bridge-ui/src/domain/chain.ts
+++ b/packages/bridge-ui/src/domain/chain.ts
@@ -1,5 +1,5 @@
 import type { Chain as WagmiChain } from '@wagmi/core';
-import { BigNumber } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import type { ComponentType } from 'svelte';
 
 import Eth from '../components/icons/ETH.svelte';
@@ -137,3 +137,8 @@ export const taiko: WagmiChain = {
   //   address: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
   // },
 };
+
+// Will help us to map from chain id to RPC provider
+export const providers = new Map<number, ethers.providers.JsonRpcProvider>();
+providers.set(CHAIN_ID_MAINNET, new ethers.providers.JsonRpcProvider(L1_RPC));
+providers.set(CHAIN_ID_TAIKO, new ethers.providers.JsonRpcProvider(L2_RPC));

--- a/packages/bridge-ui/src/domain/chain.ts
+++ b/packages/bridge-ui/src/domain/chain.ts
@@ -1,5 +1,5 @@
 import type { Chain as WagmiChain } from '@wagmi/core';
-import { BigNumber, ethers } from 'ethers';
+import { BigNumber } from 'ethers';
 import type { ComponentType } from 'svelte';
 
 import Eth from '../components/icons/ETH.svelte';
@@ -13,10 +13,10 @@ export const CHAIN_ID_TAIKO = import.meta.env
   ? BigNumber.from(import.meta.env.VITE_TAIKO_CHAIN_ID).toNumber()
   : 167001;
 
-const L1_RPC =
+export const L1_RPC =
   import.meta.env?.VITE_L1_RPC_URL ?? 'https://l1rpc.internal.taiko.xyz/';
 
-const L2_RPC =
+export const L2_RPC =
   import.meta.env?.VITE_L2_RPC_URL ?? 'https://l2rpc.internal.taiko.xyz/';
 
 const L1_BRIDGE_ADDRESS =
@@ -137,8 +137,3 @@ export const taiko: WagmiChain = {
   //   address: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
   // },
 };
-
-// Will help us to map from chain id to RPC provider
-export const providers = new Map<number, ethers.providers.JsonRpcProvider>();
-providers.set(CHAIN_ID_MAINNET, new ethers.providers.JsonRpcProvider(L1_RPC));
-providers.set(CHAIN_ID_TAIKO, new ethers.providers.JsonRpcProvider(L2_RPC));

--- a/packages/bridge-ui/src/domain/provider.ts
+++ b/packages/bridge-ui/src/domain/provider.ts
@@ -1,0 +1,8 @@
+import { ethers } from 'ethers';
+import { CHAIN_ID_MAINNET, CHAIN_ID_TAIKO, L1_RPC, L2_RPC } from './chain';
+
+// Will help us to map from chain id to RPC provider
+export const providers = new Map<number, ethers.providers.JsonRpcProvider>();
+
+providers.set(CHAIN_ID_MAINNET, new ethers.providers.JsonRpcProvider(L1_RPC));
+providers.set(CHAIN_ID_TAIKO, new ethers.providers.JsonRpcProvider(L2_RPC));

--- a/packages/bridge-ui/src/domain/provider.ts
+++ b/packages/bridge-ui/src/domain/provider.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import { CHAIN_ID_MAINNET, CHAIN_ID_TAIKO, L1_RPC, L2_RPC } from './chain';
 
 // Will help us to map from chain id to RPC provider
-export const providers = new Map<number, ethers.providers.JsonRpcProvider>();
-
-providers.set(CHAIN_ID_MAINNET, new ethers.providers.JsonRpcProvider(L1_RPC));
-providers.set(CHAIN_ID_TAIKO, new ethers.providers.JsonRpcProvider(L2_RPC));
+export const providers = new Map([
+  [CHAIN_ID_MAINNET, new ethers.providers.JsonRpcProvider(L1_RPC)],
+  [CHAIN_ID_TAIKO, new ethers.providers.JsonRpcProvider(L2_RPC)],
+]);

--- a/packages/bridge-ui/src/proof/service.ts
+++ b/packages/bridge-ui/src/proof/service.ts
@@ -1,6 +1,5 @@
 import { Contract, ethers } from 'ethers';
 import { RLP } from 'ethers/lib/utils.js';
-import Bridge from '../constants/abi/Bridge';
 import HeaderSync from '../constants/abi/HeaderSync';
 import type { Block, BlockHeader } from '../domain/block';
 import type {

--- a/packages/bridge-ui/src/providers/map.ts
+++ b/packages/bridge-ui/src/providers/map.ts
@@ -1,8 +1,13 @@
 import { ethers } from 'ethers';
-import { CHAIN_ID_MAINNET, CHAIN_ID_TAIKO, L1_RPC, L2_RPC } from './chain';
+import {
+  CHAIN_ID_MAINNET,
+  CHAIN_ID_TAIKO,
+  L1_RPC,
+  L2_RPC,
+} from '../domain/chain';
 
 // Will help us to map from chain id to RPC provider
-export const providers = new Map([
+export const providersMap = new Map([
   [CHAIN_ID_MAINNET, new ethers.providers.JsonRpcProvider(L1_RPC)],
   [CHAIN_ID_TAIKO, new ethers.providers.JsonRpcProvider(L2_RPC)],
 ]);

--- a/packages/bridge-ui/src/providers/map.ts
+++ b/packages/bridge-ui/src/providers/map.ts
@@ -6,7 +6,6 @@ import {
   L2_RPC,
 } from '../domain/chain';
 
-// Will help us to map from chain id to RPC provider
 export const providersMap = new Map([
   [CHAIN_ID_MAINNET, new ethers.providers.JsonRpcProvider(L1_RPC)],
   [CHAIN_ID_TAIKO, new ethers.providers.JsonRpcProvider(L2_RPC)],

--- a/packages/bridge-ui/src/store/bridge.ts
+++ b/packages/bridge-ui/src/store/bridge.ts
@@ -1,10 +1,11 @@
 import { derived, writable } from 'svelte/store';
-import { BridgeType, bridges } from '../domain/bridge';
+import { BridgeType } from '../domain/bridge';
+import { bridgesMap } from '../bridges/map';
 
 export const bridgeType = writable<BridgeType>(BridgeType.ETH);
 
 export const activeBridge = derived(bridgeType, ($bridgeType) =>
-  bridges.get($bridgeType),
+  bridgesMap.get($bridgeType),
 );
 
 export const chainIdToTokenVaultAddress = writable<Map<number, string>>(

--- a/packages/bridge-ui/src/store/bridge.ts
+++ b/packages/bridge-ui/src/store/bridge.ts
@@ -1,15 +1,10 @@
 import { derived, writable } from 'svelte/store';
-import { BridgeType } from '../domain/bridge';
-import type { Bridge } from '../domain/bridge';
+import { BridgeType, bridges } from '../domain/bridge';
 
 export const bridgeType = writable<BridgeType>(BridgeType.ETH);
 
-export const bridges = writable<Map<BridgeType, Bridge>>(
-  new Map<BridgeType, Bridge>(),
-);
-
-export const activeBridge = derived([bridgeType, bridges], ($values) =>
-  $values[1].get($values[0]),
+export const activeBridge = derived(bridgeType, ($bridgeType) =>
+  bridges.get($bridgeType),
 );
 
 export const chainIdToTokenVaultAddress = writable<Map<number, string>>(

--- a/packages/bridge-ui/src/store/fee.ts
+++ b/packages/bridge-ui/src/store/fee.ts
@@ -1,5 +1,4 @@
-import { derived, writable } from 'svelte/store';
-import { ethers } from 'ethers';
+import { writable } from 'svelte/store';
 
 import { ProcessingFeeMethod } from '../domain/fee';
 

--- a/packages/bridge-ui/src/store/modal.ts
+++ b/packages/bridge-ui/src/store/modal.ts
@@ -1,4 +1,3 @@
 import { writable } from 'svelte/store';
 
 export const isSwitchEthereumChainModalOpen = writable<boolean>();
-export const isConnectWalletModalOpen = writable<boolean>();

--- a/packages/bridge-ui/src/store/providers.ts
+++ b/packages/bridge-ui/src/store/providers.ts
@@ -1,6 +1,0 @@
-import type { ethers } from 'ethers';
-import { writable } from 'svelte/store';
-
-export const providers = writable<
-  Map<number, ethers.providers.JsonRpcProvider>
->(new Map<number, ethers.providers.JsonRpcProvider>());

--- a/packages/bridge-ui/src/store/transactions.ts
+++ b/packages/bridge-ui/src/store/transactions.ts
@@ -6,12 +6,5 @@ import type { BridgeTransaction, Transactioner } from '../domain/transactions';
 const pendingTransactions = writable<Transaction[]>([]);
 const transactions = writable<BridgeTransaction[]>([]);
 const transactioner = writable<Transactioner>();
-const showTransactionDetails = writable<BridgeTransaction>();
-const showMessageStatusTooltip = writable<boolean>();
-export {
-  pendingTransactions,
-  transactions,
-  transactioner,
-  showTransactionDetails,
-  showMessageStatusTooltip,
-};
+
+export { pendingTransactions, transactions, transactioner };

--- a/packages/bridge-ui/src/store/wagmi.ts
+++ b/packages/bridge-ui/src/store/wagmi.ts
@@ -1,3 +1,0 @@
-import { writable } from 'svelte/store';
-import type { Client } from '@wagmi/core';
-export const wagmiClient = writable<Client>();

--- a/packages/bridge-ui/src/utils/recommendProcessingFee.spec.ts
+++ b/packages/bridge-ui/src/utils/recommendProcessingFee.spec.ts
@@ -10,8 +10,8 @@ import {
   CHAIN_ID_TAIKO,
   CHAIN_MAINNET,
   CHAIN_TKO,
-  providers,
 } from '../domain/chain';
+import { providers } from '../domain/provider';
 import { ProcessingFeeMethod } from '../domain/fee';
 import { ETH, TEST_ERC20 } from '../domain/token';
 import { signer } from '../store/signer';

--- a/packages/bridge-ui/src/utils/recommendProcessingFee.spec.ts
+++ b/packages/bridge-ui/src/utils/recommendProcessingFee.spec.ts
@@ -11,7 +11,7 @@ import {
   CHAIN_MAINNET,
   CHAIN_TKO,
 } from '../domain/chain';
-import { providers } from '../domain/provider';
+import { providersMap } from '../providers/map';
 import { ProcessingFeeMethod } from '../domain/fee';
 import { ETH, TEST_ERC20 } from '../domain/token';
 import { signer } from '../store/signer';
@@ -32,8 +32,8 @@ jest.mock('svelte/store', () => ({
 
 const gasPrice = 2;
 const mockGetGasPrice = async () => BigNumber.from(2);
-providers.get(CHAIN_ID_MAINNET).getGasPrice = mockGetGasPrice;
-providers.get(CHAIN_ID_TAIKO).getGasPrice = mockGetGasPrice;
+providersMap.get(CHAIN_ID_MAINNET).getGasPrice = mockGetGasPrice;
+providersMap.get(CHAIN_ID_TAIKO).getGasPrice = mockGetGasPrice;
 
 const mockContract = {
   canonicalToBridged: jest.fn(),

--- a/packages/bridge-ui/src/utils/recommendProcessingFee.ts
+++ b/packages/bridge-ui/src/utils/recommendProcessingFee.ts
@@ -1,8 +1,9 @@
 import { BigNumber, Contract, ethers, Signer } from 'ethers';
 import TokenVault from '../constants/abi/TokenVault';
-import { type Chain, providers } from '../domain/chain';
+import type { Chain } from '../domain/chain';
 import type { ProcessingFeeMethod } from '../domain/fee';
 import type { Token } from '../domain/token';
+import { providers } from '../domain/provider';
 import { ETH } from '../domain/token';
 import { chainIdToTokenVaultAddress } from '../store/bridge';
 import { get } from 'svelte/store';

--- a/packages/bridge-ui/src/utils/recommendProcessingFee.ts
+++ b/packages/bridge-ui/src/utils/recommendProcessingFee.ts
@@ -1,11 +1,10 @@
 import { BigNumber, Contract, ethers, Signer } from 'ethers';
 import TokenVault from '../constants/abi/TokenVault';
-import type { Chain } from '../domain/chain';
+import { type Chain, providers } from '../domain/chain';
 import type { ProcessingFeeMethod } from '../domain/fee';
 import type { Token } from '../domain/token';
 import { ETH } from '../domain/token';
 import { chainIdToTokenVaultAddress } from '../store/bridge';
-import { providers } from '../store/providers';
 import { get } from 'svelte/store';
 
 export const ethGasLimit = 900000;
@@ -20,8 +19,7 @@ export async function recommendProcessingFee(
   signer: Signer,
 ): Promise<string> {
   if (!toChain || !fromChain || !token || !signer || !feeType) return '0';
-  const p = get(providers);
-  const provider = p.get(toChain.id);
+  const provider = providers.get(toChain.id);
   const gasPrice = await provider.getGasPrice();
   // gasLimit for processMessage call for ETH is about ~800k.
   // to make it enticing, we say 900k.

--- a/packages/bridge-ui/src/utils/recommendProcessingFee.ts
+++ b/packages/bridge-ui/src/utils/recommendProcessingFee.ts
@@ -3,7 +3,7 @@ import TokenVault from '../constants/abi/TokenVault';
 import type { Chain } from '../domain/chain';
 import type { ProcessingFeeMethod } from '../domain/fee';
 import type { Token } from '../domain/token';
-import { providers } from '../domain/provider';
+import { providersMap } from '../providers/map';
 import { ETH } from '../domain/token';
 import { chainIdToTokenVaultAddress } from '../store/bridge';
 import { get } from 'svelte/store';
@@ -20,7 +20,7 @@ export async function recommendProcessingFee(
   signer: Signer,
 ): Promise<string> {
   if (!toChain || !fromChain || !token || !signer || !feeType) return '0';
-  const provider = providers.get(toChain.id);
+  const provider = providersMap.get(toChain.id);
   const gasPrice = await provider.getGasPrice();
   // gasLimit for processMessage call for ETH is about ~800k.
   // to make it enticing, we say 900k.


### PR DESCRIPTION
Store is s powerful tool in Svelte for state management. But if we want to store small values that are already available initially and won't ever change, then we are introducing unnecessary complexity here, and also could affect the performance. This might be the case of our providers map. It's used across different components, but its value, which is available when hitting the app, will always be the same.

Found a similar situation with our `wagmiClient` variable, which is only used in `Connect.svelte`, but initialized in `App.svelte`. It could simply be a local variable