### PR TITLE
fix(bridge-ui): fix relayer

### DIFF
--- a/packages/bridge-ui/src/App.svelte
+++ b/packages/bridge-ui/src/App.svelte
@@ -96,6 +96,7 @@
       const apiTxs = await $relayerApi.getAllBridgeTransactionByAddress(
         userAddress,
       );
+
       const blockInfoMap = await $relayerApi.getBlockInfo();
       relayerBlockInfoMap.set(blockInfoMap);
 
@@ -109,14 +110,6 @@
       const updatedStorageTxs: BridgeTransaction[] = txs.filter((tx) => {
         return !hashToApiTxsMap.has(tx.hash.toLowerCase());
       });
-
-      // const updatedStorageTxs: BridgeTransaction[] = txs.filter((tx) => {
-      //   const blockInfo = blockInfoMap.get(tx.fromChainId);
-      //   if (blockInfo?.latestProcessedBlock >= tx.receipt?.blockNumber) {
-      //     return false;
-      //   }
-      //   return true;
-      // });
 
       $transactioner.updateStorageByAddress(userAddress, updatedStorageTxs);
 

--- a/packages/bridge-ui/src/components/ChainDropdown.svelte
+++ b/packages/bridge-ui/src/components/ChainDropdown.svelte
@@ -11,7 +11,7 @@
     await switchNetwork({
       chainId: chain.id,
     });
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const provider = new ethers.providers.Web3Provider(window.ethereum, 'any');
     await provider.send('eth_requestAccounts', []);
 
     fromChain.set(chain);

--- a/packages/bridge-ui/src/components/Transactions/Transactions.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Transactions.svelte
@@ -26,7 +26,7 @@
         </tr>
       </thead>
       <tbody class="text-sm md:text-base">
-        {#each $transactions as transaction}
+        {#each $transactions as transaction (transaction.hash)}
           <Transaction
             on:claimNotice={({ detail }) => noticeModal.open(detail)}
             on:tooltipStatus={() => (showMessageStatusTooltip = true)}

--- a/packages/bridge-ui/src/components/form/SelectChain.svelte
+++ b/packages/bridge-ui/src/components/form/SelectChain.svelte
@@ -13,7 +13,10 @@
       await switchNetwork({
         chainId: chain.id,
       });
-      const provider = new ethers.providers.Web3Provider(window.ethereum);
+      const provider = new ethers.providers.Web3Provider(
+        window.ethereum,
+        'any',
+      );
       await provider.send('eth_requestAccounts', []);
 
       fromChain.set(chain);

--- a/packages/bridge-ui/src/domain/relayerApi.ts
+++ b/packages/bridge-ui/src/domain/relayerApi.ts
@@ -19,10 +19,10 @@ export type TransactionData = {
     Memo: string;
     Owner: Address;
     Sender: Address;
-    GasLimit: number;
-    CallValue: number;
-    DepositValue: number;
-    ProcessingFee: number;
+    GasLimit: string;
+    CallValue: string;
+    DepositValue: string;
+    ProcessingFee: string;
     RefundAddress: Address;
     Data: string;
   };

--- a/packages/bridge-ui/src/relayer-api/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/relayer-api/RelayerAPIService.ts
@@ -64,6 +64,17 @@ export class RelayerAPIService implements RelayerAPI {
       return [];
     }
 
+    apiTxs.items.map((t, i) => {
+      apiTxs.items.map((tx, j) => {
+        if (
+          tx.data.Raw.transactionHash === t.data.Raw.transactionHash &&
+          i !== j
+        ) {
+          apiTxs.items = apiTxs.items.filter((_, index) => index !== j);
+        }
+      });
+    });
+
     const txs = apiTxs.items.map((tx: APIResponseTransaction) => {
       let data = tx.data.Message.Data;
       if (data === '') {

--- a/packages/bridge-ui/src/relayer-api/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/relayer-api/RelayerAPIService.ts
@@ -93,12 +93,16 @@ export class RelayerAPIService implements RelayerAPI {
           memo: tx.data.Message.Memo,
           owner: tx.data.Message.Owner,
           sender: tx.data.Message.Sender,
-          gasLimit: BigNumber.from(tx.data.Message.GasLimit),
-          callValue: BigNumber.from(tx.data.Message.CallValue),
+          gasLimit: BigNumber.from(tx.data.Message.GasLimit.toString()),
+          callValue: BigNumber.from(tx.data.Message.CallValue.toString()),
           srcChainId: tx.data.Message.SrcChainId,
           destChainId: tx.data.Message.DestChainId,
-          depositValue: BigNumber.from(`${tx.data.Message.DepositValue}`),
-          processingFee: BigNumber.from(`${tx.data.Message.ProcessingFee}`),
+          depositValue: BigNumber.from(
+            `${tx.data.Message.DepositValue.toString()}`,
+          ),
+          processingFee: BigNumber.from(
+            `${tx.data.Message.ProcessingFee.toString()}`,
+          ),
           refundAddress: tx.data.Message.RefundAddress,
         },
       };

--- a/packages/bridge-ui/src/utils/switchChainAndSetSigner.ts
+++ b/packages/bridge-ui/src/utils/switchChainAndSetSigner.ts
@@ -10,7 +10,10 @@ export async function switchChainAndSetSigner(chain: Chain) {
 
   await switchNetwork({ chainId });
 
-  const provider = new ethers.providers.Web3Provider(globalThis.ethereum);
+  const provider = new ethers.providers.Web3Provider(
+    globalThis.ethereum,
+    'any',
+  );
   await provider.send('eth_requestAccounts', []);
 
   fromChain.set(chain);

--- a/packages/starter-dapp/src/components/ChainDropdown.svelte
+++ b/packages/starter-dapp/src/components/ChainDropdown.svelte
@@ -11,7 +11,7 @@
     await switchNetwork({
       chainId: chain.id,
     });
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const provider = new ethers.providers.Web3Provider(window.ethereum, "any");
     await provider.send("eth_requestAccounts", []);
 
     fromChain.set(chain);
@@ -31,13 +31,13 @@
         <svelte:component this={$fromChain.icon} />
         <span class="ml-2 hidden md:inline-block">{$fromChain.name}</span>
       {:else}
-      <span class="ml-2 flex items-center">
-          <ExclamationTriangle class='mr-2' size='20' />
+        <span class="ml-2 flex items-center">
+          <ExclamationTriangle class="mr-2" size="20" />
           <span class="hidden md:block">Invalid Chain</span>
         </span>
       {/if}
     </span>
-    <ChevronDown size='20' />
+    <ChevronDown size="20" />
   </label>
   <ul
     tabindex="0"


### PR DESCRIPTION
Changes were introducedin the bridge Ui to change all the `string` values on a message to `numbe`, without any concern for integer overflow. This breaks the Transaction list, and renders it completely unusable.

This reverts those changes.