### PR TITLE
fix(protocol): Remove duplicated events during mint and burn

### DIFF
--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -179,7 +179,6 @@ contract TaikoToken is
         override(ERC20Upgradeable, ERC20VotesUpgradeable)
     {
         super._mint(to, amount);
-        emit Transfer(address(0), to, amount);
     }
 
     function _burn(
@@ -190,7 +189,6 @@ contract TaikoToken is
         override(ERC20Upgradeable, ERC20VotesUpgradeable)
     {
         super._burn(from, amount);
-        emit Transfer(from, address(0), amount);
     }
 }
 


### PR DESCRIPTION
Remove duplicated events (ERC20Upgradeable already sending them).
See in TXN example: https://sepolia.etherscan.io/tx/0x4e2874dad191489c4397c760ced786713897f322b345e36e4b563f44dc9d9020

It says 2 x 1 TTKOj token transfers:
![kép](https://github.com/taikoxyz/taiko-mono/assets/51912515/56e23ad1-d579-4888-82c5-9f33f9535698)

When I look at the logs, it also says 2 Transfer events:
![kép](https://github.com/taikoxyz/taiko-mono/assets/51912515/c426b35e-98a8-4045-97cd-970fcb26ac40)

One is coming from our TaikoToken directly (burn) the other is from ERC20Upgradeable.