### PR TITLE
feat(eventindexer): add get events by address/name param for community

### DIFF
--- a/packages/eventindexer/contracts/taikol1/TaikoL1.go
+++ b/packages/eventindexer/contracts/taikol1/TaikoL1.go
@@ -8,12 +8,12 @@ import (
 	"math/big"
 	"strings"
 
-	ethereum "github.com/taikochain/go-taiko"
-	"github.com/taikochain/go-taiko/accounts/abi"
-	"github.com/taikochain/go-taiko/accounts/abi/bind"
-	"github.com/taikochain/go-taiko/common"
-	"github.com/taikochain/go-taiko/core/types"
-	"github.com/taikochain/go-taiko/event"
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/packages/eventindexer/event.go
+++ b/packages/eventindexer/event.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"math/big"
+	"net/http"
 
+	"github.com/morkid/paginate"
 	"gorm.io/datatypes"
 )
 
@@ -67,7 +69,8 @@ type EventRepository interface {
 	GetCountByAddressAndEventName(ctx context.Context, address string, event string) (int, error)
 	GetByAddressAndEventName(
 		ctx context.Context,
+		req *http.Request,
 		address string,
 		event string,
-	) ([]*Event, error)
+	) (paginate.Page, error)
 }

--- a/packages/eventindexer/event.go
+++ b/packages/eventindexer/event.go
@@ -65,4 +65,9 @@ type EventRepository interface {
 		id int,
 	) error
 	GetCountByAddressAndEventName(ctx context.Context, address string, event string) (int, error)
+	GetByAddressAndEventName(
+		ctx context.Context,
+		address string,
+		event string,
+	) ([]*Event, error)
 }

--- a/packages/eventindexer/http/get_by_address_and_event.go
+++ b/packages/eventindexer/http/get_by_address_and_event.go
@@ -5,16 +5,12 @@ import (
 
 	"github.com/cyberhorsey/webutils"
 	"github.com/labstack/echo/v4"
-	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
 )
 
-type GetByAddressAndEventNameResp struct {
-	Events []*eventindexer.Event `json:"events"`
-}
-
 func (srv *Server) GetByAddressAndEventName(c echo.Context) error {
-	events, err := srv.eventRepo.GetByAddressAndEventName(
+	page, err := srv.eventRepo.GetByAddressAndEventName(
 		c.Request().Context(),
+		c.Request(),
 		c.QueryParam("address"),
 		c.QueryParam("event"),
 	)
@@ -22,7 +18,5 @@ func (srv *Server) GetByAddressAndEventName(c echo.Context) error {
 		return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, err)
 	}
 
-	return c.JSON(http.StatusOK, &GetByAddressAndEventNameResp{
-		Events: events,
-	})
+	return c.JSON(http.StatusOK, page)
 }

--- a/packages/eventindexer/http/get_by_address_and_event.go
+++ b/packages/eventindexer/http/get_by_address_and_event.go
@@ -1,0 +1,28 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/cyberhorsey/webutils"
+	"github.com/labstack/echo/v4"
+	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
+)
+
+type GetByAddressAndEventNameResp struct {
+	Events []*eventindexer.Event `json:"events"`
+}
+
+func (srv *Server) GetByAddressAndEventName(c echo.Context) error {
+	events, err := srv.eventRepo.GetByAddressAndEventName(
+		c.Request().Context(),
+		c.QueryParam("address"),
+		c.QueryParam("event"),
+	)
+	if err != nil {
+		return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, err)
+	}
+
+	return c.JSON(http.StatusOK, &GetByAddressAndEventNameResp{
+		Events: events,
+	})
+}

--- a/packages/eventindexer/http/get_by_address_and_event_test.go
+++ b/packages/eventindexer/http/get_by_address_and_event_test.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cyberhorsey/webutils/testutils"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
+)
+
+func Test_GetByAddressAndEvent(t *testing.T) {
+	srv := newTestServer("")
+
+	_, err := srv.eventRepo.Save(context.Background(), eventindexer.SaveEventOpts{
+		Name:    "name",
+		Data:    `{"Owner": "0x0000000000000000000000000000000000000123"}`,
+		ChainID: big.NewInt(167001),
+		Address: "0x123",
+		Event:   eventindexer.EventNameBlockProposed,
+	})
+
+	assert.Equal(t, nil, err)
+
+	tests := []struct {
+		name                  string
+		address               string
+		event                 string
+		wantStatus            int
+		wantBodyRegexpMatches []string
+	}{
+		{
+			"successZeroEvents",
+			"0xhasntProposedAnything",
+			eventindexer.EventNameBlockProposed,
+			http.StatusOK,
+			[]string{`{"events":`},
+		},
+		{
+			"success",
+			"0x123",
+			eventindexer.EventNameBlockProposed,
+			http.StatusOK,
+			[]string{`{"events":`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := testutils.NewUnauthenticatedRequest(
+				echo.GET,
+				fmt.Sprintf("/events?address=%v&event=%v", tt.address, tt.event),
+				nil,
+			)
+
+			rec := httptest.NewRecorder()
+
+			srv.ServeHTTP(rec, req)
+
+			testutils.AssertStatusAndBody(t, rec, tt.wantStatus, tt.wantBodyRegexpMatches)
+		})
+	}
+}

--- a/packages/eventindexer/http/get_by_address_and_event_test.go
+++ b/packages/eventindexer/http/get_by_address_and_event_test.go
@@ -39,14 +39,14 @@ func Test_GetByAddressAndEvent(t *testing.T) {
 			"0xhasntProposedAnything",
 			eventindexer.EventNameBlockProposed,
 			http.StatusOK,
-			[]string{`{"events":`},
+			[]string{`{"items":`},
 		},
 		{
 			"success",
 			"0x123",
 			eventindexer.EventNameBlockProposed,
 			http.StatusOK,
-			[]string{`{"events":`},
+			[]string{`{"items":`},
 		},
 	}
 

--- a/packages/eventindexer/http/routes.go
+++ b/packages/eventindexer/http/routes.go
@@ -7,5 +7,6 @@ func (srv *Server) configureRoutes() {
 	srv.echo.GET("/uniqueProvers", srv.GetUniqueProvers)
 	srv.echo.GET("/uniqueProposers", srv.GetUniqueProposers)
 	srv.echo.GET("/eventByAddress", srv.GetCountByAddressAndEventName)
+	srv.echo.GET("/events", srv.GetByAddressAndEventName)
 	srv.echo.GET("/stats", srv.GetStats)
 }

--- a/packages/eventindexer/mock/event_repository.go
+++ b/packages/eventindexer/mock/event_repository.go
@@ -59,6 +59,22 @@ func (r *EventRepository) GetCountByAddressAndEventName(
 	return count, nil
 }
 
+func (r *EventRepository) GetByAddressAndEventName(
+	ctx context.Context,
+	address string,
+	event string,
+) ([]*eventindexer.Event, error) {
+	var events []*eventindexer.Event
+
+	for _, e := range r.events {
+		if e.Address == address && e.Event == event {
+			events = append(events, e)
+		}
+	}
+
+	return events, nil
+}
+
 func (r *EventRepository) FindByEventTypeAndBlockID(
 	ctx context.Context,
 	eventType string,

--- a/packages/eventindexer/mock/event_repository.go
+++ b/packages/eventindexer/mock/event_repository.go
@@ -3,7 +3,9 @@ package mock
 import (
 	"context"
 	"math/rand"
+	"net/http"
 
+	"github.com/morkid/paginate"
 	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -61,9 +63,10 @@ func (r *EventRepository) GetCountByAddressAndEventName(
 
 func (r *EventRepository) GetByAddressAndEventName(
 	ctx context.Context,
+	req *http.Request,
 	address string,
 	event string,
-) ([]*eventindexer.Event, error) {
+) (paginate.Page, error) {
 	var events []*eventindexer.Event
 
 	for _, e := range r.events {
@@ -72,7 +75,9 @@ func (r *EventRepository) GetByAddressAndEventName(
 		}
 	}
 
-	return events, nil
+	return paginate.Page{
+		Items: events,
+	}, nil
 }
 
 func (r *EventRepository) FindByEventTypeAndBlockID(

--- a/packages/eventindexer/repo/event.go
+++ b/packages/eventindexer/repo/event.go
@@ -112,3 +112,19 @@ func (r *EventRepository) GetCountByAddressAndEventName(
 
 	return count, nil
 }
+
+func (r *EventRepository) GetByAddressAndEventName(
+	ctx context.Context,
+	address string,
+	event string,
+) ([]*eventindexer.Event, error) {
+	var events []*eventindexer.Event
+
+	if err := r.db.GormDB().
+		Raw("SELECT * FROM events WHERE event = ? AND address = ?", event, address).
+		Find(&events).Error; err != nil {
+		return nil, errors.Wrap(err, "r.db.Find")
+	}
+
+	return events, nil
+}

--- a/packages/eventindexer/repo/event_test.go
+++ b/packages/eventindexer/repo/event_test.go
@@ -213,6 +213,60 @@ func TestIntegration_Event_GetCountByAddressAndEventName(t *testing.T) {
 	}
 }
 
+func TestIntegration_Event_GetByAddressAndEventName(t *testing.T) {
+	db, close, err := testMysql(t)
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	eventRepo, err := NewEventRepository(db)
+	assert.Equal(t, nil, err)
+
+	_, err = eventRepo.Save(context.Background(), dummyProveEventOpts)
+
+	assert.Equal(t, nil, err)
+
+	_, err = eventRepo.Save(context.Background(), dummyProposeEventOpts)
+
+	assert.Equal(t, nil, err)
+
+	tests := []struct {
+		name    string
+		address string
+		event   string
+		wantLen int
+		wantErr error
+	}{
+		{
+			"success",
+			dummyProposeEventOpts.Address,
+			dummyProposeEventOpts.Event,
+			1,
+			nil,
+		},
+		{
+			"none",
+			"0xfake",
+			dummyProposeEventOpts.Event,
+			0,
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := eventRepo.GetByAddressAndEventName(
+				context.Background(),
+				tt.address,
+				tt.event,
+			)
+			spew.Dump(resp)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.wantLen, len(resp))
+		})
+	}
+}
+
 func TestIntegration_Event_Delete(t *testing.T) {
 	db, close, err := testMysql(t)
 	assert.Equal(t, nil, err)

--- a/packages/eventindexer/repo/event_test.go
+++ b/packages/eventindexer/repo/event_test.go
@@ -213,60 +213,6 @@ func TestIntegration_Event_GetCountByAddressAndEventName(t *testing.T) {
 	}
 }
 
-func TestIntegration_Event_GetByAddressAndEventName(t *testing.T) {
-	db, close, err := testMysql(t)
-	assert.Equal(t, nil, err)
-
-	defer close()
-
-	eventRepo, err := NewEventRepository(db)
-	assert.Equal(t, nil, err)
-
-	_, err = eventRepo.Save(context.Background(), dummyProveEventOpts)
-
-	assert.Equal(t, nil, err)
-
-	_, err = eventRepo.Save(context.Background(), dummyProposeEventOpts)
-
-	assert.Equal(t, nil, err)
-
-	tests := []struct {
-		name    string
-		address string
-		event   string
-		wantLen int
-		wantErr error
-	}{
-		{
-			"success",
-			dummyProposeEventOpts.Address,
-			dummyProposeEventOpts.Event,
-			1,
-			nil,
-		},
-		{
-			"none",
-			"0xfake",
-			dummyProposeEventOpts.Event,
-			0,
-			nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resp, err := eventRepo.GetByAddressAndEventName(
-				context.Background(),
-				tt.address,
-				tt.event,
-			)
-			spew.Dump(resp)
-			assert.Equal(t, tt.wantErr, err)
-			assert.Equal(t, tt.wantLen, len(resp))
-		})
-	}
-}
-
 func TestIntegration_Event_Delete(t *testing.T) {
 	db, close, err := testMysql(t)
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
some community members need a /events endpoint to query blockproposed/blockproven/blockverified events by address and name to enable some features on their node dashboard.

@wolfderechter will utilize this I believe, the endpoint works as follows:

`/events?address=0xwhatever&event=BlockProposed|BlockProven|BlockVerified`, will return a paginated list, to consume the following pages just make the same request with `&page=2`, `&page=3`, etc, will return the next page. Will return 100 items per page. The response has a `total_pages` property to see how many pages exist.