### PR TITLE
feat(protocol): enable graffiti for provers

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -86,6 +86,7 @@ library TaikoData {
         bytes32 parentHash;
         bytes32 blockHash;
         bytes32 signalRoot;
+        bytes32 graffiti;
         address prover;
     }
 

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -144,18 +144,19 @@ library LibProving {
                     false
                 );
 
-                bytes32[8] memory inputs;
+                bytes32[9] memory inputs;
                 inputs[0] = bytes32(uint256(uint160(l1SignalService)));
                 inputs[1] = bytes32(uint256(uint160(l2SignalService)));
                 inputs[2] = bytes32(uint256(uint160(taikoL2)));
                 inputs[3] = evidence.parentHash;
                 inputs[4] = evidence.blockHash;
                 inputs[5] = evidence.signalRoot;
-                inputs[6] = bytes32(uint256(uint160(evidence.prover)));
-                inputs[7] = blk.metaHash;
+                inputs[6] = evidence.graffiti;
+                inputs[7] = bytes32(uint256(uint160(evidence.prover)));
+                inputs[8] = blk.metaHash;
 
                 assembly {
-                    instance := keccak256(inputs, mul(32, 8))
+                    instance := keccak256(inputs, mul(32, 9))
                 }
             }
 

--- a/packages/protocol/test2/TaikoL1TestBase.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.sol
@@ -126,6 +126,7 @@ abstract contract TaikoL1TestBase is Test {
             parentHash: parentHash,
             blockHash: blockHash,
             signalRoot: signalRoot,
+            graffiti: 0x0,
             prover: prover
         });
 


### PR DESCRIPTION
Inspired by Beaconchain graffiti. We now support provers to use the new `graffiti` field to attach a custom message when they are proving a block. Then we can draw a similar graffiti wall or have a dashboard of graffitis. Different proving pools/software can also use their release tag as the value of the `graffiti` field.

See:  https://beaconscan.com/stat/graffiticloud