### PR TITLE
fix(bridge-ui-v2): Ensure Modal Close Button Triggers Cancellation Logic

### DIFF
--- a/packages/bridge-ui-v2/src/components/Bridge/Recipient.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/Recipient.svelte
@@ -121,7 +121,7 @@
 
     <dialog id={dialogId} class="modal" class:modal-open={modalOpen}>
       <div class="modal-box relative px-6 md:rounded-[20px] bg-neutral-background">
-        <CloseButton onClick={closeModal} />
+        <CloseButton onClick={cancelModal} />
 
         <div class="w-full">
           <h3 class="title-body-bold mb-7">{$t('recipient.title')}</h3>


### PR DESCRIPTION
## Overview
This pull request ensures that the modal close button (the [X] in the top-right corner) adheres to the expected user interaction by invoking the `cancelModal` function. The change enhances the user experience by aligning the behavior of the close button with the cancel action, which is the standard expectation for modals across web applications.

## Changes Made
- The `CloseButton` component now has an `on:click` handler that calls `cancelModal`, ensuring the modal dismisses in a manner consistent with user expectations for a close action.

## Reasoning
When users interact with modals, the [X] button in the corner is typically associated with a dismiss or cancel action. By explicitly binding the `cancelModal` function to this button, we eliminate any ambiguity about what happens when a user wants to close the modal without taking any affirmative action. This change adheres to standard design principles and improves the application's accessibility and usability.

## Testing Done
- Manual testing to verify that clicking the [X] button cancels the modal as expected.
- Ensured that the modal still performs the correct action when the "Confirm" button is clicked.
