### PR TITLE
feat(protocol): hash parent's metahash into current metahash

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -105,6 +105,7 @@ library TaikoData {
         uint24 txListByteSize;
         uint16 minTier;
         bool blobUsed;
+        bytes32 parentMetaHash; // slot 8
     }
 
     /// @dev Struct representing transition to be proven.

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -98,7 +98,11 @@ library LibProposing {
         // If we choose to persist all data fields in the metadata, it will
         // require additional storage slots.
         unchecked {
+            TaikoData.Block storage parentBlk =
+                state.blocks[(b.numBlocks - 1) % config.blockRingBufferSize];
+
             meta = TaikoData.BlockMetadata({
+                parentMetaHash: parentBlk.metaHash,
                 l1Hash: blockhash(block.number - 1),
                 difficulty: 0, // to be initialized below
                 blobHash: 0, // to be initialized below

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -98,11 +98,7 @@ library LibProposing {
         // If we choose to persist all data fields in the metadata, it will
         // require additional storage slots.
         unchecked {
-            TaikoData.Block storage parentBlk =
-                state.blocks[(b.numBlocks - 1) % config.blockRingBufferSize];
-
             meta = TaikoData.BlockMetadata({
-                parentMetaHash: parentBlk.metaHash,
                 l1Hash: blockhash(block.number - 1),
                 difficulty: 0, // to be initialized below
                 blobHash: 0, // to be initialized below
@@ -116,7 +112,9 @@ library LibProposing {
                 txListByteOffset: 0, // to be initialized below
                 txListByteSize: 0, // to be initialized below
                 minTier: 0, // to be initialized below
-                blobUsed: txList.length == 0
+                blobUsed: txList.length == 0,
+                parentMetaHash: state.blocks[(b.numBlocks - 1)
+                    % config.blockRingBufferSize].metaHash
             });
         }
 


### PR DESCRIPTION
This will allow the a block's metahash to fully represent the history of the chain till this block.