### PR TITLE
chore(bridge-ui-v2): re-enable pre-commit hooks for bridge 

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,9 +5,9 @@ pre-commit:
     # bridge-ui:
     #   glob: "packages/bridge-ui/**.{js,svelte,ts}"
     #   run: pnpm -F bridge-ui lint:fix && git add {staged_files}
-    # bridge-ui-v2:
-    #   glob: "packages/bridge-ui-v2/**.{js,ts,css,svelte}"
-    #   run: pnpm -F bridge-ui-v2 svelte:check && pnpm -F bridge-ui-v2 lint:fix && git add {staged_files}
+    bridge-ui-v2:
+      glob: "packages/bridge-ui-v2/**.{js,ts,css,svelte}"
+      run: pnpm -F bridge-ui-v2 svelte:check && pnpm -F bridge-ui-v2 lint:fix && git add {staged_files}
     protocol_sol:
       glob: "packages/protocol/**.{sol}"
       run: pnpm -F protocol lint:sol && git add {staged_files}


### PR DESCRIPTION
I don't know why they were removed originally? @dantaik 