### PR TITLE
feat(protocol): allow oracle prover to indicate block not zk-provable

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -86,6 +86,7 @@ library TaikoData {
         address prover;
         uint32 parentGasUsed;
         uint32 gasUsed;
+        bool zkUnprovable;
         uint16 verifierId;
         bytes proof;
         bytes sig;

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -23,7 +23,8 @@ abstract contract TaikoEvents {
         bytes32 blockHash,
         bytes32 signalRoot,
         address prover,
-        uint32 parentGasUsed
+        uint32 parentGasUsed,
+        bool zkUnprovable
     );
 
     event BlockVerified(uint256 indexed id, bytes32 blockHash, uint64 reward);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -318,7 +318,11 @@ contract TaikoL1 is
     )
         public
         view
-        returns (bool provable, bool proofWindowElapsed, TaikoData.Auction memory auction)
+        returns (
+            bool provable,
+            bool proofWindowElapsed,
+            TaikoData.Auction memory auction
+        )
     {
         return LibAuction.isBlockProvableBy(state, getConfig(), blockId, prover);
     }

--- a/packages/protocol/contracts/L1/libs/LibAuction.sol
+++ b/packages/protocol/contracts/L1/libs/LibAuction.sol
@@ -130,7 +130,11 @@ library LibAuction {
     )
         internal
         view
-        returns (bool provable, bool proofWindowElapsed, TaikoData.Auction memory auction)
+        returns (
+            bool provable,
+            bool proofWindowElapsed,
+            TaikoData.Auction memory auction
+        )
     {
         // Nobody can prove a block before the auction ended,
         // including the oracle prover
@@ -148,7 +152,8 @@ library LibAuction {
                 unchecked {
                     uint64 proofWindowEndAt = auction.startedAt
                         + config.auctionWindow + auction.bid.proofWindow;
-                    proofWindowElapsed = provable = block.timestamp > proofWindowEndAt;
+                    proofWindowElapsed =
+                        provable = block.timestamp > proofWindowEndAt;
                 }
             }
         }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -22,7 +22,8 @@ library LibProving {
         bytes32 blockHash,
         bytes32 signalRoot,
         address prover,
-        uint32 parentGasUsed
+        uint32 parentGasUsed,
+        bool zkUnprovable
     );
 
     error L1_ALREADY_PROVEN();
@@ -49,7 +50,8 @@ library LibProving {
         if (
             evidence.prover == address(0)
             //
-            || evidence.parentHash == 0
+            || (evidence.prover != address(1) && evidence.zkUnprovable)
+                || evidence.parentHash == 0
             //
             || evidence.blockHash == 0
             //
@@ -67,8 +69,8 @@ library LibProving {
 
         // We also should know who can prove this block:
         // the one who bid or everyone if it is above the window
-        (bool provable, bool proofWindowEnded, TaikoData.Auction memory auction) = LibAuction
-            .isBlockProvableBy({
+        (bool provable, bool proofWindowEnded, TaikoData.Auction memory auction)
+        = LibAuction.isBlockProvableBy({
             state: state,
             config: config,
             blockId: blockId,
@@ -91,7 +93,7 @@ library LibProving {
         address authorized;
         if (evidence.prover == address(1)) {
             authorized = resolver.resolve("oracle_prover", false);
-        } else if(proofWindowEnded) {
+        } else if (proofWindowEnded) {
             // If window ended - everyone could prove
             authorized = msg.sender;
         } else {
@@ -99,18 +101,18 @@ library LibProving {
         }
 
         if (msg.sender != authorized) {
-                // Decode into 
-                uint8 v;
-                bytes32 r;
-                bytes32 s;
-                bytes memory data = evidence.sig;
-                assembly {
-                    v := mload(add(data, 1))
-                    r := mload(add(data, 33))
-                    s := mload(add(data, 65))
-                }
+            // Decode into
+            uint8 v;
+            bytes32 r;
+            bytes32 s;
+            bytes memory data = evidence.sig;
+            assembly {
+                v := mload(add(data, 1))
+                r := mload(add(data, 33))
+                s := mload(add(data, 65))
+            }
 
-                evidence.sig = new bytes(0);
+            evidence.sig = new bytes(0);
             if (
                 ecrecover(keccak256(abi.encode(evidence)), v, r, s)
                     != authorized
@@ -250,7 +252,8 @@ library LibProving {
             blockHash: evidence.blockHash,
             signalRoot: evidence.signalRoot,
             prover: evidence.prover,
-            parentGasUsed: evidence.parentGasUsed
+            parentGasUsed: evidence.parentGasUsed,
+            zkUnprovable: evidence.zkUnprovable
         });
     }
 

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -51,7 +51,8 @@ library LibProving {
             evidence.prover == address(0)
             //
             || (evidence.prover != address(1) && evidence.zkUnprovable)
-                || evidence.parentHash == 0
+            //
+            || evidence.parentHash == 0
             //
             || evidence.blockHash == 0
             //

--- a/packages/protocol/test/TaikoL1Oracle.t.sol
+++ b/packages/protocol/test/TaikoL1Oracle.t.sol
@@ -82,6 +82,7 @@ contract TaikoL1OracleTest is TaikoL1TestBase {
             prover: address(1),
             parentGasUsed: 10_000,
             gasUsed: 40_000,
+            zkUnprovable: false,
             verifierId: 0,
             proof: new bytes(0),
             sig: new bytes(0)

--- a/packages/protocol/test/TaikoL1TestBase.t.sol
+++ b/packages/protocol/test/TaikoL1TestBase.t.sol
@@ -159,6 +159,7 @@ abstract contract TaikoL1TestBase is Test {
             prover: prover,
             parentGasUsed: parentGasUsed,
             gasUsed: gasUsed,
+            zkUnprovable: false,
             verifierId: 100,
             proof: new bytes(100),
             sig: new bytes(0)

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -96,6 +96,7 @@ struct BlockEvidence {
   address prover;
   uint32 parentGasUsed;
   uint32 gasUsed;
+  bool zkUnprovable;
   uint16 verifierId;
   bytes proof;
   bytes sig;

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoEvents.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoEvents.md
@@ -19,7 +19,7 @@ event BlockProposed(uint256 id, struct TaikoData.BlockMetadata meta, uint64 bloc
 ### BlockProven
 
 ```solidity
-event BlockProven(uint256 id, bytes32 parentHash, bytes32 blockHash, bytes32 signalRoot, address prover, uint32 parentGasUsed)
+event BlockProven(uint256 id, bytes32 parentHash, bytes32 blockHash, bytes32 signalRoot, address prover, uint32 parentGasUsed, bool zkUnprovable)
 ```
 
 ### BlockVerified


### PR DESCRIPTION
@davidtaikocha the client shall respect the new zkUnprovable field and treat blocks with this flag as empty blocks immediately, which may involve chain reorg on the client side.