### PR TITLE
docs(website): Run Taiko node typo

### DIFF
--- a/packages/website/pages/docs/guides/run-a-node/enable-a-prover.mdx
+++ b/packages/website/pages/docs/guides/run-a-node/enable-a-prover.mdx
@@ -80,7 +80,7 @@ You can check all commands to see prover logs in the [node runner manual](/docs/
 
 L2
 ```sh
-docker compose logs -f l3_taiko_client_prover_relayer |egrep "block proof was|proof submission error|Block proven"
+docker compose logs -f taiko_client_prover_relayer |egrep "block proof was|proof submission error|Block proven"
 ```
 
 L3


### PR DESCRIPTION
command to check prover relayer logs for L2 there is wrong command.
Link : https://taiko.xyz/docs/guides/run-a-node/enable-a-prover#verify-prover-logs

For L2 node should use the command :  ``docker compose logs -f taiko_client_prover_relayer``
instead but in there is : ``docker compose logs -f l3_taiko_client_prover_relayer`` which should be for the L3 no