### PR TITLE
fix(protocol): Fix genesis tests

### DIFF
--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -23,6 +23,7 @@ fs_permissions = [
   { access = "read", path = "./out" },
   { access = "read-write", path = "./deployments" },
   { access = "read", path = "./test" },
+  { access = "read", path = "./genesis" },
 ]
 
 fuzz = { runs = 256 }
@@ -33,3 +34,6 @@ line_length = 80
 multiline_func_header = 'all'
 number_underscore = 'thousands'
 wrap_comments = true
+
+[profile.genesis]
+test = 'genesis'

--- a/packages/protocol/genesis/generate_genesis.test.sh
+++ b/packages/protocol/genesis/generate_genesis.test.sh
@@ -101,5 +101,5 @@ forge test \
   --fork-url http://localhost:18545 \
   --fork-retry-backoff 120 \
   --no-storage-caching \
-  --match-path $DIR/*.g.sol \
+  --match-path genesis/*.g.sol \
   --block-gas-limit 1000000000

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,7 +18,7 @@
     "snapshot": "forge snapshot --match-path 'test/**/*.t.sol'",
     "test": "forge test -vvv --gas-report --fuzz-seed $(date +%s) --nmp test/L1/TaikoL1.sim.sol",
     "test:coverage": "forge coverage --report lcov",
-    "test:genesis": "./genesis/generate_genesis.test.sh",
+    "test:genesis": "FOUNDRY_PROFILE=genesis ./genesis/generate_genesis.test.sh",
     "upgrade": "./script/upgrade_to.sh"
   },
   "keywords": [


### PR DESCRIPTION
2 problems we had with the currently new genesis tests:
- if we move a test outside of `test` folder, then we need to create a new profile (see `foundry.toml` and `package.json`)
- `forge test` script cannot handle string interpolation this way (see `generate_genesis.test.sh`)