### PR TITLE
refactor(protocol): optimize ProverPool

### DIFF
--- a/packages/protocol/contracts/L1/ProverPool.sol
+++ b/packages/protocol/contracts/L1/ProverPool.sol
@@ -287,13 +287,11 @@ contract ProverPool is EssentialContract, IProverPool {
 
         // Force the replaced prover to exit
         address replaced = idToProver[proverId];
-        // if (replaced != address(0)) {
-        _withdraw(replaced);
-        _exit(replaced);
-        // }
+        if (replaced != address(0)) {
+            _withdraw(replaced);
+            _exit(replaced);
+        }
         idToProver[proverId] = addr;
-        // Keep track of weights when changes ()
-        // Assign the staker this proverId
         staker.proverId = proverId;
 
         // Insert the prover in the top prover list

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -184,6 +184,10 @@ contract TaikoL1 is
         });
     }
 
+    function getTaikoTokenBalance(address addr) public view returns (uint256) {
+        return state.taikoTokenBalances[addr];
+    }
+
     function getBlock(uint256 blockId)
         public
         view

--- a/packages/protocol/test/ProverPool.t.sol
+++ b/packages/protocol/test/ProverPool.t.sol
@@ -54,7 +54,7 @@ contract TestProverPool is Test {
             uint16 capacity = baseCapacity + i;
             depositTaikoToken(addr, tokenPerCapacity * capacity, 1 ether);
             vm.prank(addr, addr);
-            pp.stake(uint32(capacity) * 10_000, 10 + i, capacity);
+            pp.stake(uint64(capacity) * 10_000 * 1e8, 10 + i, capacity);
         }
 
         ProverPool.Prover[] memory provers;
@@ -62,7 +62,9 @@ contract TestProverPool is Test {
 
         (provers, stakers) = printProvers();
         for (uint16 i; i < provers.length; ++i) {
-            assertEq(provers[i].stakedAmount, uint32(baseCapacity + i) * 10_000);
+            assertEq(
+                provers[i].stakedAmount, uint64(baseCapacity + i) * 10_000 * 1e8
+            );
             assertEq(provers[i].rewardPerGas, 10 + i);
             assertEq(provers[i].currentCapacity, baseCapacity + i);
         }
@@ -74,12 +76,14 @@ contract TestProverPool is Test {
             uint16 capacity = baseCapacity + i;
             depositTaikoToken(addr, tokenPerCapacity * capacity, 1 ether);
             vm.prank(addr, addr);
-            pp.stake(uint32(capacity) * 10_000, 10 + i, capacity);
+            pp.stake(uint64(capacity) * 10_000 * 1e8, 10 + i, capacity);
         }
 
         (provers, stakers) = printProvers();
         for (uint16 i; i < provers.length; ++i) {
-            assertEq(provers[i].stakedAmount, uint32(baseCapacity + i) * 10_000);
+            assertEq(
+                provers[i].stakedAmount, uint64(baseCapacity + i) * 10_000 * 1e8
+            );
             assertEq(provers[i].rewardPerGas, 10 + i);
             assertEq(provers[i].currentCapacity, baseCapacity + i);
         }
@@ -91,12 +95,14 @@ contract TestProverPool is Test {
             uint16 capacity = baseCapacity + i;
             depositTaikoToken(addr, tokenPerCapacity * capacity, 1 ether);
             vm.prank(addr, addr);
-            pp.stake(uint32(capacity) * 10_000, 10 + i, capacity);
+            pp.stake(uint64(capacity) * 10_000 * 1e8, 10 + i, capacity);
         }
 
         (provers, stakers) = printProvers();
         for (uint16 i; i < provers.length; ++i) {
-            assertEq(provers[i].stakedAmount, uint32(baseCapacity + i) * 10_000);
+            assertEq(
+                provers[i].stakedAmount, uint64(baseCapacity + i) * 10_000 * 1e8
+            );
             assertEq(provers[i].rewardPerGas, 10 + i);
             assertEq(provers[i].currentCapacity, baseCapacity + i);
         }

--- a/packages/protocol/test/ProverPool_Protocol_Interactions.t.sol
+++ b/packages/protocol/test/ProverPool_Protocol_Interactions.t.sol
@@ -185,7 +185,7 @@ contract TaikoL1ProverPool is TaikoL1TestBase {
         // 32 slots we have
         for (uint256 index; index < 32; index++) {
             vm.prank(proverArray[index], proverArray[index]);
-            realProverPool.stake(uint32(index + 1), 10, 128);
+            realProverPool.stake(uint64(index + 1) * 1e8, 10, 128);
         }
     }
 
@@ -196,7 +196,7 @@ contract TaikoL1ProverPool is TaikoL1TestBase {
         // 32 slots we have
         for (uint256 index; index < 5; index++) {
             vm.prank(proverArray[index], proverArray[index]);
-            realProverPool.stake(uint32(index + 1), 10, 128);
+            realProverPool.stake(uint64(index + 1) * 1e8, 10, 128);
         }
     }
 
@@ -272,7 +272,7 @@ contract TaikoL1ProverPool is TaikoL1TestBase {
         console2.log("Alice balance:", tko.balanceOf(Alice));
 
         vm.prank(Ivy, Ivy);
-        realProverPool.stake(uint32(2), 10, 128);
+        realProverPool.stake(uint64(2) * 1e8, 10, 128);
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         uint32 parentGasUsed = 0;
@@ -455,7 +455,8 @@ contract TaikoL1ProverPool is TaikoL1TestBase {
 
                 // Now Khloe will be the new top staker
                 vm.prank(Khloe, Khloe);
-                realProverPool.stake(6, 10, 128); // 6 * 1e8 is the biggest, Kai
+                realProverPool.stake(uint64(6) * 1e8, 10, 128); // 6 * 1e8 is
+                    // the biggest, Kai
                     // was 5 * 1e8
             }
             printVariables("before propose");

--- a/packages/website/pages/docs/reference/contract-documentation/L1/ProverPool.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/ProverPool.md
@@ -8,9 +8,10 @@ title: ProverPool
 
 ```solidity
 struct Prover {
-  uint32 stakedAmount;
+  uint64 stakedAmount;
   uint16 rewardPerGas;
   uint16 currentCapacity;
+  uint64 weight;
 }
 ```
 
@@ -19,7 +20,7 @@ struct Prover {
 ```solidity
 struct Staker {
   uint64 exitRequestedAt;
-  uint32 exitAmount;
+  uint64 exitAmount;
   uint16 maxCapacity;
   uint8 proverId;
 }
@@ -37,12 +38,6 @@ uint32 MAX_CAPACITY_LOWER_BOUND
 uint64 EXIT_PERIOD
 ```
 
-### ONE_TKO
-
-```solidity
-uint64 ONE_TKO
-```
-
 ### SLASH_POINTS
 
 ```solidity
@@ -52,7 +47,13 @@ uint32 SLASH_POINTS
 ### MIN_STAKE_PER_CAPACITY
 
 ```solidity
-uint32 MIN_STAKE_PER_CAPACITY
+uint64 MIN_STAKE_PER_CAPACITY
+```
+
+### MIN_SLASH_AMOUNT
+
+```solidity
+uint64 MIN_SLASH_AMOUNT
 ```
 
 ### MAX_NUM_PROVERS
@@ -61,16 +62,16 @@ uint32 MIN_STAKE_PER_CAPACITY
 uint256 MAX_NUM_PROVERS
 ```
 
+### provers
+
+```solidity
+struct ProverPool.Prover[1024] provers
+```
+
 ### idToProver
 
 ```solidity
 mapping(uint256 => address) idToProver
-```
-
-### idToWeights
-
-```solidity
-mapping(uint256 => uint256) idToWeights
 ```
 
 ### stakers
@@ -82,25 +83,25 @@ mapping(address => struct ProverPool.Staker) stakers
 ### Withdrawn
 
 ```solidity
-event Withdrawn(address addr, uint32 amount)
+event Withdrawn(address addr, uint64 amount)
 ```
 
 ### Exited
 
 ```solidity
-event Exited(address addr, uint32 amount)
+event Exited(address addr, uint64 amount)
 ```
 
 ### Slashed
 
 ```solidity
-event Slashed(address addr, uint32 amount)
+event Slashed(address addr, uint64 amount)
 ```
 
 ### Staked
 
 ```solidity
-event Staked(address addr, uint32 amount, uint16 rewardPerGas, uint16 currentCapacity)
+event Staked(address addr, uint64 amount, uint16 rewardPerGas, uint16 currentCapacity)
 ```
 
 ### INVALID_PARAMS
@@ -160,7 +161,7 @@ function slashProver(address addr) external
 ### stake
 
 ```solidity
-function stake(uint32 amount, uint16 rewardPerGas, uint16 maxCapacity) external
+function stake(uint64 amount, uint16 rewardPerGas, uint16 maxCapacity) external
 ```
 
 ### exit

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoL1.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoL1.md
@@ -107,6 +107,12 @@ function canDepositEthToL2(uint256 amount) public view returns (bool)
 function getBlockFee(uint32 gasLimit) public view returns (uint64)
 ```
 
+### getTaikoTokenBalance
+
+```solidity
+function getTaikoTokenBalance(address addr) public view returns (uint256)
+```
+
 ### getBlock
 
 ```solidity


### PR DESCRIPTION
- Staked amount means wei, no longer 1 TKO token
- Merge weight into Prover struct and make prover a list, not packed tightly
- Optimized gas cost
- Slash at least 1 TKO token

### Previously
| Deployment Cost                                 | Deployment Size |        |        |        |         |
|-------------------------------------------------|-----------------|--------|--------|--------|---------|
| 1662543                                         | 8336            |        |        |        |         |
| Function Name                                   | min             | avg    | median | max    | # calls |
| assignProver                                    | 28905           | 37634  | 41290  | 46905  | 463     |
| getProvers                                      | 58132           | 58132  | 58132  | 58132  | 3       |
| getStaker                                       | 2022            | 2022   | 2022   | 2022   | 18      |
| init                                            | 93061           | 93061  | 93061  | 93061  | 8       |
| releaseProver                                   | 4251            | 10774  | 4251   | 19321  | 365     |
| slashProver                                     | 5632            | 13568  | 7333   | 21787  | 9       |
| stake                                           | 22978           | 123403 | 114764 | 185356 | 151     |


### Now
| Deployment Cost                                 | Deployment Size |       |        |        |         |
|-------------------------------------------------|-----------------|-------|--------|--------|---------|
| 1695578                                         | 8501            |       |        |        |         |
| Function Name                                   | min             | avg   | median | max    | # calls |
| assignProver                                    | 15351           | 18150 | 17286  | 81351  | 463     |
| getProvers                                      | 47886           | 47886 | 47886  | 47886  | 3       |
| getStaker                                       | 1660            | 1660  | 1660   | 1660   | 18      |
| init                                            | 93061           | 93061 | 93061  | 93061  | 8       |
| releaseProver                                   | 2408            | 3105  | 3127   | 3127   | 365     |
| slashProver                                     | 5621            | 5801  | 5824   | 5824   | 9       |
| stake                                           | 29587           | 73869 | 77005  | 172248 | 151     |