### PR TITLE
chore(bridge-ui-v2): Correct Typo in JSON Validation Comment

### DIFF
--- a/packages/bridge-ui-v2/scripts/vite-plugins/generateBridgeConfig.ts
+++ b/packages/bridge-ui-v2/scripts/vite-plugins/generateBridgeConfig.ts
@@ -38,7 +38,7 @@ export function generateBridgeConfig() {
         // Decode base64 encoded JSON string
         configuredBridgesConfigFile = decodeBase64ToJson(process.env.CONFIGURED_BRIDGES || '');
 
-        // Valide JSON against schema
+        // Validate JSON against schema
         const isValid = validateJsonAgainstSchema(configuredBridgesConfigFile, configuredBridgesSchema);
 
         if (!isValid) {

--- a/packages/bridge-ui-v2/scripts/vite-plugins/generateChainConfig.ts
+++ b/packages/bridge-ui-v2/scripts/vite-plugins/generateChainConfig.ts
@@ -35,7 +35,7 @@ export function generateChainConfig() {
         }
         // Decode base64 encoded JSON string
         configuredChainsConfigFile = decodeBase64ToJson(process.env.CONFIGURED_CHAINS || '');
-        // Valide JSON against schema
+        // Validate JSON against schema
         const isValid = validateJsonAgainstSchema(configuredChainsConfigFile, configuredChainsSchema);
 
         if (!isValid) {

--- a/packages/bridge-ui-v2/scripts/vite-plugins/generateCustomTokenConfig.ts
+++ b/packages/bridge-ui-v2/scripts/vite-plugins/generateCustomTokenConfig.ts
@@ -39,7 +39,7 @@ export function generateCustomTokenConfig() {
         // Decode base64 encoded JSON string
         configuredTokenConfigFile = decodeBase64ToJson(process.env.CONFIGURED_CUSTOM_TOKEN || '');
 
-        // Valide JSON against schema
+        // Validate JSON against schema
         const isValid = validateJsonAgainstSchema(configuredTokenConfigFile, configuredChainsSchema);
 
         if (!isValid) {

--- a/packages/bridge-ui-v2/scripts/vite-plugins/generateEventIndexerConfig.ts
+++ b/packages/bridge-ui-v2/scripts/vite-plugins/generateEventIndexerConfig.ts
@@ -41,7 +41,7 @@ export function generateEventIndexerConfig() {
         // Decode base64 encoded JSON string
         configuredEventIndexerConfigFile = decodeBase64ToJson(process.env.CONFIGURED_EVENT_INDEXER || '');
 
-        // Valide JSON against schema
+        // Validate JSON against schema
         const isValid = validateJsonAgainstSchema(configuredEventIndexerConfigFile, configuredEventIndexerSchema);
         if (!isValid) {
           throw new Error('encoded configuredBridges.json is not valid.');

--- a/packages/bridge-ui-v2/scripts/vite-plugins/generateRelayerConfig.ts
+++ b/packages/bridge-ui-v2/scripts/vite-plugins/generateRelayerConfig.ts
@@ -41,7 +41,7 @@ export function generateRelayerConfig() {
         // Decode base64 encoded JSON string
         configuredRelayerConfigFile = decodeBase64ToJson(process.env.CONFIGURED_RELAYER || '');
 
-        // Valide JSON against schema
+        // Validate JSON against schema
         const isValid = validateJsonAgainstSchema(configuredRelayerConfigFile, configuredRelayerSchema);
         if (!isValid) {
           throw new Error('encoded configuredBridges.json is not valid.');


### PR DESCRIPTION
Corrected a typo in a comment from "Valide" to "Validate" for JSON schema validation.
