### PR TITLE
chore(protocol): remove mint function from TaikoToken.sol

### DIFF
--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -50,13 +50,6 @@ contract TaikoToken is EssentialContract, ERC20SnapshotUpgradeable, ERC20VotesUp
         _mint(_recipient, 1_000_000_000 ether);
     }
 
-    /// @notice Mints new tokens to the specified address.
-    /// @param to The address to receive the minted tokens.
-    /// @param amount The amount of tokens to mint.
-    function mint(address to, uint256 amount) public onlyOwner {
-        _mint(to, amount);
-    }
-
     /// @notice Burns tokens from the specified address.
     /// @param from The address to burn tokens from.
     /// @param amount The amount of tokens to burn.


### PR DESCRIPTION
This mint function is never used and is not supposed to be used anytime soon unless the DAO decides to do so. To remove concerns from the community and a few investors. I suggest we remove it.