### PR TITLE
fix(protocol): hash taiko address with assignment

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -191,9 +191,8 @@ library LibProposing {
 
         // Validate the prover assignment, then charge Ether or ERC20 as the
         // prover fee based on the block's minTier.
-        uint256 proverFee = _validateAssignment(
-            meta.minTier, config.chainId, blobHash, params.assignment
-        );
+        uint256 proverFee =
+            _validateAssignment(meta.minTier, blobHash, params.assignment);
 
         emit BlockProposed({
             blockId: blk.blockId,
@@ -207,7 +206,7 @@ library LibProposing {
 
     function hashAssignment(
         TaikoData.ProverAssignment memory assignment,
-        uint64 chainId,
+        address taikoAddress,
         bytes32 blobHash
     )
         internal
@@ -217,7 +216,7 @@ library LibProposing {
         return keccak256(
             abi.encode(
                 "PROVER_ASSIGNMENT",
-                chainId,
+                taikoAddress,
                 blobHash,
                 assignment.feeToken,
                 assignment.expiry,
@@ -228,7 +227,6 @@ library LibProposing {
 
     function _validateAssignment(
         uint16 minTier,
-        uint64 chainId,
         bytes32 blobHash,
         TaikoData.ProverAssignment memory assignment
     )
@@ -246,7 +244,7 @@ library LibProposing {
 
         // Hash the assignment with the blobHash, this hash will be signed by
         // the prover, therefore, we add a string as a prefix.
-        bytes32 hash = hashAssignment(assignment, chainId, blobHash);
+        bytes32 hash = hashAssignment(assignment, address(this), blobHash);
 
         if (!assignment.prover.isValidSignature(hash, assignment.signature)) {
             revert L1_ASSIGNMENT_INVALID_SIG();

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -191,8 +191,9 @@ library LibProposing {
 
         // Validate the prover assignment, then charge Ether or ERC20 as the
         // prover fee based on the block's minTier.
-        uint256 proverFee =
-            _validateAssignment(meta.minTier, blobHash, params.assignment);
+        uint256 proverFee = _validateAssignment(
+            meta.minTier, config.chainId, blobHash, params.assignment
+        );
 
         emit BlockProposed({
             blockId: blk.blockId,
@@ -206,6 +207,7 @@ library LibProposing {
 
     function hashAssignment(
         TaikoData.ProverAssignment memory assignment,
+        uint64 chainId,
         bytes32 blobHash
     )
         internal
@@ -215,6 +217,7 @@ library LibProposing {
         return keccak256(
             abi.encode(
                 "PROVER_ASSIGNMENT",
+                chainId,
                 blobHash,
                 assignment.feeToken,
                 assignment.expiry,
@@ -225,6 +228,7 @@ library LibProposing {
 
     function _validateAssignment(
         uint16 minTier,
+        uint64 chainId,
         bytes32 blobHash,
         TaikoData.ProverAssignment memory assignment
     )
@@ -242,7 +246,7 @@ library LibProposing {
 
         // Hash the assignment with the blobHash, this hash will be signed by
         // the prover, therefore, we add a string as a prefix.
-        bytes32 hash = hashAssignment(assignment, blobHash);
+        bytes32 hash = hashAssignment(assignment, chainId, blobHash);
 
         if (!assignment.prover.isValidSignature(hash, assignment.signature)) {
             revert L1_ASSIGNMENT_INVALID_SIG();

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -157,7 +157,7 @@ abstract contract TaikoL1TestBase is TestBase {
         bytes memory txList = new bytes(txListSize);
 
         assignment.signature =
-            _signAssignment(prover, assignment, conf.chainId, keccak256(txList));
+            _signAssignment(prover, assignment, address(L1), keccak256(txList));
 
         (, TaikoData.SlotB memory b) = L1.getStateVariables();
 
@@ -307,7 +307,7 @@ abstract contract TaikoL1TestBase is TestBase {
     function _signAssignment(
         address signer,
         TaikoData.ProverAssignment memory assignment,
-        uint64 chainId,
+        address taikoAddr,
         bytes32 blobHash
     )
         internal
@@ -315,7 +315,7 @@ abstract contract TaikoL1TestBase is TestBase {
         returns (bytes memory signature)
     {
         bytes32 digest =
-            LibProposing.hashAssignment(assignment, chainId, blobHash);
+            LibProposing.hashAssignment(assignment, taikoAddr, blobHash);
         uint256 signerPrivateKey;
 
         // In the test suite these are the 3 which acts as provers

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -157,7 +157,7 @@ abstract contract TaikoL1TestBase is TestBase {
         bytes memory txList = new bytes(txListSize);
 
         assignment.signature =
-            _signAssignment(prover, assignment, keccak256(txList));
+            _signAssignment(prover, assignment, conf.chainId, keccak256(txList));
 
         (, TaikoData.SlotB memory b) = L1.getStateVariables();
 
@@ -307,13 +307,15 @@ abstract contract TaikoL1TestBase is TestBase {
     function _signAssignment(
         address signer,
         TaikoData.ProverAssignment memory assignment,
+        uint64 chainId,
         bytes32 blobHash
     )
         internal
         view
         returns (bytes memory signature)
     {
-        bytes32 digest = LibProposing.hashAssignment(assignment, blobHash);
+        bytes32 digest =
+            LibProposing.hashAssignment(assignment, chainId, blobHash);
         uint256 signerPrivateKey;
 
         // In the test suite these are the 3 which acts as provers


### PR DESCRIPTION
This is to prevent the approval of assignment is reused across multiple Taiko deployments. 
@davidtaikocha  maybe the prover endpoint needs RPC change?