### PR TITLE
docs(starter-dapp): update README.md with correct env var values

### DIFF
--- a/packages/starter-dapp/README.md
+++ b/packages/starter-dapp/README.md
@@ -13,15 +13,14 @@
 You can use the following values in the `.env` file to spin up the Starter dapp locally.
 
 ```
-VITE_NODE_ENV=dev
-VITE_L1_RPC_URL="https://l1rpc.internal.taiko.xyz/"
-VITE_L2_RPC_URL="https://l2rpc.internal.taiko.xyz/"
-VITE_L1_EXPLORER_URL="https://l1explorer.internal.taiko.xyz/"
-VITE_L2_EXPLORER_URL="https://l2explorer.internal.taiko.xyz/"
-VITE_MAINNET_CHAIN_ID=31336
-VITE_TAIKO_CHAIN_ID=167001
-VITE_MAINNET_CHAIN_NAME="Ethereum A2"
-VITE_TAIKO_CHAIN_NAME="Taiko A2"
+VITE_L1_RPC_URL="https://rpc.sepolia.org/"
+VITE_L2_RPC_URL="https://rpc.a2.taiko.xyz/"
+VITE_L1_EXPLORER_URL="https://sepolia.etherscan.io/"
+VITE_L2_EXPLORER_URL="https://explorer.a2.taiko.xyz/"
+VITE_MAINNET_CHAIN_ID=11155111
+VITE_TAIKO_CHAIN_ID=167004
+VITE_MAINNET_CHAIN_NAME="Sepoila"
+VITE_TAIKO_CHAIN_NAME="Taiko Alpha"
 VITE_APP_NAME="Starter"
 ```
 

--- a/packages/starter-dapp/README.md
+++ b/packages/starter-dapp/README.md
@@ -13,14 +13,15 @@
 You can use the following values in the `.env` file to spin up the Starter dapp locally.
 
 ```
+VITE_NODE_ENV=dev
 VITE_L1_RPC_URL="https://rpc.sepolia.org/"
 VITE_L2_RPC_URL="https://rpc.a2.taiko.xyz/"
 VITE_L1_EXPLORER_URL="https://sepolia.etherscan.io/"
 VITE_L2_EXPLORER_URL="https://explorer.a2.taiko.xyz/"
 VITE_MAINNET_CHAIN_ID=11155111
 VITE_TAIKO_CHAIN_ID=167004
-VITE_MAINNET_CHAIN_NAME="Sepoila"
-VITE_TAIKO_CHAIN_NAME="Taiko Alpha"
+VITE_MAINNET_CHAIN_NAME="Sepolia"
+VITE_TAIKO_CHAIN_NAME="Taiko A2"
 VITE_APP_NAME="Starter"
 ```
 


### PR DESCRIPTION
Currently README.md's env config can't be used. Because https://l1rpc.internal.taiko.xyz is fake url, and metamask can't add this as a new rpc, so it will fail when request connecting.
A out of box env config will be more friendly for developer.