### PR TITLE
fix(relayer): Relayer paid gas

### DIFF
--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -61,6 +61,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
 
       - name: Login to GCR
         uses: docker/login-action@v2

--- a/packages/relayer/processor/estimate_gas.go
+++ b/packages/relayer/processor/estimate_gas.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"log/slog"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -29,6 +30,8 @@ func (p *Processor) estimateGas(
 	if err != nil {
 		return 0, nil, errors.Wrap(err, "p.destBridge.ProcessMessage")
 	}
+
+	slog.Info("estimated gas", "gas", tx.Gas(), "paddingAmt", gasPaddingAmt)
 
 	return tx.Gas() + gasPaddingAmt, tx.Cost(), nil
 }

--- a/packages/relayer/processor/estimate_gas.go
+++ b/packages/relayer/processor/estimate_gas.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	gasPaddingAmt uint64 = 50000
+	gasPaddingAmt uint64 = 80000
 )
 
 func (p *Processor) estimateGas(

--- a/packages/relayer/processor/estimate_gas.go
+++ b/packages/relayer/processor/estimate_gas.go
@@ -9,6 +9,10 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
 )
 
+var (
+	gasPaddingAmt uint64 = 50000
+)
+
 func (p *Processor) estimateGas(
 	ctx context.Context, message bridge.IBridgeMessage, proof []byte) (uint64, *big.Int, error) {
 	auth, err := bind.NewKeyedTransactorWithChainID(p.ecdsaKey, message.DestChainId)
@@ -26,5 +30,5 @@ func (p *Processor) estimateGas(
 		return 0, nil, errors.Wrap(err, "p.destBridge.ProcessMessage")
 	}
 
-	return tx.Gas(), tx.Cost(), nil
+	return tx.Gas() + gasPaddingAmt, tx.Cost(), nil
 }

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -251,6 +251,8 @@ func (p *Processor) sendProcessMessageCall(
 			if err != nil {
 				return nil, errors.Wrap(err, "p.hardcodeGasLimit")
 			}
+		} else {
+			auth.GasLimit = gas
 		}
 	}
 


### PR DESCRIPTION
As in the previous testnets, about 1 in 200 transactions are failing due to running out of gas, but barely. This pad will ensure that the transactions all can be processed, even though the padding amount is overkill for mainnet.

Note that we are not running the relayer in `profitableOnly` mode, a further PR will be incoming to make sure that the total cost is calculated correctly to only process profitable transactions given this padding, which is too large now but ensures all testnet messages will be claimed.