### PR TITLE
chore(protocol): Use hardhat loadfixtrue to speed up test case execution

### DIFF
--- a/packages/protocol/test/L1/TaikoL1.test.ts
+++ b/packages/protocol/test/L1/TaikoL1.test.ts
@@ -1,23 +1,22 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { TaikoL1 } from "../../typechain";
 import deployAddressManager from "../utils/addressManager";
 import { randomBytes32 } from "../utils/bytes";
 import { deployTaikoL1 } from "../utils/taikoL1";
 
 describe("TaikoL1", function () {
-    let taikoL1: TaikoL1;
-    let genesisHash: string;
-
-    beforeEach(async function () {
+    async function deployL1() {
         const l1Signer = (await ethers.getSigners())[0];
         const addressManager = await deployAddressManager(l1Signer);
-        genesisHash = randomBytes32();
-        taikoL1 = await deployTaikoL1(addressManager, genesisHash, false);
-    });
+        const genesisHash = randomBytes32();
+        const taikoL1 = await deployTaikoL1(addressManager, genesisHash, false);
+        return { genesisHash, taikoL1 };
+    }
 
     describe("getLatestSyncedHeader()", async function () {
         it("should be genesisHash because no headers have been synced", async function () {
+            const { genesisHash, taikoL1 } = await loadFixture(deployL1);
             const hash = await taikoL1.getLatestSyncedHeader();
             expect(hash).to.be.eq(genesisHash);
         });
@@ -25,12 +24,14 @@ describe("TaikoL1", function () {
 
     describe("getSyncedHeader()", async function () {
         it("should revert because header number has not been synced", async function () {
+            const { taikoL1 } = await loadFixture(deployL1);
             await expect(taikoL1.getSyncedHeader(1)).to.be.revertedWith(
                 "L1_BLOCK_NUMBER()"
             );
         });
 
         it("should return appropriate hash for header", async function () {
+            const { genesisHash, taikoL1 } = await loadFixture(deployL1);
             const hash = await taikoL1.getSyncedHeader(0);
             expect(hash).to.be.eq(genesisHash);
         });
@@ -38,6 +39,7 @@ describe("TaikoL1", function () {
 
     describe("proposeBlock()", async function () {
         it("should revert when size of inputs is les than 2", async function () {
+            const { taikoL1 } = await loadFixture(deployL1);
             await expect(
                 taikoL1.proposeBlock([randomBytes32()])
             ).to.be.revertedWith("L1_INPUT_SIZE()");
@@ -46,6 +48,7 @@ describe("TaikoL1", function () {
 
     describe("commitBlock()", async function () {
         it("should revert when size of inputs is les than 2", async function () {
+            const { taikoL1 } = await loadFixture(deployL1);
             await expect(
                 taikoL1.proposeBlock([randomBytes32()])
             ).to.be.revertedWith("L1_INPUT_SIZE()");

--- a/packages/protocol/test/L1/TaikoL1.test.ts
+++ b/packages/protocol/test/L1/TaikoL1.test.ts
@@ -30,7 +30,7 @@ describe("TaikoL1", function () {
             );
         });
 
-        it("should return appropraite hash for header", async function () {
+        it("should return appropriate hash for header", async function () {
             const hash = await taikoL1.getSyncedHeader(0);
             expect(hash).to.be.eq(genesisHash);
         });


### PR DESCRIPTION
Use the [hardhat fixture](https://hardhat.org/hardhat-runner/docs/guides/test-contracts#using-fixtures) to speed up test case execution. As stated in the article:
> The first time loadFixture is called, the fixture is executed. But the second time, instead of executing the fixture again, loadFixture will reset the state of the network to the point where it was right after the fixture was executed. This is faster, and it undoes any state changes done by the previous test.

I think it's better than the mocha's beforeEach method, which is used now.