### PR TITLE
docs(website): fix duplicated docs page title

### DIFF
--- a/packages/protocol/solidity-docgen/templates/contract.hbs
+++ b/packages/protocol/solidity-docgen/templates/contract.hbs
@@ -1,6 +1,3 @@
----
-title: {{name}}
----
 {{>common}}
 
 {{#each items}}

--- a/packages/website/pages/docs/reference/contract-documentation/L1/ProofVerifier.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/ProofVerifier.md
@@ -1,7 +1,3 @@
----
-title: IProofVerifier
----
-
 ## IProofVerifier
 
 ### verifyZKP
@@ -15,10 +11,6 @@ function verifyZKP(string verifierId, bytes zkproof, bytes32 instance) external 
 ```solidity
 function verifyMKP(bytes key, bytes value, bytes proof, bytes32 root) external pure returns (bool verified)
 ```
-
----
-
-## title: ProofVerifier
 
 ## ProofVerifier
 

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoCustomErrors.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoCustomErrors.md
@@ -1,7 +1,3 @@
----
-title: TaikoCustomErrors
----
-
 ## TaikoCustomErrors
 
 ### L1_0_FEE_BASE

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -1,7 +1,3 @@
----
-title: TaikoData
----
-
 ## TaikoData
 
 ### Config

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoEvents.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoEvents.md
@@ -1,7 +1,3 @@
----
-title: TaikoEvents
----
-
 ## TaikoEvents
 
 ### BlockVerified

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoL1.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoL1.md
@@ -1,7 +1,3 @@
----
-title: TaikoL1
----
-
 ## TaikoL1
 
 ### state

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoToken.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoToken.md
@@ -1,7 +1,3 @@
----
-title: TaikoToken
----
-
 ## TaikoToken
 
 _This is Taiko's governance and fee token._

--- a/packages/website/pages/docs/reference/contract-documentation/L2/TaikoL2.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L2/TaikoL2.md
@@ -1,7 +1,3 @@
----
-title: TaikoL2
----
-
 ## TaikoL2
 
 ### latestSyncedL1Height

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/Bridge.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/Bridge.md
@@ -1,7 +1,3 @@
----
-title: Bridge
----
-
 ## Bridge
 
 Bridge contract which is deployed on both L1 and L2. Mostly a thin wrapper

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/BridgeErrors.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/BridgeErrors.md
@@ -1,7 +1,3 @@
----
-title: BridgeErrors
----
-
 ## BridgeErrors
 
 ### B_CANNOT_RECEIVE

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/BridgedERC20.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/BridgedERC20.md
@@ -1,7 +1,3 @@
----
-title: BridgedERC20
----
-
 ## BridgedERC20
 
 ### srcToken

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/EtherVault.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/EtherVault.md
@@ -1,7 +1,3 @@
----
-title: EtherVault
----
-
 ## EtherVault
 
 EtherVault is a special vault contract that:

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/IBridge.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/IBridge.md
@@ -1,7 +1,3 @@
----
-title: IBridge
----
-
 ## IBridge
 
 Bridge interface.

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/TokenVault.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/TokenVault.md
@@ -1,7 +1,3 @@
----
-title: TokenVault
----
-
 ## TokenVault
 
 This vault holds all ERC20 tokens (but not Ether) that users have deposited.

--- a/packages/website/pages/docs/reference/contract-documentation/common/AddressResolver.md
+++ b/packages/website/pages/docs/reference/contract-documentation/common/AddressResolver.md
@@ -1,7 +1,3 @@
----
-title: AddressResolver
----
-
 ## AddressResolver
 
 This abstract contract provides a name-to-address lookup. Under the hood,

--- a/packages/website/pages/docs/reference/contract-documentation/common/IAddressManager.md
+++ b/packages/website/pages/docs/reference/contract-documentation/common/IAddressManager.md
@@ -1,7 +1,3 @@
----
-title: IAddressManager
----
-
 ## IAddressManager
 
 Interface to set and get an address for a name.

--- a/packages/website/pages/docs/reference/contract-documentation/common/IHeaderSync.md
+++ b/packages/website/pages/docs/reference/contract-documentation/common/IHeaderSync.md
@@ -1,7 +1,3 @@
----
-title: IHeaderSync
----
-
 ## IHeaderSync
 
 Interface implemented by both the TaikoL1 and TaikoL2 contracts. It exposes

--- a/packages/website/pages/docs/reference/contract-documentation/common/IMintableERC20.md
+++ b/packages/website/pages/docs/reference/contract-documentation/common/IMintableERC20.md
@@ -1,7 +1,3 @@
----
-title: IMintableERC20
----
-
 ## IMintableERC20
 
 ### mint

--- a/packages/website/pages/docs/reference/contract-documentation/signal/ISignalService.md
+++ b/packages/website/pages/docs/reference/contract-documentation/signal/ISignalService.md
@@ -1,7 +1,3 @@
----
-title: ISignalService
----
-
 ## ISignalService
 
 ### sendSignal

--- a/packages/website/pages/docs/reference/contract-documentation/signal/SignalService.md
+++ b/packages/website/pages/docs/reference/contract-documentation/signal/SignalService.md
@@ -1,7 +1,3 @@
----
-title: SignalService
----
-
 ## SignalService
 
 ### SignalProof


### PR DESCRIPTION
https://taiko.xyz/docs/reference/contract-documentation/L1/ProofVerifier
![20230327-180136](https://user-images.githubusercontent.com/82858858/227910006-3d3736b6-3655-4152-a33c-d42b895dd4f5.png)
This PR removes the duplicated and useless page title item and changes the page title from `IProofVerifier` to `IProofVerifier & ProofVerifier `.