### PR TITLE
feat(protocol): ERC20 helper for creating FAILED message status

### DIFF
--- a/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
+++ b/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
@@ -27,7 +27,7 @@ contract FailWhenBridgeBackCanonical is ERC20 {
 
     // When canonical token, 'safeTransfer()' is called
     //  - in receiveToken() - it will fail.
-    function safeTransfer(address, uint256) public returns (bool) {
+    function safeTransfer(address, uint256) public pure returns (bool) {
         revert("Cannot bridge back to canonical (intentional).");
     }
 }

--- a/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
+++ b/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
@@ -8,7 +8,10 @@ pragma solidity ^0.8.20;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-// An ERC20 token for creating a 'failed' status
+/// @notice An ERC20 token for creating a 'failed' status (testing only!)
+/// @dev Need to create failed messages on the destination chain, and
+/// @dev by getting a storage proof (eth_getProof) of the message
+/// @dev (that it failed) so that can perform some actions.
 contract FailWhenBridgeBackCanonical is ERC20 {
     mapping(address minter => bool hasMinted) public minters;
 
@@ -16,6 +19,11 @@ contract FailWhenBridgeBackCanonical is ERC20 {
 
     constructor(string memory name, string memory symbol) ERC20(name, symbol) { }
 
+    /**
+     * Public, open mint function
+     * @dev It is a one-time mint function / address
+     * @param to The address to mint to
+     */
     function mint(address to) public {
         if (minters[msg.sender]) {
             revert HasMinted();
@@ -25,6 +33,11 @@ contract FailWhenBridgeBackCanonical is ERC20 {
         _mint(to, 50 * (10 ** decimals()));
     }
 
+    /**
+     * transfer() function to fail when Bridge calls it.
+     * @dev This will create failed when bridges tries to
+     * recall it
+     */
     function transfer(
         address,
         uint256

--- a/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
+++ b/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
@@ -25,9 +25,15 @@ contract FailWhenBridgeBackCanonical is ERC20 {
         _mint(to, 50 * (10 ** decimals()));
     }
 
-    // When canonical token, 'safeTransfer()' is called
-    //  - in receiveToken() - it will fail.
-    function safeTransfer(address, uint256) public pure returns (bool) {
+    function transfer(
+        address,
+        uint256
+    )
+        public
+        virtual
+        override
+        returns (bool)
+    {
         revert("Cannot bridge back to canonical (intentional).");
     }
 }

--- a/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
+++ b/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
@@ -47,6 +47,6 @@ contract FailWhenBridgeBackCanonical is ERC20 {
         override
         returns (bool)
     {
-        revert("Cannot bridge back to canonical (intentional).");
+        revert("Cannot bridge back to canonical.");
     }
 }

--- a/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
+++ b/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+//  _____     _ _         _         _
+// |_   _|_ _(_) |_____  | |   __ _| |__ ___
+//   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
+//   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
+
+pragma solidity ^0.8.20;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+// An ERC20 token for creating a 'failed' status
+contract FailWhenBridgeBackCanonical is ERC20 {
+    mapping(address minter => bool hasMinted) public minters;
+
+    error HasMinted();
+
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) { }
+
+    function mint(address to) public {
+        if (minters[msg.sender]) {
+            revert HasMinted();
+        }
+
+        minters[msg.sender] = true;
+        _mint(to, 50 * (10 ** decimals()));
+    }
+
+    // When canonical token, 'safeTransfer()' is called
+    //  - in receiveToken() - it will fail.
+    function safeTransfer(address, uint256) public returns (bool) {
+        revert("Cannot bridge back to canonical (intentional).");
+    }
+}

--- a/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
+++ b/packages/protocol/contracts/test/erc20/FailBridgeBackERC20.sol
@@ -10,8 +10,8 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /// @notice An ERC20 token for creating a 'failed' status (testing only!)
 /// @dev Need to create failed messages on the destination chain, and
-/// @dev by getting a storage proof (eth_getProof) of the message
-/// @dev (that it failed) so that can perform some actions.
+/// by getting a storage proof (eth_getProof) of the message
+/// (that it failed) so that can perform some actions.
 contract FailWhenBridgeBackCanonical is ERC20 {
     mapping(address minter => bool hasMinted) public minters;
 


### PR DESCRIPTION
Testing the frontend code that it can handle error handling, we need to create failed messages on the **destination** chain, and by getting a storage proof (`eth_getProof`) of the message (that it failed) and can perform some actions. (error handling, release of tokens, etc.)


Pre-requisite:
- deploy
- mint for yourself
- approve the `bridge`

This contract will do the work (create failed message status) the following way:
1. Bridge the L1 tokens to L2 (Here, the L1 is the src and L2 is the dest)
2. Try to bridge back L2 tokens to L1 (Here, the L2 is the src, and L1 is the dest.)

`Step 2` where it will always fail -> The tokens will not be possible to transfer from the vault via `safeTransfer()` call. This way when L2 is the src and L1 is the dest, you will be able to query a message as failed.

(The reason why we doint this is: we do not want to touch the protocol, and in order to make it fail by default on the destination chain (at first bridging) we would have to touch the protocol - but it shall remain untouched)