### PR TITLE
fix(status-page): add some padding to the status page

### DIFF
--- a/packages/status-page/src/App.svelte
+++ b/packages/status-page/src/App.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <QueryProvider>
-  <main>
+  <main class="px-6">
     <Navbar />
     <Router {routes} />
   </main>


### PR DESCRIPTION
## summary
adds some horizontal padding.

before:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/13951458/226825376-a34692ef-654f-42ab-adc2-5fba6bc8f2d6.png">

after:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/13951458/226825279-35251b51-9fbd-419e-a19d-0dc22516aabb.png">
