### PR TITLE
feat(protocol): need one real ZKP every N blocks

### DIFF
--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -35,6 +35,10 @@ library TaikoConfig {
                 maxBytesPerTxList: 120000,
                 minTxGasLimit: 21000,
                 proofCooldownPeriod: 30 minutes,
+                // Only need 1 real zkp per 10 blocks.
+                // If block number is N, then only when N % 10 == 0, the real ZKP
+                // is needed. For mainnet, this must be 0 or 1.
+                realProofSkipBatch: 10,
                 ethDepositGas: 21000,
                 ethDepositMaxFee: 1 ether / 10,
                 txListCacheExpiry: 0,

--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -38,7 +38,7 @@ library TaikoConfig {
                 // Only need 1 real zkp per 10 blocks.
                 // If block number is N, then only when N % 10 == 0, the real ZKP
                 // is needed. For mainnet, this must be 0 or 1.
-                realProofSkipBatch: 10,
+                realProofSkipSize: 10,
                 ethDepositGas: 21000,
                 ethDepositMaxFee: 1 ether / 10,
                 txListCacheExpiry: 0,

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -20,6 +20,7 @@ library TaikoData {
         uint256 minTxGasLimit;
         uint256 txListCacheExpiry;
         uint256 proofCooldownPeriod;
+        uint256 realProofSkipBatch;
         uint256 ethDepositGas;
         uint256 ethDepositMaxFee;
         uint64 minEthDepositsPerBlock;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -20,7 +20,7 @@ library TaikoData {
         uint256 minTxGasLimit;
         uint256 txListCacheExpiry;
         uint256 proofCooldownPeriod;
-        uint256 realProofSkipBatch;
+        uint256 realProofSkipSize;
         uint256 ethDepositGas;
         uint256 ethDepositMaxFee;
         uint64 minEthDepositsPerBlock;

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -87,6 +87,16 @@ library LibProving {
                     ) revert L1_NOT_ORACLE_PROVER();
                 }
             }
+
+            if (
+                config.realProofSkipBatch > 1 &&
+                blockId % config.realProofSkipBatch != 0
+            ) {
+                // For this block, real ZKP is not necessary, so the oracle
+                // proof will be treated as a real proof (by setting the prover
+                // to a non-zero value)
+                evidence.prover = address(1);
+            }
         }
 
         TaikoData.ForkChoice storage fc;

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -89,8 +89,8 @@ library LibProving {
             }
 
             if (
-                config.realProofSkipBatch > 1 &&
-                blockId % config.realProofSkipBatch != 0
+                config.realProofSkipSize > 1 &&
+                blockId % config.realProofSkipSize != 0
             ) {
                 // For this block, real ZKP is not necessary, so the oracle
                 // proof will be treated as a real proof (by setting the prover

--- a/packages/protocol/test/TaikoL1.sim.sol
+++ b/packages/protocol/test/TaikoL1.sim.sol
@@ -27,6 +27,7 @@ contract TaikoL1_b is TaikoL1 {
         config.maxVerificationsPerTx = 5;
         config.proofCooldownPeriod = 1 minutes;
         config.proofTimeTarget = 200;
+        config.realProofSkipSize = 0;
     }
 }
 

--- a/packages/protocol/test/TaikoL1Oracle.t.sol
+++ b/packages/protocol/test/TaikoL1Oracle.t.sol
@@ -27,6 +27,7 @@ contract TaikoL1Oracle is TaikoL1 {
         config.maxNumProposedBlocks = 10;
         config.ringBufferSize = 12;
         config.proofCooldownPeriod = 5 minutes;
+        config.realProofSkipSize = 0;
     }
 }
 

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -18,6 +18,7 @@ struct Config {
   uint256 minTxGasLimit;
   uint256 txListCacheExpiry;
   uint256 proofCooldownPeriod;
+  uint256 realProofSkipBatch;
   uint256 ethDepositGas;
   uint256 ethDepositMaxFee;
   uint64 minEthDepositsPerBlock;

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -18,7 +18,7 @@ struct Config {
   uint256 minTxGasLimit;
   uint256 txListCacheExpiry;
   uint256 proofCooldownPeriod;
-  uint256 realProofSkipBatch;
+  uint256 realProofSkipSize;
   uint256 ethDepositGas;
   uint256 ethDepositMaxFee;
   uint64 minEthDepositsPerBlock;


### PR DESCRIPTION
To reduce the prover cost of testnets, a new config `realProofSkipSize` is introduced, assuming it's 10, then we only need real ZKP every 10 blocks (block 10, 20, ....). For other blocks, the oracle provers will be considered as the real ZKP and will allow those blocks to be verified.


@davidtaikocha this may affect the prover code.