### PR TITLE
fix(protocol): fix revert when transfer ERC20 due to inconsistent interface

### DIFF
--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -15,6 +15,7 @@
 pragma solidity 0.8.20;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../../common/EssentialContract.sol";
 import "../../libs/LibAddress.sol";
 import "../TaikoData.sol";
@@ -24,6 +25,7 @@ import "./IHook.sol";
 /// A hook that handles prover assignment varification and fee processing.
 contract AssignmentHook is EssentialContract, IHook {
     using LibAddress for address;
+    using SafeERC20 for IERC20;
 
     struct ProverAssignment {
         address feeToken;
@@ -118,7 +120,7 @@ contract AssignmentHook is EssentialContract, IHook {
                 refund = msg.value - input.tip;
             }
             // Paying ERC20 tokens
-            IERC20(assignment.feeToken).transferFrom(msg.sender, blk.assignedProver, proverFee);
+            IERC20(assignment.feeToken).safeTransferFrom(msg.sender, blk.assignedProver, proverFee);
         }
 
         // block.coinbase can be address(0) in tests

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -159,8 +159,7 @@ contract TaikoL2 is CrossChainOwned, TaikoL2Signer, ICrossChainSync {
         if (token == address(0)) {
             to.sendEther(address(this).balance);
         } else {
-            IERC20 t = IERC20(token);
-            t.transfer(to, t.balanceOf(address(this)));
+            IERC20(token).transfer(to, IERC20(token).balanceOf(address(this)));
         }
     }
 

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -322,7 +322,7 @@ contract ERC20Vault is BaseVault {
             // simply using `amount` -- some contract may deduct a fee from the
             // transferred amount.
             uint256 _balance = t.balanceOf(address(this));
-            t.transferFrom({ from: msg.sender, to: address(this), amount: amount });
+            t.safeTransferFrom({ from: msg.sender, to: address(this), value: amount });
             _balanceChange = t.balanceOf(address(this)) - _balance;
         }
 


### PR DESCRIPTION
`ERC20(token).transfer` will revert for some `token` such as USDT because USDT uses different `.transfer` and `.transferFrom` interfaces from other ERC20. 

This fix changes to use `.safeTransfer` so that the protocol can list any token.