### PR TITLE
refactor(protocol): change TaikoToken's decimals from 18 to 8

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -68,14 +68,16 @@ library TaikoData {
     // 5 slots
     struct BlockMetadata {
         uint64 id;
-        uint32 gasLimit;
         uint64 timestamp;
         uint64 l1Height;
+        uint32 gasLimit;
+        // uint32 __free
         bytes32 l1Hash;
         bytes32 mixHash;
         bytes32 txListHash;
         uint24 txListByteStart;
         uint24 txListByteEnd;
+        // uint48 __free
         address beneficiary;
     }
 
@@ -91,7 +93,8 @@ library TaikoData {
         bytes32 blockHash;
         bytes32 signalRoot;
         address prover;
-        uint64 gasUsed;
+        uint32 gasUsed;
+        // uint64 __free
     }
 
     struct ForkChoice {
@@ -99,22 +102,29 @@ library TaikoData {
         bytes32 signalRoot;
         address prover;
         uint64 provenAt;
+        // uint32 __free
     }
 
     // 4 slots
     struct ProposedBlock {
-        bytes32 metaHash;
-        uint256 deposit;
-        address proposer;
-        uint64 proposedAt;
-        uint24 nextForkChoiceId;
         // ForkChoice storage are reusable
         mapping(uint256 forkChoiceId => ForkChoice) forkChoices;
+        bytes32 metaHash;
+        address proposer;
+        uint64 deposit;
+        // uint32 __free
+        uint24 nextForkChoiceId;
+        uint64 proposedAt;
+        // uint64 __free
+        // uint64 __free
     }
 
     // 3 slots
     struct VerifiedBlock {
         uint64 blockId;
+        // uint64 __free
+        // uint64 __free
+        // uint64 __free
         bytes32 blockHash;
         bytes32 signalRoot;
     }
@@ -123,6 +133,8 @@ library TaikoData {
     struct TxListInfo {
         uint64 validSince;
         uint24 size;
+        // uint64 __free
+        // uint64 __free
     }
 
     struct State {

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -45,7 +45,7 @@ library TaikoData {
     }
 
     struct StateVariables {
-        uint64 feeBaseTwei;
+        uint64 feeBase;
         uint64 genesisHeight;
         uint64 genesisTimestamp;
         uint64 numBlocks;
@@ -155,7 +155,7 @@ library TaikoData {
         // the proof time moving average, note that for each block, only the
         // first proof's time is considered.
         uint64 avgProofTime; // miliseconds
-        uint64 feeBaseTwei;
+        uint64 feeBase;
         // Reserved
         uint256[42] __gap;
     }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -71,13 +71,11 @@ library TaikoData {
         uint64 timestamp;
         uint64 l1Height;
         uint32 gasLimit;
-        // uint32 __free
         bytes32 l1Hash;
         bytes32 mixHash;
         bytes32 txListHash;
         uint24 txListByteStart;
         uint24 txListByteEnd;
-        // uint48 __free
         address beneficiary;
     }
 
@@ -94,7 +92,6 @@ library TaikoData {
         bytes32 signalRoot;
         address prover;
         uint32 gasUsed;
-        // uint64 __free
     }
 
     struct ForkChoice {
@@ -102,29 +99,21 @@ library TaikoData {
         bytes32 signalRoot;
         address prover;
         uint64 provenAt;
-        // uint32 __free
     }
 
     // 4 slots
     struct ProposedBlock {
-        // ForkChoice storage are reusable
         mapping(uint256 forkChoiceId => ForkChoice) forkChoices;
         bytes32 metaHash;
         address proposer;
         uint64 deposit;
-        // uint32 __free
         uint24 nextForkChoiceId;
         uint64 proposedAt;
-        // uint64 __free
-        // uint64 __free
     }
 
     // 3 slots
     struct VerifiedBlock {
         uint64 blockId;
-        // uint64 __free
-        // uint64 __free
-        // uint64 __free
         bytes32 blockHash;
         bytes32 signalRoot;
     }
@@ -133,8 +122,6 @@ library TaikoData {
     struct TxListInfo {
         uint64 validSince;
         uint24 size;
-        // uint64 __free
-        // uint64 __free
     }
 
     struct State {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -28,14 +28,14 @@ contract TaikoL1 is EssentialContract, IXchainSync, TaikoEvents, TaikoErrors {
     function init(
         address _addressManager,
         bytes32 _genesisBlockHash,
-        uint64 _feeBaseTwei
+        uint64 _feeBase
     ) external initializer {
         EssentialContract._init(_addressManager);
         LibVerifying.init({
             state: state,
             config: getConfig(),
             genesisBlockHash: _genesisBlockHash,
-            feeBaseTwei: _feeBaseTwei
+            feeBase: _feeBase
         });
     }
 

--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -58,7 +58,7 @@ contract TaikoToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
         ERC20Upgradeable.__ERC20_init({
             name_: _name,
             symbol_: _symbol,
-            decimals_: 18
+            decimals_: 8
         });
 
         for (uint256 i = 0; i < _premintRecipients.length; ++i) {

--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -36,6 +36,7 @@ contract TaikoToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
 
     error TKO_INVALID_ADDR();
     error TKO_INVALID_PREMINT_PARAMS();
+    error TKO_MINT_DISALLOWED();
 
     /*********************
      * External Functions*
@@ -115,5 +116,10 @@ contract TaikoToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
         if (account == address(0)) revert TKO_INVALID_ADDR();
         _burn(account, amount);
         emit Burn(account, amount);
+    }
+
+    function _mint(address account, uint256 amount) internal override {
+        ERC20Upgradeable._mint(account, amount);
+        if (totalSupply() > type(uint64).max) revert TKO_MINT_DISALLOWED();
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -142,10 +142,10 @@ library LibProposing {
                 state.balances[msg.sender] -= burnAmount;
             }
             // Update feeBase and avgBlockTime
-            state.feeBaseTwei = LibUtils
+            state.feeBase = LibUtils
                 .movingAverage({
-                    maValue: state.feeBaseTwei,
-                    newValue: LibTokenomics.toTwei(newFeeBase),
+                    maValue: state.feeBase,
+                    newValue: newFeeBase,
                     maf: config.feeBaseMAF
                 })
                 .toUint64();

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -154,7 +154,7 @@ library LibProposing {
         TaikoData.Block storage blk = state.blocks[
             state.numBlocks % config.ringBufferSize
         ];
-        
+
         blk.blockId = state.numBlocks;
         blk.proposedAt = meta.timestamp;
         blk.deposit = uint64(deposit);

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -114,9 +114,9 @@ library LibProposing {
 
         TaikoData.BlockMetadata memory meta = TaikoData.BlockMetadata({
             id: state.numBlocks,
-            gasLimit: input.gasLimit,
             timestamp: timeNow,
             l1Height: uint64(block.number - 1),
+            gasLimit: input.gasLimit,
             l1Hash: blockhash(block.number - 1),
             mixHash: bytes32(mixHash),
             txListHash: input.txListHash,
@@ -156,10 +156,10 @@ library LibProposing {
         ];
 
         blk.metaHash = LibUtils.hashMetadata(meta);
-        blk.deposit = deposit;
         blk.proposer = msg.sender;
-        blk.proposedAt = meta.timestamp;
+        blk.deposit = uint64(deposit);
         blk.nextForkChoiceId = 1;
+        blk.proposedAt = meta.timestamp;
 
         if (state.lastProposedAt > 0) {
             uint256 blockTime;

--- a/packages/protocol/contracts/L1/libs/LibTokenomics.sol
+++ b/packages/protocol/contracts/L1/libs/LibTokenomics.sol
@@ -53,25 +53,6 @@ library LibTokenomics {
         }
     }
 
-    function fromTwei(uint64 amount) internal pure returns (uint256) {
-        if (amount == 0) {
-            return TWEI_TO_WEI;
-        } else {
-            return amount * TWEI_TO_WEI;
-        }
-    }
-
-    function toTwei(uint256 amount) internal pure returns (uint64) {
-        uint256 _twei = amount / TWEI_TO_WEI;
-        if (_twei > type(uint64).max) {
-            return type(uint64).max;
-        } else if (_twei == 0) {
-            return uint64(1);
-        } else {
-            return uint64(_twei);
-        }
-    }
-
     function getBlockFee(
         TaikoData.State storage state,
         TaikoData.Config memory config
@@ -80,14 +61,13 @@ library LibTokenomics {
         view
         returns (uint256 newFeeBase, uint256 fee, uint256 depositAmount)
     {
-        uint256 feeBase = fromTwei(state.feeBaseTwei);
         if (state.numBlocks <= config.constantFeeRewardBlocks) {
-            fee = feeBase;
-            newFeeBase = feeBase;
+            fee = state.feeBase;
+            newFeeBase = state.feeBase;
         } else {
             (newFeeBase, ) = getTimeAdjustedFee({
                 feeConfig: config.proposingConfig,
-                feeBase: feeBase,
+                feeBase: state.feeBase,
                 isProposal: true,
                 tNow: block.timestamp,
                 tLast: state.lastProposedAt,
@@ -128,15 +108,14 @@ library LibTokenomics {
     {
         if (proposedAt > provenAt) revert L1_INVALID_PARAM();
 
-        uint256 feeBase = fromTwei(state.feeBaseTwei);
         if (state.lastVerifiedBlockId <= config.constantFeeRewardBlocks) {
-            reward = feeBase;
-            newFeeBase = feeBase;
+            reward = state.feeBase;
+            newFeeBase = state.feeBase;
             // tRelBp = 0;
         } else {
             (newFeeBase, tRelBp) = getTimeAdjustedFee({
                 feeConfig: config.provingConfig,
-                feeBase: feeBase,
+                feeBase: state.feeBase,
                 isProposal: false,
                 tNow: provenAt,
                 tLast: proposedAt,

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -40,7 +40,7 @@ library LibUtils {
     ) internal view returns (TaikoData.StateVariables memory) {
         return
             TaikoData.StateVariables({
-                feeBaseTwei: state.feeBaseTwei,
+                feeBase: state.feeBase,
                 genesisHeight: state.genesisHeight,
                 genesisTimestamp: state.genesisTimestamp,
                 numBlocks: state.numBlocks,

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -31,13 +31,13 @@ library LibVerifying {
         TaikoData.State storage state,
         TaikoData.Config memory config,
         bytes32 genesisBlockHash,
-        uint64 feeBaseTwei
+        uint64 feeBase
     ) internal {
         _checkConfig(config);
 
         state.genesisHeight = uint64(block.number);
         state.genesisTimestamp = uint64(block.timestamp);
-        state.feeBaseTwei = feeBaseTwei;
+        state.feeBase = feeBase;
         state.numBlocks = 1;
 
         state.verifiedBlocks[0].blockHash = genesisBlockHash;
@@ -142,10 +142,10 @@ library LibVerifying {
             _addToBalance(state, blk.proposer, amount);
 
             // Update feeBase and avgProofTime
-            state.feeBaseTwei = LibUtils
+            state.feeBase = LibUtils
                 .movingAverage({
-                    maValue: state.feeBaseTwei,
-                    newValue: LibTokenomics.toTwei(newFeeBase),
+                    maValue: state.feeBase,
+                    newValue: newFeeBase,
                     maf: config.feeBaseMAF
                 })
                 .toUint64();

--- a/packages/protocol/test2/LibTokenomics.t.sol
+++ b/packages/protocol/test2/LibTokenomics.t.sol
@@ -17,7 +17,7 @@ contract TaikoL1WithConfig is Test {
     }
 
     function test_getTimeAdjustedFee() public {
-        uint256 feeBase = 10 ether;
+        uint256 feeBase = 10 * 1E8;
         uint256 tLast = 100000;
         uint256 tAvg = 40;
         uint256 tNow = tLast + tAvg;

--- a/packages/protocol/test2/TaikoL1.t.sol
+++ b/packages/protocol/test2/TaikoL1.t.sol
@@ -79,7 +79,7 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint64 gasUsed = 1000000;
+        uint32 gasUsed = 1000000;
 
         for (
             uint256 blockId = 1;
@@ -106,7 +106,7 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Alice, 1000 * 1E8, 1000 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint64 gasUsed = 1000000;
+        uint32 gasUsed = 1000000;
 
         for (uint256 blockId = 1; blockId <= 2; blockId++) {
             printVariables("before propose");
@@ -124,10 +124,10 @@ contract TaikoL1Test is TaikoL1TestBase {
 
     /// @dev Test verifying multiple blocks in one transaction
     function test_verifying_multiple_blocks_once() external {
-        _depositTaikoToken(Alice, 1E6 * 1E8, 1giex00 ether);
+        _depositTaikoToken(Alice, 1E6 * 1E8, 1000 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint64 gasUsed = 1000000;
+        uint32 gasUsed = 1000000;
 
         for (
             uint256 blockId = 1;
@@ -156,7 +156,7 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint64 gasUsed = 1000000;
+        uint32 gasUsed = 1000000;
 
         for (
             uint256 blockId = 1;
@@ -185,7 +185,7 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint64 gasUsed = 1000000;
+        uint32 gasUsed = 1000000;
 
         uint256 total = conf.maxNumProposedBlocks * 10;
 

--- a/packages/protocol/test2/TaikoL1.t.sol
+++ b/packages/protocol/test2/TaikoL1.t.sol
@@ -74,9 +74,9 @@ contract TaikoL1Test is TaikoL1TestBase {
 
     /// @dev Test we can propose, prove, then verify more blocks than 'maxNumProposedBlocks'
     function test_more_blocks_than_ring_buffer_size() external {
-        _depositTaikoToken(Alice, 1E6, 100);
-        _depositTaikoToken(Bob, 1E6, 100);
-        _depositTaikoToken(Carol, 1E6, 100);
+        _depositTaikoToken(Alice, 1E6 * 1E8, 100 ether);
+        _depositTaikoToken(Bob, 1E6 * 1E8, 100 ether);
+        _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         uint64 gasUsed = 1000000;
@@ -103,7 +103,7 @@ contract TaikoL1Test is TaikoL1TestBase {
     /// @dev Test more than one block can be proposed, proven, & verified in the
     ///      same L1 block.
     function test_multiple_blocks_in_one_L1_block() external {
-        _depositTaikoToken(Alice, 1000, 1000);
+        _depositTaikoToken(Alice, 1000 * 1E8, 1000 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         uint64 gasUsed = 1000000;
@@ -124,7 +124,7 @@ contract TaikoL1Test is TaikoL1TestBase {
 
     /// @dev Test verifying multiple blocks in one transaction
     function test_verifying_multiple_blocks_once() external {
-        _depositTaikoToken(Alice, 1E6, 100);
+        _depositTaikoToken(Alice, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         uint64 gasUsed = 1000000;
@@ -151,9 +151,9 @@ contract TaikoL1Test is TaikoL1TestBase {
 
     /// @dev Test block timeincrease and fee shall decrease.
     function test_block_time_increases_but_fee_decreases() external {
-        _depositTaikoToken(Alice, 1E6, 100);
-        _depositTaikoToken(Bob, 1E6, 100);
-        _depositTaikoToken(Carol, 1E6, 100);
+        _depositTaikoToken(Alice, 1E6 * 1E8, 100 ether);
+        _depositTaikoToken(Bob, 1E6 * 1E8, 100 ether);
+        _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         uint64 gasUsed = 1000000;
@@ -180,9 +180,9 @@ contract TaikoL1Test is TaikoL1TestBase {
     /// @dev Test block time goes down lover time and the fee should remain
     // the same.
     function test_block_time_decreases_but_fee_remains() external {
-        _depositTaikoToken(Alice, 1E6, 100);
-        _depositTaikoToken(Bob, 1E6, 100);
-        _depositTaikoToken(Carol, 1E6, 100);
+        _depositTaikoToken(Alice, 1E6 * 1E8, 100 ether);
+        _depositTaikoToken(Bob, 1E6 * 1E8, 100 ether);
+        _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         uint64 gasUsed = 1000000;

--- a/packages/protocol/test2/TaikoL1.t.sol
+++ b/packages/protocol/test2/TaikoL1.t.sol
@@ -124,7 +124,7 @@ contract TaikoL1Test is TaikoL1TestBase {
 
     /// @dev Test verifying multiple blocks in one transaction
     function test_verifying_multiple_blocks_once() external {
-        _depositTaikoToken(Alice, 1E6 * 1E8, 100 ether);
+        _depositTaikoToken(Alice, 1E6 * 1E8, 1giex00 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         uint64 gasUsed = 1000000;

--- a/packages/protocol/test2/TaikoL1TestBase.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.sol
@@ -21,7 +21,7 @@ abstract contract TaikoL1TestBase is Test {
 
     bytes32 public constant GENESIS_BLOCK_HASH =
         keccak256("GENESIS_BLOCK_HASH");
-    uint64 feeBaseTwei = 1000000; // 1 TKO
+    uint64 feeBase = 100000000; // 1 TKO
 
     address public constant L2SS = 0xa008AE5Ba00656a3Cc384de589579e3E52aC030C;
     address public constant L2TaikoL2 =
@@ -41,7 +41,7 @@ abstract contract TaikoL1TestBase is Test {
         addressManager.init();
 
         L1 = deployTaikoL1();
-        L1.init(address(addressManager), GENESIS_BLOCK_HASH, feeBaseTwei);
+        L1.init(address(addressManager), GENESIS_BLOCK_HASH, feeBase);
         conf = L1.getConfig();
 
         tko = new TaikoToken();
@@ -173,9 +173,9 @@ abstract contract TaikoL1TestBase is Test {
             Strings.toString(vars.lastVerifiedBlockId),
             unicode"→",
             Strings.toString(vars.numBlocks),
-            "] feeBase(twei):",
-            Strings.toString(vars.feeBaseTwei),
-            " fee(twei):",
+            "] feeBase:",
+            Strings.toString(vars.feeBase),
+            " fee:",
             Strings.toString(fee),
             " avgBlockTime:",
             Strings.toString(vars.avgBlockTime),

--- a/packages/protocol/test2/TaikoL1TestBase.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.sol
@@ -110,7 +110,7 @@ abstract contract TaikoL1TestBase is Test {
 
     function proveBlock(
         address prover,
-        uint64 gasUsed,
+        uint32 gasUsed,
         TaikoData.BlockMetadata memory meta,
         bytes32 parentHash,
         bytes32 blockHash,

--- a/packages/protocol/test2/TaikoL1TestBase.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.sol
@@ -21,7 +21,7 @@ abstract contract TaikoL1TestBase is Test {
 
     bytes32 public constant GENESIS_BLOCK_HASH =
         keccak256("GENESIS_BLOCK_HASH");
-    uint64 feeBase = 100000000; // 1 TKO
+    uint64 feeBase = 1E8; // 1 TKO
 
     address public constant L2SS = 0xa008AE5Ba00656a3Cc384de589579e3E52aC030C;
     address public constant L2TaikoL2 =
@@ -60,7 +60,7 @@ abstract contract TaikoL1TestBase is Test {
 
         // set proto_broker to this address to mint some TKO
         _registerAddress("proto_broker", address(this));
-        tko.mint(address(this), 1E12 ether);
+        tko.mint(address(this), 1E9 * 1E8);
 
         // register all addresses
         _registerAddress("taiko_token", address(tko));
@@ -157,16 +157,15 @@ abstract contract TaikoL1TestBase is Test {
         uint256 amountTko,
         uint256 amountEth
     ) internal {
-        vm.deal(who, amountEth * 1 ether);
-        tko.transfer(who, amountTko * 1 ether);
+        vm.deal(who, amountEth);
+        tko.transfer(who, amountTko);
         vm.prank(who, who);
-        L1.deposit(amountTko * 1E8);
+        L1.deposit(amountTko);
     }
 
     function printVariables(string memory comment) internal {
         TaikoData.StateVariables memory vars = L1.getStateVariables();
         (uint256 fee, ) = L1.getBlockFee();
-        fee /= 1E12;
         string memory str = string.concat(
             Strings.toString(logCount++),
             ":[",

--- a/packages/protocol/test2/TaikoL1TestBase.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.sol
@@ -160,7 +160,7 @@ abstract contract TaikoL1TestBase is Test {
         vm.deal(who, amountEth * 1 ether);
         tko.transfer(who, amountTko * 1 ether);
         vm.prank(who, who);
-        L1.deposit(amountTko * 1 ether);
+        L1.deposit(amountTko * 1E8);
     }
 
     function printVariables(string memory comment) internal {

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -78,9 +78,9 @@ struct BlockMetadataInput {
 ```solidity
 struct BlockMetadata {
   uint64 id;
-  uint32 gasLimit;
   uint64 timestamp;
   uint64 l1Height;
+  uint32 gasLimit;
   bytes32 l1Hash;
   bytes32 mixHash;
   bytes32 txListHash;
@@ -109,7 +109,7 @@ struct BlockEvidence {
   bytes32 blockHash;
   bytes32 signalRoot;
   address prover;
-  uint64 gasUsed;
+  uint32 gasUsed;
 }
 ```
 
@@ -128,12 +128,12 @@ struct ForkChoice {
 
 ```solidity
 struct ProposedBlock {
-  bytes32 metaHash;
-  uint256 deposit;
-  address proposer;
-  uint64 proposedAt;
-  uint24 nextForkChoiceId;
   mapping(uint256 => struct TaikoData.ForkChoice) forkChoices;
+  bytes32 metaHash;
+  address proposer;
+  uint64 deposit;
+  uint24 nextForkChoiceId;
+  uint64 proposedAt;
 }
 ```
 

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -49,7 +49,7 @@ struct Config {
 
 ```solidity
 struct StateVariables {
-  uint64 feeBaseTwei;
+  uint64 feeBase;
   uint64 genesisHeight;
   uint64 genesisTimestamp;
   uint64 numBlocks;
@@ -109,6 +109,7 @@ struct BlockEvidence {
   bytes32 blockHash;
   bytes32 signalRoot;
   address prover;
+  uint64 gasUsed;
 }
 ```
 
@@ -175,7 +176,7 @@ struct State {
   uint64 __reserved4;
   uint64 lastVerifiedBlockId;
   uint64 avgProofTime;
-  uint64 feeBaseTwei;
+  uint64 feeBase;
   uint256[42] __gap;
 }
 ```

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -127,6 +127,19 @@ struct ForkChoice {
 
 ### Block
 
+```solidity
+struct Block {
+  mapping(uint256 => struct TaikoData.ForkChoice) forkChoices;
+  uint64 blockId;
+  uint64 proposedAt;
+  uint64 deposit;
+  uint24 nextForkChoiceId;
+  uint24 verifiedForkChoiceId;
+  bytes32 metaHash;
+  address proposer;
+}
+```
+
 ### TxListInfo
 
 ```solidity

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoL1.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoL1.md
@@ -13,7 +13,7 @@ struct TaikoData.State state
 ### init
 
 ```solidity
-function init(address _addressManager, bytes32 _genesisBlockHash, uint64 _feeBaseTwei) external
+function init(address _addressManager, bytes32 _genesisBlockHash, uint64 _feeBase) external
 ```
 
 ### proposeBlock

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoToken.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoToken.md
@@ -30,6 +30,12 @@ error TKO_INVALID_ADDR()
 error TKO_INVALID_PREMINT_PARAMS()
 ```
 
+### TKO_MINT_DISALLOWED
+
+```solidity
+error TKO_MINT_DISALLOWED()
+```
+
 ### init
 
 ```solidity
@@ -83,3 +89,9 @@ the circulating supply._
 | ------- | ------- | ------------------------------------ |
 | account | address | The address to burn the tokens from. |
 | amount  | uint256 | The amount of tokens to burn.        |
+
+### \_mint
+
+```solidity
+function _mint(address account, uint256 amount) internal
+```


### PR DESCRIPTION
The main objective for such a change is to make sure the current and future max supply can fit in to a `uint64` so the protocol code can use one single `uint64` to hold any taiko token amount.

type(uint64).max/ (10**18) = 184,467,440,737 which is 184 billion. I don't think our max supply will ever be 10 billion.




| test2/TaikoL1.t.sol:TaikoL1WithConfig contract |                 |        |        |        |         |
|------------------------------------------------|-----------------|--------|--------|--------|---------|
| proposeBlock                                   | 18589           | 28621  | 18609  | 85536  | 309     |
| proveBlock                                     | 56012           | 66066  | 56012  | 132412 | 309     |
| verifyBlocks                                   | 14484           | 15675  | 15409  | 76980  | 301     |