### PR TITLE
docs(protocol): Update L2EIP1559.md

### DIFF
--- a/packages/protocol/docs/L2EIP1559.md
+++ b/packages/protocol/docs/L2EIP1559.md
@@ -6,7 +6,7 @@ The EIP-1559 base fee per gas (base fee) on Taiko L2 is calculated by Taiko L1 p
 
 ## Basefee Calculation
 
-We use Vitalik's idea proposed here: https://ethresear.ch/t/make-eip-1559-more-like-an-amm-curve/9082 (read it first!). The x-axis represents the current gas _excess_, the y-axis is the ether amount. When some gas are sold, excess goes up, and the difference of the new and the old y value is the total cost of the gas purchase, or $$cost(gasAmount) = e^{(gasExcess + gasAmount)} -e^{gasExcess}$$, and $$basefee(gasAmount) = cost(gasAmount)/gasAmount$$.
+We use Vitalik's idea proposed here: https://ethresear.ch/t/make-eip-1559-more-like-an-amm-curve/9082 (read it first!). The x-axis represents the current gas _excess_, the y-axis is the ether amount. When some gas is sold, excess goes up, and the difference of the new and the old y value is the total cost of the gas purchase, or $$cost(gasAmount) = e^{(gasExcess + gasAmount)} -e^{gasExcess}$$, and $$basefee(gasAmount) = cost(gasAmount)/gasAmount$$.
 
 A nice property of the $e^x$ curve is that for a chosen gas target $T$, the base fee ($basefee(T)$) for a block with $T$ gas and the base fee ($basefee(2T)$) for a block with $2T$ gas always have the fixed ratio: $$R == basefee(2T)/basefee(T)$$ regardless of the current _gas excess_ value, $T$ and $R$ together determine the shape of the curve. In Ethereum, $T$ is 15 million and $R$ is 12.5%; it's yet to be decided what value we should use in Taiko.
 


### PR DESCRIPTION
## Description
The original text had a grammatical error where "gas are" was used, and it has been corrected to "gas is" to maintain grammatical consistency.

## Changes Made
- Changed "gas are" to "gas is" to match the singular nature of the entity.

