### PR TITLE
fix(protocol): Use safeMint with ERC721

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -221,7 +221,7 @@ contract Bridge is EssentialContract, IBridge {
             status = Status.DONE;
             refundAmount = message.value;
         } else {
-            // Use the specified message gas limit if called by the owner, else
+            // Use the specified message gas limit if not called by the owner, else
             // use remaining gas
             uint256 gasLimit = msg.sender == message.owner ? gasleft() : message.gasLimit;
 

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -71,7 +71,7 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         whenNotPaused
         onlyFromNamed("erc721_vault")
     {
-        _mint(account, tokenId);
+        _safeMint(account, tokenId);
     }
 
     /// @dev Burns tokens.


### PR DESCRIPTION
- Better to use safeMint() with ERC721 as _checkOnERC721Received will be called after token transferred. It ensures if the recipient is a contract, it is indeed designed to receive ERC721 tokens.
- Comment mismatch with code.