### PR TITLE
fix(protocol): change transition ID from uint16 to uint32

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -142,11 +142,11 @@ library TaikoData {
     struct Block {
         bytes32 metaHash; // slot 1
         address prover; // slot 2
-        uint64 proposedAt;
-        uint16 nextTransitionId;
-        uint16 verifiedTransitionId;
-        uint64 blockId; // slot 3
         uint96 proofBond;
+        uint64 blockId; // slot 3
+        uint64 proposedAt;
+        uint32 nextTransitionId;
+        uint32 verifiedTransitionId;
         uint16 proofWindow;
     }
 
@@ -187,9 +187,9 @@ library TaikoData {
         // Ring buffer for proposed blocks and a some recent verified blocks.
         mapping(uint64 blockId_mode_blockRingBufferSize => Block) blocks;
         mapping(
-            uint64 blockId => mapping(bytes32 parentHash => uint16 transitionId)
+            uint64 blockId => mapping(bytes32 parentHash => uint32 transitionId)
             ) transitionIds;
-        mapping(uint64 blockId => mapping(uint16 transitionId => Transition))
+        mapping(uint64 blockId => mapping(uint32 transitionId => Transition))
             transitions;
         mapping(bytes32 txListHash => TxListInfo) txListInfo;
         mapping(uint256 depositId_mode_ethDepositRingBufferSize => uint256)

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -175,13 +175,14 @@ library LibProposing {
             // Init the block
             TaikoData.Block storage blk =
                 state.blocks[b.numBlocks % config.blockRingBufferSize];
+
             blk.metaHash = LibUtils.hashMetadata(meta);
             blk.prover = assignment.prover;
+            blk.proofBond = config.proofBond;
+            blk.blockId = meta.id;
             blk.proposedAt = meta.timestamp;
             blk.nextTransitionId = 1;
             blk.verifiedTransitionId = 0;
-            blk.blockId = meta.id;
-            blk.proofBond = config.proofBond;
             blk.proofWindow = config.proofWindow;
 
             emit BlockProposed({

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -84,7 +84,7 @@ library LibProving {
         }
 
         TaikoData.Transition storage tz;
-        uint16 tid =
+        uint32 tid =
             LibUtils.getTransitionId(state, blk, blockId, evidence.parentHash);
 
         if (tid == 0) {
@@ -152,7 +152,7 @@ library LibProving {
             state.blocks[blockId % config.blockRingBufferSize];
         if (blk.blockId != blockId) revert L1_BLOCK_ID_MISMATCH();
 
-        uint16 tid = LibUtils.getTransitionId(state, blk, blockId, parentHash);
+        uint32 tid = LibUtils.getTransitionId(state, blk, blockId, parentHash);
         if (tid == 0) revert L1_TRANSITION_NOT_FOUND();
 
         tz = state.transitions[blockId][tid];

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -40,7 +40,7 @@ library LibUtils {
     )
         internal
         view
-        returns (uint16 tid)
+        returns (uint32 tid)
     {
         if (state.transitions[blk.blockId][1].key == parentHash) {
             tid = 1;

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -105,7 +105,7 @@ library LibVerifying {
             state.blocks[blockId % config.blockRingBufferSize];
         if (blk.blockId != blockId) revert L1_BLOCK_ID_MISMATCH();
 
-        uint16 tid = blk.verifiedTransitionId;
+        uint32 tid = blk.verifiedTransitionId;
         if (tid == 0) revert L1_UNEXPECTED_TRANSITION_ID();
 
         bytes32 blockHash = state.transitions[blockId][tid].blockHash;


### PR DESCRIPTION
This PR address this comment from Brecht: https://github.com/taikoxyz/taiko-mono/pull/14565#discussion_r1310433846

I think uint24 should be good enough, but the storage layout is the same as using uint32.