### PR TITLE
feat(protocol): disable oracle proofs to be over written by regular proofs

### DIFF
--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -22,7 +22,6 @@ abstract contract TaikoErrors {
     error L1_INVALID_METADATA();
     error L1_INVALID_PARAM();
     error L1_INVALID_PROOF();
-    error L1_INVALID_PROOF_OVERWRITE();
     error L1_NOT_PROVEABLE();
     error L1_NOT_BETTER_BID();
     error L1_NOT_SPECIAL_PROVER();
@@ -34,6 +33,4 @@ abstract contract TaikoErrors {
     error L1_TX_LIST_RANGE();
     error L1_TX_LIST();
     error L1_UNAUTHORIZED();
-
-    // Prover pool related error
 }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -32,7 +32,6 @@ library LibProving {
     error L1_FORK_CHOICE_NOT_FOUND();
     error L1_INVALID_EVIDENCE();
     error L1_INVALID_PROOF();
-    error L1_INVALID_PROOF_OVERWRITE();
     error L1_NOT_PROVEABLE();
     error L1_NOT_SPECIAL_PROVER();
     error L1_SAME_PROOF();
@@ -126,20 +125,7 @@ library LibProving {
                     && fc.gasUsed == evidence.gasUsed
             ) revert L1_SAME_PROOF();
         } else {
-            // This is the branch provers trying to overwrite
-            fc = blk.forkChoices[fcId];
-
-            // Only oracle proof can be overwritten by regular proof
-            if (fc.prover != address(1)) {
-                revert L1_ALREADY_PROVEN();
-            }
-
-            // The regular proof must be the same as the oracle proof
-            if (
-                fc.blockHash != evidence.blockHash
-                    || fc.signalRoot != evidence.signalRoot
-                    || fc.gasUsed != evidence.gasUsed
-            ) revert L1_INVALID_PROOF_OVERWRITE();
+            revert L1_ALREADY_PROVEN();
         }
 
         fc.blockHash = evidence.blockHash;

--- a/packages/protocol/test/TaikoL1Oracle.t.sol
+++ b/packages/protocol/test/TaikoL1Oracle.t.sol
@@ -348,7 +348,8 @@ contract TaikoL1OracleTest is TaikoL1TestBase {
     }
 
     /// @dev Test if system prover cannot be overwritten
-    function test_if_systemProver_can_prove_but_regular_provers_can_overwrite()
+    function test_if_systemProver_can_prove_but_regular_provers_can_not_overwrite(
+    )
         external
     {
         // Dave is the oracle prover
@@ -400,7 +401,8 @@ contract TaikoL1OracleTest is TaikoL1TestBase {
             uint256 lastVerifiedBlockId =
                 L1.getStateVariables().lastVerifiedBlockId;
 
-            // Bob could overwrite it
+            // Bob cannot overwrite it
+            vm.expectRevert(TaikoErrors.L1_ALREADY_PROVEN.selector);
             proveBlock(
                 Bob,
                 Bob,
@@ -413,12 +415,12 @@ contract TaikoL1OracleTest is TaikoL1TestBase {
             );
 
             vm.warp(block.timestamp + 1 seconds);
-            vm.warp(block.timestamp + conf.proofRegularCooldown);
+            vm.warp(block.timestamp + conf.proofOracleCooldown);
 
             TaikoData.ForkChoice memory fc =
                 L1.getForkChoice(blockId, parentHash, parentGasUsed);
 
-            assertEq(fc.prover, Bob);
+            assertEq(fc.prover, address(1));
 
             verifyBlock(Carol, 1);
 

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoErrors.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoErrors.md
@@ -82,12 +82,6 @@ error L1_INVALID_PARAM()
 error L1_INVALID_PROOF()
 ```
 
-### L1_INVALID_PROOF_OVERWRITE
-
-```solidity
-error L1_INVALID_PROOF_OVERWRITE()
-```
-
 ### L1_NOT_PROVEABLE
 
 ```solidity


### PR DESCRIPTION
In alpha-3, when the chain has too many unverified blocks, some blocks that have already been proven by oracle proofs are over written by regular proofs, which forces the protocol to mint many tokens to reward those provers. This change will fix that.