### PR TITLE
feat(protocol):optimize and reset proofWindow

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -188,9 +188,13 @@ library LibProving {
         fc.provenAt = uint64(block.timestamp);
 
         if (evidence.prover != address(0) && evidence.prover != address(1)) {
-            // set the proof window to zero so after the first regular proof,
-            // other provers can submit proofs without any delay.
-            auction.bid.proofWindow = 0;
+            if (auction.batchId != 0) {
+                // set the proof window to zero so after the first regular
+                // proof, other provers can submit proofs without any delay.
+                state.auctions[auction.batchId % config.auctionRingBufferSize]
+                    .bid
+                    .proofWindow = 0;
+            }
 
             uint256[10] memory inputs;
 

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -188,51 +188,47 @@ library LibProving {
         fc.provenAt = uint64(block.timestamp);
 
         if (evidence.prover != address(0) && evidence.prover != address(1)) {
-            if (auction.batchId != 0) {
-                // set the proof window to zero so after the first regular
-                // proof, other provers can submit proofs without any delay.
-                state.auctions[auction.batchId % config.auctionRingBufferSize]
-                    .bid
-                    .proofWindow = 0;
-            }
+            bytes32 instance;
+            {
+                uint256[10] memory inputs;
 
-            uint256[10] memory inputs;
-
-            inputs[0] = uint256(
-                uint160(address(resolver.resolve("signal_service", false)))
-            );
-            inputs[1] = uint256(
-                uint160(
-                    address(
-                        resolver.resolve(
-                            config.chainId, "signal_service", false
+                inputs[0] = uint256(
+                    uint160(address(resolver.resolve("signal_service", false)))
+                );
+                inputs[1] = uint256(
+                    uint160(
+                        address(
+                            resolver.resolve(
+                                config.chainId, "signal_service", false
+                            )
                         )
                     )
-                )
-            );
-            inputs[2] = uint256(
-                uint160(
-                    address(resolver.resolve(config.chainId, "taiko", false))
-                )
-            );
+                );
+                inputs[2] = uint256(
+                    uint160(
+                        address(
+                            resolver.resolve(config.chainId, "taiko", false)
+                        )
+                    )
+                );
 
-            inputs[3] = uint256(evidence.metaHash);
-            inputs[4] = uint256(evidence.parentHash);
-            inputs[5] = uint256(evidence.blockHash);
-            inputs[6] = uint256(evidence.signalRoot);
-            inputs[7] = uint256(evidence.graffiti);
-            inputs[8] = (uint256(uint160(evidence.prover)) << 96)
-                | (uint256(evidence.parentGasUsed) << 64)
-                | (uint256(evidence.gasUsed) << 32);
+                inputs[3] = uint256(evidence.metaHash);
+                inputs[4] = uint256(evidence.parentHash);
+                inputs[5] = uint256(evidence.blockHash);
+                inputs[6] = uint256(evidence.signalRoot);
+                inputs[7] = uint256(evidence.graffiti);
+                inputs[8] = (uint256(uint160(evidence.prover)) << 96)
+                    | (uint256(evidence.parentGasUsed) << 64)
+                    | (uint256(evidence.gasUsed) << 32);
 
-            // Also hash configs that will be used by circuits
-            inputs[9] = uint256(config.blockMaxGasLimit) << 192
-                | uint256(config.maxTransactionsPerBlock) << 128
-                | uint256(config.maxBytesPerTxList) << 64;
+                // Also hash configs that will be used by circuits
+                inputs[9] = uint256(config.blockMaxGasLimit) << 192
+                    | uint256(config.maxTransactionsPerBlock) << 128
+                    | uint256(config.maxBytesPerTxList) << 64;
 
-            bytes32 instance;
-            assembly {
-                instance := keccak256(inputs, mul(32, 10))
+                assembly {
+                    instance := keccak256(inputs, mul(32, 10))
+                }
             }
 
             (bool verified, bytes memory ret) = resolver.resolve(
@@ -256,6 +252,14 @@ library LibProving {
                 || bytes32(ret) != keccak256("taiko")
             ) {
                 revert L1_INVALID_PROOF();
+            }
+
+            if (auction.batchId != 0) {
+                // set the proof window to zero so after the first regular
+                // proof, other provers can submit proofs without any delay.
+                state.auctions[auction.batchId % config.auctionRingBufferSize]
+                    .bid
+                    .proofWindow = 0;
             }
         }
 


### PR DESCRIPTION
- Try to return the Auction once we read it from storage, this should reduce gas cost (not tested)
- Try to set `auciton.bid.proofWindow` to zero once a regular proof (which should be the auction winner's proof) is submitted, this allows other provers to submit proofs immediately afterwards.