### PR TITLE
feat(protocol): update `ANCHOR_GAS_COST`

### DIFF
--- a/packages/protocol/contracts/L2/LibL2Consts.sol
+++ b/packages/protocol/contracts/L2/LibL2Consts.sol
@@ -7,5 +7,5 @@
 pragma solidity ^0.8.18;
 
 library LibL2Consts {
-    uint64 public constant ANCHOR_GAS_COST = 150000; // owner:david
+    uint64 public constant ANCHOR_GAS_COST = 180000; // owner:david
 }


### PR DESCRIPTION
Increase `ANCHOR_GAS_COST`, since after testing in a geth node, the gas cost of an anchor transaction after 256 L2 blocks is ~160000:
<img width="1507" alt="image" src="https://user-images.githubusercontent.com/104078303/234057095-2699392b-d0e3-4936-a36c-21f99511df21.png">
