### PR TITLE
feat(protocol): allow Taiko token as L2 fee token

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -75,7 +75,7 @@
 * **protocol:** fix `TaikoL1.init()` call arguments in `DeployOnL1` script ([#13774](https://github.com/taikoxyz/taiko-mono/issues/13774)) ([7bffff4](https://github.com/taikoxyz/taiko-mono/commit/7bffff40494c734acc880a976056a24cdea63749))
 * **protocol:** Fix name mismatch(build) issue ([#13803](https://github.com/taikoxyz/taiko-mono/issues/13803)) ([e55e39a](https://github.com/taikoxyz/taiko-mono/commit/e55e39a7652e0af484dab9ac58cb2d3e8a668c38))
 * **protocol:** rename treasure to treasury ([#13780](https://github.com/taikoxyz/taiko-mono/issues/13780)) ([ccecd70](https://github.com/taikoxyz/taiko-mono/commit/ccecd708276bce3eca84b92c7c48c95b2156dd18))
-* **protocol:** Replace LibEthDeposit assembly ([#13781](https://github.com/taikoxyz/taiko-mono/issues/13781)) ([285c756](https://github.com/taikoxyz/taiko-mono/commit/285c756c270fa4041c10aa06d95e2067fcc1b69f))
+* **protocol:** Replace LibFeeTokenDeposit assembly ([#13781](https://github.com/taikoxyz/taiko-mono/issues/13781)) ([285c756](https://github.com/taikoxyz/taiko-mono/commit/285c756c270fa4041c10aa06d95e2067fcc1b69f))
 * **relayer:** Out of gas ([#13778](https://github.com/taikoxyz/taiko-mono/issues/13778)) ([a42a33b](https://github.com/taikoxyz/taiko-mono/commit/a42a33b30bc0daec707ff51cc639c966642e50ca))
 
 ## [0.7.0](https://github.com/taikoxyz/taiko-mono/compare/protocol-v0.6.1...protocol-v0.7.0) (2023-05-11)

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -57,20 +57,21 @@ library TaikoData {
         // ---------------------------------------------------------------------
         // Group 4: ETH deposit related configs
         // ---------------------------------------------------------------------
+        bool feeTokenIsEther;
         // The size of the ETH deposit ring buffer.
-        uint256 ethDepositRingBufferSize;
+        uint256 feeTokenDepositRingBufferSize;
         // The minimum number of ETH deposits allowed per block.
-        uint64 ethDepositMinCountPerBlock;
+        uint64 feeTokenDepositMinCountPerBlock;
         // The maximum number of ETH deposits allowed per block.
-        uint64 ethDepositMaxCountPerBlock;
+        uint64 feeTokenDepositMaxCountPerBlock;
         // The minimum amount of ETH required for a deposit.
-        uint96 ethDepositMinAmount;
+        uint96 feeTokenDepositMinAmount;
         // The maximum amount of ETH allowed for a deposit.
-        uint96 ethDepositMaxAmount;
+        uint96 feeTokenDepositMaxAmount;
         // The gas cost for processing an ETH deposit.
-        uint256 ethDepositGas;
+        uint256 feeTokenDepositGas;
         // The maximum fee allowed for an ETH deposit.
-        uint256 ethDepositMaxFee;
+        uint256 feeTokenDepositMaxFee;
     }
 
     /// @dev Struct holding state variables.
@@ -79,8 +80,8 @@ library TaikoData {
         uint64 genesisTimestamp;
         uint64 numBlocks;
         uint64 lastVerifiedBlockId;
-        uint64 nextEthDepositToProcess;
-        uint64 numEthDeposits;
+        uint64 nextFeeTokenDepositToProcess;
+        uint64 numFeeTokenDeposits;
     }
 
     /// @dev Struct representing input data for block metadata.
@@ -113,7 +114,7 @@ library TaikoData {
         uint24 txListByteEnd;
         uint32 gasLimit;
         address beneficiary;
-        TaikoData.EthDeposit[] depositsProcessed;
+        TaikoData.FeeTokenDeposit[] depositsProcessed;
     }
 
     /// @dev Struct representing block evidence.
@@ -157,7 +158,7 @@ library TaikoData {
     }
 
     /// @dev Struct representing an Ethereum deposit.
-    struct EthDeposit {
+    struct FeeTokenDeposit {
         address recipient;
         uint96 amount;
         uint64 id;
@@ -171,13 +172,13 @@ library TaikoData {
     struct SlotA {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
-        uint64 numEthDeposits;
-        uint64 nextEthDepositToProcess;
+        uint64 numFeeTokenDeposits;
+        uint64 nextFeeTokenDepositToProcess;
     }
 
     struct SlotB {
         uint64 numBlocks;
-        uint64 nextEthDepositToProcess;
+        uint64 nextFeeTokenDepositToProcess;
         uint64 lastVerifiedAt;
         uint64 lastVerifiedBlockId;
     }
@@ -192,8 +193,8 @@ library TaikoData {
         mapping(uint64 blockId => mapping(uint16 transitionId => Transition))
             transitions;
         mapping(bytes32 txListHash => TxListInfo) txListInfo;
-        mapping(uint256 depositId_mode_ethDepositRingBufferSize => uint256)
-            ethDeposits;
+        mapping(uint256 depositId_mode_feeTokenDepositRingBufferSize => uint256)
+            feeTokenDeposits;
         mapping(address account => uint256 balance) taikoTokenBalances;
         SlotA slotA; // slot 7
         SlotB slotB; // slot 8

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -20,8 +20,8 @@ abstract contract TaikoErrors {
     error L1_INVALID_ASSIGNMENT();
     error L1_INVALID_BLOCK_ID();
     error L1_INVALID_CONFIG();
-    error L1_INVALID_ETH_DEPOSIT();
     error L1_INVALID_EVIDENCE();
+    error L1_INVALID_FEE_TOKEN_DEPOSIT();
     error L1_INVALID_METADATA();
     error L1_INVALID_ORACLE_PROVER();
     error L1_INVALID_PARAM();

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -54,5 +54,5 @@ abstract contract TaikoEvents {
     /// @dev Emitted when an Ethereum deposit is made.
     /// @param deposit The Ethereum deposit information including recipient,
     /// amount, and ID.
-    event EthDeposited(TaikoData.EthDeposit deposit);
+    event FeeTokenDeposited(TaikoData.FeeTokenDeposit deposit);
 }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -37,13 +37,14 @@ contract TaikoL1 is TaikoL1Base {
             proofWindow: 90 minutes,
             proofBond: 1024e18,
             skipProverAssignmentVerificaiton: false,
-            ethDepositRingBufferSize: 1024,
-            ethDepositMinCountPerBlock: 8,
-            ethDepositMaxCountPerBlock: 32,
-            ethDepositMinAmount: 1 ether,
-            ethDepositMaxAmount: 10_000 ether,
-            ethDepositGas: 21_000,
-            ethDepositMaxFee: 1 ether / 10
+            feeTokenIsEther: true,
+            feeTokenDepositRingBufferSize: 1024,
+            feeTokenDepositMinCountPerBlock: 8,
+            feeTokenDepositMaxCountPerBlock: 32,
+            feeTokenDepositMinAmount: 1 ether,
+            feeTokenDepositMaxAmount: 10_000 ether,
+            feeTokenDepositGas: 21_000,
+            feeTokenDepositMaxFee: 1 ether / 10
         });
     }
 }

--- a/packages/protocol/contracts/L1/TaikoL1Base.sol
+++ b/packages/protocol/contracts/L1/TaikoL1Base.sol
@@ -42,7 +42,10 @@ abstract contract TaikoL1Base is
 
     /// @dev Fallback function to receive Ether and deposit to to Layer 2.
     receive() external payable {
-        require(getConfig().feeTokenIsEther, "");
+        if (!getConfig().feeTokenIsEther) {
+            revert L1_INVALID_FEE_TOKEN_DEPOSIT();
+        }
+
         depositL2FeeToken(address(0), msg.value.toUint96());
     }
 

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -169,8 +169,9 @@ library LibProposing {
             meta.txListByteEnd = input.txListByteEnd;
             meta.gasLimit = config.blockMaxGasLimit;
             meta.beneficiary = input.beneficiary;
-            meta.depositsProcessed =
-                LibDepositing.processDeposits(state, config, input.beneficiary);
+            meta.depositsProcessed = LibDepositing.processFeeTokenDeposits(
+                state, config, input.beneficiary
+            );
 
             // Init the block
             TaikoData.Block storage blk =

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -66,8 +66,9 @@ library LibUtils {
             genesisTimestamp: a.genesisTimestamp,
             numBlocks: b.numBlocks,
             lastVerifiedBlockId: b.lastVerifiedBlockId,
-            nextEthDepositToProcess: a.nextEthDepositToProcess,
-            numEthDeposits: a.numEthDeposits - a.nextEthDepositToProcess
+            nextFeeTokenDepositToProcess: a.nextFeeTokenDepositToProcess,
+            numFeeTokenDeposits: a.numFeeTokenDeposits
+                - a.nextFeeTokenDepositToProcess
         });
     }
 
@@ -85,7 +86,7 @@ library LibUtils {
         inputs[1] = uint256(meta.l1Hash);
         inputs[2] = uint256(meta.mixHash);
         inputs[3] =
-            uint256(LibDepositing.hashEthDeposits(meta.depositsProcessed));
+            uint256(LibDepositing.hashFeeTokenDeposits(meta.depositsProcessed));
         inputs[4] = uint256(meta.txListHash);
 
         inputs[5] = (uint256(meta.txListByteStart) << 232)

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -49,17 +49,19 @@ library LibVerifying {
                 || config.proofRegularCooldown < config.proofOracleCooldown
                 || config.proofWindow == 0 || config.proofBond == 0
                 || config.proofBond < 10 * config.proposerRewardPerSecond
-                || config.ethDepositRingBufferSize <= 1
-                || config.ethDepositMinCountPerBlock == 0
-                || config.ethDepositMaxCountPerBlock
-                    < config.ethDepositMinCountPerBlock
-                || config.ethDepositMinAmount == 0
-                || config.ethDepositMaxAmount <= config.ethDepositMinAmount
-                || config.ethDepositMaxAmount >= type(uint96).max
-                || config.ethDepositGas == 0 || config.ethDepositMaxFee == 0
-                || config.ethDepositMaxFee >= type(uint96).max
-                || config.ethDepositMaxFee
-                    >= type(uint96).max / config.ethDepositMaxCountPerBlock
+                || config.feeTokenDepositRingBufferSize <= 1
+                || config.feeTokenDepositMinCountPerBlock == 0
+                || config.feeTokenDepositMaxCountPerBlock
+                    < config.feeTokenDepositMinCountPerBlock
+                || config.feeTokenDepositMinAmount == 0
+                || config.feeTokenDepositMaxAmount
+                    <= config.feeTokenDepositMinAmount
+                || config.feeTokenDepositMaxAmount >= type(uint96).max
+                || config.feeTokenDepositGas == 0
+                || config.feeTokenDepositMaxFee == 0
+                || config.feeTokenDepositMaxFee >= type(uint96).max
+                || config.feeTokenDepositMaxFee
+                    >= type(uint96).max / config.feeTokenDepositMaxCountPerBlock
         ) revert L1_INVALID_CONFIG();
 
         unchecked {

--- a/packages/protocol/docs/how_taiko_proves_blocks.md
+++ b/packages/protocol/docs/how_taiko_proves_blocks.md
@@ -87,7 +87,7 @@ struct BlockMetadata {
  uint32 gasLimit;
  address beneficiary;
  address treasury;
- TaikoData.EthDeposit[] depositsProcessed;
+ TaikoData.FeeTokenDeposit[] depositsProcessed;
 }
 ```
 
@@ -264,7 +264,7 @@ m_treasury(treasury)
 m_beneficiary(beneficiary)
 l2_treasury("L2 basefee goes to treasury"):::constant;
 tx_list("txList\n(blob or calldata)"):::constant;
-m_processed_deposits("ethDepositsProcessed"):::constant
+m_processed_deposits("feeTokenDepositsProcessed"):::constant
 end
 
 BlockMetadata:::group

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -227,10 +227,10 @@ abstract contract TaikoL1TestBase is TestBase {
 
         str = string.concat(
             str,
-            " nextEthDepositToProcess:",
-            Strings.toString(vars.nextEthDepositToProcess),
-            " numEthDeposits:",
-            Strings.toString(vars.numEthDeposits),
+            " nextFeeTokenDepositToProcess:",
+            Strings.toString(vars.nextFeeTokenDepositToProcess),
+            " numFeeTokenDeposits:",
+            Strings.toString(vars.numFeeTokenDeposits),
             " // ",
             comment
         );

--- a/packages/protocol/test/misc/GasComparison.t.sol
+++ b/packages/protocol/test/misc/GasComparison.t.sol
@@ -87,7 +87,7 @@ contract FooBar {
             gasLimit: 1,
             mixHash: bytes32(uint256(1)),
             timestamp: 1,
-            depositsProcessed: new TaikoData.EthDeposit[](0)
+            depositsProcessed: new TaikoData.FeeTokenDeposit[](0)
         });
     }
 
@@ -103,7 +103,7 @@ contract FooBar {
             gasLimit: 1,
             mixHash: bytes32(uint256(1)),
             timestamp: 1,
-            depositsProcessed: new TaikoData.EthDeposit[](0)
+            depositsProcessed: new TaikoData.FeeTokenDeposit[](0)
         });
     }
 


### PR DESCRIPTION
Note that this is only the first step necessary. The bridge also needs to be changed so Ether on L2 will be wrapped as a BridgedERC20 token.

At this point, I think it may not be worthy it to support "Taiko token as the L2 fee token" due to unnecessary implementation complexity. @Brechtpd what do you think?