### PR TITLE
fix(protocol): Fix deploy script, and typo

### DIFF
--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -6,52 +6,51 @@
 
 pragma solidity ^0.8.20;
 
-import {TaikoData} from "../L1/TaikoData.sol";
+import { TaikoData } from "../L1/TaikoData.sol";
 
 library TaikoConfig {
     function getConfig() internal pure returns (TaikoData.Config memory) {
-        return
-            TaikoData.Config({
-                chainId: 167,
-                // Two weeks if avg block time is 10 seconds
-                maxNumProposedBlocks: 120_960,
-                blockRingBufferSize: 120_960 + 10,
-                // 1 block batch consist of 100 blocks, so divided block ring buffer
-                // by 100
-                // to be kind of in-sync, but it does not have to be fully in sync,
-                // they are decoupled
-                auctionRingBufferSize: 1209,
-                // Each time one more block is verified, there will be ~20k
-                // more gas cost.
-                maxVerificationsPerTx: 10,
-                // Set it to 6M, since its the upper limit of the Alpha-2
-                // testnet's circuits.
-                blockMaxGasLimit: 6_000_000,
-                blockFeeBaseGas: 20_000,
-                // Set it to 79  (+1 TaikoL2.anchor transaction = 80),
-                // and 80 is the upper limit of the Alpha-2 testnet's circuits.
-                maxTransactionsPerBlock: 79,
-                minEthDepositsPerBlock: 8,
-                maxEthDepositsPerBlock: 32,
-                maxEthDepositAmount: 10_000 ether,
-                minEthDepositAmount: 1 ether,
-                // Set it to 120KB, since 128KB is the upper size limit
-                // of a geth transaction, so using 120KB for the proposed
-                // transactions list calldata, 8K for the remaining tx fields.
-                maxBytesPerTxList: 120_000,
-                proofCooldownPeriod: 30 minutes,
-                systemProofCooldownPeriod: 15 minutes,
-                ethDepositGas: 21_000,
-                ethDepositMaxFee: 1 ether / 10,
-                txListCacheExpiry: 0,
-                auctionWindow: 120,
-                auctionProofWindowMultiplier: 2,
-                auctionDepositMultipler: 10,
-                auctionMaxFeePerGasMultipler: 5,
-                auctionMaxAheadOfProposals: 10,
-                auctionBatchSize: 100,
-                auctionMaxProofWindow: 7200,
-                relaySignalRoot: false
-            });
+        return TaikoData.Config({
+            chainId: 167,
+            // Two weeks if avg block time is 10 seconds
+            maxNumProposedBlocks: 120_960,
+            blockRingBufferSize: 120_960 + 10,
+            // 1 block batch consist of 100 blocks, so divided block ring buffer
+            // by 100
+            // to be kind of in-sync, but it does not have to be fully in sync,
+            // they are decoupled
+            auctionRingBufferSize: 1209,
+            // Each time one more block is verified, there will be ~20k
+            // more gas cost.
+            maxVerificationsPerTx: 10,
+            // Set it to 6M, since its the upper limit of the Alpha-2
+            // testnet's circuits.
+            blockMaxGasLimit: 6_000_000,
+            blockFeeBaseGas: 20_000,
+            // Set it to 79  (+1 TaikoL2.anchor transaction = 80),
+            // and 80 is the upper limit of the Alpha-2 testnet's circuits.
+            maxTransactionsPerBlock: 79,
+            minEthDepositsPerBlock: 8,
+            maxEthDepositsPerBlock: 32,
+            maxEthDepositAmount: 10_000 ether,
+            minEthDepositAmount: 1 ether,
+            // Set it to 120KB, since 128KB is the upper size limit
+            // of a geth transaction, so using 120KB for the proposed
+            // transactions list calldata, 8K for the remaining tx fields.
+            maxBytesPerTxList: 120_000,
+            proofCooldownPeriod: 30 minutes,
+            systemProofCooldownPeriod: 15 minutes,
+            ethDepositGas: 21_000,
+            ethDepositMaxFee: 1 ether / 10,
+            txListCacheExpiry: 0,
+            auctionWindow: 120,
+            auctionProofWindowMultiplier: 2,
+            auctionDepositMultipler: 10,
+            auctionMaxFeePerGasMultipler: 5,
+            auctionMaxAheadOfProposals: 10,
+            auctionBatchSize: 100,
+            auctionMaxProofWindow: 7200,
+            relaySignalRoot: false
+        });
     }
 }

--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -6,51 +6,52 @@
 
 pragma solidity ^0.8.20;
 
-import { TaikoData } from "../L1/TaikoData.sol";
+import {TaikoData} from "../L1/TaikoData.sol";
 
 library TaikoConfig {
     function getConfig() internal pure returns (TaikoData.Config memory) {
-        return TaikoData.Config({
-            chainId: 167,
-            // Two weeks if avg block time is 10 seconds
-            maxNumProposedBlocks: 120_960,
-            blockRingBufferSize: 120_960 + 10,
-            // 1 block batch consist of 100 blocks, so divided block ring buffer
-            // by 100
-            // to be kind of in-sync, but it does not have to be fully in sync,
-            // they are decoupled
-            auctionRingBufferSize: 1209,
-            // Each time one more block is verified, there will be ~20k
-            // more gas cost.
-            maxVerificationsPerTx: 10,
-            // Set it to 6M, since its the upper limit of the Alpha-2
-            // testnet's circuits.
-            blockMaxGasLimit: 6_000_000,
-            blockFeeBaseGas: 20_000,
-            // Set it to 79  (+1 TaikoL2.anchor transaction = 80),
-            // and 80 is the upper limit of the Alpha-2 testnet's circuits.
-            maxTransactionsPerBlock: 79,
-            minEthDepositsPerBlock: 8,
-            maxEthDepositsPerBlock: 32,
-            maxEthDepositAmount: 10_000 ether,
-            minEthDepositAmount: 1 ether,
-            // Set it to 120KB, since 128KB is the upper size limit
-            // of a geth transaction, so using 120KB for the proposed
-            // transactions list calldata, 8K for the remaining tx fields.
-            maxBytesPerTxList: 120_000,
-            proofCooldownPeriod: 30 minutes,
-            systemProofCooldownPeriod: 15 minutes,
-            ethDepositGas: 21_000,
-            ethDepositMaxFee: 1 ether / 10,
-            txListCacheExpiry: 0,
-            auctionWindow: 120,
-            auctionProofWindowMultiplier: 2,
-            auctionDepositMultipler: 10,
-            auctionMaxFeePerGasMultipler: 5,
-            auctonMaxAheadOfProposals: 10,
-            auctionBatchSize: 100,
-            auctionMaxProofWindow: 7200,
-            relaySignalRoot: false
-        });
+        return
+            TaikoData.Config({
+                chainId: 167,
+                // Two weeks if avg block time is 10 seconds
+                maxNumProposedBlocks: 120_960,
+                blockRingBufferSize: 120_960 + 10,
+                // 1 block batch consist of 100 blocks, so divided block ring buffer
+                // by 100
+                // to be kind of in-sync, but it does not have to be fully in sync,
+                // they are decoupled
+                auctionRingBufferSize: 1209,
+                // Each time one more block is verified, there will be ~20k
+                // more gas cost.
+                maxVerificationsPerTx: 10,
+                // Set it to 6M, since its the upper limit of the Alpha-2
+                // testnet's circuits.
+                blockMaxGasLimit: 6_000_000,
+                blockFeeBaseGas: 20_000,
+                // Set it to 79  (+1 TaikoL2.anchor transaction = 80),
+                // and 80 is the upper limit of the Alpha-2 testnet's circuits.
+                maxTransactionsPerBlock: 79,
+                minEthDepositsPerBlock: 8,
+                maxEthDepositsPerBlock: 32,
+                maxEthDepositAmount: 10_000 ether,
+                minEthDepositAmount: 1 ether,
+                // Set it to 120KB, since 128KB is the upper size limit
+                // of a geth transaction, so using 120KB for the proposed
+                // transactions list calldata, 8K for the remaining tx fields.
+                maxBytesPerTxList: 120_000,
+                proofCooldownPeriod: 30 minutes,
+                systemProofCooldownPeriod: 15 minutes,
+                ethDepositGas: 21_000,
+                ethDepositMaxFee: 1 ether / 10,
+                txListCacheExpiry: 0,
+                auctionWindow: 120,
+                auctionProofWindowMultiplier: 2,
+                auctionDepositMultipler: 10,
+                auctionMaxFeePerGasMultipler: 5,
+                auctionMaxAheadOfProposals: 10,
+                auctionBatchSize: 100,
+                auctionMaxProofWindow: 7200,
+                relaySignalRoot: false
+            });
     }
 }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -35,7 +35,7 @@ library TaikoData {
         uint64 auctionDepositMultipler;
         uint64 auctionMaxFeePerGasMultipler;
         uint16 auctionBatchSize;
-        uint16 auctonMaxAheadOfProposals;
+        uint16 auctionMaxAheadOfProposals;
         uint16 auctionMaxProofWindow;
         bool relaySignalRoot;
     }
@@ -157,13 +157,7 @@ library TaikoData {
     struct State {
         // Ring buffer for proposed blocks and a some recent verified blocks.
         mapping(uint256 blockId_mode_blockRingBufferSize => Block) blocks;
-        mapping(
-            uint256 blockId
-                => mapping(
-                    bytes32 parentHash
-                        => mapping(uint32 parentGasUsed => uint256 forkChoiceId)
-                )
-            ) forkChoiceIds;
+        mapping(uint256 blockId => mapping(bytes32 parentHash => mapping(uint32 parentGasUsed => uint256 forkChoiceId))) forkChoiceIds;
         mapping(address account => uint256 balance) taikoTokenBalances;
         mapping(bytes32 txListHash => TxListInfo) txListInfo;
         mapping(uint256 batchId => Auction auction) auctions;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -157,7 +157,13 @@ library TaikoData {
     struct State {
         // Ring buffer for proposed blocks and a some recent verified blocks.
         mapping(uint256 blockId_mode_blockRingBufferSize => Block) blocks;
-        mapping(uint256 blockId => mapping(bytes32 parentHash => mapping(uint32 parentGasUsed => uint256 forkChoiceId))) forkChoiceIds;
+        mapping(
+            uint256 blockId
+                => mapping(
+                    bytes32 parentHash
+                        => mapping(uint32 parentGasUsed => uint256 forkChoiceId)
+                )
+            ) forkChoiceIds;
         mapping(address account => uint256 balance) taikoTokenBalances;
         mapping(bytes32 txListHash => TxListInfo) txListInfo;
         mapping(uint256 batchId => Auction auction) auctions;

--- a/packages/protocol/contracts/L1/libs/LibAuction.sol
+++ b/packages/protocol/contracts/L1/libs/LibAuction.sol
@@ -6,11 +6,11 @@
 
 pragma solidity ^0.8.20;
 
-import {AddressResolver} from "../../common/AddressResolver.sol";
-import {LibAddress} from "../../libs/LibAddress.sol";
-import {LibUtils} from "./LibUtils.sol";
-import {TaikoData} from "../../L1/TaikoData.sol";
-import {TaikoToken} from "../TaikoToken.sol";
+import { AddressResolver } from "../../common/AddressResolver.sol";
+import { LibAddress } from "../../libs/LibAddress.sol";
+import { LibUtils } from "./LibUtils.sol";
+import { TaikoData } from "../../L1/TaikoData.sol";
+import { TaikoToken } from "../TaikoToken.sol";
 
 library LibAuction {
     using LibAddress for address;
@@ -30,20 +30,22 @@ library LibAuction {
         TaikoData.Config memory config,
         uint64 batchId,
         TaikoData.Bid memory bid
-    ) internal {
+    )
+        internal
+    {
         unchecked {
             if (
-                bid.prover != address(0) || // auto-fill
-                bid.blockMaxGasLimit != 0 || // auto-fill
-                bid.feePerGas == 0 || // cannot be zero
-                bid.proofWindow == 0 || // cannot be zero
-                bid.deposit == 0 || // cannot be zero
-                bid.proofWindow >
-                state.avgProofWindow * config.auctionProofWindowMultiplier ||
-                bid.deposit <
-                state.feePerGas *
-                    (config.blockFeeBaseGas + config.blockMaxGasLimit) *
-                    config.auctionDepositMultipler
+                bid.prover != address(0) // auto-fill
+                    || bid.blockMaxGasLimit != 0 // auto-fill
+                    || bid.feePerGas == 0 // cannot be zero
+                    || bid.proofWindow == 0 // cannot be zero
+                    || bid.deposit == 0 // cannot be zero
+                    || bid.proofWindow
+                        > state.avgProofWindow * config.auctionProofWindowMultiplier
+                    || bid.deposit
+                        < state.feePerGas
+                            * (config.blockFeeBaseGas + config.blockMaxGasLimit)
+                            * config.auctionDepositMultipler
             ) {
                 revert L1_INVALID_BID();
             }
@@ -57,9 +59,8 @@ library LibAuction {
         bid.blockMaxGasLimit = config.blockMaxGasLimit;
 
         // Have in-memory and write it back at the end of the function
-        TaikoData.Auction memory auction = state.auctions[
-            batchId % config.auctionRingBufferSize
-        ];
+        TaikoData.Auction memory auction =
+            state.auctions[batchId % config.auctionRingBufferSize];
 
         uint64 totalDeposit = bid.deposit * config.auctionBatchSize;
 
@@ -112,9 +113,8 @@ library LibAuction {
         uint256 i;
         for (; i < count; ++i) {
             uint256 _batchId = startBatchId + i;
-            TaikoData.Auction memory auction = state.auctions[
-                _batchId % config.auctionRingBufferSize
-            ];
+            TaikoData.Auction memory auction =
+                state.auctions[_batchId % config.auctionRingBufferSize];
 
             if (auction.batchId == _batchId) {
                 auctions[i] = auction;
@@ -127,7 +127,11 @@ library LibAuction {
         TaikoData.Config memory config,
         uint256 blockId,
         address prover
-    ) internal view returns (bool provable, TaikoData.Auction memory auction) {
+    )
+        internal
+        view
+        returns (bool provable, TaikoData.Auction memory auction)
+    {
         if (blockId != 0) {
             if (prover == address(0)) {
                 // Note that auction may not exist at all.
@@ -146,9 +150,8 @@ library LibAuction {
                         provable = true;
                     } else {
                         unchecked {
-                            uint64 proofWindowEndAt = auction.startedAt +
-                                config.auctionWindow +
-                                auction.bid.proofWindow;
+                            uint64 proofWindowEndAt = auction.startedAt
+                                + config.auctionWindow + auction.bid.proofWindow;
                             provable = block.timestamp > proofWindowEndAt;
                         }
                     }
@@ -162,7 +165,11 @@ library LibAuction {
     function batchForBlock(
         TaikoData.Config memory config,
         uint256 blockId
-    ) internal pure returns (uint64) {
+    )
+        internal
+        pure
+        returns (uint64)
+    {
         if (blockId == 0) {
             return 0;
         } else {
@@ -176,21 +183,21 @@ library LibAuction {
     function isBidBetter(
         TaikoData.Bid memory a,
         TaikoData.Bid memory b
-    ) internal pure returns (bool) {
+    )
+        internal
+        pure
+        returns (bool)
+    {
         // Normalize both feePerGas and deposit to a comparable scale.
         // feePerGas is considered more important than proofWindow, below
         // we use 1 as the weight of feePerGas, 1/2 as the weight of deposit,
         // and 1/4 as the weight of proofWindow.
         //
         // Bid a is only better than bid b if its score is 10% higher.
-        return
-            _adjustBidPropertyScore((ONE * b.feePerGas) / a.feePerGas, 1) *
-                _adjustBidPropertyScore((ONE * a.deposit) / b.deposit, 2) *
-                _adjustBidPropertyScore(
-                    (ONE * b.proofWindow) / a.proofWindow,
-                    4
-                ) >=
-            (ONE * ONE * ONE * 110) / 100;
+        return _adjustBidPropertyScore((ONE * b.feePerGas) / a.feePerGas, 1)
+            * _adjustBidPropertyScore((ONE * a.deposit) / b.deposit, 2)
+            * _adjustBidPropertyScore((ONE * b.proofWindow) / a.proofWindow, 4)
+            >= (ONE * ONE * ONE * 110) / 100;
     }
 
     // isBatchAuctionable determines whether a new bid for a batch of blocks
@@ -200,16 +207,18 @@ library LibAuction {
         TaikoData.State storage state,
         TaikoData.Config memory config,
         uint256 batchId
-    ) internal view returns (bool result) {
+    )
+        internal
+        view
+        returns (bool result)
+    {
         if (batchId == 0) return false;
 
         unchecked {
             uint64 lastProposedBatchId = batchForBlock(config, state.numBlocks);
 
-            uint64 lastVerifiedBatchId = batchForBlock(
-                config,
-                state.lastVerifiedBlockId + 1
-            );
+            uint64 lastVerifiedBatchId =
+                batchForBlock(config, state.lastVerifiedBlockId + 1);
 
             // Regardless of auction started or not - do not allow too many
             // auctions to be open
@@ -217,27 +226,25 @@ library LibAuction {
                 // the batch of lastVerifiedBlockId is never auctionable as it
                 // has to be ended before the last verifeid block can be
                 // verified.
-                batchId <= lastVerifiedBatchId ||
+                batchId <= lastVerifiedBatchId
                 // cannot start a new auction if the previous one has not
                 // started
-                batchId > state.numAuctions + 1 ||
+                || batchId > state.numAuctions + 1
                 // cannot start a new auction if we have to keep all the
                 // auctions info in order to prove/verify blocks
-                batchId >= lastVerifiedBatchId + config.auctionRingBufferSize ||
+                || batchId >= lastVerifiedBatchId + config.auctionRingBufferSize
                 // cannot start too many auctions
-                batchId >=
-                lastProposedBatchId + config.auctionMaxAheadOfProposals
+                || batchId
+                    >= lastProposedBatchId + config.auctionMaxAheadOfProposals
             ) {
                 return false;
             }
 
-            TaikoData.Auction memory auction = state.auctions[
-                batchId % config.auctionRingBufferSize
-            ];
+            TaikoData.Auction memory auction =
+                state.auctions[batchId % config.auctionRingBufferSize];
 
-            return
-                auction.batchId != batchId ||
-                block.timestamp <= auction.startedAt + config.auctionWindow;
+            return auction.batchId != batchId
+                || block.timestamp <= auction.startedAt + config.auctionWindow;
         }
     }
 
@@ -246,17 +253,18 @@ library LibAuction {
         TaikoData.State storage state,
         TaikoData.Config memory config,
         uint64 batchId
-    ) private view returns (bool ended, TaikoData.Auction memory auction) {
+    )
+        private
+        view
+        returns (bool ended, TaikoData.Auction memory auction)
+    {
         if (batchId == 0) {
             ended = true;
         } else {
             unchecked {
-                auction = state.auctions[
-                    batchId % config.auctionRingBufferSize
-                ];
-                ended =
-                    auction.batchId == batchId &&
-                    block.timestamp > auction.startedAt + config.auctionWindow;
+                auction = state.auctions[batchId % config.auctionRingBufferSize];
+                ended = auction.batchId == batchId
+                    && block.timestamp > auction.startedAt + config.auctionWindow;
             }
         }
     }
@@ -264,7 +272,11 @@ library LibAuction {
     function _adjustBidPropertyScore(
         uint256 score,
         uint256 weightInverse
-    ) private pure returns (uint256) {
+    )
+        private
+        pure
+        returns (uint256)
+    {
         assert(weightInverse >= 1);
         if (score == ONE || weightInverse == 1) {
             return score;

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -6,14 +6,15 @@
 
 pragma solidity ^0.8.20;
 
-import {AddressResolver} from "../../common/AddressResolver.sol";
-import {ISignalService} from "../../signal/ISignalService.sol";
-import {LibAuction} from "./LibAuction.sol";
-import {LibUtils} from "./LibUtils.sol";
-import {LibMath} from "../../libs/LibMath.sol";
-import {SafeCastUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
-import {TaikoData} from "../../L1/TaikoData.sol";
-import {TaikoToken} from "../TaikoToken.sol";
+import { AddressResolver } from "../../common/AddressResolver.sol";
+import { ISignalService } from "../../signal/ISignalService.sol";
+import { LibAuction } from "./LibAuction.sol";
+import { LibUtils } from "./LibUtils.sol";
+import { LibMath } from "../../libs/LibMath.sol";
+import { SafeCastUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
+import { TaikoData } from "../../L1/TaikoData.sol";
+import { TaikoToken } from "../TaikoToken.sol";
 
 library LibVerifying {
     using SafeCastUpgradeable for uint256;
@@ -23,9 +24,7 @@ library LibVerifying {
     event BlockVerified(uint256 indexed id, bytes32 blockHash, uint64 reward);
 
     event CrossChainSynced(
-        uint256 indexed srcHeight,
-        bytes32 blockHash,
-        bytes32 signalRoot
+        uint256 indexed srcHeight, bytes32 blockHash, bytes32 signalRoot
     );
 
     error L1_INVALID_CONFIG();
@@ -36,36 +35,40 @@ library LibVerifying {
         bytes32 genesisBlockHash,
         uint64 initFeePerGas,
         uint64 initAvgProofWindow
-    ) internal {
+    )
+        internal
+    {
         if (
-            config.chainId <= 1 || //
-            config.maxNumProposedBlocks == 1 ||
-            config.blockRingBufferSize <= config.maxNumProposedBlocks + 1 ||
-            config.blockMaxGasLimit == 0 ||
-            config.maxTransactionsPerBlock == 0 ||
-            config.maxBytesPerTxList == 0 ||
+            config.chainId <= 1 //
+                || config.maxNumProposedBlocks == 1
+                || config.blockRingBufferSize <= config.maxNumProposedBlocks + 1
+                || config.blockMaxGasLimit == 0
+                || config.maxTransactionsPerBlock == 0
+                || config.maxBytesPerTxList == 0
             // EIP-4844 blob size up to 128K
-            config.maxBytesPerTxList > 128 * 1024 ||
-            config.maxEthDepositsPerBlock == 0 ||
-            config.maxEthDepositsPerBlock < config.minEthDepositsPerBlock ||
+            || config.maxBytesPerTxList > 128 * 1024
+                || config.maxEthDepositsPerBlock == 0
+                || config.maxEthDepositsPerBlock < config.minEthDepositsPerBlock
             // EIP-4844 blob deleted after 30 days
-            config.txListCacheExpiry > 30 * 24 hours ||
-            config.ethDepositGas == 0 || //
-            config.ethDepositMaxFee == 0 ||
-            config.ethDepositMaxFee >= type(uint96).max ||
-            config.auctionWindow == 0 ||
-            config.auctionMaxProofWindow == 0 ||
-            config.auctionBatchSize == 0 ||
-            config.auctionRingBufferSize <=
-            (config.maxNumProposedBlocks /
-                (config.auctionBatchSize +
-                    1 +
-                    config.auctionMaxAheadOfProposals)) || //
-            config.auctionProofWindowMultiplier <= 1 ||
-            config.auctionWindow <= 24 ||
-            config.auctionDepositMultipler <= 1 ||
-            config.auctionMaxFeePerGasMultipler <= 1 ||
-            config.auctionDepositMultipler < config.auctionMaxFeePerGasMultipler
+            || config.txListCacheExpiry > 30 * 24 hours
+                || config.ethDepositGas == 0 //
+                || config.ethDepositMaxFee == 0
+                || config.ethDepositMaxFee >= type(uint96).max
+                || config.auctionWindow == 0 || config.auctionMaxProofWindow == 0
+                || config.auctionBatchSize == 0
+                || config.auctionRingBufferSize
+                    <= (
+                        config.maxNumProposedBlocks
+                            / (
+                                config.auctionBatchSize + 1
+                                    + config.auctionMaxAheadOfProposals
+                            )
+                    ) //
+                || config.auctionProofWindowMultiplier <= 1
+                || config.auctionWindow <= 24 || config.auctionDepositMultipler <= 1
+                || config.auctionMaxFeePerGasMultipler <= 1
+                || config.auctionDepositMultipler
+                    < config.auctionMaxFeePerGasMultipler
         ) revert L1_INVALID_CONFIG();
 
         uint64 timeNow = uint64(block.timestamp);
@@ -95,11 +98,12 @@ library LibVerifying {
         TaikoData.Config memory config,
         AddressResolver resolver,
         uint256 maxBlocks
-    ) internal {
+    )
+        internal
+    {
         uint256 i = state.lastVerifiedBlockId;
-        TaikoData.Block storage blk = state.blocks[
-            i % config.blockRingBufferSize
-        ];
+        TaikoData.Block storage blk =
+            state.blocks[i % config.blockRingBufferSize];
 
         uint256 fcId = blk.verifiedForkChoiceId;
         // assert(fcId > 0);
@@ -163,9 +167,7 @@ library LibVerifying {
                     .sendSignal(signalRoot);
             }
             emit CrossChainSynced(
-                state.lastVerifiedBlockId,
-                blockHash,
-                signalRoot
+                state.lastVerifiedBlockId, blockHash, signalRoot
             );
         }
     }
@@ -176,7 +178,9 @@ library LibVerifying {
         TaikoData.Block storage blk,
         TaikoData.ForkChoice storage fc,
         uint24 fcId
-    ) private {
+    )
+        private
+    {
         TaikoData.Auction memory auction;
         {
             uint64 batchId = LibAuction.batchForBlock(config, blk.blockId);
@@ -187,8 +191,7 @@ library LibVerifying {
         // Refund the diff to the proposer
         assert(fc.gasUsed <= blk.gasLimit);
         state.taikoTokenBalances[blk.proposer] +=
-            (blk.gasLimit - fc.gasUsed) *
-            blk.feePerGas;
+            (blk.gasLimit - fc.gasUsed) * blk.feePerGas;
 
         bool refundBidder;
         bool rewardProver;
@@ -209,8 +212,8 @@ library LibVerifying {
             }
 
             if (
-                fc.prover == auction.bid.prover &&
-                fc.provenAt <= proofWindowEndAt
+                fc.prover == auction.bid.prover
+                    && fc.provenAt <= proofWindowEndAt
             ) {
                 // The prover is the auction winner and proof submitted within
                 // the proof window
@@ -241,12 +244,9 @@ library LibVerifying {
         uint64 proofReward;
         if (rewardProver) {
             proofReward =
-                (config.blockFeeBaseGas + fc.gasUsed) *
-                auction.bid.feePerGas;
+                (config.blockFeeBaseGas + fc.gasUsed) * auction.bid.feePerGas;
             state.taikoTokenBalances[fc.prover] +=
-                auction.bid.deposit /
-                2 +
-                proofReward;
+                auction.bid.deposit / 2 + proofReward;
         }
 
         if (updateAverage) {


### PR DESCRIPTION
this small PR fixes a typo, and also fixes the deploy script, which had a mathematical error rendering it undeployable with `L1_INVALID_CONFIG`.

I seem to have differences in formatting on save, @Daniel  W | Taiko is there something new i need to install to work on the Solidity files? The only real change in this file is adding `( )` around the demoninator in this math in `LibVerifying`, and a typo from `aucton` => `auction`

```ts
  (config.maxNumProposedBlocks /
                (config.auctionBatchSize +
                    1 +
                    config.auctionMaxAheadOfProposals)) || //
  ```