### PR TITLE
feat(protocol): use withdrawalsRoot

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -125,6 +125,7 @@ library TaikoData {
         uint24 nextForkChoiceId;
         uint24 verifiedForkChoiceId;
         bytes32 metaHash;
+        bytes32 withdrawalsRoot;
         address proposer;
     }
 
@@ -134,6 +135,12 @@ library TaikoData {
         uint24 size;
     }
 
+    // Represents a L1-to-L2 Ether transfer
+    struct Withdrawal {
+        address account;
+        uint64 amount;
+    }
+
     struct State {
         // Ring buffer for proposed blocks and a some recent verified blocks.
         mapping(uint256 blockId_mode_ringBufferSize => Block) blocks;
@@ -141,6 +148,7 @@ library TaikoData {
         mapping(uint256 blockId => mapping(bytes32 parentHash => mapping(uint32 parentGasUsed => uint256 forkChoiceId))) forkChoiceIds;
         mapping(address account => uint256 balance) balances;
         mapping(bytes32 txListHash => TxListInfo) txListInfo;
+        Withdrawal[] withdrawals;
         // Never or rarely changed
         uint64 genesisHeight;
         uint64 genesisTimestamp;
@@ -151,7 +159,7 @@ library TaikoData {
         uint64 numBlocks;
         uint64 lastProposedAt; // Timestamp when the last block is proposed.
         uint64 avgBlockTime; // miliseconds
-        uint64 __reserved3;
+        uint64 nextWithdrawalToInclude;
         // Changed when a block is proven/verified
         uint64 lastVerifiedBlockId;
         uint64 __reserved4;
@@ -160,6 +168,6 @@ library TaikoData {
         uint64 avgProofTime; // miliseconds
         uint64 feeBase;
         // Reserved
-        uint256[43] __gap;
+        uint256[42] __gap;
     }
 }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -68,6 +68,9 @@ library TaikoData {
         uint64 l1Height;
         bytes32 l1Hash;
         bytes32 mixHash;
+        bytes32 withdrawalsRoot;
+        uint64 withdrawlStartIndex;
+        uint64 withdrawlUntilIndex;
         bytes32 txListHash;
         uint24 txListByteStart;
         uint24 txListByteEnd;
@@ -125,7 +128,6 @@ library TaikoData {
         uint24 nextForkChoiceId;
         uint24 verifiedForkChoiceId;
         bytes32 metaHash;
-        bytes32 withdrawalsRoot;
         address proposer;
     }
 

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -13,6 +13,8 @@ abstract contract TaikoEvents {
     event BlockProposed(
         uint256 indexed id,
         TaikoData.BlockMetadata meta,
+        uint64 withdrawlStartIndex,
+        uint64 withdrawlUntilIndex,
         bool txListCached
     );
 

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -13,8 +13,6 @@ abstract contract TaikoEvents {
     event BlockProposed(
         uint256 indexed id,
         TaikoData.BlockMetadata meta,
-        uint64 withdrawlStartIndex,
-        uint64 withdrawlUntilIndex,
         bool txListCached
     );
 


### PR DESCRIPTION
Very simple code to show how L1-to-L2 Ether transfer can be done using withdrawalsRoot.

## Pros
-  L1-to-L2 Ether transfer are fast and guaranteed in order they were created.

## Cons
- Proposer ends up paying the Ether on L1 to compute `withdrawalsRoot` without fee incomes.
- `_calcWithdrawalsRoot` may be expensive as it requires building a Trie on L1 (@Brechtpd is TransactionRoot using binary tree or Patricia 16-branch tree?)
- The L2-to-L1 withdrawal has to be using a different design (the current design)
- Ether transfer were transparent to core protocol, but now it has to be part of the core protocol.

We can also discuss here https://github.com/taikoxyz/taiko-mono/issues/13183