### PR TITLE
feat(protocol): L2 1559 no longer use block gas limit

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -199,9 +199,11 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         uint256 basefee;
         EIP1559Config memory config = getEIP1559Config();
         if (config.gasIssuedPerSecond != 0) {
-            (basefee, gasExcess) = _calcBasefee(
-                config, block.timestamp - parentTimestamp, parentGasUsed
-            );
+            (basefee, gasExcess) = _calcBasefee({
+                config: config,
+                timeSinceParent: block.timestamp - parentTimestamp,
+                parentGasUsed: parentGasUsed
+            });
         }
 
         // On L2, basefee is not burnt, but sent to a treasury instead.
@@ -237,8 +239,11 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         view
         returns (uint256 _basefee)
     {
-        (_basefee,) =
-            _calcBasefee(getEIP1559Config(), timeSinceParent, parentGasUsed);
+        (_basefee,) = _calcBasefee({
+            config: getEIP1559Config(),
+            timeSinceParent: timeSinceParent,
+            parentGasUsed: parentGasUsed
+        });
     }
 
     function getCrossChainBlockHash(uint256 number)

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -349,13 +349,9 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
 
         // Very important to cap _gasExcess uint64
         unchecked {
-            uint256 _newlyIssued = timeSinceParent * config.gasIssuedPerSecond;
-            _gasExcess = uint64(
-                (
-                    uint256(gasExcess).max(_newlyIssued) + parentGasUsedNet
-                        - _newlyIssued
-                ).min(type(uint64).max)
-            );
+            uint256 issued = timeSinceParent * config.gasIssuedPerSecond;
+            uint256 excess = (uint256(gasExcess) + parentGasUsedNet).max(issued);
+            _gasExcess = uint64((excess - issued).min(type(uint64).max));
         }
     }
 }

--- a/packages/protocol/test/TaikoL1TestBase.t.sol
+++ b/packages/protocol/test/TaikoL1TestBase.t.sol
@@ -168,7 +168,6 @@ abstract contract TaikoL1TestBase is Test {
         bytes memory txList = new bytes(txListSize);
         TaikoData.BlockMetadataInput memory input = TaikoData.BlockMetadataInput({
             beneficiary: proposer,
-            gasLimit: gasLimit,
             txListHash: keccak256(txList),
             txListByteStart: 0,
             txListByteEnd: txListSize,

--- a/packages/protocol/test/TaikoL2.t.sol
+++ b/packages/protocol/test/TaikoL2.t.sol
@@ -39,7 +39,7 @@ contract TestTaikoL2 is Test {
     function testAnchorTxsBlocktimeConstant() external {
         uint256 firstBasefee;
         for (uint256 i = 0; i < 100; i++) {
-            uint256 basefee = _getBasefeeAndPrint(0, BLOCK_GAS_LIMIT);
+            uint256 basefee = _getBasefeeAndPrint2(0, BLOCK_GAS_LIMIT);
             vm.fee(basefee);
 
             if (firstBasefee == 0) {
@@ -60,7 +60,7 @@ contract TestTaikoL2 is Test {
         uint256 prevBasefee;
 
         for (uint256 i = 0; i < 32; i++) {
-            uint256 basefee = _getBasefeeAndPrint(0, BLOCK_GAS_LIMIT);
+            uint256 basefee = _getBasefeeAndPrint2(0, BLOCK_GAS_LIMIT);
             vm.fee(basefee);
 
             assertGe(basefee, prevBasefee);
@@ -78,7 +78,7 @@ contract TestTaikoL2 is Test {
         uint256 prevBasefee;
 
         for (uint256 i = 0; i < 30; i++) {
-            uint256 basefee = _getBasefeeAndPrint(0, BLOCK_GAS_LIMIT);
+            uint256 basefee = _getBasefeeAndPrint2(0, BLOCK_GAS_LIMIT);
             vm.fee(basefee);
 
             if (prevBasefee != 0) {
@@ -97,7 +97,7 @@ contract TestTaikoL2 is Test {
 
     // calling anchor in the same block more than once should fail
     function testAnchorTxsFailInTheSameBlock() external {
-        uint256 expectedBasefee = _getBasefeeAndPrint(0, BLOCK_GAS_LIMIT);
+        uint256 expectedBasefee = _getBasefeeAndPrint2(0, BLOCK_GAS_LIMIT);
         vm.fee(expectedBasefee);
 
         vm.prank(L2.GOLDEN_TOUCH_ADDRESS());
@@ -110,7 +110,7 @@ contract TestTaikoL2 is Test {
 
     // calling anchor in the same block more than once should fail
     function testAnchorTxsFailByNonTaikoL2Signer() external {
-        uint256 expectedBasefee = _getBasefeeAndPrint(0, BLOCK_GAS_LIMIT);
+        uint256 expectedBasefee = _getBasefeeAndPrint2(0, BLOCK_GAS_LIMIT);
         vm.fee(expectedBasefee);
         vm.expectRevert();
         _anchor(BLOCK_GAS_LIMIT);
@@ -134,31 +134,14 @@ contract TestTaikoL2 is Test {
 
     function testGetBasefee() external {
         uint32 timeSinceParent = uint32(block.timestamp - L2.parentTimestamp());
-        assertEq(_getBasefeeAndPrint(timeSinceParent, 0, 0), 317_609_019);
-        assertEq(_getBasefeeAndPrint(timeSinceParent, 1, 0), 317_609_019);
-        assertEq(
-            _getBasefeeAndPrint(timeSinceParent, 1_000_000, 0), 320_423_332
-        );
-        assertEq(
-            _getBasefeeAndPrint(timeSinceParent, 5_000_000, 0), 332_018_053
-        );
-        assertEq(
-            _getBasefeeAndPrint(timeSinceParent, 10_000_000, 0), 347_305_199
-        );
+        assertEq(_getBasefeeAndPrint(timeSinceParent, 0), 538_808_482);
 
-        timeSinceParent = uint32(100 + block.timestamp - L2.parentTimestamp());
-        assertEq(_getBasefeeAndPrint(timeSinceParent, 0, 0), 54_544_902);
-        assertEq(_getBasefeeAndPrint(timeSinceParent, 1, 0), 54_544_902);
-        assertEq(_getBasefeeAndPrint(timeSinceParent, 1_000_000, 0), 55_028_221);
-        assertEq(_getBasefeeAndPrint(timeSinceParent, 5_000_000, 0), 57_019_452);
-        assertEq(
-            _getBasefeeAndPrint(timeSinceParent, 10_000_000, 0), 59_644_805
-        );
+        timeSinceParent += 1000;
+        assertEq(_getBasefeeAndPrint(timeSinceParent, 0), 538_808_482);
     }
 
     function _getBasefeeAndPrint(
         uint32 timeSinceParent,
-        uint32 gasLimit,
         uint32 parentGasUsed
     )
         private
@@ -175,12 +158,10 @@ contract TestTaikoL2 is Test {
             Strings.toString(timeSinceParent),
             ", gasIssued=",
             Strings.toString(gasIssued),
-            ", gasLimit=",
-            Strings.toString(gasLimit),
             ", parentGasUsed=",
             Strings.toString(parentGasUsed)
         );
-        _basefee = L2.getBasefee(timeSinceParent, gasLimit, parentGasUsed);
+        _basefee = L2.getBasefee(timeSinceParent, parentGasUsed);
         assertTrue(_basefee != 0);
 
         _msg = string.concat(
@@ -194,7 +175,7 @@ contract TestTaikoL2 is Test {
         console2.log(_msg);
     }
 
-    function _getBasefeeAndPrint(
+    function _getBasefeeAndPrint2(
         uint32 timeSinceNow,
         uint32 gasLimit
     )
@@ -203,7 +184,6 @@ contract TestTaikoL2 is Test {
     {
         return _getBasefeeAndPrint(
             uint32(timeSinceNow + block.timestamp - L2.parentTimestamp()),
-            gasLimit,
             gasLimit + ANCHOR_GAS_COST
         );
     }

--- a/packages/protocol/test/TaikoL2.t.sol
+++ b/packages/protocol/test/TaikoL2.t.sol
@@ -133,15 +133,18 @@ contract TestTaikoL2 is Test {
     }
 
     function testGetBasefee() external {
-        uint32 timeSinceParent = uint32(block.timestamp - L2.parentTimestamp());
-        assertEq(_getBasefeeAndPrint(timeSinceParent, 0), 538_808_482);
+        uint64 timeSinceParent = uint64(block.timestamp - L2.parentTimestamp());
+        assertEq(_getBasefeeAndPrint(timeSinceParent, 0), 317_609_019);
 
-        timeSinceParent += 1000;
-        assertEq(_getBasefeeAndPrint(timeSinceParent, 0), 538_808_482);
+        timeSinceParent += 100;
+        assertEq(_getBasefeeAndPrint(timeSinceParent, 0), 54_544_902);
+
+        timeSinceParent += 10_000;
+        assertEq(_getBasefeeAndPrint(timeSinceParent, 0), 1);
     }
 
     function _getBasefeeAndPrint(
-        uint32 timeSinceParent,
+        uint64 timeSinceParent,
         uint32 parentGasUsed
     )
         private

--- a/packages/protocol/test/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/test/genesis/GenerateGenesis.g.sol
@@ -34,7 +34,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
     address private owner = configJSON.readAddress(".contractOwner");
     address private admin = configJSON.readAddress(".contractAdmin");
 
-    uint32 public constant BLOCK_GAS_LIMIT = 30_000_000;
+    // uint32 public constant BLOCK_GAS_LIMIT = 30_000_000;
 
     function testContractDeployment() public {
         assertEq(block.chainid, 167);
@@ -107,11 +107,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
         for (uint32 i = 0; i < 300; i++) {
             vm.roll(block.number + 1);
             vm.warp(taikoL2.parentTimestamp() + 12);
-            vm.fee(
-                taikoL2.getBasefee(
-                    12, BLOCK_GAS_LIMIT, i + LibL2Consts.ANCHOR_GAS_COST
-                )
-            );
+            vm.fee(taikoL2.getBasefee(12, i + LibL2Consts.ANCHOR_GAS_COST));
 
             uint256 gasLeftBefore = gasleft();
 


### PR DESCRIPTION
With this PR, the current block's gasLimit is no longer used in L2's EIP1559 base fee calculation. Instead, in side block N's anchor transaction, we first purchase block N-1's gasUsed, then issue new gas and adjust gasExcess.