### PR TITLE
fix(docs): fix error in curl command results in Run a Taiko node

### DIFF
--- a/packages/website/pages/docs/guides/run-a-taiko-node.mdx
+++ b/packages/website/pages/docs/guides/run-a-taiko-node.mdx
@@ -170,7 +170,7 @@ curl http://localhost:8547 \
 which should return the chainId as `0x28c5d` (167005):
 
 ```json
-{ "jsonrpc": "2.0", "id": 0, "result": "0x28c5d" }
+{ "jsonrpc": "2.0", "id": 1, "result": "0x28c5d" }
 ```
 
 2. Check if the Execution Layer client is synced by requesting the latest Taiko L2 / L3 block from the Execution Layer client:


### PR DESCRIPTION
The ID specified in the curl command matches the ID displayed in the results. Please correct this as it may be incorrectly identified if the results are incorrect.