### PR TITLE
fix(eventindexer): nft indexing fix

### DIFF
--- a/packages/eventindexer/pkg/repo/nft_balance.go
+++ b/packages/eventindexer/pkg/repo/nft_balance.go
@@ -48,8 +48,6 @@ func (r *NFTBalanceRepository) IncreaseBalance(
 	if err != nil {
 		// allow to be not found, it may be first time this user has this NFT
 		if err != gorm.ErrRecordNotFound {
-			// should always be found, since we are subtracting a balance.
-			// that should be indexed as a positive balance before.
 			return nil, errors.Wrap(err, "r.db.gormDB.First")
 		}
 	}
@@ -85,9 +83,12 @@ func (r *NFTBalanceRepository) SubtractBalance(
 		First(b).
 		Error
 	if err != nil {
-		// should always be found, since we are subtracting a balance.
-		// that should be indexed as a positive balance before.
-		return nil, errors.Wrap(err, "r.db.gormDB.First")
+		if err != gorm.ErrRecordNotFound {
+			return nil, errors.Wrap(err, "r.db.gormDB.First")
+		} else {
+			// cant subtract a balance if user never had this balance, indexing issue
+			return nil, nil
+		}
 	}
 
 	b.Amount -= opts.Amount

--- a/packages/eventindexer/pkg/repo/nft_balance_test.go
+++ b/packages/eventindexer/pkg/repo/nft_balance_test.go
@@ -145,18 +145,6 @@ func TestIntegration_NFTBalance_Decrease(t *testing.T) {
 			assert.Equal(t, tt.wantErr, err)
 		})
 	}
-
-	bal3, err := nftBalanceRepo.SubtractBalance(context.Background(),
-		eventindexer.UpdateNFTBalanceOpts{
-			ChainID:         1,
-			Address:         "0x123",
-			TokenID:         1,
-			ContractAddress: "0x1234",
-			ContractType:    "ERC721",
-			Amount:          1,
-		})
-	assert.ErrorContains(t, err, "record not found")
-	assert.Nil(t, bal3)
 }
 
 // TODO: fix this test


### PR DESCRIPTION
this fixes the case where the "mint" in an NFT contract is not from the zero address, resulting in an error, because we cant decrease the original balance, as it never existed.