### PR TITLE
fix(protocol): Wipe stuck prover ids

### DIFF
--- a/packages/protocol/contracts/L1/ProverPool.sol
+++ b/packages/protocol/contracts/L1/ProverPool.sol
@@ -87,6 +87,18 @@ contract ProverPool is EssentialContract, IProverPool {
         EssentialContract._init(_addressManager);
     }
 
+    /// @dev Admin function to clear/wipe trash data. Be careful with the length
+    /// of the array - (with lots of addresses might gas out)
+    /// @param wrongAddresses The array of addresses which have proverId stuck
+    function clearWrongProverIds(address[] memory wrongAddresses)
+        external
+        onlyOwner
+    {
+        for (uint256 i = 0; i < wrongAddresses.length; i++) {
+            stakers[wrongAddresses[i]].proverId = 0;
+        }
+    }
+
     /// @dev Protocol specifies the current feePerGas and assigns a prover to a
     /// block.
     /// @param blockId The block id.


### PR DESCRIPTION
@davidtaikocha When you cherry-picked the fix from main ( here is the function to wipe away data). (Or just copy this file over to Eldfell).

I'll send you the python script in DMs with which you can determine the address lists which are stuck with a non-zero proverId.