### PR TITLE
feat(protocol): Fix burn() issue and add more tests to NFT vaults

### DIFF
--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -6,8 +6,6 @@
 
 pragma solidity ^0.8.20;
 
-import { console2 } from "forge-std/console2.sol";
-import { Test } from "forge-std/Test.sol";
 import { EssentialContract } from "../common/EssentialContract.sol";
 import { ERC721Upgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
@@ -20,6 +18,7 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
 
     error BRIDGED_TOKEN_CANNOT_RECEIVE();
     error BRIDGED_TOKEN_INVALID_PARAMS();
+    error BRIDGED_TOKEN_INVALID_BURN();
 
     /// @dev Initializer to be called after being deployed behind a proxy.
     // Intention is for a different BridgedERC721 Contract to be deployed
@@ -67,6 +66,13 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         public
         onlyFromNamed("erc721_vault")
     {
+        // ERC721Upgradeable internal _burn() function
+        // does not have this ownership check so we
+        // need to be careful when exposing the function.
+        if (ownerOf(tokenId) != account) {
+            revert BRIDGED_TOKEN_INVALID_BURN();
+        }
+
         _burn(tokenId);
         emit Transfer(account, address(0), tokenId);
     }

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -6,8 +6,6 @@
 
 pragma solidity ^0.8.20;
 
-import { console2 } from "forge-std/console2.sol";
-import { Test } from "forge-std/Test.sol";
 import { IERC165 } from
     "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { IERC721Receiver } from
@@ -108,8 +106,6 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
         if (ctoken.chainId == block.chainid) {
             token = ctoken.addr;
             for (uint256 i; i < tokenIds.length; i++) {
-                console2.log(address(this));
-                console2.log(ERC721Upgradeable(token).ownerOf(tokenIds[i]));
                 ERC721Upgradeable(token).transferFrom(
                     address(this), to, tokenIds[i]
                 );
@@ -224,7 +220,6 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
 
         // is a btoken, meaning, it does not live on this chain
         if (isBridgedToken) {
-            console2.log("we burning");
             for (uint256 i; i < opt.tokenIds.length; i++) {
                 BridgedERC721(opt.token).burn(owner, opt.tokenIds[i]);
             }

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -6,6 +6,8 @@
 
 pragma solidity ^0.8.20;
 
+import { console2 } from "forge-std/console2.sol";
+import { Test } from "forge-std/Test.sol";
 import { IERC165 } from
     "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { IERC721Receiver } from
@@ -106,6 +108,8 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
         if (ctoken.chainId == block.chainid) {
             token = ctoken.addr;
             for (uint256 i; i < tokenIds.length; i++) {
+                console2.log(address(this));
+                console2.log(ERC721Upgradeable(token).ownerOf(tokenIds[i]));
                 ERC721Upgradeable(token).transferFrom(
                     address(this), to, tokenIds[i]
                 );
@@ -220,6 +224,7 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
 
         // is a btoken, meaning, it does not live on this chain
         if (isBridgedToken) {
+            console2.log("we burning");
             for (uint256 i; i < opt.tokenIds.length; i++) {
                 BridgedERC721(opt.token).burn(owner, opt.tokenIds[i]);
             }

--- a/packages/protocol/test/ERC721Vault.t.sol
+++ b/packages/protocol/test/ERC721Vault.t.sol
@@ -77,6 +77,15 @@ contract PrankDestBridge {
         destERC721Vault = ERC721Vault(addr);
     }
 
+    function sendMessage(IBridge.Message memory message)
+        external
+        payable
+        returns (bytes32 msgHash)
+    {
+        // Dummy return value
+        return keccak256(abi.encode(message.id));
+    }
+
     function context() public view returns (BridgeContext memory) {
         return ctx;
     }
@@ -191,6 +200,7 @@ contract ERC721VaultTest is Test {
     function setUp() public {
         vm.startPrank(Alice);
         vm.deal(Alice, 100 ether);
+        vm.deal(Bob, 100 ether);
         addressManager = new AddressManager();
         addressManager.init();
 
@@ -557,6 +567,122 @@ contract ERC721VaultTest is Test {
         );
 
         assertEq(bridgedContract, deployedContract);
+    }
+
+    function test_bridge_back_but_owner_is_different_now_721() public {
+        vm.prank(Alice, Alice);
+        canonicalToken721.approve(address(erc721Vault), 1);
+        vm.prank(Alice, Alice);
+        canonicalToken721.approve(address(erc721Vault), 2);
+
+        assertEq(canonicalToken721.ownerOf(1), Alice);
+
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 1;
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 0;
+
+        BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault
+            .BridgeTransferOp(
+            destChainId,
+            Alice,
+            address(canonicalToken721),
+            tokenIds,
+            amounts,
+            140_000,
+            140_000,
+            Alice,
+            ""
+        );
+        vm.prank(Alice, Alice);
+        erc721Vault.sendToken{ value: 140_000 }(sendOpts);
+
+        assertEq(canonicalToken721.ownerOf(1), address(erc721Vault));
+
+        // This canonicalToken is basically need to be exact same as the
+        // sendToken() puts together
+        // - here is just mocking putting it together.
+        BaseNFTVault.CanonicalNFT memory canonicalToken = BaseNFTVault
+            .CanonicalNFT({
+            chainId: 31_337,
+            addr: address(canonicalToken721),
+            symbol: "TT",
+            name: "TT"
+        });
+
+        uint256 chainId = block.chainid;
+        vm.chainId(destChainId);
+
+        vm.prank(Alice, Alice);
+        addressManager.setAddress(chainId, "bridge", address(destChainIdBridge));
+
+        destChainIdBridge.sendReceiveERC721ToERC721Vault(
+            canonicalToken,
+            Alice,
+            Alice,
+            tokenIds,
+            bytes32(0),
+            address(erc721Vault),
+            chainId
+        );
+
+        // Query canonicalToBridged
+        address deployedContract = destChainErc721Vault.canonicalToBridged(
+            chainId, address(canonicalToken721)
+        );
+
+        // Alice bridged over tokenId 1
+        assertEq(ERC721(deployedContract).ownerOf(1), Alice);
+
+        // Transfer the asset to Bob, and Bob can receive it back on canonical
+        // chain
+        vm.prank(Alice, Alice);
+        ERC721(deployedContract).transferFrom(Alice, Bob, 1);
+
+        assertEq(ERC721(deployedContract).ownerOf(1), Bob);
+
+        vm.prank(Bob, Bob);
+        ERC721(deployedContract).approve(address(destChainErc721Vault), 1);
+
+        sendOpts = BaseNFTVault.BridgeTransferOp(
+            chainId,
+            Bob,
+            address(deployedContract),
+            tokenIds,
+            amounts,
+            140_000,
+            140_000,
+            Bob,
+            ""
+        );
+
+        vm.prank(Bob, Bob);
+        destChainErc721Vault.sendToken{ value: 140_000 }(sendOpts);
+
+        //assertEq(ERC721(deployedContract).ownerOf(1), Bob);
+        //uint256 chainId = block.chainid;
+        vm.chainId(chainId);
+
+        assertEq(ERC721(canonicalToken721).ownerOf(1), address(erc721Vault));
+        console2.log("Vault address is:");
+        console2.log(address(erc721Vault));
+        console2.log("Alice address is:");
+        console2.log(address(Alice));
+        console2.log("Bob address is:");
+        console2.log(address(Bob));
+        console2.log("Destionation address is:");
+        console2.log(address(destChainErc721Vault));
+        console2.log("END");
+        destChainIdBridge.sendReceiveERC721ToERC721Vault(
+            canonicalToken,
+            Bob,
+            Bob,
+            tokenIds,
+            bytes32(0),
+            address(erc721Vault),
+            chainId
+        );
     }
 
     function test_releaseToken_721() public {


### PR DESCRIPTION
Added 2-2 tests to each erc1155 and erc721 and observed and fixed a security issue with them.

Scenario I.:
1. Alice bridges an asset to layer X
2. User transfers that NFT to Bob on layer X
3. Bob bridges it back to canonical layer


Scenario II.:
1. Alice bridges an asset to layer X
2. User transfers that NFT to Bob on layer X
3. Alice (malicious) tries to send a message to bridge the asset back.


During scenario II. i found a security issue, that in the ERC721Upgradeable standard's internal `_burn()` function does not have a check if user is owning an asset or not. So we (everyone) has to be very careful exposing `_burn() `functions to the public.