### PR TITLE
feat(protocol): force nonzero blockhash and signalroot

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -78,7 +78,9 @@ library LibProving {
         returns (uint8 maxBlocksToVerify)
     {
         // Make sure parentHash is not zero
-        if (tran.parentHash == 0) revert L1_INVALID_TRANSITION();
+        if (tran.parentHash == 0 || tran.blockHash == 0 || tran.signalRoot == 0) {
+            revert L1_INVALID_TRANSITION();
+        }
 
         // Check that the block has been proposed but has not yet been verified.
         TaikoData.SlotB memory b = state.slotB;
@@ -227,12 +229,6 @@ library LibProving {
 
             // It means prover is right (not the contester)
             bool sameTransition = tran.blockHash == ts.blockHash && tran.signalRoot == ts.signalRoot;
-            // We should outright prohibit the use of zero values for both
-            // blockHash and signalRoot since, when we initialize a new
-            // transition, we set both blockHash and signalRoot to 0.
-            if (tran.blockHash == 0 || tran.signalRoot == 0) {
-                revert L1_INVALID_TRANSITION();
-            }
 
             // A special return value from the top tier prover can signal this
             // contract to return all liveness bond.
@@ -316,11 +312,6 @@ library LibProving {
             // The new tier is higher than the previous tier, we are in the
             // proving mode. This works even if this transition's contester is
             // address zero, see more info below.
-
-            // zero values are not allowed
-            if (tran.blockHash == 0 || tran.signalRoot == 0) {
-                revert L1_INVALID_TRANSITION();
-            }
 
             // The ability to prove a transition is granted under the following
             // two circumstances:

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -835,7 +835,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
         printVariables("");
     }
 
-    function test_L1_ContestingWithLowerTierProofRevertspn() external {
+    function test_L1_ContestingWithLowerTierProofReverts() external {
         giveEthAndTko(Alice, 1e7 ether, 1000 ether);
         giveEthAndTko(Carol, 1e7 ether, 1000 ether);
         console2.log("Alice balance:", tko.balanceOf(Alice));

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -435,7 +435,16 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             proveBlock(Bob, Bob, meta, parentHash, blockHash, signalRoot, meta.minTier, "");
             console2.log("mintTier is:", meta.minTier);
             // Try to contest
-            proveBlock(Carol, Carol, meta, parentHash, 0, 0, meta.minTier, "");
+            proveBlock(
+                Carol,
+                Carol,
+                meta,
+                parentHash,
+                bytes32(uint256(1)),
+                bytes32(uint256(1)),
+                meta.minTier,
+                ""
+            );
             vm.roll(block.number + 15 * 12);
 
             uint16 minTier = meta.minTier;


### PR DESCRIPTION
@davidtaikocha this change means for contesters, they have to use non-zero values for blockHash and signalRoot to contest existing transitions, 0s are not allowed.


Added a test to make sure contesting with a lower tier will fail.