### PR TITLE
refactor(protocol): make sure L1.init called in genesis, not the first block

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -77,17 +77,12 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         if (block.chainid <= 1 || block.chainid >= type(uint64).max) {
             revert L2_INVALID_CHAIN_ID();
         }
-        if (block.number > 1) revert L2_TOO_LATE();
+        if (block.number != 0) revert L2_TOO_LATE();
 
         parentTimestamp = uint64(block.timestamp);
         (publicInputHash,) = _calcPublicInputHash(block.number);
 
         gasExcess = getEIP1559Config().gasExcessMax / 2;
-
-        if (block.number > 0) {
-            uint256 parentHeight = block.number - 1;
-            _l2Hashes[parentHeight] = blockhash(parentHeight);
-        }
     }
 
     /// @notice Anchors the latest L1 block details to L2 for cross-layer


### PR DESCRIPTION
David, in the previous code, the block.number can be either 0 or 1. With our current way of genesis the L2, the value should always be 0, is it?

@davidtaikocha @adaki2004 could one of you run the genesis test, my docker is broken locally.