### PR TITLE
fix(protocol): fix 2 bridge bugs reported by Victor

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -99,14 +99,15 @@ contract Bridge is EssentialContract, IBridge {
 
         if (message.to == address(0)) revert B_INVALID_TO();
         if (message.to == destBridge) revert B_INVALID_TO();
+        if (message.to == resolve(message.destChainId, "ether_vault", true)) {
+            revert B_INVALID_TO();
+        }
 
-        address etherVault = resolve("ether_vault", false);
-        if (message.to == etherVault) revert B_INVALID_TO();
         // Ensure the sent value matches the expected amount.
         uint256 expectedAmount = message.value + message.fee;
         if (expectedAmount != msg.value) revert B_INVALID_VALUE();
 
-        etherVault.sendEther(expectedAmount);
+        resolve("ether_vault", false).sendEther(expectedAmount);
 
         _message = message;
         // Configure message details and send signal to indicate message

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -99,8 +99,8 @@ contract Bridge is EssentialContract, IBridge {
 
         if (
             message.to == address(0) || message.to == destBridge
-                || message.to == resolve(message.destChainId, "taiko", true)
                 || message.to == resolve(message.destChainId, "ether_vault", true)
+                || message.to == resolve(message.destChainId, "taiko", true)
         ) {
             revert B_INVALID_TO();
         }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -199,7 +199,7 @@ contract Bridge is EssentialContract, IBridge {
         // Process message differently based on the target address
         if (
             message.to == address(0) || message.to == address(this)
-                || message.to == ethVault || message.to == resolve("taiko", true)
+                || message.to == ethVault || message.to == resolve("taiko", false)
         ) {
             // Handle special addresses that don't require actual invocation but
             // mark message as DONE

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -97,9 +97,11 @@ contract Bridge is EssentialContract, IBridge {
             revert B_INVALID_CHAINID();
         }
 
-        if (message.to == address(0)) revert B_INVALID_TO();
-        if (message.to == destBridge) revert B_INVALID_TO();
-        if (message.to == resolve(message.destChainId, "ether_vault", true)) {
+        if (
+            message.to == address(0) || message.to == destBridge
+                || message.to == resolve(message.destChainId, "taiko", true)
+                || message.to == resolve(message.destChainId, "ether_vault", true)
+        ) {
             revert B_INVALID_TO();
         }
 
@@ -207,7 +209,7 @@ contract Bridge is EssentialContract, IBridge {
         // Process message differently based on the target address
         if (
             message.to == address(this) || message.to == address(0)
-                || message.to == ethVault
+                || message.to == ethVault || message.to == resolve("taiko", true)
         ) {
             // Handle special addresses that don't require actual invocation but
             // mark message as DONE

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -100,11 +100,13 @@ contract Bridge is EssentialContract, IBridge {
         if (message.to == address(0)) revert B_INVALID_TO();
         if (message.to == destBridge) revert B_INVALID_TO();
 
+        address etherVault = resolve("ether_vault", false);
+        if (message.to == etherVault) revert B_INVALID_TO();
         // Ensure the sent value matches the expected amount.
         uint256 expectedAmount = message.value + message.fee;
         if (expectedAmount != msg.value) revert B_INVALID_VALUE();
 
-        resolve("ether_vault", false).sendEther(expectedAmount);
+        etherVault.sendEther(expectedAmount);
 
         _message = message;
         // Configure message details and send signal to indicate message
@@ -202,7 +204,10 @@ contract Bridge is EssentialContract, IBridge {
         uint256 refundAmount;
 
         // Process message differently based on the target address
-        if (message.to == address(this) || message.to == address(0)) {
+        if (
+            message.to == address(this) || message.to == address(0)
+                || message.to == ethVault
+        ) {
             // Handle special addresses that don't require actual invocation but
             // mark message as DONE
             status = Status.DONE;

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -208,7 +208,7 @@ contract Bridge is EssentialContract, IBridge {
 
         // Process message differently based on the target address
         if (
-            message.to == address(this) || message.to == address(0)
+            message.to == address(0) || message.to == address(this)
                 || message.to == ethVault || message.to == resolve("taiko", true)
         ) {
             // Handle special addresses that don't require actual invocation but

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -149,9 +149,23 @@ contract Bridge is EssentialContract, IBridge {
         bool support =
             message.from.supportsInterface(type(IRecallableSender).interfaceId);
         if (support) {
+            _ctx = Context({
+                msgHash: msgHash,
+                from: address(this),
+                srcChainId: message.srcChainId
+            });
+
+            // Perform recall
             IRecallableSender(message.from).onMessageRecalled{
                 value: message.value
             }(message, msgHash);
+
+            // Reset the context after the message call
+            _ctx = Context({
+                msgHash: MESSAGE_HASH_PLACEHOLDER,
+                from: SRC_CHAIN_SENDER_PLACEHOLDER,
+                srcChainId: CHAINID_PLACEHOLDER
+            });
         } else {
             message.user.sendEther(message.value);
         }
@@ -373,10 +387,8 @@ contract Bridge is EssentialContract, IBridge {
         returns (bool success)
     {
         if (gasLimit == 0) revert B_INVALID_GAS_LIMIT();
+        assert(message.from != address(this));
 
-        // Update the context for the message call
-        // Should we simply provide the message itself rather than
-        // a context object?
         _ctx = Context({
             msgHash: msgHash,
             from: message.from,

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -125,7 +125,7 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
     {
         // Check context validity
         IBridge.Context memory ctx =
-            LibVaultUtils.checkValidContext("erc1155_vault", address(this));
+            LibVaultUtils.checkValidContext("erc1155_vault");
         address token;
 
         unchecked {
@@ -177,6 +177,8 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
         whenNotPaused
         onlyFromNamed("bridge")
     {
+        LibVaultUtils.checkValidContext("bridge");
+
         (
             CanonicalNFT memory nft,
             ,

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -191,7 +191,7 @@ contract ERC20Vault is
         onlyFromNamed("bridge")
     {
         IBridge.Context memory ctx =
-            LibVaultUtils.checkValidContext("erc20_vault", address(this));
+            LibVaultUtils.checkValidContext("erc20_vault");
 
         address token;
         if (ctoken.chainId == block.chainid) {
@@ -226,6 +226,8 @@ contract ERC20Vault is
         whenNotPaused
         onlyFromNamed("bridge")
     {
+        LibVaultUtils.checkValidContext("bridge");
+
         (, address token,, uint256 amount) = abi.decode(
             message.data[4:], (CanonicalERC20, address, address, uint256)
         );

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -108,7 +108,7 @@ contract ERC721Vault is
         onlyFromNamed("bridge")
     {
         IBridge.Context memory ctx =
-            LibVaultUtils.checkValidContext("erc721_vault", address(this));
+            LibVaultUtils.checkValidContext("erc721_vault");
         address token;
 
         unchecked {
@@ -154,6 +154,8 @@ contract ERC721Vault is
         whenNotPaused
         onlyFromNamed("bridge")
     {
+        LibVaultUtils.checkValidContext("bridge");
+
         if (message.user == address(0)) revert VAULT_INVALID_USER();
         if (message.srcChainId != block.chainid) {
             revert VAULT_INVALID_SRC_CHAIN_ID();

--- a/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
+++ b/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
@@ -42,19 +42,15 @@ library LibVaultUtils {
     }
 
     /// @dev Checks if context is valid
-    /// @param validSender The valid sender to be allowed
-    /// @param resolver The address of the resolver
-    function checkValidContext(
-        bytes32 validSender,
-        address resolver
-    )
-        external
+    /// @param senderName The valid sender to be allowed
+    function checkValidContext(bytes32 senderName)
+        internal
         view
         returns (IBridge.Context memory ctx)
     {
         ctx = IBridge(msg.sender).context();
-        address sender = AddressResolver(resolver).resolve(
-            ctx.srcChainId, validSender, false
+        address sender = AddressResolver(address(this)).resolve(
+            ctx.srcChainId, senderName, false
         );
         if (ctx.from != sender) revert VAULT_INVALID_FROM();
     }
@@ -64,7 +60,7 @@ library LibVaultUtils {
         address to,
         address token
     )
-        external
+        internal
         pure
     {
         if (to == address(0) || to == vault) revert VAULT_INVALID_TO();
@@ -76,7 +72,7 @@ library LibVaultUtils {
         uint256[] memory tokenIds,
         bool isERC721
     )
-        external
+        internal
         pure
     {
         if (tokenIds.length != amounts.length) {

--- a/packages/protocol/test/bridge/Bridge.t.sol
+++ b/packages/protocol/test/bridge/Bridge.t.sol
@@ -280,41 +280,6 @@ contract BridgeTest is TestBase {
         bridge.sendMessage{ value: amount }(message);
     }
 
-    function test_Bridge_send_message_ether_reverts_when_to_is_destination_bridge_address(
-    )
-        public
-    {
-        uint256 amount = 1 wei;
-        IBridge.Message memory message = newMessage({
-            user: Alice,
-            to: address(destChainBridge),
-            value: 0,
-            gasLimit: 0,
-            fee: 0,
-            destChain: destChainId
-        });
-
-        vm.expectRevert(Bridge.B_INVALID_TO.selector);
-        bridge.sendMessage{ value: amount }(message);
-    }
-
-    function test_Bridge_send_message_ether_reverts_when_to_is_zero_address()
-        public
-    {
-        uint256 amount = 1 wei;
-        IBridge.Message memory message = newMessage({
-            user: Alice,
-            to: address(0),
-            value: 0,
-            gasLimit: 0,
-            fee: 0,
-            destChain: destChainId
-        });
-
-        vm.expectRevert(Bridge.B_INVALID_TO.selector);
-        bridge.sendMessage{ value: amount }(message);
-    }
-
     function test_Bridge_send_message_ether_with_no_processing_fee() public {
         uint256 amount = 0 wei;
         IBridge.Message memory message = newMessage({

--- a/packages/protocol/test/bridge/Bridge.t.sol
+++ b/packages/protocol/test/bridge/Bridge.t.sol
@@ -91,6 +91,8 @@ contract BridgeTest is TestBase {
             destChainId, "ether_vault", address(etherVault)
         );
 
+        addressManager.setAddress(destChainId, "taiko", address(uint160(123)));
+
         addressManager.setAddress(block.chainid, "bridge", address(bridge));
 
         vm.stopPrank();


### PR DESCRIPTION
Reported by Victor from QuillAudits:

1.  if message.to == etherVault bug, then message can call releaseEther to drain all Ether from the audit.

2. currently attacker can steal all tokens in the ERC20Vault through the same bug I mentioned, calling the onMessageRecalled which also has a constraint that shouldn't be called unless failed, currently through this bug that is not handled fully attacker is able to bypass this regardless and steal all tokens

