### PR TITLE
refactor(protocol): gas optimization with shift right instead of division

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -253,7 +253,7 @@ library LibProving {
 
             if (ts.contester != address(0)) {
                 // At this point we know that the contester was right
-                tko.transfer(ts.contester, ts.validityBond / 4 + ts.contestBond);
+                tko.transfer(ts.contester, ts.validityBond >> 2 + ts.contestBond);
                 ts.contester = address(0);
                 ts.validityBond = 0;
             }
@@ -377,7 +377,7 @@ library LibProving {
                     // winner, half of the contest bond is designated as the
                     // reward, to be divided equally between the new prover and
                     // the previous prover -- 1/4 each
-                    reward = ts.contestBond / 4;
+                    reward = ts.contestBond >> 2;
 
                     // Mint the reward and the validity bond and return it to
                     // the previous prover.
@@ -386,7 +386,7 @@ library LibProving {
                     // In the event that the contester is the winner, half of
                     // the validity bond is designated as the reward, to be
                     // divided equally between the new prover and the contester.
-                    reward = ts.validityBond / 4;
+                    reward = ts.validityBond >> 2;
 
                     // It's important to note that the contester is set to zero
                     // for the tier-0 transition. Consequently, we only grant a

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -198,7 +198,7 @@ library LibVerifying {
                 // Consequently, we have chosen to grant the actual prover only
                 // half of the liveness bond as a reward.
                 if (ts.prover != blk.assignedProver) {
-                    bondToReturn -= blk.livenessBond / 2;
+                    bondToReturn -= blk.livenessBond >> 1;
                 }
 
                 IERC20 tko = IERC20(resolver.resolve("taiko_token", false));

--- a/packages/protocol/contracts/L1/provers/Guardians.sol
+++ b/packages/protocol/contracts/L1/provers/Guardians.sol
@@ -51,7 +51,7 @@ abstract contract Guardians is EssentialContract {
             revert INVALID_GUARDIAN_SET();
         }
         if (
-            _minGuardians == 0 || _minGuardians < _guardians.length / 2
+            _minGuardians == 0 || _minGuardians < _guardians.length >> 1
                 || _minGuardians > _guardians.length
         ) revert INVALID_MIN_GUARDIANS();
 


### PR DESCRIPTION
- The DIV instruction takes more computing resources (5 gas), while the SHR instruction is more efficient and only takes 3 gas.
- Here is the gas report after the changes

| test/L1/Guardians.t.sol:DummyGuardians contract |                 |       |        |        |         |
|-------------------------------------------------|-----------------|-------|--------|--------|---------|
| Function Name                                   | min             | avg   | median | max    | # calls |
| setGuardians                                    | 8167            | 71983 | 11509  | 279343 | 7       |
| setGuardians (new)                                    | 8167            | 71944 | 11452  | 279286 | 7       |

| test/L1/TaikoL1LibProvingWithTiers.t.sol:TaikoL1Tiers contract |                 |        |        |        |         |
|----------------------------------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                                                  | min             | avg    | median | max    | # calls |
| proveBlock                                                     | 18610           | 87277  | 79678  | 209971 | 719     |
| proveBlock (new)                                                    | 18610           | 87259  | 79640  | 209933 | 719     |
| verifyBlocks                                                   | 6341            | 36683  | 45360  | 89062  | 393     |
| verifyBlocks (new)                                                  | 6341            | 36675  | 45360  | 89042  | 393     |