### PR TITLE
chore(protocol): upgrade solidity complier to `0.8.24`

### DIFF
--- a/packages/protocol/.solhint.json
+++ b/packages/protocol/.solhint.json
@@ -2,7 +2,7 @@
   "extends": "solhint:recommended",
   "rules": {
     "avoid-low-level-calls": "off",
-    "compiler-version": ["error", "^0.8.20"],
+    "compiler-version": ["error", "^0.8.24"],
     "func-visibility": ["warn", { "ignoreConstructors": true }],
     "max-line-length": "off",
     "no-empty-blocks": "off",

--- a/packages/protocol/contracts/4844/IBlobHashReader.sol
+++ b/packages/protocol/contracts/4844/IBlobHashReader.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title IBlobHashReader
 /// @dev Labeled in AddressResolver as "blob_hash_reader"

--- a/packages/protocol/contracts/4844/Lib4844.sol
+++ b/packages/protocol/contracts/4844/Lib4844.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title Lib4844
 /// @notice A library for handling EIP-4844 blobs

--- a/packages/protocol/contracts/L1/ITaikoL1.sol
+++ b/packages/protocol/contracts/L1/ITaikoL1.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./TaikoData.sol";
 

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title TaikoData
 /// @notice This library defines various data structures used in the Taiko

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title TaikoErrors
 /// @notice This abstract contract provides custom error declartions used in

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./TaikoData.sol";
 

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../common/EssentialContract.sol";
 import "./libs/LibDepositing.sol";

--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
 import

--- a/packages/protocol/contracts/L1/gov/TaikoGovernor.sol
+++ b/packages/protocol/contracts/L1/gov/TaikoGovernor.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/governance/GovernorUpgradeable.sol";
 import

--- a/packages/protocol/contracts/L1/gov/TaikoTimelockController.sol
+++ b/packages/protocol/contracts/L1/gov/TaikoTimelockController.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import
     "lib/openzeppelin-contracts-upgradeable/contracts/governance/TimelockControllerUpgradeable.sol";

--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/protocol/contracts/L1/hooks/IHook.sol
+++ b/packages/protocol/contracts/L1/hooks/IHook.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoData.sol";
 

--- a/packages/protocol/contracts/L1/libs/LibDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibDepositing.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../common/AddressResolver.sol";
 import "../../libs/LibAddress.sol";

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "../../4844/IBlobHashReader.sol";

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "../../common/AddressResolver.sol";

--- a/packages/protocol/contracts/L1/libs/LibProvingAlt.sol
+++ b/packages/protocol/contracts/L1/libs/LibProvingAlt.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "../../common/AddressResolver.sol";

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../common/ICrossChainSync.sol";
 import "../TaikoData.sol";

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "../../common/AddressResolver.sol";

--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../tiers/ITierProvider.sol";
 import "../ITaikoL1.sol";

--- a/packages/protocol/contracts/L1/provers/Guardians.sol
+++ b/packages/protocol/contracts/L1/provers/Guardians.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../common/EssentialContract.sol";
 import "../TaikoData.sol";

--- a/packages/protocol/contracts/L1/tiers/ITierProvider.sol
+++ b/packages/protocol/contracts/L1/tiers/ITierProvider.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title ITierProvider
 /// @notice Defines interface to return tier configuration.

--- a/packages/protocol/contracts/L1/tiers/TaikoA6TierProvider.sol
+++ b/packages/protocol/contracts/L1/tiers/TaikoA6TierProvider.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../common/EssentialContract.sol";
 import "./ITierProvider.sol";

--- a/packages/protocol/contracts/L1/verifiers/GuardianVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/GuardianVerifier.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../common/EssentialContract.sol";
 import "../TaikoData.sol";

--- a/packages/protocol/contracts/L1/verifiers/IVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/IVerifier.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoData.sol";
 

--- a/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/PseZkVerifier.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../4844/Lib4844.sol";
 import "../../common/EssentialContract.sol";

--- a/packages/protocol/contracts/L1/verifiers/SgxAndZkVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxAndZkVerifier.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../common/EssentialContract.sol";
 import "../../thirdparty/LibBytesUtils.sol";

--- a/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 import "../../common/EssentialContract.sol";

--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/protocol/contracts/L2/Lib1559Math.sol
+++ b/packages/protocol/contracts/L2/Lib1559Math.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../thirdparty/LibFixedPointMath.sol";
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
+++ b/packages/protocol/contracts/L2/TaikoL2EIP1559Configurable.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./TaikoL2.sol";
 

--- a/packages/protocol/contracts/L2/TaikoL2Signer.sol
+++ b/packages/protocol/contracts/L2/TaikoL2Signer.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../thirdparty/LibUint512Math.sol";
 

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../common/EssentialContract.sol";
 import "../libs/LibAddress.sol";

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title IBridge
 /// @notice The bridge used in conjunction with the {ISignalService}.

--- a/packages/protocol/contracts/common/AddressManager.sol
+++ b/packages/protocol/contracts/common/AddressManager.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./OwnerUUPSUpgradable.sol";
 

--- a/packages/protocol/contracts/common/AddressResolver.sol
+++ b/packages/protocol/contracts/common/AddressResolver.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 import "./AddressManager.sol";

--- a/packages/protocol/contracts/common/AuthorizableContract.sol
+++ b/packages/protocol/contracts/common/AuthorizableContract.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../common/EssentialContract.sol";
 

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./AddressResolver.sol";
 import "./OwnerUUPSUpgradable.sol";

--- a/packages/protocol/contracts/common/ICrossChainSync.sol
+++ b/packages/protocol/contracts/common/ICrossChainSync.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title ICrossChainSync
 /// @dev This interface is implemented by both the TaikoL1 and TaikoL2

--- a/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
+++ b/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";

--- a/packages/protocol/contracts/libs/LibAddress.sol
+++ b/packages/protocol/contracts/libs/LibAddress.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/utils/Address.sol";
 import "lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";

--- a/packages/protocol/contracts/libs/LibDeploy.sol
+++ b/packages/protocol/contracts/libs/LibDeploy.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";

--- a/packages/protocol/contracts/libs/LibMath.sol
+++ b/packages/protocol/contracts/libs/LibMath.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title LibMath
 /// @dev This library offers additional math functions for uint256.

--- a/packages/protocol/contracts/signal/ISignalService.sol
+++ b/packages/protocol/contracts/signal/ISignalService.sol
@@ -5,7 +5,7 @@
 //   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
 //   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title ISignalService
 /// @notice The SignalService contract serves as a secure cross-chain message

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
 import "../common/AuthorizableContract.sol";

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/packages/protocol/contracts/team/airdrop/ERC20Airdrop.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC20Airdrop.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
 import "./MerkleClaimable.sol";

--- a/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
 import "../../libs/LibMath.sol";

--- a/packages/protocol/contracts/team/airdrop/ERC721Airdrop.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC721Airdrop.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
 import "./MerkleClaimable.sol";

--- a/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol
+++ b/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import { MerkleProofUpgradeable } from
     "lib/openzeppelin-contracts-upgradeable/contracts/utils/cryptography/MerkleProofUpgradeable.sol";

--- a/packages/protocol/contracts/test/erc20/FreeMintERC20.sol
+++ b/packages/protocol/contracts/test/erc20/FreeMintERC20.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/protocol/contracts/test/erc20/MayFailFreeMintERC20.sol
+++ b/packages/protocol/contracts/test/erc20/MayFailFreeMintERC20.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/protocol/contracts/test/erc20/RegularERC20.sol
+++ b/packages/protocol/contracts/test/erc20/RegularERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/protocol/contracts/thirdparty/LibBytesUtils.sol
+++ b/packages/protocol/contracts/thirdparty/LibBytesUtils.sol
@@ -25,7 +25,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /**
  * @title LibBytesUtils

--- a/packages/protocol/contracts/thirdparty/LibFixedPointMath.sol
+++ b/packages/protocol/contracts/thirdparty/LibFixedPointMath.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Taken from the contract below, expWad() function tailored to Taiko's need
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 library LibFixedPointMath {
     uint128 public constant MAX_EXP_INPUT = 135_305_999_368_893_231_588;

--- a/packages/protocol/contracts/thirdparty/LibMerkleTrie.sol
+++ b/packages/protocol/contracts/thirdparty/LibMerkleTrie.sol
@@ -25,7 +25,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /* Library Imports */
 import "./LibBytesUtils.sol";

--- a/packages/protocol/contracts/thirdparty/LibRLPReader.sol
+++ b/packages/protocol/contracts/thirdparty/LibRLPReader.sol
@@ -25,7 +25,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /**
  * @title LibRLPReader

--- a/packages/protocol/contracts/thirdparty/LibSecureMerkleTrie.sol
+++ b/packages/protocol/contracts/thirdparty/LibSecureMerkleTrie.sol
@@ -25,7 +25,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /* Library Imports */
 import "./LibMerkleTrie.sol";

--- a/packages/protocol/contracts/thirdparty/LibUint512Math.sol
+++ b/packages/protocol/contracts/thirdparty/LibUint512Math.sol
@@ -23,7 +23,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title LibUint512Math
 library LibUint512Math {

--- a/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./BaseVault.sol";
 

--- a/packages/protocol/contracts/tokenvault/BaseVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseVault.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/utils/introspection/IERC165Upgradeable.sol";
 import "../bridge/IBridge.sol";

--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 import "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/ERC1155Upgradeable.sol";

--- a/packages/protocol/contracts/tokenvault/BridgedERC20.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import
     "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";

--- a/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/ERC20Upgradeable.sol";
 import "../common/EssentialContract.sol";

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
 import "lib/openzeppelin-contracts/contracts/utils/Strings.sol";

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC1155/ERC1155.sol";
 import

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 import

--- a/packages/protocol/contracts/tokenvault/IBridgedERC20.sol
+++ b/packages/protocol/contracts/tokenvault/IBridgedERC20.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 /// @title IBridgedERC20
 /// @notice Interface for all bridged tokens.

--- a/packages/protocol/contracts/tokenvault/LibBridgedToken.sol
+++ b/packages/protocol/contracts/tokenvault/LibBridgedToken.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 

--- a/packages/protocol/contracts/tokenvault/adaptors/USDCAdaptor.sol
+++ b/packages/protocol/contracts/tokenvault/adaptors/USDCAdaptor.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../BridgedERC20Base.sol";
 

--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -1,11 +1,11 @@
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 [profile.default]
-solc-version = "0.8.20"
+solc-version = "0.8.24"
 src = 'contracts'
 out = 'out'
 test = 'test'
 libs = ['lib']
-gas_price = 10000000000            # gas price is 10 Gwei
+gas_price = 10000000000 # gas price is 10 Gwei
 optimizer = true
 optimizer_runs = 200
 ffi = true
@@ -16,7 +16,6 @@ memory_limit = 2073741824
 block_gas_limit = 80000000 #80M
 # For mainnet_mock tokenomics test we need a huge value to run lots of iterations.
 # Use the above 30M for TaikoL2.t.sol related tests, only use this number with mainnet simulation.
-
 
 fs_permissions = [
   { access = "read", path = "./out" },
@@ -29,7 +28,7 @@ fuzz = { runs = 256 }
 
 # Workaround as a fixed fuzz seed.
 # Bug is confirmed, will be fixed soon:
-# https://github.com/foundry-rs/foundry/issues/5913 
+# https://github.com/foundry-rs/foundry/issues/5913
 seed = 13623721389213
 
 [fmt]

--- a/packages/protocol/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/genesis/GenerateGenesis.g.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "forge-std/console2.sol";
 import "forge-std/StdJson.sol";

--- a/packages/protocol/script/AddSGXVerifierInstances.s.sol
+++ b/packages/protocol/script/AddSGXVerifierInstances.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../test/DeployCapability.sol";
 import "../contracts/L1/gov/TaikoTimelockController.sol";

--- a/packages/protocol/script/AuthorizeRemoteTaikoProtocols.s.sol
+++ b/packages/protocol/script/AuthorizeRemoteTaikoProtocols.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 

--- a/packages/protocol/script/DeployUSDCAdaptor.s.sol
+++ b/packages/protocol/script/DeployUSDCAdaptor.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../contracts/tokenvault/adaptors/USDCAdaptor.sol";
 import "../contracts/tokenvault/ERC20Vault.sol";

--- a/packages/protocol/script/SetAddress.s.sol
+++ b/packages/protocol/script/SetAddress.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/SetRemoteBridgeSuites.s.sol
+++ b/packages/protocol/script/SetRemoteBridgeSuites.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../test/DeployCapability.sol";
 import "../contracts/L1/gov/TaikoTimelockController.sol";

--- a/packages/protocol/script/upgrade/UpgradeAddressManager.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeAddressManager.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeAssignmentHook.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeAssignmentHook.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeBridge.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeBridge.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeERC1155Vault.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeERC1155Vault.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeERC20Vault.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeERC20Vault.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeERC721Vault.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeERC721Vault.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeGuardianProver.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeGuardianProver.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeScript.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeScript.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../contracts/L1/gov/TaikoTimelockController.sol";
 import "lib/openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";

--- a/packages/protocol/script/upgrade/UpgradeSignalService.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeSignalService.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeTaikoGovernor.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeTaikoGovernor.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeTaikoL1.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeTaikoL1.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/script/upgrade/UpgradeTimelockController.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeTimelockController.s.sol
@@ -12,7 +12,7 @@
 //   Blog: https://mirror.xyz/labs.taiko.eth
 //   Youtube: https://www.youtube.com/@taikoxyz
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/test/DeployCapability.sol
+++ b/packages/protocol/test/DeployCapability.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";

--- a/packages/protocol/test/HelperContracts.sol
+++ b/packages/protocol/test/HelperContracts.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../contracts/bridge/Bridge.sol";
 import "../contracts/signal/SignalService.sol";

--- a/packages/protocol/test/L1/Guardians.t.sol
+++ b/packages/protocol/test/L1/Guardians.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/L1/SgxVerifier.t.sol
+++ b/packages/protocol/test/L1/SgxVerifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./TaikoL1TestBase.sol";
 

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./TaikoL1TestBase.sol";
 

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "./TaikoL1TestBase.sol";
 

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/TaikoTest.sol
+++ b/packages/protocol/test/TaikoTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "forge-std/Test.sol";
 import "forge-std/console2.sol";

--- a/packages/protocol/test/bridge/Bridge.t.sol
+++ b/packages/protocol/test/bridge/Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/common/EssentialContract.t.sol
+++ b/packages/protocol/test/common/EssentialContract.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/libs/LibFixedPointMath.t.sol
+++ b/packages/protocol/test/libs/LibFixedPointMath.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 // Some of the tests are taken from:
 // https://github.com/recmo/experiment-solexp/blob/main/src/test/FixedPointMathLib.t.sol
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/signal/SignalService.t.sol
+++ b/packages/protocol/test/signal/SignalService.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/team/TimelockTokenPool.t.sol
+++ b/packages/protocol/test/team/TimelockTokenPool.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/team/airdrop/MerkleClaimable.t.sol
+++ b/packages/protocol/test/team/airdrop/MerkleClaimable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../../TaikoTest.sol";
 

--- a/packages/protocol/test/tokenvault/BridgedERC20.t.sol
+++ b/packages/protocol/test/tokenvault/BridgedERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/tokenvault/ERC1155Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC1155Vault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC1155/ERC1155.sol";
 import "../TaikoTest.sol";

--- a/packages/protocol/test/tokenvault/ERC20Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC20Vault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/tokenvault/ERC721Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC721Vault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity 0.8.24;
 
 import "lib/openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
 import "../TaikoTest.sol";


### PR DESCRIPTION
Now we can use  `blobhash()`, https://soliditylang.org/blog/2024/01/26/solidity-0.8.24-release-announcement/

