### PR TITLE
feat(protocol): Revamp sgx verifier

### DIFF
--- a/packages/protocol/contracts/L1/verifiers/SgxAndZkVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxAndZkVerifier.sol
@@ -17,7 +17,7 @@ import { IVerifier } from "./IVerifier.sol";
 /// @title SgxAndZkVerifier
 /// @notice See the documentation in {IVerifier}.
 contract SgxAndZkVerifier is EssentialContract, IVerifier {
-    uint8 public constant SGX_PROOF_SIZE = 85;
+    uint8 public constant SGX_PROOF_SIZE = 87;
     uint256[50] private __gap;
 
     /// @notice Initializes the contract with the provided address manager.

--- a/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
@@ -22,8 +22,15 @@ contract SgxVerifier is EssentialContract, IVerifier {
 
     uint256 public constant INSTANCE_EXPIRY = 180 days;
 
-    event InstanceAdded(uint256 indexed instanceId, address instanceInitAddress, uint64 timstamp);
-    event InstanceChanged(uint256 indexed instanceId, address oldInstance, address newInstance, uint64 timstamp);
+    event InstanceAdded(
+        uint256 indexed instanceId, address instanceInitAddress, uint64 timstamp
+    );
+    event InstanceChanged(
+        uint256 indexed instanceId,
+        address oldInstance,
+        address newInstance,
+        uint64 timstamp
+    );
 
     struct InstanceData {
         address activeAddress;
@@ -91,7 +98,8 @@ contract SgxVerifier is EssentialContract, IVerifier {
 
         // Invalidate current key, because it cannot be used again (side-channel
         // attacks).
-        sgxRegistry[instanceId] = InstanceData(newAddress, uint64(block.timestamp));
+        sgxRegistry[instanceId] =
+            InstanceData(newAddress, uint64(block.timestamp));
     }
 
     /// @inheritdoc IVerifier
@@ -131,9 +139,12 @@ contract SgxVerifier is EssentialContract, IVerifier {
 
         // Invalidate current key, because it cannot be used again (side-channel
         // attacks).
-        sgxRegistry[instanceId] = InstanceData(newInstance, uint64(block.timestamp));
+        sgxRegistry[instanceId] =
+            InstanceData(newInstance, uint64(block.timestamp));
 
-        emit InstanceChanged(instanceId, oldInstance, newInstance, uint64(block.timestamp));
+        emit InstanceChanged(
+            instanceId, oldInstance, newInstance, uint64(block.timestamp)
+        );
     }
 
     function getSignedHash(
@@ -166,14 +177,21 @@ contract SgxVerifier is EssentialContract, IVerifier {
         view
         returns (bool)
     {
-        return (sgxRegistry[instanceId].activeAddress == instance && sgxRegistry[instanceId].effectiveSince + INSTANCE_EXPIRY > block.timestamp);
+        return (
+            sgxRegistry[instanceId].activeAddress == instance
+                && sgxRegistry[instanceId].effectiveSince + INSTANCE_EXPIRY
+                    > block.timestamp
+        );
     }
 
     function addTrustedInstances(address[] memory trustedInstances) internal {
         for (uint256 i; i < trustedInstances.length; i++) {
-            sgxRegistry[uniqueVerifiers] = InstanceData(trustedInstances[i], uint64(block.timestamp));
+            sgxRegistry[uniqueVerifiers] =
+                InstanceData(trustedInstances[i], uint64(block.timestamp));
 
-            emit InstanceAdded(uniqueVerifiers, trustedInstances[i], uint64(block.timestamp));
+            emit InstanceAdded(
+                uniqueVerifiers, trustedInstances[i], uint64(block.timestamp)
+            );
 
             uniqueVerifiers++;
         }

--- a/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
@@ -116,9 +116,9 @@ contract SgxVerifier is EssentialContract, IVerifier {
         // Do not run proof verification to contest an existing proof
         if (isContesting) return;
 
-        // Size is: 85 bytes
-        // 20 bytes + 65 bytes (signature) = 85
-        if (evidence.proof.length != 85) {
+        // Size is: 87 bytes
+        // 2 bytes + 20 bytes + 65 bytes (signature) = 87
+        if (evidence.proof.length != 87) {
             revert SGX_INVALID_PROOF_SIZE();
         }
 

--- a/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
@@ -16,7 +16,7 @@ import { TaikoData } from "../TaikoData.sol";
 
 import { IVerifier } from "./IVerifier.sol";
 
-/// @title GuardianVerifier
+/// @title SgxVerifier
 contract SgxVerifier is EssentialContract, IVerifier {
     using ECDSAUpgradeable for bytes32;
 

--- a/packages/protocol/test/L1/SgxVerifier.t.sol
+++ b/packages/protocol/test/L1/SgxVerifier.t.sol
@@ -21,7 +21,7 @@ contract TestSgxVerifier is TaikoL1TestBase {
         trustedInstances[0] = SGX_X_1;
         trustedInstances[1] = SGX_Y;
         trustedInstances[2] = SGX_Z;
-        sv.registerInstance(trustedInstances);
+        sv.registerInstances(trustedInstances);
     }
 
     function test_addToRegistryByOwner_WithoutOwnerRole() external {
@@ -32,7 +32,7 @@ contract TestSgxVerifier is TaikoL1TestBase {
 
         vm.expectRevert();
         vm.prank(Bob, Bob);
-        sv.registerInstance(trustedInstances);
+        sv.registerInstances(trustedInstances);
     }
 
     function test_addToRegistryBySgxInstance() external {
@@ -44,7 +44,7 @@ contract TestSgxVerifier is TaikoL1TestBase {
             createAddRegistrySignature(SGX_X_1, trustedInstances, 0x4);
 
         vm.prank(Bob, Bob);
-        sv.registerBySgxInstance(SGX_X_1, trustedInstances, signature);
+        sv.registerInstancesBySgx(0, SGX_X_1, trustedInstances, signature);
     }
 
     function createAddRegistrySignature(

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -73,7 +73,7 @@ abstract contract TaikoL1TestBase is TestBase {
         address[] memory initSgxInstances = new address[](2);
         initSgxInstances[0] = SGX_X_0;
         initSgxInstances[1] = SGX_VARIANT;
-        sv.registerInstance(initSgxInstances);
+        sv.registerInstances(initSgxInstances);
 
         sgxZkVerifier = new SgxAndZkVerifier();
         sgxZkVerifier.init(address(addressManager));

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -219,27 +219,31 @@ abstract contract TaikoL1TestBase is TestBase {
             new bytes(100)
         );
 
+        address newPubKey;
+        // Keep changing the pub key associated with an instance to avoid
+        // attacks,
+        // obviously just a mock due to 2 addresses changing all the time.
+        (newPubKey, )= sv.sgxRegistry(0);
+        if (newPubKey == SGX_X_0) {
+            newPubKey = SGX_X_1;
+        } else {
+            newPubKey = SGX_X_0;
+        }
+
         if (tier == LibTiers.TIER_SGX) {
-            address newPubKey = vm.addr(variablePKey + 1);
             bytes memory signature =
                 createSgxSignatureProof(evidence, newPubKey, prover);
 
-            evidence.proof = bytes.concat(bytes20(newPubKey), signature);
-
-            variablePKey += 1;
+            evidence.proof = bytes.concat(bytes2(0),bytes20(newPubKey), signature);
         }
 
         if (tier == LibTiers.TIER_SGX_AND_PSE_ZKEVM) {
-            address newPubKey = vm.addr(variablePKey + 1);
-
             bytes memory signature =
                 createSgxSignatureProof(evidence, newPubKey, prover);
 
-            bytes memory sgxProof = bytes.concat(bytes20(newPubKey), signature);
+            bytes memory sgxProof = bytes.concat(bytes2(0),bytes20(newPubKey), signature);
             // Concatenate SGX and ZK (in this order)
             evidence.proof = bytes.concat(sgxProof, evidence.proof);
-
-            variablePKey += 1;
         }
 
         if (tier == LibTiers.TIER_GUARDIAN) {
@@ -323,7 +327,15 @@ abstract contract TaikoL1TestBase is TestBase {
                 newPubKey
             )
         );
-        uint256 signerPrivateKey = variablePKey;
+
+        uint256 signerPrivateKey;
+
+        // In the test suite these are the 3 which acts as provers
+        if (SGX_X_0 == newPubKey) {
+            signerPrivateKey = 0x5;
+        } else if (SGX_X_1 == newPubKey) {
+            signerPrivateKey = 0x4;
+        }
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, digest);
         signature = abi.encodePacked(r, s, v);


### PR DESCRIPTION
@dantaik @Brechtpd 

Please have a look guys! This is a revamp of an old version (from [here](https://github.com/taikoxyz/taiko-mono/blob/b6f3dc2cb7b6fc0d57179629fba08d5c4b70d56d/packages/protocol/contracts/L1/verifiers/SGXVerifier.sol)), ID-based, where the system (contract) distributed the IDs first and based on that, an instance have a fixed position in the mapping. (For easy identification and optimization).

UPDATE: updated tests.