### PR TITLE
fix(protocol): Fix LibAddress

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -104,7 +104,8 @@ contract Bridge is EssentialContract, IBridge {
         // On Taiko, send the expectedAmount to the EtherVault; otherwise, store
         // it on the Bridge.
         address ethVault = resolve("ether_vault", true);
-        ethVault.sendEther(expectedAmount);
+
+        if (ethVault != address(0)) ethVault.sendEther(expectedAmount);
 
         _message = message;
         // Configure message details and send signal to indicate message

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -224,7 +224,7 @@ contract Bridge is EssentialContract, IBridge {
                 status = Status.DONE;
             } else {
                 status = Status.RETRIABLE;
-                ethVault.sendEther(message.value);
+                if (ethVault != address(0)) ethVault.sendEther(message.value);
             }
         }
 
@@ -292,7 +292,7 @@ contract Bridge is EssentialContract, IBridge {
             _updateMessageStatus(msgHash, Status.FAILED);
             // Release Ether back to EtherVault (if on Taiko it is OK)
             // otherwise funds stay at Bridge anyways.
-            ethVault.sendEther(message.value);
+            if (ethVault != address(0)) ethVault.sendEther(message.value);
         }
     }
 

--- a/packages/protocol/contracts/libs/LibAddress.sol
+++ b/packages/protocol/contracts/libs/LibAddress.sol
@@ -30,7 +30,7 @@ library LibAddress {
     /// @param amount The amount of Ether to send in wei.
     function sendEther(address to, uint256 amount) internal {
         // Check for zero-value or zero-address transactions
-        if (to == address(0)) return;
+        if (to == address(0)) revert ETH_TRANSFER_FAILED();
 
         // Attempt to send Ether to the recipient address
         (bool success,) = payable(to).call{ value: amount }("");
@@ -65,14 +65,11 @@ library LibAddress {
         view
         returns (bool valid)
     {
-        if (
-            AddressUpgradeable.isContract(addr)
-                && IERC1271Upgradeable(addr).isValidSignature(hash, sig)
-                    == EIP1271_MAGICVALUE
-        ) {
-            valid = true;
-        } else if (ECDSAUpgradeable.recover(hash, sig) == addr) {
-            valid = true;
+        if (AddressUpgradeable.isContract(addr)) {
+            return IERC1271Upgradeable(addr).isValidSignature(hash, sig)
+                == EIP1271_MAGICVALUE;
+        } else {
+            return ECDSAUpgradeable.recover(hash, sig) == addr;
         }
     }
 }

--- a/packages/protocol/contracts/libs/LibAddress.sol
+++ b/packages/protocol/contracts/libs/LibAddress.sol
@@ -36,7 +36,7 @@ library LibAddress {
         (bool success,) = payable(to).call{ value: amount }("");
 
         // Ensure the transfer was successful
-        if (!success) {
+if (!success)  revert ETH_TRANSFER_FAILED();
             revert ETH_TRANSFER_FAILED();
         }
     }

--- a/packages/protocol/contracts/libs/LibAddress.sol
+++ b/packages/protocol/contracts/libs/LibAddress.sol
@@ -36,9 +36,7 @@ library LibAddress {
         (bool success,) = payable(to).call{ value: amount }("");
 
         // Ensure the transfer was successful
-if (!success)  revert ETH_TRANSFER_FAILED();
-            revert ETH_TRANSFER_FAILED();
-        }
+        if (!success) revert ETH_TRANSFER_FAILED();
     }
 
     function supportsInterface(


### PR DESCRIPTION
2 issues we had - and never figured it out before. Let me explain.

**Nr.1.:**
`AddressUpgradeable.sendValue` is not proper (not properly implemented, or documented up to debate) -> So i reverted back the old.

```
    function sendValue(address payable recipient, uint256 amount) internal {
        require(address(this).balance >= amount, "Address: insufficient balance");
        (bool success, ) = recipient.call{value: amount}("");
        require(success, "Address: unable to send value, recipient may have reverted");
    }
```

This function - if recipient is `0x0` (as our `EtherVault` is 0 and non-existent on L1) - would return the funds to `msg.sender()` and `success` would be `true`. -> Resulting the funds never actually sent to the Bridge.

**Nr. 2.:**
```
try IERC165Upgradeable(addr).supportsInterface(interfaceId) returns (
                bool _result
            ) {
                result = _result;
            } catch {}
```
If called on EOA (if `addr` is EOA) it will revert and that revert would not be catched by the try-catch ! It is misused here. (If we call it on a contract and it reverts, that is fine (because our trusted `ERCXXXTokenVault` would never revert), but not fine reverting on EOAs. )

Please see convo here: https://forum.soliditylang.org/t/call-for-feedback-the-future-of-try-catch-in-solidity/1497
