### PR TITLE
feat(protocol): Alpha 4 fix inception bridge embedded naming

### DIFF
--- a/packages/protocol/contracts/bridge/BridgedERC20.sol
+++ b/packages/protocol/contracts/bridge/BridgedERC20.sol
@@ -33,7 +33,8 @@ contract BridgedERC20 is
     address public srcToken;
     uint256 public srcChainId;
     uint8 private srcDecimals;
-    uint256[47] private __gap;
+    bool private inceptionBridged;
+    uint256[46] private __gap;
 
     /**
      * Initializes the contract.
@@ -45,6 +46,8 @@ contract BridgedERC20 is
      * @param _decimals The number of decimal places of the source token.
      * @param _symbol The symbol of the token.
      * @param _name The name of the token.
+     * @param _inceptionBridged If true, it means the canonical token
+     * is at least 2 layers below.
      */
     function init(
         address _addressManager,
@@ -52,7 +55,8 @@ contract BridgedERC20 is
         uint256 _srcChainId,
         uint8 _decimals,
         string memory _symbol,
-        string memory _name
+        string memory _name,
+        bool _inceptionBridged
     )
         external
         initializer
@@ -69,6 +73,7 @@ contract BridgedERC20 is
         srcToken = _srcToken;
         srcChainId = _srcChainId;
         srcDecimals = _decimals;
+        inceptionBridged = _inceptionBridged;
     }
 
     /**
@@ -155,6 +160,9 @@ contract BridgedERC20 is
         override(ERC20Upgradeable, IERC20MetadataUpgradeable)
         returns (string memory)
     {
+        if(inceptionBridged) {
+            return super.name();
+        }
         return string.concat(
             super.name(), unicode" ⭀", Strings.toString(srcChainId)
         );

--- a/packages/protocol/contracts/bridge/BridgedERC20.sol
+++ b/packages/protocol/contracts/bridge/BridgedERC20.sol
@@ -34,7 +34,7 @@ contract BridgedERC20 is
     uint256 public srcChainId;
     uint8 private srcDecimals;
     bool private inceptionBridged;
-    uint256[46] private __gap;
+    uint256[47] private __gap;
 
     /**
      * Initializes the contract.

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/BridgedERC20.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/BridgedERC20.md
@@ -22,7 +22,7 @@ uint256 srcChainId
 ### init
 
 ```solidity
-function init(address _addressManager, address _srcToken, uint256 _srcChainId, uint8 _decimals, string _symbol, string _name) external
+function init(address _addressManager, address _srcToken, uint256 _srcChainId, uint8 _decimals, string _symbol, string _name, bool _inceptionBridged) external
 ```
 
 Initializes the contract.
@@ -32,14 +32,15 @@ per unique \_srcToken i.e. one for USDC, one for USDT etc._
 
 #### Parameters
 
-| Name             | Type    | Description                                       |
-| ---------------- | ------- | ------------------------------------------------- |
-| \_addressManager | address | The address manager.                              |
-| \_srcToken       | address | The source token address.                         |
-| \_srcChainId     | uint256 | The source chain ID.                              |
-| \_decimals       | uint8   | The number of decimal places of the source token. |
-| \_symbol         | string  | The symbol of the token.                          |
-| \_name           | string  | The name of the token.                            |
+| Name               | Type    | Description                                                       |
+| ------------------ | ------- | ----------------------------------------------------------------- |
+| \_addressManager   | address | The address manager.                                              |
+| \_srcToken         | address | The source token address.                                         |
+| \_srcChainId       | uint256 | The source chain ID.                                              |
+| \_decimals         | uint8   | The number of decimal places of the source token.                 |
+| \_symbol           | string  | The symbol of the token.                                          |
+| \_name             | string  | The name of the token.                                            |
+| \_inceptionBridged | bool    | If true, it means the canonical token is at least 2 layers below. |
 
 ### mint
 

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/TokenVault.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/TokenVault.md
@@ -56,6 +56,12 @@ mapping(uint256 => mapping(address => address)) canonicalToBridged
 mapping(bytes32 => struct TokenVault.MessageDeposit) messageDeposits
 ```
 
+### otherTokenVaults
+
+```solidity
+address[] otherTokenVaults
+```
+
 ### BridgedERC20Deployed
 
 ```solidity
@@ -86,6 +92,12 @@ event ERC20Released(bytes32 msgHash, address from, address token, uint256 amount
 event ERC20Received(bytes32 msgHash, address from, address to, uint256 srcChainId, address token, uint256 amount)
 ```
 
+### TokenVaultAdded
+
+```solidity
+event TokenVaultAdded(address vaultAddress)
+```
+
 ### TOKENVAULT_INVALID_TO
 
 ```solidity
@@ -114,6 +126,14 @@ error TOKENVAULT_INVALID_TOKEN()
 Thrown when the token address in a transaction is invalid.
 This could happen if the token address is zero or doesn't conform to the
 ERC20 standard.
+
+### TOKENVAULT_INVALID_TOKENVAULT
+
+```solidity
+error TOKENVAULT_INVALID_TOKENVAULT()
+```
+
+Thrown when the address supplied is not a valid token vault.
 
 ### TOKENVAULT_INVALID_AMOUNT
 
@@ -212,7 +232,7 @@ a proof that the message processing on the destination Bridge has failed.
 ### receiveERC20
 
 ```solidity
-function receiveERC20(struct TokenVault.CanonicalERC20 canonicalToken, address from, address to, uint256 amount) external
+function receiveERC20(struct TokenVault.CanonicalERC20 canonicalToken, address from, address to, uint256 amount, bool isInceptedBridging) external
 ```
 
 This function can only be called by the bridge contract while
@@ -221,12 +241,27 @@ this function.
 
 #### Parameters
 
-| Name           | Type                             | Description                                                                                                          |
-| -------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| canonicalToken | struct TokenVault.CanonicalERC20 | The canonical ERC20 token which may or may not live on this chain. If not, a BridgedERC20 contract will be deployed. |
-| from           | address                          | The source address.                                                                                                  |
-| to             | address                          | The destination address.                                                                                             |
-| amount         | uint256                          | The amount of tokens to be sent. 0 is a valid value.                                                                 |
+| Name               | Type                             | Description                                                                                                          |
+| ------------------ | -------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| canonicalToken     | struct TokenVault.CanonicalERC20 | The canonical ERC20 token which may or may not live on this chain. If not, a BridgedERC20 contract will be deployed. |
+| from               | address                          | The source address.                                                                                                  |
+| to                 | address                          | The destination address.                                                                                             |
+| amount             | uint256                          | The amount of tokens to be sent. 0 is a valid value.                                                                 |
+| isInceptedBridging | bool                             | This means it is an incepted token so canonical is at least 2 layers below.                                          |
+
+### addTokenVault
+
+```solidity
+function addTokenVault(address vaultAddress) external
+```
+
+This function can add an address to the otherTokenVaults array
+
+#### Parameters
+
+| Name         | Type    | Description                                      |
+| ------------ | ------- | ------------------------------------------------ |
+| vaultAddress | address | The vaultAddress of another deployed tokenVault. |
 
 ---
 


### PR DESCRIPTION
Currently, we embedded the previous layer's name into the bridged asset, tho it would create an 'ever-embedding' effect seen in the screenshot below.

![kép](https://github.com/taikoxyz/taiko-mono/assets/51912515/a1cbca20-da7b-4abf-b80c-51cfd3749123)

This PR aim's to fix it with the following way:

Assume we have 2 Networks, `A` and **B.**

`A:` is a L2 with a settlement layer (TaikoL1 contracts) on L1.
`B:` is a L3 with a settlement layer (TaikoL1 contracts) on L2.

It would require 4 TokenVault deployments.
1-1 for network A on both chain.
1-1 for network B on both chains

On Layer2, there will be 2 deployments. 

With this solution they can communicate with each other, by calling `_checkIfInceptedBridging` if `B`'s TokenVault (on L2) knows the other TokenVault (which is the destination token vault of network `A`).

SO how it works (technically):

When someone wants to bridge a token from L2 to L3, during sendErc20() it invokes _checkIfInceptedBridging(). It will query the other (registered) TokenVault instance (which is the destination TokenVault of network A) - if it is indeed an already bridged token, it passes a boolean flag within the `message.data` towards L3.