### PR TITLE
fix(protocol): Fix alpha-4 ability to build protocol and run tests

### DIFF
--- a/packages/protocol/test/TaikoL1TestBase.t.sol
+++ b/packages/protocol/test/TaikoL1TestBase.t.sol
@@ -306,8 +306,8 @@ abstract contract TaikoL1TestBase is Test {
 
         // Also hash configs that will be used by circuits
         inputs[9] = uint256(config.blockMaxGasLimit) << 192
-            | uint256(config.maxTransactionsPerBlock) << 128
-            | uint256(config.maxBytesPerTxList) << 64;
+            | uint256(config.blockMaxTransactions) << 128
+            | uint256(config.blockMaxTxListBytes) << 64;
 
         assembly {
             instance := keccak256(inputs, mul(32, 10))


### PR DESCRIPTION
Some files were not using updated config, disallowing protocol to compile.