### PR TITLE
feat(protocol): add extraData to proposed block

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -92,7 +92,7 @@ library TaikoData {
     /// {LibProposing.hashMetadata} accordingly.
     struct BlockMetadata {
         bytes32 l1Hash;
-        // On L2, `block.difficulty` is the pseuduo name of `block.prevrandao`,
+        // On L2, `block.difficulty` is the pseudo name of `block.prevrandao`,
         // which returns a random number provided by the layer 1 chain.
         bytes32 difficulty;
         bytes32 txListHash;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -92,8 +92,9 @@ library TaikoData {
     /// {LibProposing.hashMetadata} accordingly.
     struct BlockMetadata {
         bytes32 l1Hash;
-        bytes32 mixHash;
+        bytes32 difficulty;
         bytes32 txListHash;
+        bytes32 extraData;
         uint64 id;
         uint64 timestamp;
         uint64 l1Height;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -92,6 +92,8 @@ library TaikoData {
     /// {LibProposing.hashMetadata} accordingly.
     struct BlockMetadata {
         bytes32 l1Hash;
+        // On L2, `block.difficulty` is the pseuduo name of `block.prevrandao`,
+        // which returns a random number provided by the layer 1 chain.
         bytes32 difficulty;
         bytes32 txListHash;
         bytes32 extraData;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -73,6 +73,7 @@ contract TaikoL1 is
     /// @return meta The metadata of the proposed L2 block.
     function proposeBlock(
         bytes32 txListHash,
+        bytes32 extraData,
         bytes calldata assignment,
         bytes calldata txList
     )
@@ -87,6 +88,7 @@ contract TaikoL1 is
             config: config,
             resolver: AddressResolver(this),
             txListHash: txListHash,
+            extraData: extraData,
             assignment: abi.decode(assignment, (TaikoData.ProverAssignment)),
             txList: txList
         });

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -149,15 +149,15 @@ abstract contract TaikoL1TestBase is TestBase {
 
         TaikoData.StateVariables memory variables = L1.getStateVariables();
 
-        uint256 _mixHash;
+        uint256 _difficulty;
         unchecked {
-            _mixHash = block.prevrandao * variables.numBlocks;
+            _difficulty = block.prevrandao * variables.numBlocks;
         }
 
         meta.timestamp = uint64(block.timestamp);
         meta.l1Height = uint64(block.number - 1);
         meta.l1Hash = blockhash(block.number - 1);
-        meta.difficulty = bytes32(_mixHash);
+        meta.difficulty = bytes32(_difficulty);
         meta.txListHash = keccak256(txList);
         meta.gasLimit = gasLimit;
 

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -157,13 +157,13 @@ abstract contract TaikoL1TestBase is TestBase {
         meta.timestamp = uint64(block.timestamp);
         meta.l1Height = uint64(block.number - 1);
         meta.l1Hash = blockhash(block.number - 1);
-        meta.mixHash = bytes32(_mixHash);
+        meta.difficulty = bytes32(_mixHash);
         meta.txListHash = keccak256(txList);
         meta.gasLimit = gasLimit;
 
         vm.prank(proposer, proposer);
         meta = L1.proposeBlock{ value: msgValue }(
-            meta.txListHash, abi.encode(assignment), txList
+            meta.txListHash, bytes32(0), abi.encode(assignment), txList
         );
     }
 


### PR DESCRIPTION
- Add `extraData` to block proposal
- Change `mixHash` to `difficulty` to avoid confusion


@davidtaikocha in your RPC, please return extraData and make sure L2's  `block.difficult` (`block.prevrandao`) returns the value of `metadata.difficulty.`

@davidtaikocha please also pay attention to this issue: https://github.com/taikoxyz/blockscout-frontend/issues/27