### PR TITLE
chore(protocol): remove skipProofCheck from SignalService

### DIFF
--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -166,7 +166,6 @@ contract SignalService is AuthorizableContract, ISignalService {
         return keccak256(abi.encodePacked("SIGNAL", chainId, app, signal));
     }
 
-
     /// @notice Translate a RLP-encoded list of RLP-encoded TrieNodes into a list of LP-encoded
     /// TrieNodes.
     function _transcode(bytes memory proof) internal pure returns (bytes[] memory proofs) {

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -92,8 +92,6 @@ contract SignalService is AuthorizableContract, ISignalService {
         virtual
         returns (bool)
     {
-        if (skipProofCheck()) return true;
-
         if (app == address(0) || signal == 0 || srcChainId == 0 || srcChainId == block.chainid) {
             return false;
         }
@@ -168,11 +166,6 @@ contract SignalService is AuthorizableContract, ISignalService {
         return keccak256(abi.encodePacked("SIGNAL", chainId, app, signal));
     }
 
-    /// @notice Tells if we need to check real proof or it is a test.
-    /// @return Returns true to skip checking inclusion proofs.
-    function skipProofCheck() public pure virtual returns (bool) {
-        return false;
-    }
 
     /// @notice Translate a RLP-encoded list of RLP-encoded TrieNodes into a list of LP-encoded
     /// TrieNodes.

--- a/packages/protocol/test/HelperContracts.sol
+++ b/packages/protocol/test/HelperContracts.sol
@@ -37,18 +37,19 @@ contract NonNftContract {
 }
 
 contract SkipProofCheckSignal is SignalService {
-       function proveSignalReceived(
-        uint64 srcChainId,
-        address app,
-        bytes32 signal,
-        bytes calldata proof
+    function proveSignalReceived(
+        uint64, /*srcChainId*/
+        address, /*app*/
+        bytes32, /*signal*/
+        bytes calldata /*proof*/
     )
         public
         pure
         override
-        returns (bool) {
-            return true;
-        }
+        returns (bool)
+    {
+        return true;
+    }
 }
 
 contract DummyCrossChainSync is EssentialContract, ICrossChainSync {

--- a/packages/protocol/test/HelperContracts.sol
+++ b/packages/protocol/test/HelperContracts.sol
@@ -37,9 +37,18 @@ contract NonNftContract {
 }
 
 contract SkipProofCheckSignal is SignalService {
-    function skipProofCheck() public pure override returns (bool) {
-        return true;
-    }
+       function proveSignalReceived(
+        uint64 srcChainId,
+        address app,
+        bytes32 signal,
+        bytes calldata proof
+    )
+        public
+        pure
+        override
+        returns (bool) {
+            return true;
+        }
 }
 
 contract DummyCrossChainSync is EssentialContract, ICrossChainSync {


### PR DESCRIPTION
Tests shall simply override `proveSignalReceived` instead.