### PR TITLE
chore(protocol): with transient storage, the default should be 0, not 1

### DIFF
--- a/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
+++ b/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
@@ -44,7 +44,7 @@ abstract contract OwnerUUPSUpgradable is UUPSUpgradeable, OwnableUpgradeable {
         if (_loadReentryLock() == _TRUE) revert REENTRANT_CALL();
         _storeReentryLock(_TRUE);
         _;
-        _storeReentryLock(_FALSE);
+        _storeReentryLock(0);
     }
 
     modifier whenPaused() {


### PR DESCRIPTION
With this change, the transient slot is actually cleared earlier in the call frames rather than at the end of the tx. But realisticly, it makes no difference.