### PR TITLE
fix(bridge-ui): handle scientific notation

### DIFF
--- a/packages/bridge-ui/package.json
+++ b/packages/bridge-ui/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "pnpm run dev",
+    "start:a3": "pnpm run dev --mode a3",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/packages/bridge-ui/src/relayer-api/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/relayer-api/RelayerAPIService.ts
@@ -18,6 +18,7 @@ import type {
 } from '../domain/relayerApi';
 import type { BridgeTransaction } from '../domain/transaction';
 import { getLogger } from '../utils/logger';
+import { toBigNumber } from '../utils/toBigNumber';
 import { tokenVaults } from '../vault/tokenVaults';
 
 const log = getLogger('RelayerAPIService');
@@ -212,14 +213,12 @@ export class RelayerAPIService implements RelayerAPI {
           memo: tx.data.Message.Memo,
           owner: tx.data.Message.Owner,
           sender: tx.data.Message.Sender,
-          gasLimit: BigNumber.from(tx.data.Message.GasLimit.toString()),
-          callValue: BigNumber.from(tx.data.Message.CallValue.toString()),
+          gasLimit: toBigNumber(tx.data.Message.GasLimit),
+          callValue: toBigNumber(tx.data.Message.CallValue),
           srcChainId: tx.data.Message.SrcChainId,
           destChainId: tx.data.Message.DestChainId,
-          depositValue: BigNumber.from(tx.data.Message.DepositValue.toString()),
-          processingFee: BigNumber.from(
-            tx.data.Message.ProcessingFee.toString(),
-          ),
+          depositValue: toBigNumber(tx.data.Message.DepositValue),
+          processingFee: toBigNumber(tx.data.Message.ProcessingFee),
           refundAddress: tx.data.Message.RefundAddress,
         },
       };

--- a/packages/bridge-ui/src/utils/toBigNumber.spec.ts
+++ b/packages/bridge-ui/src/utils/toBigNumber.spec.ts
@@ -8,5 +8,8 @@ describe('toBigNumber', () => {
     expect(toBigNumber(2e+21).toString()).toEqual('2000000000000000000000');
     expect(toBigNumber(3e21).toString()).toEqual('3000000000000000000000');
     expect(toBigNumber(1000).toString()).toEqual('1000');
+
+    // Number.MAX_SAFE_INTEGER = 9007199254740991. Maximum safe integer (2^53 – 1)
+    expect(toBigNumber(BigInt(Number.MAX_SAFE_INTEGER) * 3n).toString()).toEqual('27021597764222973');
   });
 });

--- a/packages/bridge-ui/src/utils/toBigNumber.spec.ts
+++ b/packages/bridge-ui/src/utils/toBigNumber.spec.ts
@@ -1,0 +1,12 @@
+import { BigNumber } from "ethers";
+
+import { toBigNumber } from "./toBigNumber";
+
+describe('toBigNumber', () => {
+  it('should handle different notation for big ints', () => {
+    expect(toBigNumber('1000000000000000000000').toString()).toEqual('1000000000000000000000');
+    expect(toBigNumber(2e+21).toString()).toEqual('2000000000000000000000');
+    expect(toBigNumber(3e21).toString()).toEqual('3000000000000000000000');
+    expect(toBigNumber(1000).toString()).toEqual('1000');
+  });
+});

--- a/packages/bridge-ui/src/utils/toBigNumber.ts
+++ b/packages/bridge-ui/src/utils/toBigNumber.ts
@@ -1,0 +1,5 @@
+import { BigNumber } from "ethers";
+
+export function toBigNumber(value: string | number | bigint | boolean): BigNumber {
+  return BigNumber.from(BigInt(value).toString());
+}

--- a/packages/bridge-ui/src/utils/toBigNumber.ts
+++ b/packages/bridge-ui/src/utils/toBigNumber.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from "ethers";
 
+// This will also handle scientific notation (or e notation: 2e+21)
 export function toBigNumber(value: string | number | bigint | boolean): BigNumber {
   return BigNumber.from(BigInt(value).toString());
 }


### PR DESCRIPTION
**Problem**: Relayer might return e-notation ints such as `2e+21`. `BigNumber` cannot handle this format

**Solution**: using built-in `BigInt` to help us handle it

_Note_: Bridge-UI v2 is no longer using BigNumber library. will be using built-in `bigint` instead 😉