### PR TITLE
fix(status-page): proposer title

### DIFF
--- a/packages/status-page/src/pages/home/Home.svelte
+++ b/packages/status-page/src/pages/home/Home.svelte
@@ -105,7 +105,7 @@
 {/if}
 
 {#if proposerDetailsOpen}
-  <DetailsModal title={"Prover Details"} bind:isOpen={proposerDetailsOpen}>
+  <DetailsModal title={"Proposer Details"} bind:isOpen={proposerDetailsOpen}>
     <div
       class="grid grid-cols-2 gap-4 text-center my-10 max-h-96 overflow-y-auto"
       slot="body"


### PR DESCRIPTION
The `Unique Proposers` had a wrong title:
![image](https://github.com/taikoxyz/taiko-mono/assets/60930264/79cdaaeb-56f0-4128-bedd-4aa656dbdf02)
