### PR TITLE
feat(protocol)!: allow setting L2 coinbase

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -84,6 +84,7 @@ library TaikoData {
 
     struct BlockParams {
         address assignedProver;
+        address coinbase;
         bytes32 extraData;
         bytes32 blobHash;
         uint24 txListByteOffset;

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -77,6 +77,10 @@ library LibProposing {
             revert L1_INVALID_PROVER();
         }
 
+        if (params.coinbase == address(0)) {
+            params.coinbase = msg.sender;
+        }
+
         // Taiko, as a Based Rollup, enables permissionless block proposals.
         // However, if the "proposer" address is set to a non-zero value, we
         // ensure that only that specific address has the authority to propose
@@ -101,7 +105,7 @@ library LibProposing {
 
         // Each transaction must handle a specific quantity of L1-to-L2
         // Ether deposits.
-        depositsProcessed = LibDepositing.processDeposits(state, config, msg.sender);
+        depositsProcessed = LibDepositing.processDeposits(state, config, params.coinbase);
 
         // Initialize metadata to compute a metaHash, which forms a part of
         // the block data to be stored on-chain for future integrity checks.
@@ -114,7 +118,7 @@ library LibProposing {
                 blobHash: 0, // to be initialized below
                 extraData: params.extraData,
                 depositsHash: keccak256(abi.encode(depositsProcessed)),
-                coinbase: msg.sender,
+                coinbase: params.coinbase,
                 id: b.numBlocks,
                 gasLimit: config.blockMaxGasLimit,
                 timestamp: uint64(block.timestamp),

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -221,7 +221,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
 
         vm.prank(proposer, proposer);
         (meta, depositsProcessed) = L1.proposeBlock{ value: msgValue }(
-            abi.encode(TaikoData.BlockParams(prover, 0, 0, 0, 0, false, 0, hookcalls)),
+            abi.encode(TaikoData.BlockParams(prover, address(0), 0, 0, 0, 0, false, 0, hookcalls)),
             new bytes(txListSize)
         );
     }


### PR DESCRIPTION
Previously the coinbase address is the L1 proposer address. Now we allow it to be a different address.