### PR TITLE
feat(bridge-ui): Allow custom recipient for ETH

### DIFF
--- a/packages/bridge-ui/src/bridge/ETHBridge.spec.ts
+++ b/packages/bridge-ui/src/bridge/ETHBridge.spec.ts
@@ -94,7 +94,7 @@ describe('bridge tests', () => {
     expect(mockSigner.getAddress).toHaveBeenCalled();
     expect(mockContract.sendMessage).toHaveBeenCalledWith(
       {
-        callValue: BigNumber.from('0x01'),
+        callValue: BigNumber.from('0x01'), // callValue !== 0 because message owner is NOT the same as recipient
         data: '0x',
         depositValue: BigNumber.from('0x00'),
         destChainId: 167001,
@@ -134,7 +134,7 @@ describe('bridge tests', () => {
     await bridge.Bridge(opts);
     expect(mockContract.sendMessage).toHaveBeenCalledWith(
       {
-        callValue: BigNumber.from('0x00'),
+        callValue: BigNumber.from('0x00'), // callValue == 0 because message owner is same as recipient
         data: '0x',
         depositValue: BigNumber.from('0x01'),
         destChainId: 167001,

--- a/packages/bridge-ui/src/components/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transaction.svelte
@@ -233,7 +233,11 @@
   <td>
     {transaction.message &&
     (transaction.message?.data === '0x' || !transaction.message?.data)
-      ? ethers.utils.formatEther(transaction.message?.depositValue)
+      ? ethers.utils.formatEther(
+          transaction.message?.depositValue.eq(0)
+            ? transaction.message?.callValue.toString()
+            : transaction.message?.depositValue,
+        )
       : ethers.utils.formatUnits(transaction.amountInWei)}
     {transaction.symbol ?? 'ETH'}
   </td>

--- a/packages/bridge-ui/src/components/TransactionDetail.svelte
+++ b/packages/bridge-ui/src/components/TransactionDetail.svelte
@@ -54,7 +54,8 @@
         <tr>
           <td>Call value</td>
           <td class="text-right">
-            {ethers.utils.formatEther(transaction.message.callValue)} ETH
+            {ethers.utils.formatEther(transaction.message.callValue.toString())}
+            ETH
           </td>
         </tr>
       {/if}

--- a/packages/bridge-ui/src/components/form/BridgeForm.svelte
+++ b/packages/bridge-ui/src/components/form/BridgeForm.svelte
@@ -251,6 +251,7 @@
         fromChainId: $fromChain.id,
         toChainId: $toChain.id,
         tokenVaultAddress: $chainIdToTokenVaultAddress.get($fromChain.id),
+        bridgeAddress: chainsRecord[$fromChain.id].bridgeAddress,
         processingFeeInWei: getProcessingFee(),
         memo: memo,
         isBridgedTokenAlreadyDeployed,

--- a/packages/bridge-ui/src/domain/bridge.ts
+++ b/packages/bridge-ui/src/domain/bridge.ts
@@ -21,7 +21,8 @@ export type BridgeOpts = {
   tokenAddress: string;
   fromChainId: number;
   toChainId: number;
-  tokenVaultAddress: string;
+  tokenVaultAddress?: string;
+  bridgeAddress?: string;
   processingFeeInWei?: BigNumber;
   tokenId?: string;
   memo?: string;


### PR DESCRIPTION
Right now, the `TokenVault` disallows setting a `callValue` on a message, which sets into motion a chain of events whihc ends up with the result of: only ERC20 can be sent to custom recipient.

We can not fix this bug without redeploy of contracts, but this is a workaround :)

If we use `Bridge.sendMessage` directly, this is avoided.
I have also updated the UI to show the callValue when present, which will be set, and added test coverage to make sure `callValue` and `depositValue` are set correctly.