### PR TITLE
feat(protocol): apply slight reward penalty based on timing

### DIFF
--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -48,7 +48,8 @@ library TaikoConfig {
             ethDepositMaxFee: 1 ether / 10,
             // Group 5: tokenomics
             rewardOpenMultipler: 200, // percentage
-            rewardOpenMaxCount: 2000
-        });
+            rewardOpenMaxCount: 2000,
+            rewardMaxDelayPenalty: 250 // bps
+         });
     }
 }

--- a/packages/protocol/contracts/L1/TaikoConfig.sol
+++ b/packages/protocol/contracts/L1/TaikoConfig.sol
@@ -48,7 +48,7 @@ library TaikoConfig {
             ethDepositMaxFee: 1 ether / 10,
             // Group 5: tokenomics
             rewardOpenMultipler: 200, // percentage
-            rewardOpenMaxCount: 201_600 // blockMaxProposals / 2,
+            rewardOpenMaxCount: 201_600, // blockMaxProposals / 2,
             rewardMaxDelayPenalty: 250 // bps
          });
     }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -37,7 +37,8 @@ library TaikoData {
         uint256 ethDepositMaxFee;
         // Group 5: tokenomics
         uint8 rewardOpenMultipler;
-        uint256 rewardOpenMaxCount;
+        uint32 rewardOpenMaxCount;
+        uint32 rewardMaxDelayPenalty;
     }
 
     struct StateVariables {

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -222,7 +222,7 @@ library LibVerifying {
             proofReward = proofReward * config.rewardOpenMultipler / 100;
             proverPool.slashProver(blk.assignedProver);
         } else if (fc.provenAt <= blk.proposedAt + blk.proofWindow) {
-            // proving inside the window
+            // proving inside the window, by the assigned prover
             uint64 proofDelay;
             unchecked {
                 proofDelay = fc.provenAt - blk.proposedAt;

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -216,40 +216,46 @@ library LibVerifying {
         } else if (blk.assignedProver == address(0)) {
             // open prover is rewarded with more tokens
             proofReward = proofReward * config.rewardOpenMultipler / 100;
-        } else if (
-            fc.prover == blk.assignedProver
-                && fc.provenAt <= blk.proposedAt + blk.proofWindow
-        ) {
-            uint64 proofDelay;
-            unchecked {
-                proofDelay = fc.provenAt - blk.proposedAt;
+        } else if (fc.prover == blk.assignedProver) {
+            if (fc.provenAt <= blk.proposedAt + blk.proofWindow) {
+                // proving inside the window
+                uint64 proofDelay;
+                unchecked {
+                    proofDelay = fc.provenAt - blk.proposedAt;
 
-                if (config.rewardMaxDelayPenalty > 0) {
-                    // Give the reward a penalty up to a small percentage.
-                    // This will encourage prover to submit proof ASAP.
-                    proofReward -= proofReward * proofDelay
-                        * config.rewardMaxDelayPenalty / 10_000 / blk.proofWindow;
+                    if (config.rewardMaxDelayPenalty > 0) {
+                        // Give the reward a penalty up to a small percentage.
+                        // This will encourage prover to submit proof ASAP.
+                        proofReward -= proofReward * proofDelay
+                            * config.rewardMaxDelayPenalty / 10_000
+                            / blk.proofWindow;
+                    }
                 }
+
+                // The selected prover managed to prove the block in time
+                state.avgProofDelay = uint16(
+                    LibUtils.movingAverage({
+                        maValue: state.avgProofDelay,
+                        newValue: proofDelay,
+                        maf: 7200
+                    })
+                );
+
+                state.feePerGas = uint32(
+                    LibUtils.movingAverage({
+                        maValue: state.feePerGas,
+                        newValue: blk.rewardPerGas,
+                        maf: 7200
+                    })
+                );
+            } else {
+                // proving out side of the proof window, by the assigned prover
+                proofReward = 0;
+                proverPool.slashProver(blk.assignedProver);
             }
-
-            // The selected prover managed to prove the block in time
-            state.avgProofDelay = uint16(
-                LibUtils.movingAverage({
-                    maValue: state.avgProofDelay,
-                    newValue: proofDelay,
-                    maf: 7200
-                })
-            );
-
-            state.feePerGas = uint32(
-                LibUtils.movingAverage({
-                    maValue: state.feePerGas,
-                    newValue: blk.rewardPerGas,
-                    maf: 7200
-                })
-            );
         } else {
-            // proving out side of the proof window
+            // proving out side of the proof window, by a prover other
+            // than the assigned prover
             proofReward = proofReward * config.rewardOpenMultipler / 100;
             proverPool.slashProver(blk.assignedProver);
         }

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoData.md
@@ -30,7 +30,8 @@ struct Config {
   uint256 ethDepositGas;
   uint256 ethDepositMaxFee;
   uint8 rewardOpenMultipler;
-  uint256 rewardOpenMaxCount;
+  uint32 rewardOpenMaxCount;
+  uint32 rewardMaxDelayPenalty;
 }
 ```
 


### PR DESCRIPTION
Introduce a new config rewardMaxDelayPenalty, if it is set to 250 bps (2.5%), then when the proof is submitted with a delay == provingWindow, then the reward to the prover is 97.5%*origianlProofReward, if the proof is submitted with a 0 delay, then the reward to prover is 100%*origianlProofReward.

This will encourage assigned provers to submit proofs ASAP.