### PR TITLE
feat(bridge-ui-v2): update the style of chain selector

### DIFF
--- a/packages/bridge-ui-v2/src/components/ChainSelector/ChainSelector.svelte
+++ b/packages/bridge-ui-v2/src/components/ChainSelector/ChainSelector.svelte
@@ -135,7 +135,7 @@
         <Icon type="x-close" fillClass="fill-secondary-icon" size={24} />
       </button>
       <h3 class="title-body-bold mb-[20px]">{$t('chain_selector.placeholder')}</h3>
-      <ul role="menu" class="space-y-4">
+      <ul role="menu">
         {#each chains as chain (chain.id)}
           {@const disabled = chain.id === value?.id}
           <li
@@ -156,7 +156,7 @@
                 </i>
                 <span class="body-bold">{chain.name}</span>
               </div>
-              <span class="body-regular">{chain.network}</span>
+              <span class="f-items-center body-regular">{chain.network}</span>
             </div>
           </li>
         {/each}


### PR DESCRIPTION
- Fix labels in the select chain model are not centered vertically 
<img width="552" alt="Screen Shot 2023-08-15 at 9 13 03 AM" src="https://github.com/taikoxyz/taiko-mono/assets/104292916/9022eea8-4e86-4517-b968-b1a9b15250c0">
- Removed margin-top 