### PR TITLE
feat(protocol): calculate EIP1559 base fee on L1.

### DIFF
--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -41,6 +41,9 @@ library TaikoConfig {
                 bootstrapDiscountHalvingPeriod: 1 seconds, // owner:daniel
                 constantFeeRewardBlocks: 1024,
                 txListCacheExpiry: 0,
+                gasTarget: 10000000, // 10 million
+                gasFeeAdjustmentQuotient: 1023, // TODO
+                gasFeeSlackCoefficient: 2,
                 enableSoloProposer: false,
                 enableOracleProver: true,
                 enableTokenomics: true,

--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -37,8 +37,10 @@ library TaikoConfig {
                 bootstrapDiscountHalvingPeriod: 1 seconds, // owner:daniel
                 constantFeeRewardBlocks: 1024,
                 txListCacheExpiry: 0,
-                blockGasTarget: 1500000, // 1.5 million
-                blockGasThrottle: 30000000, // 30 million
+                // Set it to 6M, since its the upper limit of the Alpha-2
+                // testnet's circuits.
+                blockGasTarget: 3000000, // 3M as target, 6M max
+                blockGasThrottle: 60000000, // 60M max
                 basefeePerGasQuotient: 1023, // TODO
                 enableSoloProposer: false,
                 enableOracleProver: true,

--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -20,9 +20,6 @@ library TaikoConfig {
                 //Each time one more block is verified, there will be ~20k
                 // more gas cost.
                 maxVerificationsPerTx: 10,
-                // Set it to 6M, since its the upper limit of the Alpha-2
-                // testnet's circuits.
-                blockMaxGasLimit: 6000000,
                 //   Set it to 79  (+1 TaikoL2.anchor transaction = 80),
                 // and 80 is the upper limit of the Alpha-2 testnet's circuits.
                 maxTransactionsPerBlock: 79,
@@ -32,7 +29,6 @@ library TaikoConfig {
                 maxBytesPerTxList: 120000,
                 minTxGasLimit: 21000,
                 slotSmoothingFactor: 946649,
-                anchorTxGasLimit: 180000,
                 // 100 basis points or 1%
                 rewardBurnBips: 100,
                 proposerDepositPctg: 25, // - 25%
@@ -41,9 +37,9 @@ library TaikoConfig {
                 bootstrapDiscountHalvingPeriod: 1 seconds, // owner:daniel
                 constantFeeRewardBlocks: 1024,
                 txListCacheExpiry: 0,
-                gasTarget: 10000000, // 10 million
-                gasFeeAdjustmentQuotient: 1023, // TODO
-                gasFeeSlackCoefficient: 2,
+                blockGasTarget: 1500000, // 1.5 million
+                blockGasThrottle: 30000000, // 30 million
+                basefeePerGasQuotient: 1023, // TODO
                 enableSoloProposer: false,
                 enableOracleProver: true,
                 enableTokenomics: true,

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -37,6 +37,9 @@ library TaikoData {
         uint64 bootstrapDiscountHalvingPeriod;
         uint64 constantFeeRewardBlocks;
         uint64 txListCacheExpiry;
+        uint32 gasTarget;
+        uint32 gasFeeAdjustmentQuotient;
+        uint32 gasFeeSlackCoefficient;
         bool enableSoloProposer;
         bool enableOracleProver;
         bool enableTokenomics;
@@ -78,6 +81,7 @@ library TaikoData {
         uint24 txListByteStart;
         uint24 txListByteEnd;
         address beneficiary;
+        uint256 basefee1559;
     }
 
     struct ZKProof {
@@ -92,7 +96,6 @@ library TaikoData {
         bytes32 blockHash;
         bytes32 signalRoot;
         address prover;
-        uint32 gasUsed;
     }
 
     // 3 slots
@@ -137,6 +140,7 @@ library TaikoData {
         uint64 __reserved2;
         // Changed when a block is proposed or proven/finalized
         // Changed when a block is proposed
+        uint256 excessGasIssued;
         uint64 numBlocks;
         uint64 lastProposedAt; // Timestamp when the last block is proposed.
         uint64 avgBlockTime; // miliseconds

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -24,12 +24,10 @@ library TaikoData {
         // This number is calculated from maxNumProposedBlocks to make
         // the 'the maximum value of the multiplier' close to 20.0
         uint256 maxVerificationsPerTx;
-        uint256 blockMaxGasLimit;
         uint256 maxTransactionsPerBlock;
         uint256 maxBytesPerTxList;
         uint256 minTxGasLimit;
         uint256 slotSmoothingFactor;
-        uint256 anchorTxGasLimit;
         uint256 rewardBurnBips;
         uint256 proposerDepositPctg;
         // Moving average factors
@@ -37,9 +35,15 @@ library TaikoData {
         uint64 bootstrapDiscountHalvingPeriod;
         uint64 constantFeeRewardBlocks;
         uint64 txListCacheExpiry;
-        uint32 gasTarget;
-        uint32 gasFeeAdjustmentQuotient;
-        uint32 gasFeeSlackCoefficient;
+        // This is the L2 block target. The max block gasLimit
+        // is twice this value.
+        uint32 blockGasTarget;
+        // This is the max amount of gas that can be sold to all
+        // L2 blocks proposed within one L1 block.
+        // `blockGasThrottle / ( 2 * blockGasTarget)` indicates how much
+        // we can scale Ethereum as a single L2.
+        uint32 blockGasThrottle;
+        uint32 basefeePerGasQuotient;
         bool enableSoloProposer;
         bool enableOracleProver;
         bool enableTokenomics;
@@ -81,7 +85,8 @@ library TaikoData {
         uint24 txListByteStart;
         uint24 txListByteEnd;
         address beneficiary;
-        uint256 basefee1559;
+        // L2 1559 basefee, not to confuse with proposing feeBase.
+        uint64 basefeePerGas;
     }
 
     struct ZKProof {
@@ -140,15 +145,16 @@ library TaikoData {
         uint64 __reserved2;
         // Changed when a block is proposed or proven/finalized
         // Changed when a block is proposed
-        uint256 excessGasIssued;
+        uint256 gasExcess; // L2 1559 gas pool
         uint64 numBlocks;
         uint64 lastProposedAt; // Timestamp when the last block is proposed.
+        uint64 lastProposedHeight; // Block number in which the last block is proposed.
         uint64 avgBlockTime; // miliseconds
-        uint64 __reserved3;
         // Changed when a block is proven/finalized
-        uint64 __reserved4;
+        // Total L2 gas sold in the lastProposedHeight-th L1 block.
+        uint32 gasSoldThisBlock;
         uint64 lastVerifiedBlockId;
-        // the proof time moving average, note that for each block, only the
+        // The proof time moving average, note that for each block, only the
         // first proof's time is considered.
         uint64 avgProofTime; // miliseconds
         uint64 feeBase;

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -14,7 +14,7 @@ abstract contract TaikoErrors {
     error L1_EVIDENCE_MISMATCH();
     error L1_FORK_CHOICE_NOT_FOUND();
     error L1_INSUFFICIENT_BLOCKSPACE();
-    error L1_INSUFFICIENT_ETHER_BURN();
+    error L1_INSUFFICIENT_ETHER();
     error L1_INSUFFICIENT_TOKEN();
     error L1_INVALID_CONFIG();
     error L1_INVALID_EVIDENCE();

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -10,9 +10,11 @@ abstract contract TaikoErrors {
     // The following custom errors must match the definitions in other V1 libraries.
     error L1_ALREADY_PROVEN();
     error L1_BLOCK_ID();
+    error L1_BLOCK_GAS_LIMIT_TOO_LARGE();
     error L1_CONTRACT_NOT_ALLOWED();
     error L1_EVIDENCE_MISMATCH();
     error L1_FORK_CHOICE_NOT_FOUND();
+    error L1_INSUFFICIENT_ETHER_BURN();
     error L1_INSUFFICIENT_TOKEN();
     error L1_INVALID_CONFIG();
     error L1_INVALID_EVIDENCE();

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -10,10 +10,10 @@ abstract contract TaikoErrors {
     // The following custom errors must match the definitions in other V1 libraries.
     error L1_ALREADY_PROVEN();
     error L1_BLOCK_ID();
-    error L1_BLOCK_GAS_LIMIT_TOO_LARGE();
     error L1_CONTRACT_NOT_ALLOWED();
     error L1_EVIDENCE_MISMATCH();
     error L1_FORK_CHOICE_NOT_FOUND();
+    error L1_INSUFFICIENT_BLOCKSPACE();
     error L1_INSUFFICIENT_ETHER_BURN();
     error L1_INSUFFICIENT_TOKEN();
     error L1_INVALID_CONFIG();

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -29,7 +29,7 @@ contract TaikoL1 is EssentialContract, IXchainSync, TaikoEvents, TaikoErrors {
     function init(
         address _addressManager,
         bytes32 _genesisBlockHash,
-        uint256 _excessGasIssued,
+        uint256 _gasExcess,
         uint64 _feeBase
     ) external initializer {
         EssentialContract._init(_addressManager);
@@ -37,7 +37,7 @@ contract TaikoL1 is EssentialContract, IXchainSync, TaikoEvents, TaikoErrors {
             state: state,
             config: getConfig(),
             genesisBlockHash: _genesisBlockHash,
-            excessGasIssued: _excessGasIssued,
+            gasExcess: _gasExcess,
             feeBase: _feeBase
         });
     }
@@ -225,20 +225,18 @@ contract TaikoL1 is EssentialContract, IXchainSync, TaikoEvents, TaikoErrors {
         return state.getStateVariables();
     }
 
-    function get1559BurnAmountAndBaseFee(
-        TaikoData.Config memory config,
-        uint256 blockGasLimit
+    function getGasFeeStatus(
+        uint256 gasPurchaseAmount
     )
         public
         view
-        returns (uint256 ethToBurn, uint256 basefee, uint256 newExcessGasIssued)
+        returns (
+            uint256 basefeePerGas,
+            uint256 gasPurchaseCost,
+            uint256 maxGasPurchaseAmount
+        )
     {
-        return
-            Lib1559.get1559BurnAmountAndBaseFee(
-                getConfig(),
-                state.excessGasIssued,
-                blockGasLimit
-            );
+        return Lib1559.getGasFeeStatus(state, getConfig(), gasPurchaseAmount);
     }
 
     function getConfig() public pure virtual returns (TaikoData.Config memory) {

--- a/packages/protocol/contracts/L1/libs/Lib1559.sol
+++ b/packages/protocol/contracts/L1/libs/Lib1559.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+//  _____     _ _         _         _
+// |_   _|_ _(_) |_____  | |   __ _| |__ ___
+//   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
+//   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
+
+pragma solidity ^0.8.18;
+
+import {AddressResolver} from "../../common/AddressResolver.sol";
+import {LibMath} from "../../libs/LibMath.sol";
+// import {
+//     SafeCastUpgradeable
+// } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
+import {TaikoData} from "../TaikoData.sol";
+// import {TaikoToken} from "../TaikoToken.sol";
+
+library LibTokenomics {
+    using LibMath for uint256;
+    uint256 private constant ADJUSTMENT_QUOTIENT = 1E12;
+
+    error L1_INSUFFICIENT_TOKEN();
+    error L1_INVALID_PARAM();
+
+    function withdraw(
+        TaikoData.State storage state,
+        AddressResolver resolver,
+        uint256 amount
+    ) internal {
+        uint256 balance = state.balances[msg.sender];
+        if (balance < amount) revert L1_INSUFFICIENT_TOKEN();
+
+        unchecked {
+            state.balances[msg.sender] -= amount;
+        }
+
+        TaikoToken(resolver.resolve("taiko_token", false)).mint(
+            msg.sender,
+            amount
+        );
+    }
+
+    function calcGasFee(uint256 TARGET, uint256 excessGasIssued, uint256 gasLimit) internal pure returns (uint256 fee, uint256 newExcessGasIssued) {
+        uint a = eth_qty(TARGET, excessGasIssued+ gasLimit) - eth_qty(TARGET, excessGasIssued);
+        newExcessGasIssued = (excessGasIssued + gasLimit).max(TARGET) - TARGET;
+
+    }
+
+    function eth_qty(uint256 TARGET, uint256 gasQuantity) internal pure returns (uint256) {
+        return exp(gasQuantity / TARGET / ADJUSTMENT_QUOTIENT);
+    }
+
+    function exp(uint256 b) internal pure returns(uint256 c) {}
+}

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -7,9 +7,9 @@
 pragma solidity ^0.8.18;
 
 import {AddressResolver} from "../../common/AddressResolver.sol";
+import {Lib1559} from "./Lib1559.sol";
 import {LibAddress} from "../../libs/LibAddress.sol";
 import {LibTokenomics} from "./LibTokenomics.sol";
-import {Lib1559} from "./Lib1559.sol";
 import {LibUtils} from "./LibUtils.sol";
 import {
     SafeCastUpgradeable

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -29,7 +29,7 @@ library LibProposing {
 
     error L1_BLOCK_ID();
     error L1_INSUFFICIENT_BLOCKSPACE();
-    error L1_INSUFFICIENT_ETHER_BURN();
+    error L1_INSUFFICIENT_ETHER();
     error L1_INSUFFICIENT_TOKEN();
     error L1_INVALID_METADATA();
     error L1_NOT_SOLO_PROPOSER();
@@ -82,8 +82,7 @@ library LibProposing {
             (meta.basefeePerGas, gasPurchaseCost, state.gasExcess) = Lib1559
                 .purchaseGas(config, state.gasExcess, input.gasLimit);
 
-            if (msg.value < gasPurchaseCost)
-                revert L1_INSUFFICIENT_ETHER_BURN();
+            if (msg.value < gasPurchaseCost) revert L1_INSUFFICIENT_ETHER();
 
             unchecked {
                 if (state.lastProposedHeight == block.number) {

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -144,7 +144,7 @@ library LibProving {
                     false
                 );
 
-                bytes32[10] memory inputs;
+                bytes32[9] memory inputs;
                 inputs[0] = bytes32(uint256(uint160(l1SignalService)));
                 inputs[1] = bytes32(uint256(uint160(l2SignalService)));
                 inputs[2] = bytes32(uint256(uint160(taikoL2)));
@@ -152,17 +152,16 @@ library LibProving {
                 inputs[4] = evidence.blockHash;
                 inputs[5] = evidence.signalRoot;
                 inputs[6] = bytes32(uint256(uint160(evidence.prover)));
-                inputs[7] = bytes32(uint256(evidence.gasUsed)); // TODO(daniel): document this
-                inputs[8] = blk.metaHash;
+                inputs[7] = blk.metaHash;
 
                 // Circuits shall use this value to check anchor gas limit.
                 // Note that this value is not necessary and can be hard-coded
                 // in to the circuit code, but if we upgrade the protocol
                 // and the gas limit changes, then having it here may be handy.
-                inputs[9] = bytes32(config.anchorTxGasLimit);
+                inputs[8] = bytes32(config.anchorTxGasLimit);
 
                 assembly {
-                    instance := keccak256(inputs, mul(32, 10))
+                    instance := keccak256(inputs, mul(32, 9))
                 }
             }
 

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -158,7 +158,7 @@ library LibProving {
                 // Note that this value is not necessary and can be hard-coded
                 // in to the circuit code, but if we upgrade the protocol
                 // and the gas limit changes, then having it here may be handy.
-                inputs[8] = bytes32(config.anchorTxGasLimit);
+                inputs[8] = bytes32(uint256(180000));
 
                 assembly {
                     instance := keccak256(inputs, mul(32, 9))

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -31,6 +31,7 @@ library LibVerifying {
         TaikoData.State storage state,
         TaikoData.Config memory config,
         bytes32 genesisBlockHash,
+        uint256 excessGasIssued,
         uint64 feeBase
     ) internal {
         _checkConfig(config);
@@ -38,6 +39,7 @@ library LibVerifying {
         uint64 timeNow = uint64(block.number);
         state.genesisHeight = timeNow;
         state.genesisTimestamp = timeNow;
+        state.excessGasIssued = excessGasIssued;
         state.feeBase = feeBase;
         state.numBlocks = 1;
 

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -31,26 +31,27 @@ library LibVerifying {
         TaikoData.State storage state,
         TaikoData.Config memory config,
         bytes32 genesisBlockHash,
-        uint256 excessGasIssued,
+        uint256 gasExcess,
         uint64 feeBase
     ) internal {
         _checkConfig(config);
 
-        uint64 timeNow = uint64(block.number);
-        state.genesisHeight = timeNow;
-        state.genesisTimestamp = timeNow;
-        state.excessGasIssued = excessGasIssued;
+        state.genesisHeight = uint64(block.number);
+        state.genesisTimestamp = uint64(block.timestamp);
+        state.lastProposedAt = uint64(block.timestamp);
+        state.lastProposedHeight = uint64(block.number);
+        state.gasExcess = gasExcess;
         state.feeBase = feeBase;
         state.numBlocks = 1;
 
         TaikoData.Block storage blk = state.blocks[0];
-        blk.proposedAt = timeNow;
+        blk.proposedAt = uint64(block.timestamp);
         blk.nextForkChoiceId = 2;
         blk.verifiedForkChoiceId = 1;
 
         TaikoData.ForkChoice storage fc = state.blocks[0].forkChoices[1];
         fc.blockHash = genesisBlockHash;
-        fc.provenAt = timeNow;
+        fc.provenAt = uint64(block.timestamp);
 
         emit BlockVerified(0, genesisBlockHash);
     }
@@ -186,14 +187,14 @@ library LibVerifying {
             config.maxNumProposedBlocks == 1 ||
             config.ringBufferSize <= config.maxNumProposedBlocks + 1 ||
             config.maxNumVerifiedBlocks == 0 ||
-            config.blockMaxGasLimit == 0 ||
+            config.blockGasTarget == 0 ||
+            config.blockGasThrottle < config.blockGasTarget * 2 ||
             config.maxTransactionsPerBlock == 0 ||
             config.maxBytesPerTxList == 0 ||
             // EIP-4844 blob size up to 128K
             config.maxBytesPerTxList > 128 * 1024 ||
             config.minTxGasLimit == 0 ||
             config.slotSmoothingFactor == 0 ||
-            config.anchorTxGasLimit == 0 ||
             // EIP-4844 blob deleted after 30 days
             config.txListCacheExpiry > 30 * 24 hours ||
             config.rewardBurnBips >= 10000

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -36,10 +36,12 @@ library LibVerifying {
     ) internal {
         _checkConfig(config);
 
-        state.genesisHeight = uint64(block.number);
         state.genesisTimestamp = uint64(block.timestamp);
+        state.genesisHeight = uint64(block.number);
+
         state.lastProposedAt = uint64(block.timestamp);
         state.lastProposedHeight = uint64(block.number);
+
         state.gasExcess = gasExcess;
         state.feeBase = feeBase;
         state.numBlocks = 1;

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -170,7 +170,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, IXchainSync {
     function _calcPublicInputHash(
         uint256 blockNumber
     ) private view returns (bytes32 prevPIH, bytes32 currPIH) {
-        bytes32[256] memory inputs;
+        bytes32[257] memory inputs;
         unchecked {
             // put the previous 255 blockhashes (excluding the parent's) into a
             // ring buffer.
@@ -181,15 +181,15 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, IXchainSync {
         }
 
         inputs[255] = bytes32(block.chainid);
-        // inputs[256] = bytes32(block.basefee);
+        inputs[256] = bytes32(block.basefee); // 1559
 
         assembly {
-            prevPIH := keccak256(inputs, mul(256, 32))
+            prevPIH := keccak256(inputs, mul(257, 32))
         }
 
         inputs[blockNumber % 255] = blockhash(blockNumber);
         assembly {
-            currPIH := keccak256(inputs, mul(256, 32))
+            currPIH := keccak256(inputs, mul(257, 32))
         }
     }
 }

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -170,7 +170,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, IXchainSync {
     function _calcPublicInputHash(
         uint256 blockNumber
     ) private view returns (bytes32 prevPIH, bytes32 currPIH) {
-        bytes32[257] memory inputs;
+        bytes32[256] memory inputs;
         unchecked {
             // put the previous 255 blockhashes (excluding the parent's) into a
             // ring buffer.
@@ -181,15 +181,14 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, IXchainSync {
         }
 
         inputs[255] = bytes32(block.chainid);
-        inputs[256] = bytes32(block.basefee); // 1559
 
         assembly {
-            prevPIH := keccak256(inputs, mul(257, 32))
+            prevPIH := keccak256(inputs, mul(256, 32))
         }
 
         inputs[blockNumber % 255] = blockhash(blockNumber);
         assembly {
-            currPIH := keccak256(inputs, mul(257, 32))
+            currPIH := keccak256(inputs, mul(256, 32))
         }
     }
 }

--- a/packages/protocol/contracts/test/L1/TestTaikoL1.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL1.sol
@@ -23,12 +23,12 @@ contract TestTaikoL1 is TaikoL1 {
         // This number is calculated from maxNumProposedBlocks to make
         // the 'the maximum value of the multiplier' close to 20.0
         config.maxVerificationsPerTx = 0;
-        config.blockMaxGasLimit = 30000000;
+        config.blockGasTarget = 15000000;
+        config.blockGasThrottle = 300000000;
         config.maxTransactionsPerBlock = 20;
         config.maxBytesPerTxList = 120000;
         config.minTxGasLimit = 21000;
         config.slotSmoothingFactor = 590000;
-        config.anchorTxGasLimit = 180000;
         config.rewardBurnBips = 100; // 100 basis points or 1%
         config.proposerDepositPctg = 25; // 25%
 

--- a/packages/protocol/contracts/test/L1/TestTaikoL1EnableTokenomics.sol
+++ b/packages/protocol/contracts/test/L1/TestTaikoL1EnableTokenomics.sol
@@ -23,12 +23,11 @@ contract TestTaikoL1EnableTokenomics is TaikoL1 {
         // This number is calculated from maxNumProposedBlocks to make
         // the 'the maximum value of the multiplier' close to 20.0
         config.maxVerificationsPerTx = 0; // dont verify blocks automatically
-        config.blockMaxGasLimit = 30000000;
+
         config.maxTransactionsPerBlock = 20;
         config.maxBytesPerTxList = 120000;
         config.minTxGasLimit = 21000;
         config.slotSmoothingFactor = 590000;
-        config.anchorTxGasLimit = 180000;
         config.rewardBurnBips = 100; // 100 basis points or 1%
         config.proposerDepositPctg = 25; // 25%
 

--- a/packages/protocol/test2/GasComparison.t.sol
+++ b/packages/protocol/test2/GasComparison.t.sol
@@ -82,7 +82,8 @@ contract FooBar {
             txListByteEnd: 1000,
             gasLimit: 1,
             mixHash: bytes32(uint256(1)),
-            timestamp: 1
+            timestamp: 1,
+            basefee1559: 0
         });
     }
 
@@ -97,7 +98,8 @@ contract FooBar {
             txListByteEnd: 1000,
             gasLimit: 1,
             mixHash: bytes32(uint256(1)),
-            timestamp: 1
+            timestamp: 1,
+            basefee1559: 0
         });
     }
 

--- a/packages/protocol/test2/GasComparison.t.sol
+++ b/packages/protocol/test2/GasComparison.t.sol
@@ -83,7 +83,7 @@ contract FooBar {
             gasLimit: 1,
             mixHash: bytes32(uint256(1)),
             timestamp: 1,
-            basefee1559: 0
+            basefeePerGas: 0
         });
     }
 
@@ -99,7 +99,7 @@ contract FooBar {
             gasLimit: 1,
             mixHash: bytes32(uint256(1)),
             timestamp: 1,
-            basefee1559: 0
+            basefeePerGas: 0
         });
     }
 

--- a/packages/protocol/test2/TaikoL1.t.sol
+++ b/packages/protocol/test2/TaikoL1.t.sol
@@ -33,7 +33,6 @@ contract TaikoL1WithConfig is TaikoL1 {
         config.ringBufferSize = 12;
         // this value must be changed if `maxNumProposedBlocks` is changed.
         config.slotSmoothingFactor = 4160;
-        config.anchorTxGasLimit = 180000;
 
         config.proposingConfig = TaikoData.FeeConfig({
             avgTimeMAF: 64,
@@ -79,7 +78,6 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint32 gasUsed = 1000000;
 
         for (
             uint256 blockId = 1;
@@ -93,7 +91,7 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Bob, gasUsed, meta, parentHash, blockHash, signalRoot);
+            proveBlock(Bob, meta, parentHash, blockHash, signalRoot);
             verifyBlock(Carol, 1);
             parentHash = blockHash;
         }
@@ -106,7 +104,6 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Alice, 1000 * 1E8, 1000 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint32 gasUsed = 1000000;
 
         for (uint256 blockId = 1; blockId <= 2; blockId++) {
             printVariables("before propose");
@@ -115,7 +112,7 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Alice, gasUsed, meta, parentHash, blockHash, signalRoot);
+            proveBlock(Alice, meta, parentHash, blockHash, signalRoot);
             verifyBlock(Alice, 2);
             parentHash = blockHash;
         }
@@ -127,7 +124,6 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Alice, 1E6 * 1E8, 1000 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint32 gasUsed = 1000000;
 
         for (
             uint256 blockId = 1;
@@ -140,7 +136,7 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Alice, gasUsed, meta, parentHash, blockHash, signalRoot);
+            proveBlock(Alice, meta, parentHash, blockHash, signalRoot);
             parentHash = blockHash;
         }
         verifyBlock(Alice, conf.maxNumProposedBlocks - 1);
@@ -156,7 +152,6 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint32 gasUsed = 1000000;
 
         for (
             uint256 blockId = 1;
@@ -169,7 +164,7 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Bob, gasUsed, meta, parentHash, blockHash, signalRoot);
+            proveBlock(Bob, meta, parentHash, blockHash, signalRoot);
             verifyBlock(Carol, 1);
             mine(blockId);
             parentHash = blockHash;
@@ -185,7 +180,6 @@ contract TaikoL1Test is TaikoL1TestBase {
         _depositTaikoToken(Carol, 1E6 * 1E8, 100 ether);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
-        uint32 gasUsed = 1000000;
 
         uint256 total = conf.maxNumProposedBlocks * 10;
 
@@ -196,7 +190,7 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Bob, gasUsed, meta, parentHash, blockHash, signalRoot);
+            proveBlock(Bob, meta, parentHash, blockHash, signalRoot);
             verifyBlock(Carol, 1);
             mine(total + 1 - blockId);
             parentHash = blockHash;

--- a/packages/protocol/test2/TaikoL1TestBase.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.sol
@@ -22,7 +22,7 @@ abstract contract TaikoL1TestBase is Test {
     bytes32 public constant GENESIS_BLOCK_HASH =
         keccak256("GENESIS_BLOCK_HASH");
     uint64 feeBase = 1E8; // 1 TKO
-    uint256 excessGasIssued = 1E24;
+    uint256 gasExcess = 1E24;
 
     address public constant L2SS = 0xa008AE5Ba00656a3Cc384de589579e3E52aC030C;
     address public constant L2TaikoL2 =
@@ -45,7 +45,7 @@ abstract contract TaikoL1TestBase is Test {
         L1.init(
             address(addressManager),
             GENESIS_BLOCK_HASH,
-            excessGasIssued,
+            gasExcess,
             feeBase
         );
         conf = L1.getConfig();
@@ -116,7 +116,6 @@ abstract contract TaikoL1TestBase is Test {
 
     function proveBlock(
         address prover,
-        uint32 gasUsed,
         TaikoData.BlockMetadata memory meta,
         bytes32 parentHash,
         bytes32 blockHash,

--- a/packages/protocol/test2/TaikoL1TestBase.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.sol
@@ -22,6 +22,7 @@ abstract contract TaikoL1TestBase is Test {
     bytes32 public constant GENESIS_BLOCK_HASH =
         keccak256("GENESIS_BLOCK_HASH");
     uint64 feeBase = 1E8; // 1 TKO
+    uint256 excessGasIssued = 1E24;
 
     address public constant L2SS = 0xa008AE5Ba00656a3Cc384de589579e3E52aC030C;
     address public constant L2TaikoL2 =
@@ -41,7 +42,12 @@ abstract contract TaikoL1TestBase is Test {
         addressManager.init();
 
         L1 = deployTaikoL1();
-        L1.init(address(addressManager), GENESIS_BLOCK_HASH, feeBase);
+        L1.init(
+            address(addressManager),
+            GENESIS_BLOCK_HASH,
+            excessGasIssued,
+            feeBase
+        );
         conf = L1.getConfig();
 
         tko = new TaikoToken();
@@ -127,8 +133,7 @@ abstract contract TaikoL1TestBase is Test {
             parentHash: parentHash,
             blockHash: blockHash,
             signalRoot: signalRoot,
-            prover: prover,
-            gasUsed: gasUsed
+            prover: prover
         });
 
         vm.prank(prover, prover);


### PR DESCRIPTION
- the L2's EIP-1559 `basefee` is now [calculated using the AMM style math](https://ethresear.ch/t/make-eip-1559-more-like-an-amm-curve/9082) on L1 and is made part of the block metadata. Note that `basefee` for the next block only depends on the parent block ,not the block being proposed. This is to ensure `basefee` for next block is deterministic so users can chose their transaction settings correctly. Also note that this is not to be confused with the proposer/prover fees/rewards (`feeBase`) in TaikoToken. `basefee` is an Ether amount.
- Implementation is incomplete and tests are not written, please review first before I spent more time on it.
- @davidtaikocha In taiko-client, we need to make sure the EIP1559 base fees are not burnt, but send to the block beneficiary address together with 1559 tips. 
- After this PR: proposers pays:
    1. Ether as transaction fees to L1 validators to include their transactions
    2. Ether to Taiko DAO to buy block space, the amount to send is `baseCharge1559` in the code, which is `basefee * gasLimit`.
    3. Taiko Token to provers for proving their blocks.


@Brechtpd  please let me know if you want to have a quick chat. 