### PR TITLE
fix(website): Correcting broken link

### DIFF
--- a/packages/website/pages/docs/reference/node-troubleshooting.mdx
+++ b/packages/website/pages/docs/reference/node-troubleshooting.mdx
@@ -169,7 +169,7 @@ This means that you are not able to connect to the RPC endpoint. Check if you ha
 
 #### `WARNING: Found orphan containers`
 
-You should not have orphan containers as the L2 and L3 image container names are different in each docker compose file. Check the [node runner manual](/docs/manual/node-runner-manual) for a command to remove orphan containers.
+You should not have orphan containers as the L2 and L3 image container names are different in each docker compose file. Check the [node runner manual](/docs/manuals/node-runner-manual) for a command to remove orphan containers.
 
 #### `WARN Snapshot extension registration failed err="peer connected on snap without compatible eth support"`
 


### PR DESCRIPTION
Incorrect:
https://taiko.xyz/docs/manual/node-runner-manual

Correct:
https://taiko.xyz/docs/manuals/node-runner-manual