### PR TITLE
fix(bridge-ui-v2): validate amount only if component is mounted

### DIFF
--- a/packages/bridge-ui-v2/src/components/Bridge/Bridge.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/Bridge.svelte
@@ -296,7 +296,7 @@
       }
     }
   }
-  $: if ($selectedToken) {
+  $: if ($selectedToken && amountComponent) {
     amountComponent.validateAmount();
   }
 </script>


### PR DESCRIPTION
The bridge now only validates the amount when the selectedToken store updates, if the amount component is also mounted.