### PR TITLE
fix(bridge-ui): ui fixes

### DIFF
--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -159,7 +159,7 @@
 
       const updatedStorageTxs: BridgeTransaction[] = txs.filter((tx) => {
         const blockInfo = blockInfoMap.get(tx.fromChainId);
-        if (blockInfo?.latestProcessedBlock >= tx.receipt.blockNumber) {
+        if (blockInfo?.latestProcessedBlock >= tx.receipt?.blockNumber) {
           return false;
         }
         return true;

--- a/packages/bridge-ui/src/bridge/ETHBridge.ts
+++ b/packages/bridge-ui/src/bridge/ETHBridge.ts
@@ -41,7 +41,7 @@ export class ETHBridge implements Bridge {
       callValue: 0,
       processingFee: opts.processingFeeInWei ?? BigNumber.from(0),
       gasLimit: opts.processingFeeInWei
-        ? BigNumber.from(900000)
+        ? BigNumber.from(140000)
         : BigNumber.from(0),
       memo: opts.memo ?? '',
     };

--- a/packages/bridge-ui/src/bridge/ETHBridge.ts
+++ b/packages/bridge-ui/src/bridge/ETHBridge.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Contract } from 'ethers';
+import { BigNumber, Contract, ethers } from 'ethers';
 import type { Transaction } from 'ethers';
 import type {
   ApproveOpts,
@@ -41,7 +41,7 @@ export class ETHBridge implements Bridge {
       callValue: 0,
       processingFee: opts.processingFeeInWei ?? BigNumber.from(0),
       gasLimit: opts.processingFeeInWei
-        ? BigNumber.from(140000)
+        ? BigNumber.from(900000)
         : BigNumber.from(0),
       memo: opts.memo ?? '',
     };
@@ -133,7 +133,23 @@ export class ETHBridge implements Bridge {
       };
 
       const proof = await this.prover.GenerateProof(proofOpts);
-      return await contract.processMessage(opts.message, proof);
+      let processMessageTx;
+      try {
+        processMessageTx = await contract.processMessage(opts.message, proof);
+      } catch (error) {
+        if (error.code === ethers.errors.UNPREDICTABLE_GAS_LIMIT) {
+          processMessageTx = await contract.processMessage(
+            opts.message,
+            proof,
+            {
+              gasLimit: 1e6,
+            },
+          );
+        } else {
+          throw new Error(error);
+        }
+      }
+      return processMessageTx;
     } else {
       return await contract.retryMessage(opts.message, true);
     }

--- a/packages/bridge-ui/src/components/InsufficientBalanceTooltip.svelte
+++ b/packages/bridge-ui/src/components/InsufficientBalanceTooltip.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import TooltipModal from './modals/TooltipModal.svelte';
+
+  export let show: boolean;
+</script>
+
+<TooltipModal title="Insufficient Balance" bind:isOpen={show}>
+  <span slot="body">
+    <div class="text-left">
+      You have insufficient balance to claim this transaction. Please wait for
+      the relayer to claim the transaction for you.
+    </div>
+  </span>
+</TooltipModal>

--- a/packages/bridge-ui/src/components/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transaction.svelte
@@ -80,10 +80,10 @@
         await switchChainAndSetSigner(chain);
       }
 
-      // For now just handling this case for when the user has 0 balance during their first bridge transaction to L2
+      // For now just handling this case for when the user has near 0 balance during their first bridge transaction to L2
       // TODO: estimate Claim transaction
       const userBalance = await $signer.getBalance('latest');
-      if (!userBalance.gt(0)) {
+      if (!userBalance.gt(ethers.utils.parseEther('0.0001'))) {
         onTooltipClick(true);
         return;
       }

--- a/packages/bridge-ui/src/components/Transactions.svelte
+++ b/packages/bridge-ui/src/components/Transactions.svelte
@@ -3,11 +3,13 @@
   import Transaction from './Transaction.svelte';
   import TransactionDetail from './TransactionDetail.svelte';
   import MessageStatusTooltip from './MessageStatusTooltip.svelte';
+  import InsufficientBalanceTooltip from './InsufficientBalanceTooltip.svelte';
   import type { BridgeTransaction } from '../domain/transactions';
   import { chainsRecord } from '../chain/chains';
 
   let selectedTransaction: BridgeTransaction;
   let showMessageStatusTooltip: boolean;
+  let showInsufficientBalance: boolean;
 </script>
 
 <div class="my-4 md:px-4">
@@ -25,8 +27,12 @@
       <tbody class="text-sm md:text-base">
         {#each $transactions as transaction}
           <Transaction
-            onTooltipClick={() => {
-              showMessageStatusTooltip = true;
+            onTooltipClick={(showInsufficientBalanceMessage = false) => {
+              if (showInsufficientBalanceMessage) {
+                showInsufficientBalance = true;
+              } else {
+                showMessageStatusTooltip = true;
+              }
             }}
             onShowTransactionDetailsClick={() => {
               selectedTransaction = transaction;
@@ -47,5 +53,6 @@
       onClose={() => (selectedTransaction = null)} />
   {/if}
 
-  <MessageStatusTooltip show={showMessageStatusTooltip} />
+  <MessageStatusTooltip bind:show={showMessageStatusTooltip} />
+  <InsufficientBalanceTooltip bind:show={showInsufficientBalance} />
 </div>

--- a/packages/bridge-ui/src/domain/message.ts
+++ b/packages/bridge-ui/src/domain/message.ts
@@ -6,6 +6,7 @@ export enum MessageStatus {
   Done,
   Failed,
   FailedReleased,
+  ClaimInProgress,
 }
 
 export type Message = {


### PR DESCRIPTION
- Adds a new message status to track when user has already triggered a claim transaction (we will lose this status if the user refreshes the page).
- Checks if user has zero balance (in case it's the first bridge transaction) and shows insufficient balance message on claim
- Passes explicit `gasLimit` if claim fails with `UNPREDICTABLE_GAS_LIMIT` error.