### PR TITLE
docs(repo): update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 <p align="center">
-  A decentralized, Ethereum-equivalent ZK-Rollup.
+  A fully decentralized, Ethereum-equivalent ZK-Rollup.
   <br />
   <a href="https://taiko.xyz" target="_blank"><strong>Explore the website</strong></a>
 </p>
@@ -17,15 +17,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/taikoxyz?style=social)](https://twitter.com/taikoxyz)
 [![Discord](https://img.shields.io/discord/984015101017346058?color=%235865F2&label=Discord&logo=discord&logoColor=%23fff)](https://discord.gg/taikoxyz)
 [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/taikoxyz/taiko-mono/badge)](https://www.gitpoap.io/gh/taikoxyz/taiko-mono)
-
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/taikoxyz/taiko-mono/protocol.yml?branch=main&label=Protocol&logo=github)](https://github.com/taikoxyz/taiko-mono/actions/workflows/protocol.yml)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/taikoxyz/taiko-mono/relayer.yml?branch=main&label=Relayer&logo=github)](https://github.com/taikoxyz/taiko-mono/actions/workflows/relayer.yml)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/taikoxyz/taiko-mono/bridge-ui.yml?branch=main&label=Bridge%20UI&logo=github)](https://github.com/taikoxyz/taiko-mono/actions/workflows/bridge-ui.yml)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/taikoxyz/taiko-mono/website.yml?branch=main&label=Website&logo=github)](https://github.com/taikoxyz/taiko-mono/actions/workflows/website.yml)
-
-[![Codecov](https://img.shields.io/codecov/c/github/taikoxyz/taiko-mono?flag=protocol&label=Protocol&logo=codecov&token=E468X2PTJC)](https://app.codecov.io/gh/taikoxyz/taiko-mono/tree/main/packages/protocol)
-[![Codecov](https://img.shields.io/codecov/c/github/taikoxyz/taiko-mono?flag=relayer&label=Relayer&logo=codecov&token=E468X2PTJC)](https://app.codecov.io/gh/taikoxyz/taiko-mono/tree/main/packages/relayer)
-[![Codecov](https://img.shields.io/codecov/c/github/taikoxyz/taiko-mono?flag=bridge-ui&label=Bridge%20UI&logo=codecov&token=E468X2PTJC)](https://app.codecov.io/gh/taikoxyz/taiko-mono/tree/main/packages/bridge-ui)
+[![License](https://img.shields.io/github/license/taikoxyz/taiko-mono)](https://github.com/taikoxyz/taiko-mono/blob/main/LICENSE.md)
 
 </div>
 
@@ -36,11 +28,11 @@ Most documentation can be found on the website, at [taiko.xyz](https://taiko.xyz
 ## Project structure
 
 <pre>
-taiko-mono
+taiko-mono/
+├── <a href="./CHANGELOG.md">CHANGELOG.md</a>
 ├── <a href="./CONTRIBUTING.md">CONTRIBUTING.md</a>
 ├── <a href="./LICENSE.md">LICENSE.md</a>
 ├── <a href="./README.md">README.md</a>
-...
 ├── <a href="./packages">packages</a>
 │   ├── <a href="./packages/branding">branding</a>: Taiko branding materials
 │   ├── <a href="./packages/bridge-ui">bridge-ui</a>: Taiko Bridge frontend UI


### PR DESCRIPTION
## summary of changes
1. i don't feel like the build status are very useful, but could be wrong. the build on main is already displayed on the last commit as ✅ or ❌ , plus, as we add new things (eventindexer, etc.) we have to maintain this, and the list grows long. if anything, we can maybe have a single badge which represents the last workflow run for the last commit on main, happy to make that change if desired.
2. the code coverage badges also have the maintenance overhead, and probably don't make sense as code coverage is not really an external deliverable at this stage.