### PR TITLE
fix(protocol): use safeTransferFrom to transfer ERC721 to unspecified address `to`

### DIFF
--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -104,6 +104,24 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         return ERC721Upgradeable.transferFrom(from, to, tokenId);
     }
 
+    /// @dev Safely transfers tokens from one address to another.
+    /// @param from Address from which the token is transferred.
+    /// @param to Address to which the token is transferred.
+    /// @param tokenId ID of the token to transfer.
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    )
+        public
+        override(ERC721Upgradeable)
+    {
+        if (to == address(this)) {
+            revert BRIDGED_TOKEN_CANNOT_RECEIVE();
+        }
+        return ERC721Upgradeable.safeTransferFrom(from, to, tokenId);
+    }
+
     /// @notice Gets the concatenated name of the bridged token.
     /// @return The concatenated name.
     function name()

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -106,7 +106,7 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver, IERC165Upgradeable {
             if (ctoken.chainId == block.chainid) {
                 token = ctoken.addr;
                 for (uint256 i; i < tokenIds.length; ++i) {
-                    ERC721Upgradeable(token).transferFrom({
+                    ERC721Upgradeable(token).safeTransferFrom({
                         from: address(this),
                         to: to,
                         tokenId: tokenIds[i]


### PR DESCRIPTION
Use `safeTransferFrom` to ensure target address `to` implements `onERC721received`