### PR TITLE
feat(protocol): reduce eldfell `MIN_CAPACITY` config to `5`

### DIFF
--- a/packages/protocol/contracts/L1/ProverPool.sol
+++ b/packages/protocol/contracts/L1/ProverPool.sol
@@ -44,7 +44,7 @@ contract ProverPool is EssentialContract, IProverPool {
     // can support 1 block per second with an average proof time of 1 hour,
     // then we need a min capacity of 3600, which means each prover shall
     // provide a capacity of at least 3600/32=112.
-    uint32 public constant MIN_CAPACITY = 32;
+    uint32 public constant MIN_CAPACITY = 5;
     uint64 public constant EXIT_PERIOD = 1 weeks;
     uint64 public constant SLASH_POINTS = 25; // basis points or 0.25%
     uint64 public constant SLASH_MULTIPLIER = 4;

--- a/packages/website/pages/docs/reference/contract-documentation/L1/IProverPool.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/IProverPool.md
@@ -19,5 +19,5 @@ function releaseProver(address prover) external
 ### slashProver
 
 ```solidity
-function slashProver(address prover) external
+function slashProver(address prover, uint64 proofReward) external
 ```

--- a/packages/website/pages/docs/reference/contract-documentation/L1/ProverPool.md
+++ b/packages/website/pages/docs/reference/contract-documentation/L1/ProverPool.md
@@ -37,10 +37,10 @@ struct Staker {
 }
 ```
 
-### MAX_CAPACITY_LOWER_BOUND
+### MIN_CAPACITY
 
 ```solidity
-uint32 MAX_CAPACITY_LOWER_BOUND
+uint32 MIN_CAPACITY
 ```
 
 ### EXIT_PERIOD
@@ -55,16 +55,16 @@ uint64 EXIT_PERIOD
 uint64 SLASH_POINTS
 ```
 
+### SLASH_MULTIPLIER
+
+```solidity
+uint64 SLASH_MULTIPLIER
+```
+
 ### MIN_STAKE_PER_CAPACITY
 
 ```solidity
 uint64 MIN_STAKE_PER_CAPACITY
-```
-
-### MIN_SLASH_AMOUNT
-
-```solidity
-uint64 MIN_SLASH_AMOUNT
 ```
 
 ### MAX_NUM_PROVERS
@@ -203,16 +203,17 @@ _Increases the capacity of the prover by releasing a prover._
 ### slashProver
 
 ```solidity
-function slashProver(address addr) external
+function slashProver(address addr, uint64 proofReward) external
 ```
 
 _Slashes a prover._
 
 #### Parameters
 
-| Name | Type    | Description                         |
-| ---- | ------- | ----------------------------------- |
-| addr | address | The address of the prover to slash. |
+| Name        | Type    | Description                         |
+| ----------- | ------- | ----------------------------------- |
+| addr        | address | The address of the prover to slash. |
+| proofReward | uint64  |                                     |
 
 ### stake
 


### PR DESCRIPTION
ZKpool suggested that we need to decrease our a4 prover capacity (`32` at this point) since its seems too large for every testnet prover at this point.