### PR TITLE
fix(bridge-ui): ignoring minters for BLL error

### DIFF
--- a/packages/bridge-ui/src/sentry.ts
+++ b/packages/bridge-ui/src/sentry.ts
@@ -24,6 +24,7 @@ export function setupSentry(dsn?: string) {
     sampleRate: isProd ? 0.1 : 1.0,
     tracesSampleRate: isProd ? 0.1 : 1.0,
     maxBreadcrumbs: 50,
+    ignoreErrors: ['issue getting minters for BLL'],
 
     beforeSend(event, hint) {
       const processedEvent = { ...event };

--- a/packages/bridge-ui/vite.config.ts
+++ b/packages/bridge-ui/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     sentryVitePlugin({
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
-      // authToken: process.env.SENTRY_AUTH_TOKEN,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
   ],
 });

--- a/packages/bridge-ui/vite.config.ts
+++ b/packages/bridge-ui/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     svelte(),
     polyfillNode(),
     sentryVitePlugin({
+      telemetry: false,
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
       authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/packages/bridge-ui/vite.config.ts
+++ b/packages/bridge-ui/vite.config.ts
@@ -10,10 +10,9 @@ export default defineConfig({
     svelte(),
     polyfillNode(),
     sentryVitePlugin({
-      telemetry: false,
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
-      authToken: process.env.SENTRY_AUTH_TOKEN,
+      // authToken: process.env.SENTRY_AUTH_TOKEN,
     }),
   ],
 });


### PR DESCRIPTION
This "useless" error is bloating Sentry and affecting our quota
![Screenshot 2023-08-11 at 10 32 23](https://github.com/taikoxyz/taiko-mono/assets/613724/b9a92815-d57d-49cd-9f73-0323f91aae13)
