### PR TITLE
fix(website): Fix Incorrect Argument Order in Foundry Verification Command

### DIFF
--- a/packages/website/pages/docs/guides/verify-a-contract.mdx
+++ b/packages/website/pages/docs/guides/verify-a-contract.mdx
@@ -76,7 +76,7 @@ This guide will help get your contract verified on Taiko!
 
     Deploy to Taiko and verify at the same time on Blockscout (with EIP-1559 gas [transaction type 1]):
     ```sh
-    forge create --rpc-url https://rpc.jolnir.taiko.xyz --private-key $devTestnetPrivateKey src/Contract.sol:SimpleStorage --verify --verifier blockscout --verifier-url https://blockscoutapi.jolnir.taiko.xyz/api\?
+    forge create --rpc-url https://rpc.jolnir.taiko.xyz --private-key $devTestnetPrivateKey --verify --verifier blockscout --verifier-url https://blockscoutapi.jolnir.taiko.xyz/api src/Contract.sol:SimpleStorage
     ```
     <Callout type="info">
         To use Legacy gas for [transaction type 0], add the
@@ -85,7 +85,7 @@ This guide will help get your contract verified on Taiko!
         ```
         flag with forge create. Example:
         ```
-        forge create --legacy --rpc-url https://rpc.jolnir.taiko.xyz --private-key $devTestnetPrivateKey src/Contract.sol:SimpleStorage --verify --verifier blockscout --verifier-url https://blockscoutapi.jolnir.taiko.xyz/api\?
+        forge create --legacy --rpc-url https://rpc.jolnir.taiko.xyz --private-key $devTestnetPrivateKey --verify --verifier blockscout --verifier-url https://blockscoutapi.jolnir.taiko.xyz/api src/Contract.sol:SimpleStorage
         ```
     </Callout>
 


### PR DESCRIPTION
**Description:**

This pull request corrects an error in the documentation where the command provided for verifying contracts using Foundry has its arguments out of order. This causes the command to fail when users attempt to verify their contracts. Closes #15133.

**Changes Made:**
- Adjusted the order of arguments in the `forge create` command to match the required format by Foundry.

**Files Changed:**
- `docs/guides/verify-contract.mdx`

**Proposed Changes:**
```diff
- forge create --rpc-url https://rpc.jolnir.taiko.xyz --private-key $devTestnetPrivateKey src/Contract.sol:SimpleStorage --verify --verifier blockscout --verifier-url https://blockscoutapi.jolnir.taiko.xyz/api\?
+ forge create --rpc-url https://rpc.jolnir.taiko.xyz --private-key $devTestnetPrivateKey --verify --verifier blockscout --verifier-url https://blockscoutapi.jolnir.taiko.xyz/api src/Contract.sol:SimpleStorage
```

**Testing:**

Before submitting this pull request, I tested the updated command in my local environment to ensure that it executes without errors and initiates the contract verification process as expected.

**Additional Notes:**

Users should replace `$devTestnetPrivateKey` with their actual private key and `src/Contract.sol:SimpleStorage` with the appropriate path and contract name for their use case. The documentation now reflects the correct usage of the command in accordance with Foundry's requirements.
