### PR TITLE
feat(protocol): New status for 2 step briding

### DIFF
--- a/packages/protocol/test/bridge/Bridge.t.sol
+++ b/packages/protocol/test/bridge/Bridge.t.sol
@@ -187,8 +187,7 @@ contract BridgeTest is TaikoTest {
         dest2StepBridge.processMessage(message, proof);
 
         Bridge.Status status = dest2StepBridge.messageStatus(msgHash);
-        // Still new ! Because of the delay, no processing happened
-        assertEq(status == Bridge.Status.NEW, true);
+        assertEq(status == Bridge.Status.PROOF_SUBMITTED, true);
         // Alice has 100 ether
         assertEq(Alice.balance, 100_000_000_000_000_000_000);
 
@@ -243,8 +242,7 @@ contract BridgeTest is TaikoTest {
         dest2StepBridge.processMessage(message, proof);
 
         Bridge.Status status = dest2StepBridge.messageStatus(msgHash);
-        // Still new ! Because of the delay, no processing happened
-        assertEq(status == Bridge.Status.NEW, true);
+        assertEq(status == Bridge.Status.PROOF_SUBMITTED, true);
         // Alice has 100 ether
         assertEq(Alice.balance, 100_000_000_000_000_000_000);
 


### PR DESCRIPTION
For the `bridge UI` + `relayer` it needs to be know when the first process message is done and if is is done - and can proceed to the second transaction. (+ for the `Bridge solvency checker` it is a valuable information too)
