### PR TITLE
chore(bridge-ui-v2): fix minor color issue in notification toast

### DIFF
--- a/packages/bridge-ui-v2/src/i18n/en.json
+++ b/packages/bridge-ui-v2/src/i18n/en.json
@@ -25,7 +25,7 @@
           "title": "Transaction completed"
         },
         "tx": {
-          "message": "Your bridge transaction was confirmed. The transaction can take a few minutes to complete, track it <a href=\"{url}\" class=\"link\" target=\"_blank\"><b>here</b></a>.",
+          "message": "Your bridge transaction was confirmed. The transaction can take a few minutes to complete, track it <a href=\"{url}\" target=\"_blank\"><b>here</b></a>.",
           "title": "Transaction sent"
         }
       },


### PR DESCRIPTION
Before
<img width="337" alt="Screen Shot 2023-12-19 at 10 20 12 AM" src="https://github.com/taikoxyz/taiko-mono/assets/104292916/837e6de8-c76c-48d2-8214-72222881c154">

After
<img width="344" alt="Screen Shot 2023-12-19 at 10 19 36 AM" src="https://github.com/taikoxyz/taiko-mono/assets/104292916/d7825baf-e30b-476a-aca6-7f8def25c602">
