### PR TITLE
fix(protocol): fix cooldown/proof window caused by pausing proving (again)

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProvingAlt.sol
+++ b/packages/protocol/contracts/L1/libs/LibProvingAlt.sol
@@ -67,6 +67,10 @@ library LibProvingAlt {
         if (state.slotB.provingPaused == pause) revert L1_INVALID_PAUSE_STATUS();
 
         state.slotB.provingPaused = pause;
+
+        if (!toPause) {
+            state.slotB.lastUnpausedAt = uint64(block.timestamp);
+        }
         emit ProvingPaused(pause);
     }
 

--- a/packages/protocol/contracts/L1/libs/LibProvingAlt.sol
+++ b/packages/protocol/contracts/L1/libs/LibProvingAlt.sol
@@ -63,15 +63,15 @@ library LibProvingAlt {
     error L1_NOT_ASSIGNED_PROVER();
     error L1_UNEXPECTED_TRANSITION_TIER();
 
-    function pauseProving(TaikoData.State storage state, bool pause) external {
-        if (state.slotB.provingPaused == pause) revert L1_INVALID_PAUSE_STATUS();
+    function pauseProving(TaikoData.State storage state, bool toPause) external {
+        if (state.slotB.provingPaused == toPause) revert L1_INVALID_PAUSE_STATUS();
 
-        state.slotB.provingPaused = pause;
+        state.slotB.provingPaused = toPause;
 
         if (!toPause) {
             state.slotB.lastUnpausedAt = uint64(block.timestamp);
         }
-        emit ProvingPaused(pause);
+        emit ProvingPaused(toPause);
     }
 
     /// @dev Proves or contests a block transition.


### PR DESCRIPTION
https://github.com/taikoxyz/taiko-mono/pull/15585 added the necessary code in LibProving, but not in LibProvingAlt which is currently the only version left.