### PR TITLE
chore(bridge-ui): remove unnecessary interface

### DIFF
--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -42,13 +42,13 @@
   import { ethers } from 'ethers';
   import type { Prover } from './domain/proof';
   import { successToast } from './utils/toast';
-  import { StorageService } from './storage/service';
+  import { StorageService } from './storage/StorageService';
   import { MessageStatus } from './domain/message';
   import BridgeABI from './constants/abi/Bridge';
   import { providers } from './store/providers';
   import HeaderAnnouncement from './components/HeaderAnnouncement.svelte';
   import type { TokenService } from './domain/token';
-  import { CustomTokenService } from './storage/customTokenService';
+  import { CustomTokenService } from './storage/CustomTokenService';
   import { userTokens, tokenService } from './store/userToken';
   import RelayerAPIService from './relayer-api/service';
   import type { RelayerAPI } from './domain/relayerApi';
@@ -145,7 +145,6 @@
       const userAddress = await store.getAddress();
 
       const apiTxs = await $relayerApi.GetAllByAddress(userAddress);
-
 
       const blockInfoMap = await $relayerApi.GetBlockInfo();
       relayerBlockInfoMap.set(blockInfoMap);

--- a/packages/bridge-ui/src/storage/CustomTokenService.ts
+++ b/packages/bridge-ui/src/storage/CustomTokenService.ts
@@ -1,14 +1,9 @@
 import type { Token, TokenService } from 'src/domain/token';
 
-interface storage {
-  getItem(key: string): string;
-  setItem(key: string, value: string);
-}
+export class CustomTokenService implements TokenService {
+  private readonly storage: Storage;
 
-class CustomTokenService implements TokenService {
-  private readonly storage: storage;
-
-  constructor(storage: storage) {
+  constructor(storage: Storage) {
     this.storage = storage;
   }
 
@@ -57,5 +52,3 @@ class CustomTokenService implements TokenService {
     return updatedTokenList;
   }
 }
-
-export { CustomTokenService };

--- a/packages/bridge-ui/src/storage/StorageService.spec.ts
+++ b/packages/bridge-ui/src/storage/StorageService.spec.ts
@@ -1,13 +1,8 @@
 import { BigNumber, BigNumberish, ethers } from 'ethers';
 import { TKO } from '../domain/token';
-import {
-  CHAIN_ID_MAINNET,
-  CHAIN_ID_TAIKO,
-  CHAIN_MAINNET,
-  CHAIN_TKO,
-} from '../domain/chain';
+import { CHAIN_ID_MAINNET, CHAIN_ID_TAIKO } from '../domain/chain';
 import { MessageStatus } from '../domain/message';
-import { StorageService } from './service';
+import { StorageService } from './StorageService';
 import type { BridgeTransaction } from '../domain/transactions';
 const mockStorage = {
   getItem: jest.fn(),

--- a/packages/bridge-ui/src/storage/StorageService.ts
+++ b/packages/bridge-ui/src/storage/StorageService.ts
@@ -1,24 +1,19 @@
 import type { BridgeTransaction, Transactioner } from '../domain/transactions';
 import { BigNumber, Contract, ethers } from 'ethers';
 import Bridge from '../constants/abi/Bridge';
-import { chains, CHAIN_MAINNET, CHAIN_TKO } from '../domain/chain';
+import { chains } from '../domain/chain';
 import TokenVault from '../constants/abi/TokenVault';
 import { chainIdToTokenVaultAddress } from '../store/bridge';
 import { get } from 'svelte/store';
 import ERC20 from '../constants/abi/ERC20';
 import { MessageStatus } from '../domain/message';
 
-interface storage {
-  getItem(key: string): string;
-  setItem(key: string, value: unknown): void;
-}
-
-class StorageService implements Transactioner {
-  private readonly storage: storage;
+export class StorageService implements Transactioner {
+  private readonly storage: Storage;
   private readonly providerMap: Map<number, ethers.providers.JsonRpcProvider>;
 
   constructor(
-    storage: storage,
+    storage: Storage,
     providerMap: Map<number, ethers.providers.JsonRpcProvider>,
   ) {
     this.storage = storage;
@@ -154,5 +149,3 @@ class StorageService implements Transactioner {
     );
   }
 }
-
-export { StorageService };


### PR DESCRIPTION
We can use the `Storage` type provided by `lib.dom.d.ts`. Also renamed files affected after the service exported