### PR TITLE
fix(bridge-ui-v2): fixing getFilterLogs errors

### DIFF
--- a/packages/bridge-ui-v2/src/components/Bridge/NFTBridgeSteps/ReviewStep.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/NFTBridgeSteps/ReviewStep.svelte
@@ -44,7 +44,7 @@
   $: isERC1155 = $selectedNFTs ? $selectedNFTs.some((nft) => nft.type === 'ERC1155') : false;
 </script>
 
-<div class="container mx-auto inline-block align-middle space-y-[25px] mt-[30px]">
+<div class="container mx-auto inline-block align-middle space-y-[25px] w-full md:w-[524px] mt-[30px]">
   <div class="flex justify-between mb-2 items-center">
     <div class="font-bold text-primary-content">{$t('bridge.nft.step.review.transfer_details')}</div>
   </div>

--- a/packages/bridge-ui-v2/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui-v2/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -18,6 +18,7 @@
   import { getLogger } from '$libs/util/logger';
   import { uid } from '$libs/util/uid';
   import { account } from '$stores/account';
+  import { network } from '$stores/network';
 
   import { destNetwork } from '../Bridge/state';
 
@@ -44,7 +45,7 @@
       tokenService.storeToken(customToken, $account?.address as Address);
       customTokens = tokenService.getTokens($account?.address as Address);
 
-      const { chain: srcChain } = getNetwork();
+      const srcChain = $network;
       const destChain = $destNetwork;
 
       if (!srcChain || !destChain) return;
@@ -119,7 +120,7 @@
       return;
     }
 
-    const { chain: srcChain } = getNetwork();
+    const srcChain = $network;
     if (!srcChain) return;
     try {
       const token = await getTokenWithInfoFromAddress({

--- a/packages/bridge-ui-v2/src/components/TokenDropdown/TokenDropdown.svelte
+++ b/packages/bridge-ui-v2/src/components/TokenDropdown/TokenDropdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { type Address, getNetwork } from '@wagmi/core';
+  import type { Address } from '@wagmi/core';
   import { onDestroy } from 'svelte';
   import { t } from 'svelte-i18n';
 
@@ -12,6 +12,7 @@
   import { getCrossChainAddress } from '$libs/token/getCrossChainAddress';
   import { uid } from '$libs/util/uid';
   import { account } from '$stores/account';
+  import { network } from '$stores/network';
 
   import { destNetwork } from '../Bridge/state';
   import DialogView from './DialogView.svelte';
@@ -64,12 +65,12 @@
   };
 
   const selectToken = async (token: Token) => {
-    const { chain } = getNetwork();
+    const srcChain = $network;
     const destChain = $destNetwork;
 
     // In order to select a token, we only need the source chain to be selected,
     // unless it's an imported token...
-    if (!chain) {
+    if (!srcChain) {
       warningToast({ title: $t('messages.network.required') });
       return;
     }
@@ -88,7 +89,7 @@
       try {
         bridgedAddress = await getCrossChainAddress({
           token,
-          srcChainId: chain.id,
+          srcChainId: srcChain.id,
           destChainId: destChain.id,
         });
       } catch (error) {

--- a/packages/bridge-ui-v2/src/libs/relayer/RelayerAPIService.ts
+++ b/packages/bridge-ui-v2/src/libs/relayer/RelayerAPIService.ts
@@ -9,8 +9,8 @@ import { apiService } from '$config';
 import type { BridgeTransaction, MessageStatus } from '$libs/bridge';
 import { isSupportedChain } from '$libs/chain';
 import { TokenType } from '$libs/token';
+import { fetchTransactionReceipt } from '$libs/util/fetchTransactionReceipt';
 import { getLogger } from '$libs/util/logger';
-import { publicClient } from '$libs/wagmi';
 
 import type {
   APIRequestParams,
@@ -36,9 +36,7 @@ export class RelayerAPIService {
   //Todo: duplicate code in BridgeTxService
   private static async _getTransactionReceipt(chainId: number, hash: Hash) {
     try {
-      const client = publicClient({ chainId });
-      const receipt = await client.getTransactionReceipt({ hash });
-      return receipt;
+      return await fetchTransactionReceipt(hash, chainId);
     } catch (error) {
       log(`Error getting transaction receipt for ${hash}: ${error}`);
       return null;

--- a/packages/bridge-ui-v2/src/libs/storage/BridgeTxService.ts
+++ b/packages/bridge-ui-v2/src/libs/storage/BridgeTxService.ts
@@ -6,6 +6,7 @@ import { routingContractsMap } from '$bridgeConfig';
 import { pendingTransaction, storageService } from '$config';
 import { type BridgeTransaction, MessageStatus } from '$libs/bridge';
 import { isSupportedChain } from '$libs/chain';
+import { fetchTransactionReceipt } from '$libs/util/fetchTransactionReceipt';
 import { jsonParseWithDefault } from '$libs/util/jsonParseWithDefault';
 import { getLogger } from '$libs/util/logger';
 import { publicClient } from '$libs/wagmi';
@@ -23,11 +24,8 @@ export class BridgeTxService {
 
   //Todo: duplicate code in RelayerAPIService
   private static async _getTransactionReceipt(chainId: number, hash: Hash) {
-    log(`Getting transaction receipt for ${hash} on chain ${chainId}`);
     try {
-      const client = publicClient({ chainId });
-      const receipt = await client.getTransactionReceipt({ hash });
-      return receipt;
+      return await fetchTransactionReceipt(hash, chainId);
     } catch (error) {
       log(`Error getting transaction receipt for ${hash}: ${error}`);
       return null;

--- a/packages/bridge-ui-v2/src/libs/storage/CustomTokenService.ts
+++ b/packages/bridge-ui-v2/src/libs/storage/CustomTokenService.ts
@@ -31,6 +31,7 @@ export class CustomTokenService implements TokenService {
       doesTokenAlreadyExist = tokens.findIndex((tokenFromStorage) => tokenFromStorage.symbol === token.symbol) >= 0;
     }
     if (!doesTokenAlreadyExist) {
+      token.imported = true;
       tokens.push(token);
     }
 

--- a/packages/bridge-ui-v2/src/libs/token/getBalance.ts
+++ b/packages/bridge-ui-v2/src/libs/token/getBalance.ts
@@ -17,7 +17,7 @@ const log = getLogger('token:getBalance');
 
 export async function getBalance({ userAddress, token, srcChainId, destChainId }: GetBalanceArgs) {
   let tokenBalance: FetchBalanceResult;
-
+  log('getBalance', { userAddress, token, srcChainId, destChainId });
   if (!token || token.type === TokenType.ETH) {
     // If no token is passed in, we assume is ETH
     tokenBalance = await fetchBalance({ address: userAddress, chainId: srcChainId });
@@ -37,8 +37,6 @@ export async function getBalance({ userAddress, token, srcChainId, destChainId }
       chainId: srcChainId,
     });
   }
-
   log('Token balance', tokenBalance);
-
   return tokenBalance;
 }

--- a/packages/bridge-ui-v2/src/libs/util/fetchTransactionReceipt.ts
+++ b/packages/bridge-ui-v2/src/libs/util/fetchTransactionReceipt.ts
@@ -1,0 +1,31 @@
+import type { Hash } from 'viem';
+
+import { chains } from '$libs/chain';
+
+export async function fetchTransactionReceipt(transactionHash: Hash, chainId: number) {
+  try {
+    const nodeUrl = chains.find((c) => c.id === chainId)?.rpcUrls?.public?.http[0];
+    if (!nodeUrl) {
+      throw new Error('Node URL not found');
+    }
+
+    const response = await fetch(nodeUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'eth_getTransactionReceipt',
+        params: [transactionHash],
+        id: 1,
+      }),
+    });
+
+    const data = await response.json();
+    return data.result;
+  } catch (error) {
+    console.error('Error fetching transaction receipt:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
**does not show up anymore with these fixes, will keep an eye on this** 


Investigating this error. 

```bash
InvalidInputRpcError: Missing or invalid parameters.
Double check you have provided the correct parameters.

URL: https://.....
Request body: {"method":"eth_getFilterLogs","params":["0x88128c706347c3b42fba42940526c8e"]}

Details: filter not found
Version: viem@2.0.3
    at withRetry.delay.count.count (chunk-RE42PZLX.js?v=4f56e106:1619:19)
    at async attemptRetry (chunk-RE42PZLX.js?v=4f56e106:1583:22)
 ```

**TODO:**

- [x]  Try other RPC endpoints
- [x]  Switch to manual calling RPCs (may have fixed it)
- [x] check if cached transactions interfere