### PR TITLE
chore(protocol): optimize _hashEthDeposits

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -110,11 +110,15 @@ library LibEthDepositing {
 
     function _hashDeposits(TaikoData.EthDeposit[] memory deposits) private pure returns (bytes32) {
         bytes memory buffer;
-        for (uint256 i = 0; i < deposits.length; i++) {
+        for (uint256 i; i < deposits.length;) {
             uint256 encoded =
                 uint256(uint160(deposits[i].recipient)) << 96 | uint256(deposits[i].amount);
             buffer = bytes.concat(buffer, bytes32(encoded));
+            unchecked {
+                ++i;
+            }
         }
+
         return keccak256(buffer);
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -104,16 +104,15 @@ library LibEthDepositing {
         assembly {
             mstore(depositsProcessed, j)
         }
-        depositsRoot = hashDeposits(depositsProcessed);
-    }
 
-    function hashDeposits(TaikoData.EthDeposit[] memory deposits) internal pure returns (bytes32) {
         bytes memory buffer;
 
-        for (uint256 i = 0; i < deposits.length; i++) {
-            buffer = abi.encodePacked(buffer, deposits[i].recipient, deposits[i].amount);
+        for (uint256 i = 0; i < depositsProcessed.length; i++) {
+            uint256 encoded = uint256(uint160(depositsProcessed[i].recipient)) << 96
+                | uint256(depositsProcessed[i].amount);
+            buffer = bytes.concat(buffer, bytes32(encoded));
         }
 
-        return keccak256(buffer);
+        depositsRoot = keccak256(buffer);
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -109,7 +109,7 @@ library LibEthDepositing {
     }
 
     function _hashDeposits(TaikoData.EthDeposit[] memory deposits) private pure returns (bytes32) {
-        bytes memory buffer = new bytes(32*deposits.length);
+        bytes memory buffer = new bytes(32 * deposits.length);
 
         for (uint256 i; i < deposits.length;) {
             uint256 encoded =

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -115,7 +115,7 @@ library LibEthDepositing {
             uint256 encoded =
                 uint256(uint160(deposits[i].recipient)) << 96 | uint256(deposits[i].amount);
             assembly {
-                mstore(add(add(buffer, 32), mul(32, i)), encoded)
+                mstore(add(buffer, mul(32, add(1, i))), encoded)
             }
             unchecked {
                 ++i;

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -109,11 +109,14 @@ library LibEthDepositing {
     }
 
     function _hashDeposits(TaikoData.EthDeposit[] memory deposits) private pure returns (bytes32) {
-        bytes memory buffer;
+        bytes memory buffer = new bytes(32*deposits.length);
+
         for (uint256 i; i < deposits.length;) {
             uint256 encoded =
                 uint256(uint160(deposits[i].recipient)) << 96 | uint256(deposits[i].amount);
-            buffer = bytes.concat(buffer, bytes32(encoded));
+            assembly {
+                mstore(add(add(buffer, 32), mul(32, i)), encoded)
+            }
             unchecked {
                 ++i;
             }

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -105,10 +105,14 @@ library LibEthDepositing {
             mstore(depositsProcessed, j)
         }
 
-        depositsRoot = _hashDeposits(depositsProcessed);
+        depositsRoot = _hashEthDeposits(depositsProcessed);
     }
 
-    function _hashDeposits(TaikoData.EthDeposit[] memory deposits) private pure returns (bytes32) {
+    function _hashEthDeposits(TaikoData.EthDeposit[] memory deposits)
+        private
+        pure
+        returns (bytes32)
+    {
         bytes memory buffer = new bytes(32 * deposits.length);
 
         for (uint256 i; i < deposits.length;) {

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -105,14 +105,16 @@ library LibEthDepositing {
             mstore(depositsProcessed, j)
         }
 
-        bytes memory buffer;
+        depositsRoot = _hashDeposits(depositsProcessed);
+    }
 
-        for (uint256 i = 0; i < depositsProcessed.length; i++) {
-            uint256 encoded = uint256(uint160(depositsProcessed[i].recipient)) << 96
-                | uint256(depositsProcessed[i].amount);
+    function _hashDeposits(TaikoData.EthDeposit[] memory deposits) private pure returns (bytes32) {
+        bytes memory buffer;
+        for (uint256 i = 0; i < deposits.length; i++) {
+            uint256 encoded =
+                uint256(uint160(deposits[i].recipient)) << 96 | uint256(deposits[i].amount);
             buffer = bytes.concat(buffer, bytes32(encoded));
         }
-
-        depositsRoot = keccak256(buffer);
+        return keccak256(buffer);
     }
 }

--- a/packages/protocol/test/TaikoL1.t.sol
+++ b/packages/protocol/test/TaikoL1.t.sol
@@ -249,7 +249,7 @@ contract TaikoL1Test is TaikoL1TestBase {
     }
 
     function test_deposit_hash_creation() external {
-        uint96 minAmount = conf.minEthDepositAmount;
+        // uint96 minAmount = conf.minEthDepositAmount;
         uint96 maxAmount = conf.maxEthDepositAmount;
 
         // We need 8 depostis otherwise we are not processing them !

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoL1.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoL1.md
@@ -126,7 +126,7 @@ function getBlockFee() public view returns (uint64)
 ### getProofReward
 
 ```solidity
-function getProofReward(uint64 provenAt, uint64 proposedAt) public view returns (uint64)
+function getProofReward(uint64 proofTime) public view returns (uint64)
 ```
 
 ### getBlock


### PR DESCRIPTION
Reduce `proposeblock` gas cost from 97908 to 94780

It turns out for a dynamic array, each element's location is stored in side a continuous region in memory, but the actual elements are stored somewhere else.