### PR TITLE
refactor(protocol): check if amount > 0 inside sendEther

### DIFF
--- a/packages/protocol/contracts/bridge/EtherVault.sol
+++ b/packages/protocol/contracts/bridge/EtherVault.sol
@@ -78,9 +78,7 @@ contract EtherVault is EssentialContract, BridgeErrors {
      * @param amount Amount of Ether to send.
      */
     function releaseEther(uint256 amount) public onlyAuthorized nonReentrant {
-        if (amount > 0) {
-            msg.sender.sendEther(amount);
-        }
+        msg.sender.sendEther(amount);
         emit EtherReleased(msg.sender, amount);
     }
 
@@ -97,9 +95,7 @@ contract EtherVault is EssentialContract, BridgeErrors {
         if (recipient == address(0)) {
             revert B_EV_DO_NOT_BURN();
         }
-        if (amount > 0) {
-            recipient.sendEther(amount);
-        }
+        recipient.sendEther(amount);
         emit EtherReleased(recipient, amount);
     }
 

--- a/packages/protocol/contracts/bridge/libs/LibBridgeProcess.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeProcess.sol
@@ -127,9 +127,7 @@ library LibBridgeProcess {
                 status = LibBridgeStatus.MessageStatus.DONE;
             } else {
                 status = LibBridgeStatus.MessageStatus.RETRIABLE;
-                if (ethVault != address(0)) {
-                    ethVault.sendEther(message.callValue);
-                }
+                ethVault.sendEther(message.callValue);
             }
         }
 

--- a/packages/protocol/contracts/bridge/libs/LibBridgeProcess.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeProcess.sol
@@ -97,9 +97,7 @@ library LibBridgeProcess {
         }
         // We send the Ether before the message call in case the call will
         // actually consume Ether.
-        if (message.depositValue > 0) {
-            message.owner.sendEther(message.depositValue);
-        }
+        message.owner.sendEther(message.depositValue);
 
         LibBridgeStatus.MessageStatus status;
         uint256 refundAmount;
@@ -129,7 +127,7 @@ library LibBridgeProcess {
                 status = LibBridgeStatus.MessageStatus.DONE;
             } else {
                 status = LibBridgeStatus.MessageStatus.RETRIABLE;
-                if (ethVault != address(0) && message.callValue > 0) {
+                if (ethVault != address(0)) {
                     ethVault.sendEther(message.callValue);
                 }
             }
@@ -145,19 +143,13 @@ library LibBridgeProcess {
         // if sender is the refundAddress
         if (msg.sender == refundAddress) {
             uint256 amount = message.processingFee + refundAmount;
-            if (amount > 0) {
-                refundAddress.sendEther(amount);
-            }
+            refundAddress.sendEther(amount);
         } else {
             // if sender is another address (eg. the relayer)
             // First attempt relayer is rewarded the processingFee
             // message.owner has to eat the cost
-            if (message.processingFee > 0) {
-                msg.sender.sendEther(message.processingFee);
-            }
-            if (refundAmount > 0) {
-                refundAddress.sendEther(refundAmount);
-            }
+            msg.sender.sendEther(message.processingFee);
+            refundAddress.sendEther(refundAmount);
         }
     }
 }

--- a/packages/protocol/contracts/bridge/libs/LibBridgeRetry.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeRetry.sol
@@ -91,7 +91,7 @@ library LibBridgeRetry {
                 : message.refundAddress;
 
             refundAddress.sendEther(message.callValue);
-        } else if (ethVault != address(0)) {
+        } else {
             ethVault.sendEther(message.callValue);
         }
     }

--- a/packages/protocol/contracts/bridge/libs/LibBridgeRetry.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeRetry.sol
@@ -89,10 +89,9 @@ library LibBridgeRetry {
             address refundAddress = message.refundAddress == address(0)
                 ? message.owner
                 : message.refundAddress;
-            if (message.callValue > 0) {
-                refundAddress.sendEther(message.callValue);
-            }
-        } else if (ethVault != address(0) && message.callValue > 0) {
+
+            refundAddress.sendEther(message.callValue);
+        } else if (ethVault != address(0)) {
             ethVault.sendEther(message.callValue);
         }
     }

--- a/packages/protocol/contracts/bridge/libs/LibBridgeSend.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeSend.sol
@@ -74,9 +74,7 @@ library LibBridgeSend {
         // store it here on the Bridge. Processing will release Ether from the
         // EtherVault or the Bridge on the destination chain.
         address ethVault = resolver.resolve("ether_vault", true);
-        if (ethVault != address(0)) {
-            ethVault.sendEther(expectedAmount);
-        }
+        ethVault.sendEther(expectedAmount);
 
         message.id = state.nextMessageId++;
         message.sender = msg.sender;

--- a/packages/protocol/contracts/bridge/libs/LibBridgeSend.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeSend.sol
@@ -74,7 +74,7 @@ library LibBridgeSend {
         // store it here on the Bridge. Processing will release Ether from the
         // EtherVault or the Bridge on the destination chain.
         address ethVault = resolver.resolve("ether_vault", true);
-        if (ethVault != address(0) && expectedAmount > 0) {
+        if (ethVault != address(0)) {
             ethVault.sendEther(expectedAmount);
         }
 

--- a/packages/protocol/contracts/libs/LibAddress.sol
+++ b/packages/protocol/contracts/libs/LibAddress.sol
@@ -18,6 +18,7 @@ library LibAddress {
      * @param amount The amount of Ether to send.
      */
     function sendEther(address to, uint256 amount) internal {
+        if (amount == 0) return;
         (bool success, ) = payable(to).call{value: amount}("");
         require(success, "ETH transfer failed");
     }

--- a/packages/protocol/contracts/libs/LibAddress.sol
+++ b/packages/protocol/contracts/libs/LibAddress.sol
@@ -18,7 +18,7 @@ library LibAddress {
      * @param amount The amount of Ether to send.
      */
     function sendEther(address to, uint256 amount) internal {
-        if (amount == 0) return;
+        if (amount == 0 || to == address(0)) return;
         (bool success, ) = payable(to).call{value: amount}("");
         require(success, "ETH transfer failed");
     }

--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -5,6 +5,6 @@ test = 'test2'
 libs = ['lib']
 optimizer = true
 optimizer_runs = 200
-gas_reports = ["TaikoL1", "TaikoL1WithConfig", "TaikoL2",  "GasComparision", "SignalService", "Bridge", "BridgedERC20", "TaikoToken", "EtherVault", "TokenVault"]
+gas_reports = ["FooBar", "TaikoL1", "TaikoL1WithConfig", "TaikoL2",  "GasComparision", "SignalService", "Bridge", "BridgedERC20", "TaikoToken", "EtherVault", "TokenVault"]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -5,6 +5,6 @@ test = 'test2'
 libs = ['lib']
 optimizer = true
 optimizer_runs = 200
-gas_reports = ["FooBar", "TaikoL1", "TaikoL1WithConfig", "TaikoL2",  "GasComparision", "SignalService", "Bridge", "BridgedERC20", "TaikoToken", "EtherVault", "TokenVault"]
+gas_reports = ["TaikoL1", "TaikoL1WithConfig", "TaikoL2",  "GasComparision", "SignalService", "Bridge", "BridgedERC20", "TaikoToken", "EtherVault", "TokenVault"]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/protocol/test2/GasComparison.t.sol
+++ b/packages/protocol/test2/GasComparison.t.sol
@@ -196,9 +196,8 @@ contract FooBar {
 
     // ------
     function send0Ether_CheckOutside(address to, uint256 amount) public {
-        if (amount > 0) {
-            LibAddress2.sendEther(to, amount);
-        }
+        if (amount == 0 || to == address(0)) return;
+        LibAddress2.sendEther(to, amount);
     }
 
     function send0Ether_CheckInside(address to, uint256 amount) public {

--- a/packages/protocol/test2/GasComparison.t.sol
+++ b/packages/protocol/test2/GasComparison.t.sol
@@ -8,13 +8,6 @@ import "../contracts/libs/LibAddress.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 library LibAddress2 {
-    /**
-     * Sends Ether to an address. Zero-value will also be sent.
-     * See more information at:
-     * https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now.
-     * @param to The target address.
-     * @param amount The amount of Ether to send.
-     */
     function sendEther(address to, uint256 amount) internal {
         (bool success, ) = payable(to).call{value: amount}("");
         require(success, "ETH transfer failed");

--- a/packages/protocol/test2/GasComparison.t.sol
+++ b/packages/protocol/test2/GasComparison.t.sol
@@ -4,7 +4,22 @@ pragma solidity ^0.8.18;
 import "forge-std/Test.sol";
 import "forge-std/console2.sol";
 import "../contracts/L1/TaikoData.sol";
+import "../contracts/libs/LibAddress.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+library LibAddress2 {
+    /**
+     * Sends Ether to an address. Zero-value will also be sent.
+     * See more information at:
+     * https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now.
+     * @param to The target address.
+     * @param amount The amount of Ether to send.
+     */
+    function sendEther(address to, uint256 amount) internal {
+        (bool success, ) = payable(to).call{value: amount}("");
+        require(success, "ETH transfer failed");
+    }
+}
 
 struct MyStruct {
     uint256 id;
@@ -180,16 +195,14 @@ contract FooBar {
     }
 
     // ------
-    function send0Ether_check(address to, uint256 amount) public {
+    function send0Ether_CheckOutside(address to, uint256 amount) public {
         if (amount > 0) {
-            (bool success, ) = payable(to).call{value: amount}("");
-            require(success, "ETH transfer failed");
+            LibAddress2.sendEther(to, amount);
         }
     }
 
-    function send0Ether_noCheck(address to, uint256 amount) public {
-        (bool success, ) = payable(to).call{value: amount}("");
-        require(success, "ETH transfer failed");
+    function send0Ether_CheckInside(address to, uint256 amount) public {
+        LibAddress.sendEther(to, amount);
     }
 }
 
@@ -261,8 +274,8 @@ contract GasComparisonTest is Test {
 
         {
             address to = 0x50081b12838240B1bA02b3177153Bca678a86078;
-            foobar.send0Ether_check(to, 0);
-            foobar.send0Ether_noCheck(to, 0);
+            foobar.send0Ether_CheckInside(to, 0);
+            foobar.send0Ether_CheckOutside(to, 0);
         }
     }
 }


### PR DESCRIPTION
It's quite weird that checking `amount>0` inside the sendEther function is actually cheaper...how come