### PR TITLE
feat(protocol): Use authorize instead of onlyFrom

### DIFF
--- a/packages/protocol/contracts/L1/Valami.bak
+++ b/packages/protocol/contracts/L1/Valami.bak
@@ -1,0 +1,23 @@
+
+
+    struct Slot7{
+        uint64 genesisHeight;
+        uint64 genesisTimestamp;
+        uint64 __reserved70;
+        uint64 __reserved71;
+    }
+
+    struct Slot8{
+        uint64 numOpenBlocks;
+        uint64 numEthDeposits;
+        uint64 numBlocks;
+        uint64 nextEthDepositToProcess;
+    }
+
+    struct Slot9{
+        uint64 lastVerifiedAt;
+        uint64 lastVerifiedBlockId;
+        uint64 __reserved90;
+        uint32 feePerGas;
+        uint16 avgProofDelay;
+    }

--- a/packages/protocol/contracts/L1/libs/LibProposing_with_debug_prints_for_simulation.bak
+++ b/packages/protocol/contracts/L1/libs/LibProposing_with_debug_prints_for_simulation.bak
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: MIT
+//  _____     _ _         _         _
+// |_   _|_ _(_) |_____  | |   __ _| |__ ___
+//   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
+//   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
+
+pragma solidity ^0.8.20;
+
+import { ERC20Upgradeable } from "@ozu/token/ERC20/ERC20Upgradeable.sol";
+
+import { AddressResolver } from "../../common/AddressResolver.sol";
+import { LibAddress } from "../../libs/LibAddress.sol";
+import { LibMath } from "../../libs/LibMath.sol";
+
+import { ITierProvider } from "../tiers/ITierProvider.sol";
+import { TaikoData } from "../TaikoData.sol";
+
+import { console2 } from "forge-std/console2.sol";
+import { LibDepositing } from "./LibDepositing.sol";
+import { LibTaikoToken } from "./LibTaikoToken.sol";
+
+/// @title LibProposing
+/// @notice A library for handling block proposals in the Taiko protocol.
+library LibProposing {
+    using LibAddress for address;
+    using LibMath for uint256;
+
+    // Warning: Any events defined here must also be defined in TaikoEvents.sol.
+    event BlockProposed(
+        uint256 indexed blockId,
+        address indexed assignedProver,
+        uint96 livenessBond,
+        uint256 proverFee,
+        uint256 reward,
+        uint16 minTier,
+        TaikoData.BlockMetadata meta
+    );
+
+    // Warning: Any errors defined here must also be defined in TaikoErrors.sol.
+    error L1_ASSIGNMENT_EXPIRED();
+    error L1_ASSIGNMENT_INVALID_SIG();
+    error L1_ASSIGNMENT_INVALID_PARAMS();
+    error L1_ASSIGNMENT_INSUFFICIENT_FEE();
+    error L1_TIER_NOT_FOUND();
+    error L1_TOO_MANY_BLOCKS();
+    error L1_TXLIST_INVALID_RANGE();
+    error L1_TXLIST_MISMATCH();
+    error L1_TXLIST_NOT_FOUND();
+    error L1_TXLIST_TOO_LARGE();
+    error L1_UNAUTHORIZED();
+
+    /// @dev Proposes a Taiko L2 block.
+    function proposeBlock(
+        TaikoData.State storage state,
+        TaikoData.Config memory config,
+        AddressResolver resolver,
+        bytes32 txListHash,
+        bytes32 extraData,
+        TaikoData.ProverAssignment memory assignment,
+        bytes calldata txList
+    )
+        internal
+        returns (TaikoData.BlockMetadata memory meta)
+    {
+        // Taiko, as a Based Rollup, enables permissionless block proposals.
+        // However, if the "proposer" address is set to a non-zero value, we
+        // ensure that only that specific address has the authority to propose
+        // blocks.
+        address proposer = resolver.resolve("proposer", true);
+        if (proposer != address(0) && msg.sender != proposer) {
+            revert L1_UNAUTHORIZED();
+        }
+
+        if (txList.length > config.blockMaxTxListBytes) {
+            revert L1_TXLIST_TOO_LARGE();
+        }
+
+        // It's necessary to verify that the txHash matches the provided hash.
+        // However, when we employ a blob for the txList, the verification
+        // process will differ.
+        if (txListHash != keccak256(txList)) {
+            revert L1_TXLIST_MISMATCH();
+        }
+
+        // It's essential to ensure that the ring buffer for proposed blocks
+        // still has space for at least one more block.
+        TaikoData.SlotB memory b = state.slotB;
+        if (b.numBlocks >= b.lastVerifiedBlockId + config.blockMaxProposals + 1)
+        {
+            revert L1_TOO_MANY_BLOCKS();
+        }
+
+        // In situations where the network lacks sufficient transactions for the
+        // proposer to profit, they are still obligated to pay the prover the
+        // proving fee, which can be a substantial cost compared to the total L2
+        // transaction fees collected. As a solution, Taiko mints additional
+        // Taiko tokens per second as block rewards. It's important to note that
+        // if multiple blocks are proposed within the same L1 block, only the
+        // first one will receive the block reward.
+
+        // The block reward doesn't undergo automatic halving; instead, we
+        // depend on Taiko DAO to make necessary adjustments to the rewards.
+        uint256 reward;
+
+        // First proposer per L1 block updates the L1 block height and the accumulated reward.
+        if(state.slotC.latestRewardAccL1Height < block.number) {
+            // The very first proposal within the protocol starts the 'clock' and from that point on we calculate the accumulation.
+            if(state.slotC.latestRewardAccL1Height != 0) {
+                // Calculate the addition to the accumulated rewards by getting how many blocks elapsed since the last 'sync' then multiply it by 12 (L1 block time) and the reward issued per second.
+                state.slotC.accumulatedReward += uint128((block.number - state.slotC.latestRewardAccL1Height) * 12 * config.proposerRewardPerSecond);
+                state.slotC.latestRewardAccL1Height = uint128(block.number);
+            }
+            state.slotC.latestRewardAccL1Height = uint128(block.number);
+        }
+
+        if (config.proposerRewardPerSecond > 0 && config.proposerRewardMax > 0 && state.slotC.accumulatedReward > 0)
+        {
+            // Might happen that network is congested on L1, so the pool would grow too big for the next proposeBlock() so best to have an absolute maximum upper limit.
+            reward = uint256(state.slotC.accumulatedReward / config.proposerRewardHalving).min(
+                config.proposerRewardMax
+            );
+
+            console2.log("RewardPool:", state.slotC.accumulatedReward);
+            console2.log("reward:", reward);
+            // Always "halven" even if reward is config.proposerRewardMax, so that to shrinken the pool.
+            state.slotC.accumulatedReward -= state.slotC.accumulatedReward / config.proposerRewardHalving;
+            // Reward must be minted
+            LibTaikoToken.creditToken(
+                state, resolver, msg.sender, reward, true
+            );
+        }
+
+        // Initialize metadata to compute a metaHash, which forms a part of
+        // the block data to be stored on-chain for future integrity checks.
+        // If we choose to persist all data fields in the metadata, it will
+        // require additional storage slots.
+        unchecked {
+            meta = TaikoData.BlockMetadata({
+                l1Hash: blockhash(block.number - 1),
+                // Following the Merge, the L1 mixHash incorporates the
+                // prevrandao value from the beacon chain. Given the possibility
+                // of multiple Taiko blocks being proposed within a single
+                // Ethereum block, we must introduce a salt to this random
+                // number as the L2 mixHash.
+                difficulty: bytes32(block.prevrandao * b.numBlocks),
+                txListHash: txListHash,
+                extraData: extraData,
+                id: b.numBlocks,
+                timestamp: uint64(block.timestamp),
+                l1Height: uint64(block.number - 1),
+                gasLimit: config.blockMaxGasLimit,
+                coinbase: msg.sender,
+                // Each transaction must handle a specific quantity of L1-to-L2
+                // Ether deposits.
+                depositsProcessed: LibDepositing.processDeposits(
+                    state, config, msg.sender
+                    )
+            });
+        }
+
+        // Now, it's essential to initialize the block that will be stored
+        // on L1. We should aim to utilize as few storage slots as possible,
+        // alghouth using a ring buffer can minimize storage writes once
+        // the buffer reaches its capacity.
+        TaikoData.Block storage blk =
+            state.blocks[b.numBlocks % config.blockRingBufferSize];
+
+        // Please note that all fields must be re-initialized since we are
+        // utilizing an existing ring buffer slot, not creating a new storage
+        // slot.
+        blk.metaHash = hashMetadata(meta);
+
+        // Safeguard the liveness bond to ensure its preservation,
+        // particularly in scenarios where it might be altered after the
+        // block's proposal but before it has been proven or verified.
+        blk.livenessBond = config.livenessBond;
+        blk.blockId = b.numBlocks;
+        blk.proposedAt = meta.timestamp;
+
+        // For a new block, the next transition ID is always 1, not 0.
+        blk.nextTransitionId = 1;
+
+        // For unverified block, its verifiedTransitionId is always 0.
+        blk.verifiedTransitionId = 0;
+
+        // The LibTiers play a crucial role in determining the minimum tier
+        // required for the block's validity proof. It's imperative to
+        // maintain a certain percentage of blocks for each tier to ensure
+        // that provers are consistently available when needed.
+        blk.minTier = ITierProvider(resolver.resolve("tier_provider", false))
+            .getMinTier(uint256(blk.metaHash));
+
+        // Verify assignment authorization; if prover's address is an IProver
+        // contract, transfer Ether and call "validateAssignment" for
+        // verification.
+        // Prover can charge ERC20/NFT as fees; msg.value can be zero. Taiko
+        // doesn't mandate Ether as the only proofing fee.
+        blk.assignedProver = assignment.prover;
+
+        // The assigned prover burns Taiko tokens, referred to as the
+        // "liveness bond." This bond remains non-refundable to the
+        // assigned prover under two conditions: if the block's verification
+        // transition is not the initial one or if it was generated and
+        // validated by different provers. Instead, a portion of the assignment
+        // bond serves as a reward for the actual prover.
+        LibTaikoToken.debitToken(
+            state, resolver, blk.assignedProver, config.livenessBond
+        );
+
+        // Increment the counter (cursor) by 1.
+        unchecked {
+            ++state.slotB.numBlocks;
+        }
+
+        // Validate the prover assignment, then charge Ether or ERC20 as the
+        // prover fee based on the block's minTier.
+        uint256 proverFee = _validateAssignment({
+            minTier: blk.minTier,
+            txListHash: txListHash,
+            assignment: assignment
+        });
+
+        emit BlockProposed({
+            blockId: blk.blockId,
+            assignedProver: blk.assignedProver,
+            livenessBond: config.livenessBond,
+            proverFee: proverFee,
+            reward: reward,
+            minTier: blk.minTier,
+            meta: meta
+        });
+    }
+
+    /// @dev Hashing the block metadata.
+    function hashMetadata(TaikoData.BlockMetadata memory meta)
+        internal
+        pure
+        returns (bytes32 hash)
+    {
+        uint256[7] memory inputs;
+        inputs[0] = uint256(meta.l1Hash);
+        inputs[1] = uint256(meta.difficulty);
+        inputs[2] = uint256(meta.txListHash);
+        inputs[3] = uint256(meta.extraData);
+        inputs[4] = (uint256(meta.id)) | (uint256(meta.timestamp) << 64)
+            | (uint256(meta.l1Height) << 128) | (uint256(meta.gasLimit) << 192);
+        inputs[5] = uint256(uint160(meta.coinbase));
+        inputs[6] = uint256(keccak256(abi.encode(meta.depositsProcessed)));
+
+        assembly {
+            hash := keccak256(inputs, 224 /*mul(7, 32)*/ )
+        }
+    }
+
+    function hashAssignmentForTxList(
+        TaikoData.ProverAssignment memory assignment,
+        bytes32 txListHash
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                "PROVER_ASSIGNMENT",
+                txListHash,
+                assignment.feeToken,
+                assignment.expiry,
+                assignment.tierFees
+            )
+        );
+    }
+
+    function _validateAssignment(
+        uint16 minTier,
+        bytes32 txListHash,
+        TaikoData.ProverAssignment memory assignment
+    )
+        private
+        returns (uint256 proverFee)
+    {
+        // Check assignment not expired
+        if (block.timestamp >= assignment.expiry) {
+            revert L1_ASSIGNMENT_EXPIRED();
+        }
+
+        if (txListHash == 0 || assignment.prover == address(0)) {
+            revert L1_ASSIGNMENT_INVALID_PARAMS();
+        }
+
+        // Hash the assignment with the txListHash, this hash will be signed by
+        // the prover, therefore, we add a string as a prefix.
+        bytes32 hash = hashAssignmentForTxList(assignment, txListHash);
+
+        if (!assignment.prover.isValidSignature(hash, assignment.signature)) {
+            revert L1_ASSIGNMENT_INVALID_SIG();
+        }
+
+        // Find the prover fee using the minimal tier
+        proverFee = _getProverFee(assignment.tierFees, minTier);
+
+        // The proposer irrevocably pays a fee to the assigned prover, either in
+        // Ether or ERC20 tokens.
+        if (assignment.feeToken == address(0)) {
+            // Paying Ether
+            if (msg.value < proverFee) revert L1_ASSIGNMENT_INSUFFICIENT_FEE();
+            assignment.prover.sendEther(proverFee);
+            unchecked {
+                // Return the extra Ether to the proposer
+                uint256 refund = msg.value - proverFee;
+                if (refund != 0) msg.sender.sendEther(refund);
+            }
+        } else {
+            // Paying ERC20 tokens
+            if (msg.value != 0) msg.sender.sendEther(msg.value);
+            ERC20Upgradeable(assignment.feeToken).transferFrom(
+                msg.sender, assignment.prover, proverFee
+            );
+        }
+    }
+
+    function _getProverFee(
+        TaikoData.TierFee[] memory tierFees,
+        uint16 tierId
+    )
+        private
+        pure
+        returns (uint256)
+    {
+        for (uint256 i; i < tierFees.length; ++i) {
+            if (tierFees[i].tier == tierId) {
+                return tierFees[i].fee;
+            }
+        }
+        revert L1_TIER_NOT_FOUND();
+    }
+}

--- a/packages/protocol/contracts/bridge/EtherVault.sol
+++ b/packages/protocol/contracts/bridge/EtherVault.sol
@@ -8,30 +8,21 @@ pragma solidity ^0.8.20;
 
 import { EssentialContract } from "../common/EssentialContract.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
+import { AuthorizationBase } from "../common/AuthorizationBase.sol";
 import { Proxied } from "../common/Proxied.sol";
 
 /// @title EtherVault
 /// @notice This contract is initialized with 2^128 Ether and allows authorized
 /// addresses to release Ether.
 /// @dev Only the contract owner can authorize or deauthorize addresses.
-contract EtherVault is EssentialContract {
+contract EtherVault is AuthorizationBase, EssentialContract {
     using LibAddress for address;
 
-    mapping(address addr => bool authorized) public isAuthorized;
-    uint256[49] private __gap;
+    uint256[50] private __gap;
 
-    event Authorized(address indexed addr, bool authorized);
     event EtherReleased(address indexed to, uint256 amount);
 
-    error VAULT_PERMISSION_DENIED();
     error VAULT_INVALID_RECIPIENT();
-    error VAULT_INVALID_PARAMS();
-
-    modifier onlyAuthorized() {
-        // Ensure the caller is authorized to perform the action
-        if (!isAuthorized[msg.sender]) revert VAULT_PERMISSION_DENIED();
-        _;
-    }
 
     receive() external payable { }
 
@@ -78,11 +69,7 @@ contract EtherVault is EssentialContract {
     /// @param addr Address to set the authorized status of.
     /// @param authorized Authorized status to set.
     function authorize(address addr, bool authorized) public onlyOwner {
-        if (addr == address(0)) revert VAULT_INVALID_PARAMS();
-        if (isAuthorized[addr] == authorized) revert VAULT_INVALID_PARAMS();
-
-        isAuthorized[addr] = authorized;
-        emit Authorized(addr, authorized);
+        _authorize(addr, authorized);
     }
 }
 

--- a/packages/protocol/contracts/bridge/EtherVault.sol
+++ b/packages/protocol/contracts/bridge/EtherVault.sol
@@ -6,16 +6,15 @@
 
 pragma solidity ^0.8.20;
 
-import { EssentialContract } from "../common/EssentialContract.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
-import { AuthorizationBase } from "../common/AuthorizationBase.sol";
+import { AuthorizableContract } from "../common/AuthorizableContract.sol";
 import { Proxied } from "../common/Proxied.sol";
 
 /// @title EtherVault
 /// @notice This contract is initialized with 2^128 Ether and allows authorized
 /// addresses to release Ether.
 /// @dev Only the contract owner can authorize or deauthorize addresses.
-contract EtherVault is AuthorizationBase, EssentialContract {
+contract EtherVault is AuthorizableContract {
     using LibAddress for address;
 
     uint256[50] private __gap;
@@ -25,12 +24,6 @@ contract EtherVault is AuthorizationBase, EssentialContract {
     error VAULT_INVALID_RECIPIENT();
 
     receive() external payable { }
-
-    /// @notice Initializes the contract with an {AddressManager}.
-    /// @param addressManager The address of the {AddressManager} contract.
-    function init(address addressManager) external initializer {
-        EssentialContract._init(addressManager);
-    }
 
     /// @notice Transfers Ether from EtherVault to the sender, checking that the
     /// sender is authorized.
@@ -62,14 +55,6 @@ contract EtherVault is AuthorizationBase, EssentialContract {
 
         recipient.sendEther(amount);
         emit EtherReleased(recipient, amount);
-    }
-
-    /// @notice Sets the authorized status of an address, only the owner can
-    /// call this function.
-    /// @param addr Address to set the authorized status of.
-    /// @param authorized Authorized status to set.
-    function authorize(address addr, bool authorized) public onlyOwner {
-        _authorize(addr, authorized);
     }
 }
 

--- a/packages/protocol/contracts/common/AuthorizableContract.sol
+++ b/packages/protocol/contracts/common/AuthorizableContract.sol
@@ -9,7 +9,8 @@ pragma solidity ^0.8.20;
 import { EssentialContract } from "../common/EssentialContract.sol";
 
 /// @title AuthorizableContract
-/// @notice Every contract which needs to have authorization (EtherVault, ERCXXVault)
+/// @notice Every contract which needs to have authorization (EtherVault,
+/// ERCXXVault)
 contract AuthorizableContract is EssentialContract {
     // Authorized addresses
     mapping(address addr => bool authorized) public isAuthorized;
@@ -28,6 +29,7 @@ contract AuthorizableContract is EssentialContract {
     }
     /// @notice Initializes the contract with an address manager.
     /// @param addressManager The address of the address manager.
+
     function init(address addressManager) external initializer {
         EssentialContract._init(addressManager);
     }

--- a/packages/protocol/contracts/common/AuthorizableContract.sol
+++ b/packages/protocol/contracts/common/AuthorizableContract.sol
@@ -8,9 +8,9 @@ pragma solidity ^0.8.20;
 
 import { EssentialContract } from "../common/EssentialContract.sol";
 
-/// @title AuthorizationBase
+/// @title AuthorizableContract
 /// @notice Every contract which needs to have authorization (EtherVault, ERCXXVault)
-abstract contract AuthorizationBase {
+contract AuthorizableContract is EssentialContract {
     // Authorized addresses
     mapping(address addr => bool authorized) public isAuthorized;
 
@@ -26,8 +26,13 @@ abstract contract AuthorizationBase {
         if (!isAuthorized[msg.sender]) revert VAULT_PERMISSION_DENIED();
         _;
     }
+    /// @notice Initializes the contract with an address manager.
+    /// @param addressManager The address of the address manager.
+    function init(address addressManager) external initializer {
+        EssentialContract._init(addressManager);
+    }
 
-    function _authorize(address addr, bool authorized) internal {
+    function authorize(address addr, bool authorized) public onlyOwner {
         if (addr == address(0)) revert VAULT_INVALID_PARAMS();
         if (isAuthorized[addr] == authorized) revert VAULT_INVALID_PARAMS();
 

--- a/packages/protocol/contracts/common/AuthorizationBase.sol
+++ b/packages/protocol/contracts/common/AuthorizationBase.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+//  _____     _ _         _         _
+// |_   _|_ _(_) |_____  | |   __ _| |__ ___
+//   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
+//   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
+
+pragma solidity ^0.8.20;
+
+import { EssentialContract } from "../common/EssentialContract.sol";
+
+/// @title AuthorizationBase
+/// @notice Every contract which needs to have authorization (EtherVault, ERCXXVault)
+abstract contract AuthorizationBase {
+    // Authorized addresses
+    mapping(address addr => bool authorized) public isAuthorized;
+
+    uint256[49] private __gap;
+
+    event Authorized(address indexed addr, bool authorized);
+
+    error VAULT_PERMISSION_DENIED();
+    error VAULT_INVALID_PARAMS();
+
+    modifier onlyAuthorized() {
+        // Ensure the caller is authorized to perform the action
+        if (!isAuthorized[msg.sender]) revert VAULT_PERMISSION_DENIED();
+        _;
+    }
+
+    function _authorize(address addr, bool authorized) internal {
+        if (addr == address(0)) revert VAULT_INVALID_PARAMS();
+        if (isAuthorized[addr] == authorized) revert VAULT_INVALID_PARAMS();
+
+        isAuthorized[addr] = authorized;
+        emit Authorized(addr, authorized);
+    }
+}

--- a/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
@@ -6,12 +6,12 @@
 
 pragma solidity ^0.8.20;
 
-import { EssentialContract } from "../common/EssentialContract.sol";
+import { AuthorizableContract } from "../common/AuthorizableContract.sol";
 import { IRecallableSender } from "../bridge/IBridge.sol";
 
 /// @title BaseNFTVault
 /// @notice Abstract contract for bridging NFTs across different chains.
-abstract contract BaseNFTVault is EssentialContract, IRecallableSender {
+abstract contract BaseNFTVault is AuthorizableContract, IRecallableSender {
     // Struct representing the canonical NFT on another chain.
     struct CanonicalNFT {
         // Chain ID of the NFT.
@@ -108,10 +108,4 @@ abstract contract BaseNFTVault is EssentialContract, IRecallableSender {
     error VAULT_MESSAGE_RELEASED_ALREADY();
     error VAULT_TOKEN_ARRAY_MISMATCH();
     error VAULT_MAX_TOKEN_PER_TXN_EXCEEDED();
-
-    /// @notice Initializes the contract with an address manager.
-    /// @param addressManager The address of the address manager.
-    function init(address addressManager) external initializer {
-        EssentialContract._init(addressManager);
-    }
 }

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -19,7 +19,6 @@ import {
 } from
     "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/ERC1155Upgradeable.sol";
 
-import { AuthorizationBase } from "../common/AuthorizationBase.sol";
 import { Proxied } from "../common/Proxied.sol";
 import { IBridge, IRecallableSender } from "../bridge/IBridge.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
@@ -42,7 +41,7 @@ interface ERC1155NameAndSymbol {
 /// @notice This vault holds all ERC1155 tokens that users have deposited.
 /// It also manages the mapping between canonical tokens and their bridged
 /// tokens.
-contract ERC1155Vault is AuthorizationBase, BaseNFTVault, ERC1155ReceiverUpgradeable {
+contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
     using LibAddress for address;
 
     uint256[50] private __gap;
@@ -372,14 +371,6 @@ contract ERC1155Vault is AuthorizationBase, BaseNFTVault, ERC1155ReceiverUpgrade
             ctokenSymbol: ctoken.symbol,
             ctokenName: ctoken.name
         });
-    }
-
-    /// @notice Sets the authorized status of an address, only the owner can
-    /// call this function.
-    /// @param addr Address to set the authorized status of.
-    /// @param authorized Authorized status to set.
-    function authorize(address addr, bool authorized) public onlyOwner {
-        _authorize(addr, authorized);
     }
 }
 

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -19,6 +19,7 @@ import {
 } from
     "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/ERC1155Upgradeable.sol";
 
+import { AuthorizationBase } from "../common/AuthorizationBase.sol";
 import { Proxied } from "../common/Proxied.sol";
 import { IBridge, IRecallableSender } from "../bridge/IBridge.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
@@ -41,7 +42,7 @@ interface ERC1155NameAndSymbol {
 /// @notice This vault holds all ERC1155 tokens that users have deposited.
 /// It also manages the mapping between canonical tokens and their bridged
 /// tokens.
-contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
+contract ERC1155Vault is AuthorizationBase, BaseNFTVault, ERC1155ReceiverUpgradeable {
     using LibAddress for address;
 
     uint256[50] private __gap;
@@ -121,7 +122,7 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
         payable
         nonReentrant
         whenNotPaused
-        onlyFromNamed("bridge")
+        onlyAuthorized
     {
         // Check context validity
         IBridge.Context memory ctx =
@@ -175,7 +176,7 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
         override
         nonReentrant
         whenNotPaused
-        onlyFromNamed("bridge")
+        onlyAuthorized
     {
         (
             CanonicalNFT memory nft,
@@ -371,6 +372,14 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
             ctokenSymbol: ctoken.symbol,
             ctokenName: ctoken.name
         });
+    }
+
+    /// @notice Sets the authorized status of an address, only the owner can
+    /// call this function.
+    /// @param addr Address to set the authorized status of.
+    /// @param authorized Authorized status to set.
+    function authorize(address addr, bool authorized) public onlyOwner {
+        _authorize(addr, authorized);
     }
 }
 

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -15,8 +15,7 @@ import { SafeERC20Upgradeable } from
 import { IERC165Upgradeable } from
     "lib/openzeppelin-contracts-upgradeable/contracts/utils/introspection/IERC165Upgradeable.sol";
 
-import { EssentialContract } from "../common/EssentialContract.sol";
-import { AuthorizationBase } from "../common/AuthorizationBase.sol";
+import { AuthorizableContract } from "../common/AuthorizableContract.sol";
 import { Proxied } from "../common/Proxied.sol";
 import { IBridge, IRecallableSender } from "../bridge/IBridge.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
@@ -30,8 +29,7 @@ import { LibVaultUtils } from "./libs/LibVaultUtils.sol";
 /// deposited. It also manages the mapping between canonical ERC20 tokens and
 /// their bridged tokens.
 contract ERC20Vault is
-    AuthorizationBase,
-    EssentialContract,
+    AuthorizableContract,
     IERC165Upgradeable,
     IRecallableSender
 {
@@ -121,12 +119,6 @@ contract ERC20Vault is
         }
         if (token == address(0)) revert VAULT_INVALID_TOKEN();
         _;
-    }
-
-    /// @notice Initializes the contract with the address manager.
-    /// @param addressManager Address manager contract address.
-    function init(address addressManager) external initializer {
-        EssentialContract._init(addressManager);
     }
 
     /// @notice Transfers ERC20 tokens to this vault and sends a message to the
@@ -373,14 +365,6 @@ contract ERC20Vault is
             ctokenName: ctoken.name,
             ctokenDecimal: ctoken.decimals
         });
-    }
-
-    /// @notice Sets the authorized status of an address, only the owner can
-    /// call this function.
-    /// @param addr Address to set the authorized status of.
-    /// @param authorized Authorized status to set.
-    function authorize(address addr, bool authorized) public onlyOwner {
-        _authorize(addr, authorized);
     }
 }
 

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -20,7 +20,6 @@ import { IERC721ReceiverUpgradeable } from
 
 import { IBridge, IRecallableSender } from "../bridge/IBridge.sol";
 import { LibAddress } from "../libs/LibAddress.sol";
-import { AuthorizationBase } from "../common/AuthorizationBase.sol";
 import { Proxied } from "../common/Proxied.sol";
 
 import { BaseNFTVault } from "./BaseNFTVault.sol";
@@ -32,7 +31,6 @@ import { ProxiedBridgedERC721 } from "./BridgedERC721.sol";
 /// It also manages the mapping between canonical tokens and their bridged
 /// tokens.
 contract ERC721Vault is
-    AuthorizationBase,
     BaseNFTVault,
     IERC721ReceiverUpgradeable,
     IERC165Upgradeable
@@ -322,14 +320,6 @@ contract ERC721Vault is
             ctokenSymbol: ctoken.symbol,
             ctokenName: ctoken.name
         });
-    }
-
-    /// @notice Sets the authorized status of an address, only the owner can
-    /// call this function.
-    /// @param addr Address to set the authorized status of.
-    /// @param authorized Authorized status to set.
-    function authorize(address addr, bool authorized) public onlyOwner {
-        _authorize(addr, authorized);
     }
 }
 

--- a/packages/protocol/test/tokenvault/ERC1155Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC1155Vault.t.sol
@@ -202,8 +202,10 @@ contract ERC1155VaultTest is TestBase {
             block.chainid, "ether_vault", address(etherVault)
         );
         // Authorize
-        etherVault.authorize(address(destChainIdBridge), true);
+        destChainErc1155Vault.authorize(address(destChainIdBridge), true);
         etherVault.authorize(address(bridge), true);
+        erc1155Vault.authorize(address(bridge), true);
+        erc1155Vault.authorize(address(destChainIdBridge), true);
 
         vm.deal(address(etherVault), 100 ether);
 

--- a/packages/protocol/test/tokenvault/ERC20Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC20Vault.t.sol
@@ -155,8 +155,10 @@ contract TestERC20Vault is Test {
         );
 
         // Authorize
-        etherVault.authorize(address(destChainIdBridge), true);
+        destChainIdERC20Vault.authorize(address(destChainIdBridge), true);
         etherVault.authorize(address(bridge), true);
+        erc20Vault.authorize(address(bridge), true);
+        erc20Vault.authorize(address(destChainIdBridge), true);
 
         vm.stopPrank();
     }

--- a/packages/protocol/test/tokenvault/ERC721Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC721Vault.t.sol
@@ -221,8 +221,10 @@ contract ERC721VaultTest is TestBase {
             block.chainid, "ether_vault", address(etherVault)
         );
         // Authorize
-        etherVault.authorize(address(destChainBridge), true);
+        destChainErc721Vault.authorize(address(destChainIdBridge), true);
         etherVault.authorize(address(bridge), true);
+        erc721Vault.authorize(address(bridge), true);
+        erc721Vault.authorize(address(destChainIdBridge), true);
 
         vm.stopPrank();
 

--- a/packages/protocol/test/tokenvault/EtherVault.t.sol
+++ b/packages/protocol/test/tokenvault/EtherVault.t.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.20;
 
 import { TestBase } from "../TestBase.sol";
-import { AuthorizableContract } from "../../contracts/common/AuthorizableContract.sol";
+import { AuthorizableContract } from
+    "../../contracts/common/AuthorizableContract.sol";
 import { AddressManager } from "../../contracts/common/AddressManager.sol";
 import { EtherVault } from "../../contracts/bridge/EtherVault.sol";
 

--- a/packages/protocol/test/tokenvault/EtherVault.t.sol
+++ b/packages/protocol/test/tokenvault/EtherVault.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import { TestBase } from "../TestBase.sol";
+import { AuthorizationBase } from "../../contracts/common/AuthorizationBase.sol";
 import { AddressManager } from "../../contracts/common/AddressManager.sol";
 import { EtherVault } from "../../contracts/bridge/EtherVault.sol";
 
@@ -25,12 +26,12 @@ contract TestEtherVault is TestBase {
         etherVault.authorize(Bob, true);
 
         vm.prank(Alice);
-        vm.expectRevert(EtherVault.VAULT_INVALID_PARAMS.selector);
+        vm.expectRevert(AuthorizationBase.VAULT_INVALID_PARAMS.selector);
         etherVault.authorize(address(0), true);
 
         vm.startPrank(Alice);
         etherVault.authorize(Bob, true);
-        vm.expectRevert(EtherVault.VAULT_INVALID_PARAMS.selector);
+        vm.expectRevert(AuthorizationBase.VAULT_INVALID_PARAMS.selector);
         etherVault.authorize(Bob, true);
         assertTrue(etherVault.isAuthorized(Bob));
     }

--- a/packages/protocol/test/tokenvault/EtherVault.t.sol
+++ b/packages/protocol/test/tokenvault/EtherVault.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import { TestBase } from "../TestBase.sol";
-import { AuthorizationBase } from "../../contracts/common/AuthorizationBase.sol";
+import { AuthorizableContract } from "../../contracts/common/AuthorizableContract.sol";
 import { AddressManager } from "../../contracts/common/AddressManager.sol";
 import { EtherVault } from "../../contracts/bridge/EtherVault.sol";
 
@@ -26,12 +26,12 @@ contract TestEtherVault is TestBase {
         etherVault.authorize(Bob, true);
 
         vm.prank(Alice);
-        vm.expectRevert(AuthorizationBase.VAULT_INVALID_PARAMS.selector);
+        vm.expectRevert(AuthorizableContract.VAULT_INVALID_PARAMS.selector);
         etherVault.authorize(address(0), true);
 
         vm.startPrank(Alice);
         etherVault.authorize(Bob, true);
-        vm.expectRevert(AuthorizationBase.VAULT_INVALID_PARAMS.selector);
+        vm.expectRevert(AuthorizableContract.VAULT_INVALID_PARAMS.selector);
         etherVault.authorize(Bob, true);
         assertTrue(etherVault.isAuthorized(Bob));
     }


### PR DESCRIPTION
Use authorize with vaults to be able to share common vaults across different L2 instances.