### PR TITLE
fix(protocol): correct typo on the bridge contract docs

### DIFF
--- a/packages/protocol/contracts/bridge/README.md
+++ b/packages/protocol/contracts/bridge/README.md
@@ -16,7 +16,7 @@ Let's go deeper into the steps that occur when bridging ETH from srcChain to des
 ### Send message / Send token
 
 The bridge distinguishes 4 different token types: `Ether`, `Erc20`, `Erc1155`, `Erc721`.
-Each type has its own vault contract both deployed to the source and destination chain. (Except `EtherVault`, which is only deployed on L1 and Bridge itself holds the funds on L2.)
+Each type has its own vault contract both deployed to the source and destination chain. (Except `EtherVault`, which is only deployed on L2 and Bridge itself holds the funds on L1.)
 
 #### Bridging Ether
 


### PR DESCRIPTION
The bridge docs state that the EtherVault contract only exists on L1 and that the Bridge contract holds the funds on L2. Isn't that the other way around? As per the diagrams in https://docs.taiko.xyz/core-concepts/bridging/#how-does-ether-bridging-work, it seems that would be the case.