### PR TITLE
fix(relayer): fix scanning blocks twice

### DIFF
--- a/packages/relayer/indexer/detect_and_handle_reorg.go
+++ b/packages/relayer/indexer/detect_and_handle_reorg.go
@@ -19,7 +19,6 @@ func (svc *Service) detectAndHandleReorg(ctx context.Context, eventType string, 
 	}
 
 	// reorg detected
-
 	log.Infof("reorg detected for msgHash %v and eventType %v", msgHash, eventType)
 
 	err = svc.eventRepo.Delete(ctx, e.ID)

--- a/packages/relayer/indexer/filter_then_subscribe.go
+++ b/packages/relayer/indexer/filter_then_subscribe.go
@@ -58,17 +58,21 @@ func (svc *Service) FilterThenSubscribe(
 
 	for i := svc.processingBlockHeight; i < header.Number.Uint64(); i += svc.blockBatchSize {
 		end := svc.processingBlockHeight + svc.blockBatchSize
-		fmt.Printf("block batch from %v to %v", i, end)
-		fmt.Println()
 		// if the end of the batch is greater than the latest block number, set end
 		// to the latest block number
 		if end > header.Number.Uint64() {
 			end = header.Number.Uint64()
 		}
 
+		// filter exclusive of the end block
+		filterEnd := end - 1
+
+		fmt.Printf("block batch from %v to %v", i, filterEnd)
+		fmt.Println()
+
 		filterOpts := &bind.FilterOpts{
-			Start:   svc.processingBlockHeight + 1,
-			End:     &end,
+			Start:   svc.processingBlockHeight,
+			End:     &filterEnd,
 			Context: ctx,
 		}
 

--- a/packages/relayer/indexer/filter_then_subscribe.go
+++ b/packages/relayer/indexer/filter_then_subscribe.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/pkg/errors"
@@ -57,6 +58,8 @@ func (svc *Service) FilterThenSubscribe(
 
 	for i := svc.processingBlockHeight; i < header.Number.Uint64(); i += svc.blockBatchSize {
 		end := svc.processingBlockHeight + svc.blockBatchSize
+		fmt.Printf("block batch from %v to %v", i, end)
+		fmt.Println()
 		// if the end of the batch is greater than the latest block number, set end
 		// to the latest block number
 		if end > header.Number.Uint64() {
@@ -64,7 +67,7 @@ func (svc *Service) FilterThenSubscribe(
 		}
 
 		filterOpts := &bind.FilterOpts{
-			Start:   svc.processingBlockHeight,
+			Start:   svc.processingBlockHeight + 1,
 			End:     &end,
 			Context: ctx,
 		}

--- a/packages/relayer/indexer/filter_then_subscribe.go
+++ b/packages/relayer/indexer/filter_then_subscribe.go
@@ -64,7 +64,9 @@ func (svc *Service) FilterThenSubscribe(
 			end = header.Number.Uint64()
 		}
 
-		// filter exclusive of the end block
+		// filter exclusive of the end block.
+		// we use "end" as the next starting point of the batch, and
+		// process up to end - 1 for this batch.
 		filterEnd := end - 1
 
 		fmt.Printf("block batch from %v to %v", i, filterEnd)
@@ -95,6 +97,8 @@ func (svc *Service) FilterThenSubscribe(
 		}
 
 		if !messageSentEvents.Next() || messageSentEvents.Event == nil {
+			// use "end" not "filterEnd" here, because it will be used as the start
+			// of the next batch.
 			if err := svc.handleNoEventsInBatch(ctx, chainID, int64(end)); err != nil {
 				return errors.Wrap(err, "svc.handleNoEventsInBatch")
 			}


### PR DESCRIPTION
we were encounting "fake" reorgs due to re-scanning the first block of every batch, which was actually the end of the previous batch. we were actually processing "blockBatchSize + 1" batches before due to faulty batching logic, however this was never an issue previously because we allowed duplicate event creation and were not attempting to handle reorgs.