### PR TITLE
fix(protocol): fix bridge bug message.to=valut,message.call=onMessageRecalled

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -387,7 +387,7 @@ contract Bridge is EssentialContract, IBridge {
         returns (bool success)
     {
         if (gasLimit == 0) revert B_INVALID_GAS_LIMIT();
-        assert(message.from != address(0));
+        assert(message.from != address(this));
 
         _ctx = Context({
             msgHash: msgHash,

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -151,7 +151,7 @@ contract Bridge is EssentialContract, IBridge {
         if (support) {
             _ctx = Context({
                 msgHash: msgHash,
-                from: address(0),
+                from: address(this),
                 srcChainId: message.srcChainId
             });
 

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -155,7 +155,7 @@ contract Bridge is EssentialContract, IBridge {
                 srcChainId: message.srcChainId
             });
 
-            // Perform the message call and capture the success value
+            // Perform recall
             IRecallableSender(message.from).onMessageRecalled{
                 value: message.value
             }(message, msgHash);

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -177,6 +177,8 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
         whenNotPaused
         onlyFromNamed("bridge")
     {
+        LibVaultUtils.checkRecallContext();
+
         (
             CanonicalNFT memory nft,
             ,

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -125,7 +125,7 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
     {
         // Check context validity
         IBridge.Context memory ctx =
-            LibVaultUtils.checkValidContext("erc1155_vault", address(this));
+            LibVaultUtils.checkValidContext("erc1155_vault");
         address token;
 
         unchecked {
@@ -177,7 +177,7 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
         whenNotPaused
         onlyFromNamed("bridge")
     {
-        LibVaultUtils.checkRecallContext();
+        LibVaultUtils.checkValidContext("bridge");
 
         (
             CanonicalNFT memory nft,

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -191,7 +191,7 @@ contract ERC20Vault is
         onlyFromNamed("bridge")
     {
         IBridge.Context memory ctx =
-            LibVaultUtils.checkValidContext("erc20_vault", address(this));
+            LibVaultUtils.checkValidContext("erc20_vault");
 
         address token;
         if (ctoken.chainId == block.chainid) {
@@ -226,7 +226,7 @@ contract ERC20Vault is
         whenNotPaused
         onlyFromNamed("bridge")
     {
-        LibVaultUtils.checkRecallContext();
+        LibVaultUtils.checkValidContext("bridge");
 
         (, address token,, uint256 amount) = abi.decode(
             message.data[4:], (CanonicalERC20, address, address, uint256)

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -226,6 +226,8 @@ contract ERC20Vault is
         whenNotPaused
         onlyFromNamed("bridge")
     {
+        LibVaultUtils.checkRecallContext();
+
         (, address token,, uint256 amount) = abi.decode(
             message.data[4:], (CanonicalERC20, address, address, uint256)
         );

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -108,7 +108,7 @@ contract ERC721Vault is
         onlyFromNamed("bridge")
     {
         IBridge.Context memory ctx =
-            LibVaultUtils.checkValidContext("erc721_vault", address(this));
+            LibVaultUtils.checkValidContext("erc721_vault");
         address token;
 
         unchecked {
@@ -154,7 +154,7 @@ contract ERC721Vault is
         whenNotPaused
         onlyFromNamed("bridge")
     {
-        LibVaultUtils.checkRecallContext();
+        LibVaultUtils.checkValidContext("bridge");
 
         if (message.user == address(0)) revert VAULT_INVALID_USER();
         if (message.srcChainId != block.chainid) {

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -154,6 +154,8 @@ contract ERC721Vault is
         whenNotPaused
         onlyFromNamed("bridge")
     {
+        LibVaultUtils.checkRecallContext();
+
         if (message.user == address(0)) revert VAULT_INVALID_USER();
         if (message.srcChainId != block.chainid) {
             revert VAULT_INVALID_SRC_CHAIN_ID();

--- a/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
+++ b/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
@@ -32,7 +32,7 @@ library LibVaultUtils {
         address owner,
         bytes memory initializationData
     )
-        external
+        internal
         returns (address proxy)
     {
         if (implementation == address(0)) revert VAULT_INVALID_IMPL();
@@ -42,21 +42,30 @@ library LibVaultUtils {
     }
 
     /// @dev Checks if context is valid
-    /// @param validSender The valid sender to be allowed
+    /// @param senderName The valid sender to be allowed
     /// @param resolver The address of the resolver
     function checkValidContext(
-        bytes32 validSender,
+        bytes32 senderName,
         address resolver
     )
-        external
+        internal
         view
         returns (IBridge.Context memory ctx)
     {
         ctx = IBridge(msg.sender).context();
-        address sender = AddressResolver(resolver).resolve(
-            ctx.srcChainId, validSender, false
-        );
+        address sender =
+            AddressResolver(resolver).resolve(ctx.srcChainId, senderName, false);
         if (ctx.from != sender) revert VAULT_INVALID_FROM();
+    }
+
+    /// @dev Checks if context is valid
+    function checkRecallContext()
+        internal
+        view
+        returns (IBridge.Context memory ctx)
+    {
+        ctx = IBridge(msg.sender).context();
+        if (ctx.from != address(0)) revert VAULT_INVALID_FROM();
     }
 
     function checkIfValidAddresses(
@@ -64,7 +73,7 @@ library LibVaultUtils {
         address to,
         address token
     )
-        external
+        internal
         pure
     {
         if (to == address(0) || to == vault) revert VAULT_INVALID_TO();
@@ -76,7 +85,7 @@ library LibVaultUtils {
         uint256[] memory tokenIds,
         bool isERC721
     )
-        external
+        internal
         pure
     {
         if (tokenIds.length != amounts.length) {

--- a/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
+++ b/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
@@ -43,29 +43,16 @@ library LibVaultUtils {
 
     /// @dev Checks if context is valid
     /// @param senderName The valid sender to be allowed
-    /// @param resolver The address of the resolver
-    function checkValidContext(
-        bytes32 senderName,
-        address resolver
-    )
+    function checkValidContext(bytes32 senderName)
         internal
         view
         returns (IBridge.Context memory ctx)
     {
         ctx = IBridge(msg.sender).context();
-        address sender =
-            AddressResolver(resolver).resolve(ctx.srcChainId, senderName, false);
+        address sender = AddressResolver(address(this)).resolve(
+            ctx.srcChainId, senderName, false
+        );
         if (ctx.from != sender) revert VAULT_INVALID_FROM();
-    }
-
-    /// @dev Checks if context is valid
-    function checkRecallContext()
-        internal
-        view
-        returns (IBridge.Context memory ctx)
-    {
-        ctx = IBridge(msg.sender).context();
-        if (ctx.from != address(0)) revert VAULT_INVALID_FROM();
     }
 
     function checkIfValidAddresses(

--- a/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
+++ b/packages/protocol/contracts/tokenvault/libs/LibVaultUtils.sol
@@ -32,7 +32,7 @@ library LibVaultUtils {
         address owner,
         bytes memory initializationData
     )
-        internal
+        external
         returns (address proxy)
     {
         if (implementation == address(0)) revert VAULT_INVALID_IMPL();


### PR DESCRIPTION
Reported by Victor from QuillAudits
> Alright, for more context, currently attacker can steal all tokens in the ERC20Vault through the same bug I mentioned, calling the onMessageRecalled which also has a constraint that shouldn't be called unless failed, currently through this bug that is not handled fully attacker is able to bypass this regardless and steal all tokens


Before this fix: a message can be constructed with to=ERC2Vault, data=abi.encode(onMessageRecalled(...))