### PR TITLE
docs(website): changed chainlist link to list taiko chains and testnets

### DIFF
--- a/packages/website/pages/docs/guides/setup-your-wallet.mdx
+++ b/packages/website/pages/docs/guides/setup-your-wallet.mdx
@@ -33,7 +33,7 @@ This guide helps you connect your wallet to Taiko.
 
 ### The add chain buttons did not work
 
-Try to manually add the network to your wallet using the [RPC configuration](/docs/reference/rpc-configuration), or by using [chainlist.org](https://chainlist.org) (make sure to check the box for "Include testnets").
+Try to manually add the network to your wallet using the [RPC configuration](/docs/reference/rpc-configuration), or by using [chainlist.org](https://chainlist.org/?search=taiko&testnets=true) (make sure to check the box for "Include testnets").
 
 ### Transactions are stuck in "pending"
 


### PR DESCRIPTION
Changed chainlist link so users can see taiko chains directly and 'Include testnets' checked as documents suggest.