### PR TITLE
fix(protocol): add delete-instance function (TKO16)

### DIFF
--- a/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/L1/verifiers/SgxVerifier.sol
@@ -54,6 +54,7 @@ contract SgxVerifier is EssentialContract, IVerifier {
     event InstanceAdded(
         uint256 indexed id, address indexed instance, address replaced, uint256 timstamp
     );
+    event InstanceDeleted(uint256 indexed id, address indexed instance);
 
     error SGX_INVALID_INSTANCE();
     error SGX_INVALID_INSTANCES();
@@ -75,6 +76,22 @@ contract SgxVerifier is EssentialContract, IVerifier {
     {
         if (_instances.length == 0) revert SGX_INVALID_INSTANCES();
         ids = _addInstances(_instances);
+    }
+
+    /// @notice Deletes SGX instances from the registry.
+    /// @param _ids The ids array of SGX instances.
+    function deleteInstances(uint256[] calldata _ids)
+        external
+        onlyFromOwnerOrNamed("rollup_watchdog")
+    {
+        if (_ids.length == 0) revert SGX_INVALID_INSTANCES();
+        for (uint256 i; i < _ids.length; ++i) {
+            if (instances[_ids[i]].addr == address(0)) revert SGX_INVALID_INSTANCE();
+
+            emit InstanceDeleted(_ids[i], instances[_ids[i]].addr);
+
+            delete instances[_ids[i]];
+        }
     }
 
     /// @notice Adds SGX instances to the registry by another SGX instance.

--- a/packages/protocol/test/L1/SgxVerifier.t.sol
+++ b/packages/protocol/test/L1/SgxVerifier.t.sol
@@ -28,6 +28,20 @@ contract TestSgxVerifier is TaikoL1TestBase {
         sv.addInstances(_instances);
     }
 
+    function test_deleteInstancesByOwner() external {
+        uint256[] memory _ids = new uint256[](1);
+        _ids[0] = 0;
+
+        address instance;
+        (instance,) = sv.instances(0);
+        assertEq(instance, SGX_X_0);
+
+        sv.deleteInstances(_ids);
+
+        (instance,) = sv.instances(0);
+        assertEq(instance, address(0));
+    }
+
     function test_addInstancesBySgxInstance() external {
         address[] memory _instances = new address[](2);
         _instances[0] = SGX_Y;


### PR DESCRIPTION
This change is an exact same copy of what we have in the [onchain_remote_attestation](https://github.com/taikoxyz/taiko-mono/pull/15559) - the intention to make this PR is in case the on-chain attestation still has lots of questions to be resolved, we have the feature proposed by auditors merged in sooner.

(Still prefer to merge the other branch first - if there are no more questions there).
