### PR TITLE
fix(relayer): wait for confirmations before saving event when indexing

### DIFF
--- a/packages/relayer/indexer/handle_event.go
+++ b/packages/relayer/indexer/handle_event.go
@@ -41,6 +41,11 @@ func (i *Indexer) handleEvent(
 		return nil
 	}
 
+	if event.Raw.Removed {
+		slog.Info("event is removed")
+		return nil
+	}
+
 	// check if we have seen this event and msgHash before - if we have, it is being reorged.
 	if err := i.detectAndHandleReorg(ctx, relayer.EventNameMessageSent, common.Hash(event.MsgHash).Hex()); err != nil {
 		return errors.Wrap(err, "svc.detectAndHandleReorg")

--- a/packages/relayer/indexer/handle_event.go
+++ b/packages/relayer/indexer/handle_event.go
@@ -58,7 +58,12 @@ func (i *Indexer) handleEvent(
 
 	defer confCtxCancel()
 
-	if err := relayer.WaitConfirmations(confCtx, i.srcEthClient, uint64(defaultConfirmations), event.Raw.TxHash); err != nil {
+	if err := relayer.WaitConfirmations(
+		confCtx,
+		i.srcEthClient,
+		uint64(defaultConfirmations),
+		event.Raw.TxHash,
+	); err != nil {
 		return err
 	}
 

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -56,6 +56,8 @@ type ethClient interface {
 	ChainID(ctx context.Context) (*big.Int, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+	BlockNumber(ctx context.Context) (uint64, error)
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 }
 
 type DB interface {

--- a/packages/relayer/types.go
+++ b/packages/relayer/types.go
@@ -70,7 +70,7 @@ func WaitReceipt(ctx context.Context, confirmer confirmer, txHash common.Hash) (
 }
 
 // WaitConfirmations won't return before N blocks confirmations have been seen
-// on destination chain.
+// on destination chain, or context is cancelled.
 func WaitConfirmations(ctx context.Context, confirmer confirmer, confirmations uint64, txHash common.Hash) error {
 	slog.Info("beginning waiting for confirmations", "txHash", txHash.Hex())
 


### PR DESCRIPTION
We are experiencing some very rare (2-4 in 1 million) message ID comparison issues in the relayer indexing, this is most likely due to a re-org on the source chain due to not waiting for confirmations before indexing the event to the database.

As well, due to the removal of the `.Raw.Removed` flag check, we have some entries that got Removed due to reorg, but were still being indexed and stored.