### PR TITLE
fix(bridge-ui-v2): update mint button state

### DIFF
--- a/packages/bridge-ui-v2/src/components/Faucet/Faucet.svelte
+++ b/packages/bridge-ui-v2/src/components/Faucet/Faucet.svelte
@@ -95,6 +95,7 @@
       }
     } finally {
       minting = false;
+      updateMintButtonState(connected, selectedToken, $network);
     }
   }
 


### PR DESCRIPTION
The button now no longer remains clickable after minting a token.