### PR TITLE
feat(protocol): L2 1559 use gasUsed to adjust basefee

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -48,6 +48,8 @@ library TaikoData {
         uint64 avgBlockTime;
         uint64 avgProofTime;
         uint64 lastProposedAt;
+        uint64 l2Basefee; // L2 1559
+        uint64 l2GasExcess; // L2 1559
     }
 
     // 3 slots

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -141,13 +141,13 @@ library TaikoData {
         uint64 numBlocks;
         uint64 lastProposedAt; // Timestamp when the last block is proposed.
         uint64 avgBlockTime; // miliseconds
-        uint64 l2GasExcess;
+        uint64 avgProofTime; // miliseconds
         // Changed when a block is proven/finalized
         uint64 lastVerifiedBlockId;
         uint64 l2Basefee;
+        uint64 l2GasExcess;
         // the proof time moving average, note that for each block, only the
         // first proof's time is considered.
-        uint64 avgProofTime; // miliseconds
         uint64 feeBase;
         // Reserved
         uint256[43] __gap;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -92,6 +92,8 @@ library TaikoData {
         bytes32 signalRoot;
         bytes32 graffiti;
         address prover;
+        uint32 gasUsed;
+        uint64 basefee;
     }
 
     // 3 slots
@@ -126,7 +128,7 @@ library TaikoData {
         mapping(uint256 blockId_mode_ringBufferSize => Block) blocks;
         // A mapping from (blockId, parentHash) to a reusable ForkChoice storage pointer.
         // solhint-disable-next-line max-line-length
-        mapping(uint256 blockId => mapping(bytes32 parentHash => uint256 forkChoiceId)) forkChoiceIds;
+        mapping(uint256 blockId => mapping(bytes32 parentHash => mapping(uint64 basefee => uint256 forkChoiceId))) forkChoiceIds;
         mapping(address account => uint256 balance) balances;
         mapping(bytes32 txListHash => TxListInfo) txListInfo;
         // Never or rarely changed

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -48,8 +48,6 @@ library TaikoData {
         uint64 avgBlockTime;
         uint64 avgProofTime;
         uint64 lastProposedAt;
-        uint64 l2Basefee; // L2 1559
-        uint64 l2GasExcess; // L2 1559
     }
 
     // 3 slots
@@ -68,7 +66,6 @@ library TaikoData {
         uint64 id;
         uint64 timestamp;
         uint64 l1Height;
-        uint64 l2Basefee;
         bytes32 l1Hash;
         bytes32 mixHash;
         bytes32 txListHash;
@@ -100,8 +97,9 @@ library TaikoData {
     struct ForkChoice {
         bytes32 blockHash;
         bytes32 signalRoot;
-        uint64 provenAt;
         address prover;
+        uint32 gasUsed;
+        uint64 provenAt;
     }
 
     // 4 slots
@@ -144,7 +142,7 @@ library TaikoData {
         uint64 l2GasExcess;
         // Changed when a block is proven/finalized
         uint64 lastVerifiedBlockId;
-        uint64 __reserved4;
+        uint64 l2Basefee;
         // the proof time moving average, note that for each block, only the
         // first proof's time is considered.
         uint64 avgProofTime; // miliseconds

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -237,8 +237,8 @@ contract TaikoL1 is EssentialContract, IXchainSync, TaikoEvents, TaikoErrors {
                 : bytes32(0);
     }
 
-    function getL2Basefee() public view returns (uint64 basefee) {
-        (basefee, ) = LibL2Tokenomics.getL2Basefee(state, getConfig(), 0);
+    function getL2Basefee(uint64 gasUsed) public view returns (uint64 basefee) {
+        (basefee, ) = LibL2Tokenomics.getL2Basefee(state, getConfig(), gasUsed);
     }
 
     function getStateVariables()

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -237,14 +237,8 @@ contract TaikoL1 is EssentialContract, IXchainSync, TaikoEvents, TaikoErrors {
                 : bytes32(0);
     }
 
-    function getL2Basefee(
-        uint32 gasLimit
-    ) public view returns (uint64 basefee) {
-        (basefee, ) = LibL2Tokenomics.getL2Basefee(
-            state,
-            getConfig(),
-            gasLimit
-        );
+    function getL2Basefee() public view returns (uint64 basefee) {
+        (basefee, ) = LibL2Tokenomics.getL2Basefee(state, getConfig(), 0);
     }
 
     function getStateVariables()

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -195,14 +195,16 @@ contract TaikoL1 is EssentialContract, IXchainSync, TaikoEvents, TaikoErrors {
 
     function getForkChoice(
         uint256 blockId,
-        bytes32 parentHash
+        bytes32 parentHash,
+        uint64 basefee
     ) public view returns (TaikoData.ForkChoice memory) {
         return
             LibProving.getForkChoice({
                 state: state,
                 config: getConfig(),
                 blockId: blockId,
-                parentHash: parentHash
+                parentHash: parentHash,
+                basefee: basefee
             });
     }
 

--- a/packages/protocol/contracts/L1/libs/LibL2Tokenomics.sol
+++ b/packages/protocol/contracts/L1/libs/LibL2Tokenomics.sol
@@ -26,7 +26,7 @@ library LibL2Tokenomics {
     function getL2Basefee(
         TaikoData.State storage state,
         TaikoData.Config memory config,
-        uint32 gasUsed
+        uint64 gasUsed
     ) internal view returns (uint64 basefee, uint64 newGasExcess) {
         if (config.gasIssuedPerSecond == 0) {
             // L2 1559 disabled

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -9,7 +9,6 @@ pragma solidity ^0.8.18;
 import {AddressResolver} from "../../common/AddressResolver.sol";
 import {LibAddress} from "../../libs/LibAddress.sol";
 import {LibL1Tokenomics} from "./LibL1Tokenomics.sol";
-import {LibL2Tokenomics} from "./LibL2Tokenomics.sol";
 import {LibUtils} from "./LibUtils.sol";
 import {
     SafeCastUpgradeable
@@ -71,7 +70,6 @@ library LibProposing {
                 id: state.numBlocks,
                 timestamp: uint64(block.timestamp),
                 l1Height: uint64(block.number - 1),
-                l2Basefee: 0, // will be set later
                 l1Hash: blockhash(block.number - 1),
                 mixHash: bytes32(block.prevrandao * state.numBlocks),
                 txListHash: input.txListHash,
@@ -80,23 +78,6 @@ library LibProposing {
                 gasLimit: input.gasLimit,
                 beneficiary: input.beneficiary,
                 treasure: resolver.resolve(config.chainId, "treasure", false)
-            });
-        }
-
-        // Calculate L2 EIP-1559 basefee per gas
-        //
-        // Note that we do not charge basefee * gaslimit on L1 as we do not
-        // know the actual gas used in the L2 block. If we charge the proposer
-        // here, the proposer may suffer a loss depends on how many enclosed
-        // transactions become invalid and are filtered out.
-        //
-        // On L2, EIP-1559's basefee will not be burned but send to a Taiko
-        // treasure address.
-        if (config.gasIssuedPerSecond != 0) {
-            (meta.l2Basefee, state.l2GasExcess) = LibL2Tokenomics.getL2Basefee({
-                state: state,
-                config: config,
-                gasLimit: input.gasLimit
             });
         }
 

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -157,11 +157,11 @@ library LibProving {
                 inputs[0] = uint160(l1SignalService);
                 inputs[1] = uint160(l2SignalService);
                 inputs[2] = uint160(taikoL2);
-                inputs[3] = uint256(evidence.parentHash);
-                inputs[4] = uint256(evidence.blockHash);
-                inputs[5] = uint256(evidence.signalRoot);
-                inputs[6] = uint256(evidence.graffiti);
-                inputs[7] = uint256(blk.metaHash);
+                inputs[3] = uint256(blk.metaHash);
+                inputs[4] = uint256(evidence.parentHash);
+                inputs[5] = uint256(evidence.blockHash);
+                inputs[6] = uint256(evidence.signalRoot);
+                inputs[7] = uint256(evidence.graffiti);
                 inputs[8] =
                     (uint256(uint160(evidence.prover)) << 96) |
                     (uint256(evidence.gasUsed) << 64) |

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -100,11 +100,13 @@ library LibProving {
                 oracleProving = true;
                 // we are reusing storage slots, still need to reset the
                 // [provenAt+prover] slot.
-                fc.provenAt = uint64(1);
                 fc.prover = address(0);
+                fc.gasUsed = 0;
+                fc.provenAt = uint64(1);
             } else {
-                fc.provenAt = uint64(block.timestamp);
                 fc.prover = evidence.prover;
+                fc.gasUsed = evidence.gasUsed;
+                fc.provenAt = uint64(block.timestamp);
             }
         } else {
             assert(fcId < blk.nextForkChoiceId);
@@ -127,8 +129,9 @@ library LibProving {
 
             if (fc.prover != address(0)) revert L1_ALREADY_PROVEN();
 
-            fc.provenAt = uint64(block.timestamp);
             fc.prover = evidence.prover;
+            fc.gasUsed = evidence.gasUsed;
+            fc.provenAt = uint64(block.timestamp);
         }
 
         if (!oracleProving && !config.skipZKPVerification) {

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -161,8 +161,11 @@ library LibProving {
                 inputs[4] = uint256(evidence.blockHash);
                 inputs[5] = uint256(evidence.signalRoot);
                 inputs[6] = uint256(evidence.graffiti);
-                inputs[7] = uint160(evidence.prover);
-                inputs[8] = uint256(blk.metaHash);
+                inputs[7] = uint256(blk.metaHash);
+                inputs[8] =
+                    (uint256(uint160(evidence.prover)) << 96) |
+                    (uint256(evidence.gasUsed) << 64) |
+                    uint256(evidence.basefee);
 
                 assembly {
                     instance := keccak256(inputs, mul(32, 9))

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.18;
 
 import {LibMath} from "../../libs/LibMath.sol";
 import {LibL1Tokenomics} from "./LibL1Tokenomics.sol";
-import {LibL2Tokenomics} from "./LibL2Tokenomics.sol";
+// import {LibL2Tokenomics} from "./LibL2Tokenomics.sol";
 import {
     SafeCastUpgradeable
 } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
@@ -33,11 +33,6 @@ library LibUtils {
         TaikoData.State storage state,
         TaikoData.Config memory config
     ) internal view returns (TaikoData.StateVariables memory) {
-        (uint64 basefee1559, ) = LibL2Tokenomics.getL2Basefee({
-            state: state,
-            config: config,
-            gasLimit: 1
-        });
         return
             TaikoData.StateVariables({
                 feeBase: state.feeBase,
@@ -47,9 +42,7 @@ library LibUtils {
                 lastProposedAt: state.lastProposedAt,
                 avgBlockTime: state.avgBlockTime,
                 lastVerifiedBlockId: state.lastVerifiedBlockId,
-                avgProofTime: state.avgProofTime,
-                l2Basefee: basefee1559,
-                l2GasExcess: state.l2GasExcess
+                avgProofTime: state.avgProofTime
             });
     }
 
@@ -88,8 +81,7 @@ library LibUtils {
         inputs[0] =
             (uint256(meta.id) << 192) |
             (uint256(meta.timestamp) << 128) |
-            (uint256(meta.l1Height) << 64) |
-            uint256(meta.l2Basefee);
+            (uint256(meta.l1Height) << 64);
 
         inputs[1] = uint256(meta.l1Hash);
         inputs[2] = uint256(meta.mixHash);

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -8,7 +8,6 @@ pragma solidity ^0.8.18;
 
 import {LibMath} from "../../libs/LibMath.sol";
 import {LibL1Tokenomics} from "./LibL1Tokenomics.sol";
-// import {LibL2Tokenomics} from "./LibL2Tokenomics.sol";
 import {
     SafeCastUpgradeable
 } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
@@ -42,7 +41,9 @@ library LibUtils {
                 lastProposedAt: state.lastProposedAt,
                 avgBlockTime: state.avgBlockTime,
                 lastVerifiedBlockId: state.lastVerifiedBlockId,
-                avgProofTime: state.avgProofTime
+                avgProofTime: state.avgProofTime,
+                l2Basefee: state.l2Basefee,
+                l2GasExcess: state.l2GasExcess
             });
     }
 

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -95,6 +95,7 @@ library LibVerifying {
 
         bytes32 signalRoot;
         uint64 processed;
+        uint32 basefee; // 1559 basefee
         unchecked {
             ++i;
         }
@@ -102,7 +103,7 @@ library LibVerifying {
         while (i < state.numBlocks && processed < maxBlocks) {
             blk = state.blocks[i % config.ringBufferSize];
 
-            fcId = state.forkChoiceIds[i][blockHash];
+            fcId = state.forkChoiceIds[i][blockHash][basefee];
             if (fcId == 0) break;
 
             TaikoData.ForkChoice storage fc = blk.forkChoices[fcId];

--- a/packages/protocol/test2/GasComparison.t.sol
+++ b/packages/protocol/test2/GasComparison.t.sol
@@ -86,7 +86,6 @@ contract FooBar {
             txListByteStart: 0,
             txListByteEnd: 1000,
             gasLimit: 1,
-            l2Basefee: 1000000,
             mixHash: bytes32(uint256(1)),
             timestamp: 1
         });
@@ -103,7 +102,6 @@ contract FooBar {
             txListByteStart: 0,
             txListByteEnd: 1000,
             gasLimit: 1,
-            l2Basefee: 1000000,
             mixHash: bytes32(uint256(1)),
             timestamp: 1
         });

--- a/packages/protocol/test2/TaikoL1.t.sol
+++ b/packages/protocol/test2/TaikoL1.t.sol
@@ -52,6 +52,8 @@ contract Verifier {
 }
 
 contract TaikoL1Test is TaikoL1TestBase {
+    uint64 public constant basefee = 0;
+
     function deployTaikoL1() internal override returns (TaikoL1 taikoL1) {
         taikoL1 = new TaikoL1WithConfig();
     }
@@ -84,7 +86,15 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Bob, meta, parentHash, blockHash, signalRoot);
+            proveBlock(
+                Bob,
+                meta,
+                parentHash,
+                blockHash,
+                signalRoot,
+                1024,
+                basefee
+            );
             verifyBlock(Carol, 1);
             parentHash = blockHash;
         }
@@ -105,7 +115,15 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Alice, meta, parentHash, blockHash, signalRoot);
+            proveBlock(
+                Alice,
+                meta,
+                parentHash,
+                blockHash,
+                signalRoot,
+                1024,
+                basefee
+            );
             verifyBlock(Alice, 2);
             parentHash = blockHash;
         }
@@ -129,7 +147,15 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Alice, meta, parentHash, blockHash, signalRoot);
+            proveBlock(
+                Alice,
+                meta,
+                parentHash,
+                blockHash,
+                signalRoot,
+                1024,
+                basefee
+            );
             parentHash = blockHash;
         }
         verifyBlock(Alice, conf.maxNumProposedBlocks - 1);
@@ -157,7 +183,15 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Bob, meta, parentHash, blockHash, signalRoot);
+            proveBlock(
+                Bob,
+                meta,
+                parentHash,
+                blockHash,
+                signalRoot,
+                1024,
+                basefee
+            );
             verifyBlock(Carol, 1);
             mine(blockId);
             parentHash = blockHash;
@@ -182,7 +216,15 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1E10 + blockId);
             bytes32 signalRoot = bytes32(1E9 + blockId);
-            proveBlock(Bob, meta, parentHash, blockHash, signalRoot);
+            proveBlock(
+                Bob,
+                meta,
+                parentHash,
+                blockHash,
+                signalRoot,
+                1024,
+                basefee
+            );
             verifyBlock(Carol, 1);
             mine(total + 1 - blockId);
             parentHash = blockHash;

--- a/packages/protocol/test2/TaikoL1TestBase.t.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.t.sol
@@ -115,7 +115,6 @@ abstract contract TaikoL1TestBase is Test {
         meta.id = variables.numBlocks;
         meta.timestamp = uint64(block.timestamp);
         meta.l1Height = uint64(block.number - 1);
-        meta.l2Basefee = 0;
         meta.l1Hash = blockhash(block.number - 1);
         meta.mixHash = bytes32(_mixHash);
         meta.txListHash = keccak256(txList);

--- a/packages/protocol/test2/TaikoL1TestBase.t.sol
+++ b/packages/protocol/test2/TaikoL1TestBase.t.sol
@@ -134,7 +134,9 @@ abstract contract TaikoL1TestBase is Test {
         TaikoData.BlockMetadata memory meta,
         bytes32 parentHash,
         bytes32 blockHash,
-        bytes32 signalRoot
+        bytes32 signalRoot,
+        uint32 gasUsed,
+        uint64 basefee
     ) internal {
         TaikoData.ZKProof memory zkproof = TaikoData.ZKProof({
             data: new bytes(100),
@@ -148,7 +150,9 @@ abstract contract TaikoL1TestBase is Test {
             blockHash: blockHash,
             signalRoot: signalRoot,
             graffiti: 0x0,
-            prover: prover
+            prover: prover,
+            gasUsed: gasUsed,
+            basefee: basefee
         });
 
         vm.prank(prover, prover);


### PR DESCRIPTION
@Brechtpd  this PR enables L2 1559 gas fee to be calculated and verified when a block is to be verified. When a block is proven, `gasfee` and `gasUsed` must be provided by the prover, `gasUsed` will be part of the fork choice, and `gasfee` is used as a link to this fork choice.

Something to notice: now for a block, its basefee does not depends on its own actual gas used, instead, the basefee is the one updated after its parent block. In other words, the basefee is the spot price of the curve, not the average price of a gas sale. The major reason for such a change is to remove basefee calculate's self-dependency. **If we keep using the average price of a gas sale, then we have to iterate through all fork choices to find the correct one**, as basefee depends on gasUsed, while gasUsed maybe affected by the value of basefee. But I'm ok to implementation suggestions so we can still use the average price, not the spot price.

It seems Ethereum also uses the basefee calculated on the previous blocks, not the current block's gas used.

TODOs:
- [ ] add more testing
- [ ] Talk to client team so they know how to implement this and how to tell users the basefee value at any given moment.
