### PR TITLE
feat(protocol): add `blockId` to `Slashed` event

### DIFF
--- a/packages/protocol/contracts/L1/IProverPool.sol
+++ b/packages/protocol/contracts/L1/IProverPool.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //  _____     _ _         _         _
 // |_   _|_ _(_) |_____  | |   __ _| |__ ___
 //   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
@@ -15,5 +16,10 @@ interface IProverPool {
 
     function releaseProver(address prover) external;
 
-    function slashProver(address prover, uint64 proofReward) external;
+    function slashProver(
+        uint64 blockId,
+        address prover,
+        uint64 proofReward
+    )
+        external;
 }

--- a/packages/protocol/contracts/L1/ProverPool.sol
+++ b/packages/protocol/contracts/L1/ProverPool.sol
@@ -62,7 +62,7 @@ contract ProverPool is EssentialContract, IProverPool {
 
     event Withdrawn(address indexed addr, uint64 amount);
     event Exited(address indexed addr, uint64 amount);
-    event Slashed(address indexed addr, uint64 amount);
+    event Slashed(uint64 indexed blockId, address indexed addr, uint64 amount);
     event Staked(
         address indexed addr,
         uint64 amount,
@@ -136,6 +136,7 @@ contract ProverPool is EssentialContract, IProverPool {
     /// @dev Slashes a prover.
     /// @param addr The address of the prover to slash.
     function slashProver(
+        uint64 blockId,
         address addr,
         uint64 proofReward
     )
@@ -171,7 +172,7 @@ contract ProverPool is EssentialContract, IProverPool {
                     provers[staker.proverId].stakedAmount = 0;
                 }
             }
-            emit Slashed(addr, amountToSlash);
+            emit Slashed(blockId, addr, amountToSlash);
         }
     }
 

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -221,7 +221,7 @@ library LibVerifying {
             // proving out side of the proof window, by a prover other
             // than the assigned prover
             proofReward = proofReward * config.rewardOpenMultipler / 100;
-            proverPool.slashProver(blk.assignedProver, proofReward);
+            proverPool.slashProver(blk.blockId, blk.assignedProver, proofReward);
         } else if (fc.provenAt <= blk.proposedAt + blk.proofWindow) {
             // proving inside the window, by the assigned prover
             uint64 proofDelay;
@@ -254,7 +254,7 @@ library LibVerifying {
             );
         } else {
             // proving out side of the proof window, by the assigned prover
-            proverPool.slashProver(blk.assignedProver, proofReward);
+            proverPool.slashProver(blk.blockId, blk.assignedProver, proofReward);
             proofReward = 0;
         }
 

--- a/packages/protocol/test/TaikoL1TestBase.t.sol
+++ b/packages/protocol/test/TaikoL1TestBase.t.sol
@@ -46,6 +46,7 @@ contract MockProverPool is IProverPool {
     function releaseProver(address prover) external pure override { }
 
     function slashProver(
+        uint64 blockId,
         address prover,
         uint64 proofReward
     )


### PR DESCRIPTION
According to the feedbacks from the community and zkpool, right now since the `Slashed` event lacks the `blockId` field, its really hard for them to find out which exact block leads to the slash. 