### PR TITLE
fix(protocol): Handle 1559 vars together

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -258,7 +258,7 @@ contract TaikoL1 is
     /// @return Config struct containing configuration parameters.
     function getConfig()
         public
-        pure
+        view
         virtual
         returns (TaikoData.Config memory)
     {
@@ -293,7 +293,7 @@ contract TaikoL1 is
         });
     }
 
-    function isConfigValid() public pure returns (bool) {
+    function isConfigValid() public view returns (bool) {
         return LibVerifying.isConfigValid(getConfig());
     }
 }

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -43,6 +43,7 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
     uint256[145] private __gap;
 
     event Anchored(bytes32 parentHash, uint128 gasExcess);
+    event ConfigChanged(Config);
 
     error L2_BASEFEE_MISMATCH();
     error L2_INVALID_CHAIN_ID();
@@ -161,6 +162,8 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
         )
     {
         baseFeeConfig = _baseFeeConfig;
+
+        emit ConfigChanged(_baseFeeConfig);
     }
 
     /// @inheritdoc ICrossChainSync

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -39,9 +39,9 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
     bytes32 public publicInputHash; // slot 3
     uint64 public latestSyncedL1Height; // slot 4
     /// @dev These 3 below always need to be aligned!
-    uint64 gasExcess;
-    uint32 gasTargetPerL1Block;
-    uint8 basefeeAdjustmentQuotient;
+    uint64 public gasExcess;
+    uint32 public gasTargetPerL1Block;
+    uint8 public basefeeAdjustmentQuotient;
 
     uint256[146] private __gap;
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -173,7 +173,11 @@ contract TaikoL2 is EssentialContract, TaikoL2Signer, ICrossChainSync {
 
     /// @notice Returns EIP1559 related configurations
     function getConfig() public view virtual returns (Config memory config) {
-        config.gasTargetPerL1Block = 15 * 1e6 * 10; // 10x Ethereum gas target
+        // 4x Ethereum gas target, if we assume most of the time, L2 block time
+        // is 3s, and each block is full (gasUsed is 15_000_000), then its
+        // ~60_000_000, if the  network is congester than that, the base fee
+        // will increase.
+        config.gasTargetPerL1Block = 15 * 1e6 * 4;
         config.basefeeAdjustmentQuotient = 8;
     }
 

--- a/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
+++ b/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
@@ -12,21 +12,34 @@ import { Proxied } from "../common/Proxied.sol";
 /// @title TaikoL2EIP1559Configurable
 /// @notice Taiko L2 extended with parameter setting
 contract TaikoL2EIP1559Configurable is TaikoL2 {
-    event ConfigChanged(Config config);
+    Config private _config;
+    uint256[49] private __gap;
+
+    event ConfigAndExcessChanged(Config config, uint64 gasExcess);
+
+    error L2_INVALID_CONFIG();
 
     /// @notice Sets EIP1559 related configurations
-    /// @param _baseFeeConfig The new config settings.
-    function setConfig(Config memory _baseFeeConfig)
-        public
+    /// @param config The new config settings.
+    function setConfigAndExcess(
+        Config memory config,
+        uint64 newGasExcess
+    )
+        external
         virtual
         onlyOwner
-        validConfig(_baseFeeConfig)
     {
-        gasExcess = _baseFeeConfig.gasExcess;
-        gasTargetPerL1Block = _baseFeeConfig.gasTargetPerL1Block;
-        basefeeAdjustmentQuotient = _baseFeeConfig.basefeeAdjustmentQuotient;
+        if (config.gasTargetPerL1Block == 0) revert L2_INVALID_CONFIG();
+        if (config.basefeeAdjustmentQuotient == 0) revert L2_INVALID_CONFIG();
 
-        emit ConfigChanged(_baseFeeConfig);
+        _config = config;
+        gasExcess = newGasExcess;
+
+        emit ConfigAndExcessChanged(config, newGasExcess);
+    }
+
+    function getConfig() public view override returns (Config memory) {
+        return _config;
     }
 }
 

--- a/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
+++ b/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
@@ -19,8 +19,9 @@ contract TaikoL2EIP1559Configurable is TaikoL2 {
 
     error L2_INVALID_CONFIG();
 
-    /// @notice Sets EIP1559 related configurations
-    /// @param config The new config settings.
+    /// @notice Sets EIP1559 configuration and gas excess.
+    /// @param config The new EIP1559 config.
+    /// @param newGasExcess The new gas excess
     function setConfigAndExcess(
         Config memory config,
         uint64 newGasExcess

--- a/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
+++ b/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
@@ -10,7 +10,7 @@ import { TaikoL2 } from "./TaikoL2.sol";
 import { Proxied } from "../common/Proxied.sol";
 
 /// @title TaikoL2EIP1559Configurable
-/// @notice Taiko L2 extended with parameter setting
+/// @notice Taiko L2 with a setter to change EIP-1559 configurations and states.
 contract TaikoL2EIP1559Configurable is TaikoL2 {
     Config private _config;
     uint256[49] private __gap;

--- a/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
+++ b/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+//  _____     _ _         _         _
+// |_   _|_ _(_) |_____  | |   __ _| |__ ___
+//   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
+//   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
+
+pragma solidity ^0.8.20;
+
+import { TaikoL2 } from "./TaikoL2.sol";
+import { Proxied } from "../common/Proxied.sol";
+
+/// @title TaikoL2EIP1559Configurable
+/// @notice Taiko L2 extended with parameter setting
+contract TaikoL2EIP1559Configurable is TaikoL2 {
+    event ConfigChanged(Config config);
+
+    /// @notice Sets EIP1559 related configurations
+    /// @param _baseFeeConfig The new config settings.
+    function setConfig(Config memory _baseFeeConfig)
+        public
+        virtual
+        onlyOwner
+        validConfig(_baseFeeConfig)
+    {
+        gasExcess = _baseFeeConfig.gasExcess;
+        gasTargetPerL1Block = _baseFeeConfig.gasTargetPerL1Block;
+        basefeeAdjustmentQuotient = _baseFeeConfig.basefeeAdjustmentQuotient;
+
+        emit ConfigChanged(_baseFeeConfig);
+    }
+}
+
+/// @title ProxiedTaikoL2EIP1559Configurable
+/// @notice Proxied version of the TaikoL2EIP1559Configurable contract.
+contract ProxiedTaikoL2EIP1559Configurable is
+    Proxied,
+    TaikoL2EIP1559Configurable
+{ }

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -15,12 +15,12 @@ import { TaikoL1TestBase } from "./TaikoL1TestBase.sol";
 contract TaikoL1_NoCooldown is TaikoL1 {
     function getConfig()
         public
-        pure
+        view
         override
         returns (TaikoData.Config memory config)
     {
         config = TaikoL1.getConfig();
-
+        // over-write the following
         config.maxBlocksToVerifyPerProposal = 0;
         config.blockMaxProposals = 10;
         config.blockRingBufferSize = 12;

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -21,7 +21,7 @@ import { LibTiers } from "../../contracts/L1/tiers/ITierProvider.sol";
 contract TaikoL1Tiers is TaikoL1 {
     function getConfig()
         public
-        pure
+        view
         override
         returns (TaikoData.Config memory config)
     {

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -42,12 +42,16 @@ contract TestTaikoL2 is TestBase {
         uint128 gasExcess = 0;
         uint8 quotient = 8;
         uint64 gasTarget = 60_000_000;
-        L2.init(address(addressManager), gasExcess, gasTarget, quotient);
+        L2.init(
+            address(addressManager),
+            TaikoL2.Config(gasExcess, gasTarget, quotient)
+        );
 
         L2FeeSimulation = new SkipBasefeeCheckL2();
         gasExcess = 195_420_300_100;
         L2FeeSimulation.init(
-            address(addressManager), gasExcess, gasTarget, quotient
+            address(addressManager),
+            TaikoL2.Config(gasExcess, gasTarget, quotient)
         );
 
         vm.roll(block.number + 1);

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -44,16 +44,15 @@ contract TestTaikoL2 is TestBase {
         uint64 gasExcess = 0;
         uint8 quotient = 8;
         uint32 gasTarget = 60_000_000;
-        L2.init(
-            address(addressManager),
-            TaikoL2.Config(gasExcess, gasTarget, quotient)
-        );
+        L2.init(address(addressManager), gasExcess);
+        L2.setConfigAndExcess(TaikoL2.Config(gasTarget, quotient), gasExcess);
 
         L2FeeSimulation = new SkipBasefeeCheckL2();
         gasExcess = 195_420_300_100;
-        L2FeeSimulation.init(
-            address(addressManager),
-            TaikoL2.Config(gasExcess, gasTarget, quotient)
+
+        L2FeeSimulation.init(address(addressManager), gasExcess);
+        L2FeeSimulation.setConfigAndExcess(
+            TaikoL2.Config(gasTarget, quotient), gasExcess
         );
 
         vm.roll(block.number + 1);

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -7,10 +7,12 @@ import { SafeCastUpgradeable } from
     "lib/openzeppelin-contracts-upgradeable/contracts/utils/math/SafeCastUpgradeable.sol";
 import { AddressManager } from "../../contracts/common/AddressManager.sol";
 import { SignalService } from "../../contracts/signal/SignalService.sol";
+import { TaikoL2EIP1559Configurable } from
+    "../../contracts/L2/TaikoL2EIP1559Configurable.sol";
 import { TaikoL2 } from "../../contracts/L2/TaikoL2.sol";
 import { TestBase } from "../TestBase.sol";
 
-contract SkipBasefeeCheckL2 is TaikoL2 {
+contract SkipBasefeeCheckL2 is TaikoL2EIP1559Configurable {
     function skipFeeCheck() public pure override returns (bool) {
         return true;
     }
@@ -26,7 +28,7 @@ contract TestTaikoL2 is TestBase {
 
     AddressManager public addressManager;
     SignalService public ss;
-    TaikoL2 public L2;
+    TaikoL2EIP1559Configurable public L2;
     SkipBasefeeCheckL2 public L2FeeSimulation;
     uint256 private logIndex;
 
@@ -38,10 +40,10 @@ contract TestTaikoL2 is TestBase {
         ss.init(address(addressManager));
         registerAddress("signal_service", address(ss));
 
-        L2 = new TaikoL2();
-        uint128 gasExcess = 0;
+        L2 = new TaikoL2EIP1559Configurable();
+        uint64 gasExcess = 0;
         uint8 quotient = 8;
-        uint64 gasTarget = 60_000_000;
+        uint32 gasTarget = 60_000_000;
         L2.init(
             address(addressManager),
             TaikoL2.Config(gasExcess, gasTarget, quotient)

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -40,11 +40,15 @@ contract TestTaikoL2 is TestBase {
 
         L2 = new TaikoL2();
         uint128 gasExcess = 0;
-        L2.init(address(addressManager), gasExcess);
+        uint8 quotient = 8;
+        uint64 gasTarget = 60_000_000;
+        L2.init(address(addressManager), gasExcess, gasTarget, quotient);
 
         L2FeeSimulation = new SkipBasefeeCheckL2();
-        gasExcess = 49_954_623_777;
-        L2FeeSimulation.init(address(addressManager), gasExcess);
+        gasExcess = 195_420_300_100;
+        L2FeeSimulation.init(
+            address(addressManager), gasExcess, gasTarget, quotient
+        );
 
         vm.roll(block.number + 1);
         vm.warp(block.timestamp + 30);
@@ -89,7 +93,7 @@ contract TestTaikoL2 is TestBase {
 
     function test_simulation_lower_traffic() external {
         console2.log("LOW TRAFFIC STARTS"); // For parser
-        _simulation(100_000, 60_000_000, 1, 8);
+        _simulation(100_000, 10_000_000, 1, 8);
         console2.log("LOW TRAFFIC ENDS");
     }
 
@@ -101,7 +105,7 @@ contract TestTaikoL2 is TestBase {
 
     function test_simulation_target_traffic() external {
         console2.log("TARGET TRAFFIC STARTS"); // For parser
-        _simulation(150_000_000, 0, 12, 0);
+        _simulation(60_000_000, 0, 12, 0);
         console2.log("TARGET TRAFFIC ENDS");
     }
 

--- a/packages/protocol/utils/generate_genesis/taikoL2.ts
+++ b/packages/protocol/utils/generate_genesis/taikoL2.ts
@@ -303,7 +303,6 @@ async function generateContractConfigs(
                             ]),
                     ]
                 )}`,
-                gasExcess: ethers.BigNumber.from(param1559.gasExcess),
                 // AddressResolver
                 addressManager: addressMap.AddressManagerProxy,
             },


### PR DESCRIPTION
As per convo here: https://github.com/taikoxyz/taiko-mono/pull/15025#discussion_r1372647928 - we need to handle (and re-set) gasExcess together with the target (and quotient).