### PR TITLE
fix(bridge-ui): Key transaction items

### DIFF
--- a/packages/bridge-ui/src/components/Transactions/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Transaction.svelte
@@ -240,7 +240,7 @@
   }
 </script>
 
-<tr class="text-transaction-table">
+<tr id={transaction.hash} class="text-transaction-table">
   <td>
     <svelte:component this={txFromChain.icon} height={18} width={18} />
     <span class="ml-2 hidden md:inline-block">{txFromChain.name}</span>

--- a/packages/bridge-ui/src/components/Transactions/Transactions.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Transactions.svelte
@@ -26,7 +26,7 @@
         </tr>
       </thead>
       <tbody class="text-sm md:text-base">
-        {#each $transactions as transaction}
+        {#each $transactions as transaction (transaction.hash)}
           <Transaction
             on:claimNotice={({ detail }) => noticeModal.open(detail)}
             on:tooltipStatus={() => (showMessageStatusTooltip = true)}


### PR DESCRIPTION
Keying transaction items. I also added an id to each row to better identify the transaction (this is more for debugging purposes)