### PR TITLE
fix(protocol): allow deposit Ether to any address on L2

### DIFF
--- a/packages/protocol/contracts/bridge/TokenVault.sol
+++ b/packages/protocol/contracts/bridge/TokenVault.sol
@@ -140,6 +140,10 @@ contract TokenVault is EssentialContract {
     /**
      * Receives Ether and constructs a Bridge message. Sends the Ether and
      * message along to the Bridge.
+     *
+     * @dev This function doesn't' seem to belong here as it has nothing to
+     *      do with ERC20 tokens. It's added here only for convenience.
+     *
      * @param destChainId @custom:see IBridge.Message
      * @param to @custom:see IBridge.Message
      * @param gasLimit @custom:see IBridge.Message

--- a/packages/protocol/contracts/bridge/TokenVault.sol
+++ b/packages/protocol/contracts/bridge/TokenVault.sol
@@ -121,7 +121,6 @@ contract TokenVault is EssentialContract {
 
     error TOKENVAULT_INVALID_TO();
     error TOKENVAULT_INVALID_VALUE();
-    error TOKENVAULT_INVALID_CALL_VALUE();
     error TOKENVAULT_INVALID_TOKEN();
     error TOKENVAULT_INVALID_AMOUNT();
     error TOKENVAULT_CANONICAL_TOKEN_NOT_FOUND();
@@ -168,12 +167,10 @@ contract TokenVault is EssentialContract {
         message.to = to;
         message.gasLimit = gasLimit;
         message.processingFee = processingFee;
-        message.depositValue = msg.value - processingFee;
+        message.callValue = msg.value - processingFee;
         message.refundAddress = refundAddress;
         message.memo = memo;
-
-        // prevent future PRs from changing the callValue when it must be zero
-        if (message.callValue != 0) revert TOKENVAULT_INVALID_CALL_VALUE();
+        // message.depositValue = 0;
 
         bytes32 msgHash = IBridge(resolve("bridge", false)).sendMessage{
             value: msg.value
@@ -184,7 +181,7 @@ contract TokenVault is EssentialContract {
             from: message.owner,
             to: message.to,
             destChainId: destChainId,
-            amount: message.depositValue
+            amount: message.callValue
         });
     }
 

--- a/packages/protocol/contracts/bridge/libs/LibBridgeProcess.sol
+++ b/packages/protocol/contracts/bridge/libs/LibBridgeProcess.sol
@@ -115,7 +115,6 @@ library LibBridgeProcess {
                 ? gasleft()
                 : message.gasLimit;
 
-            // this will call receiveERC20 on the tokenVault, sending the tokens to the user
             bool success = LibBridgeInvoke.invokeMessageCall({
                 state: state,
                 message: message,


### PR DESCRIPTION
@Dani | Taiko @Daniel | Taiko i think we have a bug. ourBBridge cant actually allow send ETH to custom recipient.
because 
LibBridgeProcess.sol

        if (message.depositValue > 0) {
            // we use message.owner here, not message.to
            message.owner.sendEther(message.depositValue);
        }


so the workaround, in oru code, is to set no depositValue, and set the message.callValue when sending ETH to an address that is diffeernt than the person who owns the message.

            bool success = LibBridgeInvoke.invokeMessageCall({
                state: state,
                message: message,
                msgHash: msgHash,
                gasLimit: gasLimit
            });


which does:

  (success, ) = message.to.call{value: message.callValue, gas: gasLimit}(
            message.data
        );


All fine and dandy so far, just set callValue and to appropriately.
Except in TokenVault.sol, sendEther method:

        // prevent future PRs from changing the callValue when it must be zero
        if (message.callValue != 0) revert TOKENVAULT_INVALID_CALL_VALUE();


so callValue can never be set for sendEther.