### PR TITLE
feat(protocol): Fix new token migration change

### DIFF
--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -144,8 +144,6 @@ contract ERC20Vault is BaseVault {
             // Start the migration
             IBridgedERC20(btokenOld).changeMigrationStatus(btokenNew, false);
             IBridgedERC20(btokenNew).changeMigrationStatus(btokenOld, true);
-        } else {
-            IBridgedERC20(btokenNew).changeMigrationStatus(address(0), false);
         }
 
         bridgedToCanonical[btokenNew] = ctoken;


### PR DESCRIPTION
Current scenario:

1. Canonical token X lives on L1.
2. No bridged counterpart is bridged to L2 - yet. (Hence noone bridged token X just yet.)
3. We decide to pre-deploy a native X on L2 and we call the `changeBridgedToken()` in `ERC20Vault` afterwards.
4. It would call (wrongly) the `IBridgedERC20(btokenNew).changeMigrationStatus(address(0), false);` but in `BridgedERC20Base.sol` , this check would revert - because `inbound` is `false`, and `migratingAddress` is `address(0)` (exactly how we call that BridgedERC20Base..)
```
        if (addr == migratingAddress && inbound == migratingInbound) {
            revert BB_INVALID_PARAMS();
        }
```