### PR TITLE
fix: fixed fee selection modal bug

### DIFF
--- a/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
@@ -47,7 +47,7 @@
   }
 
   function closeModal() {
-    // Let's check if we are closing with CUSTOM method selected and zero amount entered
+    // Let's check if we are closing with CUSTOM method selected and the input box is empty
     if ($processingFeeMethod === ProcessingFeeMethod.CUSTOM && inputBox?.getValue() === '') {
       prettier;
       // If so, let's switch to RECOMMENDED method

--- a/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
@@ -33,15 +33,23 @@
   let modalOpen = false;
   let inputBox: InputBox | undefined;
 
+  let tempProcessingFeeMethod = $processingFeeMethod;
+
   // Public API
   export function resetProcessingFee() {
     inputBox?.clear();
     $processingFeeMethod = ProcessingFeeMethod.RECOMMENDED;
   }
 
+  function confirmChanges() {
+    $processingFeeMethod = tempProcessingFeeMethod;
+    closeModal();
+  }
+
   function closeModal() {
     // Let's check if we are closing with CUSTOM method selected and zero amount entered
     if ($processingFeeMethod === ProcessingFeeMethod.CUSTOM && $processingFee === BigInt(0)) {
+      prettier;
       // If so, let's switch to RECOMMENDED method
       $processingFeeMethod = ProcessingFeeMethod.RECOMMENDED;
     }
@@ -50,6 +58,8 @@
   }
 
   function openModal() {
+    tempProcessingFeeMethod = $processingFeeMethod;
+
     // Keep track of the selected method before opening the modal
     // so if we cancel we can go back to the previous method
     prevOptionSelected = $processingFeeMethod;
@@ -59,7 +69,6 @@
 
   function cancelModal() {
     inputBox?.clear();
-    $processingFeeMethod = prevOptionSelected;
     closeModal();
   }
 
@@ -68,7 +77,7 @@
   }
 
   function inputProcessFee(event: Event) {
-    if ($processingFeeMethod !== ProcessingFeeMethod.CUSTOM) return;
+    if (tempProcessingFeeMethod !== ProcessingFeeMethod.CUSTOM) return;
 
     const { value } = event.target as HTMLInputElement;
     $processingFee = parseToWei(value);
@@ -212,7 +221,7 @@
                 type="radio"
                 value={ProcessingFeeMethod.RECOMMENDED}
                 name="processingFeeMethod"
-                bind:group={$processingFeeMethod} />
+                bind:group={tempProcessingFeeMethod} />
             </li>
 
             <!-- NONE -->
@@ -233,7 +242,7 @@
                   disabled={!hasEnoughEth}
                   value={ProcessingFeeMethod.NONE}
                   name="processingFeeMethod"
-                  bind:group={$processingFeeMethod} />
+                  bind:group={tempProcessingFeeMethod} />
               </div>
 
               {#if !hasEnoughEth}
@@ -257,16 +266,16 @@
                 type="radio"
                 value={ProcessingFeeMethod.CUSTOM}
                 name="processingFeeMethod"
-                bind:group={$processingFeeMethod} />
+                bind:group={tempProcessingFeeMethod} />
             </li>
           </ul>
           <div class="relative f-items-center my-[20px]">
-            {#if $processingFeeMethod === ProcessingFeeMethod.CUSTOM}
+            {#if tempProcessingFeeMethod === ProcessingFeeMethod.CUSTOM}
               <InputBox
                 type="number"
                 min="0"
                 placeholder="0.01"
-                disabled={$processingFeeMethod !== ProcessingFeeMethod.CUSTOM}
+                disabled={tempProcessingFeeMethod !== ProcessingFeeMethod.CUSTOM}
                 class="w-full input-box p-6 pr-16 title-subsection-bold placeholder:text-tertiary-content"
                 on:input={inputProcessFee}
                 bind:this={inputBox} />
@@ -277,7 +286,7 @@
             <ActionButton on:click={cancelModal} priority="secondary">
               <span class="body-bold">{$t('common.cancel')}</span>
             </ActionButton>
-            <ActionButton priority="primary" on:click={closeModal}>
+            <ActionButton priority="primary" on:click={confirmChanges}>
               <span class="body-bold">{$t('common.confirm')}</span>
             </ActionButton>
           </div>

--- a/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
@@ -49,7 +49,6 @@
   function closeModal() {
     // Let's check if we are closing with CUSTOM method selected and the input box is empty
     if ($processingFeeMethod === ProcessingFeeMethod.CUSTOM && inputBox?.getValue() === '') {
-      prettier;
       // If so, let's switch to RECOMMENDED method
       $processingFeeMethod = ProcessingFeeMethod.RECOMMENDED;
     }

--- a/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/ProcessingFee/ProcessingFee.svelte
@@ -48,7 +48,7 @@
 
   function closeModal() {
     // Let's check if we are closing with CUSTOM method selected and zero amount entered
-    if ($processingFeeMethod === ProcessingFeeMethod.CUSTOM && $processingFee === BigInt(0)) {
+    if ($processingFeeMethod === ProcessingFeeMethod.CUSTOM && inputBox?.getValue() === '') {
       prettier;
       // If so, let's switch to RECOMMENDED method
       $processingFeeMethod = ProcessingFeeMethod.RECOMMENDED;


### PR DESCRIPTION
### Description

This pull request introduces fixes to the fee selection modal for the bridge. It addresses the issue where selecting a custom fee, then switching to the recommended or zero fee, and subsequently cancelling the modal results in unpredictable fee selections. Furthermore, it implements logic allowing users to set a zero fee by entering '0' in the custom fee field and defaults to the recommended fee if the input box is left empty, 

### Changes Made

- Added a temporary variable `tempProcessingFeeMethod` to store the current processing fee method. This ensures the selected fee method does not change until confirmed by the user, thereby resolving the issue of unpredictable selections.
- Modified the closeModal function to use `inputBox?.getValue()` instead of `$processingFee` to distinguish between an empty input and a zero value. This change allows users to explicitly set a fee to zero and defaults to the recommended fee if the custom fee input is left empty.
- Updated the `inputProcessFee` event to reference `tempProcessingFeeMethod` to correctly capture the state of the selected fee method during user interaction.

### Testing
The fixes have been thoroughly tested under various scenarios to ensure the modal behaves as expected. The following cases have been tested:
- Setting a custom fee and then selecting recommended and cancelling retains the previously selected fee method.
- Setting a custom fee and then selecting zero fee and cancelling retains the previously selected fee method.
- Setting a custom fee to zero and confirming now accurately sets the fee to zero.
- Leaving the custom fee input empty and confirming defaults to the recommended fee.

### Video Demo 

<div align="center">
  <table>
    <tr>
      <td align="center"><img src="https://github.com/taikoxyz/taiko-mono/assets/114240091/9dff540f-e629-441d-ba8d-11b2527066f0" width="100px;" alt="image1"/></td>
    </tr>
  </table>
</div>
