### PR TITLE
fix(protocol): fix deployonl1 script

### DIFF
--- a/packages/protocol/script/test_deploy_on_l1.sh
+++ b/packages/protocol/script/test_deploy_on_l1.sh
@@ -19,4 +19,4 @@ forge script script/DeployOnL1.s.sol:DeployOnL1 \
     --broadcast \
     --ffi \
     -vvvv \
-    --via-ir \
+    --block-gas-limit 100000000


### PR DESCRIPTION
deployonl1script needs a `--block-gas-limit` set with our new plonk verifier, or it fails with reverting. Also, now if we use `--via-ir` on anvil, it hangs, but it works on Geth.

As the `taiko-client` adds `--via-ir` manually, I think its OK to remove from the test here, but if someone wants to dive in and see why via IR fails on anvil, that could be good too.

closes #13718