### PR TITLE
feat(protocol): Add setter to IAddressManager of AddressResolver

### DIFF
--- a/packages/protocol/contracts/common/AddressResolver.sol
+++ b/packages/protocol/contracts/common/AddressResolver.sol
@@ -29,7 +29,7 @@ abstract contract AddressResolver {
         _;
     }
 
-    event IAddressManagerChanged(address changedOn, address newAddress);
+    event AddressManagerChanged(address addressManager);
 
     /**
      * Resolves a name to an address on the current chain.

--- a/packages/protocol/contracts/common/AddressResolver.sol
+++ b/packages/protocol/contracts/common/AddressResolver.sol
@@ -29,6 +29,8 @@ abstract contract AddressResolver {
         _;
     }
 
+    event IAddressManagerChanged(address changedOn, address newAddress);
+
     /**
      * Resolves a name to an address on the current chain.
      *

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -6,6 +6,7 @@
 
 pragma solidity ^0.8.18;
 
+import {IAddressManager} from "./AddressManager.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ReentrancyGuardUpgradeable} from
     "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
@@ -24,5 +25,17 @@ abstract contract EssentialContract is
         ReentrancyGuardUpgradeable.__ReentrancyGuard_init();
         OwnableUpgradeable.__Ownable_init();
         AddressResolver._init(_addressManager);
+    }
+
+    /**
+     * Sets a new AddressManager's address.
+     *
+     * @param newAddressManager New address manager contract address
+     */
+    function setIAddressManager(address newAddressManager) external onlyOwner {
+        if (newAddressManager == address(0)) revert RESOLVER_INVALID_ADDR();
+        _addressManager = IAddressManager(newAddressManager);
+
+        emit IAddressManagerChanged(address(this), newAddressManager);
     }
 }

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -32,7 +32,7 @@ abstract contract EssentialContract is
      *
      * @param newAddressManager New address manager contract address
      */
-    function setIAddressManager(address newAddressManager) external onlyOwner {
+    function setAddressManager(address newAddressManager) external onlyOwner {
         if (newAddressManager == address(0)) revert RESOLVER_INVALID_ADDR();
         _addressManager = IAddressManager(newAddressManager);
 

--- a/packages/website/pages/docs/reference/contract-documentation/common/AddressResolver.md
+++ b/packages/website/pages/docs/reference/contract-documentation/common/AddressResolver.md
@@ -37,6 +37,12 @@ error RESOLVER_ZERO_ADDR(uint256 chainId, bytes32 name)
 modifier onlyFromNamed(bytes32 name)
 ```
 
+### IAddressManagerChanged
+
+```solidity
+event IAddressManagerChanged(address changedOn, address newAddress)
+```
+
 ### resolve
 
 ```solidity


### PR DESCRIPTION
Adding a setter to IAddressManager.

Because contracts connected to AddressManager (be it static or not) via an interface, a setter is necessary.

See issue : https://github.com/taikoxyz/taiko-mono/issues/13798

Also I feel there is a need for the setter, because both @dantaik and @Brechtpd indicated, that each contract (i.e. ProofVerifier, TaikoL1, Bridge) shall have it's own AddressResolver (= IAddressManager interface) - tho currently the TaikoL1, Bridge, TaikoToken sharing the same AddressManager (as we can see within the tests and also within the deployment script).

There could be situations (as described in discord convo) which implies security issues for not having a setter OR we indeed need separate instances for those contracts. For an example like: TaikoL1 needs BridgeV2, although TaikoNFTBridge still needs BridgeV1, therefore TaikoL1 and TaikoNFTBridge cannot share the same.