### PR TITLE
feat(relayer): Allow relayer to run in "target single transaction hash" mode

### DIFF
--- a/packages/relayer/bridge.go
+++ b/packages/relayer/bridge.go
@@ -26,4 +26,5 @@ type Bridge interface {
 		sink chan<- *bridge.BridgeMessageStatusChanged,
 		msgHash [][32]byte,
 	) (event.Subscription, error)
+	ParseMessageSent(log types.Log) (*bridge.BridgeMessageSent, error)
 }

--- a/packages/relayer/cmd/flags/processor.go
+++ b/packages/relayer/cmd/flags/processor.go
@@ -126,6 +126,13 @@ var (
 		Category: processorCategory,
 		EnvVars:  []string{"HOP_RPC_URLS"},
 	}
+	TargetTxHash = &cli.StringFlag{
+		Name:     "targetTxHash",
+		Usage:    "Target transaction hash, set to ignore processing from queue and only process this individual transaction",
+		Category: processorCategory,
+		Required: false,
+		EnvVars:  []string{"TARGET_TX_HASH"},
+	}
 )
 
 var ProcessorFlags = MergeFlags(CommonFlags, QueueFlags, []cli.Flag{
@@ -148,4 +155,5 @@ var ProcessorFlags = MergeFlags(CommonFlags, QueueFlags, []cli.Flag{
 	HopSignalServiceAddresses,
 	HopTaikoAddresses,
 	DestBridgeAddress,
+	TargetTxHash,
 })

--- a/packages/relayer/pkg/mock/bridge.go
+++ b/packages/relayer/pkg/mock/bridge.go
@@ -149,3 +149,7 @@ func (b *Bridge) ProveMessageReceived(opts *bind.CallOpts, message bridge.IBridg
 
 	return false, nil
 }
+
+func (b *Bridge) ParseMessageSent(log types.Log) (*bridge.BridgeMessageSent, error) {
+	return &bridge.BridgeMessageSent{}, nil
+}

--- a/packages/relayer/processor/config.go
+++ b/packages/relayer/processor/config.go
@@ -99,6 +99,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	}
 
 	var targetTxHash *common.Hash
+
 	if c.IsSet(flags.TargetTxHash.Name) {
 		hash := common.HexToHash(c.String(flags.TargetTxHash.Name))
 		targetTxHash = &hash

--- a/packages/relayer/processor/config.go
+++ b/packages/relayer/processor/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	// private key
 	ProcessorPrivateKey *ecdsa.PrivateKey
 
+	TargetTxHash *common.Hash
+
 	// processing configs
 	HeaderSyncInterval   uint64
 	Confirmations        uint64
@@ -96,6 +98,12 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		})
 	}
 
+	var targetTxHash *common.Hash
+	if c.IsSet(flags.TargetTxHash.Name) {
+		hash := common.HexToHash(c.String(flags.TargetTxHash.Name))
+		targetTxHash = &hash
+	}
+
 	return &Config{
 		hopConfigs:              hopConfigs,
 		ProcessorPrivateKey:     processorPrivateKey,
@@ -127,6 +135,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		BackoffRetryInterval:    c.Uint64(flags.BackOffRetryInterval.Name),
 		BackOffMaxRetrys:        c.Uint64(flags.BackOffMaxRetrys.Name),
 		ETHClientTimeout:        c.Uint64(flags.ETHClientTimeout.Name),
+		TargetTxHash:            targetTxHash,
 		OpenDBFunc: func() (DB, error) {
 			return db.OpenDBConnection(db.DBConnectionOpts{
 				Name:            c.String(flags.DatabaseUsername.Name),

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -299,9 +299,13 @@ func (p *Processor) processMessage(
 		relayer.DoneEvents.Inc()
 	}
 
-	// update message status
-	if err := p.eventRepo.UpdateStatus(ctx, msgBody.ID, relayer.EventStatus(messageStatus)); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("p.eventRepo.UpdateStatus, id: %v", msgBody.ID))
+	// internal will only be set if it's an actual queue message, not a targeted
+	// transaction hash.
+	if msg.Internal != nil {
+		// update message status
+		if err := p.eventRepo.UpdateStatus(ctx, msgBody.ID, relayer.EventStatus(messageStatus)); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("p.eventRepo.UpdateStatus, id: %v", msgBody.ID))
+		}
 	}
 
 	return nil

--- a/packages/relayer/processor/process_single.go
+++ b/packages/relayer/processor/process_single.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
@@ -36,8 +35,6 @@ func (p *Processor) processSingle(ctx context.Context) error {
 			s.Raw.BlockNumber = receipt.BlockNumber.Uint64()
 			s.Raw.Address = log.Address
 			s.Raw.Topics = log.Topics
-
-			spew.Dump(s)
 
 			msg := queue.QueueMessageBody{
 				ID:    0,

--- a/packages/relayer/processor/process_single.go
+++ b/packages/relayer/processor/process_single.go
@@ -1,0 +1,61 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
+)
+
+func (p *Processor) processSingle(ctx context.Context) error {
+	bridgeAbi, err := abi.JSON(strings.NewReader(bridge.BridgeABI))
+	if err != nil {
+		return err
+	}
+
+	receipt, err := p.srcEthClient.TransactionReceipt(ctx, *p.targetTxHash)
+	if err != nil {
+		return err
+	}
+
+	for _, log := range receipt.Logs {
+		topic := log.Topics[0]
+		if topic == bridgeAbi.Events["MessageSent"].ID {
+			s := &bridge.BridgeMessageSent{}
+			err = bridgeAbi.UnpackIntoInterface(s, "MessageSent", log.Data)
+			if err != nil {
+				return err
+			}
+
+			s.MsgHash = log.Topics[1]
+			s.Raw.TxHash = *p.targetTxHash
+			s.Raw.BlockNumber = receipt.BlockNumber.Uint64()
+			s.Raw.Address = log.Address
+			s.Raw.Topics = log.Topics
+
+			spew.Dump(s)
+
+			msg := queue.QueueMessageBody{
+				ID:    0,
+				Event: s,
+			}
+
+			marshalledMsg, err := json.Marshal(msg)
+			if err != nil {
+				return err
+			}
+
+			if err := p.processMessage(ctx, queue.Message{
+				Body: marshalledMsg,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/packages/relayer/processor/process_single.go
+++ b/packages/relayer/processor/process_single.go
@@ -27,6 +27,7 @@ func (p *Processor) processSingle(ctx context.Context) error {
 		if topic == bridgeAbi.Events["MessageSent"].ID {
 			s := &bridge.BridgeMessageSent{}
 			err = bridgeAbi.UnpackIntoInterface(s, "MessageSent", log.Data)
+
 			if err != nil {
 				return err
 			}

--- a/packages/relayer/processor/process_single.go
+++ b/packages/relayer/processor/process_single.go
@@ -25,21 +25,14 @@ func (p *Processor) processSingle(ctx context.Context) error {
 		topic := log.Topics[0]
 
 		if topic == bridgeAbi.Events["MessageSent"].ID {
-			s := &bridge.BridgeMessageSent{}
-			err = bridgeAbi.UnpackIntoInterface(s, "MessageSent", log.Data)
+			event, err := p.destBridgeFilterer.ParseMessageSent(*log)
 			if err != nil {
 				return err
 			}
 
-			s.MsgHash = log.Topics[1]
-			s.Raw.TxHash = *p.targetTxHash
-			s.Raw.BlockNumber = receipt.BlockNumber.Uint64()
-			s.Raw.Address = log.Address
-			s.Raw.Topics = log.Topics
-
 			msg := queue.QueueMessageBody{
 				ID:    0,
-				Event: s,
+				Event: event,
 			}
 
 			marshalledMsg, err := json.Marshal(msg)

--- a/packages/relayer/processor/process_single.go
+++ b/packages/relayer/processor/process_single.go
@@ -23,6 +23,7 @@ func (p *Processor) processSingle(ctx context.Context) error {
 
 	for _, log := range receipt.Logs {
 		topic := log.Topics[0]
+
 		if topic == bridgeAbi.Events["MessageSent"].ID {
 			s := &bridge.BridgeMessageSent{}
 			err = bridgeAbi.UnpackIntoInterface(s, "MessageSent", log.Data)

--- a/packages/relayer/processor/process_single.go
+++ b/packages/relayer/processor/process_single.go
@@ -25,7 +25,7 @@ func (p *Processor) processSingle(ctx context.Context) error {
 		topic := log.Topics[0]
 
 		if topic == bridgeAbi.Events["MessageSent"].ID {
-			event, err := p.destBridgeFilterer.ParseMessageSent(*log)
+			event, err := p.destBridge.ParseMessageSent(*log)
 			if err != nil {
 				return err
 			}

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -92,6 +92,7 @@ type Processor struct {
 	relayerAddr             common.Address
 	srcSignalServiceAddress common.Address
 	destHeaderSyncAddress   common.Address
+	srcBridgeAddress        common.Address
 
 	confirmations uint64
 
@@ -112,6 +113,8 @@ type Processor struct {
 	destChainId *big.Int
 
 	taikoL2 *taikol2.TaikoL2
+
+	targetTxHash *common.Hash // optional, set to target processing a specific txHash only
 }
 
 func (p *Processor) InitFromCli(ctx context.Context, c *cli.Context) error {
@@ -207,11 +210,6 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 		})
 	}
 
-	q, err := cfg.OpenQueueFunc()
-	if err != nil {
-		return err
-	}
-
 	srcSignalService, err := signalservice.NewSignalService(
 		cfg.SrcSignalServiceAddress,
 		srcEthClient,
@@ -294,6 +292,14 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 		p.taikoL2 = taikoL2
 	}
 
+	var q queue.Queue
+	if p.targetTxHash != nil {
+		q, err = cfg.OpenQueueFunc()
+		if err != nil {
+			return err
+		}
+	}
+
 	p.hops = hops
 	p.prover = prover
 	p.eventRepo = eventRepository
@@ -335,6 +341,8 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 	p.backOffMaxRetries = cfg.BackOffMaxRetrys
 	p.ethClientTimeout = time.Duration(cfg.ETHClientTimeout) * time.Second
 
+	p.targetTxHash = cfg.TargetTxHash
+
 	return nil
 }
 
@@ -352,6 +360,14 @@ func (p *Processor) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	p.cancel = cancel
+
+	// if a targetTxHash is set, we only want to process that specific one.
+	if p.targetTxHash != nil {
+		return p.processSingle(ctx)
+	}
+
+	// otherwise, we can start the queue, and process messages from it
+	// via eventloop.
 
 	if err := p.queue.Start(ctx, p.queueName()); err != nil {
 		return err

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -92,7 +92,6 @@ type Processor struct {
 	relayerAddr             common.Address
 	srcSignalServiceAddress common.Address
 	destHeaderSyncAddress   common.Address
-	srcBridgeAddress        common.Address
 
 	confirmations uint64
 

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -78,12 +78,11 @@ type Processor struct {
 
 	srcSignalService relayer.SignalService
 
-	destBridge         relayer.Bridge
-	destBridgeFilterer *bridge.BridgeFilterer
-	destHeaderSyncer   relayer.HeaderSyncer
-	destERC20Vault     relayer.TokenVault
-	destERC1155Vault   relayer.TokenVault
-	destERC721Vault    relayer.TokenVault
+	destBridge       relayer.Bridge
+	destHeaderSyncer relayer.HeaderSyncer
+	destERC20Vault   relayer.TokenVault
+	destERC1155Vault relayer.TokenVault
+	destERC721Vault  relayer.TokenVault
 
 	prover *proof.Prover
 
@@ -258,11 +257,6 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 		return err
 	}
 
-	destBridgeFilter, err := bridge.NewBridgeFilterer(cfg.DestBridgeAddress, destEthClient)
-	if err != nil {
-		return err
-	}
-
 	srcChainID, err := srcEthClient.ChainID(context.Background())
 	if err != nil {
 		return err
@@ -315,7 +309,6 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 	p.srcSignalService = srcSignalService
 
 	p.destBridge = destBridge
-	p.destBridgeFilterer = destBridgeFilter
 	p.destERC1155Vault = destERC1155Vault
 	p.destERC20Vault = destERC20Vault
 	p.destERC721Vault = destERC721Vault

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -78,11 +78,12 @@ type Processor struct {
 
 	srcSignalService relayer.SignalService
 
-	destBridge       relayer.Bridge
-	destHeaderSyncer relayer.HeaderSyncer
-	destERC20Vault   relayer.TokenVault
-	destERC1155Vault relayer.TokenVault
-	destERC721Vault  relayer.TokenVault
+	destBridge         relayer.Bridge
+	destBridgeFilterer *bridge.BridgeFilterer
+	destHeaderSyncer   relayer.HeaderSyncer
+	destERC20Vault     relayer.TokenVault
+	destERC1155Vault   relayer.TokenVault
+	destERC721Vault    relayer.TokenVault
 
 	prover *proof.Prover
 
@@ -257,6 +258,11 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 		return err
 	}
 
+	destBridgeFilter, err := bridge.NewBridgeFilterer(cfg.DestBridgeAddress, destEthClient)
+	if err != nil {
+		return err
+	}
+
 	srcChainID, err := srcEthClient.ChainID(context.Background())
 	if err != nil {
 		return err
@@ -309,6 +315,7 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 	p.srcSignalService = srcSignalService
 
 	p.destBridge = destBridge
+	p.destBridgeFilterer = destBridgeFilter
 	p.destERC1155Vault = destERC1155Vault
 	p.destERC20Vault = destERC20Vault
 	p.destERC721Vault = destERC721Vault


### PR DESCRIPTION
This lets us help debug a potential issue with a bridge message, or manually process for easier testing.