### PR TITLE
chore(bridge-ui-v2): fix Chainselector styling weird sometimes

### DIFF
--- a/packages/bridge-ui-v2/src/components/ChainSelector/ChainSelector.svelte
+++ b/packages/bridge-ui-v2/src/components/ChainSelector/ChainSelector.svelte
@@ -142,7 +142,7 @@
         <Icon type="x-close" fillClass="fill-secondary-icon" size={24} />
       </button>
       <h3 class="title-body-bold mb-[20px]">{$t('chain_selector.placeholder')}</h3>
-      <ul role="menu">
+      <ul role="menu" class="min-w-full">
         {#each chains as chain (chain.id)}
           {@const disabled = validOptions
             ? !validOptions.some((validOption) => validOption.id === chain.id)


### PR DESCRIPTION
Before
![before-select-chain](https://github.com/taikoxyz/taiko-mono/assets/104292916/42fe4e6d-83ff-4669-b360-9c12c44e166a)

After

<img width="481" alt="Screen Shot 2023-09-06 at 4 05 15 PM" src="https://github.com/taikoxyz/taiko-mono/assets/104292916/edec72d9-7a68-4e05-b5e0-3e4301be1471">
