### PR TITLE
feat(protocol): reward proposer using gas used on L2

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -34,9 +34,6 @@ library TaikoData {
         uint32 blockFeeBaseGas;
         // The maximum allowed bytes for the proposed transaction list calldata.
         uint24 blockMaxTxListBytes;
-        // Amount of token to reward to the first block propsoed in each L1
-        // block.
-        uint128 proposerRewardPerL1Block;
         uint128 proposerRewardMax;
         uint8 proposerRewardPoolPctg;
         // ---------------------------------------------------------------------
@@ -102,7 +99,6 @@ library TaikoData {
         uint64 l1Height;
         uint32 gasLimit;
         address coinbase; // L2 coinbase
-        uint96 rewardBase;
         TaikoData.EthDeposit[] depositsProcessed;
     }
 

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -30,12 +30,8 @@ library TaikoData {
         uint64 maxBlocksToVerifyPerProposal;
         // The maximum gas limit allowed for a block.
         uint32 blockMaxGasLimit;
-        // The base gas for processing a block.
-        uint32 blockFeeBaseGas;
         // The maximum allowed bytes for the proposed transaction list calldata.
         uint24 blockMaxTxListBytes;
-        uint128 proposerRewardMax;
-        uint8 proposerRewardPoolPctg;
         // ---------------------------------------------------------------------
         // Group 3: Proof related configs
         // ---------------------------------------------------------------------

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -102,6 +102,7 @@ library TaikoData {
         uint64 l1Height;
         uint32 gasLimit;
         address coinbase; // L2 coinbase
+        uint96 rewardBase;
         TaikoData.EthDeposit[] depositsProcessed;
     }
 

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -20,7 +20,6 @@ abstract contract TaikoEvents {
     /// @param assignedProver The block's assigned prover.
     /// @param livenessBond The bond in Taiko token from the assigned prover.
     /// @param proverFee The fee paid to the assigned prover.
-    /// @param rewardBase The proposer's block reward base in Taiko token.
     /// @param meta The block metadata containing information about the proposed
     /// block.
     event BlockProposed(
@@ -28,7 +27,6 @@ abstract contract TaikoEvents {
         address indexed assignedProver,
         uint96 livenessBond,
         uint256 proverFee,
-        uint96 rewardBase,
         uint16 minTier,
         TaikoData.BlockMetadata meta
     );

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -20,7 +20,7 @@ abstract contract TaikoEvents {
     /// @param assignedProver The block's assigned prover.
     /// @param livenessBond The bond in Taiko token from the assigned prover.
     /// @param proverFee The fee paid to the assigned prover.
-    /// @param reward The proposer's block reward in Taiko token.
+    /// @param rewardBase The proposer's block reward base in Taiko token.
     /// @param meta The block metadata containing information about the proposed
     /// block.
     event BlockProposed(
@@ -28,7 +28,7 @@ abstract contract TaikoEvents {
         address indexed assignedProver,
         uint96 livenessBond,
         uint256 proverFee,
-        uint256 reward,
+        uint96 rewardBase,
         uint16 minTier,
         TaikoData.BlockMetadata meta
     );

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -317,7 +317,6 @@ contract TaikoL1 is
             blockMaxGasLimit: 8_000_000,
             blockFeeBaseGas: 20_000,
             blockMaxTxListBytes: 120_000,
-            proposerRewardPerL1Block: 3e18, // 0.25 Taiko token * 12s = 3 TKO
             proposerRewardMax: 32e18, // 32 Taiko token
             proposerRewardPoolPctg: 30, // means that 30% of the accumulated
                 // reward is given to the next proposer

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -315,11 +315,7 @@ contract TaikoL1 is
             // maximum value of the multiplier close to 20.0
             maxBlocksToVerifyPerProposal: 10,
             blockMaxGasLimit: 8_000_000,
-            blockFeeBaseGas: 20_000,
             blockMaxTxListBytes: 120_000,
-            proposerRewardMax: 32e18, // 32 Taiko token
-            proposerRewardPoolPctg: 30, // means that 30% of the accumulated
-                // reward is given to the next proposer
             livenessBond: 10_240e18,
             ethDepositRingBufferSize: 1024,
             ethDepositMinCountPerBlock: 8,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -311,8 +311,6 @@ contract TaikoL1 is
             relaySignalRoot: false,
             blockMaxProposals: 403_200,
             blockRingBufferSize: 403_210,
-            // This number is calculated from blockMaxProposals to make the
-            // maximum value of the multiplier close to 20.0
             maxBlocksToVerifyPerProposal: 10,
             blockMaxGasLimit: 8_000_000,
             blockMaxTxListBytes: 120_000,

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -10,7 +10,6 @@ import { ERC20Upgradeable } from "@ozu/token/ERC20/ERC20Upgradeable.sol";
 
 import { AddressResolver } from "../../common/AddressResolver.sol";
 import { LibAddress } from "../../libs/LibAddress.sol";
-import { LibMath } from "../../libs/LibMath.sol";
 
 import { ITierProvider } from "../tiers/ITierProvider.sol";
 import { TaikoData } from "../TaikoData.sol";
@@ -22,8 +21,6 @@ import { LibTaikoToken } from "./LibTaikoToken.sol";
 /// @notice A library for handling block proposals in the Taiko protocol.
 library LibProposing {
     using LibAddress for address;
-    using LibMath for uint256;
-    using LibMath for uint128;
 
     // Warning: Any events defined here must also be defined in TaikoEvents.sol.
     event BlockProposed(

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -31,7 +31,6 @@ library LibProposing {
         address indexed assignedProver,
         uint96 livenessBond,
         uint256 proverFee,
-        uint96 rewardBase,
         uint16 minTier,
         TaikoData.BlockMetadata meta
     );
@@ -90,58 +89,6 @@ library LibProposing {
             revert L1_TOO_MANY_BLOCKS();
         }
 
-        // In situations where the network lacks sufficient transactions for the
-        // proposer to profit, they are still obligated to pay the prover the
-        // proving fee, which can be a substantial cost compared to the total L2
-        // transaction fees collected. As a solution, Taiko mints additional
-        // Taiko tokens per second as block rewards. It's important to note that
-        // if multiple blocks are proposed within the same L1 block, only the
-        // first one will receive the block reward.
-
-        // The block reward doesn't undergo automatic halving; instead, we
-        // depend on Taiko DAO to make necessary adjustments to the rewards.
-        uint96 rewardBase;
-
-        // Reward block proposers with Taiko tokens to encourage chain adoption
-        // and ensure liveness.
-        // Rewards are issued only if `proposerRewardPerL1Block` and
-        // `proposerRewardMax` are set to nonzero values in the configuration.
-        if (config.proposerRewardPerL1Block != 0) {
-            unchecked {
-                // Mint additional tokens into the reward pool as L1 block
-                // numbers increase, to incentivize future proposers.
-                if (
-                    state.slotC.lastProposedHeight != 0
-                        && state.slotC.lastProposedHeight < block.number
-                ) {
-                    uint256 extraRewardMinted = (
-                        block.number - state.slotC.lastProposedHeight
-                    ) * config.proposerRewardPerL1Block;
-
-                    // Reward pool is capped to `proposerRewardMax`
-                    state.slotC.accumulatedReward = uint128(
-                        (extraRewardMinted + state.slotC.accumulatedReward).min(
-                            config.proposerRewardMax
-                        )
-                    );
-                }
-
-                if (state.slotC.accumulatedReward != 0) {
-                    // The current proposer receives a fixed percentage of the
-                    // reward pool.
-                    rewardBase = uint96(
-                        (
-                            state.slotC.accumulatedReward / 100
-                                * config.proposerRewardPoolPctg
-                        ).min(type(uint96).max)
-                    );
-
-                    state.slotC.accumulatedReward -= rewardBase;
-                }
-                state.slotC.lastProposedHeight = uint64(block.number);
-            }
-        }
-
         // Initialize metadata to compute a metaHash, which forms a part of
         // the block data to be stored on-chain for future integrity checks.
         // If we choose to persist all data fields in the metadata, it will
@@ -164,7 +111,6 @@ library LibProposing {
                 coinbase: msg.sender,
                 // Each transaction must handle a specific quantity of L1-to-L2
                 // Ether deposits.
-                rewardBase: rewardBase,
                 depositsProcessed: LibDepositing.processDeposits(
                     state, config, msg.sender
                     )
@@ -238,7 +184,6 @@ library LibProposing {
             assignedProver: blk.assignedProver,
             livenessBond: config.livenessBond,
             proverFee: proverFee,
-            rewardBase: rewardBase,
             minTier: blk.minTier,
             meta: meta
         });
@@ -257,8 +202,7 @@ library LibProposing {
         inputs[3] = uint256(meta.extraData);
         inputs[4] = (uint256(meta.id)) | (uint256(meta.timestamp) << 64)
             | (uint256(meta.l1Height) << 128) | (uint256(meta.gasLimit) << 192);
-        inputs[5] =
-            uint256(uint160(meta.coinbase)) << 96 | uint256(meta.rewardBase);
+        inputs[5] = uint256(uint160(meta.coinbase));
         inputs[6] = uint256(keccak256(abi.encode(meta.depositsProcessed)));
 
         assembly {

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -49,9 +49,7 @@ library LibVerifying {
                 || config.blockRingBufferSize <= config.blockMaxProposals + 1
                 || config.blockMaxGasLimit == 0 || config.blockMaxTxListBytes == 0
                 || config.blockMaxTxListBytes > 128 * 1024 //blob up to 128K
-                || config.livenessBond == 0
-                || config.livenessBond < 10 * config.proposerRewardPerL1Block
-                || config.ethDepositRingBufferSize <= 1
+                || config.livenessBond == 0 || config.ethDepositRingBufferSize <= 1
                 || config.ethDepositMinCountPerBlock == 0
                 || config.ethDepositMaxCountPerBlock
                     < config.ethDepositMinCountPerBlock
@@ -63,13 +61,6 @@ library LibVerifying {
                 || config.ethDepositMaxFee
                     >= type(uint96).max / config.ethDepositMaxCountPerBlock
         ) revert L1_INVALID_CONFIG();
-
-        if (config.proposerRewardPerL1Block != 0) {
-            if (
-                config.proposerRewardMax == 0
-                    || config.proposerRewardPoolPctg == 0
-            ) revert L1_INVALID_CONFIG();
-        }
 
         // Init state
         state.slotA.genesisHeight = uint64(block.number);

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -234,8 +234,7 @@ library LibVerifying {
                 || config.blockRingBufferSize <= config.blockMaxProposals + 1
                 || config.blockMaxGasLimit == 0 || config.blockMaxTxListBytes == 0
                 || config.blockMaxTxListBytes > 128 * 1024 //blob up to 128K
-                || config.livenessBond == 0
-                || config.ethDepositRingBufferSize <= 1
+                || config.livenessBond == 0 || config.ethDepositRingBufferSize <= 1
                 || config.ethDepositMinCountPerBlock == 0
                 || config.ethDepositMaxCountPerBlock
                     < config.ethDepositMinCountPerBlock

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -264,7 +264,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
             return 0;
         }
 
-        address tt = resolve("taiko", true);
+        address tt = resolve("taiko_token", true);
         if (tt == address(0)) return 0;
 
         // The ratio is in [0-20000]

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -43,8 +43,8 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
 
     // Mapping from L2 block numbers to their block hashes.
     // All L2 block hashes will be saved in this mapping.
-    mapping(uint256 blockId => bytes32 blockHash) private _l2Hashes;
-    mapping(uint256 blockId => VerifiedBlock) private _l1VerifiedBlocks;
+    mapping(uint256 blockId => bytes32 blockHash) public l2Hashes;
+    mapping(uint256 blockId => VerifiedBlock) public l1VerifiedBlocks;
 
     // A hash to check the integrity of public inputs.
     bytes32 public publicInputHash; // slot 3
@@ -85,7 +85,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
 
         if (block.number > 0) {
             uint256 parentHeight = block.number - 1;
-            _l2Hashes[parentHeight] = blockhash(parentHeight);
+            l2Hashes[parentHeight] = blockhash(parentHeight);
         }
 
         gasExcess = _gasExcess;
@@ -130,9 +130,8 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
             _rewardParentBlock(config, l1Height, parentGasUsed);
 
         // Update state variables
-        _l2Hashes[block.number - 1] = blockhash(block.number - 1);
-        _l1VerifiedBlocks[l1Height] = VerifiedBlock(l1Hash, l1SignalRoot);
-
+        l2Hashes[block.number - 1] = blockhash(block.number - 1);
+        l1VerifiedBlocks[l1Height] = VerifiedBlock(l1Hash, l1SignalRoot);
         publicInputHash = publicInputHashNew;
         latestSyncedL1Height = l1Height;
         parentProposer = block.coinbase;
@@ -150,7 +149,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         returns (bytes32)
     {
         uint256 id = blockId == 0 ? latestSyncedL1Height : blockId;
-        return _l1VerifiedBlocks[id].blockHash;
+        return l1VerifiedBlocks[id].blockHash;
     }
 
     /// @inheritdoc ICrossChainSync
@@ -161,7 +160,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         returns (bytes32)
     {
         uint256 id = blockId == 0 ? latestSyncedL1Height : blockId;
-        return _l1VerifiedBlocks[id].signalRoot;
+        return l1VerifiedBlocks[id].signalRoot;
     }
 
     /// @notice Gets the basefee and gas excess using EIP-1559 configuration for
@@ -190,7 +189,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         } else if (blockId < block.number && blockId >= block.number - 256) {
             return blockhash(blockId);
         } else {
-            return _l2Hashes[blockId];
+            return l2Hashes[blockId];
         }
     }
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -26,8 +26,6 @@ import { TaikoL2Signer } from "./TaikoL2Signer.sol";
 contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
     using LibMath for uint256;
 
-    uint32 public constant ANCHOR_GAS_DEDUCT = 40_000;
-
     struct Config {
         uint64 blockGasTarget;
         uint256 basefeeAdjustmentQuotient;
@@ -41,6 +39,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         bytes32 signalRoot;
     }
 
+    uint32 public constant ANCHOR_GAS_DEDUCT = 40_000;
     // Mapping from L2 block numbers to their block hashes.
     // All L2 block hashes will be saved in this mapping.
     mapping(uint256 blockId => bytes32 blockHash) public l2Hashes;

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -267,7 +267,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         address tt = resolve("taiko_token", true);
         if (tt == address(0)) return 0;
 
-        // The ratio is in [0-20000]
+        // The ratio is in [0-200]
         uint128 ratio = uint128(
             (
                 uint256(parentGasUsed - ANCHOR_GAS_DEDUCT) * 100

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -132,9 +132,12 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         address tt = resolve("taiko", true);
         if (tt != address(0) && avgGasUsed != 0 && parentProposer != address(0))
         {
-            // TODO(daniel): correct the calculation
+            // TODO(daniel): correct the calculation below - it is not right but
+            // good enough to show the idea.
             // TODO(daniel): adjust anchor gas cost
-            uint256 reward = parentRewardBase * parentGasUsed / avgGasUsed / 2;
+            uint256 anchorTxCost = 100_000;
+            uint256 reward = parentRewardBase * (parentGasUsed - anchorTxCost)
+                / (avgGasUsed - anchorTxCost) / 2;
             TaikoToken(tt).mint(parentProposer, reward);
         }
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -27,7 +27,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
     using LibMath for uint256;
 
     struct Config {
-        uint64 blockGasTarget;
+        uint64 gasTargetPerL1Block;
         uint256 basefeeAdjustmentQuotient;
         uint256 blockRewardPerL1Block;
         uint128 blockRewardPoolMax;
@@ -196,7 +196,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
 
     /// @notice Returns EIP1559 related configurations
     function getConfig() public pure virtual returns (Config memory config) {
-        config.blockGasTarget = 15 * 1e6 * 10; // 10x Ethereum gas target
+        config.gasTargetPerL1Block = 15 * 1e6 * 10; // 10x Ethereum gas target
         config.basefeeAdjustmentQuotient = 8;
         config.blockRewardPerL1Block = 1e15; // 0.001 Taiko token;
         config.blockRewardPoolMax = 12e18; // 12 Taiko token
@@ -334,7 +334,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
             }
 
             if (numL1Blocks > 0) {
-                uint128 issuance = numL1Blocks * config.blockGasTarget;
+                uint128 issuance = numL1Blocks * config.gasTargetPerL1Block;
                 excess = excess > issuance ? excess - issuance : 1;
             }
 
@@ -346,7 +346,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
             // block's base fee.
             _basefee = Lib1559Math.basefee(
                 _gasExcess,
-                config.basefeeAdjustmentQuotient * config.blockGasTarget
+                config.basefeeAdjustmentQuotient * config.gasTargetPerL1Block
             );
         }
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -40,6 +40,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
     }
 
     uint32 public constant ANCHOR_GAS_DEDUCT = 40_000;
+
     // Mapping from L2 block numbers to their block hashes.
     // All L2 block hashes will be saved in this mapping.
     mapping(uint256 blockId => bytes32 blockHash) public l2Hashes;

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -253,6 +253,10 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
 
         avgGasUsed = avgGasUsed / 1024 * 1023 + parentGasUsed / 1024;
 
+        uint128 maxBlockReward =
+            accumulatedReward / 100 * config.blockRewardPoolPctg;
+        accumulatedReward -= maxBlockReward;
+
         if (
             parentGasUsed <= ANCHOR_GAS_DEDUCT
                 || avgGasUsed <= ANCHOR_GAS_DEDUCT || parentProposer == address(0)
@@ -271,11 +275,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
             ).min(200)
         );
 
-        uint128 maxBlockReward =
-            accumulatedReward / 100 * config.blockRewardPoolPctg;
-
         blockReward = maxBlockReward * ratio / 200;
-        accumulatedReward -= maxBlockReward;
         TaikoToken(tt).mint(parentProposer, blockReward);
     }
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -6,7 +6,6 @@
 
 pragma solidity ^0.8.20;
 
-import { LibFixedPointMath } from "../thirdparty/LibFixedPointMath.sol";
 import { EssentialContract } from "../common/EssentialContract.sol";
 import { ICrossChainSync } from "../common/ICrossChainSync.sol";
 import { Proxied } from "../common/Proxied.sol";

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -26,7 +26,7 @@ import { TaikoL2Signer } from "./TaikoL2Signer.sol";
 contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
     using LibMath for uint256;
 
-    uint32 public constant ANCHOR_GAS = 100_000;
+    uint32 public constant ANCHOR_GAS_DEDUCT = 40_000;
 
     struct Config {
         uint64 blockGasTarget;
@@ -255,8 +255,8 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         avgGasUsed = avgGasUsed / 1024 * 1023 + parentGasUsed / 1024;
 
         if (
-            parentGasUsed <= ANCHOR_GAS || avgGasUsed <= ANCHOR_GAS
-                || parentProposer == address(0)
+            parentGasUsed <= ANCHOR_GAS_DEDUCT
+                || avgGasUsed <= ANCHOR_GAS_DEDUCT || parentProposer == address(0)
         ) {
             return 0;
         }
@@ -267,15 +267,15 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         // The ratio is in [0-20000]
         uint128 ratio = uint128(
             (
-                uint256(parentGasUsed - ANCHOR_GAS) * 10_000
-                    / (avgGasUsed - ANCHOR_GAS)
-            ).min(20_000)
+                uint256(parentGasUsed - ANCHOR_GAS_DEDUCT) * 100
+                    / (avgGasUsed - ANCHOR_GAS_DEDUCT)
+            ).min(200)
         );
 
         uint128 maxBlockReward =
             accumulatedReward / 100 * config.blockRewardPoolPctg;
 
-        blockReward = maxBlockReward * ratio / 20_000;
+        blockReward = maxBlockReward * ratio / 200;
         accumulatedReward -= maxBlockReward;
         TaikoToken(tt).mint(parentProposer, blockReward);
     }

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -39,6 +39,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         bytes32 signalRoot;
     }
 
+    // TODO(david): figure out this value from internal devnet.
     uint32 public constant ANCHOR_GAS_DEDUCT = 40_000;
 
     // Mapping from L2 block numbers to their block hashes.

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -206,9 +206,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
     // proposer to profit, they are still obligated to pay the prover the
     // proving fee, which can be a substantial cost compared to the total L2
     // transaction fees collected. As a solution, Taiko mints additional Taiko
-    // tokens per second as block rewards. It's important to note that if
-    // multiple blocks are proposed within the same L1 block, only the first one
-    // will receive the block reward.
+    // tokens per second as block rewards.
     //
     // The block reward doesn't undergo automatic halving; instead, we depend on
     // Taiko DAO to make necessary adjustments to the rewards. uint96

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -25,7 +25,6 @@ contract TaikoL1_NoCooldown is TaikoL1 {
         config.blockMaxProposals = 10;
         config.blockRingBufferSize = 12;
         config.livenessBond = 1e18; // 1 Taiko token
-        config.proposerRewardPerL1Block = 1e15; // 0.001 Taiko token
     }
 }
 

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -30,7 +30,6 @@ contract TaikoL1Tiers is TaikoL1 {
         config.blockMaxProposals = 10;
         config.blockRingBufferSize = 12;
         config.livenessBond = 1e18; // 1 Taiko token
-        config.proposerRewardPerL1Block = 1e15; // 0.001 Taiko token
     }
 }
 

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -101,6 +101,6 @@ contract TestTaikoL2 is TestBase {
     function _anchor(uint32 parentGasLimit) private {
         bytes32 l1Hash = getRandomBytes32();
         bytes32 l1SignalRoot = getRandomBytes32();
-        L2.anchor(l1Hash, l1SignalRoot, 12_345, parentGasLimit, 0);
+        L2.anchor(l1Hash, l1SignalRoot, 12_345, parentGasLimit);
     }
 }

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -101,6 +101,6 @@ contract TestTaikoL2 is TestBase {
     function _anchor(uint32 parentGasLimit) private {
         bytes32 l1Hash = getRandomBytes32();
         bytes32 l1SignalRoot = getRandomBytes32();
-        L2.anchor(l1Hash, l1SignalRoot, 12_345, parentGasLimit);
+        L2.anchor(l1Hash, l1SignalRoot, 12_345, parentGasLimit, 0);
     }
 }


### PR DESCRIPTION
This PR has the following changes:
- L1 taiko token block reward (or proposer reward) has been moved from L1 to L2
- In each L2 block's anchor tx, block reward are minted to the parent block's propser, not the current block's proposer
- The amount of block reward now also depends on the block's gas used. L2 tracks a moving average of recent blocks' gas used, `avgGasUsed`, then for any block whose gas used is `gasUsed`, we calculate a ratio `gasUsed/avgGasUsed` then cap it to `2.0`, then we mint `maxBlockReward * min(2.0, gasUsed/avgGasUsed)`, where `maxBlockReward` is calculated the same way as previously. 

This PR has the following benefit:

- The gas used for proposing a block is reduced
- Proposing empty blocks will end up receiving very small block reward.