### PR TITLE
chore(bridge-ui): move tailwind directives into css file

### DIFF
--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -267,10 +267,6 @@
 </QueryProvider>
 
 <style global lang="postcss">
-  @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
-
   main {
     font-family: 'Inter', sans-serif;
   }

--- a/packages/bridge-ui/src/app.css
+++ b/packages/bridge-ui/src/app.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 .btn.btn-wide {
   width: 194px;
   height: 56px;


### PR DESCRIPTION
A better place for the tailwind base directives is in a global css file. Let's leave the component scoped style for the component. Also, if we wanted to add a `@layer`, we would have to do it inside App.svelte 