### PR TITLE
chore(bridge-ui-v2): Improve tooltip ux (new PR)

### DIFF
--- a/packages/bridge-ui-v2/README.md
+++ b/packages/bridge-ui-v2/README.md
@@ -62,6 +62,7 @@ To get started, open your terminal in `/packages/bridge-ui-v2/`
    cp config/sample/configuredChains.example config/configuredChains.json
    cp config/sample/configuredRelayer.example config/configuredRelayer.json
    cp config/sample/configuredCustomTokens.example config/configuredCustomTokens.json
+   cp config/sample/configuredEventIndexer.example config/configuredEventIndexer.json
    ```
 2. Change or fill in all the information that will be used by the bridge UI inside these files.
 

--- a/packages/bridge-ui-v2/src/components/Tooltip/Tooltip.svelte
+++ b/packages/bridge-ui-v2/src/components/Tooltip/Tooltip.svelte
@@ -17,8 +17,10 @@
   let triggerElem: HTMLButtonElement;
   let dialogElem: HTMLDialogElement;
 
-  function closeTooltip() {
-    tooltipOpen = false;
+  function closeTooltip(ms = 0) {
+    setTimeout(() => {
+      tooltipOpen = false;
+    }, ms);
   }
 
   function openTooltip(event: Event) {
@@ -31,22 +33,21 @@
       tooltipClass = `block dialog-tooltip dialog-tooltip-top`;
     }
     positionElementByTarget(dialogElem, triggerElem, position, GAP);
-    document.addEventListener('click', closeTooltip);
   });
 
   onDestroy(() => {
     closeTooltip();
-    document.removeEventListener('click', closeTooltip);
   });
 </script>
 
-<div class={classes}>
+<div class={classes} role="presentation" on:mouseleave={() => closeTooltip(200)}>
   <button
     aria-haspopup="dialog"
     aria-controls={tooltipId}
     aria-expanded={tooltipOpen}
     on:click={openTooltip}
     on:focus={openTooltip}
+    on:mouseenter={openTooltip}
     bind:this={triggerElem}>
     <Icon type="question-circle" />
   </button>


### PR DESCRIPTION
from: https://github.com/taikoxyz/taiko-mono/pull/15437

since rebasing to `alpha-6` has a lot of changes and conflict files, I created a new PR instead

- improve the UX of the tooltip
    - open the tooltip when hover or click
    - close the tooltip when the mouse leaves or click outside with some delay
