### PR TITLE
fix(protocol): fix issues in alpha-2 and prepare alpha-2a

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -143,7 +143,7 @@ library LibProposing {
         state.avgBlockTime = LibUtils
             .movingAverage({
                 maValue: state.avgBlockTime,
-                newValue: meta.timestamp - state.lastProposedAt,
+                newValue: (meta.timestamp - state.lastProposedAt) * 1000,
                 maf: config.blockTimeMAF
             })
             .toUint64();

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -80,7 +80,7 @@ library LibUtils {
         uint64 tAvg,
         uint64 tCap
     ) internal view returns (uint256 newFeeBase, uint256 tRelBp) {
-        newFeeBase = state.feeBase;
+        newFeeBase = 1e18;
         tRelBp = 0;
         // if (
         //     tCap == 0 ||

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -80,7 +80,8 @@ library LibUtils {
         uint64 tAvg,
         uint64 tCap
     ) internal view returns (uint256 newFeeBase, uint256 tRelBp) {
-        return state.feeBase;
+        newFeeBase = state.feeBase;
+        tRelBp = 0;
         // if (
         //     tCap == 0 ||
         //     tAvg == 0 ||

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -80,29 +80,30 @@ library LibUtils {
         uint64 tAvg,
         uint64 tCap
     ) internal view returns (uint256 newFeeBase, uint256 tRelBp) {
-        if (
-            tCap == 0 ||
-            tAvg == 0 ||
-            config.feeMaxPeriodPctg <= config.feeGracePeriodPctg ||
-            config.rewardMultiplierPctg <= 100
-        ) {
-            newFeeBase = state.feeBase;
-            // tRelBp = 0;
-        } else {
-            uint256 _tAvg = uint256(tAvg).min(tCap);
-            uint256 grace = (config.feeGracePeriodPctg * _tAvg) / 100;
-            uint256 max = (config.feeMaxPeriodPctg * _tAvg) / 100;
-            uint256 t = uint256(tNow - tLast).max(grace).min(max);
-            tRelBp = ((t - grace) * 10000) / (max - grace); // [0 - 10000]
-            uint256 alpha = 10000 +
-                ((config.rewardMultiplierPctg - 100) * tRelBp) /
-                100;
-            if (isProposal) {
-                newFeeBase = (state.feeBase * 10000) / alpha; // fee
-            } else {
-                newFeeBase = (state.feeBase * alpha) / 10000; // reward
-            }
-        }
+        return state.feeBase;
+        // if (
+        //     tCap == 0 ||
+        //     tAvg == 0 ||
+        //     config.feeMaxPeriodPctg <= config.feeGracePeriodPctg ||
+        //     config.rewardMultiplierPctg <= 100
+        // ) {
+        //     newFeeBase = state.feeBase;
+        //     // tRelBp = 0;
+        // } else {
+        //     uint256 _tAvg = uint256(tAvg).min(tCap);
+        //     uint256 grace = (config.feeGracePeriodPctg * _tAvg) / 100;
+        //     uint256 max = (config.feeMaxPeriodPctg * _tAvg) / 100;
+        //     uint256 t = uint256(tNow - tLast).max(grace).min(max);
+        //     tRelBp = ((t - grace) * 10000) / (max - grace); // [0 - 10000]
+        //     uint256 alpha = 10000 +
+        //         ((config.rewardMultiplierPctg - 100) * tRelBp) /
+        //         100;
+        //     if (isProposal) {
+        //         newFeeBase = (state.feeBase * 10000) / alpha; // fee
+        //     } else {
+        //         newFeeBase = (state.feeBase * alpha) / 10000; // reward
+        //     }
+        // }
     }
 
     // Implement "Slot-availability Multipliers", see the whitepaper.
@@ -112,15 +113,16 @@ library LibUtils {
         bool isProposal,
         uint256 feeBase
     ) internal view returns (uint256) {
-        // m is the `n'` in the whitepaper
-        uint256 m = 1000 *
-            (config.maxNumBlocks - 1) +
-            config.slotSmoothingFactor;
-        // n is the number of unverified blocks
-        uint256 n = 1000 * (state.nextBlockId - state.latestVerifiedId - 1);
-        // k is `m − n + 1` or `m − n - 1`in the whitepaper
-        uint256 k = isProposal ? m - n - 1000 : m - n + 1000;
-        return (feeBase * (m - 1000) * m) / (m - n) / k;
+        return feeBase;
+        // // m is the `n'` in the whitepaper
+        // uint256 m = 1000 *
+        //     (config.maxNumBlocks - 1) +
+        //     config.slotSmoothingFactor;
+        // // n is the number of unverified blocks
+        // uint256 n = 1000 * (state.nextBlockId - state.latestVerifiedId - 1);
+        // // k is `m − n + 1` or `m − n - 1`in the whitepaper
+        // uint256 k = isProposal ? m - n - 1000 : m - n + 1000;
+        // return (feeBase * (m - 1000) * m) / (m - n) / k;
     }
 
     // Implement "Bootstrap Discount Multipliers", see the whitepaper.
@@ -129,10 +131,11 @@ library LibUtils {
         TaikoData.Config memory config,
         uint256 feeBase
     ) internal view returns (uint256) {
-        uint256 halves = uint256(block.timestamp - state.genesisTimestamp) /
-            config.bootstrapDiscountHalvingPeriod;
-        uint256 gamma = 1024 - (1024 >> halves);
-        return (feeBase * gamma) / 1024;
+        return feeBase;
+        // uint256 halves = uint256(block.timestamp - state.genesisTimestamp) /
+        //     config.bootstrapDiscountHalvingPeriod;
+        // uint256 gamma = 1024 - (1024 >> halves);
+        // return (feeBase * gamma) / 1024;
     }
 
     function hashMetadata(

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -227,7 +227,7 @@ library LibVerifying {
         state.avgProofTime = LibUtils
             .movingAverage({
                 maValue: state.avgProofTime,
-                newValue: fc.provenAt - target.proposedAt,
+                newValue: (fc.provenAt - target.proposedAt) * 1000,
                 maf: config.proofTimeMAF
             })
             .toUint64();


### PR DESCRIPTION
Changes in this PR shall not be merged into main (to avoid merging conflict with alpha-3 ongoing work)

- Disabled dynamic fee/rewards, now the fee/reward is hardcoded to 1 Taiko Token.
- Changed avgBlockTime and avgProof from "seconds" to "milliseconds" (we need to verify this works in alpha-2a) - this change has already been made for alpha-3.