### PR TITLE
chore(bridge-ui-v2): Update right top buttons to same UI styles

### DIFF
--- a/packages/bridge-ui-v2/src/components/ConnectButton/ConnectButton.svelte
+++ b/packages/bridge-ui-v2/src/components/ConnectButton/ConnectButton.svelte
@@ -31,17 +31,17 @@
 </script>
 
 {#if connected}
-  <Button class="hidden sm:flex px-[20px] py-2 mr-[8px] rounded-full" type="neutral" on:click={connectWallet}>
-    <span class="body-regular f-items-center space-x-2">
-      <svelte:component this={EthIcon} size={20} />
+  <Button class="hidden sm:flex  pl-[10px] pr-[15px] h-[40px] mr-[8px] rounded-full" type="neutral" on:click={connectWallet}>
+    <span class="body-regular f-items-center">
+      <svelte:component this={EthIcon} size={24} />
       {#if $ethBalance >= 0}
-        <span>{renderEthBalance($ethBalance)}</span>
+        <span class="ml-[6px]">{renderEthBalance($ethBalance)}</span>
       {:else}
         <Spinner /> <span>Fetching balance...</span>
       {/if}
     </span>
   </Button>
-  <w3m-core-button balance="hide" />
+  <w3m-core-button class="h-[40px]" balance="hide" />
 {:else}
   <Button class="px-[20px] py-2 rounded-full w-[215px]" type="neutral" loading={web3modalOpen} on:click={connectWallet}>
     <span class="body-regular f-items-center space-x-2">


### PR DESCRIPTION
Before
![Screen Shot 2023-09-30 at 11 48 04 PM](https://github.com/taikoxyz/taiko-mono/assets/104292916/e0bf5eee-4c79-4eee-93a8-5f138122484e)



After
![Screen Shot 2023-09-30 at 11 47 25 PM](https://github.com/taikoxyz/taiko-mono/assets/104292916/8d506d2f-62a7-49cd-af07-2d379e82b8f8)

It's not easy to change the UI styles of w3m-core-button. So I update our button. After the change, UI is not aligned to the design. 
