### PR TITLE
fix(relayer): update relayer flag env var name

### DIFF
--- a/packages/relayer/cmd/flags/indexer.go
+++ b/packages/relayer/cmd/flags/indexer.go
@@ -60,7 +60,7 @@ var (
 		`,
 		Value:    "filter-and-subscribe",
 		Category: indexerCategory,
-		EnvVars:  []string{"SYNC_MODE"},
+		EnvVars:  []string{"WATCH_MODE"},
 	}
 	SrcTaikoAddress = &cli.StringFlag{
 		Name:     "srcTaikoAddress",

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -96,6 +96,8 @@ type Indexer struct {
 	numLatestBlocksToIgnoreWhenCrawling uint64
 
 	ctx context.Context
+
+	mu *sync.Mutex
 }
 
 func (i *Indexer) InitFromCli(ctx context.Context, c *cli.Context) error {
@@ -191,6 +193,8 @@ func InitFromConfig(ctx context.Context, i *Indexer, cfg *Config) (err error) {
 	i.ethClientTimeout = time.Duration(cfg.ETHClientTimeout) * time.Second
 
 	i.numLatestBlocksToIgnoreWhenCrawling = cfg.NumLatestBlocksToIgnoreWhenCrawling
+
+	i.mu = &sync.Mutex{}
 
 	return nil
 }

--- a/packages/relayer/indexer/indexer_test.go
+++ b/packages/relayer/indexer/indexer_test.go
@@ -36,5 +36,6 @@ func newTestService(syncMode SyncMode, watchMode WatchMode) (*Indexer, relayer.B
 		destChainId: mock.MockChainID,
 
 		ethClientTimeout: 10 * time.Second,
+		mu:               &sync.Mutex{},
 	}, b
 }

--- a/packages/relayer/indexer/subscribe.go
+++ b/packages/relayer/indexer/subscribe.go
@@ -72,6 +72,10 @@ func (i *Indexer) subscribeMessageSent(ctx context.Context, chainID *big.Int, er
 					return
 				}
 
+				i.mu.Lock()
+
+				defer i.mu.Unlock()
+
 				block, err := i.blockRepo.GetLatestBlockProcessedForEvent(relayer.EventNameMessageSent, chainID)
 				if err != nil {
 					slog.Error("i.subscribe, blockRepo.GetLatestBlockProcessedForEvent", "error", err)


### PR DESCRIPTION
also add a mutex on subscription so we dont get multiple block errors being saved when multiple bridges are located in the same block.