### PR TITLE
feat(protocol): bring back whitelisted proposer

### DIFF
--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -25,6 +25,7 @@ abstract contract TaikoErrors {
     error L1_NOT_PROVEABLE();
     error L1_NOT_BETTER_BID();
     error L1_NOT_SPECIAL_PROVER();
+    error L1_PERMISSION_DENIED();
     error L1_SAME_PROOF();
     error L1_TOO_MANY_BLOCKS();
     error L1_TOO_MANY_OPEN_BLOCKS();

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -35,6 +35,7 @@ library LibProposing {
     error L1_BLOCK_ID();
     error L1_INSUFFICIENT_TOKEN();
     error L1_INVALID_METADATA();
+    error L1_PERMISSION_DENIED();
     error L1_TOO_MANY_BLOCKS();
     error L1_TOO_MANY_OPEN_BLOCKS();
     error L1_TX_LIST_NOT_EXIST();
@@ -52,6 +53,12 @@ library LibProposing {
         internal
         returns (TaikoData.BlockMetadata memory meta)
     {
+        {
+            address proposer = resolver.resolve("proposer", true);
+            if (proposer != address(0) && msg.sender != proposer) {
+                revert L1_PERMISSION_DENIED();
+            }
+        }
         // Try to select a prover first to revert as earlier as possible
         (address assignedProver, uint32 rewardPerGas) = IProverPool(
             resolver.resolve("prover_pool", false)

--- a/packages/website/pages/docs/reference/contract-documentation/L1/TaikoErrors.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/TaikoErrors.md
@@ -100,6 +100,12 @@ error L1_NOT_BETTER_BID()
 error L1_NOT_SPECIAL_PROVER()
 ```
 
+### L1_PERMISSION_DENIED
+
+```solidity
+error L1_PERMISSION_DENIED()
+```
+
 ### L1_SAME_PROOF
 
 ```solidity


### PR DESCRIPTION
This is to enable L3 as app-chains will have permissioned proposers.
On our L2 networks, we should make sure the whitelisted proposer address is always address(0).