### PR TITLE
fix(bridge-ui-v2): refresh ETH balance at the top right

### DIFF
--- a/packages/bridge-ui-v2/src/components/ConnectButton/ConnectButton.svelte
+++ b/packages/bridge-ui-v2/src/components/ConnectButton/ConnectButton.svelte
@@ -4,9 +4,11 @@
 
   import { Button } from '$components/Button';
   import { DesktopOrLarger } from '$components/DesktopOrLarger';
-  import { Icon } from '$components/Icon';
+  import { EthIcon, Icon } from '$components/Icon';
   import { web3modal } from '$libs/connect';
   import { noop } from '$libs/util/noop';
+  import { renderBalance } from '$libs/util/renderBalance';
+  import { ethBalance } from '$stores/balance';
 
   export let connected = false;
 
@@ -16,8 +18,6 @@
 
   let web3modalOpen = false;
   let unsubscribeWeb3Modal = noop;
-
-  $: web3ButtonBalance = connected && isDesktopOrLarger ? 'show' : 'hide';
 
   function connectWallet() {
     if (web3modalOpen) return;
@@ -43,7 +43,13 @@
   https://docs.walletconnect.com/2.0/web/web3modal/html/wagmi/components
 -->
 {#if connected}
-  <w3m-core-button balance={web3ButtonBalance} />
+  <Button class="px-[20px] py-2 mr-[8px] rounded-full" type="neutral" on:click={connectWallet}>
+    <span class="body-regular f-items-center space-x-2">
+      <svelte:component this={EthIcon} size={20} />
+      <span>{renderBalance($ethBalance)}</span>
+    </span>
+  </Button>
+  <w3m-core-button balance="hide" />
 {:else}
   <!-- TODO: fixing the width for English. i18n? -->
   <Button class="px-[20px] py-2 rounded-full w-[215px]" type="neutral" loading={web3modalOpen} on:click={connectWallet}>

--- a/packages/bridge-ui-v2/src/components/Icon/BLL.svelte
+++ b/packages/bridge-ui-v2/src/components/Icon/BLL.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  export let width = 32;
-  export let height = 32;
+  export let size = 32;
+  export let width = size;
+  export let height = size;
 </script>
 
 <svg {width} {height} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/packages/bridge-ui-v2/src/components/Icon/ERC20.svelte
+++ b/packages/bridge-ui-v2/src/components/Icon/ERC20.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  export let height = 30;
-  export let width = 30;
+  export let size = 30;
+  export let height = size;
+  export let width = size;
 </script>
 
 <svg

--- a/packages/bridge-ui-v2/src/components/Icon/HORSE.svelte
+++ b/packages/bridge-ui-v2/src/components/Icon/HORSE.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  export let width = 32;
-  export let height = 32;
+  export let size = 32;
+  export let width = size;
+  export let height = size;
 </script>
 
 <svg {width} {height} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/packages/bridge-ui-v2/src/components/TokenDropdown/TokenDropdown.svelte
+++ b/packages/bridge-ui-v2/src/components/TokenDropdown/TokenDropdown.svelte
@@ -110,11 +110,11 @@
         <div class="flex space-x-2 items-center">
           {#if symbolToIconMap[value.symbol]}
             <i role="img" aria-label={value.name}>
-              <svelte:component this={symbolToIconMap[value.symbol]} />
+              <svelte:component this={symbolToIconMap[value.symbol]} size={28}/>
             </i>
           {:else}
             <i role="img" aria-label={value.symbol}>
-              <Erc20 />
+              <svelte:component this={Erc20} size={28}/>
             </i>
           {/if}
           <span class="title-subsection-bold">{value.symbol}</span>

--- a/packages/bridge-ui-v2/src/libs/util/renderBalance.ts
+++ b/packages/bridge-ui-v2/src/libs/util/renderBalance.ts
@@ -1,0 +1,10 @@
+import type { FetchBalanceResult } from '@wagmi/core';
+
+import { truncateString } from '$libs/util/truncateString';
+
+export function renderBalance(balance: Maybe<FetchBalanceResult>) {
+  if (!balance) return '0.00';
+
+  const maxlength = Number(balance.formatted) < 0.000001 ? balance.decimals : 6;
+  return `${truncateString(balance.formatted, maxlength, '')} ${balance.symbol}`;
+}

--- a/packages/bridge-ui-v2/src/stores/balance.ts
+++ b/packages/bridge-ui-v2/src/stores/balance.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const ethBalance = writable<FetchBalanceResult>();

--- a/packages/bridge-ui-v2/src/stores/balance.ts
+++ b/packages/bridge-ui-v2/src/stores/balance.ts
@@ -1,3 +1,4 @@
+import type { FetchBalanceResult } from '@wagmi/core';
 import { writable } from 'svelte/store';
 
-export const ethBalance = writable<FetchBalanceResult>();
+export const ethBalance = writable<Maybe<FetchBalanceResult>>(null);


### PR DESCRIPTION
Before
<img width="973" alt="Screen Shot 2023-08-18 at 11 20 05 PM" src="https://github.com/taikoxyz/taiko-mono/assets/104292916/78c1a9d0-c00b-484c-9526-9363c1d8d3c2">

After
<img width="1012" alt="Screen Shot 2023-08-18 at 11 16 09 PM" src="https://github.com/taikoxyz/taiko-mono/assets/104292916/513fd94f-8196-4a2e-89a4-2286e21e5a96">
