### PR TITLE
fix(bridge-ui): only request connect if require

### DIFF
--- a/packages/bridge-ui/src/components/buttons/Connect.svelte
+++ b/packages/bridge-ui/src/components/buttons/Connect.svelte
@@ -70,7 +70,12 @@
 
   async function connectWithConnector(connector: Connector) {
     try {
-      await wagmiConnect({ connector });
+      if (
+        !$wagmiClient.connector ||
+        $wagmiClient.connector.id !== connector.id
+      ) {
+        await wagmiConnect({ connector });
+      }
       await onConnect();
       successToast('Connected');
     } catch (error) {

--- a/packages/starter-dapp/src/components/buttons/Connect.svelte
+++ b/packages/starter-dapp/src/components/buttons/Connect.svelte
@@ -53,7 +53,9 @@
 
   async function connectWithConnector(connector: Connector) {
     try {
-      await wagmiConnect({ connector });
+      if (!$wagmiClient.connector || $wagmiClient.connector.id !== connector.id) {
+        await wagmiConnect({ connector });
+      }
       await onConnect();
       successToast("Connected");
     } catch (error) {


### PR DESCRIPTION
Without this check, wagmi will throw ConnectorAlreadyConnectedError when Metamask is already available . 

