### PR TITLE
fix(bridge-ui): Typos in Update ProcessingFee.svelte

### DIFF
--- a/packages/bridge-ui/src/components/form/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui/src/components/form/ProcessingFee/ProcessingFee.svelte
@@ -91,7 +91,7 @@
   <!-- TODO: translations? -->
   <div class="text-center">
     Selecting <strong>None</strong> means that you'll require ETH on the receiving
-    chain in otder to claim the bridged token. Pleas, come back later to manually
+    chain in order to claim the bridged token. Please, come back later to manually
     claim.
   </div>
 </NoticeModal>


### PR DESCRIPTION
Just a few typos in the Notice window when selecting Processing Fee: None

<img width="512" alt="Screenshot 2023-03-31 at 11 02 51 AM" src="https://user-images.githubusercontent.com/104391159/229174553-f4ac1cc0-ce90-4798-9555-aa1aaaf93870.png">
