### PR TITLE
feat(protocol): Implement token uri differently

### DIFF
--- a/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
@@ -27,15 +27,12 @@ abstract contract BaseNFTVault is BaseVault {
         address addr;
         string symbol;
         string name;
-        string uri;
     }
 
     struct BridgeTransferOp {
         uint256 destChainId;
         address to;
         address token;
-        string baseTokenUri; // TODO(dani): remove this,we have multiple options
-            // please see my answer at ERC721Vault.sol line 57
         uint256[] tokenIds;
         uint256[] amounts;
         uint256 gasLimit;


### PR DESCRIPTION
@dantaik Please see. This is the Nr.3 option i was talking about. (Basically have a direct mapping and use it over on the 'bridged' chain).

Feel free to merge it if you like it. Nr. 1 and Nr.3 both could fit, but with this we eliminate the need of having to input by the FrontEnd a base token uri.