### PR TITLE
feat(bridge-ui-v2): AddressInput component

### DIFF
--- a/packages/bridge-ui-v2/src/components/Bridge/AddressInput.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/AddressInput.svelte
@@ -4,7 +4,8 @@
   import { t } from 'svelte-i18n';
   import type { Address } from 'viem';
 
-  import { Alert } from '$components/Alert';
+  import FlatAlert from '$components/Alert/FlatAlert.svelte';
+  import { Icon } from '$components/Icon';
   import { uid } from '$libs/util/uid';
 
   let input: HTMLInputElement;
@@ -21,9 +22,11 @@
     if (address && address instanceof EventTarget) {
       address = (address as HTMLInputElement).value;
     }
+
     const addr = address as string;
     if (addr.length < 42) {
       tooShort = true;
+      isValidEthereumAddress = false;
     } else {
       tooShort = false;
       isValidEthereumAddress = isAddress(addr);
@@ -46,26 +49,24 @@
   <div class="f-between-center text-secondary-content">
     <label class="body-regular" for={inputId}>{$t('inputs.address_input.label')}</label>
   </div>
-  <div class="relative f-items-center">
+  <div class="relative f-items-center }">
     <input
+      bind:this={input}
       id={inputId}
       type="string"
       placeholder="0x1B77..."
       bind:value={ethereumAddress}
       on:input={(e) => validateEthereumAddress(e.target)}
-      class="w-full input-box outline-none py-6 pr-16 px-[26px] title-subsection-bold placeholder:text-tertiary-content" />
+      class="w-full input-box py-6 pr-16 px-[26px] title-subsection-bold placeholder:text-tertiary-content" />
+    <button class="absolute right-6 uppercase body-bold text-secondary-content" on:click={clear}>
+      <Icon type="x-close-circle" fillClass="fill-primary-icon" size={24} />
+    </button>
   </div>
 </div>
-<div>
+<div class="mt-3">
   {#if !isValidEthereumAddress && !tooShort}
-    <Alert type="error" forceColumnFlow>
-      <!-- TODO: i18n! -->
-      <p class="font-bold">Invalid address</p>
-      <p>This doesn't seem to be a valid Ethereum address</p>
-    </Alert>
+    <FlatAlert type="error" forceColumnFlow message={$t('inputs.address_input.errors.invalid')} />
   {:else if isValidEthereumAddress && !tooShort && showAlert}
-    <Alert type="success">
-      <p class="font-bold">Valid address format</p>
-    </Alert>
+    <FlatAlert type="success" forceColumnFlow message={$t('inputs.address_input.success')} />
   {/if}
 </div>

--- a/packages/bridge-ui-v2/src/components/Bridge/Amount.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/Amount.svelte
@@ -220,7 +220,7 @@
         error={$insufficientBalance}
         on:input={inputAmount}
         bind:this={inputBox}
-        class="py-6 pr-16 px-[26px] title-subsection-bold" />
+        class="py-6 pr-16 px-[26px] title-subsection-bold border-0" />
       <!-- TODO: talk to Jane about the MAX button and its styling -->
       <button
         class="absolute right-6 uppercase hover:font-bold"

--- a/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
@@ -3,7 +3,7 @@
   import { t } from 'svelte-i18n';
   import { formatEther } from 'viem';
 
-  import { Alert } from '$components/Alert';
+  import FlatAlert from '$components/Alert/FlatAlert.svelte';
   import { Button } from '$components/Button';
   import { Icon } from '$components/Icon';
   import { InputBox } from '$components/InputBox';
@@ -195,9 +195,7 @@
           </div>
 
           {#if !hasEnoughEth}
-            <Alert type="warning">
-              {$t('processing_fee.none.warning')}
-            </Alert>
+            <FlatAlert type="error" message={$t('processing_fee.none.warning')} />
           {/if}
         </li>
 
@@ -227,7 +225,7 @@
             min="0"
             placeholder="0.01"
             disabled={selectedFeeMethod !== ProcessingFeeMethod.CUSTOM}
-            class="w-full input-box outline-none p-6 pr-16 title-subsection-bold placeholder:text-tertiary-content"
+            class="w-full input-box p-6 pr-16 title-subsection-bold placeholder:text-tertiary-content"
             on:input={inputProcessFee}
             bind:this={inputBox} />
           <span class="absolute right-6 uppercase body-bold text-secondary-content">ETH</span>

--- a/packages/bridge-ui-v2/src/components/InputBox/InputBox.svelte
+++ b/packages/bridge-ui-v2/src/components/InputBox/InputBox.svelte
@@ -6,7 +6,7 @@
   let input: HTMLInputElement;
 
   let classes = classNames(
-    'w-full input-box placeholder:text-tertiary-content bg-neutral-background border-0 shadow-none outline-none font-bold text-2xl',
+    'w-full input-box placeholder:text-tertiary-content bg-neutral-background shadow-none font-bold text-2xl',
     $$props.class,
   );
 

--- a/packages/bridge-ui-v2/src/i18n/en.json
+++ b/packages/bridge-ui-v2/src/i18n/en.json
@@ -72,7 +72,7 @@
     "none": {
       "label": "None",
       "text": "Use ETH to manually claim your bridged token later",
-      "warning": "This option cannot be selected. You have not enough ETH to cover the gas fees for claiming."
+      "warning": "Insufficient ETH to cover the gas fees for claiming."
     },
     "custom": {
       "label": "Custom",
@@ -189,7 +189,11 @@
     },
     "address_input": {
       "label": "Address",
-      "placeholder": "Enter an address"
+      "placeholder": "Enter an address",
+      "errors": {
+        "invalid": "Invalid address format"
+      },
+      "success": "Valid address format"
     },
     "amount": {
       "label": "Amount",

--- a/packages/bridge-ui-v2/src/libs/token/getAddress.test.ts
+++ b/packages/bridge-ui-v2/src/libs/token/getAddress.test.ts
@@ -1,4 +1,4 @@
-import { type Address, getContract, type GetContractResult } from '@wagmi/core';
+import { getContract, type GetContractResult } from '@wagmi/core';
 
 import { PUBLIC_L1_CHAIN_ID, PUBLIC_L2_CHAIN_ID } from '$env/static/public';
 

--- a/packages/bridge-ui-v2/src/styles/components.css
+++ b/packages/bridge-ui-v2/src/styles/components.css
@@ -165,5 +165,8 @@
     backdrop-filter: blur(10px);
   }
 
+  input {
+    border: 1px solid var(--border-dark-primary, #5d636f);
+  }
   /* TODO: add more components here */
 }


### PR DESCRIPTION
Update and integrate the address component. Validates the address a user enters to be a valid Ethereum Address. 
Aligned some styles to new design.

Using this now in the custom recipient: recipient can only be set if the validations pass.

Previously only used in custom tokens.