### PR TITLE
feat(protocol): NFT vault addressed code comments

### DIFF
--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -169,7 +169,7 @@ contract TaikoToken is
         super._mint(to, amount);
 
         if (totalSupply() > type(uint64).max) revert TKO_MINT_DISALLOWED();
-        emit Mint(to, amount);
+        emit Transfer(address(0), to, amount);
     }
 
     function _burn(
@@ -180,7 +180,7 @@ contract TaikoToken is
         override(ERC20Upgradeable, ERC20VotesUpgradeable)
     {
         super._burn(from, amount);
-        emit Burn(from, amount);
+        emit Transfer(from, address(0), amount);
     }
 }
 

--- a/packages/protocol/contracts/common/IMintableERC20.sol
+++ b/packages/protocol/contracts/common/IMintableERC20.sol
@@ -10,10 +10,6 @@ import { IERC20Upgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
 interface IMintableERC20 is IERC20Upgradeable {
-    // TODO(dani): remove these events, use Transfer event
-    event Mint(address indexed account, uint256 amount);
-    event Burn(address indexed account, uint256 amount);
-
     function mint(address account, uint256 amount) external;
     function burn(address from, uint256 amount) external;
 }

--- a/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
@@ -102,7 +102,6 @@ abstract contract BaseNFTVault is BaseVault {
         }
     }
 
-    // TODO(dani): what are we trying to extra from the data?
     function extractCalldata(bytes memory calldataWithSelector)
         internal
         pure

--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -29,12 +29,11 @@ contract BridgedERC1155 is
     string public srcUri;
     uint256[47] private __gap;
 
-    // TODO(dani): remove these events, use Transfer event
-    event BridgeERC1155Mint(
-        address indexed account, uint256 tokenId, uint256 amount
-    );
-    event BridgeERC1155Burn(
-        address indexed account, uint256 tokenId, uint256 amount
+    event Transfer(
+        address indexed from,
+        address indexed to,
+        uint256 tokenId,
+        uint256 amount
     );
 
     /// @dev Initializer to be called after being deployed behind a proxy.
@@ -73,7 +72,7 @@ contract BridgedERC1155 is
         onlyFromNamed("erc1155_vault")
     {
         _mint(account, tokenId, amount, data);
-        emit BridgeERC1155Mint(account, tokenId, amount);
+        emit Transfer(address(0), account, tokenId, amount);
     }
 
     /// @dev only a TokenVault can call this function
@@ -86,7 +85,7 @@ contract BridgedERC1155 is
         onlyFromNamed("erc1155_vault")
     {
         _burn(account, tokenId, amount);
-        emit BridgeERC1155Burn(account, tokenId, amount);
+        emit Transfer(account, address(0), tokenId, amount);
     }
 
     /// @dev any address can call this

--- a/packages/protocol/contracts/tokenvault/BridgedERC20.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20.sol
@@ -86,7 +86,7 @@ contract BridgedERC20 is
         onlyFromNamed4("taiko", "prover_pool", "dao", "erc20_vault")
     {
         _mint(account, amount);
-        emit Mint(account, amount);
+        emit Transfer(address(0), account, amount);
     }
 
     /**
@@ -103,7 +103,7 @@ contract BridgedERC20 is
         onlyFromNamed4("taiko", "prover_pool", "dao", "erc20_vault")
     {
         _burn(account, amount);
-        emit Burn(account, amount);
+        emit Transfer(account, address(0), amount);
     }
 
     /**

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -19,10 +19,6 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
     error BRIDGED_TOKEN_CANNOT_RECEIVE();
     error BRIDGED_TOKEN_INVALID_PARAMS();
 
-    // TODO(dani): remove these events, use Transfer event
-    event BridgeERC721Mint(address indexed account, uint256 tokenId);
-    event BridgeERC721Burn(address indexed account, uint256 tokenId);
-
     /// @dev Initializer to be called after being deployed behind a proxy.
     // Intention is for a different BridgedERC721 Contract to be deployed
     // per unique _srcToken i.e. one for Loopheads, one for CryptoPunks, etc.
@@ -60,7 +56,7 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         onlyFromNamed("erc721_vault")
     {
         _mint(account, tokenId);
-        emit BridgeERC721Mint(account, tokenId);
+        emit Transfer(address(0), account, tokenId);
     }
 
     /// @dev only a TokenVault can call this function
@@ -72,7 +68,7 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         onlyFromNamed("erc721_vault")
     {
         _burn(tokenId);
-        emit BridgeERC721Burn(account, tokenId);
+        emit Transfer(account, address(0), tokenId);
     }
 
     /// @dev any address can call this

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -44,10 +44,7 @@ contract ERC20Vault is BaseVault {
         string name;
     }
 
-    // TODO(dani): this struct has a very different meaning than those defined
-    // for NFTs. It may be an issue.
-
-    struct BridgeTransferOp {
+    struct MessageDeposit {
         address token;
         uint256 amount;
     }
@@ -71,7 +68,7 @@ contract ERC20Vault is BaseVault {
     ) public canonicalToBridged;
 
     // Tracks the token and amount associated with a message hash.
-    mapping(bytes32 msgHash => BridgeTransferOp messageDeposit) public
+    mapping(bytes32 msgHash => MessageDeposit messageDeposit) public
         messageDeposits;
 
     uint256[46] private __gap;
@@ -216,7 +213,7 @@ contract ERC20Vault is BaseVault {
         }(message);
 
         // record the deposit for this message
-        messageDeposits[msgHash] = BridgeTransferOp(token, _amount);
+        messageDeposits[msgHash] = MessageDeposit(token, _amount);
 
         emit ERC20Sent({
             msgHash: msgHash,
@@ -259,8 +256,8 @@ contract ERC20Vault is BaseVault {
         if (!bridge.isMessageFailed(msgHash, message.destChainId, proof)) {
             revert VAULT_MESSAGE_NOT_FAILED();
         }
-        // TODO(dani): why 1155 and 721 vault dontt have this
-        messageDeposits[msgHash] = BridgeTransferOp(address(0), 0);
+
+        messageDeposits[msgHash] = MessageDeposit(address(0), 0);
 
         if (amount > 0) {
             if (isBridgedToken[token] || token == resolve("taiko_token", true))


### PR DESCRIPTION
Addressed the comments from code comments `Todo(dani)`. (`pnpm lint:sol` not run bc. it is easier to comare now. Once merged, will do.)