### PR TITLE
this change will fail a test, not sure why...

### DIFF
--- a/packages/protocol/contracts/L1/provers/Guardians.sol
+++ b/packages/protocol/contracts/L1/provers/Guardians.sol
@@ -41,7 +41,7 @@ abstract contract Guardians is EssentialContract {
     /// @notice Set the set of guardians
     /// @param _newGuardians The new set of guardians
     /// @param _minGuardians The minimum required to sign
-    function setGuardians(address[] memory _newGuardians, uint8 _minGuardians) external onlyOwner {
+    function setGuardians(address[] memory _newGuardians, uint8 _minGuardians) external nonReentrant onlyOwner {
         // We need at least MIN_NUM_GUARDIANS and at most 255 guardians (so the approval bits fit in
         // a uint256)
         if (_newGuardians.length < MIN_NUM_GUARDIANS || _newGuardians.length > type(uint8).max) {


### PR DESCRIPTION
In `DeployOnL1.s.sol`, we have:

```
GuardianProver(guardianProver).setGuardians(guardians, minGuardians);
```
With the new nonReentrant impl, if we add `nonReentrant` to `setGuardians`, DeployOnL1.s.sol will fail. I haven not yet figured out why!