### PR TITLE
fix(protocol): Non-recursive abi.encode for Zk Verifier

### DIFF
--- a/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
@@ -141,8 +141,8 @@ contract PseZkVerifier is EssentialContract, IVerifier {
                 metaHash,
                 txListHash,
                 pointValue
-            );
-        )
+            )
+        );
     }
 
     function getVerifierName(uint16 id) public pure returns (bytes32) {

--- a/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
@@ -131,7 +131,18 @@ contract PseZkVerifier is EssentialContract, IVerifier {
         pure
         returns (bytes32 instance)
     {
-        return keccak256(abi.encode(tran, prover, metaHash, txListHash, pointValue));
+        return keccak256(
+            abi.encode(
+                tran.parentHash,
+                tran.blockHash,
+                tran.signalRoot,
+                tran.graffiti,
+                prover,
+                metaHash,
+                txListHash,
+                pointValue
+            );
+        )
     }
 
     function getVerifierName(uint16 id) public pure returns (bytes32) {

--- a/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
@@ -139,11 +139,11 @@ contract SgxVerifier is EssentialContract, IVerifier {
             if (_instances[i] == address(0)) revert SGX_INVALID_INSTANCE();
 
             instances[nextInstanceId] = Instance(_instances[i], uint64(block.timestamp));
-            ids[i] = nextInstanceId;x
+            ids[i] = nextInstanceId;
 
             emit InstanceAdded(nextInstanceId, _instances[i], address(0), block.timestamp);
 
-            nextInstanceId++;x
+            nextInstanceId++;
         }
     }
 

--- a/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
@@ -139,11 +139,11 @@ contract SgxVerifier is EssentialContract, IVerifier {
             if (_instances[i] == address(0)) revert SGX_INVALID_INSTANCE();
 
             instances[nextInstanceId] = Instance(_instances[i], uint64(block.timestamp));
-            ids[i] = nextInstanceId;
+            ids[i] = nextInstanceId;x
 
             emit InstanceAdded(nextInstanceId, _instances[i], address(0), block.timestamp);
 
-            nextInstanceId++;
+            nextInstanceId++;x
         }
     }
 


### PR DESCRIPTION
The current circuit is not able to handle abi.encode of recursive structs unless the RLP gadget is ready. A few lines of changes in the contract would fix this.