### PR TITLE
fix(bridge-ui-v2): improve claim message when not enough funds

### DIFF
--- a/packages/bridge-ui-v2/src/i18n/en.json
+++ b/packages/bridge-ui-v2/src/i18n/en.json
@@ -150,7 +150,7 @@
       }
     },
     "errors": {
-      "insufficient_balance": "Insufficient balance to claim. Please add some ETH to your wallet.",
+      "insufficient_balance": "Insufficient balance to claim yourself. Please wait for the relayer to claim for you automatically. Refer to our guide for more information.",
       "relayer_offline": "Relayer did not respond. Your transactions may only be loaded partially."
     }
   },


### PR DESCRIPTION
The message now clearly states, the relayer will do the claiming:

`Insufficient balance to claim yourself. Please wait for the relayer to claim for you automatically. Refer to our guide for more information.`