### PR TITLE
fix(protocol): fix genesis test issue

### DIFF
--- a/packages/protocol/contracts/libs/LibTrieProof.sol
+++ b/packages/protocol/contracts/libs/LibTrieProof.sol
@@ -34,9 +34,9 @@ library LibTrieProof {
         address addr,
         bytes32 slot,
         bytes32 value,
-        bytes calldata mkproof
+        bytes memory mkproof
     )
-        public
+        internal
         pure
         returns (bool verified)
     {


### PR DESCRIPTION
Changing the function to internal can avoid linking the library explicitly.