### PR TITLE
chore(bridge-ui-v2): revert walletconnect tests

### DIFF
--- a/packages/bridge-ui-v2/__mocks__/@wagmi/core.ts
+++ b/packages/bridge-ui-v2/__mocks__/@wagmi/core.ts
@@ -18,6 +18,6 @@ export const configureChains = vi.fn(() => {
   return { publicClient: 'mockPublicClient' };
 });
 
-export const defaultWagmiConfig = vi.fn(() => {
+export const createConfig = vi.fn(() => {
   return 'mockWagmiConfig';
 });

--- a/packages/bridge-ui-v2/src/libs/relayer/RelayerAPIService.test.ts
+++ b/packages/bridge-ui-v2/src/libs/relayer/RelayerAPIService.test.ts
@@ -6,7 +6,6 @@ import { RelayerAPIService } from './RelayerAPIService';
 vi.mock('axios');
 
 vi.mock('@wagmi/core');
-vi.mock('@web3modal/wagmi');
 
 vi.mock('$libs/chain', () => {
   return {

--- a/packages/bridge-ui-v2/src/libs/util/mergeTransactions.test.ts
+++ b/packages/bridge-ui-v2/src/libs/util/mergeTransactions.test.ts
@@ -6,7 +6,6 @@ import { mergeAndCaptureOutdatedTransactions } from '$libs/util/mergeTransaction
 
 function setupMocks() {
   vi.mock('@wagmi/core');
-  vi.mock('@web3modal/wagmi');
 
   vi.mock('$libs/chain', () => {
     return {


### PR DESCRIPTION
Fixed the tests missed in the previous PR for the WCv3 revert.

This fixes the current build failures