### PR TITLE
feat(website): better prover endpoint page

### DIFF
--- a/packages/website/components/ProverEndpointsTable.tsx
+++ b/packages/website/components/ProverEndpointsTable.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { getProverEndpoints } from "../utils/proverEndpoints";
+import { StyledLink } from "/components/StyledLink";
+
+export default function ProverEndpointsTable() {
+  const [provers, setProvers] = useState([]);
+
+  useEffect(() => {
+    async function fetchProverEndpoints() {
+      try {
+        const proverEndpoints = await getProverEndpoints();
+        setProvers(proverEndpoints);
+        console.log(proverEndpoints);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    fetchProverEndpoints();
+  }, []);
+
+  return (
+    <table className="table-auto w-[80%] text-left mt-8">
+      <thead>
+        <tr>
+          <th>API Endpoint</th>
+          <th>Minimum Fee</th>
+          <th>Current Capacity</th>
+        </tr>
+      </thead>
+      <tbody>
+        {provers.map((prover, index) => (
+          <tr key={index}>
+            <td><StyledLink href={prover.url} text={prover.url}/></td>
+            <td>{prover.minimumGas}</td>
+            <td>{prover.currentCapacity}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export {ProverEndpointsTable}

--- a/packages/website/components/ProverEndpointsTable.tsx
+++ b/packages/website/components/ProverEndpointsTable.tsx
@@ -5,7 +5,7 @@ import PocketBase from "pocketbase";
 
 export function ProverEndpointsTable() {
   const [provers, setProvers] = useState([]);
-  const [sortOrder, setSortOrder] = useState(null);
+  const [sortOrder, setSortOrder] = useState("asc");
   const [sortColumn, setSortColumn] = useState("currentCapacity");
   const [newProverEndpoint, setNewProverEndpoint] = useState("");
 

--- a/packages/website/components/ProverEndpointsTable.tsx
+++ b/packages/website/components/ProverEndpointsTable.tsx
@@ -1,44 +1,131 @@
 import { useEffect, useState } from "react";
 import { getProverEndpoints } from "../utils/proverEndpoints";
-import { StyledLink } from "/components/StyledLink";
+import { StyledLink } from "../components/StyledLink";
+import PocketBase from "pocketbase";
 
-export default function ProverEndpointsTable() {
+export function ProverEndpointsTable() {
   const [provers, setProvers] = useState([]);
+  const [sortOrder, setSortOrder] = useState(null);
+  const [sortColumn, setSortColumn] = useState("currentCapacity");
+  const [newProverEndpoint, setNewProverEndpoint] = useState("");
 
-  useEffect(() => {
-    async function fetchProverEndpoints() {
-      try {
-        const proverEndpoints = await getProverEndpoints();
-        setProvers(proverEndpoints);
-        console.log(proverEndpoints);
-      } catch (error) {
-        console.error(error);
+  async function addProverEndpoint(e) {
+    e.preventDefault();
+
+    try {
+      const pb = new PocketBase("https://provers.dojonode.xyz");
+      // dummy login to allow anyone to add their endpoint
+      await pb.collection("users").authWithPassword("dummy", "dummy12345");
+
+      // Remove trailing slashes
+      const newProverEndpointValue = newProverEndpoint.replace(/\/+$/, "");
+
+      // Add the prover to the DB
+      await pb.collection("prover_endpoints").create({
+        url: newProverEndpointValue,
+      });
+
+      // Success: refresh data and show toast?
+      fetchProverEndpoints();
+      setNewProverEndpoint("");
+    } catch (error) {
+      console.error(error);
+      // Show error as a toast message
+    }
+  }
+
+  async function fetchProverEndpoints() {
+    try {
+      const proverEndpoints = await getProverEndpoints();
+      setProvers(
+        proverEndpoints.sort((a, b) => b.currentCapacity - a.currentCapacity)
+      );
+      console.log(proverEndpoints);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  const sortData = (column) => {
+    const sortedProvers = [...provers];
+    sortedProvers.sort((a, b) => {
+      if (sortOrder === "asc") {
+        return a[column] - b[column];
+      } else {
+        return b[column] - a[column];
+      }
+    });
+    setProvers(sortedProvers);
+    setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+    setSortColumn(column);
+  };
+
+  // Function to render the sorting arrow in the table header
+  const renderSortArrow = (column) => {
+    if (column === sortColumn) {
+      if (sortOrder === "asc") {
+        return <span>&uarr;</span>; // Up arrow
+      } else {
+        return <span>&darr;</span>; // Down arrow
       }
     }
+    return null;
+  };
 
+  useEffect(() => {
     fetchProverEndpoints();
   }, []);
 
   return (
-    <table className="table-auto w-[80%] text-left mt-8">
-      <thead>
-        <tr>
-          <th>API Endpoint</th>
-          <th>Minimum Fee</th>
-          <th>Current Capacity</th>
-        </tr>
-      </thead>
-      <tbody>
-        {provers.map((prover, index) => (
-          <tr key={index}>
-            <td><StyledLink href={prover.url} text={prover.url}/></td>
-            <td>{prover.minimumGas}</td>
-            <td>{prover.currentCapacity}</td>
+    <div>
+      <form
+        className="flex flex-col items-center my-4"
+        onSubmit={(e) => addProverEndpoint(e)}
+      >
+        <input
+          value={newProverEndpoint}
+          onChange={(e) => setNewProverEndpoint(e.target.value)}
+          className="my-3 py-1 text-center"
+          placeholder="http://192.168.20.1:9876"
+        />
+        <button
+          className="hover:cursor-pointer text-neutral-100 bg-[#E81899] hover:bg-[#d1168a] border-solid border-neutral-200 focus:ring-4 focus:outline-none focus:ring-neutral-100 font-medium rounded-lg text-sm px-3 py-2 text-center inline-flex items-center m-1 w-48 justify-center"
+          type="submit"
+        >
+          Add prover pool
+        </button>
+      </form>
+
+      <table className="table-auto w-full text-center mt-8">
+        <thead>
+          <tr>
+            <th>API Endpoint</th>
+            <th
+              className="cursor-pointer"
+              onClick={() => sortData("minimumGas")}
+            >
+              Minimum Fee {renderSortArrow("minimumGas")}
+            </th>
+            <th
+              className="cursor-pointer"
+              onClick={() => sortData("currentCapacity")}
+            >
+              Current Capacity {renderSortArrow("currentCapacity")}
+            </th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {provers.map((prover, index) => (
+            <tr key={index}>
+              <td>
+                <StyledLink href={prover.url} text={prover.url} />
+              </td>
+              <td>{prover.minimumGas}</td>
+              <td>{prover.currentCapacity}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
-
-export {ProverEndpointsTable}

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,6 +12,7 @@
     "next-themes": "^0.2.1",
     "nextra": "^2.13.2",
     "nextra-theme-docs": "^2.13.2",
+    "pocketbase": "^0.19.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "remark-mdx-disable-explicit-jsx": "^0.1.0",

--- a/packages/website/pages/docs/reference/prover-market-page.mdx
+++ b/packages/website/pages/docs/reference/prover-market-page.mdx
@@ -1,37 +1,19 @@
 import { Callout } from "nextra-theme-docs";
+import { ProverEndpointsTable } from "components/ProverEndpointsTable";
+import { StyledLink } from "/components/StyledLink";
 
 # Prover market registration page
 
-Edit this page by opening a pull request and modifying the table below to add your prover to the prover market table. Proposers can also use this page to find the endpoints of provers offering their service to the open market.
-
-You can edit the page by clicking [here](https://github.com/taikoxyz/taiko-mono/edit/main/packages/website/pages/docs/reference/prover-market-page.mdx).
+Add your own endpoint at <StyledLink href="" text="dojonode.xyz" />.
 
 ## Prover market table
 
-<Callout type="warning">
-  These endpoints are not checked, so it's possible they don't work or a
-  community member has shut off their prover. Additionally, these are community
-  listed endpoints, **Taiko has not audited them for security**. If you find an
-  endpoint not working please feel free to open a PR and remove it from this
-  list.
+<Callout type="info">
+  These endpoints and their values get retrieved on every page refresh which make them almost realtime.
+  However they are still community controlled endpoints.
+  **Taiko has not audited them for security**.
 </Callout>
 
-| Name           | API Endpoint                            | Minimum fee |
-| -------------- | --------------------------------------- | ----------- |
-| ZKPool (HTTP)  | http://taiko-a5-prover-simple.zkpool.io | 10 wei      |
-| ZKPool (HTTPS) | https://taiko-a5-prover.zkpool.io       | 10 wei      |
-| Davaymne       | http://pool-1.taikopool.xyz             | 10 wei      |
-| Web3Cript 1    | http://taiko.web3cript.xyz:9876         | 10 wei      |
-| Web3Cript 2    | http://ttko.web3cript.xyz:9876          | 10 wei      |
-| Purethereal    | http://purethereal.xyz:9876             | 10 wei      |
-| Karma Nodes    | http://karmanodes.xyz                   | 10 wei      |
-| Cryptic Node   | http://taiko.crypticnode.xyz:9876       | 10 wei      |
-| dannyletra     | http://158.220.89.198:9876              | 10 wei      |
-| AlexIT         | http://62.183.54.219:9876               | 10 wei      |
-| ZK Nodes       | http://45.144.28.60:9876                | 10 wei      |     
-| RexCloud       | http://185.173.38.221:9876              | 10 wei      |
-| RZF Node       | http://45.142.214.132:9876              | 10 wei      |
-| Vitek73        | http://65.21.14.11:9876                 | 10 wei      |
-| FTP Crypto     | http://161.97.133.1:9876                | 10 wei      |
-| snowleopard    | http://161.97.146.121:9876              | 10 wei      |
-| Elsass Node    | http://90.11.209.115:9876               | 10 wei      |
+
+<ProverEndpointsTable/>
+

--- a/packages/website/pages/docs/reference/prover-market-page.mdx
+++ b/packages/website/pages/docs/reference/prover-market-page.mdx
@@ -1,19 +1,12 @@
 import { Callout } from "nextra-theme-docs";
 import { ProverEndpointsTable } from "components/ProverEndpointsTable";
-import { StyledLink } from "/components/StyledLink";
 
-# Prover market registration page
-
-Add your own endpoint at <StyledLink href="" text="dojonode.xyz" />.
-
-## Prover market table
+# Prover market page
 
 <Callout type="info">
-  These endpoints and their values get retrieved on every page refresh which make them almost realtime.
-  However they are still community controlled endpoints.
+  These endpoints are community controlled endpoints. \
   **Taiko has not audited them for security**.
 </Callout>
-
 
 <ProverEndpointsTable/>
 

--- a/packages/website/utils/proverEndpoints.ts
+++ b/packages/website/utils/proverEndpoints.ts
@@ -1,0 +1,23 @@
+interface proverEndpoint {
+  url: string,
+  currentCapacity: number,
+  minimumFee: number,
+}
+
+export async function getProverEndpoints() {
+  try {
+    const response = await fetch('https://provers.dojonode.xyz/validProvers');
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const provers = await response.json(); // Parse the response as JSON
+
+    console.log(provers);
+    return provers as proverEndpoint[];
+  } catch (error) {
+    console.error(error);
+    throw error; // Rethrow the error so that the caller can handle it
+  }
+}

--- a/packages/website/utils/proverEndpoints.ts
+++ b/packages/website/utils/proverEndpoints.ts
@@ -13,8 +13,6 @@ export async function getProverEndpoints() {
     }
 
     const provers = await response.json(); // Parse the response as JSON
-
-    console.log(provers);
     return provers as proverEndpoint[];
   } catch (error) {
     console.error(error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -797,6 +797,9 @@ importers:
       nextra-theme-docs:
         specifier: ^2.13.2
         version: 2.13.2(next@13.5.6)(nextra@2.13.2)(react-dom@18.2.0)(react@18.2.0)
+      pocketbase:
+        specifier: ^0.19.0
+        version: 0.19.0
       react:
         specifier: ^18.2.0
         version: 18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20101,6 +20101,10 @@ packages:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
 
+  /pocketbase@0.19.0:
+    resolution: {integrity: sha512-bUVZfVdD17K8GnwbeDMZPEdREVg2YE0F8uHPDC0zer4VtwXUqoPCCeudTy3fhUE7pfuKnfpuPxeBSYsBY3AGIQ==}
+    dev: false
+
   /posix-character-classes@0.1.1:
     resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==}
     engines: {node: '>=0.10.0'}


### PR DESCRIPTION
A better prover market where anyone can add a prover and only the online provers get shown. The DB has an endpoint where it will loop every prover pool and do a `/status` check to get the latest status. 

The input field sends a request to the DB to create a new prover, where there is a hook that first does a `/status` check to see if the endpoint is a valid prover pool.

Some features:
- automatically filter out deprecated/offline endpoints
- shows the latest capacity and minimum gas fee
- anyone can permissionlessly add their prover pool endpoint

The database can be found here [github.com/wolfderechter/prover-market-page](github.com/wolfderechter/prover-market-page)  and is currently hosted at provers.dojonode.xyz.

Todo:
 

- [ ] add success/error messages for the input field
 - [ ] add a one line copy paste command with all the online provers 
 - [ ] add caching to the DB
 - [ ] add a prover pool name -> needs an extra .env value in the taiko-client
 - [ ] taiko-client has breaking changes in the near future in the `/status`, update once these changes are released

Current layout:
![image](https://github.com/taikoxyz/taiko-mono/assets/60930264/de07cb62-2d01-4762-8403-5e2ec7c4d08e)
