### PR TITLE
fix(bridge-ui): Network change fix

### DIFF
--- a/packages/bridge-ui/src/components/ChainDropdown.svelte
+++ b/packages/bridge-ui/src/components/ChainDropdown.svelte
@@ -11,7 +11,7 @@
     await switchNetwork({
       chainId: chain.id,
     });
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const provider = new ethers.providers.Web3Provider(window.ethereum, 'any');
     await provider.send('eth_requestAccounts', []);
 
     fromChain.set(chain);

--- a/packages/bridge-ui/src/components/form/SelectChain.svelte
+++ b/packages/bridge-ui/src/components/form/SelectChain.svelte
@@ -13,7 +13,10 @@
       await switchNetwork({
         chainId: chain.id,
       });
-      const provider = new ethers.providers.Web3Provider(window.ethereum);
+      const provider = new ethers.providers.Web3Provider(
+        window.ethereum,
+        'any',
+      );
       await provider.send('eth_requestAccounts', []);
 
       fromChain.set(chain);

--- a/packages/bridge-ui/src/utils/switchChainAndSetSigner.ts
+++ b/packages/bridge-ui/src/utils/switchChainAndSetSigner.ts
@@ -10,7 +10,10 @@ export async function switchChainAndSetSigner(chain: Chain) {
 
   await switchNetwork({ chainId });
 
-  const provider = new ethers.providers.Web3Provider(globalThis.ethereum);
+  const provider = new ethers.providers.Web3Provider(
+    globalThis.ethereum,
+    'any',
+  );
   await provider.send('eth_requestAccounts', []);
 
   fromChain.set(chain);

--- a/packages/starter-dapp/src/components/ChainDropdown.svelte
+++ b/packages/starter-dapp/src/components/ChainDropdown.svelte
@@ -11,7 +11,7 @@
     await switchNetwork({
       chainId: chain.id,
     });
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const provider = new ethers.providers.Web3Provider(window.ethereum, "any");
     await provider.send("eth_requestAccounts", []);
 
     fromChain.set(chain);
@@ -31,13 +31,13 @@
         <svelte:component this={$fromChain.icon} />
         <span class="ml-2 hidden md:inline-block">{$fromChain.name}</span>
       {:else}
-      <span class="ml-2 flex items-center">
-          <ExclamationTriangle class='mr-2' size='20' />
+        <span class="ml-2 flex items-center">
+          <ExclamationTriangle class="mr-2" size="20" />
           <span class="hidden md:block">Invalid Chain</span>
         </span>
       {/if}
     </span>
-    <ChevronDown size='20' />
+    <ChevronDown size="20" />
   </label>
   <ul
     tabindex="0"


### PR DESCRIPTION
A regression introduced by changing the wagmi signing connectors has caused claiming to fail, due to an underlying network change in the Web3Provider, if you need to switchyour network from Src => Dest to claim. 

This solves that regression.