### PR TITLE
docs(website): improve taiko nodes documentation

### DIFF
--- a/packages/website/pages/docs/concepts/taiko-nodes.mdx
+++ b/packages/website/pages/docs/concepts/taiko-nodes.mdx
@@ -1,98 +1,119 @@
-There are two parts to a Taiko node, which are connected over the engine API:
-- `taiko-geth`
-- `taiko-client`
+## Overview
+
+Taiko nodes are minimally modified Ethereum execution clients that consist of two parts: `taiko-geth` and `taiko-client`. The two parts communicate with each other through the Engine API.
 
 ![taiko nodes diagram](/images/diagrams/concepts/taiko-nodes/taiko-nodes.png)
 
 ## Taiko geth
 
-The [taiko-geth](https://github.com/taikoxyz/taiko-geth) repo is a fork of [go-ethereum](https://github.com/ethereum/go-ethereum) with some changes according to Taiko protocol, it serves as a L2 execution engine, which needs to be coupled to a consensus client (in Taiko network, this will be the taiko client's driver software), like L1 ethereum execution engines, it will listen to new L2 transactions broadcasted in the L2 network, executes them in EVM, and holds the latest state and database of all current L2 data.
+The [taiko-geth](https://github.com/taikoxyz/taiko-geth) repository is a fork of [go-ethereum](https://github.com/ethereum/go-ethereum) with some changes made according to the Taiko protocol. In the Taiko network, `taiko-geth` is the `driver` software for the Taiko client.
+
+Like Ethereum mainnet execution engines, `taiko-geth` listens to new L2 transactions broadcasted in the L2 network, executes them in the EVM, and holds the latest state and database of all current L2 data.
 
 ## Taiko client
 
-The compiled binary `bin/taiko-client` is the main entrypoint which includes three sub-commands:
+The compiled binary `bin/taiko-client` is the main entrypoint. It includes three sub-commands:
 
-- `driver`: keep the L2 execution engine's chain in sync with the `TaikoL1` contract, by directing the L2 [execution engine](https://ethereum.org/en/glossary/#execution-client).
-- `proposer`: propose new transactions from the L2 execution engine's transaction pool to the `TaikoL1` contract.
-- `prover`: request ZK proofs from the zkEVM, and send transactions to prove the proposed blocks are valid or invalid.
+- `driver`: keeps the L2 execution engine's chain in sync with the `TaikoL1` contract by directing the L2 execution engine [execution engine](https://ethereum.org/en/glossary/#execution-client).
+- [`proposer`](https://rollup-glossary.vercel.app/other-terms#proposer): proposes new transactions from the L2 execution engine's transaction pool to the `TaikoL1` contract.
+- [`prover`](https://rollup-glossary.vercel.app/other-terms#prover): requests [validity proofs](https://rollup-glossary.vercel.app/other-terms#validity-proof) from the [ZK-EVM](https://rollup-glossary.vercel.app/spicy-terms#zk-evm) and sends transactions to prove the proposed blocks are valid or invalid.
 
 ### Driver
 
-Taiko client's driver software serves as an L2 consensus client. It will listen for new L2 blocks from the Taiko layer 1 protocol contract, then direct the connected L2 execution engine to insert them into its local chain through the Engine API.
+Taiko client's `driver` software serves as an L2 consensus client. It listens for new L2 blocks from the Taiko L1 protocol contract, then directs the connected L2 execution engine to insert them into its local chain through the Engine API.
 
 #### Engine API
 
-Driver directs a L2 execution engine to insert new blocks or reorg the local chain through the [Engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md).
+Taiko client's `driver` directs an L2 execution engine to insert new blocks or reorganize the local chain through the [Engine API](https://github.com/ethereum/execution-apis/tree/main/src/engine).
 
 #### Chain synchronization process
 
-> NOTE: The Taiko protocol allows a block's timestamp to be equal to its parent block's timestamp, which differs from the original Ethereum protocol. So it's fine that there are two `TaikoL1.proposeBlock` transactions included in one L1 block.
+import { Callout } from 'nextra-theme-docs'
 
-Driver will inform the L2 execution engine Taiko protocol contract's latest verified L2 head, and try to let it catch up the latest verified L2 block through P2P at first. Driver will monitor the execution engine's sync progress, if it is not able to make any new sync progress in a period of time, driver will switch to insert the verified blocks to its local chain through the Engine API one by one.
+<Callout type="info" emoji="ℹ️">
+The Taiko protocol allows a block's timestamp to be equal to its parent block's timestamp, which differs from the original Ethereum protocol. So it's fine that there are two `TaikoL1.proposeBlock` transactions included in one L1 block.
+</Callout>
+  
+Taiko client's driver informs the L2 execution engine about Taiko protocol contract's latest verified L2 head and tries to let it catch up with the latest verified L2 block through P2P at first.
 
-After the L2 execution engine catches up the latest verified L2 head, driver will subscribe to `TaikoL1.BlockProposed` events, and when a new pending block is proposed:
+The driver monitors the execution engine's sync progress: If it's unable to make any new sync progress in a period of time, the driver switches to inserting the verified blocks into its local chain through the Engine API one by one.
 
-1. Get the corresponding `TaikoL1.proposeBlock` L1 transaction.
-2. Decode the txList and block metadata from the transaction's calldata.
-3. Check whether the txList is valid based on the rules defined in Taiko protocol.
+After the L2 execution engine catches up with the latest verified L2 head, the driver subscribes to `TaikoL1.BlockProposed` events. When a new pending block is proposed, the driver:
 
-If the txList is **valid**:
+1. Gets the corresponding `TaikoL1.proposeBlock` L1 transaction.
+2. Decodes the `txList` and block metadata from the transaction's calldata.
+3. Checks whether the `txList` is valid based on the rules defined in the Taiko protocol.
 
-4. Assemble a deterministic `TaikoL2.anchor` transaction based on the rules defined in the protocol, and put it as the first transaction in the proposed txList.
-5. Use this txList and the decoded block metadata to assemble a deterministic L2 block.
-6. Direct L2 execution engine to insert this assembled block and set it as the current canonical chain's head via the Engine API.
+If the `txList` is **valid**, the driver:
 
-If the txList is **invalid**:
+1. Assembles a deterministic `TaikoL2.anchor` transaction based on the rules defined in the protocol and puts it as the first transaction in the proposed `txList`.
+2. Uses this `txList` and the decoded block metadata to assemble a deterministic L2 block.
+3. Directs the L2 execution engine to insert this assembled block and sets it as the current canonical chain's head via the Engine API.
 
-4. Create a `TaikoL2.invalidateBlock` transaction and then assemble a L2 block only including this transaction.
-5. Direct the L2 execution engine to insert this block, but does not set it as the chain's head via the Engine API.
+If the `txList` is **invalid**, the driver:
 
-> NOTE: For more detailed information about: block metadata, please see `5.2.2 Block Metadata` in the white paper.
+1. Creates a `TaikoL2.invalidateBlock` transaction and then assembles an L2 block including only this transaction.
+2. Directs the L2 execution engine to insert this block, but does not set it as the chain's head via the Engine API.
 
-> NOTE: For more detailed information about txList validation rules, please see `5.3.1 Validation` in the white paper.
+import { Callout } from 'nextra-theme-docs'
 
-> NOTE: For more detailed information about the `TaikoL2.anchor` transaction and proposed block's determination, please see `5.4.1 Construction of Anchor Transactions` in the white paper.
+<Callout type="info" emoji="ℹ️">
+Read more about block metadata [here](https://taiko.xyz/docs/concepts/creating-taiko-blocks/intrinsic-validity-functions) or see `5.2.2 Block Metadata` in the [whitepaper](https://taikoxyz.github.io/taiko-mono/taiko-whitepaper.pdf).
 
+Read more about `txList` validation rules [here](https://taiko.xyz/docs/concepts/creating-taiko-blocks/intrinsic-validity-functions) or see `5.3.1 Validation` in the [whitepaper](https://taikoxyz.github.io/taiko-mono/taiko-whitepaper.pdf).
+
+Read more about the `TaikoL2.anchor` transaction and proposed block's determination [here](https://taiko.xyz/docs/concepts/creating-taiko-blocks/anchor-transaction) or see `5.4.1 Construction of Anchor Transactions` in the [whitepaper](https://taikoxyz.github.io/taiko-mono/taiko-whitepaper.pdf).
+</Callout>
+  
 ### Proposer
 
-Taiko client's proposer software will fetch pending transactions in a L2 execution engine's mempool intervally, then try to propose them to the Taiko layer 1 protocol contract.
+Taiko client's `proposer` software fetches pending transactions in a L2 execution engine's mempool intervally, then tries to propose them to the Taiko L1 protocol contract.
 
 #### Proposing strategy
 
 Since tokenomics have not been fully implemented in the Taiko protocol, the current proposing strategy is simply based on time interval.
 
 #### Proposing process
+To propose a block, the `proposer`:
 
-Proposing a block involves a few steps:
+1. Fetches the pending transactions from the L2 execution engine through the `txpool_content` RPC method.
+2. If there are too many pending transactions in the L2 execution engine, splits them into several smaller `txLists`. This is because the Taiko protocol restricts the max size of each proposed `txList`.
+3. Commits hashes of the `txLists` by sending `TaikoL1.commitBlock` transactions to L1.
+4. Waits for `TaikoData.Config.commitConfirmations` (currently `0`) L1 blocks confirmations.
+5. Proposse all splitted `txLists` by sending `TaikoL1.proposeBlock` transactions.
 
-1. Fetch the pending transactions from the L2 execution engine through the `txpool_content` RPC method.
-2. If there are too many pending transactions in the L2 execution engine, split them into several smaller txLists. This is because the Taiko protocol restricts the max size of each proposed txList.
-3. Commit hashes of the txLists by sending `TaikoL1.commitBlock` transactions to L1.
-4. Wait for `TaikoData.Config.commitConfirmations` (currently `0`) L1 blocks confirmations.
-5. Propose all splitted txLists by sending `TaikoL1.proposeBlock` transactions.
+import { Callout } from 'nextra-theme-docs'
+
+<Callout type="info" emoji="ℹ️">
+Read more about proposing blocks on Taiko [here](https://taiko.xyz/docs/concepts/creating-taiko-blocks/proposing-blocks) or see `5.2 Proposing Blocks` in the [whitepaper](https://taikoxyz.github.io/taiko-mono/taiko-whitepaper.pdf).
+</Callout>
 
 ### Prover
 
 #### Proving strategy
 
-Since tokenomics have not been fully implemented in the Taiko protocol, the prover software currently proves all proposed blocks.
+Since tokenomics have not been fully implemented in the Taiko protocol, the `prover` software currently proves all proposed blocks.
 
 #### Proving process
 
-When a new block is proposed:
+When a new block is proposed, the `prover`:
 
-1. Get the `TaikoL1.proposeBlock` L1 transaction calldata, decode it, and validate the txList. Just like what the `driver` software does.
-2. Wait until the corresponding block is inserted by the L2 execution engine's `driver` software.
-3. Generate a ZK proof for that block asynchronously.
+1. Gets the `TaikoL1.proposeBlock` L1 transaction calldata, decodes it, and validates the `txList`, just like what the `driver` software does.
+2. Waits until the corresponding block is inserted by the L2 execution engine's `driver` software.
+3. Generates a validity proof for that block asynchronously.
 
-If the proposed block has a valid txList:
+If the proposed block has a **valid** `txList`, the `prover`:
 
-4. Generate the merkel proof of the block's `TaikoL2.anchor` transaction to prove its existence in the `block.txRoot`'s [MPT](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/), and also this transaction receipt's merkel proof in the `block.receiptRoot`'s MPT from the L2 execution engine.
-5. Submit the `TaikoL2.anchor` transaction's RLP encoded bytes, its receipt's RLP encoded bytes, generated merkel proofs, and ZK proof to prove this block **valid**, by sending a `TaikoL1.proveBlock` transaction.
+1. Generates a Merkle proof of the block's `TaikoL2.anchor` transaction to prove its existence in the `block.txRoot`'s [MPT](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/) and this transaction receipt's [Merkle proof](https://rollup-glossary.vercel.app/other-terms#merkle-proofs) in the `block.receiptRoot`'s MPT from the L2 execution engine.
+2. Submits the `TaikoL2.anchor` transaction's RLP encoded bytes, its receipt's RLP encoded bytes, the generated Merkle proofs, and a validity proof to prove this block **valid** by sending a `TaikoL1.proveBlock` transaction.
 
-If the proposed block has an invalid txList:
+If the proposed block has an **invalid** `txList`, the `prover`:
 
-4. Generate the merkel proof of the block's `TaikoL2.invalidateBlock` transaction receipt to prove its existence in the `block.receiptRoot`'s MPT from the L2 execution engine.
-5. Submit the `TaikoL2.invalidateBlock` transaction receipt's RLP encoded bytes, generated merkel proof, and ZK proof to prove this block **invalid**, by sending a `TaikoL1.proveBlockInvalid` transaction.
+1. Generates a Merkle proof of the block's `TaikoL2.invalidateBlock` transaction receipt to prove its existence in the `block.receiptRoot`'s MPT from the L2 execution engine.
+2. Submits the `TaikoL2.invalidateBlock` transaction receipt's RLP encoded bytes, the generated Merkle proof, and a validity proof to prove this block **invalid**, by sending a `TaikoL1.proveBlockInvalid` transaction.
 
-> NOTE: For more information about why we need these merkel proofs when proving, please see `5.5 Proving Blocks` in the white paper.
+import { Callout } from 'nextra-theme-docs'
+
+<Callout type="info" emoji="ℹ️">
+Read more about why we need these Merkle proofs when proving in `5.5 Proving Blocks` in the [whitepaper](https://taikoxyz.github.io/taiko-mono/taiko-whitepaper.pdf).
+</Callout>

--- a/packages/website/pages/docs/concepts/taiko-nodes.mdx
+++ b/packages/website/pages/docs/concepts/taiko-nodes.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra-theme-docs'
+
 ## Overview
 
 Taiko nodes are minimally modified Ethereum execution clients that consist of two parts: `taiko-geth` and `taiko-client`. The two parts communicate with each other through the Engine API.
@@ -14,7 +16,7 @@ Like Ethereum mainnet execution engines, `taiko-geth` listens to new L2 transact
 
 The compiled binary `bin/taiko-client` is the main entrypoint. It includes three sub-commands:
 
-- `driver`: keeps the L2 execution engine's chain in sync with the `TaikoL1` contract by directing the L2 execution engine [execution engine](https://ethereum.org/en/glossary/#execution-client).
+- `driver`: keeps the L2 execution engine's chain in sync with the `TaikoL1` contract by directing the L2 [execution engine](https://ethereum.org/en/glossary/#execution-client).
 - [`proposer`](https://rollup-glossary.vercel.app/other-terms#proposer): proposes new transactions from the L2 execution engine's transaction pool to the `TaikoL1` contract.
 - [`prover`](https://rollup-glossary.vercel.app/other-terms#prover): requests [validity proofs](https://rollup-glossary.vercel.app/other-terms#validity-proof) from the [ZK-EVM](https://rollup-glossary.vercel.app/spicy-terms#zk-evm) and sends transactions to prove the proposed blocks are valid or invalid.
 
@@ -27,8 +29,6 @@ Taiko client's `driver` software serves as an L2 consensus client. It listens fo
 Taiko client's `driver` directs an L2 execution engine to insert new blocks or reorganize the local chain through the [Engine API](https://github.com/ethereum/execution-apis/tree/main/src/engine).
 
 #### Chain synchronization process
-
-import { Callout } from 'nextra-theme-docs'
 
 <Callout type="info" emoji="ℹ️">
 The Taiko protocol allows a block's timestamp to be equal to its parent block's timestamp, which differs from the original Ethereum protocol. So it's fine that there are two `TaikoL1.proposeBlock` transactions included in one L1 block.
@@ -55,8 +55,6 @@ If the `txList` is **invalid**, the driver:
 1. Creates a `TaikoL2.invalidateBlock` transaction and then assembles an L2 block including only this transaction.
 2. Directs the L2 execution engine to insert this block, but does not set it as the chain's head via the Engine API.
 
-import { Callout } from 'nextra-theme-docs'
-
 <Callout type="info" emoji="ℹ️">
 Read more about block metadata [here](https://taiko.xyz/docs/concepts/creating-taiko-blocks/intrinsic-validity-functions) or see `5.2.2 Block Metadata` in the [whitepaper](https://taikoxyz.github.io/taiko-mono/taiko-whitepaper.pdf).
 
@@ -81,8 +79,6 @@ To propose a block, the `proposer`:
 3. Commits hashes of the `txLists` by sending `TaikoL1.commitBlock` transactions to L1.
 4. Waits for `TaikoData.Config.commitConfirmations` (currently `0`) L1 blocks confirmations.
 5. Proposse all splitted `txLists` by sending `TaikoL1.proposeBlock` transactions.
-
-import { Callout } from 'nextra-theme-docs'
 
 <Callout type="info" emoji="ℹ️">
 Read more about proposing blocks on Taiko [here](https://taiko.xyz/docs/concepts/creating-taiko-blocks/proposing-blocks) or see `5.2 Proposing Blocks` in the [whitepaper](https://taikoxyz.github.io/taiko-mono/taiko-whitepaper.pdf).
@@ -111,8 +107,6 @@ If the proposed block has an **invalid** `txList`, the `prover`:
 
 1. Generates a Merkle proof of the block's `TaikoL2.invalidateBlock` transaction receipt to prove its existence in the `block.receiptRoot`'s MPT from the L2 execution engine.
 2. Submits the `TaikoL2.invalidateBlock` transaction receipt's RLP encoded bytes, the generated Merkle proof, and a validity proof to prove this block **invalid**, by sending a `TaikoL1.proveBlockInvalid` transaction.
-
-import { Callout } from 'nextra-theme-docs'
 
 <Callout type="info" emoji="ℹ️">
 Read more about why we need these Merkle proofs when proving in `5.5 Proving Blocks` in the [whitepaper](https://taikoxyz.github.io/taiko-mono/taiko-whitepaper.pdf).


### PR DESCRIPTION
Hey @d1onys1us, here's a revamped version of the Taiko nodes docs.

A few comments:

1. I replaced the Engine API link with another one because the old one was broken. Need to check if it's the correct one.
2. I added a few links to terms from the rollup glossary. I'm not sure if it's the right move but I thought since we have some definitions there that we don't have on the website, why not use it?
3. I used the callout components as you said but at least in the preview, the code doesn't seem to work for some reason. Would appreciate it if you could look into it.
4. Do we have anything unique to say in the `Engine API` section? We kind of repeat ourselves there, I wonder if we even need it?

Let me know what you think!