### PR TITLE
feat(protocol): Enable designated address to propose 1st block post-genesis.

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -45,6 +45,7 @@ library LibProposing {
     error L1_UNAUTHORIZED();
 
     /// @dev Proposes a Taiko L2 block.
+
     function proposeBlock(
         TaikoData.State storage state,
         TaikoData.Config memory config,
@@ -61,10 +62,8 @@ library LibProposing {
         // However, if the "proposer" address is set to a non-zero value, we
         // ensure that only that specific address has the authority to propose
         // blocks.
-        address proposer = resolver.resolve("proposer", true);
-        if (proposer != address(0) && msg.sender != proposer) {
-            revert L1_UNAUTHORIZED();
-        }
+        TaikoData.SlotB memory b = state.slotB;
+        if (!_isProposerValid(b, resolver)) revert L1_UNAUTHORIZED();
 
         if (txList.length > config.blockMaxTxListBytes) {
             revert L1_TXLIST_TOO_LARGE();
@@ -79,7 +78,7 @@ library LibProposing {
 
         // It's essential to ensure that the ring buffer for proposed blocks
         // still has space for at least one more block.
-        TaikoData.SlotB memory b = state.slotB;
+
         if (b.numBlocks >= b.lastVerifiedBlockId + config.blockMaxProposals + 1)
         {
             revert L1_TOO_MANY_BLOCKS();
@@ -268,6 +267,26 @@ library LibProposing {
                 msg.sender, assignment.prover, proverFee
             );
         }
+    }
+
+    function _isProposerValid(
+        TaikoData.SlotB memory slotB,
+        AddressResolver resolver
+    )
+        private
+        view
+        returns (bool)
+    {
+        if (slotB.numBlocks == 1) {
+            // Only proposer_one can propose the first block after genesis
+            address proposerOne = resolver.resolve("proposer_one", true);
+            if (proposerOne != address(0) && msg.sender != proposerOne) {
+                return false;
+            }
+        }
+
+        address proposer = resolver.resolve("proposer", true);
+        return proposer == address(0) || msg.sender == proposer;
     }
 
     function _getProverFee(

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -63,7 +63,7 @@ library LibProposing {
         // ensure that only that specific address has the authority to propose
         // blocks.
         TaikoData.SlotB memory b = state.slotB;
-        if (!_isProposerValid(b, resolver)) revert L1_UNAUTHORIZED();
+        if (!_isProposerPermitted(b, resolver)) revert L1_UNAUTHORIZED();
 
         if (txList.length > config.blockMaxTxListBytes) {
             revert L1_TXLIST_TOO_LARGE();
@@ -269,7 +269,7 @@ library LibProposing {
         }
     }
 
-    function _isProposerValid(
+    function _isProposerPermitted(
         TaikoData.SlotB memory slotB,
         AddressResolver resolver
     )


### PR DESCRIPTION

This feature allows a specific address to exclusively propose the first block in Taiko following mainnet launch.