### PR TITLE
Update run-a-taiko-node.mdx

### DIFF
--- a/packages/website/pages/docs/guides/run-a-node/run-a-taiko-node.mdx
+++ b/packages/website/pages/docs/guides/run-a-node/run-a-taiko-node.mdx
@@ -154,13 +154,13 @@ Make sure Docker is running and then run the following command to start the node
 For a Grimsvotn L2 node:
 
 ```sh
-sudo docker compose up -d
+docker compose up -d
 ```
 
 For an Eldfell L3 node:
 
 ```sh
-sudo docker compose -f ./docker-compose.l3.yml --env-file .env.l3 up -d
+docker compose -f ./docker-compose.l3.yml --env-file .env.l3 up -d
 ```
 
 ### Verify node is running


### PR DESCRIPTION
Avoid Using Sudo: Generally, we don't need to use sudo for Docker commands on a personal machine, especially on MacOS. The Docker daemon itself should run with elevated privileges, but individual commands shouldn't require sudo. I removed the sudo and it worked nicely.