### PR TITLE
fix(website): Fix error in curl command results

### DIFF
--- a/packages/website/pages/docs/guides/run-a-sepolia-node.mdx
+++ b/packages/website/pages/docs/guides/run-a-sepolia-node.mdx
@@ -71,7 +71,7 @@ curl http://localhost:8545 \
 which should return chainId = 0xaa36a7 = 11155111
 
 ```json
-{ "jsonrpc": "2.0", "id": 0, "result": "0xaa36a7" }
+{ "jsonrpc": "2.0", "id": 1, "result": "0xaa36a7" }
 ```
 
 Wait for your Consensus Layer client to fully sync by checking


### PR DESCRIPTION
The ID specified in the curl command matches the ID displayed in the results. Please correct this as it may be incorrectly identified if the results are incorrect.