### PR TITLE
fix(website): fix port number on node-runner-manual.mdx and run-a-taiko-node.mdx

### DIFF
--- a/packages/website/pages/docs/guides/run-a-node/run-a-taiko-node.mdx
+++ b/packages/website/pages/docs/guides/run-a-node/run-a-taiko-node.mdx
@@ -163,7 +163,7 @@ docker compose -f ./docker-compose.l3.yml --env-file .env.l3 up -d
 
 ### Verify node is running
 
-A node dashboard will be running on `localhost` on the `GRAFANA_PORT` you set in your `.env` or `.env.l3` file. For a Grimsvotn L2 node that would default to: [http://localhost:3000/d/L2ExecutionEngine/l2-execution-engine-overview](http://localhost:3000/d/L2ExecutionEngine/l2-execution-engine-overview).
+A node dashboard will be running on `localhost` on the `GRAFANA_PORT` you set in your `.env` or `.env.l3` file. For a Grimsvotn L2 node that would default to: [http://localhost:3001/d/L2ExecutionEngine/l2-execution-engine-overview](http://localhost:3000/d/L2ExecutionEngine/l2-execution-engine-overview).
 
 You can verify that your node is syncing by checking the **chain head** on the dashboard and seeing that it is increasing. Once the chain head matches what's on the block explorer, you are fully synced.
 

--- a/packages/website/pages/docs/guides/run-a-node/run-a-taiko-node.mdx
+++ b/packages/website/pages/docs/guides/run-a-node/run-a-taiko-node.mdx
@@ -163,7 +163,7 @@ docker compose -f ./docker-compose.l3.yml --env-file .env.l3 up -d
 
 ### Verify node is running
 
-A node dashboard will be running on `localhost` on the `GRAFANA_PORT` you set in your `.env` or `.env.l3` file. For a Grimsvotn L2 node that would default to: [http://localhost:3001/d/L2ExecutionEngine/l2-execution-engine-overview](http://localhost:3000/d/L2ExecutionEngine/l2-execution-engine-overview).
+A node dashboard will be running on `localhost` on the `GRAFANA_PORT` you set in your `.env` or `.env.l3` file. For a Grimsvotn L2 node that would default to: [http://localhost:3001/d/L2ExecutionEngine/l2-execution-engine-overview](http://localhost:3001/d/L2ExecutionEngine/l2-execution-engine-overview).
 
 You can verify that your node is syncing by checking the **chain head** on the dashboard and seeing that it is increasing. Once the chain head matches what's on the block explorer, you are fully synced.
 

--- a/packages/website/pages/docs/manuals/node-runner-manual.mdx
+++ b/packages/website/pages/docs/manuals/node-runner-manual.mdx
@@ -75,13 +75,13 @@ docker compose -f ./docker-compose.l3.yml --env-file .env.l3 down -v
 **Grimsvotn L2:**
 
 ```sh
-open http://localhost:3000/d/L2ExecutionEngine/l2-execution-engine-overview
+open http://localhost:3001/d/L2ExecutionEngine/l2-execution-engine-overview
 ```
 
 **Eldfell L3:**
 
 ```sh
-open http://localhost:3001/d/L2ExecutionEngine/l2-execution-engine-overview
+open http://localhost:3002/d/L2ExecutionEngine/l2-execution-engine-overview
 ```
 
 ## View all logs


### PR DESCRIPTION
[#14302](https://github.com/taikoxyz/taiko-mono/issues/14302)
A node dashboard will be running on localhost on the GRAFANA_PORT you set in your .env or .env.l3 file. For a Grimsvotn L2 node that would default to: http://localhost:3000/d/L2ExecutionEngine/l2-execution-engine-overview.

However, on env file right now(installed node on July 28th) default port number is
Grimsvotn L2 node: 3001, L3 node: 3002
