### PR TITLE
feat(protocol): allow L1 timelock to be the L2 owner

### DIFF
--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -11,20 +11,22 @@ import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "../common/EssentialContract.sol";
 import "../signal/ISignalService.sol";
 
+/// @title CrossChainOwned
+/// @notice This contract's owner lives on another chain who uses signal for transaction approval.
 abstract contract CrossChainOwned is EssentialContract {
-    mapping(bytes32 approvalHashe => bool executed) public executed; // slot 1
-    uint64 public ownerChainId; // slot 2
+    uint64 public ownerChainId; // slot 1
     uint64 public nextXchainTxId;
-    uint256[48] private __gap;
+    uint256[49] private __gap;
 
     event TransactionExecuted(uint64 indexed txId, bytes32 indexed approvalHash);
 
     error INVALID_PARAMS();
     error TX_NOT_APPROVED();
     error TX_REVERTED();
+    error NOT_CALLABLE();
 
-    function executeTransaction(bytes calldata txdata, bytes calldata proof) external {
-        bytes32 approvalHash = _isTxApproved(txdata, proof);
+    function executeApprovedTransaction(bytes calldata txdata, bytes calldata proof) external {
+        bytes32 approvalHash = _isTransactionApproved(txdata, proof);
         if (approvalHash == 0) revert TX_NOT_APPROVED();
 
         (bool success,) = address(this).call(txdata);
@@ -32,23 +34,28 @@ abstract contract CrossChainOwned is EssentialContract {
         emit TransactionExecuted(nextXchainTxId++, approvalHash);
     }
 
-    function isTxApproved(bytes calldata txdata, bytes calldata proof) public view returns (bool) {
-        return _isTxApproved(txdata, proof) != 0;
+    function isTransactionApproved(
+        bytes calldata txdata,
+        bytes calldata proof
+    )
+        public
+        view
+        returns (bool)
+    {
+        return _isTransactionApproved(txdata, proof) != 0;
     }
 
-    function _isTxApproved(
+    function _isTransactionApproved(
         bytes calldata txdata,
         bytes calldata proof
     )
         internal
         view
-        returns (bytes32 approvalHash)
+        returns (bytes32)
     {
-        if (bytes4(txdata) == this.executeTransaction.selector) return 0;
+        if (bytes4(txdata) == this.executeApprovedTransaction.selector) return 0;
 
-        bytes32 hash = keccak256(abi.encode("CROSSCHAIN_TX", nextXchainTxId, txdata));
-        if (executed[hash]) return 0;
-
+        bytes32 hash = keccak256(abi.encode("CROSS_CHAIN_TX", nextXchainTxId, txdata));
         if (
             !ISignalService(resolve("signal_service", false)).proveSignalReceived({
                 srcChainId: ownerChainId,
@@ -61,13 +68,17 @@ abstract contract CrossChainOwned is EssentialContract {
         return hash;
     }
 
+    function _checkOwner() internal view virtual override {
+        if (msg.sender != address(this)) revert NOT_CALLABLE();
+    }
+
     /// @notice Initializes the contract.
-    /// @param _ownerChainId The owner's deployment chain ID.
     /// @param _addressManager The address of the address manager.
+    /// @param _ownerChainId The owner's deployment chain ID.
     // solhint-disable-next-line func-name-mixedcase
     function __CrossChainOwned_init(
-        uint64 _ownerChainId,
-        address _addressManager
+        address _addressManager,
+        uint64 _ownerChainId
     )
         internal
         virtual

--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -45,6 +45,24 @@ abstract contract CrossChainOwned is EssentialContract {
         return _isTransactionApproved(txdata, proof) != 0;
     }
 
+    /// @notice Initializes the contract.
+    /// @param _addressManager The address of the address manager.
+    /// @param _ownerChainId The owner's deployment chain ID.
+    // solhint-disable-next-line func-name-mixedcase
+    function __CrossChainOwned_init(
+        address _addressManager,
+        uint64 _ownerChainId
+    )
+        internal
+        virtual
+    {
+        __Essential_init(_addressManager);
+
+        if (_ownerChainId == 0 || _ownerChainId == block.chainid) revert INVALID_PARAMS();
+        ownerChainId = _ownerChainId;
+        nextXchainTxId = 1;
+    }
+
     function _isTransactionApproved(
         bytes calldata txdata,
         bytes calldata proof
@@ -80,23 +98,5 @@ abstract contract CrossChainOwned is EssentialContract {
 
     function _checkOwner() internal view virtual override {
         if (msg.sender != address(this)) revert NOT_CALLABLE();
-    }
-
-    /// @notice Initializes the contract.
-    /// @param _addressManager The address of the address manager.
-    /// @param _ownerChainId The owner's deployment chain ID.
-    // solhint-disable-next-line func-name-mixedcase
-    function __CrossChainOwned_init(
-        address _addressManager,
-        uint64 _ownerChainId
-    )
-        internal
-        virtual
-    {
-        __Essential_init(_addressManager);
-
-        if (_ownerChainId == 0 || _ownerChainId == block.chainid) revert INVALID_PARAMS();
-        ownerChainId = _ownerChainId;
-        nextXchainTxId = 1;
     }
 }

--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+//  _____     _ _         _         _
+// |_   _|_ _(_) |_____  | |   __ _| |__ ___
+//   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
+//   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
+
+pragma solidity 0.8.20;
+
+import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+import "../common/EssentialContract.sol";
+import "../signal/ISignalService.sol";
+
+abstract contract CrossChainOwned is EssentialContract {
+    mapping(bytes32 approvalHashe => bool executed) public executed; // slot 1
+    uint64 public ownerChainId; // slot 2
+    uint64 public nextXchainTxId;
+    uint256[48] private __gap;
+
+    event TransactionExecuted(uint64 indexed txId, bytes32 indexed approvalHash);
+
+    error INVALID_PARAMS();
+    error TX_NOT_APPROVED();
+    error TX_REVERTED();
+
+    function executeTransaction(bytes calldata txdata, bytes calldata proof) external {
+        bytes32 approvalHash = _isTxApproved(txdata, proof);
+        if (approvalHash == 0) revert TX_NOT_APPROVED();
+
+        (bool success,) = address(this).call(txdata);
+        if (!success) revert TX_REVERTED();
+        emit TransactionExecuted(nextXchainTxId++, approvalHash);
+    }
+
+    function isTxApproved(bytes calldata txdata, bytes calldata proof) public view returns (bool) {
+        return _isTxApproved(txdata, proof) != 0;
+    }
+
+    function _isTxApproved(
+        bytes calldata txdata,
+        bytes calldata proof
+    )
+        internal
+        view
+        returns (bytes32 approvalHash)
+    {
+        if (bytes4(txdata) == this.executeTransaction.selector) return 0;
+
+        bytes32 hash = keccak256(abi.encode("CROSSCHAIN_TX", nextXchainTxId, txdata));
+        if (executed[hash]) return 0;
+
+        if (
+            !ISignalService(resolve("signal_service", false)).proveSignalReceived({
+                srcChainId: ownerChainId,
+                app: owner(),
+                signal: hash,
+                proof: proof
+            })
+        ) return 0;
+
+        return hash;
+    }
+
+    /// @notice Initializes the contract.
+    /// @param _ownerChainId The owner's deployment chain ID.
+    /// @param _addressManager The address of the address manager.
+    // solhint-disable-next-line func-name-mixedcase
+    function __CrossChainOwned_init(
+        uint64 _ownerChainId,
+        address _addressManager
+    )
+        internal
+        virtual
+    {
+        __Essential_init(_addressManager);
+
+        if (_ownerChainId == 0 || _ownerChainId == block.chainid) revert INVALID_PARAMS();
+        ownerChainId = _ownerChainId;
+        nextXchainTxId = 1;
+    }
+}

--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -71,7 +71,7 @@ abstract contract CrossChainOwned is EssentialContract {
         view
         returns (bytes32 approvalHash)
     {
-        if (bytes4(txdata) == this.executeApprovedTransaction.selector) return 0;
+        if (bytes4(txdata) == this.executeApprovedTransaction.selector) revert NOT_CALLABLE();
 
         bytes32 hash = keccak256(abi.encode("CROSS_CHAIN_TX", nextXchainTxId, txdata));
 

--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -73,7 +73,8 @@ abstract contract CrossChainOwned is EssentialContract {
     {
         if (bytes4(txdata) == this.executeApprovedTransaction.selector) revert NOT_CALLABLE();
 
-        bytes32 hash = keccak256(abi.encode("CROSS_CHAIN_TX", nextTxId, txdata));
+        bytes32 hash =
+            keccak256(abi.encode("APPROVE_CROSS_CHAIN_TX", block.chainid, nextTxId, txdata));
 
         if (_isSignalReceived(hash, proof)) return hash;
         else return 0;

--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -15,7 +15,7 @@ import "../signal/ISignalService.sol";
 /// @notice This contract's owner lives on another chain who uses signal for transaction approval.
 abstract contract CrossChainOwned is EssentialContract {
     uint64 public ownerChainId; // slot 1
-    uint64 public nextXchainTxId;
+    uint64 public nextTxId;
     uint256[49] private __gap;
 
     event TransactionExecuted(uint64 indexed txId, bytes32 indexed approvalHash);
@@ -31,7 +31,7 @@ abstract contract CrossChainOwned is EssentialContract {
 
         (bool success,) = address(this).call(txdata);
         if (!success) revert TX_REVERTED();
-        emit TransactionExecuted(nextXchainTxId++, approvalHash);
+        emit TransactionExecuted(nextTxId++, approvalHash);
     }
 
     function isTransactionApproved(
@@ -60,7 +60,7 @@ abstract contract CrossChainOwned is EssentialContract {
 
         if (_ownerChainId == 0 || _ownerChainId == block.chainid) revert INVALID_PARAMS();
         ownerChainId = _ownerChainId;
-        nextXchainTxId = 1;
+        nextTxId = 1;
     }
 
     function _isTransactionApproved(
@@ -73,7 +73,7 @@ abstract contract CrossChainOwned is EssentialContract {
     {
         if (bytes4(txdata) == this.executeApprovedTransaction.selector) revert NOT_CALLABLE();
 
-        bytes32 hash = keccak256(abi.encode("CROSS_CHAIN_TX", nextXchainTxId, txdata));
+        bytes32 hash = keccak256(abi.encode("CROSS_CHAIN_TX", nextTxId, txdata));
 
         if (_isSignalReceived(hash, proof)) return hash;
         else return 0;

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -52,18 +52,18 @@ contract TaikoL2 is CrossChainOwned, TaikoL2Signer, ICrossChainSync {
     error L2_TOO_LATE();
 
     /// @notice Initializes the TaikoL2 contract.
-    /// @param _l1ChainId The ID of the base layer.
     /// @param _addressManager Address of the AddressManager contract.
+    /// @param _l1ChainId The ID of the base layer.
     /// @param _gasExcess The initial gasExcess.
     function init(
-        uint64 _l1ChainId,
         address _addressManager,
+        uint64 _l1ChainId,
         uint64 _gasExcess
     )
         external
         initializer
     {
-        __CrossChainOwned_init(_l1ChainId, _addressManager);
+        __CrossChainOwned_init(_addressManager, _l1ChainId);
 
         if (block.chainid <= 1 || block.chainid >= type(uint64).max) {
             revert L2_INVALID_CHAIN_ID();

--- a/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
+++ b/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
@@ -21,14 +21,7 @@ contract TaikoL2EIP1559Configurable is TaikoL2 {
     /// @notice Sets EIP1559 configuration and gas excess.
     /// @param config The new EIP1559 config.
     /// @param newGasExcess The new gas excess
-    function setConfigAndExcess(
-        Config memory config,
-        uint64 newGasExcess
-    )
-        external
-        virtual
-        onlyOwner
-    {
+    function setConfigAndExcess(Config memory config, uint64 newGasExcess) external {
         if (config.gasTargetPerL1Block == 0) revert L2_INVALID_CONFIG();
         if (config.basefeeAdjustmentQuotient == 0) revert L2_INVALID_CONFIG();
 

--- a/packages/protocol/test/L1/Guardians.t.sol
+++ b/packages/protocol/test/L1/Guardians.t.sol
@@ -31,7 +31,7 @@ contract TestSignalService is TaikoTest {
             deployProxy({
                 name: "guardians",
                 impl: address(new DummyGuardians()),
-                data: bytes.concat(DummyGuardians.init.selector)
+                data: abi.encodeCall(DummyGuardians.init, ())
             })
         );
     }

--- a/packages/protocol/test/L2/CrossChainOwned.t.sol
+++ b/packages/protocol/test/L2/CrossChainOwned.t.sol
@@ -68,6 +68,13 @@ contract TestCrossChainOwned is TaikoTest {
         assertEq(xchainowned.counter(), 2);
     }
 
+    function test_xchainowned_exec_executeApprovedTransaction_revert() public {
+        bytes memory proof = "";
+        bytes memory data = abi.encodeCall(xchainowned.executeApprovedTransaction, ("", ""));
+        vm.expectRevert(CrossChainOwned.NOT_CALLABLE.selector);
+        xchainowned.executeApprovedTransaction(data, proof);
+    }
+
     function test_xchainowned_exec_upgrade() public {
         bytes memory proof = "";
 

--- a/packages/protocol/test/L2/CrossChainOwned.t.sol
+++ b/packages/protocol/test/L2/CrossChainOwned.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import "../TaikoTest.sol";
+
+contract CrossChainOwnedContract is CrossChainOwned {
+    uint256 public counter;
+
+    function increment() external virtual onlyOwner {
+        counter += 1;
+    }
+
+    function init(address addressManager) external initializer {
+        __CrossChainOwned_init(addressManager, 12_345);
+    }
+
+    function _isSignalReceived(
+        bytes32, /*signal*/
+        bytes calldata /*proof*/
+    )
+        internal
+        pure
+        override
+        returns (bool)
+    {
+        return true;
+    }
+}
+
+contract CrossChainOwnedContract2 is CrossChainOwnedContract {
+    function increment() external override onlyOwner {
+        counter -= 1;
+    }
+}
+
+contract TestCrossChainOwned is TaikoTest {
+    CrossChainOwnedContract public xchainowned;
+
+    function setUp() public {
+        address addressManager = deployProxy({
+            name: "address_manager",
+            impl: address(new AddressManager()),
+            data: abi.encodeCall(AddressManager.init, ())
+        });
+        xchainowned = CrossChainOwnedContract(
+            deployProxy({
+                name: "contract",
+                impl: address(new CrossChainOwnedContract()),
+                data: abi.encodeCall(CrossChainOwnedContract.init, (addressManager))
+            })
+        );
+    }
+
+    function test_xchainowned_ower_cannot_be_msgsender() public {
+        vm.startPrank(xchainowned.owner());
+        vm.expectRevert(CrossChainOwned.NOT_CALLABLE.selector);
+        xchainowned.increment();
+        vm.stopPrank();
+    }
+
+    function test_xchainowned_exec_tx() public {
+        bytes memory proof = "";
+        bytes memory data = abi.encodeCall(xchainowned.increment, ());
+
+        assertEq(xchainowned.counter(), 0);
+        xchainowned.executeApprovedTransaction(data, proof);
+        xchainowned.executeApprovedTransaction(data, proof);
+        assertEq(xchainowned.counter(), 2);
+    }
+
+    function test_xchainowned_exec_upgrade() public {
+        bytes memory proof = "";
+
+        bytes memory incrementCall = abi.encodeCall(xchainowned.increment, ());
+        bytes memory upgradetoCall =
+            abi.encodeCall(xchainowned.upgradeTo, (address(new CrossChainOwnedContract2())));
+
+        assertEq(xchainowned.counter(), 0);
+        xchainowned.executeApprovedTransaction(incrementCall, proof);
+        assertEq(xchainowned.counter(), 1);
+
+        xchainowned.executeApprovedTransaction(upgradetoCall, proof);
+        assertEq(xchainowned.counter(), 1);
+
+        xchainowned.executeApprovedTransaction(incrementCall, proof);
+        assertEq(xchainowned.counter(), 0);
+    }
+}

--- a/packages/protocol/test/L2/CrossChainOwned.t.sol
+++ b/packages/protocol/test/L2/CrossChainOwned.t.sol
@@ -63,16 +63,24 @@ contract TestCrossChainOwned is TaikoTest {
         bytes memory data = abi.encodeCall(xchainowned.increment, ());
 
         assertEq(xchainowned.counter(), 0);
-        xchainowned.executeApprovedTransaction(data, proof);
-        xchainowned.executeApprovedTransaction(data, proof);
+        xchainowned.executeApprovedTransaction(data, proof, address(0));
+        xchainowned.executeApprovedTransaction(data, proof, address(0));
         assertEq(xchainowned.counter(), 2);
+
+        vm.expectRevert(CrossChainOwned.INVALID_EXECUTOR.selector);
+        xchainowned.executeApprovedTransaction(data, proof, Alice);
+
+        vm.prank(Alice);
+        xchainowned.executeApprovedTransaction(data, proof, Alice);
+        assertEq(xchainowned.counter(), 3);
     }
 
     function test_xchainowned_exec_executeApprovedTransaction_revert() public {
         bytes memory proof = "";
-        bytes memory data = abi.encodeCall(xchainowned.executeApprovedTransaction, ("", ""));
+        bytes memory data =
+            abi.encodeCall(xchainowned.executeApprovedTransaction, ("", "", address(1)));
         vm.expectRevert(CrossChainOwned.NOT_CALLABLE.selector);
-        xchainowned.executeApprovedTransaction(data, proof);
+        xchainowned.executeApprovedTransaction(data, proof, address(0));
     }
 
     function test_xchainowned_exec_upgrade() public {
@@ -83,13 +91,13 @@ contract TestCrossChainOwned is TaikoTest {
             abi.encodeCall(xchainowned.upgradeTo, (address(new CrossChainOwnedContract2())));
 
         assertEq(xchainowned.counter(), 0);
-        xchainowned.executeApprovedTransaction(incrementCall, proof);
+        xchainowned.executeApprovedTransaction(incrementCall, proof, address(0));
         assertEq(xchainowned.counter(), 1);
 
-        xchainowned.executeApprovedTransaction(upgradetoCall, proof);
+        xchainowned.executeApprovedTransaction(upgradetoCall, proof, address(0));
         assertEq(xchainowned.counter(), 1);
 
-        xchainowned.executeApprovedTransaction(incrementCall, proof);
+        xchainowned.executeApprovedTransaction(incrementCall, proof, address(0));
         assertEq(xchainowned.counter(), 0);
     }
 }

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -50,7 +50,10 @@ contract TestTaikoL2 is TaikoTest {
                 deployProxy({
                     name: "taiko_l2",
                     impl: address(new TaikoL2EIP1559Configurable()),
-                    data: bytes.concat(TaikoL2.init.selector, abi.encode(address(ss), gasExcess))
+                    data: bytes.concat(
+                        TaikoL2.init.selector,
+                        abi.encode(uint64(block.chainid), address(addressManager), gasExcess)
+                        )
                 })
             )
         );
@@ -63,7 +66,10 @@ contract TestTaikoL2 is TaikoTest {
                 deployProxy({
                     name: "taiko_l2",
                     impl: address(new SkipBasefeeCheckL2()),
-                    data: bytes.concat(TaikoL2.init.selector, abi.encode(address(ss), gasExcess))
+                    data: bytes.concat(
+                        TaikoL2.init.selector,
+                        abi.encode(uint64(block.chainid), address(addressManager), gasExcess)
+                        )
                 })
             )
         );

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -17,42 +17,36 @@ contract TestTaikoL2 is TaikoTest {
     // same as `block_gas_limit` in foundry.toml
     uint32 public constant BLOCK_GAS_LIMIT = 30_000_000;
 
-    AddressManager public addressManager;
-    SignalService public ss;
+    address public addressManager;
     TaikoL2EIP1559Configurable public L2;
     SkipBasefeeCheckL2 public L2skip;
 
     function setUp() public {
-        addressManager = AddressManager(
-            deployProxy({
-                name: "address_manager",
-                impl: address(new AddressManager()),
-                data: abi.encodeCall(AddressManager.init, ())
-            })
-        );
+        addressManager = deployProxy({
+            name: "address_manager",
+            impl: address(new AddressManager()),
+            data: abi.encodeCall(AddressManager.init, ())
+        });
 
-        ss = SignalService(
-            deployProxy({
-                name: "signal_service",
-                impl: address(new SignalService()),
-                data: abi.encodeCall(SignalService.init, ()),
-                registerTo: address(addressManager),
-                owner: address(0)
-            })
-        );
+        deployProxy({
+            name: "signal_service",
+            impl: address(new SignalService()),
+            data: abi.encodeCall(SignalService.init, ()),
+            registerTo: addressManager,
+            owner: address(0)
+        });
 
         uint64 gasExcess = 0;
         uint8 quotient = 8;
         uint32 gasTarget = 60_000_000;
+        uint64 l1ChainId = 12_345;
 
         L2 = TaikoL2EIP1559Configurable(
             payable(
                 deployProxy({
                     name: "taiko_l2",
                     impl: address(new TaikoL2EIP1559Configurable()),
-                    data: abi.encodeCall(
-                        TaikoL2.init, (address(addressManager), uint64(block.chainid), gasExcess)
-                        )
+                    data: abi.encodeCall(TaikoL2.init, (addressManager, l1ChainId, gasExcess))
                 })
             )
         );
@@ -65,9 +59,7 @@ contract TestTaikoL2 is TaikoTest {
                 deployProxy({
                     name: "taiko_l2",
                     impl: address(new SkipBasefeeCheckL2()),
-                    data: abi.encodeCall(
-                        TaikoL2.init, (address(addressManager), uint64(block.chainid), gasExcess)
-                        )
+                    data: abi.encodeCall(TaikoL2.init, (addressManager, l1ChainId, gasExcess))
                 })
             )
         );
@@ -260,11 +252,6 @@ contract TestTaikoL2 is TaikoTest {
         bytes32 l1Hash = randBytes32();
         bytes32 l1SignalRoot = randBytes32();
         L2skip.anchor(l1Hash, l1SignalRoot, l1Height, parentGasLimit);
-    }
-
-    function registerAddress(bytes32 nameHash, address addr) internal {
-        addressManager.setAddress(uint64(block.chainid), nameHash, addr);
-        console2.log(block.chainid, uint256(nameHash), unicode"→", addr);
     }
 
     // Semi-random number generator

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -52,7 +52,7 @@ contract TestTaikoL2 is TaikoTest {
                     impl: address(new TaikoL2EIP1559Configurable()),
                     data: bytes.concat(
                         TaikoL2.init.selector,
-                        abi.encode(uint64(block.chainid), address(addressManager), gasExcess)
+                        abi.encode(address(addressManager), uint64(block.chainid), gasExcess)
                         )
                 })
             )
@@ -68,7 +68,7 @@ contract TestTaikoL2 is TaikoTest {
                     impl: address(new SkipBasefeeCheckL2()),
                     data: bytes.concat(
                         TaikoL2.init.selector,
-                        abi.encode(uint64(block.chainid), address(addressManager), gasExcess)
+                        abi.encode(address(addressManager), uint64(block.chainid), gasExcess)
                         )
                 })
             )

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -27,7 +27,7 @@ contract TestTaikoL2 is TaikoTest {
             deployProxy({
                 name: "address_manager",
                 impl: address(new AddressManager()),
-                data: bytes.concat(AddressManager.init.selector)
+                data: abi.encodeCall(AddressManager.init, ())
             })
         );
 
@@ -35,7 +35,7 @@ contract TestTaikoL2 is TaikoTest {
             deployProxy({
                 name: "signal_service",
                 impl: address(new SignalService()),
-                data: bytes.concat(SignalService.init.selector),
+                data: abi.encodeCall(SignalService.init, ()),
                 registerTo: address(addressManager),
                 owner: address(0)
             })
@@ -50,9 +50,8 @@ contract TestTaikoL2 is TaikoTest {
                 deployProxy({
                     name: "taiko_l2",
                     impl: address(new TaikoL2EIP1559Configurable()),
-                    data: bytes.concat(
-                        TaikoL2.init.selector,
-                        abi.encode(address(addressManager), uint64(block.chainid), gasExcess)
+                    data: abi.encodeCall(
+                        TaikoL2.init, (address(addressManager), uint64(block.chainid), gasExcess)
                         )
                 })
             )
@@ -66,9 +65,8 @@ contract TestTaikoL2 is TaikoTest {
                 deployProxy({
                     name: "taiko_l2",
                     impl: address(new SkipBasefeeCheckL2()),
-                    data: bytes.concat(
-                        TaikoL2.init.selector,
-                        abi.encode(address(addressManager), uint64(block.chainid), gasExcess)
+                    data: abi.encodeCall(
+                        TaikoL2.init, (address(addressManager), uint64(block.chainid), gasExcess)
                         )
                 })
             )

--- a/packages/protocol/test/common/EssentialContract.t.sol
+++ b/packages/protocol/test/common/EssentialContract.t.sol
@@ -28,7 +28,7 @@ contract Target2 is Target1 {
 
 contract TestOwnerUUPSUpgradable is TaikoTest {
     function test_essential_behind_1967_proxy() external {
-        bytes memory data = bytes.concat(Target1.init.selector);
+        bytes memory data = abi.encodeCall(Target1.init, ());
         vm.startPrank(Alice);
         ERC1967Proxy proxy = new ERC1967Proxy(address(new Target1()), data);
         Target1 target = Target1(address(proxy));
@@ -49,7 +49,7 @@ contract TestOwnerUUPSUpgradable is TaikoTest {
         target.adjust();
 
         address v2 = address(new Target2());
-        data = bytes.concat(Target2.update.selector);
+        data = abi.encodeCall(Target2.update, ());
 
         vm.prank(Bob);
         vm.expectRevert();
@@ -67,7 +67,7 @@ contract TestOwnerUUPSUpgradable is TaikoTest {
     // This tests shows that the admin() and owner() cannot be the same, otherwise,
     // the owner cannot transact delegated functions on implementation.
     function test_essential_behind_transparent_proxy() external {
-        bytes memory data = bytes.concat(Target1.init.selector);
+        bytes memory data = abi.encodeCall(Target1.init, ());
         vm.startPrank(Alice);
         TransparentUpgradeableProxy proxy =
             new TransparentUpgradeableProxy(address(new Target1()), Bob, data);

--- a/packages/protocol/test/signal/SignalService.t.sol
+++ b/packages/protocol/test/signal/SignalService.t.sol
@@ -19,7 +19,7 @@ contract TestSignalService is TaikoTest {
             deployProxy({
                 name: "address_manager",
                 impl: address(new AddressManager()),
-                data: bytes.concat(AddressManager.init.selector),
+                data: abi.encodeCall(AddressManager.init, ()),
                 registerTo: address(addressManager),
                 owner: address(0)
             })
@@ -29,7 +29,7 @@ contract TestSignalService is TaikoTest {
             deployProxy({
                 name: "signal_service",
                 impl: address(new SignalService()),
-                data: bytes.concat(SignalService.init.selector)
+                data: abi.encodeCall(SignalService.init, ())
             })
         );
 
@@ -37,7 +37,7 @@ contract TestSignalService is TaikoTest {
             deployProxy({
                 name: "signal_service",
                 impl: address(new SignalService()),
-                data: bytes.concat(SignalService.init.selector)
+                data: abi.encodeCall(SignalService.init, ())
             })
         );
 

--- a/packages/protocol/test/team/TimelockTokenPool.t.sol
+++ b/packages/protocol/test/team/TimelockTokenPool.t.sol
@@ -20,7 +20,7 @@ contract TestTimelockTokenPool is TaikoTest {
             deployProxy({
                 name: "time_lock_token_pool",
                 impl: address(new TimelockTokenPool()),
-                data: bytes.concat(TimelockTokenPool.init.selector, abi.encode(address(tko), Vault))
+                data: abi.encodeCall(TimelockTokenPool.init, (address(tko), Vault))
             })
         );
     }

--- a/packages/protocol/test/team/airdrop/MerkleClaimable.t.sol
+++ b/packages/protocol/test/team/airdrop/MerkleClaimable.t.sol
@@ -27,9 +27,7 @@ contract TestERC20Airdrop is TaikoTest {
             deployProxy({
                 name: "airdrop",
                 impl: address(new ERC20Airdrop()),
-                data: bytes.concat(
-                    ERC20Airdrop.init.selector, abi.encode(0, 0, merkleRoot, address(token), owner)
-                    )
+                data: abi.encodeCall(ERC20Airdrop.init, (0, 0, merkleRoot, address(token), owner))
             })
         );
 
@@ -39,9 +37,8 @@ contract TestERC20Airdrop is TaikoTest {
             deployProxy({
                 name: "airdrop",
                 impl: address(new ERC20Airdrop2()),
-                data: bytes.concat(
-                    ERC20Airdrop2.init.selector,
-                    abi.encode(0, 0, merkleRoot, address(token), owner, 10 days)
+                data: abi.encodeCall(
+                    ERC20Airdrop2.init, (0, 0, merkleRoot, address(token), owner, 10 days)
                     )
             })
         );

--- a/packages/protocol/test/tokenvault/BridgedERC20.t.sol
+++ b/packages/protocol/test/tokenvault/BridgedERC20.t.sol
@@ -12,7 +12,7 @@ contract TestBridgedERC20 is TaikoTest {
         manager = deployProxy({
             name: "address_manager",
             impl: address(new AddressManager()),
-            data: bytes.concat(AddressManager.init.selector)
+            data: abi.encodeCall(AddressManager.init, ())
         });
 
         register(manager, "erc20_vault", vault);
@@ -130,9 +130,8 @@ contract TestBridgedERC20 is TaikoTest {
             deployProxy({
                 name: "bridged_token1",
                 impl: address(new BridgedERC20()),
-                data: bytes.concat(
-                    BridgedERC20.init.selector,
-                    abi.encode(address(manager), srcToken, srcChainId, srcDecimals, name, name)
+                data: abi.encodeCall(
+                    BridgedERC20.init, (address(manager), srcToken, srcChainId, srcDecimals, name, name)
                     ),
                 registerTo: manager,
                 owner: owner

--- a/packages/protocol/test/tokenvault/ERC1155Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC1155Vault.t.sol
@@ -111,7 +111,7 @@ contract ERC1155VaultTest is TaikoTest {
             deployProxy({
                 name: "address_manager",
                 impl: address(new AddressManager()),
-                data: bytes.concat(AddressManager.init.selector)
+                data: abi.encodeCall(AddressManager.init, ())
             })
         );
 
@@ -120,7 +120,7 @@ contract ERC1155VaultTest is TaikoTest {
                 deployProxy({
                     name: "bridge",
                     impl: address(new Bridge()),
-                    data: bytes.concat(Bridge.init.selector, abi.encode(addressManager)),
+                    data: abi.encodeCall(Bridge.init, (address(addressManager))),
                     registerTo: address(addressManager),
                     owner: address(0)
                 })
@@ -132,7 +132,7 @@ contract ERC1155VaultTest is TaikoTest {
                 deployProxy({
                     name: "bridge",
                     impl: address(new Bridge()),
-                    data: bytes.concat(Bridge.init.selector, abi.encode(addressManager)),
+                    data: abi.encodeCall(Bridge.init, (address(addressManager))),
                     registerTo: address(addressManager),
                     owner: address(0)
                 })
@@ -143,7 +143,7 @@ contract ERC1155VaultTest is TaikoTest {
             deployProxy({
                 name: "signal_service",
                 impl: address(new SignalService()),
-                data: bytes.concat(SignalService.init.selector)
+                data: abi.encodeCall(SignalService.init, ())
             })
         );
 
@@ -151,7 +151,7 @@ contract ERC1155VaultTest is TaikoTest {
             deployProxy({
                 name: "erc1155_vault",
                 impl: address(new ERC1155Vault()),
-                data: bytes.concat(BaseVault.init.selector, abi.encode(address(addressManager)))
+                data: abi.encodeCall(BaseVault.init, (address(addressManager)))
             })
         );
 
@@ -159,7 +159,7 @@ contract ERC1155VaultTest is TaikoTest {
             deployProxy({
                 name: "erc1155_vault",
                 impl: address(new ERC1155Vault()),
-                data: bytes.concat(BaseVault.init.selector, abi.encode(address(addressManager)))
+                data: abi.encodeCall(BaseVault.init, (address(addressManager)))
             })
         );
 
@@ -170,7 +170,7 @@ contract ERC1155VaultTest is TaikoTest {
             deployProxy({
                 name: "signal_service",
                 impl: address(new SkipProofCheckSignal()),
-                data: bytes.concat(SignalService.init.selector)
+                data: abi.encodeCall(SignalService.init, ())
             })
         );
 

--- a/packages/protocol/test/tokenvault/ERC20Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC20Vault.t.sol
@@ -89,9 +89,7 @@ contract TestERC20Vault is TaikoTest {
             deployProxy({
                 name: "taiko_token",
                 impl: address(new TaikoToken()),
-                data: bytes.concat(
-                    TaikoToken.init.selector, abi.encode("Taiko Token", "TTKOk", address(this))
-                    )
+                data: abi.encodeCall(TaikoToken.init, ("Taiko Token", "TTKOk", address(this)))
             })
         );
 
@@ -99,7 +97,7 @@ contract TestERC20Vault is TaikoTest {
             deployProxy({
                 name: "address_manager",
                 impl: address(new AddressManager()),
-                data: bytes.concat(AddressManager.init.selector)
+                data: abi.encodeCall(AddressManager.init, ())
             })
         );
 
@@ -109,7 +107,7 @@ contract TestERC20Vault is TaikoTest {
             deployProxy({
                 name: "erc20_vault",
                 impl: address(new ERC20Vault()),
-                data: bytes.concat(BaseVault.init.selector, abi.encode(address(addressManager)))
+                data: abi.encodeCall(BaseVault.init, (address(addressManager)))
             })
         );
 
@@ -117,7 +115,7 @@ contract TestERC20Vault is TaikoTest {
             deployProxy({
                 name: "erc20_vault",
                 impl: address(new ERC20Vault()),
-                data: bytes.concat(BaseVault.init.selector, abi.encode(address(addressManager)))
+                data: abi.encodeCall(BaseVault.init, (address(addressManager)))
             })
         );
 
@@ -129,7 +127,7 @@ contract TestERC20Vault is TaikoTest {
                 deployProxy({
                     name: "bridge",
                     impl: address(new Bridge()),
-                    data: bytes.concat(Bridge.init.selector, abi.encode(addressManager)),
+                    data: abi.encodeCall(Bridge.init, (address(addressManager))),
                     registerTo: address(addressManager),
                     owner: address(0)
                 })
@@ -143,7 +141,7 @@ contract TestERC20Vault is TaikoTest {
             deployProxy({
                 name: "signal_service",
                 impl: address(new SignalService()),
-                data: bytes.concat(SignalService.init.selector),
+                data: abi.encodeCall(SignalService.init, ()),
                 registerTo: address(0),
                 owner: address(0)
             })

--- a/packages/protocol/test/tokenvault/ERC721Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC721Vault.t.sol
@@ -127,7 +127,7 @@ contract ERC721VaultTest is TaikoTest {
             deployProxy({
                 name: "address_manager",
                 impl: address(new AddressManager()),
-                data: bytes.concat(AddressManager.init.selector)
+                data: abi.encodeCall(AddressManager.init, ())
             })
         );
 
@@ -136,7 +136,7 @@ contract ERC721VaultTest is TaikoTest {
                 deployProxy({
                     name: "bridge",
                     impl: address(new Bridge()),
-                    data: bytes.concat(Bridge.init.selector, abi.encode(addressManager)),
+                    data: abi.encodeCall(Bridge.init, (address(addressManager))),
                     registerTo: address(addressManager),
                     owner: address(0)
                 })
@@ -148,7 +148,7 @@ contract ERC721VaultTest is TaikoTest {
                 deployProxy({
                     name: "bridge",
                     impl: address(new Bridge()),
-                    data: bytes.concat(Bridge.init.selector, abi.encode(addressManager)),
+                    data: abi.encodeCall(Bridge.init, (address(addressManager))),
                     registerTo: address(addressManager),
                     owner: address(0)
                 })
@@ -159,7 +159,7 @@ contract ERC721VaultTest is TaikoTest {
             deployProxy({
                 name: "signal_service",
                 impl: address(new SignalService()),
-                data: bytes.concat(SignalService.init.selector)
+                data: abi.encodeCall(SignalService.init, ())
             })
         );
 
@@ -167,7 +167,7 @@ contract ERC721VaultTest is TaikoTest {
             deployProxy({
                 name: "erc721_vault",
                 impl: address(new ERC721Vault()),
-                data: bytes.concat(BaseVault.init.selector, abi.encode(address(addressManager)))
+                data: abi.encodeCall(BaseVault.init, (address(addressManager)))
             })
         );
 
@@ -175,7 +175,7 @@ contract ERC721VaultTest is TaikoTest {
             deployProxy({
                 name: "erc721_vault",
                 impl: address(new ERC721Vault()),
-                data: bytes.concat(BaseVault.init.selector, abi.encode(address(addressManager)))
+                data: abi.encodeCall(BaseVault.init, (address(addressManager)))
             })
         );
 
@@ -186,7 +186,7 @@ contract ERC721VaultTest is TaikoTest {
             deployProxy({
                 name: "signal_service",
                 impl: address(new SkipProofCheckSignal()),
-                data: bytes.concat(SignalService.init.selector)
+                data: abi.encodeCall(SignalService.init, ())
             })
         );
 


### PR DESCRIPTION
Before this PR, the ownership of the TaikoL2 contract is really not given to the DAO as DAO lives on L1. 

This PR introduces a new contract CrossChainOwned.sol that checks the owner address sent signals from L1 to L2 to authorize onlyOwner transactions.

- [ ] @davidtaikocha The L2 genesis script may need some changes as the init() function of TaikoL2 changed.
- [x] @dantaik will add a test for it.