### PR TITLE
feat(protocol): add `minTier` to `BlockProposed` event

### DIFF
--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -29,6 +29,7 @@ abstract contract TaikoEvents {
         uint96 livenessBond,
         uint256 proverFee,
         uint256 reward,
+        uint16 minTier,
         TaikoData.BlockMetadata meta
     );
 

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -31,6 +31,7 @@ library LibProposing {
         uint96 livenessBond,
         uint256 proverFee,
         uint256 reward,
+        uint16 minTier,
         TaikoData.BlockMetadata meta
     );
 
@@ -218,6 +219,7 @@ library LibProposing {
             livenessBond: config.livenessBond,
             proverFee: proverFee,
             reward: reward,
+            minTier: blk.minTier,
             meta: meta
         });
     }


### PR DESCRIPTION
Will be convenient for clients to know the `minTier` of the proposed block in its `BlockProposed` event