### PR TITLE
fix(eventindexer): exit gracefully after start finishes

### DIFF
--- a/packages/eventindexer/generator/generator.go
+++ b/packages/eventindexer/generator/generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -66,6 +67,8 @@ func (g *Generator) Start() error {
 	if err := g.generateTimeSeriesData(context.Background()); err != nil {
 		return err
 	}
+
+	defer os.Exit(0)
 
 	return nil
 }


### PR DESCRIPTION
This PR will stop the pods in kubernetes from remaining in `Running` status, and instead move to `Completed`, after daily task generations.