### PR TITLE
fix(protocol): fix immutable-variable bug in UUPSUpgradeable for L2 predeployment

### DIFF
--- a/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
+++ b/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
@@ -14,8 +14,8 @@
 
 pragma solidity 0.8.20;
 
-import "lib/openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import "./UUPSUpgradeable.sol";
 
 /// @title OwnerUUPSUpgradable
 /// @notice This contract serves as the base contract for many core components.

--- a/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
+++ b/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
@@ -15,13 +15,13 @@
 pragma solidity 0.8.20;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import "./UUPSUpgradeable.sol";
+import "./UUPSUpgradeableAlt.sol";
 
 /// @title OwnerUUPSUpgradable
 /// @notice This contract serves as the base contract for many core components.
 /// @dev We didn't use OpenZeppelin's PausableUpgradeable and
 /// ReentrancyGuardUpgradeable contract to optimize storage reads.
-abstract contract OwnerUUPSUpgradable is UUPSUpgradeable, OwnableUpgradeable {
+abstract contract OwnerUUPSUpgradable is UUPSUpgradeableAlt, OwnableUpgradeable {
     uint8 private constant _FALSE = 1;
     uint8 private constant _TRUE = 2;
 

--- a/packages/protocol/contracts/common/UUPSUpgradeable.sol
+++ b/packages/protocol/contracts/common/UUPSUpgradeable.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.8.0) (proxy/utils/UUPSUpgradeable.sol)
+
+pragma solidity 0.8.20;
+
+import "lib/openzeppelin-contracts/contracts/interfaces/draft-IERC1822.sol";
+import "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
+
+/**
+ * @dev An upgradeability mechanism designed for UUPS proxies. The functions included here can
+ * perform an upgrade of an
+ * {ERC1967Proxy}, when this contract is set as the implementation behind such a proxy.
+ *
+ * A security mechanism ensures that an upgrade does not turn off upgradeability accidentally,
+ * although this risk is
+ * reinstated if the upgrade retains upgradeability but removes the security mechanism, e.g. by
+ * replacing
+ * `UUPSUpgradeable` with a custom implementation of upgrades.
+ *
+ * The {_authorizeUpgrade} function must be overridden to include access restriction to the upgrade
+ * mechanism.
+ *
+ * _Available since v4.1._
+ */
+abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable state-variable-assignment
+    address private immutable __self = address(this);
+
+    function self() public view returns (address) {
+        return __self;
+    }
+
+    /**
+     * @dev Check that the execution is being performed through a delegatecall call and that the
+     * execution context is
+     * a proxy contract with an implementation (as defined in ERC1967) pointing to self. This should
+     * only be the case
+     * for UUPS and transparent proxies that are using the current contract as their implementation.
+     * Execution of a
+     * function through ERC1167 minimal proxies (clones) would not normally pass this test, but is
+     * not guaranteed to
+     * fail.
+     */
+    modifier onlyProxy() {
+        require(address(this) != __self, "Function must be called through delegatecall");
+        require(_getImplementation() == __self, "Function must be called through active proxy");
+        _;
+    }
+
+    /**
+     * @dev Check that the execution is not being performed through a delegate call. This allows a
+     * function to be
+     * callable on the implementing contract but not through proxies.
+     */
+    modifier notDelegated() {
+        require(address(this) == __self, "UUPSUpgradeable: must not be called through delegatecall");
+        _;
+    }
+
+    /**
+     * @dev Implementation of the ERC1822 {proxiableUUID} function. This returns the storage slot
+     * used by the
+     * implementation. It is used to validate the implementation's compatibility when performing an
+     * upgrade.
+     *
+     * IMPORTANT: A proxy pointing at a proxiable contract should not be considered proxiable
+     * itself, because this risks
+     * bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is
+     * critical that this
+     * function revert if invoked through a proxy. This is guaranteed by the `notDelegated`
+     * modifier.
+     */
+    function proxiableUUID() external view virtual override notDelegated returns (bytes32) {
+        return _IMPLEMENTATION_SLOT;
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy to `newImplementation`.
+     *
+     * Calls {_authorizeUpgrade}.
+     *
+     * Emits an {Upgraded} event.
+     */
+    function upgradeTo(address newImplementation) external virtual onlyProxy {
+        _authorizeUpgrade(newImplementation);
+        _upgradeToAndCallUUPS(newImplementation, new bytes(0), false);
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy to `newImplementation`, and subsequently execute
+     * the function call
+     * encoded in `data`.
+     *
+     * Calls {_authorizeUpgrade}.
+     *
+     * Emits an {Upgraded} event.
+     */
+    function upgradeToAndCall(
+        address newImplementation,
+        bytes memory data
+    )
+        external
+        payable
+        virtual
+        onlyProxy
+    {
+        _authorizeUpgrade(newImplementation);
+        _upgradeToAndCallUUPS(newImplementation, data, true);
+    }
+
+    /**
+     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
+     * Called by
+     * {upgradeTo} and {upgradeToAndCall}.
+     *
+     * Normally, this function will use an xref:access.adoc[access control] modifier such as
+     * {Ownable-onlyOwner}.
+     *
+     * ```solidity
+     * function _authorizeUpgrade(address) internal override onlyOwner {}
+     * ```
+     */
+    function _authorizeUpgrade(address newImplementation) internal virtual;
+}

--- a/packages/protocol/contracts/common/UUPSUpgradeable.sol
+++ b/packages/protocol/contracts/common/UUPSUpgradeable.sol
@@ -1,5 +1,16 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v4.8.0) (proxy/utils/UUPSUpgradeable.sol)
+//  _____     _ _         _         _
+// |_   _|_ _(_) |_____  | |   __ _| |__ ___
+//   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
+//   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
+//
+//   Email: security@taiko.xyz
+//   Website: https://taiko.xyz
+//   GitHub: https://github.com/taikoxyz
+//   Discord: https://discord.gg/taikoxyz
+//   Twitter: https://twitter.com/taikoxyz
+//   Blog: https://mirror.xyz/labs.taiko.eth
+//   Youtube: https://www.youtube.com/@taikoxyz
 
 pragma solidity 0.8.20;
 
@@ -7,20 +18,10 @@ import "lib/openzeppelin-contracts/contracts/interfaces/draft-IERC1822.sol";
 import "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 /**
- * @dev An upgradeability mechanism designed for UUPS proxies. The functions included here can
- * perform an upgrade of an
- * {ERC1967Proxy}, when this contract is set as the implementation behind such a proxy.
- *
- * A security mechanism ensures that an upgrade does not turn off upgradeability accidentally,
- * although this risk is
- * reinstated if the upgrade retains upgradeability but removes the security mechanism, e.g. by
- * replacing
- * `UUPSUpgradeable` with a custom implementation of upgrades.
- *
- * The {_authorizeUpgrade} function must be overridden to include access restriction to the upgrade
- * mechanism.
- *
- * _Available since v4.1._
+ * @dev An upgradeability mechanism designed for UUPS proxies.
+ * This is an alternative impl based on
+ * lib/openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol
+ * without the immutable variable so we can pre-deploy these contracts on L2.
  */
 abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
     uint256[50] private __gap;

--- a/packages/protocol/contracts/common/UUPSUpgradeable.sol
+++ b/packages/protocol/contracts/common/UUPSUpgradeable.sol
@@ -26,15 +26,15 @@ import "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
     uint256[50] private __gap;
 
-    error NOT_DELEGAATED();
-    error IS_DELEGATED();
+    error DISALLOWED_WHEN_NOT_DELEGAATED();
+    error DISALLOWED_WHEN_IS_DELEGATED();
     /**
      * @dev Check that the execution is being performed through a delegatecall call and that the
      * execution context is a proxy contract with an implementation (as defined in ERC1967).
      */
 
     modifier onlyProxy() {
-        if (!isDelegated()) revert NOT_DELEGAATED();
+        if (!isDelegated()) revert DISALLOWED_WHEN_NOT_DELEGAATED();
         _;
     }
 
@@ -43,7 +43,7 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
      * function to be callable on the implementing contract but not through proxies.
      */
     modifier notDelegated() {
-        if (isDelegated()) revert IS_DELEGATED();
+        if (isDelegated()) revert DISALLOWED_WHEN_IS_DELEGATED();
         _;
     }
 

--- a/packages/protocol/contracts/common/UUPSUpgradeable.sol
+++ b/packages/protocol/contracts/common/UUPSUpgradeable.sol
@@ -107,6 +107,5 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
      * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
      * Called by {upgradeTo} and {upgradeToAndCall}.
      */
-
     function _authorizeUpgrade(address newImplementation) internal virtual;
 }

--- a/packages/protocol/contracts/common/UUPSUpgradeable.sol
+++ b/packages/protocol/contracts/common/UUPSUpgradeable.sol
@@ -98,6 +98,9 @@ abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
         return _IMPLEMENTATION_SLOT;
     }
 
+    /**
+     * @dev Returns whether the current call is through a delegatecall (proxy).
+     */
     function isDelegated() public view virtual returns (bool) {
         address impl = _getImplementation();
         return impl != address(0) && impl != address(this);

--- a/packages/protocol/contracts/common/UUPSUpgradeableAlt.sol
+++ b/packages/protocol/contracts/common/UUPSUpgradeableAlt.sol
@@ -23,7 +23,7 @@ import "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
  * lib/openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol
  * without the immutable variable so we can pre-deploy these contracts on L2.
  */
-abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
+abstract contract UUPSUpgradeableAlt is IERC1822Proxiable, ERC1967Upgrade {
     uint256[50] private __gap;
 
     error DISALLOWED_WHEN_NOT_DELEGAATED();

--- a/packages/protocol/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/genesis/GenerateGenesis.g.sol
@@ -88,7 +88,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
 
         vm.startPrank(addressManager.owner());
 
-        addressManager.upgradeTo(address(newAddressManager));
+        addressManagerProxy.upgradeTo(address(newAddressManager));
 
         vm.stopPrank();
     }
@@ -109,7 +109,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
 
         vm.startPrank(addressManager.owner());
 
-        addressManager.upgradeTo(address(newAddressManager));
+        addressManagerProxy.upgradeTo(address(newAddressManager));
 
         vm.stopPrank();
     }
@@ -149,7 +149,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
 
         TaikoL2 newTaikoL2 = new TaikoL2();
 
-        taikoL2.upgradeTo(address(newTaikoL2));
+        taikoL2Proxy.upgradeTo(address(newTaikoL2));
 
         vm.stopPrank();
     }
@@ -210,7 +210,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
 
         Bridge newBridge = new Bridge();
 
-        bridge.upgradeTo(address(newBridge));
+        bridgeProxy.upgradeTo(address(newBridge));
 
         vm.stopPrank();
     }
@@ -236,7 +236,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
 
         ERC20Vault newERC20Vault = new ERC20Vault();
 
-        erc20Vault.upgradeTo(address(newERC20Vault));
+        erc20VaultProxy.upgradeTo(address(newERC20Vault));
 
         vm.stopPrank();
     }
@@ -261,7 +261,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
         vm.startPrank(erc721Vault.owner());
         ERC721Vault newERC721Vault = new ERC721Vault();
 
-        erc721Vault.upgradeTo(address(newERC721Vault));
+        erc721VaultProxy.upgradeTo(address(newERC721Vault));
 
         vm.stopPrank();
     }
@@ -289,7 +289,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
 
         ERC1155Vault newERC1155Vault = new ERC1155Vault();
 
-        erc1155Vault.upgradeTo(address(newERC1155Vault));
+        erc1155VaultProxy.upgradeTo(address(newERC1155Vault));
 
         vm.stopPrank();
     }
@@ -316,7 +316,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
 
         SignalService newSignalService = new SignalService();
 
-        signalService.upgradeTo(address(newSignalService));
+        signalServiceProxy.upgradeTo(address(newSignalService));
 
         vm.stopPrank();
     }
@@ -358,7 +358,6 @@ contract TestGenerateGenesis is Test, AddressResolver {
         private
     {
         vm.startPrank(owner);
-        address contractAddress = getPredeployedContractAddress(contractName);
         address proxyAddress = getPredeployedContractAddress(proxyName);
 
         OwnerUUPSUpgradable proxy = OwnerUUPSUpgradable(payable(proxyAddress));

--- a/packages/protocol/script/upgrade/UpgradeScript.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeScript.s.sol
@@ -15,7 +15,7 @@
 pragma solidity 0.8.20;
 
 import "../../contracts/L1/gov/TaikoTimelockController.sol";
-import "lib/openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";
+import "../../contracts/common/UUPSUpgradeable.sol";
 
 import "forge-std/console2.sol";
 import "forge-std/Script.sol";

--- a/packages/protocol/script/upgrade/UpgradeScript.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeScript.s.sol
@@ -15,7 +15,7 @@
 pragma solidity 0.8.20;
 
 import "../../contracts/L1/gov/TaikoTimelockController.sol";
-import "../../contracts/common/UUPSUpgradeable.sol";
+import "../../contracts/common/UUPSUpgradeableAlt.sol";
 
 import "forge-std/console2.sol";
 import "forge-std/Script.sol";
@@ -25,7 +25,7 @@ contract UpgradeScript is Script {
     address public timelockAddress = vm.envAddress("TIMELOCK_ADDRESS");
     address public proxyAddress = vm.envAddress("PROXY_ADDRESS");
 
-    UUPSUpgradeable proxy;
+    UUPSUpgradeableAlt proxy;
     TaikoTimelockController timelock;
 
     modifier setUp() {
@@ -33,7 +33,7 @@ contract UpgradeScript is Script {
         require(proxyAddress != address(0), "PROXY_ADDRESS not set");
         require(timelockAddress != address(0), "TIMELOCK_ADDRESS not set");
 
-        proxy = UUPSUpgradeable(payable(proxyAddress));
+        proxy = UUPSUpgradeableAlt(payable(proxyAddress));
         timelock = TaikoTimelockController(payable(timelockAddress));
 
         vm.startBroadcast(privateKey);

--- a/packages/protocol/test/common/EssentialContract.t.sol
+++ b/packages/protocol/test/common/EssentialContract.t.sol
@@ -30,12 +30,17 @@ contract TestOwnerUUPSUpgradable is TaikoTest {
     function test_essential_behind_1967_proxy() external {
         bytes memory data = abi.encodeCall(Target1.init, ());
         vm.startPrank(Alice);
-        ERC1967Proxy proxy = new ERC1967Proxy(address(new Target1()), data);
+
+        Target1 t1 = new Target1();
+        assertEq(t1.isDelegated(), false);
+
+        ERC1967Proxy proxy = new ERC1967Proxy(address(t1), data);
         Target1 target = Target1(address(proxy));
         vm.stopPrank();
 
         // Owner is Alice
         vm.prank(Carol);
+        assertEq(target.isDelegated(), true);
         assertEq(target.owner(), Alice);
 
         // Alice can adjust();


### PR DESCRIPTION
Please carefully review this PR. 

The original issue: the OZ's UUPSUpgradeable implementation of has the following code:

```solidity
abstract contract UUPSUpgradeable is IERC1822Proxiable, ERC1967Upgrade {
    address private immutable __self = address(this);
...
}
```

When we pre-deploy a sub-contract of UUPSUpgradeable to L2 genesis, immutable variable `__self` will not be initialized and there is no storage slot for this variable (see https://medium.com/@ajaotosinserah/a-comprehensive-guide-to-implementing-constant-and-immutable-variables-in-solidity-4026ebadc6aa). 

We need to remove immutable variables from the code of all contracts we pre-deploy.