### PR TITLE
fix(protocol): Change sgx instanceId to 4bytes

### DIFF
--- a/packages/protocol/contracts/L1/verifiers/SgxAndZkVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxAndZkVerifier.sol
@@ -17,7 +17,7 @@ import { IVerifier } from "./IVerifier.sol";
 /// @title SgxAndZkVerifier
 /// @notice See the documentation in {IVerifier}.
 contract SgxAndZkVerifier is EssentialContract, IVerifier {
-    uint8 public constant SGX_PROOF_SIZE = 87;
+    uint8 public constant SGX_PROOF_SIZE = 89;
     uint256[50] private __gap;
 
     /// @notice Initializes the contract with the provided address manager.

--- a/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
@@ -110,14 +110,14 @@ contract SgxVerifier is EssentialContract, IVerifier {
         // Do not run proof verification to contest an existing proof
         if (isContesting) return;
 
-        // Size is: 87 bytes
-        // 2 bytes + 20 bytes + 65 bytes (signature) = 87
-        if (evidence.proof.length != 87) revert SGX_INVALID_PROOF();
+        // Size is: 89 bytes
+        // 4 bytes + 20 bytes + 65 bytes (signature) = 89
+        if (evidence.proof.length != 89) revert SGX_INVALID_PROOF();
 
-        uint16 id = uint16(bytes2(LibBytesUtils.slice(evidence.proof, 0, 2)));
+        uint32 id = uint32(bytes4(LibBytesUtils.slice(evidence.proof, 0, 4)));
         address newInstance =
-            address(bytes20(LibBytesUtils.slice(evidence.proof, 2, 20)));
-        bytes memory signature = LibBytesUtils.slice(evidence.proof, 22);
+            address(bytes20(LibBytesUtils.slice(evidence.proof, 4, 20)));
+        bytes memory signature = LibBytesUtils.slice(evidence.proof, 24);
         address oldInstance = ECDSAUpgradeable.recover(
             getSignedHash(evidence, prover, newInstance), signature
         );

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -223,7 +223,7 @@ abstract contract TaikoL1TestBase is TestBase {
                 createSgxSignatureProof(evidence, newPubKey, prover);
 
             evidence.proof =
-                bytes.concat(bytes2(0), bytes20(newPubKey), signature);
+                bytes.concat(bytes4(0), bytes20(newPubKey), signature);
         }
 
         if (tier == LibTiers.TIER_SGX_AND_PSE_ZKEVM) {
@@ -231,7 +231,7 @@ abstract contract TaikoL1TestBase is TestBase {
                 createSgxSignatureProof(evidence, newPubKey, prover);
 
             bytes memory sgxProof =
-                bytes.concat(bytes2(0), bytes20(newPubKey), signature);
+                bytes.concat(bytes4(0), bytes20(newPubKey), signature);
             // Concatenate SGX and ZK (in this order)
             evidence.proof = bytes.concat(sgxProof, evidence.proof);
         }


### PR DESCRIPTION
As per title.
According to Brecht, to minimize a possibility to spam the sgx bootstrap nodes successfully, we shall increase the range from 65K max possible ids.