### PR TITLE
feat(protocol): notify the verifier when a proof lost a contestation

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -394,11 +394,29 @@ library LibProving {
                             false
                         );
                     } else if (reward != 0) {
-                        //The prover is also the contester, so the reward is
+                        // The prover is also the contester, so the reward is
                         // sent to him.
                         LibTaikoToken.creditToken(
                             state, resolver, msg.sender, reward, false
                         );
+                    }
+
+                    {
+                        // We tell the verifyer that a proof verified by itself
+                        // is
+                        // contested and lost, this will enable the verifiery to
+                        // implement logics to disable itself.
+                        ITierProvider.Tier memory prevTier = ITierProvider(
+                            resolver.resolve("tier_provider", false)
+                        ).getTier(tran.tier);
+
+                        address verifier =
+                            resolver.resolve(prevTier.verifierName, true);
+                        if (verifier != address(0)) {
+                            IVerifier(verifier).handleLostContestation(
+                                blockId, tran.prover, tran.blockHash
+                            );
+                        }
                     }
 
                     // Given that the contester emerges as the winner, the

--- a/packages/protocol/contracts/L1/verifiers/GuardianVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/GuardianVerifier.sol
@@ -6,15 +6,14 @@
 
 pragma solidity ^0.8.20;
 
-import { EssentialContract } from "../../common/EssentialContract.sol";
 import { Proxied } from "../../common/Proxied.sol";
 
 import { TaikoData } from "../TaikoData.sol";
 
-import { IVerifier } from "./IVerifier.sol";
+import { BaseVerifier } from "./IVerifier.sol";
 
 /// @title GuardianVerifier
-contract GuardianVerifier is EssentialContract, IVerifier {
+contract GuardianVerifier is BaseVerifier {
     uint256[50] private __gap;
 
     error PERMISSION_DENIED();
@@ -22,10 +21,9 @@ contract GuardianVerifier is EssentialContract, IVerifier {
     /// @notice Initializes the contract with the provided address manager.
     /// @param _addressManager The address of the address manager contract.
     function init(address _addressManager) external initializer {
-        EssentialContract._init(_addressManager);
+        BaseVerifier._init(_addressManager);
     }
 
-    /// @inheritdoc IVerifier
     function verifyProof(
         uint64,
         address prover,
@@ -37,15 +35,6 @@ contract GuardianVerifier is EssentialContract, IVerifier {
     {
         if (prover != resolve("guardian", false)) revert PERMISSION_DENIED();
     }
-
-    function handleLostContestation(
-        uint64 blockId,
-        address prover,
-        bytes32 blockHash
-    )
-        public
-        pure
-    { }
 }
 
 /// @title ProxiedGuardianVerifier

--- a/packages/protocol/contracts/L1/verifiers/GuardianVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/GuardianVerifier.sol
@@ -37,6 +37,15 @@ contract GuardianVerifier is EssentialContract, IVerifier {
     {
         if (prover != resolve("guardian", false)) revert PERMISSION_DENIED();
     }
+
+    function handleLostContestation(
+        uint64 blockId,
+        address prover,
+        bytes32 blockHash
+    )
+        public
+        pure
+    { }
 }
 
 /// @title ProxiedGuardianVerifier

--- a/packages/protocol/contracts/L1/verifiers/IVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/IVerifier.sol
@@ -7,9 +7,10 @@
 pragma solidity ^0.8.20;
 
 import { TaikoData } from "../TaikoData.sol";
-
+import { EssentialContract } from "../../common/EssentialContract.sol";
 /// @title IVerifier Interface
 /// @notice Defines the function that handles proof verification.
+
 interface IVerifier {
     /// @notice Verify a proof
     function verifyProof(
@@ -28,4 +29,25 @@ interface IVerifier {
         bytes32 blockHash
     )
         external;
+}
+
+abstract contract BaseVerifier is EssentialContract, IVerifier {
+    event ContestationLost(
+        uint64 indexed blockId, address prover, bytes32 blockHash
+    );
+
+    function handleLostContestation(
+        uint64 blockId,
+        address prover,
+        bytes32 blockHash
+    )
+        external
+        onlyFromNamed("taiko")
+    {
+        emit ContestationLost(blockId, prover, blockHash);
+    }
+
+    function _init(address _addressManager) internal override {
+        EssentialContract._init(_addressManager);
+    }
 }

--- a/packages/protocol/contracts/L1/verifiers/IVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/IVerifier.sol
@@ -6,8 +6,9 @@
 
 pragma solidity ^0.8.20;
 
-import { TaikoData } from "../TaikoData.sol";
 import { EssentialContract } from "../../common/EssentialContract.sol";
+
+import { TaikoData } from "../TaikoData.sol";
 /// @title IVerifier Interface
 /// @notice Defines the function that handles proof verification.
 

--- a/packages/protocol/contracts/L1/verifiers/IVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/IVerifier.sol
@@ -11,11 +11,21 @@ import { TaikoData } from "../TaikoData.sol";
 /// @title IVerifier Interface
 /// @notice Defines the function that handles proof verification.
 interface IVerifier {
+    /// @notice Verify a proof
     function verifyProof(
         uint64 blockId,
         address prover,
         bool isContesting,
         TaikoData.BlockEvidence memory evidence
+    )
+        external;
+
+    /// @notice Handle notification when a verified proof is contested and
+    /// failed.
+    function handleLostContestation(
+        uint64 blockId,
+        address prover,
+        bytes32 blockHash
     )
         external;
 }

--- a/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
@@ -6,17 +6,16 @@
 
 pragma solidity ^0.8.20;
 
-import { EssentialContract } from "../../common/EssentialContract.sol";
 import { LibBytesUtils } from "../../thirdparty/LibBytesUtils.sol";
 import { Proxied } from "../../common/Proxied.sol";
 
 import { TaikoData } from "../TaikoData.sol";
 
-import { IVerifier } from "./IVerifier.sol";
+import { BaseVerifier } from "./IVerifier.sol";
 
 /// @title PseZkVerifier
 /// @notice See the documentation in {IVerifier}.
-contract PseZkVerifier is EssentialContract, IVerifier {
+contract PseZkVerifier is BaseVerifier {
     uint256[50] private __gap;
 
     error L1_INVALID_PROOF();
@@ -24,13 +23,10 @@ contract PseZkVerifier is EssentialContract, IVerifier {
     /// @notice Initializes the contract with the provided address manager.
     /// @param _addressManager The address of the address manager contract.
     function init(address _addressManager) external initializer {
-        EssentialContract._init(_addressManager);
+        BaseVerifier._init(_addressManager);
     }
 
-    /// @inheritdoc IVerifier
     function verifyProof(
-        // blockId is unused now, but can be used later when supporting
-        // different types of proofs.
         uint64,
         address prover,
         bool isContesting,
@@ -80,15 +76,6 @@ contract PseZkVerifier is EssentialContract, IVerifier {
             revert L1_INVALID_PROOF();
         }
     }
-
-    function handleLostContestation(
-        uint64 blockId,
-        address prover,
-        bytes32 blockHash
-    )
-        public
-        pure
-    { }
 
     function getInstance(
         address prover,

--- a/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
@@ -81,6 +81,15 @@ contract PseZkVerifier is EssentialContract, IVerifier {
         }
     }
 
+    function handleLostContestation(
+        uint64 blockId,
+        address prover,
+        bytes32 blockHash
+    )
+        public
+        pure
+    { }
+
     function getInstance(
         address prover,
         TaikoData.BlockEvidence memory evidence

--- a/packages/protocol/contracts/L1/verifiers/SGXVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SGXVerifier.sol
@@ -11,11 +11,11 @@ import { Proxied } from "../../common/Proxied.sol";
 
 import { TaikoData } from "../TaikoData.sol";
 
-import { IVerifier } from "./IVerifier.sol";
+import { BaseVerifier } from "./IVerifier.sol";
 
 /// @title GuardianVerifier
 // TODO(dani): implement this verifier.
-contract SGXVerifier is EssentialContract, IVerifier {
+contract SGXVerifier is BaseVerifier {
     uint256[50] private __gap;
 
     error UNIMPLEMENTED();
@@ -23,13 +23,10 @@ contract SGXVerifier is EssentialContract, IVerifier {
     /// @notice Initializes the contract with the provided address manager.
     /// @param _addressManager The address of the address manager contract.
     function init(address _addressManager) external initializer {
-        EssentialContract._init(_addressManager);
+        BaseVerifier._init(_addressManager);
     }
 
-    /// @inheritdoc IVerifier
     function verifyProof(
-        // blockId is unused now, but can be used later when supporting
-        // different types of proofs.
         uint64,
         address,
         bool,
@@ -40,15 +37,6 @@ contract SGXVerifier is EssentialContract, IVerifier {
     {
         revert UNIMPLEMENTED();
     }
-
-    function handleLostContestation(
-        uint64 blockId,
-        address prover,
-        bytes32 blockHash
-    )
-        public
-        pure
-    { }
 }
 
 /// @title ProxiedSGXVerifier

--- a/packages/protocol/contracts/L1/verifiers/SGXVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SGXVerifier.sol
@@ -40,6 +40,15 @@ contract SGXVerifier is EssentialContract, IVerifier {
     {
         revert UNIMPLEMENTED();
     }
+
+    function handleLostContestation(
+        uint64 blockId,
+        address prover,
+        bytes32 blockHash
+    )
+        public
+        pure
+    { }
 }
 
 /// @title ProxiedSGXVerifier


### PR DESCRIPTION
Inspired by Vitalik's [multi-prover video](https://www.google.com/search?q=vitalik+multi+prover+youtube&oq=vitalik+multi+prover+youtube&gs_lcrp=EgZjaHJvbWUyBggAEEUYOdIBCDYzMzRqMGo3qAIAsAIA&sourceid=chrome&ie=UTF-8#fpstate=ive&vld=cid:598c69d0,vid:6hfVzCWT6YI,st:0), verifiers can now receive notifications from TaikoL1 when their proofs are contested and proven to be wrong. Verifiers can implement custom logic to handle these notifications, such as disabling themselves.


<img width="535" alt="Screenshot 2023-10-03 at 13 26 54" src="https://github.com/taikoxyz/taiko-mono/assets/99078276/2d4faa6d-ef5b-4226-97a1-7acf16c6c4ad">
