### PR TITLE
chore(bridge-ui-v2): clean amount warning  when left bridge page

### DIFF
--- a/packages/bridge-ui-v2/src/components/Bridge/Amount.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/Amount.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { t } from 'svelte-i18n';
   import { formatUnits, parseUnits } from 'viem';
 
@@ -35,6 +36,10 @@
   let inputId = `input-${uid()}`;
   let inputBox: InputBox;
   let computingMaxAmount = false;
+
+  onDestroy(() => {
+    clearAmount();
+  });
 
   // Public API
   export function clearAmount() {


### PR DESCRIPTION
Fix the warning. It should not have a warning when the input text field for amount is empty. 

![Screen Shot 2023-09-16 at 10 57 50 PM](https://github.com/taikoxyz/taiko-mono/assets/104292916/0ca7d1a4-4ebc-474f-8220-fca6ee42908b)
