### PR TITLE
chore(website): add some updates to eip4844 PR

### DIFF
--- a/packages/website/pages/docs/concepts/overview.mdx
+++ b/packages/website/pages/docs/concepts/overview.mdx
@@ -25,7 +25,7 @@ cheaper than on L1, it is still necessary to adjust
 its price in a way to avoid L2 space being abused.
 EIP-1559 on Taiko dynamically adjusts the block space price.
 
-## Rate Limiting using EIP-1559
+## Rate limiting using EIP-1559
 
 Although rollups can have significantly
 higher network capacity than L1s,
@@ -55,7 +55,7 @@ the same mechanism is used on Ethereum it allows Taiko to be Ethereum equivalent
 (with some small implementation detail changes) even for this part of its network,
 which is not obviously the case for L2s.
 
-## EIP-1559 Powered Prover fees
+## EIP-1559 powered prover fees
 
 Proving blocks requires significant compute power to calculate the proof
 to submit and verify the proof on Ethereum. Provers need
@@ -110,6 +110,8 @@ one predicted by the model.
 ## EIP-4844 scaling via blob data
 
 EIP-4844 is an Ethereum upgrade that bolts blob data to consensus layer blocks.
+
+<br />
 <center>
   <Image
     src="/images/diagrams/concepts/eip-4844/blob-bolt-block.png"
@@ -122,19 +124,19 @@ EIP-4844 is an Ethereum upgrade that bolts blob data to consensus layer blocks.
 YouTube Video Presentation: [Ethereum's first steps towards serious scalability/EIP-4844 (Proto-danksharding)](https://www.youtube.com/watch?v=JQDUvqv60qw)
 
 The main motivation for EIP-4844 is scaling Ethereum with transactions that are:
-```
--compressed [similar to raw byte calldata for rollups to read and execute from]
--cheap [blob data is cheaper than calldata]
--expire
-    -exist long enough for rollups to execute data
-    -with enough verification data after expiration recorded to prove blob data 
-```
-Impact: 
-```
--cheaper transactions are achieved 
--increase rollup TPS [transactions per second] by 10 times as much
-``` 
 
+- Compressed (similar to raw byte calldata for rollups to read and execute from)
+- Cheap (blob data is cheaper than calldata)
+- Ephemeral
+  - Exist long enough for rollups to execute data
+  - With enough verification data after expiration recorded to prove blob data
+
+The impact is:
+
+- Cheaper transactions are achieved
+- Increase in rollup TPS (transactions per second); possibly, 10 times as much
+
+<br />
 <center>
   <Image
     src="/images/diagrams/concepts/eip-4844/scale-rollup-ten-times.png"
@@ -146,8 +148,9 @@ Impact:
 
 EIP-4844 focuses on using Polynomial Commitments instead of Merkle Trees.
 This is because Polynomial Commitments have data recovery and are more lightweight than Merkle Trees as shown below.
-However, Polynomial Commitments are more challenging to develop with, since they use complicated math. 
+However, Polynomial Commitments are more challenging to develop with, since they use complicated math.
 
+<br />
 <center>
   <Image
     src="/images/diagrams/concepts/eip-4844/merkle-tree-vs-polynomial-commitment.png"
@@ -160,8 +163,4 @@ However, Polynomial Commitments are more challenging to develop with, since they
 EIP-4844 will be released in the Ethereum Cancun upgrade.
 The Cancun upgrade ETA is Q4 2023 and can be tracked with other Ethereum upgrades at [Wen Merge?](https://wenmerge.com/)
 
-Taiko Mainnet will launch with blob data transaction support after EIP-4844 is released.
-
-<Callout type="info">
-Taiko can support transactions without EIP-4844 blob data as well. 
-</Callout> 
+Taiko Mainnet expects to launch with blob data transaction support after EIP-4844 is released. However, Taiko can support transactions without EIP-4844 blob data as well.


### PR DESCRIPTION
1. converted all headings within the doc to sentence case as per our writing style guide in the contributing manual
2. added a <br /> element to each screenshot/embed because visually there is not enough vertical padding in this component, it looks "squished" against the text
3. removed the code block annotation from the bullet points because semantically in markdown this should only be reserved for code blocks. also converted them with correct styling on hyphens "- " <- follow the hyphen with a space, and sentence cased
4. removed the alert thing at the bottom and combined into last sentence. generally, we actually want to stay away from using this nextra specific features. they are not "portable" / markdown compliant, and we want to be as portable as possible.