### PR TITLE
feat(protocol): allow someone to ack message reception then invoke the message before others to earn the fee

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -176,9 +176,7 @@ contract Bridge is EssentialContract, IBridge {
             messageReceive[failureSignal].timestamp = uint64(block.timestamp);
         }
 
-        Receive memory _receive = messageReceive[failureSignal];
-
-        if (block.timestamp >= getInvocationDelay() + _receive.timestamp) {
+        if (block.timestamp >= getInvocationDelay() + messageReceive[failureSignal].timestamp) {
             delete messageReceive[failureSignal];
             messageStatus[failureSignal] = Status.RECALLED;
 


### PR DESCRIPTION
Allow someone to ack the reception of a message then be the preferred transactor to invoke the transaction before any other addresses (including the message's owner). This solves the fee issue:

> A challenge is that the previous message.fee is designed for a one-step process, now with a two-step process, in theory we need two fees, one for each step, but this is not implemented in this PR as it will have data incompatibility issue.