### PR TITLE
fix(protocol): fix guardian prover bug

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -226,7 +226,7 @@ library LibProving {
             assert(tier.validityBond == 0);
 
             // It means prover is right (not the contester)
-            bool proverIsRight = tran.blockHash == ts.blockHash && tran.signalRoot == ts.signalRoot;
+            bool sameTransition = tran.blockHash == ts.blockHash && tran.signalRoot == ts.signalRoot;
             // We should outright prohibit the use of zero values for both
             // blockHash and signalRoot since, when we initialize a new
             // transition, we set both blockHash and signalRoot to 0.
@@ -249,7 +249,7 @@ library LibProving {
             ts.prover = msg.sender;
 
             if (ts.contester != address(0)) {
-                if (!proverIsRight) {
+                if (!sameTransition) {
                     // At this point we know that the contester was right
                     tko.transfer(ts.contester, ts.validityBond >> 2 + ts.contestBond);
                 }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -224,6 +224,9 @@ library LibProving {
 
         if (tier.contestBond == 0) {
             assert(tier.validityBond == 0);
+
+            // It means prover is right (not the contester)
+            bool proverIsRight = tran.blockHash == ts.blockHash && tran.signalRoot == ts.signalRoot;
             // We should outright prohibit the use of zero values for both
             // blockHash and signalRoot since, when we initialize a new
             // transition, we set both blockHash and signalRoot to 0.
@@ -246,8 +249,10 @@ library LibProving {
             ts.prover = msg.sender;
 
             if (ts.contester != address(0)) {
-                // At this point we know that the contester was right
-                tko.transfer(ts.contester, ts.validityBond >> 2 + ts.contestBond);
+                if (!proverIsRight) {
+                    // At this point we know that the contester was right
+                    tko.transfer(ts.contester, ts.validityBond >> 2 + ts.contestBond);
+                }
                 ts.contester = address(0);
                 ts.validityBond = 0;
             }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -344,20 +344,12 @@ library LibProving {
                 revert L1_ALREADY_PROVED();
             }
 
-            if (tid == 1 && ts.prover == blk.assignedProver) {
+            if (tid == 1 && ts.tier == 0 && block.timestamp <= ts.timestamp + tier.provingWindow) {
                 // For the first transition, (1) if the previous prover is
                 // still the assigned prover, we exclusively grant permission to
                 // the assigned approver to re-prove the block, (2) unless the
                 // proof window has elapsed.
-                if (
-                    block.timestamp <= ts.timestamp + tier.provingWindow
-                        && msg.sender != blk.assignedProver
-                ) revert L1_NOT_ASSIGNED_PROVER();
-
-                if (
-                    block.timestamp > ts.timestamp + tier.provingWindow
-                        && msg.sender == blk.assignedProver
-                ) revert L1_ASSIGNED_PROVER_NOT_ALLOWED();
+                if (msg.sender != blk.assignedProver) revert L1_NOT_ASSIGNED_PROVER();
             } else if (msg.sender == blk.assignedProver) {
                 // However, if the previous prover of the first transition is
                 // not the block's assigned prover, or for any other

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -224,12 +224,6 @@ library LibProving {
 
         if (tier.contestBond == 0) {
             assert(tier.validityBond == 0);
-            // When contestBond is zero for the current tier, it signifies
-            // it's the top tier. In this case, it can overwrite existing
-            // transitions without contestation.
-            if (tran.blockHash == ts.blockHash && tran.signalRoot == ts.signalRoot) {
-                revert L1_ALREADY_PROVED();
-            }
             // We should outright prohibit the use of zero values for both
             // blockHash and signalRoot since, when we initialize a new
             // transition, we set both blockHash and signalRoot to 0.


### PR DESCRIPTION
The blelow code section.If transition is correct but contested AND guardian came with the (same) correct proof, this check would not allow it to execute properly.

```
            // When contestBond is zero for the current tier, it signifies
            // it's the top tier. In this case, it can overwrite existing
            // transitions without contestation.
            if (tran.blockHash == ts.blockHash && tran.signalRoot == ts.signalRoot) {
                revert L1_ALREADY_PROVED();
            }
```
