### PR TITLE
Fix typos in RLP decoding and transaction splitting documentation

### DIFF
--- a/packages/website/pages/docs/concepts/proposing.mdx
+++ b/packages/website/pages/docs/concepts/proposing.mdx
@@ -18,7 +18,7 @@ The Ethereum yellow paper has well-defined rules to compute the state transition
 
    2.1 Asserts that the length of the transaction list does not exceed a predefined maximum (MAX_TX_LIST_BYTES), ensuring that the list is within the limits.
 
-   2.2 The transaction list is (RLP) decoded into a list of transactions (txList). If the bytes are not decodeable it will result in an empty block.
+   2.2 The transaction list is (RLP) decoded into a list of transactions (txList). If the bytes are not decodable it will result in an empty block.
 
    2.3 The amount of gas required to include transactions is available. (If a transaction cannot fit into a block, it is simply excluded from it, but the block is still valid with other transactions.)
 

--- a/packages/website/pages/docs/concepts/taiko-nodes.mdx
+++ b/packages/website/pages/docs/concepts/taiko-nodes.mdx
@@ -83,7 +83,7 @@ To propose a block, the `proposer`:
 
 1. Fetches the pending transactions from the L2 execution engine through the `txpool_content` RPC method.
 2. If there are too many pending transactions in the L2 execution engine, splits them into several smaller `txLists`. This is because the Taiko protocol restricts the max size of each proposed `txList`.
-3. Proposes all splitted `txLists` by sending `TaikoL1.proposeBlock` transactions.
+3. Proposes all split `txLists` by sending `TaikoL1.proposeBlock` transactions.
 
 ## Process of proving a block
 


### PR DESCRIPTION
This pull request includes two minor documentation fixes to improve clarity and correctness.

**Changes:**

1. **Fixed typo in RLP decoding process documentation**
   Commit: `7640ce9212970ecf2fa629e4c3f80d221159b514`
   
   Corrected the spelling of 'decodeable' to 'decodable' in the context of RLP decoding. This change is made in the `proposing.mdx` file and ensures that the documentation is more readable and professional.

2. **Corrected usage of 'splitted' to 'split'**
   Commit: `5d216e84d20e821009e1258a4f4daeb6213ef11d`
   
   Updated the word 'splitted' to 'split' in the `taiko-nodes.mdx` file, which is the proper past tense and past participle form of the verb 'split'. This typo correction maintains the quality of our documentation.


**Justification:**

Maintaining accurate and error-free documentation is essential for both current users and new adopters of the Taiko protocol. These typo fixes contribute to the overall quality and understandability of our documentation.
