### PR TITLE
feat(protocol): deployment script updates based on #15104

### DIFF
--- a/packages/protocol/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/genesis/GenerateGenesis.g.sol
@@ -42,6 +42,9 @@ contract TestGenerateGenesis is Test, AddressResolver {
         checkDeployedCode("ProxiedSingletonBridge");
         checkDeployedCode("ProxiedSingletonSignalService");
         checkDeployedCode("ProxiedSingletonAddressManagerForSingletons");
+        checkDeployedCode("ProxiedBridgedERC20");
+        checkDeployedCode("ProxiedBridgedERC721");
+        checkDeployedCode("ProxiedBridgedERC1155");
 
         // check proxy implementations
         checkProxyImplementation("SingletonERC20VaultProxy", "ProxiedSingletonERC20Vault");

--- a/packages/protocol/genesis/test_config.js
+++ b/packages/protocol/genesis/test_config.js
@@ -95,6 +95,9 @@ module.exports = {
       // Non-singletons
       ProxiedSingletonTaikoL2: getConstantAddress(`0${this.chainId}`, 10001),
       ProxiedAddressManager: getConstantAddress(`0${this.chainId}`, 10002),
+      ProxiedBridgedERC20: getConstantAddress(`0${this.chainId}`, 10096),
+      ProxiedBridgedERC721: getConstantAddress(`0${this.chainId}`, 10097),
+      ProxiedBridgedERC1155: getConstantAddress(`0${this.chainId}`, 10098),
       RegularERC20: getConstantAddress(`0${this.chainId}`, 10099),
       // ============ Proxies ============
       // Singletons

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -161,15 +161,6 @@ contract DeployOnL1 is Script {
             taikoL1Proxy, bytes32(block.chainid)
         );
 
-        // Deploy ProxiedBridged token contracts (!!! also on L2 !!)
-        address proxiedBridgedERC20 = address(new ProxiedBridgedERC20());
-        address proxiedBridgedERC721 = address(new ProxiedBridgedERC721());
-        address proxiedBridgedERC1155 = address(new ProxiedBridgedERC1155());
-
-        setAddress("proxied_bridged_erc20", proxiedBridgedERC20);
-        setAddress("proxied_bridged_erc721", proxiedBridgedERC721);
-        setAddress("proxied_bridged_erc1155", proxiedBridgedERC1155);
-
         // Guardian prover
         ProxiedGuardianProver guardianProver = new ProxiedGuardianProver();
         address guardianProverProxy = deployProxy(
@@ -357,6 +348,26 @@ contract DeployOnL1 is Script {
                 signalService.init.selector,
                 abi.encode(addressManagerForSingletonsProxy)
             )
+        );
+
+        // Deploy ProxiedBridged token contracts
+        setAddress(
+            addressManagerForSingletonsProxy,
+            uint64(block.chainid),
+            "proxied_bridged_erc20",
+            address(new ProxiedBridgedERC20())
+        );
+        setAddress(
+            addressManagerForSingletonsProxy,
+            uint64(block.chainid),
+            "proxied_bridged_erc721",
+            address(new ProxiedBridgedERC721())
+        );
+        setAddress(
+            addressManagerForSingletonsProxy,
+            uint64(block.chainid),
+            "proxied_bridged_erc1155",
+            address(new ProxiedBridgedERC1155())
         );
     }
 

--- a/packages/protocol/utils/generate_genesis/taikoL2.ts
+++ b/packages/protocol/utils/generate_genesis/taikoL2.ts
@@ -162,6 +162,24 @@ async function generateContractConfigs(
                 "./AddressManager.sol/ProxiedAddressManager.json",
             ),
         ),
+        ProxiedBridgedERC20: require(
+            path.join(
+                ARTIFACTS_PATH,
+                "./BridgedERC20.sol/ProxiedBridgedERC20.json",
+            ),
+        ),
+        ProxiedBridgedERC721: require(
+            path.join(
+                ARTIFACTS_PATH,
+                "./BridgedERC721.sol/ProxiedBridgedERC721.json",
+            ),
+        ),
+        ProxiedBridgedERC1155: require(
+            path.join(
+                ARTIFACTS_PATH,
+                "./BridgedERC1155.sol/ProxiedBridgedERC1155.json",
+            ),
+        ),
         // Non-singletons
         ProxiedSingletonTaikoL2: require(
             path.join(
@@ -423,6 +441,21 @@ async function generateContractConfigs(
                 contractArtifacts.ProxiedSingletonSignalService,
                 addressMap,
             ),
+        },
+        ProxiedBridgedERC20: {
+            address: addressMap.ProxiedBridgedERC20,
+            deployedBytecode:
+                contractArtifacts.ProxiedBridgedERC20.deployedBytecode.object,
+        },
+        ProxiedBridgedERC721: {
+            address: addressMap.ProxiedBridgedERC721,
+            deployedBytecode:
+                contractArtifacts.ProxiedBridgedERC721.deployedBytecode.object,
+        },
+        ProxiedBridgedERC1155: {
+            address: addressMap.ProxiedBridgedERC1155,
+            deployedBytecode:
+                contractArtifacts.ProxiedBridgedERC1155.deployedBytecode.object,
         },
         SingletonSignalServiceProxy: {
             address: addressMap.SingletonSignalServiceProxy,

--- a/packages/protocol/utils/generate_genesis/taikoL2.ts
+++ b/packages/protocol/utils/generate_genesis/taikoL2.ts
@@ -298,6 +298,15 @@ async function generateContractConfigs(
                         [ethers.utils.hexlify(
                             ethers.utils.toUtf8Bytes("signal_service"),
                         )]: addressMap.SingletonSignalServiceProxy,
+                        [ethers.utils.hexlify(
+                            ethers.utils.toUtf8Bytes("proxied_bridged_erc20"),
+                        )]: addressMap.ProxiedBridgedERC20,
+                        [ethers.utils.hexlify(
+                            ethers.utils.toUtf8Bytes("proxied_bridged_erc721"),
+                        )]: addressMap.ProxiedBridgedERC721,
+                        [ethers.utils.hexlify(
+                            ethers.utils.toUtf8Bytes("proxied_bridged_erc1155"),
+                        )]: addressMap.ProxiedBridgedERC1155,
                     },
                 },
             },


### PR DESCRIPTION
- add deployment on L2
- change the L1 deployment script, use `addressManagerForSingletonsProxy` to save those addresses instead of the default L1 address manager