### PR TITLE
chore(protocol): Remove unnecessary nonReentrant 

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -123,7 +123,7 @@ contract TaikoL1 is
     /// @notice Deposits Ether to Layer 2.
     /// @param recipient Address of the recipient for the deposited Ether on
     /// Layer 2.
-    function depositEtherToL2(address recipient) external payable nonReentrant whenNotPaused {
+    function depositEtherToL2(address recipient) external payable whenNotPaused {
         LibDepositing.depositEtherToL2(state, getConfig(), AddressResolver(this), recipient);
     }
 

--- a/packages/protocol/contracts/L1/provers/Guardians.sol
+++ b/packages/protocol/contracts/L1/provers/Guardians.sol
@@ -47,7 +47,6 @@ abstract contract Guardians is EssentialContract {
     )
         external
         onlyOwner
-        nonReentrant
     {
         // We need at least MIN_NUM_GUARDIANS and at most 255 guardians (so the approval bits fit in
         // a uint256)

--- a/packages/protocol/contracts/L1/provers/Guardians.sol
+++ b/packages/protocol/contracts/L1/provers/Guardians.sol
@@ -41,13 +41,7 @@ abstract contract Guardians is EssentialContract {
     /// @notice Set the set of guardians
     /// @param _newGuardians The new set of guardians
     /// @param _minGuardians The minimum required to sign
-    function setGuardians(
-        address[] memory _newGuardians,
-        uint8 _minGuardians
-    )
-        external
-        onlyOwner
-    {
+    function setGuardians(address[] memory _newGuardians, uint8 _minGuardians) external onlyOwner {
         // We need at least MIN_NUM_GUARDIANS and at most 255 guardians (so the approval bits fit in
         // a uint256)
         if (_newGuardians.length < MIN_NUM_GUARDIANS || _newGuardians.length > type(uint8).max) {

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -118,7 +118,6 @@ contract Bridge is EssentialContract, IBridge {
     )
         external
         onlyFromOwnerOrNamed("bridge_watchdog")
-        nonReentrant
     {
         if (addressBanned[addr] == toBan) revert B_INVALID_STATUS();
         addressBanned[addr] = toBan;
@@ -132,7 +131,6 @@ contract Bridge is EssentialContract, IBridge {
         external
         payable
         override
-        nonReentrant
         whenNotPaused
         returns (bytes32 msgHash, Message memory _message)
     {

--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -79,7 +79,6 @@ contract BridgedERC1155 is
         uint256 amount
     )
         public
-        nonReentrant
         whenNotPaused
         onlyFromNamed("erc1155_vault")
     {
@@ -96,7 +95,6 @@ contract BridgedERC1155 is
         uint256 amount
     )
         public
-        nonReentrant
         whenNotPaused
         onlyFromNamed("erc1155_vault")
     {

--- a/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
@@ -50,7 +50,7 @@ abstract contract BridgedERC20Base is EssentialContract, IBridgedERC20 {
         emit MigrationStatusChanged(_migratingAddress, _migratingInbound);
     }
 
-    function mint(address account, uint256 amount) public nonReentrant whenNotPaused {
+    function mint(address account, uint256 amount) public  whenNotPaused {
         // mint is disabled while migrating outbound.
         if (_isMigratingOut()) revert BB_MINT_DISALLOWED();
 

--- a/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
@@ -50,7 +50,7 @@ abstract contract BridgedERC20Base is EssentialContract, IBridgedERC20 {
         emit MigrationStatusChanged(_migratingAddress, _migratingInbound);
     }
 
-    function mint(address account, uint256 amount) public  whenNotPaused {
+    function mint(address account, uint256 amount) public whenNotPaused {
         // mint is disabled while migrating outbound.
         if (_isMigratingOut()) revert BB_MINT_DISALLOWED();
 

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -64,7 +64,6 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         uint256 tokenId
     )
         public
-        nonReentrant
         whenNotPaused
         onlyFromNamed("erc721_vault")
     {
@@ -79,7 +78,6 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         uint256 tokenId
     )
         public
-        nonReentrant
         whenNotPaused
         onlyFromNamed("erc721_vault")
     {


### PR DESCRIPTION
Given that the new nonReentrant rely on transient storage which is only cleared at the end of the whole transaction. Having unnecesaary nonReentrant checks may hurt contract composability. 

@Brechtpd @adaki2004 please reveiw this carefully.