### PR TITLE
chore(repo): Add Solc Download Suite for PlonkVerifier Compilation

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -21,7 +21,8 @@
     "test": "forge test -vvv --gas-report --fuzz-seed $(date +%s) --nmp test/L1/TaikoL1.sim.sol",
     "test:coverage": "forge coverage --report lcov",
     "test:genesis": "./genesis/generate_genesis.test.sh",
-    "upgrade": "./script/upgrade_to.sh"
+    "upgrade": "./script/upgrade_to.sh",
+    "install:solc": "mkdir -p ./bin && curl -o ./bin/solc https://github.com/ethereum/solidity/releases/download/v0.8.18/solc-static-linux && chmod +x ./bin/solc"
   },
   "keywords": [
     "ZKP",

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -216,7 +216,7 @@ contract DeployOnL1 is Script {
         cmds[1] = "-c";
         cmds[2] = string.concat(
             vm.projectRoot(),
-            "/bin/solc --yul --bin ",
+            "/bin/solc --yul --bin ", //Ensure solc exists in ./protocol/bin by running pnpm install:solc
             string.concat(vm.projectRoot(), "/", contractPath),
             " | grep -A1 Binary | tail -1"
         );


### PR DESCRIPTION
Although the issue [taiko-mono/pull/13970](https://github.com/taikoxyz/taiko-mono/pull/13970) upgraded all contract code to use Solidity version 0.8.20, the PlonkVerifier still only compiles with version 0.8.18. Also, its solc environment is separate and located in ./protocol/bin/solc. I think it's important to give a heads-up to others about this. Currently, it's unclear why version 0.8.20 can't compile the PlonkVerifier's Yul files. I'll propose a more optimized solution once I figure it out.