### PR TITLE
refactor(protocol): simplify oracle proof and system proof

### DIFF
--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -26,7 +26,6 @@ abstract contract TaikoErrors {
     error L1_NOT_PROVEABLE();
     error L1_NOT_BETTER_BID();
     error L1_NOT_SPECIAL_PROVER();
-    error L1_NOT_THE_BEST_BID();
     error L1_SAME_PROOF();
     error L1_TOO_MANY_BLOCKS();
     error L1_TX_LIST_NOT_EXIST();

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -47,7 +47,9 @@ library LibProving {
         internal
     {
         if (
-            evidence.parentHash == 0
+            evidence.prover == address(0)
+            //
+            || evidence.parentHash == 0
             //
             || evidence.blockHash == 0
             //

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -88,17 +88,9 @@ library LibProving {
             revert L1_EVIDENCE_MISMATCH(blk.metaHash, evidence.metaHash);
         }
 
-        // Separate between oracle proof (which needs to be overwritten)
-        // and non-oracle but system proofs
         address authorized;
-        if (evidence.prover == address(0)) {
+        if (evidence.prover == address(1)) {
             authorized = resolver.resolve("oracle_prover", false);
-
-            if (evidence.verifierId != 0 || evidence.proof.length != 0) {
-                revert L1_INVALID_PROOF();
-            }
-        } else if (evidence.prover == address(1)) {
-            authorized = resolver.resolve("system_prover", false);
 
             if (evidence.verifierId != 0 || evidence.proof.length != 0) {
                 revert L1_INVALID_PROOF();
@@ -147,7 +139,7 @@ library LibProving {
                 state.forkChoiceIds[blk.blockId][evidence.parentHash][evidence
                     .parentGasUsed] = fcId;
             }
-        } else if (evidence.prover == address(0)) {
+        } else if (evidence.prover == address(1)) {
             // This is the branch the oracle prover is trying to overwrite
             // We need to check the previous proof is not the same as the
             // new proof
@@ -161,13 +153,12 @@ library LibProving {
             // This is the branch provers trying to overwrite
             fc = blk.forkChoices[fcId];
 
-            // Only oracle proof and system proof can be overwritten
-            // by regular proof
-            if (fc.prover != address(0) && fc.prover != address(1)) {
+            // Only oracle proof can be overwritten by regular proof
+            if (fc.prover != address(1)) {
                 revert L1_ALREADY_PROVEN();
             }
 
-            // The regular proof must be the same as the oracle/system proof
+            // The regular proof must be the same as the oracle proof
             if (
                 fc.blockHash != evidence.blockHash
                     || fc.signalRoot != evidence.signalRoot
@@ -181,7 +172,7 @@ library LibProving {
         fc.prover = evidence.prover;
         fc.provenAt = uint64(block.timestamp);
 
-        if (evidence.prover != address(0) && evidence.prover != address(1)) {
+        if (evidence.prover != address(1)) {
             bytes32 instance;
             {
                 uint256[10] memory inputs;

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -234,42 +234,36 @@ library LibVerifying {
 
         if (refundBidder) {
             state.taikoTokenBalances[auction.bid.prover] += auction.bid.deposit;
-        } else {
-            // During the deposit we already burnt it. So it is rather
-            // minting.
-            uint64 amountToDeduct = rewardProver // deduct all or half
-                ? auction.bid.deposit / 2
-                : auction.bid.deposit;
-
-            state.taikoTokenBalances[auction.bid.prover] -= amountToDeduct;
         }
 
         uint64 proofReward;
         if (rewardProver) {
             proofReward =
                 (config.blockFeeBaseGas + fc.gasUsed) * auction.bid.feePerGas;
-            state.taikoTokenBalances[fc.prover] +=
-                auction.bid.deposit / 2 + proofReward;
+
+            // if we do not refund the bidder, then half of the deposit
+            // is given to the actual block prover.
+            if (!refundBidder) proofReward += auction.bid.deposit / 2;
+
+            state.taikoTokenBalances[fc.prover] += proofReward;
         }
 
         if (updateAverage) {
-            unchecked {
-                state.avgProofWindow = uint16(
-                    LibUtils.movingAverage({
-                        maValue: state.avgProofWindow,
-                        newValue: auction.bid.proofWindow,
-                        maf: 7200
-                    })
-                );
+            state.avgProofWindow = uint16(
+                LibUtils.movingAverage({
+                    maValue: state.avgProofWindow,
+                    newValue: auction.bid.proofWindow,
+                    maf: 7200
+                })
+            );
 
-                state.feePerGas = uint48(
-                    LibUtils.movingAverage({
-                        maValue: state.feePerGas,
-                        newValue: auction.bid.feePerGas,
-                        maf: 7200
-                    })
-                );
-            }
+            state.feePerGas = uint48(
+                LibUtils.movingAverage({
+                    maValue: state.feePerGas,
+                    newValue: auction.bid.feePerGas,
+                    maf: 7200
+                })
+            );
         }
 
         blk.nextForkChoiceId = 1;

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -201,7 +201,7 @@ library LibVerifying {
         bool updateAverage;
 
         if (fc.prover == address(1)) {
-            // This is the system prover.
+            // This is an oracle prove.
             refundBidder = true;
             // rewardProver = false;
             // updateAverage = false;

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoErrors.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoErrors.md
@@ -94,16 +94,16 @@ error L1_INVALID_PROOF_OVERWRITE()
 error L1_NOT_PROVEABLE()
 ```
 
-### L1_NOT_SPECIAL_PROVER
-
-```solidity
-error L1_NOT_SPECIAL_PROVER()
-```
-
 ### L1_NOT_BETTER_BID
 
 ```solidity
 error L1_NOT_BETTER_BID()
+```
+
+### L1_NOT_SPECIAL_PROVER
+
+```solidity
+error L1_NOT_SPECIAL_PROVER()
 ```
 
 ### L1_SAME_PROOF


### PR DESCRIPTION
Simplify oracle/system proof by merging them into a one

|  type | Can override existing | Can be overridden | Can prove without auction ended | Can verify block |
|----------|----------|----------|----------|----------|
|   oracle proof  |   Yes  |   Yes  |   Yes  |   No |
|   system proof |   No  |   Yes - only by oracle and regular proof  |   No  |   Yes  |
|   **new oracle proof**  |   Yes  |   Yes  |   Yes  |   Yes |