### PR TITLE
fix(bridge-ui): minor ui fixes for alpha 2

### DIFF
--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -146,24 +146,24 @@
       relayerBlockInfoMap.set(blockInfoMap);
 
       const txs = await $transactioner.GetAllByAddress(userAddress);
-      // const hashToApiTxsMap = new Map(apiTxs.map((tx) => {
-      //   return [tx.hash, tx];
-      // }))
+      const hashToApiTxsMap = new Map(
+        apiTxs.map((tx) => {
+          return [tx.hash.toLowerCase(), 1];
+        }),
+      );
+
+      const updatedStorageTxs: BridgeTransaction[] = txs.filter((tx) => {
+        console.log(tx.hash, hashToApiTxsMap.has(tx.hash.toLowerCase()));
+        return !hashToApiTxsMap.has(tx.hash.toLowerCase());
+      });
 
       // const updatedStorageTxs: BridgeTransaction[] = txs.filter((tx) => {
-      //   if (apiTxs.find((apiTx) => apiTx.hash.toLowerCase() === tx.hash)) {
+      //   const blockInfo = blockInfoMap.get(tx.fromChainId);
+      //   if (blockInfo?.latestProcessedBlock >= tx.receipt?.blockNumber) {
       //     return false;
       //   }
       //   return true;
       // });
-
-      const updatedStorageTxs: BridgeTransaction[] = txs.filter((tx) => {
-        const blockInfo = blockInfoMap.get(tx.fromChainId);
-        if (blockInfo?.latestProcessedBlock >= tx.receipt?.blockNumber) {
-          return false;
-        }
-        return true;
-      });
 
       $transactioner.UpdateStorageByAddress(userAddress, updatedStorageTxs);
 

--- a/packages/bridge-ui/src/app.css
+++ b/packages/bridge-ui/src/app.css
@@ -35,16 +35,6 @@
   border-color: hsla(var(--a) / var(--tw-bg-opacity, 1));
 }
 
-.btn.btn-accent.approve-btn {
-  background-color: #4c1d95;
-  border-color: #4c1d95;
-}
-
-.btn.btn-accent.approve-btn:hover {
-  background-color: #5b21b6;
-  border-color: #5b21b6;
-}
-
 .dropdown .dropdown-content {
   border-radius: 0 0 var(--rounded-box) var(--rounded-box);
 }

--- a/packages/bridge-ui/src/app.css
+++ b/packages/bridge-ui/src/app.css
@@ -35,6 +35,16 @@
   border-color: hsla(var(--a) / var(--tw-bg-opacity, 1));
 }
 
+.btn.btn-accent.approve-btn {
+  background-color: #4c1d95;
+  border-color: #4c1d95;
+}
+
+.btn.btn-accent.approve-btn:hover {
+  background-color: #5b21b6;
+  border-color: #5b21b6;
+}
+
 .dropdown .dropdown-content {
   border-radius: 0 0 var(--rounded-box) var(--rounded-box);
 }

--- a/packages/bridge-ui/src/components/TransactionDetail.svelte
+++ b/packages/bridge-ui/src/components/TransactionDetail.svelte
@@ -5,6 +5,7 @@
   import Modal from './modals/Modal.svelte';
   import type { BridgeTransaction } from '../domain/transactions';
   import { chainsRecord } from '../chain/chains';
+  import { addressSubsection } from '../utils/addressSubsection';
 
   // TODO: can we always guarantee that this object is defined?
   //       in which case we need to guard => transaction?.prop
@@ -25,7 +26,7 @@
           href={`${chainsRecord[transaction.fromChainId].explorerUrl}/tx/${
             transaction.hash
           }`}>
-          <span class="mr-2">{truncateString(transaction.hash)}</span>
+          <span class="mr-1">{addressSubsection(transaction.hash)}</span>
           <ArrowTopRightOnSquare />
         </a>
       </td>
@@ -34,19 +35,19 @@
       <tr>
         <td>Sender</td>
         <td class="text-right">
-          {truncateString(transaction.message.sender)}
+          {addressSubsection(transaction.message.sender)}
         </td>
       </tr>
       <tr>
         <td>Owner</td>
         <td class="text-right">
-          {truncateString(transaction.message.owner)}
+          {addressSubsection(transaction.message.owner)}
         </td>
       </tr>
       <tr>
         <td>Refund Address</td>
         <td class="text-right">
-          {truncateString(transaction.message.refundAddress)}
+          {addressSubsection(transaction.message.refundAddress)}
         </td>
       </tr>
       {#if transaction.message.callValue}

--- a/packages/bridge-ui/src/components/form/BridgeForm.svelte
+++ b/packages/bridge-ui/src/components/form/BridgeForm.svelte
@@ -457,7 +457,7 @@
   </button>
 {:else}
   <button
-    class="btn btn-accent w-full mt-4"
+    class="btn btn-accent approve-btn w-full mt-4"
     on:click={approve}
     disabled={btnDisabled}>
     {$_('home.approve')}

--- a/packages/bridge-ui/src/components/form/BridgeForm.svelte
+++ b/packages/bridge-ui/src/components/form/BridgeForm.svelte
@@ -472,4 +472,14 @@
     margin: 0;
     -moz-appearance: textfield !important;
   }
+
+  .btn.btn-accent.approve-btn {
+    background-color: #4c1d95;
+    border-color: #4c1d95;
+  }
+
+  .btn.btn-accent.approve-btn:hover {
+    background-color: #5b21b6;
+    border-color: #5b21b6;
+  }
 </style>


### PR DESCRIPTION
- Changes approve button color
- Changes tx dedup logic to avoid duplication between relayer and localStorage in some cases. In future we will revert back to the commented out logic and will instead try to tweak the relayer response for this.
- Fix address display in transaction detail popup