### PR TITLE
fix(protocol): Fix prover duplicate

### DIFF
--- a/packages/protocol/contracts/L1/ProverPool.sol
+++ b/packages/protocol/contracts/L1/ProverPool.sol
@@ -366,6 +366,11 @@ contract ProverPool is EssentialContract, IProverPool {
         if (staker.proverId == 0) return;
 
         Prover memory prover = provers[staker.proverId];
+
+        // Delete the prover but make it non-zero for cheaper rewrites
+        // by keep rewardPerGas = 1
+        provers[staker.proverId] = Prover(0, 1, 0);
+
         if (prover.stakedAmount > 0) {
             if (
                 checkExitTimestamp
@@ -378,10 +383,6 @@ contract ProverPool is EssentialContract, IProverPool {
             staker.exitRequestedAt = uint64(block.timestamp);
             staker.proverId = 0;
         }
-
-        // Delete the prover but make it non-zero for cheaper rewrites
-        // by keep rewardPerGas = 1
-        provers[staker.proverId] = Prover(0, 1, 0);
 
         delete proverIdToAddress[staker.proverId];
 

--- a/packages/protocol/contracts/L1/ProverPool.sol
+++ b/packages/protocol/contracts/L1/ProverPool.sol
@@ -367,6 +367,8 @@ contract ProverPool is EssentialContract, IProverPool {
 
         Prover memory prover = provers[staker.proverId];
 
+        delete proverIdToAddress[staker.proverId];
+
         // Delete the prover but make it non-zero for cheaper rewrites
         // by keep rewardPerGas = 1
         provers[staker.proverId] = Prover(0, 1, 0);
@@ -383,8 +385,6 @@ contract ProverPool is EssentialContract, IProverPool {
             staker.exitRequestedAt = uint64(block.timestamp);
             staker.proverId = 0;
         }
-
-        delete proverIdToAddress[staker.proverId];
 
         emit Exited(addr, staker.exitAmount);
     }


### PR DESCRIPTION
staking then restaking keeps the original prover in the provers array because it's updated after the proverid is set to 0, so it isnt removed. 

This issue has been encountered on our testnet and will require an upgrade via proxy.