### PR TITLE
docs(protocol): fix some typos

### DIFF
--- a/packages/protocol/contracts/actors_privileges_deployments.md
+++ b/packages/protocol/contracts/actors_privileges_deployments.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 This document provides a comprehensive overview of the actors involved in the smart contract system and outlines their respective privileges and roles.
-Different `roles` (we call them `domain`) are granted via `AddressManager` contract's `setAddress()` function. Idea is very similar Optimism's `AddressManager` except that we use the `chainId + domainName` as the key for a given address. We need so, because for bridging purposes, the destination chain's bridge address needs to be inculded signaling the messgae hash is tamper-proof.
+Different `roles` (we call them `domain`) are granted via `AddressManager` contract's `setAddress()` function. Idea is very similar Optimism's `AddressManager` except that we use the `chainId + domainName` as the key for a given address. We need so, because for bridging purposes, the destination chain's bridge address needs to be included signaling the message hash is tamper-proof.
 Every contract which needs some role-based authentication, needs to inherit from `AddressResolver` contract, which will serve as a 'middleman/lookup' by querying the `AddressManager` per given address is allowed to act on behalf of that domain or not.
 
 ## 1. Domains (≈role per chainId)
@@ -26,9 +26,9 @@ In the context of the smart contract system, various actors play distinct roles.
 
 ### 1.3 ERCXXX_Vault
 
-- **Role**: This role is givne to respective token vault contracts (ERC20, ERC721, ERC1155)
+- **Role**: This role is given to respective token vault contracts (ERC20, ERC721, ERC1155)
 - **Privileges**:
-  - Part of token briding, the possibility to burn and mint the respective standard tokens (no autotelic minting/burning)
+  - Part of token bridging, the possibility to burn and mint the respective standard tokens (no autotelic minting/burning)
 
 ## 2. Different access modifiers
 

--- a/packages/protocol/contracts/bridge/README.md
+++ b/packages/protocol/contracts/bridge/README.md
@@ -40,7 +40,7 @@ If user wants to bridge ether, he/she will initiate a bridge transaction with `s
         address refundAddress;
         // value to invoke on the destination chain, for ERC20 transfers.
         uint256 value;
-        // Processing fee for the relayer. Zero if user will process themself.
+        // Processing fee for the relayer. Zero if user will process themselves.
         uint256 fee;
         // gasLimit to invoke on the destination chain, for ERC20 transfers.
         uint256 gasLimit;

--- a/packages/protocol/docs/iprover.md
+++ b/packages/protocol/docs/iprover.md
@@ -57,4 +57,4 @@ The proposer and prover interact off-chain to agree on the price and perform the
 
 3. Proposer creates the `ProverAssignment` struct data (obviously together with the `input` and `txList`) and submits the `proposeBlock()` with the necessary parameters.
 
-During `proposeBlock()` transaction, the `onBlockAssigned()` hook which will evaluate the validity of the prover signature, and if that one is correct then executest he transfer of `10 DAI`.
+During `proposeBlock()` transaction, the `onBlockAssigned()` hook which will evaluate the validity of the prover signature, and if that one is correct then execute he transfer of `10 DAI`.


### PR DESCRIPTION
Hello
I fixed some typos in the documentations.