### PR TITLE
fix(protocol): Fix taiko token domain separator

### DIFF
--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -45,6 +45,7 @@ contract TaikoToken is EssentialContract, ERC20SnapshotUpgradeable, ERC20VotesUp
         __ERC20_init(_name, _symbol);
         __ERC20Snapshot_init();
         __ERC20Votes_init();
+        __ERC20Permit_init(_name);
 
         // Mint 1 billion tokens
         _mint(_recipient, 1_000_000_000 ether);


### PR DESCRIPTION
Without this we cannot set proper domain separator which is important for (`delegateBySig` for example). This function calls the `__EIP712_init_`.