### PR TITLE
refactor(protocol): remove staticRefs

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -129,7 +129,6 @@ library TaikoData {
         mapping(address account => uint256 balance) taikoTokenBalances;
         mapping(bytes32 txListHash => TxListInfo) txListInfo;
         EthDeposit[] ethDeposits;
-        bytes32 staticRefs;
         // Never or rarely changed
         // Slot 7: never or rarely changed
         uint64 genesisHeight;
@@ -147,6 +146,6 @@ library TaikoData {
         uint64 lastVerifiedBlockId;
         uint64 __reserved91;
         // Reserved
-        uint256[41] __gap;
+        uint256[42] __gap;
     }
 }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -41,7 +41,8 @@ contract TaikoL1 is
      * @param _addressManager The AddressManager address.
      * @param _genesisBlockHash The block hash of the genesis block.
      * @param _initBlockFee Initial (reasonable) block fee value.
-     * @param _initProofTimeIssued Initial proof time issued corresponding with the initial block fee.
+     * @param _initProofTimeIssued Initial proof time issued corresponding
+     *        with the initial block fee.
      */
     function init(
         address _addressManager,

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -147,39 +147,41 @@ library LibProving {
         fc.prover = evidence.prover;
 
         if (evidence.prover != address(0)) {
-            bytes32 instance;
+            uint256[9] memory inputs;
 
-            // Set state.staticRefs
-            if (state.staticRefs == 0) {
-                address[3] memory addresses;
-                addresses[0] = resolver.resolve("signal_service", false);
-                addresses[1] = resolver.resolve(
-                    config.chainId,
-                    "signal_service",
-                    false
-                );
-                addresses[2] = resolver.resolve(config.chainId, "taiko", false);
-                bytes32 staticRefs;
-                assembly {
-                    staticRefs := keccak256(addresses, mul(32, 3))
-                }
-                state.staticRefs = staticRefs;
-            }
+            inputs[0] = uint256(
+                uint160(address(resolver.resolve("signal_service", false)))
+            );
+            inputs[1] = uint256(
+                uint160(
+                    address(
+                        resolver.resolve(
+                            config.chainId,
+                            "signal_service",
+                            false
+                        )
+                    )
+                )
+            );
+            inputs[2] = uint256(
+                uint160(
+                    address(resolver.resolve(config.chainId, "taiko", false))
+                )
+            );
 
-            uint256[7] memory inputs;
-            inputs[0] = uint256(state.staticRefs);
-            inputs[1] = uint256(blk.metaHash);
-            inputs[2] = uint256(evidence.parentHash);
-            inputs[3] = uint256(evidence.blockHash);
-            inputs[4] = uint256(evidence.signalRoot);
-            inputs[5] = uint256(evidence.graffiti);
-            inputs[6] =
+            inputs[3] = uint256(blk.metaHash);
+            inputs[4] = uint256(evidence.parentHash);
+            inputs[5] = uint256(evidence.blockHash);
+            inputs[6] = uint256(evidence.signalRoot);
+            inputs[7] = uint256(evidence.graffiti);
+            inputs[8] =
                 (uint256(uint160(evidence.prover)) << 96) |
                 (uint256(evidence.parentGasUsed) << 64) |
                 (uint256(evidence.gasUsed) << 32);
 
+            bytes32 instance;
             assembly {
-                instance := keccak256(inputs, mul(32, 7))
+                instance := keccak256(inputs, mul(32, 9))
             }
 
             (bool verified, bytes memory ret) = resolver

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -153,7 +153,6 @@ struct State {
   mapping(address => uint256) taikoTokenBalances;
   mapping(bytes32 => struct TaikoData.TxListInfo) txListInfo;
   struct TaikoData.EthDeposit[] ethDeposits;
-  bytes32 staticRefs;
   uint64 genesisHeight;
   uint64 genesisTimestamp;
   uint64 __reserved71;
@@ -166,6 +165,6 @@ struct State {
   uint64 proofTimeIssued;
   uint64 lastVerifiedBlockId;
   uint64 __reserved91;
-  uint256[41] __gap;
+  uint256[42] __gap;
 }
 ```

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoEvents.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoEvents.md
@@ -13,7 +13,7 @@ event BlockProposed(uint256 id, struct TaikoData.BlockMetadata meta)
 ### BlockProven
 
 ```solidity
-event BlockProven(uint256 id, bytes32 parentHash, bytes32 blockHash, bytes32 signalRoot, address prover)
+event BlockProven(uint256 id, bytes32 parentHash, bytes32 blockHash, bytes32 signalRoot, address prover, uint32 parentGasUsed)
 ```
 
 ### BlockVerified


### PR DESCRIPTION
Per https://github.com/taikoxyz/taiko-mono/issues/13708, the stateRefs caching is no long necessary.