### PR TITLE
feat(protocol): block reward to incentivize proposers

### DIFF
--- a/packages/protocol/contracts/L1/ProofVerifier.sol
+++ b/packages/protocol/contracts/L1/ProofVerifier.sol
@@ -8,10 +8,10 @@ pragma solidity ^0.8.20;
 
 import { AddressResolver } from "../common/AddressResolver.sol";
 import { EssentialContract } from "../common/EssentialContract.sol";
-import { Proxied } from "../common/Proxied.sol";
-import { LibZKPVerifier } from "./libs/verifiers/LibZKPVerifier.sol";
 import { IProofVerifier } from "./IProofVerifier.sol";
 import { LibBytesUtils } from "../thirdparty/LibBytesUtils.sol";
+import { LibZKPVerifier } from "./libs/verifiers/LibZKPVerifier.sol";
+import { Proxied } from "../common/Proxied.sol";
 
 /// @title ProofVerifier
 /// @notice See the documentation in {IProofVerifier}.

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -203,8 +203,9 @@ library TaikoData {
         mapping(bytes32 txListHash => TxListInfo) txListInfo;
         mapping(uint256 depositId_mode_ethDepositRingBufferSize => uint256)
             ethDeposits;
-        SlotA slotA; // slot 5
-        SlotB slotB; // slot 6
-        uint256[44] __gap;
+        mapping(address account => uint256 balance) taikoTokenBalances;
+        SlotA slotA; // slot 6
+        SlotB slotB; // slot 7
+        uint256[43] __gap;
     }
 }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -41,7 +41,9 @@ library TaikoData {
         uint256 blockTxListExpiry;
         // Amount of token to reward to the first block propsoed in each L1
         // block.
-        uint256 blockInitialReward;
+        uint256 proposerRewardPerSecond;
+        uint256 proposerRewardMax;
+        uint64 proposerRewardMinDelay;
         // ---------------------------------------------------------------------
         // Group 3: Proof related configs
         // ---------------------------------------------------------------------

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -52,7 +52,7 @@ library TaikoData {
         // The maximum time window allowed for a proof submission (in minutes).
         uint16 proofWindow;
         // The amount of Taiko token as a bond
-        uint256 proofBond;
+        uint96 proofBond;
         // True to skip proof verification
         bool skipProverAssignmentVerificaiton;
         // ---------------------------------------------------------------------

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -152,7 +152,8 @@ library TaikoData {
         uint16 nextForkChoiceId;
         uint16 verifiedForkChoiceId;
         uint64 blockId; // slot 4
-        uint24 bond;
+        uint96 proofBond;
+        uint16 proofWindow;
     }
 
     /// @dev Struct representing information about a transaction list.

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -39,6 +39,9 @@ library TaikoData {
         uint64 blockMaxTxListBytes;
         // The expiration time for the block transaction list.
         uint256 blockTxListExpiry;
+        // Amount of token to reward to the first block propsoed in each L1
+        // block.
+        uint256 blockInitialReward;
         // ---------------------------------------------------------------------
         // Group 3: Proof related configs
         // ---------------------------------------------------------------------
@@ -149,6 +152,7 @@ library TaikoData {
         uint16 nextForkChoiceId;
         uint16 verifiedForkChoiceId;
         uint64 blockId; // slot 4
+        uint24 bond;
     }
 
     /// @dev Struct representing information about a transaction list.

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -43,7 +43,6 @@ library TaikoData {
         // block.
         uint256 proposerRewardPerSecond;
         uint256 proposerRewardMax;
-        uint64 proposerRewardMinDelay;
         // ---------------------------------------------------------------------
         // Group 3: Proof related configs
         // ---------------------------------------------------------------------

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -17,6 +17,7 @@ abstract contract TaikoErrors {
     error L1_BLOCK_ID_MISMATCH();
     error L1_EVIDENCE_MISMATCH();
     error L1_FORK_CHOICE_NOT_FOUND();
+    error L1_INSUFFICIENT_TOKEN();
     error L1_INSTANCE_ZERO();
     error L1_INVALID_ASSIGNMENT();
     error L1_INVALID_BLOCK_ID();

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -18,11 +18,13 @@ abstract contract TaikoEvents {
     /// @dev Emitted when a block is proposed.
     /// @param blockId The ID of the proposed block.
     /// @param prover The address of the assigned prover for the block.
+    /// @param reward The proposer's block reward in Taiko token.
     /// @param meta The block metadata containing information about the proposed
     /// block.
     event BlockProposed(
         uint256 indexed blockId,
         address indexed prover,
+        uint256 reward,
         TaikoData.BlockMetadata meta
     );
 

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -31,6 +31,7 @@ contract TaikoL1 is TaikoL1Base {
             blockMaxTransactions: 79,
             blockMaxTxListBytes: 120_000,
             blockTxListExpiry: 0,
+            blockInitialReward: 4 ether, // 4 Taiko token
             proofRegularCooldown: 30 minutes,
             proofOracleCooldown: 15 minutes,
             proofWindow: 90 minutes,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -31,7 +31,9 @@ contract TaikoL1 is TaikoL1Base {
             blockMaxTransactions: 79,
             blockMaxTxListBytes: 120_000,
             blockTxListExpiry: 0,
-            blockInitialReward: 4 ether, // 4 Taiko token
+            proposerRewardPerSecond: 1e18, // 4 Taiko token
+            proposerRewardMax: 32e18, // 32 Taiko token
+            proposerRewardMinDelay: 6 seconds,
             proofRegularCooldown: 30 minutes,
             proofOracleCooldown: 15 minutes,
             proofWindow: 90 minutes,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -19,7 +19,7 @@ contract TaikoL1 is TaikoL1Base {
         returns (TaikoData.Config memory)
     {
         return TaikoData.Config({
-            chainId: 167_006,
+            chainId: 167_007,
             relaySignalRoot: false,
             blockMaxProposals: 403_200,
             blockRingBufferSize: 403_210,
@@ -31,7 +31,7 @@ contract TaikoL1 is TaikoL1Base {
             blockMaxTransactions: 79,
             blockMaxTxListBytes: 120_000,
             blockTxListExpiry: 0,
-            proposerRewardPerSecond: 1e18, // 4 Taiko token
+            proposerRewardPerSecond: 25e16, // 0.25 Taiko token
             proposerRewardMax: 32e18, // 32 Taiko token
             proposerRewardMinDelay: 6 seconds,
             proofRegularCooldown: 30 minutes,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -33,7 +33,6 @@ contract TaikoL1 is TaikoL1Base {
             blockTxListExpiry: 0,
             proposerRewardPerSecond: 25e16, // 0.25 Taiko token
             proposerRewardMax: 32e18, // 32 Taiko token
-            proposerRewardMinDelay: 6 seconds,
             proofRegularCooldown: 30 minutes,
             proofOracleCooldown: 15 minutes,
             proofWindow: 90 minutes,

--- a/packages/protocol/contracts/L1/TaikoL1Base.sol
+++ b/packages/protocol/contracts/L1/TaikoL1Base.sol
@@ -14,8 +14,8 @@ import { LibProposing } from "./libs/LibProposing.sol";
 import { LibProving } from "./libs/LibProving.sol";
 import { LibUtils } from "./libs/LibUtils.sol";
 import { LibVerifying } from "./libs/LibVerifying.sol";
-import { TaikoErrors } from "./TaikoErrors.sol";
 import { TaikoData } from "./TaikoData.sol";
+import { TaikoErrors } from "./TaikoErrors.sol";
 import { TaikoEvents } from "./TaikoEvents.sol";
 
 /// @title TaikoL1Base

--- a/packages/protocol/contracts/L1/TaikoL1Base.sol
+++ b/packages/protocol/contracts/L1/TaikoL1Base.sol
@@ -12,6 +12,7 @@ import { ICrossChainSync } from "../common/ICrossChainSync.sol";
 import { LibDepositing } from "./libs/LibDepositing.sol";
 import { LibProposing } from "./libs/LibProposing.sol";
 import { LibProving } from "./libs/LibProving.sol";
+import { LibTaikoToken } from "./libs/LibTaikoToken.sol";
 import { LibUtils } from "./libs/LibUtils.sol";
 import { LibVerifying } from "./libs/LibVerifying.sol";
 import { TaikoData } from "./TaikoData.sol";
@@ -148,6 +149,25 @@ abstract contract TaikoL1Base is
             resolver: AddressResolver(this),
             recipient: recipient
         });
+    }
+
+    /// @notice Deposits Taiko tokens to the contract.
+    /// @param amount Amount of Taiko tokens to deposit.
+    function depositTaikoToken(uint256 amount) public nonReentrant {
+        LibTaikoToken.depositTaikoToken(state, AddressResolver(this), amount);
+    }
+
+    /// @notice Withdraws Taiko tokens from the contract.
+    /// @param amount Amount of Taiko tokens to withdraw.
+    function withdrawTaikoToken(uint256 amount) public nonReentrant {
+        LibTaikoToken.withdrawTaikoToken(state, AddressResolver(this), amount);
+    }
+
+    /// @notice Gets the Taiko token balance for a specific address.
+    /// @param addr Address to check the Taiko token balance.
+    /// @return The Taiko token balance of the address.
+    function getTaikoTokenBalance(address addr) public view returns (uint256) {
+        return state.taikoTokenBalances[addr];
     }
 
     /// @notice Checks if Ether deposit is allowed for Layer 2.

--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -6,22 +6,22 @@
 
 pragma solidity ^0.8.20;
 
+import { ERC20BurnableUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import { ERC20PermitUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";
+import { ERC20SnapshotUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
 import {
     ERC20Upgradeable,
     IERC20Upgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import { ERC20BurnableUpgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
-import { ERC20SnapshotUpgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
-import { PausableUpgradeable } from
-    "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import { ERC20PermitUpgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";
 import { ERC20VotesUpgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import { EssentialContract } from "../common/EssentialContract.sol";
 import { IMintableERC20 } from "../common/IMintableERC20.sol";
+import { PausableUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import { Proxied } from "../common/Proxied.sol";
 
 /// @title TaikoToken

--- a/packages/protocol/contracts/L1/libs/LibDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibDepositing.sol
@@ -9,9 +9,9 @@ pragma solidity ^0.8.20;
 import { AddressResolver } from "../../common/AddressResolver.sol";
 import { LibAddress } from "../../libs/LibAddress.sol";
 import { LibMath } from "../../libs/LibMath.sol";
-import { TaikoData } from "../TaikoData.sol";
 import { SafeCastUpgradeable } from
     "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
+import { TaikoData } from "../TaikoData.sol";
 
 /// @title LibDepositing
 /// @notice A library for handling Ether deposits in the Taiko protocol.

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -168,7 +168,8 @@ library LibProposing {
             blk.nextForkChoiceId = 1;
             blk.verifiedForkChoiceId = 0;
             blk.blockId = meta.id;
-            blk.bond = uint24(config.proofBond / 1e18);
+            blk.proofBond = uint96(config.proofBond);
+            blk.proofWindow = config.proofWindow;
 
             emit BlockProposed({
                 blockId: state.slotB.numBlocks++,

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -101,7 +101,7 @@ library LibProposing {
         // Burn the prover's bond to this address
         tt.burn(assignment.prover, config.proofBond);
 
-        // Reward proposers
+        // Reward the proposer
         if (config.proposerRewardPerSecond > 0 && config.proposerRewardMax > 0)
         {
             unchecked {

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -114,7 +114,6 @@ library LibProposing {
                         config.proposerRewardPerSecond * blockTime
                     ).min(config.proposerRewardMax);
 
-                    // Mint block reward to proposer
                     tt.mint(input.beneficiary, reward);
                 }
             }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -105,14 +105,15 @@ library LibProposing {
         if (config.proposerRewardPerSecond > 0 && config.proposerRewardMax > 0)
         {
             unchecked {
-                uint64 parentProposedAt = state.blocks[(b.numBlocks - 1)
-                    % config.blockRingBufferSize].proposedAt;
+                uint256 blockTime = block.timestamp
+                    - state.blocks[(b.numBlocks - 1) % config.blockRingBufferSize]
+                        .proposedAt;
 
-                uint256 reward = config.proposerRewardPerSecond
-                    * (block.timestamp - parentProposedAt);
+                uint256 reward = (config.proposerRewardPerSecond * blockTime)
+                    .min(config.proposerRewardMax);
 
                 // Mint block reward to proposer
-                tt.mint(input.beneficiary, config.proposerRewardMax.min(reward));
+                tt.mint(input.beneficiary, reward);
             }
         }
 

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -29,6 +29,7 @@ library LibProposing {
     event BlockProposed(
         uint256 indexed blockId,
         address indexed prover,
+        uint256 reward,
         TaikoData.BlockMetadata meta
     );
 
@@ -102,6 +103,7 @@ library LibProposing {
         tt.burn(assignment.prover, config.proofBond);
 
         // Reward the proposer
+        uint256 reward;
         if (config.proposerRewardPerSecond > 0 && config.proposerRewardMax > 0)
         {
             unchecked {
@@ -110,9 +112,9 @@ library LibProposing {
                         .proposedAt;
 
                 if (blockTime > 0) {
-                    uint256 reward = (
-                        config.proposerRewardPerSecond * blockTime
-                    ).min(config.proposerRewardMax);
+                    reward = (config.proposerRewardPerSecond * blockTime).min(
+                        config.proposerRewardMax
+                    );
 
                     tt.mint(input.beneficiary, reward);
                 }
@@ -163,6 +165,7 @@ library LibProposing {
             emit BlockProposed({
                 blockId: state.slotB.numBlocks++,
                 prover: blk.prover,
+                reward: reward,
                 meta: meta
             });
         }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -105,18 +105,14 @@ library LibProposing {
         if (config.proposerRewardPerSecond > 0 && config.proposerRewardMax > 0)
         {
             unchecked {
-                uint256 blockDelay = block.timestamp
-                    - state.blocks[(b.numBlocks - 1) % config.blockRingBufferSize]
-                        .proposedAt;
+                uint64 parentProposedAt = state.blocks[(b.numBlocks - 1)
+                    % config.blockRingBufferSize].proposedAt;
 
-                if (blockDelay > config.proposerRewardMinDelay) {
-                    uint256 reward = config.proposerRewardMax.min(
-                        blockDelay - config.proposerRewardMinDelay
-                    ) * config.proposerRewardPerSecond;
+                uint256 reward = config.proposerRewardPerSecond
+                    * (block.timestamp - parentProposedAt);
 
-                    // Mint block reward to proposer
-                    tt.mint(input.beneficiary, reward);
-                }
+                // Mint block reward to proposer
+                tt.mint(input.beneficiary, config.proposerRewardMax.min(reward));
             }
         }
 

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -109,11 +109,14 @@ library LibProposing {
                     - state.blocks[(b.numBlocks - 1) % config.blockRingBufferSize]
                         .proposedAt;
 
-                uint256 reward = (config.proposerRewardPerSecond * blockTime)
-                    .min(config.proposerRewardMax);
+                if (blockTime > 0) {
+                    uint256 reward = (
+                        config.proposerRewardPerSecond * blockTime
+                    ).min(config.proposerRewardMax);
 
-                // Mint block reward to proposer
-                tt.mint(input.beneficiary, reward);
+                    // Mint block reward to proposer
+                    tt.mint(input.beneficiary, reward);
+                }
             }
         }
 

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -168,7 +168,7 @@ library LibProposing {
             blk.nextForkChoiceId = 1;
             blk.verifiedForkChoiceId = 0;
             blk.blockId = meta.id;
-            blk.proofBond = uint96(config.proofBond);
+            blk.proofBond = config.proofBond;
             blk.proofWindow = config.proofWindow;
 
             emit BlockProposed({

--- a/packages/protocol/contracts/L1/libs/LibTaikoToken.sol
+++ b/packages/protocol/contracts/L1/libs/LibTaikoToken.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+//  _____     _ _         _         _
+// |_   _|_ _(_) |_____  | |   __ _| |__ ___
+//   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
+//   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
+
+pragma solidity ^0.8.20;
+
+import { AddressResolver } from "../../common/AddressResolver.sol";
+import { LibFixedPointMath as Math } from
+    "../../thirdparty/LibFixedPointMath.sol";
+import { LibMath } from "../../libs/LibMath.sol";
+import { TaikoData } from "../TaikoData.sol";
+import { TaikoToken } from "../TaikoToken.sol";
+
+library LibTaikoToken {
+    error L1_INSUFFICIENT_TOKEN();
+
+    function withdrawTaikoToken(
+        TaikoData.State storage state,
+        AddressResolver resolver,
+        uint256 amount
+    )
+        internal
+    {
+        uint256 balance = state.taikoTokenBalances[msg.sender];
+        if (balance < amount) revert L1_INSUFFICIENT_TOKEN();
+
+        unchecked {
+            state.taikoTokenBalances[msg.sender] -= amount;
+        }
+
+        TaikoToken(resolver.resolve("taiko_token", false)).mint(
+            msg.sender, amount
+        );
+    }
+
+    function depositTaikoToken(
+        TaikoData.State storage state,
+        AddressResolver resolver,
+        uint256 amount
+    )
+        internal
+    {
+        if (amount > 0) {
+            TaikoToken(resolver.resolve("taiko_token", false)).burn(
+                msg.sender, amount
+            );
+            state.taikoTokenBalances[msg.sender] += amount;
+        }
+    }
+}

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -49,7 +49,6 @@ library LibVerifying {
                 || config.blockMaxTxListBytes > 128 * 1024 //blob up to 128K
                 || config.proofRegularCooldown < config.proofOracleCooldown
                 || config.proofWindow == 0 || config.proofBond == 0
-                || config.proofBond >= type(uint96).max
                 || config.proofBond < 10 * config.blockInitialReward
                 || config.ethDepositRingBufferSize <= 1
                 || config.ethDepositMinCountPerBlock == 0

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -49,7 +49,7 @@ library LibVerifying {
                 || config.blockMaxTxListBytes > 128 * 1024 //blob up to 128K
                 || config.proofRegularCooldown < config.proofOracleCooldown
                 || config.proofWindow == 0 || config.proofBond == 0
-                || config.proofBond < 10 * config.blockInitialReward
+                || config.proofBond < 10 * config.proposerRewardPerSecond
                 || config.ethDepositRingBufferSize <= 1
                 || config.ethDepositMinCountPerBlock == 0
                 || config.ethDepositMaxCountPerBlock

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -7,13 +7,13 @@
 pragma solidity ^0.8.20;
 
 import { EssentialContract } from "../common/EssentialContract.sol";
-import { Proxied } from "../common/Proxied.sol";
 import { ICrossChainSync } from "../common/ICrossChainSync.sol";
-import { LibMath } from "../libs/LibMath.sol";
 import { Lib1559Math } from "../libs/Lib1559Math.sol";
-import { TaikoL2Signer } from "./TaikoL2Signer.sol";
+import { LibMath } from "../libs/LibMath.sol";
+import { Proxied } from "../common/Proxied.sol";
 import { SafeCastUpgradeable } from
     "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
+import { TaikoL2Signer } from "./TaikoL2Signer.sol";
 
 /// @title TaikoL2
 /// @notice Taiko L2 is a smart contract that handles cross-layer message

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -6,16 +6,16 @@
 pragma solidity ^0.8.20;
 
 import { AddressResolver } from "../common/AddressResolver.sol";
-import { EssentialContract } from "../common/EssentialContract.sol";
-import { Proxied } from "../common/Proxied.sol";
-import { IBridge } from "./IBridge.sol";
 import { BridgeErrors } from "./BridgeErrors.sol";
+import { EssentialContract } from "../common/EssentialContract.sol";
+import { IBridge } from "./IBridge.sol";
 import { LibBridgeData } from "./libs/LibBridgeData.sol";
 import { LibBridgeProcess } from "./libs/LibBridgeProcess.sol";
 import { LibBridgeRecall } from "./libs/LibBridgeRecall.sol";
 import { LibBridgeRetry } from "./libs/LibBridgeRetry.sol";
 import { LibBridgeSend } from "./libs/LibBridgeSend.sol";
 import { LibBridgeStatus } from "./libs/LibBridgeStatus.sol";
+import { Proxied } from "../common/Proxied.sol";
 
 /// @title Bridge
 /// @notice See the documentation for {IBridge}.

--- a/packages/protocol/contracts/bridge/EtherVault.sol
+++ b/packages/protocol/contracts/bridge/EtherVault.sol
@@ -6,14 +6,14 @@
 
 pragma solidity ^0.8.20;
 
-import { SafeERC20Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { BridgeErrors } from "./BridgeErrors.sol";
 import { Create2Upgradeable } from
     "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
 import { EssentialContract } from "../common/EssentialContract.sol";
-import { Proxied } from "../common/Proxied.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
-import { BridgeErrors } from "./BridgeErrors.sol";
+import { Proxied } from "../common/Proxied.sol";
+import { SafeERC20Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
 /// @title EtherVault
 /// @notice This contract is initialized with 2^128 Ether and allows authorized

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -6,12 +6,12 @@
 
 pragma solidity ^0.8.20;
 
+import { AddressResolver } from "./AddressResolver.sol";
 import { IAddressManager } from "./AddressManager.sol";
 import { OwnableUpgradeable } from
     "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ReentrancyGuardUpgradeable } from
     "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import { AddressResolver } from "./AddressResolver.sol";
 
 /// @title EssentialContract
 /// @notice This contract serves as the base contract for many core components.

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -7,10 +7,10 @@
 pragma solidity ^0.8.20;
 
 import { EssentialContract } from "../common/EssentialContract.sol";
-import { Proxied } from "../common/Proxied.sol";
 import { ICrossChainSync } from "../common/ICrossChainSync.sol";
 import { ISignalService } from "./ISignalService.sol";
 import { LibSecureMerkleTrie } from "../thirdparty/LibSecureMerkleTrie.sol";
+import { Proxied } from "../common/Proxied.sol";
 
 /// @title SignalService
 /// @notice See the documentation in {ISignalService} for more details.

--- a/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
@@ -7,16 +7,16 @@
 pragma solidity ^0.8.20;
 
 import { EssentialContract } from "../common/EssentialContract.sol";
-import { IERC721Receiver } from
-    "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import { IERC721Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
 import { IERC1155Receiver } from
     "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import { IERC165 } from
     "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import { Proxied } from "../common/Proxied.sol";
+import { IERC721Receiver } from
+    "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import { IERC721Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
 import { IRecallableMessageSender, IBridge } from "../bridge/IBridge.sol";
+import { Proxied } from "../common/Proxied.sol";
 
 /// @title BaseNFTVault
 /// @notice Abstract contract for bridging NFTs across different chains.

--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -6,13 +6,13 @@
 
 pragma solidity ^0.8.20;
 
-import { IERC1155Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";
-import { IERC1155MetadataURIUpgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/IERC1155MetadataURIUpgradeable.sol";
 import { ERC1155Upgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import { EssentialContract } from "../common/EssentialContract.sol";
+import { IERC1155MetadataURIUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/IERC1155MetadataURIUpgradeable.sol";
+import { IERC1155Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";
 import { Proxied } from "../common/Proxied.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 

--- a/packages/protocol/contracts/tokenvault/BridgedERC20.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20.sol
@@ -7,13 +7,13 @@
 pragma solidity ^0.8.20;
 
 import {
-    IERC20Upgradeable,
-    ERC20Upgradeable
+    ERC20Upgradeable,
+    IERC20Upgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import { IERC20MetadataUpgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
-import { IMintableERC20 } from "../common/IMintableERC20.sol";
 import { EssentialContract } from "../common/EssentialContract.sol";
+import { IMintableERC20 } from "../common/IMintableERC20.sol";
 import { Proxied } from "../common/Proxied.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -6,25 +6,25 @@
 
 pragma solidity ^0.8.20;
 
-import { IERC165Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
+import { Create2Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
 import { ERC1155ReceiverUpgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC1155/utils/ERC1155ReceiverUpgradeable.sol";
+import { ERC1155Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import { IERC1155Receiver } from
     "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import { IERC1155Upgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";
-import { ERC1155Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
-import { Create2Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
+import { IERC165Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
 import { IRecallableMessageSender, IBridge } from "../bridge/IBridge.sol";
 import { BaseNFTVault } from "./BaseNFTVault.sol";
-import { ProxiedBridgedERC1155 } from "./BridgedERC1155.sol";
-import { Proxied } from "../common/Proxied.sol";
-import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { LibVaultUtils } from "./libs/LibVaultUtils.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
+import { LibVaultUtils } from "./libs/LibVaultUtils.sol";
+import { Proxied } from "../common/Proxied.sol";
+import { ProxiedBridgedERC1155 } from "./BridgedERC1155.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 /// @title ERC1155NameAndSymbol
 /// @notice Interface for ERC1155 contracts that provide name() and symbol()

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -6,24 +6,24 @@
 
 pragma solidity ^0.8.20;
 
-import {
-    IERC20Upgradeable,
-    ERC20Upgradeable
-} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import { IERC165Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
-import { SafeERC20Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { BridgedERC20, ProxiedBridgedERC20 } from "./BridgedERC20.sol";
 import { Create2Upgradeable } from
     "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
-import { BridgedERC20, ProxiedBridgedERC20 } from "./BridgedERC20.sol";
+import {
+    ERC20Upgradeable,
+    IERC20Upgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { EssentialContract } from "../common/EssentialContract.sol";
+import { IERC165Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
 import { IRecallableMessageSender, IBridge } from "../bridge/IBridge.sol";
 import { IMintableERC20 } from "../common/IMintableERC20.sol";
-import { Proxied } from "../common/Proxied.sol";
-import { TaikoToken } from "../L1/TaikoToken.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
 import { LibVaultUtils } from "./libs/LibVaultUtils.sol";
-import { EssentialContract } from "../common/EssentialContract.sol";
+import { Proxied } from "../common/Proxied.sol";
+import { SafeERC20Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { TaikoToken } from "../L1/TaikoToken.sol";
 
 /// @title ERC20Vault
 /// @notice This vault holds all ERC20 tokens (excluding Ether) that users have

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -6,22 +6,22 @@
 
 pragma solidity ^0.8.20;
 
-import { IERC721Receiver } from
-    "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import { IERC721Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
+import { BaseNFTVault } from "./BaseNFTVault.sol";
+import { Create2Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
 import { ERC721Upgradeable } from
     "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import { IERC165Upgradeable } from
     "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
-import { Create2Upgradeable } from
-    "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
-import { IRecallableMessageSender, IBridge } from "../bridge/IBridge.sol";
-import { BaseNFTVault } from "./BaseNFTVault.sol";
-import { ProxiedBridgedERC721 } from "./BridgedERC721.sol";
-import { Proxied } from "../common/Proxied.sol";
-import { LibVaultUtils } from "./libs/LibVaultUtils.sol";
+import { IERC721Receiver } from
+    "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import { IERC721Upgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
+import { IBridge, IRecallableMessageSender } from "../bridge/IBridge.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
+import { LibVaultUtils } from "./libs/LibVaultUtils.sol";
+import { Proxied } from "../common/Proxied.sol";
+import { ProxiedBridgedERC721 } from "./BridgedERC721.sol";
 
 /// @title ERC721Vault
 /// @notice This vault holds all ERC721 tokens that users have deposited.

--- a/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
+++ b/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
@@ -6,10 +6,10 @@
 
 pragma solidity ^0.8.20;
 
+import { AddressResolver } from "../../common/AddressResolver.sol";
+import { IBridge } from "../../bridge/IBridge.sol";
 import { TransparentUpgradeableProxy } from
     "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import { IBridge } from "../../bridge/IBridge.sol";
-import { AddressResolver } from "../../common/AddressResolver.sol";
 
 library LibVaultUtils {
     uint256 public constant MAX_TOKEN_PER_TXN = 10;

--- a/packages/protocol/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/genesis/GenerateGenesis.g.sol
@@ -1,25 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/StdJson.sol";
-import "../contracts/bridge/BridgeErrors.sol";
-import "../contracts/bridge/IBridge.sol";
-import "../contracts/common/AddressResolver.sol";
-import { Test } from "forge-std/Test.sol";
-import { console2 } from "forge-std/console2.sol";
-import { TaikoL2 } from "../contracts/L2/TaikoL2.sol";
 import { AddressManager } from "../contracts/common/AddressManager.sol";
+import { AddressResolver } from "../contracts/common/AddressResolver.sol";
 import { Bridge } from "../contracts/bridge/Bridge.sol";
+import { BridgeErrors } from "../contracts/bridge/BridgeErrors.sol";
+import { ERC1155Vault } from "../contracts/tokenvault/ERC1155Vault.sol";
 import { ERC20Vault } from "../contracts/tokenvault/ERC20Vault.sol";
 import { ERC721Vault } from "../contracts/tokenvault/ERC721Vault.sol";
-import { ERC1155Vault } from "../contracts/tokenvault/ERC1155Vault.sol";
 import { EtherVault } from "../contracts/bridge/EtherVault.sol";
-import { SignalService } from "../contracts/signal/SignalService.sol";
-import { LibBridgeStatus } from
-    "../contracts/bridge/libs/LibBridgeStatus.sol";
+import { IBridge } from "../contracts/bridge/IBridge.sol";
+import { LibBridgeStatus } from "../contracts/bridge/libs/LibBridgeStatus.sol";
 import { RegularERC20 } from "../contracts/test/erc20/RegularERC20.sol";
-import { TransparentUpgradeableProxy } from
-    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { SignalService } from "../contracts/signal/SignalService.sol";
+import { TaikoL2 } from "../contracts/L2/TaikoL2.sol";
+import { Test } from "forge-std/Test.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { console2 } from "forge-std/console2.sol";
+import { stdJson } from "forge-std/StdJson.sol";
 
 contract TestGenerateGenesis is Test, AddressResolver {
     using stdJson for string;

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -28,7 +28,7 @@ contract TaikoL1_NoCooldown is TaikoL1 {
         config.proofRegularCooldown = 15 minutes;
         config.skipProverAssignmentVerificaiton = true;
         config.proofBond = 1e18; // 1 Taiko token
-        config.blockInitialReward = 1e15; // 0.001 Taiko token
+        config.proposerRewardPerSecond = 1e15; // 0.001 Taiko token
     }
 }
 

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -27,7 +27,8 @@ contract TaikoL1_NoCooldown is TaikoL1 {
         config.blockRingBufferSize = 12;
         config.proofRegularCooldown = 15 minutes;
         config.skipProverAssignmentVerificaiton = true;
-        config.proofBond = 1 ether;
+        config.proofBond = 1e18; // 1 Taiko token
+        config.blockInitialReward = 1e15; // 0.001 Taiko token
     }
 }
 

--- a/packages/protocol/test/L1/TaikoL1Oracle.t.sol
+++ b/packages/protocol/test/L1/TaikoL1Oracle.t.sol
@@ -29,7 +29,7 @@ contract TaikoL1Oracle is TaikoL1 {
         config.proofRegularCooldown = 15 minutes;
         config.skipProverAssignmentVerificaiton = true;
         config.proofBond = 1e18; // 1 Taiko token
-        config.blockInitialReward = 1e15; // 0.001 Taiko token
+        config.proposerRewardPerSecond = 1e15; // 0.001 Taiko token
     }
 }
 

--- a/packages/protocol/test/L1/TaikoL1Oracle.t.sol
+++ b/packages/protocol/test/L1/TaikoL1Oracle.t.sol
@@ -28,7 +28,8 @@ contract TaikoL1Oracle is TaikoL1 {
         config.blockRingBufferSize = 12;
         config.proofRegularCooldown = 15 minutes;
         config.skipProverAssignmentVerificaiton = true;
-        config.proofBond = 1 ether;
+        config.proofBond = 1e18; // 1 Taiko token
+        config.blockInitialReward = 1e15; // 0.001 Taiko token
     }
 }
 


### PR DESCRIPTION
Mint `proposerRewardPerSecond` tokens per second for each block's proposer based on the block's delay since its parent.  A max reward amount (`proposerRewardMax`) of 32 Taiko token is applied.

I changed my mind not to reward provers to simplify their decision making: if proposers expect a bigger income, they will be willing to pay more proving fees to provers. 