### PR TITLE
feat(protocol): check if addresses ever reregistered in SGXProver

### DIFF
--- a/packages/protocol/contracts/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/verifiers/SgxVerifier.sol
@@ -57,7 +57,7 @@ contract SgxVerifier is EssentialContract, IVerifier {
     /// getting multiple valid instanceIds. While during proving, it is technically possible to
     /// register the old addresses, it is less of a problem, because the instanceId would be the
     /// same for those addresses and if deleted - the attestation cannot be reused anyways.
-    mapping(address instanceAddress => bool alreadyAttested) public attestationRegistered; // slot 3
+    mapping(address instanceAddress => bool alreadyAttested) public addressRegistered; // slot 3
 
     uint256[47] private __gap;
 
@@ -124,10 +124,6 @@ contract SgxVerifier is EssentialContract, IVerifier {
 
         address[] memory _address = new address[](1);
         _address[0] = address(bytes20(attestation.localEnclaveReport.reportData));
-
-        if (attestationRegistered[_address[0]]) revert SGX_ALREADY_ATTESTED();
-
-        attestationRegistered[_address[0]] = true;
 
         (bool verified,) = IAttestation(automataDcapAttestation).verifyParsedQuote(attestation);
 
@@ -203,6 +199,10 @@ contract SgxVerifier is EssentialContract, IVerifier {
         }
 
         for (uint256 i; i < _instances.length; ++i) {
+            if (addressRegistered[_instances[i]]) revert SGX_ALREADY_ATTESTED();
+
+            addressRegistered[_instances[i]] = true;
+
             if (_instances[i] == address(0)) revert SGX_INVALID_INSTANCE();
 
             instances[nextInstanceId] = Instance(_instances[i], validSince);

--- a/packages/protocol/contracts/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/verifiers/SgxVerifier.sol
@@ -122,12 +122,12 @@ contract SgxVerifier is EssentialContract, IVerifier {
             revert SGX_RA_NOT_SUPPORTED();
         }
 
-        address[] memory _address = new address[](1);
-        _address[0] = address(bytes20(attestation.localEnclaveReport.reportData));
-
         (bool verified,) = IAttestation(automataDcapAttestation).verifyParsedQuote(attestation);
 
         if (!verified) revert SGX_INVALID_ATTESTATION();
+
+        address[] memory _address = new address[](1);
+        _address[0] = address(bytes20(attestation.localEnclaveReport.reportData));
 
         return _addInstances(_address, false)[0];
     }

--- a/packages/protocol/contracts/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/verifiers/SgxVerifier.sol
@@ -54,9 +54,9 @@ contract SgxVerifier is EssentialContract, IVerifier {
     mapping(uint256 instanceId => Instance) public instances; // slot 2
     /// @dev One address shall be registered (during attestation) only once, otherwise it could
     /// bypass this contract's expiry check by always registering with the same attestation and
-    /// getting multiple valid instanceIds. While during proving, it is technically possile to
+    /// getting multiple valid instanceIds. While during proving, it is technically possible to
     /// register the old addresses, it is less of a problem, because the instanceId would be the
-    /// same for those addresses.
+    /// same for those addresses and if deleted - the attestation cannot be reused anyways.
     mapping(address instanceAddress => bool alreadyAttested) public attestationRegistered; // slot 3
 
     uint256[47] private __gap;

--- a/packages/protocol/test/verifiers/SgxVerifier.t.sol
+++ b/packages/protocol/test/verifiers/SgxVerifier.t.sol
@@ -65,6 +65,18 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         sv.registerInstance(v3quote);
     }
 
+    function test_registerInstanceTwiceWithSameAttestation() external {
+        V3Struct.ParsedV3QuoteStruct memory v3quote =
+            ParseV3QuoteBytes(address(pemCertChainLib), sampleQuote);
+
+        vm.prank(Bob, Bob);
+        sv.registerInstance(v3quote);
+
+        vm.expectRevert(SgxVerifier.SGX_ALREADY_ATTESTED.selector);
+        vm.prank(Carol, Carol);
+        sv.registerInstance(v3quote);
+    }
+
     function _getSignature(
         address _newInstance,
         address[] memory _instances,


### PR DESCRIPTION
One address shall be registered (during attestation) only once, otherwise it could bypass this contract's expiry check by always registering with the same attestation and getting multiple valid `instanceId`s.

While during proving, it is technically possible to register the old addresses, it is less of a problem, because the `instanceId` would be the same for those addresses and can be easily deleted without the possibility of re-registering again - while if we dont rate limit at registration level, it could shoot up legit (and same) sgx provers with different `instanceId`s.
