### PR TITLE
feat(protocol): Change back token decimals

### DIFF
--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -59,7 +59,7 @@ contract TaikoToken is EssentialContract, ERC20Upgradeable, IMintableERC20 {
         ERC20Upgradeable.__ERC20_init({
             name_: _name,
             symbol_: _symbol,
-            decimals_: 18
+            decimals_: 8
         });
 
         for (uint256 i = 0; i < _premintRecipients.length; ++i) {


### PR DESCRIPTION
Change back token decimal settings to 8 from 18, because it affects not only tests but the code itself.
`uint64` range of the baseFee currently implies some limitations, so decimal 8 would perfectly fit in but 18 needs to involve some other changes.