### PR TITLE
feat(status-page): ETH Deposit info

### DIFF
--- a/packages/status-page/src/pages/home/Home.svelte
+++ b/packages/status-page/src/pages/home/Home.svelte
@@ -21,6 +21,8 @@
   import { getNumProposers } from "../../utils/getNumProposers";
   import DetailsModal from "../../components/DetailsModal.svelte";
   import { addressSubsection } from "../../utils/addressSubsection";
+  import { getEthDeposits } from "../../utils/getEthDeposits";
+  import { getNextEthDepositToProcess } from "../../utils/getNextEthDepositToProcess";
 
   export let l1Provider: ethers.providers.JsonRpcProvider;
   export let l1TaikoAddress: string;
@@ -190,6 +192,36 @@
       },
       tooltip:
         "The amount of pending proposed blocks that have not been proven on the TaikoL1 smart contract.",
+    },
+    {
+      statusFunc: getEthDeposits,
+      watchStatusFunc: null,
+      provider: l1Provider,
+      contractAddress: l1TaikoAddress,
+      header: "ETH Deposits",
+      intervalInMs: 20000,
+      colorFunc: (value: Status) => {
+        if (BigNumber.from(value).eq(0)) {
+          return "green";
+        } else if (BigNumber.from(value).lt(32)) {
+          return "yellow";
+        } else {
+          return "red";
+        }
+      },
+      tooltip: "The number of pending ETH deposits for L1 => L2",
+    },
+    {
+      statusFunc: getNextEthDepositToProcess,
+      watchStatusFunc: null,
+      provider: l1Provider,
+      contractAddress: l1TaikoAddress,
+      header: "Next ETH Deposit",
+      intervalInMs: 20000,
+      colorFunc: (value: Status) => {
+        return "green";
+      },
+      tooltip: "The next ETH deposit that will be processed",
     },
     {
       statusFunc: getGasPrice,

--- a/packages/status-page/src/utils/getAvailableSlots.ts
+++ b/packages/status-page/src/utils/getAvailableSlots.ts
@@ -1,13 +1,12 @@
-import { Contract, ethers } from "ethers";
-import TaikoL1 from "../constants/abi/TaikoL1";
+import type { ethers } from "ethers";
 import { getConfig } from "./getConfig";
+import { getStateVariables } from "./getStateVariables";
 
 export const getAvailableSlots = async (
   provider: ethers.providers.JsonRpcProvider,
   contractAddress: string
 ): Promise<number> => {
-  const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
-  const stateVariables = await contract.getStateVariables();
+  const stateVariables = await getStateVariables(provider, contractAddress);
   const config = await getConfig(provider, contractAddress);
 
   const nextBlockId = stateVariables.numBlocks;

--- a/packages/status-page/src/utils/getEthDeposits.ts
+++ b/packages/status-page/src/utils/getEthDeposits.ts
@@ -1,11 +1,10 @@
-import { Contract, ethers } from "ethers";
-import TaikoL1 from "../constants/abi/TaikoL1";
+import type { ethers } from "ethers";
+import { getStateVariables } from "./getStateVariables";
 
 export const getEthDeposits = async (
   provider: ethers.providers.JsonRpcProvider,
   contractAddress: string
 ): Promise<number> => {
-  const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
-  const stateVariables = await contract.getStateVariables();
+  const stateVariables = await getStateVariables(provider, contractAddress);
   return stateVariables.numEthDeposits;
 };

--- a/packages/status-page/src/utils/getEthDeposits.ts
+++ b/packages/status-page/src/utils/getEthDeposits.ts
@@ -1,0 +1,11 @@
+import { Contract, ethers } from "ethers";
+import TaikoL1 from "../constants/abi/TaikoL1";
+
+export const getEthDeposits = async (
+  provider: ethers.providers.JsonRpcProvider,
+  contractAddress: string
+): Promise<number> => {
+  const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
+  const stateVariables = await contract.getStateVariables();
+  return stateVariables.numEthDeposits;
+};

--- a/packages/status-page/src/utils/getLastVerifiedBlockId.ts
+++ b/packages/status-page/src/utils/getLastVerifiedBlockId.ts
@@ -1,12 +1,11 @@
-import { BigNumber, Contract, ethers } from "ethers";
-import TaikoL1 from "../constants/abi/TaikoL1";
+import { BigNumber, ethers } from "ethers";
+import { getStateVariables } from "./getStateVariables";
 
 export const getLastVerifiedBlockId = async (
   provider: ethers.providers.JsonRpcProvider,
   contractAddress: string
 ): Promise<number> => {
-  const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
-  const stateVariables = await contract.getStateVariables();
+  const stateVariables = await getStateVariables(provider, contractAddress);
   const lastBlockId = stateVariables.lastVerifiedBlockId;
   return BigNumber.from(lastBlockId).toNumber();
 };

--- a/packages/status-page/src/utils/getNextBlockId.ts
+++ b/packages/status-page/src/utils/getNextBlockId.ts
@@ -1,12 +1,11 @@
-import { BigNumber, Contract, ethers } from "ethers";
-import TaikoL1 from "../constants/abi/TaikoL1";
+import { BigNumber, ethers } from "ethers";
+import { getStateVariables } from "./getStateVariables";
 
 export const getNextBlockId = async (
   provider: ethers.providers.JsonRpcProvider,
   contractAddress: string
 ): Promise<number> => {
-  const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
-  const stateVariables = await contract.getStateVariables();
+  const stateVariables = await getStateVariables(provider, contractAddress);
   const nextBlockId = stateVariables.numBlocks;
   return BigNumber.from(nextBlockId).toNumber();
 };

--- a/packages/status-page/src/utils/getNextEthDepositToProcess.ts
+++ b/packages/status-page/src/utils/getNextEthDepositToProcess.ts
@@ -1,0 +1,11 @@
+import { Contract, ethers } from "ethers";
+import TaikoL1 from "../constants/abi/TaikoL1";
+
+export const getNextEthDepositToProcess = async (
+  provider: ethers.providers.JsonRpcProvider,
+  contractAddress: string
+): Promise<number> => {
+  const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
+  const stateVariables = await contract.getStateVariables();
+  return stateVariables.nextEthDepositToProcess;
+};

--- a/packages/status-page/src/utils/getPendingBlocks.ts
+++ b/packages/status-page/src/utils/getPendingBlocks.ts
@@ -1,12 +1,12 @@
-import { Contract, ethers } from "ethers";
+import type { ethers } from "ethers";
 import TaikoL1 from "../constants/abi/TaikoL1";
+import { getStateVariables } from "./getStateVariables";
 
 export const getPendingBlocks = async (
   provider: ethers.providers.JsonRpcProvider,
   contractAddress: string
 ): Promise<number> => {
-  const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
-  const stateVariables = await contract.getStateVariables();
+  const stateVariables = await getStateVariables(provider, contractAddress);
   const nextBlockId = stateVariables.numBlocks;
   const lastBlockId = stateVariables.lastVerifiedBlockId;
   return nextBlockId - lastBlockId - 1;

--- a/packages/status-page/src/utils/getProofReward.ts
+++ b/packages/status-page/src/utils/getProofReward.ts
@@ -7,7 +7,6 @@ export const getProofReward = async (
   contractAddress: string
 ): Promise<string> => {
   const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
-  const state = await contract.getStateVariables();
   const fee = await contract.getProofReward(
     ~~(new Date().getTime() / 1000),
     ~~(new Date().getTime() / 1000) - 1200

--- a/packages/status-page/src/utils/getStateVariables.ts
+++ b/packages/status-page/src/utils/getStateVariables.ts
@@ -1,11 +1,27 @@
 import { BigNumber, Contract, ethers } from "ethers";
 import TaikoL1 from "../constants/abi/TaikoL1";
 
+const cacheTime = 1000 * 15; // 15 seconds
+type StateVarsCache = {
+  cachedAt: number;
+  stateVars: any;
+};
+
+let stateVarsCache: StateVarsCache;
+
 export const getStateVariables = async (
   provider: ethers.providers.JsonRpcProvider,
   contractAddress: string
 ) => {
+  if (stateVarsCache && stateVarsCache.cachedAt + cacheTime > Date.now()) {
+    return stateVarsCache.stateVars;
+  }
+
   const contract: Contract = new Contract(contractAddress, TaikoL1, provider);
   const vars = await contract.getStateVariables();
+  stateVarsCache = {
+    stateVars: vars,
+    cachedAt: Date.now(),
+  };
   return vars;
 };


### PR DESCRIPTION
Protocol upgrade has some new fields we can use to track the status of ETH deposits.

Also, we cache the `getStateVariables` call for 15 seconds, to reduce RPC requests for values that most likely haven't changed.