### PR TITLE
fix(docs): Documentation Corrections for Bridge Contract and Integration Manual

### DIFF
--- a/packages/website/pages/docs/manuals/integration-manual.mdx
+++ b/packages/website/pages/docs/manuals/integration-manual.mdx
@@ -1,6 +1,6 @@
 # Integration manual
 
-This manual will help you successfully integration into Taiko.
+This manual will help you successfully integrate into Taiko.
 
 Taiko is an Ethereum-equivalent network, meaning integrating with Taiko should be as simple as using our RPC instead of an Ethereum L1 RPC.
 

--- a/packages/website/pages/docs/reference/contract-documentation/bridge/Bridge.md
+++ b/packages/website/pages/docs/reference/contract-documentation/bridge/Bridge.md
@@ -301,7 +301,7 @@ Tells if we need to check real proof or it is a test.
 
 | Name | Type | Description                                                  |
 | ---- | ---- | ------------------------------------------------------------ |
-| [0]  | bool | Returns true if this contract, or can be false if mock/test. |
+| [0]  | bool | Returns true if real proof checking is required, otherwise false if it is a mock/test environment. |
 
 ---
 


### PR DESCRIPTION
## Overview
This pull request includes documentation updates to enhance clarity and correct verb tense issues. Two files have been modified with improvements to the descriptions and instructions provided.

## Changes Made

- In `Bridge.md`, the description for the return value of the `shouldCheckProof` function has been clarified. The previous description was somewhat ambiguous, and now it clearly states the function's behavior in different environments (commit 01d7058).

- In `integration-manual.mdx`, a verb tense error in the introduction sentence was corrected to improve the reading flow and grammatical accuracy (commit 05d52e7).

## Files Affected
- `packages/website/pages/docs/reference/contract-documentation/bridge/Bridge.md`
- `packages/website/pages/docs/manuals/integration-manual.mdx`

The updates aim to remove any potential confusion for readers and ensure that the documentation adheres to standard English grammar rules. 

