### PR TITLE
feat(protocol): allow TKO mint and burn

### DIFF
--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -52,6 +52,20 @@ contract TaikoToken is
         _mint(_recipient, 1_000_000_000 ether);
     }
 
+    /// @notice Mints new tokens to the specified address.
+    /// @param to The address to receive the minted tokens.
+    /// @param amount The amount of tokens to mint.
+    function mint(address to, uint256 amount) public onlyOwner {
+        _mint(to, amount);
+    }
+
+    /// @notice Burns tokens from the specified address.
+    /// @param from The address to burn tokens from.
+    /// @param amount The amount of tokens to burn.
+    function burn(address from, uint256 amount) public onlyOwner {
+        _burn(from, amount);
+    }
+
     /// @notice Creates a new token snapshot.
     function snapshot() public onlyOwner {
         _snapshot();


### PR DESCRIPTION
After the discussion of the Taiko DAO, I think we should add back the mint and burn function so the DAO can still decide to mint and burn tokens with holder approval.