### PR TITLE
add Apus Network Provers to Prover market table

### DIFF
--- a/packages/website/pages/docs/reference/prover-market-page.mdx
+++ b/packages/website/pages/docs/reference/prover-market-page.mdx
@@ -20,7 +20,8 @@ You can edit the page by clicking [here](https://github.com/taikoxyz/taiko-mono/
 | -------------- | --------------------------------------- | ----------- |
 | ZKPool (HTTP)  | http://taiko-a5-prover-simple.zkpool.io | 10 wei      |
 | ZKPool (HTTPS) | https://taiko-a5-prover.zkpool.io       | 10 wei      |
-| Davaymne       | http://pool-1.taikopool.xyz             | 10 wei      |
+| Davaymne       | http://l2pool.apus.network:9876         | 10 wei      |
+| Apus Network   | http://pool-1.taikopool.xyz             | 10 wei      |
 | Web3Cript      | http://ttko.web3cript.xyz:9876          | 10 wei      |
 | Purethereal    | http://purethereal.xyz:9876             | 10 wei      |
 | Karma Nodes    | http://karmanodes.xyz                   | 10 wei      |


### PR DESCRIPTION
add Apus Network Provers to Prover market table.

http://l2pool.apus.network:9876 

The above service has been tested for a long time and can be used to generate Prover.
