### PR TITLE
fix(website): fix broken link on run-a-sepolia-node.mdx

### DIFF
--- a/packages/website/pages/docs/guides/run-a-node/run-a-sepolia-node.mdx
+++ b/packages/website/pages/docs/guides/run-a-node/run-a-sepolia-node.mdx
@@ -60,7 +60,7 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"
 This is important especially if you `ssh` into machine or open ports to the internet (be careful about that). Here are some recommended resources:
 
 - https://eth-docker.net/Usage/LinuxSecurity
-- https://www.coincashew.com/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/guide-or-security-best-practices-for-a-eth2-validator-beaconchain-node
+- https://www.coincashew.com/coins/overview-eth/archived-guides/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/guide-or-security-best-practices-for-a-eth2-validator-beaconchain-node
 - https://tailscale.com/kb/1077/secure-server-ubuntu-18-04
 - https://danthesalmon.com/ufw-docker-tailscale
 - https://github.com/chaifeng/ufw-docker


### PR DESCRIPTION
https://www.coincashew.com/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/guide-or-security-best-practices-for-a-eth2-validator-beaconchain-node

is broken link.
Now the correct link is below and fixed.
https://www.coincashew.com/coins/overview-eth/archived-guides/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/guide-or-security-best-practices-for-a-eth2-validator-beaconchain-node