### PR TITLE
feat(relayer): support L2-L2 bridging

### DIFF
--- a/packages/relayer/indexer/handle_event.go
+++ b/packages/relayer/indexer/handle_event.go
@@ -30,6 +30,8 @@ func (i *Indexer) handleEvent(
 			"indexerDestChainID",
 			i.destChainId.Uint64(),
 		)
+
+		return nil
 	}
 
 	if err := i.detectAndHandleReorg(ctx, relayer.EventNameMessageSent, common.Hash(event.MsgHash).Hex()); err != nil {

--- a/packages/relayer/mock/bridge.go
+++ b/packages/relayer/mock/bridge.go
@@ -61,7 +61,7 @@ func (b *Bridge) WatchMessageSent(
 		sink <- &bridge.BridgeMessageSent{
 			Message: bridge.IBridgeMessage{
 				SrcChainId:  big.NewInt(1),
-				DestChainId: big.NewInt(1),
+				DestChainId: MockChainID,
 			},
 		}
 		b.MessagesSent++

--- a/packages/relayer/mock/bridge.go
+++ b/packages/relayer/mock/bridge.go
@@ -60,7 +60,8 @@ func (b *Bridge) WatchMessageSent(
 
 		sink <- &bridge.BridgeMessageSent{
 			Message: bridge.IBridgeMessage{
-				SrcChainId: big.NewInt(1),
+				SrcChainId:  big.NewInt(1),
+				DestChainId: big.NewInt(1),
 			},
 		}
 		b.MessagesSent++


### PR DESCRIPTION
all thats needed for L2-L2 bridging is to check the destination chain ID of a message before indexing on the source chain, to avoid it being added to the wrong queue. Then, one can simply bring up a new pair of indexer/processors for the L2 chains.