### PR TITLE
fix(bridge-ui-v2): fixing vercel build

### DIFF
--- a/packages/bridge-ui-v2/src/libs/wagmi/watcher.ts
+++ b/packages/bridge-ui-v2/src/libs/wagmi/watcher.ts
@@ -1,8 +1,8 @@
-import { watchAccount, watchNetwork, watchPublicClient, watchWalletClient } from '@wagmi/core';
+import { watchAccount, watchNetwork/*, watchPublicClient, watchWalletClient*/ } from '@wagmi/core';
 
 import { getLogger } from '$libs/util/logger';
 
-const log = getLogger('wagmi/watcher');
+const log = getLogger('wagmi:watcher');
 
 let isWatching = false;
 let unWatchNetwork: () => void;

--- a/packages/bridge-ui-v2/src/libs/wagmi/watcher.ts
+++ b/packages/bridge-ui-v2/src/libs/wagmi/watcher.ts
@@ -1,4 +1,4 @@
-import { watchAccount, watchNetwork/*, watchPublicClient, watchWalletClient*/ } from '@wagmi/core';
+import { watchAccount, watchNetwork /*, watchPublicClient, watchWalletClient*/ } from '@wagmi/core';
 
 import { getLogger } from '$libs/util/logger';
 

--- a/packages/bridge-ui-v2/src/routes/+layout.svelte
+++ b/packages/bridge-ui-v2/src/routes/+layout.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import '../app.css';
 
+  import { onDestroy, onMount } from 'svelte';
+
   import Header from '$components/Header';
   import SideNavigation from '$components/SideNavigation';
   import { startWatching, stopWatching } from '$libs/wagmi';
-  import { onDestroy, onMount } from 'svelte';
 
-  onMount(startWatching)
-  onDestroy(stopWatching)
+  onMount(startWatching);
+  onDestroy(stopWatching);
 </script>
 
 <SideNavigation>

--- a/packages/bridge-ui-v2/src/routes/+layout.svelte
+++ b/packages/bridge-ui-v2/src/routes/+layout.svelte
@@ -3,6 +3,11 @@
 
   import Header from '$components/Header';
   import SideNavigation from '$components/SideNavigation';
+  import { startWatching, stopWatching } from '$libs/wagmi';
+  import { onDestroy, onMount } from 'svelte';
+
+  onMount(startWatching)
+  onDestroy(stopWatching)
 </script>
 
 <SideNavigation>

--- a/packages/bridge-ui-v2/src/routes/+layout.ts
+++ b/packages/bridge-ui-v2/src/routes/+layout.ts
@@ -1,13 +1,4 @@
-/**
- * Entry point
- */
-
-import { startWatching } from '$libs/wagmi';
-
 // When setting this to false your entire app will only be rendered on the client,
 // which essentially means you turn your app into an SPA.
 // See https://kit.svelte.dev/docs/page-options#ssr
 export const ssr = false;
-
-// Start watching for network and account changes
-startWatching();

--- a/packages/bridge-ui-v2/vite.config.ts
+++ b/packages/bridge-ui-v2/vite.config.ts
@@ -3,6 +3,9 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  build: {
+    sourcemap: true,
+  },
   plugins: [
     sveltekit(),
 


### PR DESCRIPTION
This fixes Vercel build: `layout.ts` should not import client side code