### PR TITLE
fix(status-page): add max height and scrollable to prover details popup

### DIFF
--- a/packages/status-page/src/pages/home/Home.svelte
+++ b/packages/status-page/src/pages/home/Home.svelte
@@ -357,7 +357,10 @@
 
 {#if proverDetailsOpen}
   <DetailsModal title={"Prover Details"} bind:isOpen={proverDetailsOpen}>
-    <div class="grid grid-cols-2 gap-4 text-center my-10" slot="body">
+    <div
+      class="grid grid-cols-2 gap-4 text-center my-10 max-h-96 overflow-y-auto"
+      slot="body"
+    >
       {#await getNumProvers(eventIndexerApiUrl) then provers}
         {#each provers.provers as prover}
           <div>


### PR DESCRIPTION
I added a max height to make the prover details popup scrollable

Before:
![image](https://user-images.githubusercontent.com/60930264/228629250-06523e9d-c095-44d0-b008-98a5945bf4da.png)

After:
![image](https://user-images.githubusercontent.com/60930264/228630055-4018ae1c-7b12-4e62-85f4-26647185318c.png)
