### PR TITLE
feat(eventindexer): add indexes to querying optimizations

### DIFF
--- a/packages/eventindexer/migrations/1666650702_alter_events_table_add_address_index.sql
+++ b/packages/eventindexer/migrations/1666650702_alter_events_table_add_address_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `events` ADD INDEX `address_index` (`address`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX address_index on events;
+-- +goose StatementEnd

--- a/packages/eventindexer/migrations/1666650703_alter_events_table_add_event_index.sql
+++ b/packages/eventindexer/migrations/1666650703_alter_events_table_add_event_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `events` ADD INDEX `event_index` (`event`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX event_index on events;
+-- +goose StatementEnd

--- a/packages/eventindexer/migrations/1666650704_alter_events_table_add_block_id_index.sql
+++ b/packages/eventindexer/migrations/1666650704_alter_events_table_add_block_id_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `events` ADD INDEX `block_id_index` (`block_id`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX block_id_index on events;
+-- +goose StatementEnd

--- a/packages/eventindexer/migrations/1666650705_alter_events_table_add_address_and_event_index.sql
+++ b/packages/eventindexer/migrations/1666650705_alter_events_table_add_address_and_event_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `events` ADD INDEX `address_and_event_index` (`address`, `event`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX address_and_event_index on events;
+-- +goose StatementEnd


### PR DESCRIPTION
this PR will optimize the status page and the node status page the community is building, as the events table is growing quite large the lack of indices for specific queries is causing large delays or server timeouts when polling for data.