### PR TITLE
docs(website): Update enable-a-prover.mdx

### DIFF
--- a/packages/website/pages/docs/guides/enable-a-prover.mdx
+++ b/packages/website/pages/docs/guides/enable-a-prover.mdx
@@ -70,7 +70,7 @@ Open the `.env` file and set the following environment variables to enable your 
 
 You will need TTKOj deposited on the TaikoL1 contract to secure the bond for the proofs you generate.
 
-First, you will need to **approve the TaikoL1 contract as a spender**. Visit the TTKOj contract on Sepolia [here](https://sepolia.etherscan.io/address/0x75F94f04d2144cB6056CCd0CFF1771573d838974#writeProxyContract).
+First, you will need to **approve the TaikoL1 contract as a spender**. Visit the TTKOj contract on Sepolia [here](https://sepolia.etherscan.io/address/0x75F94f04d2144cB6056CCd0CFF1771573d838974#writeProxyContract#F1).
 
 Next, click the **Connect to Web3** button.
 
@@ -82,7 +82,7 @@ Finally, click the **Write** button.
 
 ### Deposit TTKOj to TaikoL1
 
-Visit the TaikoL1 contract [here](https://sepolia.etherscan.io/address/0x95fF8D3CE9dcB7455BEB7845143bEA84Fe5C4F6f#writeProxyContract).
+Visit the TaikoL1 contract [here](https://sepolia.etherscan.io/address/0x95fF8D3CE9dcB7455BEB7845143bEA84Fe5C4F6f#writeProxyContract#F2).
 
 Next, click the **Connect to Web3** button.
 


### PR DESCRIPTION
This change, which sets the contract's URL as the function's permalink, allows you to visually locate the function to operate more easily.