### PR TITLE
feat(protocol): allow system prover to prove all blocks

### DIFF
--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -34,10 +34,6 @@ library TaikoConfig {
             maxBytesPerTxList: 120_000,
             proofCooldownPeriod: 30 minutes,
             systemProofCooldownPeriod: 15 minutes,
-            // Only need 1 real zkp per 10 blocks.
-            // If block number is N, then only when N % 10 == 0, the real ZKP
-            // is needed. For mainnet, this must be 0 or 1.
-            realProofSkipSize: 10,
             ethDepositGas: 21_000,
             ethDepositMaxFee: 1 ether / 10,
             txListCacheExpiry: 0,

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -20,7 +20,6 @@ library TaikoData {
         uint256 txListCacheExpiry;
         uint256 proofCooldownPeriod;
         uint256 systemProofCooldownPeriod;
-        uint256 realProofSkipSize;
         uint256 ethDepositGas;
         uint256 ethDepositMaxFee;
         uint64 minEthDepositsPerBlock;

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -21,10 +21,7 @@ abstract contract TaikoErrors {
     error L1_INVALID_PROOF();
     error L1_INVALID_PROOF_OVERWRITE();
     error L1_NOT_SPECIAL_PROVER();
-    error L1_ORACLE_PROVER_DISABLED();
     error L1_SAME_PROOF();
-    error L1_SYSTEM_PROVER_DISABLED();
-    error L1_SYSTEM_PROVER_PROHIBITED();
     error L1_TOO_MANY_BLOCKS();
     error L1_TX_LIST_NOT_EXIST();
     error L1_TX_LIST_HASH();

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -32,10 +32,7 @@ library LibProving {
     error L1_INVALID_PROOF();
     error L1_INVALID_PROOF_OVERWRITE();
     error L1_NOT_SPECIAL_PROVER();
-    error L1_ORACLE_PROVER_DISABLED();
     error L1_SAME_PROOF();
-    error L1_SYSTEM_PROVER_DISABLED();
-    error L1_SYSTEM_PROVER_PROHIBITED();
 
     function proveBlock(
         TaikoData.State storage state,
@@ -76,22 +73,9 @@ library LibProving {
         // and non-oracle but system proofs
         address specialProver;
         if (evidence.prover == address(0)) {
-            specialProver = resolver.resolve("oracle_prover", true);
-            if (specialProver == address(0)) {
-                revert L1_ORACLE_PROVER_DISABLED();
-            }
+            specialProver = resolver.resolve("oracle_prover", false);
         } else if (evidence.prover == address(1)) {
-            specialProver = resolver.resolve("system_prover", true);
-            if (specialProver == address(0)) {
-                revert L1_SYSTEM_PROVER_DISABLED();
-            }
-
-            if (
-                config.realProofSkipSize <= 1
-                    || blockId % config.realProofSkipSize == 0
-            ) {
-                revert L1_SYSTEM_PROVER_PROHIBITED();
-            }
+            specialProver = resolver.resolve("system_prover", false);
         }
 
         if (specialProver != address(0) && msg.sender != specialProver) {

--- a/packages/protocol/test/TaikoL1.sim.sol
+++ b/packages/protocol/test/TaikoL1.sim.sol
@@ -25,7 +25,6 @@ contract TaikoL1_b is TaikoL1 {
         config.ringBufferSize = 1200;
         config.maxVerificationsPerTx = 10;
         config.proofCooldownPeriod = 5 minutes;
-        config.realProofSkipSize = 0;
     }
 }
 

--- a/packages/protocol/test/TaikoL1Oracle.t.sol
+++ b/packages/protocol/test/TaikoL1Oracle.t.sol
@@ -28,7 +28,6 @@ contract TaikoL1Oracle is TaikoL1 {
         config.maxNumProposedBlocks = 10;
         config.ringBufferSize = 12;
         config.proofCooldownPeriod = 5 minutes;
-        config.realProofSkipSize = 10;
     }
 }
 
@@ -495,7 +494,7 @@ contract TaikoL1OracleTest is TaikoL1TestBase {
             bytes32 blockHash = bytes32(1e10 + blockId);
             bytes32 signalRoot = bytes32(1e9 + blockId);
 
-            uint256 realProof = blockId % conf.realProofSkipSize;
+            uint256 realProof = blockId % 10;
 
             if (realProof == 0) {
                 proveBlock(

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -18,7 +18,6 @@ struct Config {
   uint256 txListCacheExpiry;
   uint256 proofCooldownPeriod;
   uint256 systemProofCooldownPeriod;
-  uint256 realProofSkipSize;
   uint256 ethDepositGas;
   uint256 ethDepositMaxFee;
   uint64 minEthDepositsPerBlock;

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoErrors.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoErrors.md
@@ -76,28 +76,10 @@ error L1_INVALID_PROOF_OVERWRITE()
 error L1_NOT_SPECIAL_PROVER()
 ```
 
-### L1_ORACLE_PROVER_DISABLED
-
-```solidity
-error L1_ORACLE_PROVER_DISABLED()
-```
-
 ### L1_SAME_PROOF
 
 ```solidity
 error L1_SAME_PROOF()
-```
-
-### L1_SYSTEM_PROVER_DISABLED
-
-```solidity
-error L1_SYSTEM_PROVER_DISABLED()
-```
-
-### L1_SYSTEM_PROVER_PROHIBITED
-
-```solidity
-error L1_SYSTEM_PROVER_PROHIBITED()
 ```
 
 ### L1_TOO_MANY_BLOCKS


### PR DESCRIPTION
This PR allows the system prover to prove all blocks. Why we need this changes: assuming there is a way to attack the protocol with large & unprovable block, now the system prover can prove that block without the chain being halted.