### PR TITLE
fix(protocol): Replace LibEthDeposit assembly

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -101,8 +101,8 @@ library LibEthDepositing {
             }
         }
 
-        if (depositsProcessed[0].recipient == address(0)) {
-            depositsProcessed = new TaikoData.EthDeposit[](0);
+        assembly {
+            mstore(depositsProcessed, j)
         }
         depositsRoot = hashDeposits(depositsProcessed);
     }

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -101,10 +101,19 @@ library LibEthDepositing {
             }
         }
 
-        // resize the length of depositsProcessed to j.
-        assembly {
-            mstore(depositsProcessed, j)
-            depositsRoot := keccak256(depositsProcessed, mul(j, 32))
+        if (depositsProcessed[0].recipient == address(0)) {
+            depositsProcessed = new TaikoData.EthDeposit[](0);
         }
+        depositsRoot = hashDeposits(depositsProcessed);
+    }
+
+    function hashDeposits(TaikoData.EthDeposit[] memory deposits) internal pure returns (bytes32) {
+        bytes memory buffer;
+
+        for (uint256 i = 0; i < deposits.length; i++) {
+            buffer = abi.encodePacked(buffer, deposits[i].recipient, deposits[i].amount);
+        }
+
+        return keccak256(buffer);
     }
 }

--- a/packages/protocol/test/TaikoL1.t.sol
+++ b/packages/protocol/test/TaikoL1.t.sol
@@ -247,4 +247,49 @@ contract TaikoL1Test is TaikoL1TestBase {
         // Not found
         assertEq(bytes32(0), L1.getCrossChainSignalRoot((iterationCnt + 1)));
     }
+
+    function test_deposit_hash_creation() external {
+        uint96 minAmount = conf.minEthDepositAmount;
+        uint96 maxAmount = conf.maxEthDepositAmount;
+
+        // We need 8 depostis otherwise we are not processing them !
+        depositTaikoToken(Alice, 1e6 * 1e8, maxAmount + 1 ether);
+        depositTaikoToken(Bob, 0, maxAmount + 1 ether);
+        depositTaikoToken(Carol, 0, maxAmount + 1 ether);
+        depositTaikoToken(Dave, 0, maxAmount + 1 ether);
+        depositTaikoToken(Eve, 0, maxAmount + 1 ether);
+        depositTaikoToken(Frank, 0, maxAmount + 1 ether);
+        depositTaikoToken(George, 0, maxAmount + 1 ether);
+        depositTaikoToken(Hilbert, 0, maxAmount + 1 ether);
+
+        // So after this point we have 8 deposits
+        vm.prank(Alice, Alice);
+        L1.depositEtherToL2{value: 1 ether}();
+        vm.prank(Bob, Bob);
+        L1.depositEtherToL2{value: 2 ether}();
+        vm.prank(Carol, Carol);
+        L1.depositEtherToL2{value: 3 ether}();
+        vm.prank(Dave, Dave);
+        L1.depositEtherToL2{value: 4 ether}();
+        vm.prank(Eve, Eve);
+        L1.depositEtherToL2{value: 5 ether}();
+        vm.prank(Frank, Frank);
+        L1.depositEtherToL2{value: 6 ether}();
+        vm.prank(George, George);
+        L1.depositEtherToL2{value: 7 ether}();
+        vm.prank(Hilbert, Hilbert);
+        L1.depositEtherToL2{value: 8 ether}();
+
+        assertEq(L1.getStateVariables().numEthDeposits, 8); // The number of deposits
+        assertEq(L1.getStateVariables().nextEthDepositToProcess, 0); // The index / cursos of the next deposit
+
+        // We shall invoke proposeBlock() because this is what will call the processDeposits()
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, 1000000, 1024);
+
+        // Expected: 0xcfa788c68a55976de9ba9fbab4038b8ddacedb45242ff4380163cd661d0e873f  (pre calculated with these values)
+        //console2.logBytes32(meta.depositsRoot);
+        assertEq(
+            meta.depositsRoot, 0xcfa788c68a55976de9ba9fbab4038b8ddacedb45242ff4380163cd661d0e873f
+        );
+    }
 }

--- a/packages/protocol/test/TaikoL1.t.sol
+++ b/packages/protocol/test/TaikoL1.t.sol
@@ -286,10 +286,10 @@ contract TaikoL1Test is TaikoL1TestBase {
         // We shall invoke proposeBlock() because this is what will call the processDeposits()
         TaikoData.BlockMetadata memory meta = proposeBlock(Alice, 1000000, 1024);
 
-        // Expected: 0xcfa788c68a55976de9ba9fbab4038b8ddacedb45242ff4380163cd661d0e873f  (pre calculated with these values)
+        // Expected: 0x8117066d69ff650d78f0d7383a10cc802c2b8c0eedd932d70994252e2438c636  (pre calculated with these values)
         //console2.logBytes32(meta.depositsRoot);
         assertEq(
-            meta.depositsRoot, 0xcfa788c68a55976de9ba9fbab4038b8ddacedb45242ff4380163cd661d0e873f
+            meta.depositsRoot, 0x8117066d69ff650d78f0d7383a10cc802c2b8c0eedd932d70994252e2438c636
         );
     }
 }

--- a/packages/protocol/test/TaikoL1TestBase.t.sol
+++ b/packages/protocol/test/TaikoL1TestBase.t.sol
@@ -43,6 +43,9 @@ abstract contract TaikoL1TestBase is Test {
     address public constant Carol = 0x300C9b60E19634e12FC6D68B7FEa7bFB26c2E419;
     address public constant Dave = 0x400147C0Eb43D8D71b2B03037bB7B31f8f78EF5F;
     address public constant Eve = 0x50081b12838240B1bA02b3177153Bca678a86078;
+    address public constant Frank = 0x430c9b60e19634e12FC6d68B7fEa7bFB26c2e419;
+    address public constant George = 0x520147C0eB43d8D71b2b03037bB7b31f8F78EF5f;
+    address public constant Hilbert = 0x61081B12838240B1Ba02b3177153BcA678a86078;
 
     // Calculation shall be done in derived contracts - based on testnet or mainnet expected proof time
     uint64 public initProofTimeIssued;


### PR DESCRIPTION
David asked me today to help investigate why the `depositsRoot` he calculates (seemingly from same test data) within the golang code does not match the one with the solidity calculates.

After investigation / debugging, the assembly code turned out to be the issue, because the underlying array of struct `EthDeposit` within a struct `State` is not stored on a continuous memory location but with the help of pointers rather. 

(If it would have been stored on a continuous location, the assembly would have been wrong anyways, because the first 32 bytes is reserved for the length of the array which should have been chopped).

(If anyone wants to debug how the continuous memory area of the 33-byte-long depossitsProcessed variable look like feel free to put this into `LibEthDepositing.sol` and debug print the value).

```
bytes memory result = new bytes(33 * 32); // allocate 33*32 bytes
assembly {
            for {let i := 0} lt(i, 34) {i := add(i, 1)} {
                let memLocation := add(depositsProcessed, mul(i, 32)) // calculate the memory location
                let value := mload(memLocation) // load the data from memory which is the memory location of the address (but not the deposit amount)
                mstore(add(result, add(32, mul(i, 32))), value) // store the data in the result variable
             }
        }
```

@davidtaikocha :
To help you visualizing the encoding this is how the test data looks (in `test_deposit_hash_creation` test):

0xa9bcf99f5eb19277f48b71f9b14f5960aea58a89000000000de0b6b3a7640000200708d76eb1b69761c23821809d53f65049939e000000001bc16d674ec80000300c9b60e19634e12fc6d68b7fea7bfb26c2e4190000000029a2241af62c0000400147c0eb43d8d71b2b03037bb7b31f8f78ef5f000000003782dace9d90000050081b12838240b1ba02b3177153bca678a86078000000004563918244f40000430c9b60e19634e12fc6d68b7fea7bfb26c2e4190000000053444835ec580000520147c0eb43d8d71b2b03037bb7b31f8f78ef5f000000006124fee993bc000061081b12838240b1ba02b3177153bca678a86078000000006f05b59d3b200000
