### PR TITLE
feat(protocol): Hybrid logic implementation

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -78,6 +78,7 @@ library TaikoData {
     struct TierData {
         uint8 id; // Example: 0 - none; 1 - OP; 2 - SGX; 3 - ZK; etc.
         // The cooldown period for regular proofs (in minutes).
+        // Serves as "challenge window"
         uint256 proofRegularCooldown;
         // The cooldown period for oracle proofs (in minutes).
         uint256 proofOracleCooldown;
@@ -162,7 +163,7 @@ library TaikoData {
         address challenger; // slot 5
         uint96 challengerBond;
         uint64 provenAt; // slot 6 (144 bits)
-        uint64 challengedAt;
+        uint64 challengedAt; // Todo: Do we really need this one ?
         uint8 tier;
         bytes32[4] __reserved;
     }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -56,7 +56,7 @@ contract TaikoL1 is TaikoL1Base {
         returns (TaikoData.TierConfig memory tierConfig)
     {
         tierConfig.tierData[LibTransition.TIER_ID_NONE] = TaikoData.TierData({
-            id : LibTransition.TIER_ID_NONE,
+            id: LibTransition.TIER_ID_NONE,
             proofRegularCooldown: 60 minutes,
             proofOracleCooldown: 30 minutes,
             proofWindow: 60 minutes,
@@ -65,7 +65,7 @@ contract TaikoL1 is TaikoL1Base {
         });
 
         tierConfig.tierData[LibTransition.TIER_ID_1] = TaikoData.TierData({
-            id : LibTransition.TIER_ID_1,
+            id: LibTransition.TIER_ID_1,
             proofRegularCooldown: 60 minutes,
             proofOracleCooldown: 30 minutes,
             proofWindow: 60 minutes,
@@ -74,16 +74,17 @@ contract TaikoL1 is TaikoL1Base {
         });
 
         tierConfig.tierData[LibTransition.TIER_ID_2] = TaikoData.TierData({
-            id : LibTransition.TIER_ID_2,
+            id: LibTransition.TIER_ID_2,
             proofRegularCooldown: 60 minutes,
             proofOracleCooldown: 30 minutes,
             proofWindow: 60 minutes,
             proverBond: 10_240e18,
-            challengerBond: 15_240e18 // Still can challange, but then it goes to 'GUARDIAN' level
-        });
+            challengerBond: 15_240e18 // Still can challange, but then it goes
+                // to 'GUARDIAN' level
+         });
 
         tierConfig.tierData[LibTransition.TIER_ID_GUARDIAN] = TaikoData.TierData({
-            id : LibTransition.TIER_ID_GUARDIAN,
+            id: LibTransition.TIER_ID_GUARDIAN,
             proofRegularCooldown: 60 minutes,
             proofOracleCooldown: 30 minutes,
             proofWindow: 60 minutes,

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -133,9 +133,10 @@ library LibVerifying {
 
                 TaikoData.Transition storage tran = state.transitions[slot][tid];
 
-                if(tran.challenger != address(0)) break;
+                if (tran.challenger != address(0)) break;
 
-                (uint256 proofRegular, uint256 proofOracle) = LibTransition.getTierCooldownPeriod(tierConfig, tran.tier);
+                (uint256 proofRegular, uint256 proofOracle) =
+                    LibTransition.getTierCooldownPeriod(tierConfig, tran.tier);
 
                 uint256 proofCooldown = tran.prover == LibUtils.ORACLE_PROVER
                     ? proofOracle


### PR DESCRIPTION
As per our discussion with Daniel today (15th sept) the following is the 'agenda' implementing this tunable hybrid solution:

Tasks (in chronological order):

**LibProving.sol** (+LibTransition.sol): (No focus on changing LibProposing or LibVerification for this stage)

- [x] For simplification, remove assigned prover privileges in LibProving (that he/she can be the first prover. !! Need to add back later !!)
- [x] For the same reasons, remove OracleProver related code sections
- [x] Build a simple, working logic which can: 

   - Register first transition/fork choice per given parentHash
   - Challenge transition per given parentHash
   - Answer with a (higher tier than previous) proof to a challenged transition

- [ ] Add back privilages of the assigned prover

- [ ]  Incorporate GUARDIAN (previously Oracle) prover (to challenge and proof even 1 TXN AND multiple times if necessary)

- [ ]  LibVerification.sol / LibProposing.sol / TaikoData.sol revisit:

   - Necessary, implied changes in LibVerification or LibProposing ?
   - Unused data to throw out from TaikoData

- [ ]  Make tier config flexible in a way, that in case 1: OP, 2: ZK, 3: MultiZK is the current one, but we want to upgrade the code and have SGX on the second place, than easily do so with a (separate config) contract upgrade without modifying the unverified blocks. (+ also "roll-the-dice" algorithm so that ppl can fine tune these 'chances' for their app/hybrid chains.)

- [ ] Tests