### PR TITLE
feat(bridge-ui-v2): Sort Transactions by Latest First in Bridge UI

### DIFF
--- a/packages/bridge-ui-v2/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui-v2/src/libs/bridge/fetchTransactions.ts
@@ -38,7 +38,7 @@ export async function fetchTransactions(userAddress: Address) {
   const relayerTxsFlattened = relayerTxsArrays.reduce((acc, txs) => acc.concat(txs), []);
 
   // Reverse the flattened array to sort transactions in descending order, placing the most recent transactions first
-  const relayerTxs: BridgeTransaction[]  = relayerTxsFlattened.reverse();
+  const relayerTxs: BridgeTransaction[] = relayerTxsFlattened.reverse();
 
   log(`fetched ${relayerTxs?.length ?? 0} transactions from all relayers`, relayerTxs);
 

--- a/packages/bridge-ui-v2/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui-v2/src/libs/bridge/fetchTransactions.ts
@@ -37,6 +37,7 @@ export async function fetchTransactions(userAddress: Address) {
   // Flatten the arrays into a single array
   let relayerTxsFlatted = relayerTxsArrays.reduce((acc, txs) => acc.concat(txs), []);
 
+  // Reverse the flattened array to sort transactions in descending order, placing the most recent transactions first
   const relayerTxs: BridgeTransaction[]  = relayerTxsFlatted.reverse();
 
   log(`fetched ${relayerTxs?.length ?? 0} transactions from all relayers`, relayerTxs);

--- a/packages/bridge-ui-v2/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui-v2/src/libs/bridge/fetchTransactions.ts
@@ -35,10 +35,10 @@ export async function fetchTransactions(userAddress: Address) {
   }
 
   // Flatten the arrays into a single array
-  let relayerTxsFlatted = relayerTxsArrays.reduce((acc, txs) => acc.concat(txs), []);
+  const relayerTxsFlattened = relayerTxsArrays.reduce((acc, txs) => acc.concat(txs), []);
 
   // Reverse the flattened array to sort transactions in descending order, placing the most recent transactions first
-  const relayerTxs: BridgeTransaction[]  = relayerTxsFlatted.reverse();
+  const relayerTxs: BridgeTransaction[]  = relayerTxsFlattened.reverse();
 
   log(`fetched ${relayerTxs?.length ?? 0} transactions from all relayers`, relayerTxs);
 

--- a/packages/bridge-ui-v2/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui-v2/src/libs/bridge/fetchTransactions.ts
@@ -35,7 +35,9 @@ export async function fetchTransactions(userAddress: Address) {
   }
 
   // Flatten the arrays into a single array
-  const relayerTxs: BridgeTransaction[] = relayerTxsArrays.reduce((acc, txs) => acc.concat(txs), []);
+  let relayerTxsFlatted = relayerTxsArrays.reduce((acc, txs) => acc.concat(txs), []);
+
+  const relayerTxs: BridgeTransaction[]  = relayerTxsFlatted.reverse();
 
   log(`fetched ${relayerTxs?.length ?? 0} transactions from all relayers`, relayerTxs);
 


### PR DESCRIPTION
## Overview
This PR introduces a change to the transaction sorting behavior in the Bridge UI. The transactions are now displayed in descending order, ensuring that the most recent transactions appear first. This change is implemented in the `fetchTransactions.ts` file. 

The relayer GET /events/ returns the messages in the wrong order, so they had simply be reverted for this.

## Changes
- Modified the `fetchTransactions` function to show the transactions in descending order.
- The transactions array, `relayerTxs`, is now sorted with `.reverse()` to display the latest transactions at the top, since the array returned by the relayer was in ascending order.
