### PR TITLE
fix(protocol): hash deposit IDs

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -108,8 +108,9 @@ library TaikoData {
         uint24 size;
     }
 
-    // 1 slot
+    // 2 slot
     struct EthDeposit {
+        uint64 id;
         address recipient;
         uint96 amount;
     }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -110,9 +110,9 @@ library TaikoData {
 
     // 2 slot
     struct EthDeposit {
-        uint64 id;
         address recipient;
         uint96 amount;
+        uint64 id;
     }
 
     struct State {

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -37,6 +37,7 @@ library LibEthDepositing {
         }
 
         TaikoData.EthDeposit memory deposit = TaikoData.EthDeposit({
+            id: uint64(state.ethDeposits.length),
             recipient: msg.sender,
             amount: uint96(msg.value)
         });
@@ -126,19 +127,6 @@ library LibEthDepositing {
         pure
         returns (bytes32)
     {
-        bytes memory buffer = new bytes(32 * deposits.length);
-
-        for (uint256 i; i < deposits.length;) {
-            uint256 encoded = uint256(uint160(deposits[i].recipient)) << 96
-                | uint256(deposits[i].amount);
-            assembly {
-                mstore(add(buffer, mul(32, add(1, i))), encoded)
-            }
-            unchecked {
-                ++i;
-            }
-        }
-
-        return keccak256(buffer);
+        return keccak256(abi.encode(deposits));
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibEthDepositing.sol
@@ -37,9 +37,9 @@ library LibEthDepositing {
         }
 
         TaikoData.EthDeposit memory deposit = TaikoData.EthDeposit({
-            id: uint64(state.ethDeposits.length),
             recipient: msg.sender,
-            amount: uint96(msg.value)
+            amount: uint96(msg.value),
+            id: uint64(state.ethDeposits.length)
         });
 
         address to = resolver.resolve("ether_vault", true);

--- a/packages/protocol/test/TaikoL1.t.sol
+++ b/packages/protocol/test/TaikoL1.t.sol
@@ -334,12 +334,12 @@ contract TaikoL1Test is TaikoL1TestBase {
             proposeBlock(Alice, 1_000_000, 1024);
 
         // Expected:
-        // 0x25fdce9f620e3ee4c33ae0841c3cce2030516a75c8e045847364d1c280bfb714  (pre
+        // 0x9098dca53e2412a11d456add7b3652df403e043b2a20f456d4651b9a73b70a30  (pre
         // calculated with these values)
         //console2.logBytes32(meta.depositsRoot);
         assertEq(
             LibEthDepositing.hashEthDeposits(meta.depositsProcessed),
-            0x25fdce9f620e3ee4c33ae0841c3cce2030516a75c8e045847364d1c280bfb714
+            0x9098dca53e2412a11d456add7b3652df403e043b2a20f456d4651b9a73b70a30
         );
     }
 }

--- a/packages/protocol/test/TaikoL1.t.sol
+++ b/packages/protocol/test/TaikoL1.t.sol
@@ -334,12 +334,12 @@ contract TaikoL1Test is TaikoL1TestBase {
             proposeBlock(Alice, 1_000_000, 1024);
 
         // Expected:
-        // 0x8117066d69ff650d78f0d7383a10cc802c2b8c0eedd932d70994252e2438c636  (pre
+        // 0x25fdce9f620e3ee4c33ae0841c3cce2030516a75c8e045847364d1c280bfb714  (pre
         // calculated with these values)
         //console2.logBytes32(meta.depositsRoot);
         assertEq(
             LibEthDepositing.hashEthDeposits(meta.depositsProcessed),
-            0x8117066d69ff650d78f0d7383a10cc802c2b8c0eedd932d70994252e2438c636
+            0x25fdce9f620e3ee4c33ae0841c3cce2030516a75c8e045847364d1c280bfb714
         );
     }
 }

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -134,6 +134,7 @@ struct TxListInfo {
 struct EthDeposit {
   address recipient;
   uint96 amount;
+  uint64 id;
 }
 ```
 


### PR DESCRIPTION
With this fix, Blockscout can display ETH deposits correctlhy.