### PR TITLE
try to fix a bug in proving

### DIFF
--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -12,6 +12,7 @@ abstract contract TaikoErrors {
     error L1_BLOCK_ID();
     error L1_EVIDENCE_MISMATCH(bytes32 expected, bytes32 actual);
     error L1_FORK_CHOICE_NOT_FOUND();
+    error L1_FORK_CHOICE_DIFF_ORACLE();
     error L1_INSUFFICIENT_TOKEN();
     error L1_INVALID_CONFIG();
     error L1_INVALID_ETH_DEPOSIT();
@@ -21,7 +22,6 @@ abstract contract TaikoErrors {
     error L1_INVALID_PROOF();
     error L1_NOT_ORACLE_PROVER();
     error L1_ORACLE_DISABLED();
-    error L1_SAME_PROOF();
     error L1_TOO_MANY_BLOCKS();
     error L1_TX_LIST_NOT_EXIST();
     error L1_TX_LIST_HASH();


### PR DESCRIPTION
@adaki2004 There are bugs in LibProving. Tests will fail for the following scenario on main:

1. Assume realProofSkipSize is 0 or 1.
2. Submit an oracle proof
3. Submit a real proof to override the oracle proof

I tried to fix the bug but don't have much time today, so please take it as priority. I'd like to define the following terms to help you understand things:

- An oracle proof: if evidence.prover is address(0), the proof is an oracle proof. On main branch, we sometimes override evidence.prover to a non-zero value, this is wrong, we should not do that.
- A fake proof: if the evidence.prover is the oracle prover address, then this proof can be called a fake proof. Fake proofs do not run verifiers, besides that, they are the same as regular proofs.
- A regular proof: if evidence.prover is not 0 or the oracle prover address. 


We can have  two different addresses for "oracle_prover" and "fake_prover" respectively, then things will be easier. In the code, we just use the same address for both oracle proofs and fake proofs.


