### PR TITLE
feat(protocol): Add prover param

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -73,6 +73,7 @@ library TaikoData {
     }
 
     struct TierProof {
+        address prover;
         uint16 tier;
         bytes data;
     }

--- a/packages/protocol/contracts/verifiers/IVerifier.sol
+++ b/packages/protocol/contracts/verifiers/IVerifier.sol
@@ -22,11 +22,10 @@ interface IVerifier {
     struct Context {
         bytes32 metaHash;
         bytes32 blobHash;
-        address prover;
+        address msgSender;
         uint64 blockId;
         bool isContesting;
         bool blobUsed;
-        address msgSender;
     }
 
     function verifyProof(

--- a/packages/protocol/contracts/verifiers/PseZkVerifier.sol
+++ b/packages/protocol/contracts/verifiers/PseZkVerifier.sol
@@ -85,7 +85,7 @@ contract PseZkVerifier is EssentialContract, IVerifier {
 
         bytes32 instance = calcInstance({
             tran: tran,
-            prover: ctx.prover,
+            prover: proof.prover,
             metaHash: ctx.metaHash,
             txListHash: txListHash,
             pointValue: pointValue

--- a/packages/protocol/contracts/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/verifiers/SgxVerifier.sol
@@ -152,7 +152,7 @@ contract SgxVerifier is EssentialContract, IVerifier {
         bytes memory signature = Bytes.slice(proof.data, 24);
 
         address oldInstance =
-            ECDSA.recover(getSignedHash(tran, newInstance, ctx.prover, ctx.metaHash), signature);
+            ECDSA.recover(getSignedHash(tran, newInstance, proof.prover, ctx.metaHash), signature);
 
         if (!_isInstanceValid(id, oldInstance)) revert SGX_INVALID_INSTANCE();
         _replaceInstance(id, oldInstance, newInstance);

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -794,9 +794,11 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                     __reserved: [bytes32(0), bytes32(0)]
                 });
 
-                TaikoData.TierProof memory proof;
-                proof.tier = LibTiers.TIER_GUARDIAN;
-                proof.data = bytes.concat(keccak256("RETURN_LIVENESS_BOND"));
+                TaikoData.TierProof memory proof = TaikoData.TierProof({
+                    prover: Carol,
+                    tier: LibTiers.TIER_GUARDIAN,
+                    data: bytes.concat(keccak256("RETURN_LIVENESS_BOND"))
+                });
 
                 uint256 balanceBeforeReimbursement = tko.balanceOf(Bob);
 

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -250,6 +250,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
             pv.calcInstance(tran, prover, keccak256(abi.encode(meta)), meta.blobHash, 0);
 
         TaikoData.TierProof memory proof;
+        proof.prover = prover;
         proof.tier = tier;
         {
             PseZkVerifier.ZkEvmProof memory zkProof;

--- a/packages/protocol/test/verifiers/GuardianVerifier.t.sol
+++ b/packages/protocol/test/verifiers/GuardianVerifier.t.sol
@@ -21,7 +21,6 @@ contract TestGuardianVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32(0),
             blobHash: bytes32(0),
-            prover: address(gp),
             msgSender: address(gp),
             blockId: 10,
             isContesting: false,
@@ -38,7 +37,7 @@ contract TestGuardianVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: "" });
+        TaikoData.TierProof memory proof = TaikoData.TierProof({ prover: Alice, tier: 0, data: "" });
 
         // `verifyProof()`
         gv.verifyProof(ctx, transition, proof);
@@ -50,7 +49,6 @@ contract TestGuardianVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32(0),
             blobHash: bytes32(0),
-            prover: Alice, // invalid
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -67,7 +65,11 @@ contract TestGuardianVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: "" });
+        TaikoData.TierProof memory proof = TaikoData.TierProof({
+            prover: Alice, // invalid
+            tier: 0,
+            data: ""
+        });
 
         // `verifyProof()` with invalid ctx.prover
         vm.expectRevert(GuardianVerifier.PERMISSION_DENIED.selector);

--- a/packages/protocol/test/verifiers/PseZkVerifier.t.sol
+++ b/packages/protocol/test/verifiers/PseZkVerifier.t.sol
@@ -39,7 +39,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: true, // skips all verification when true
@@ -56,7 +55,8 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: "" });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: "" });
 
         // `verifyProof()`
         pv.verifyProof(ctx, transition, proof);
@@ -68,7 +68,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -94,7 +93,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         bytes32 instance = pv.calcInstance(
-            transition, ctx.prover, ctx.metaHash, pointProof.txListHash, pointProof.pointValue
+            transition, ctx.msgSender, ctx.metaHash, pointProof.txListHash, pointProof.pointValue
         );
         bytes memory instanceWords = abi.encodePacked(
             bytes16(0), bytes16(instance), bytes16(0), bytes16(uint128(uint256(instance)))
@@ -108,7 +107,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // `verifyProof()`
         vm.expectRevert(Lib4844.EVAL_FAILED_2.selector);
@@ -121,7 +120,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -138,7 +136,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        bytes32 instance = pv.calcInstance(transition, ctx.prover, ctx.metaHash, ctx.blobHash, 0);
+        bytes32 instance = pv.calcInstance(transition, ctx.msgSender, ctx.metaHash, ctx.blobHash, 0);
         bytes memory instanceWords = abi.encodePacked(
             bytes16(0), bytes16(instance), bytes16(0), bytes16(uint128(uint256(instance)))
         );
@@ -148,7 +146,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             PseZkVerifier.ZkEvmProof({ verifierId: mockPlonkVerifierId, zkp: zkp, pointProof: "" });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // `verifyProof()`
         pv.verifyProof(ctx, transition, proof);
@@ -160,7 +158,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -178,7 +175,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
 
         // TierProof
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(uint256(0)) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(uint256(0)) });
 
         // `verifyProof()`
         vm.expectRevert();
@@ -191,7 +188,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -208,7 +204,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        bytes32 instance = pv.calcInstance(transition, ctx.prover, ctx.metaHash, ctx.blobHash, 0);
+        bytes32 instance = pv.calcInstance(transition, ctx.msgSender, ctx.metaHash, ctx.blobHash, 0);
         bytes memory instanceWords = abi.encodePacked(
             bytes16(0), bytes16(0), bytes16(0), bytes16(uint128(uint256(instance)))
         );
@@ -218,7 +214,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             PseZkVerifier.ZkEvmProof({ verifierId: mockPlonkVerifierId, zkp: zkp, pointProof: "" });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // `verifyProof()`
         vm.expectRevert(PseZkVerifier.L1_INVALID_PROOF.selector);
@@ -231,7 +227,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -248,7 +243,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        bytes32 instance = pv.calcInstance(transition, ctx.prover, ctx.metaHash, ctx.blobHash, 0);
+        bytes32 instance = pv.calcInstance(transition, ctx.msgSender, ctx.metaHash, ctx.blobHash, 0);
         bytes memory instanceWords =
             abi.encodePacked(bytes16(0), bytes16(0), bytes16(instance), bytes16(0));
         bytes memory zkp = abi.encodePacked(instanceWords, abi.encode(keccak256("taiko")));
@@ -257,7 +252,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             PseZkVerifier.ZkEvmProof({ verifierId: mockPlonkVerifierId, zkp: zkp, pointProof: "" });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // `verifyProof()`
         vm.expectRevert(PseZkVerifier.L1_INVALID_PROOF.selector);
@@ -270,7 +265,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -293,7 +287,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             PseZkVerifier.ZkEvmProof({ verifierId: mockPlonkVerifierId, zkp: zkp, pointProof: "" });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // `verifyProof()`
         vm.expectRevert("slice_outOfBounds");
@@ -306,7 +300,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -323,7 +316,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        bytes32 instance = pv.calcInstance(transition, ctx.prover, ctx.metaHash, ctx.blobHash, 0);
+        bytes32 instance = pv.calcInstance(transition, ctx.msgSender, ctx.metaHash, ctx.blobHash, 0);
         bytes memory instanceWords = abi.encodePacked(
             bytes16(0), bytes16(instance), bytes16(0), bytes16(uint128(uint256(instance)))
         );
@@ -336,7 +329,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // `verifyProof()`
         vm.expectRevert();
@@ -349,7 +342,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -366,7 +358,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        bytes32 instance = pv.calcInstance(transition, ctx.prover, ctx.metaHash, ctx.blobHash, 0);
+        bytes32 instance = pv.calcInstance(transition, ctx.msgSender, ctx.metaHash, ctx.blobHash, 0);
         bytes memory instanceWords = abi.encodePacked(
             bytes16(0), bytes16(instance), bytes16(0), bytes16(uint128(uint256(instance)))
         );
@@ -376,7 +368,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             PseZkVerifier.ZkEvmProof({ verifierId: mockPlonkVerifierId, zkp: zkp, pointProof: "" });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // Tell verifier to revert
         MockPlonkVerifier(mockPlonkVerifier).setShouldRevert(true);
@@ -392,7 +384,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -409,7 +400,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        bytes32 instance = pv.calcInstance(transition, ctx.prover, ctx.metaHash, ctx.blobHash, 0);
+        bytes32 instance = pv.calcInstance(transition, ctx.msgSender, ctx.metaHash, ctx.blobHash, 0);
         bytes memory instanceWords = abi.encodePacked(
             bytes16(0), bytes16(instance), bytes16(0), bytes16(uint128(uint256(instance)))
         );
@@ -419,7 +410,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             PseZkVerifier.ZkEvmProof({ verifierId: mockPlonkVerifierId, zkp: zkp, pointProof: "" });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // `verifyProof()`
         vm.expectRevert(PseZkVerifier.L1_INVALID_PROOF.selector);
@@ -432,7 +423,6 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -449,7 +439,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        bytes32 instance = pv.calcInstance(transition, ctx.prover, ctx.metaHash, ctx.blobHash, 0);
+        bytes32 instance = pv.calcInstance(transition, ctx.msgSender, ctx.metaHash, ctx.blobHash, 0);
         bytes memory instanceWords = abi.encodePacked(
             bytes16(0), bytes16(instance), bytes16(0), bytes16(uint128(uint256(instance)))
         );
@@ -459,7 +449,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             PseZkVerifier.ZkEvmProof({ verifierId: mockPlonkVerifierId, zkp: zkp, pointProof: "" });
 
         TaikoData.TierProof memory proof =
-            TaikoData.TierProof({ tier: 0, data: abi.encode(zkProof) });
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: abi.encode(zkProof) });
 
         // `verifyProof()`
         vm.expectRevert(PseZkVerifier.L1_INVALID_PROOF.selector);

--- a/packages/protocol/test/verifiers/SgxVerifier.t.sol
+++ b/packages/protocol/test/verifiers/SgxVerifier.t.sol
@@ -184,7 +184,6 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: KNOWN_ADDRESS,
             msgSender: KNOWN_ADDRESS,
             blockId: 10,
             isContesting: false,
@@ -203,12 +202,13 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         // TierProof
         address newInstance = address(0x33);
 
-        bytes32 signedHash = sv.getSignedHash(transition, newInstance, ctx.prover, ctx.metaHash);
+        bytes32 signedHash = sv.getSignedHash(transition, newInstance, ctx.msgSender, ctx.metaHash);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(KNOWN_ADDRESS_PRIV_KEY, signedHash);
         bytes memory signature = abi.encodePacked(r, s, v);
 
         bytes memory data = abi.encodePacked(id, newInstance, signature);
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 100, data: data });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 100, data: data });
 
         vm.warp(block.timestamp + 5);
 
@@ -234,7 +234,6 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: true, // skips all verification when true
@@ -251,7 +250,8 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         });
 
         // TierProof
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: "" });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: "" });
 
         // `verifyProof()`
         sv.verifyProof(ctx, transition, proof);
@@ -267,7 +267,6 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -285,6 +284,7 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
 
         // TierProof
         TaikoData.TierProof memory proof = TaikoData.TierProof({
+            prover: ctx.msgSender,
             tier: 0,
             data: new bytes(80) // invalid length
          });
@@ -302,7 +302,6 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -323,7 +322,8 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         address newInstance = address(0x33);
         bytes memory signature = new bytes(65); // invalid length
         bytes memory data = abi.encodePacked(id, newInstance, signature);
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: data });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: data });
 
         // `verifyProof()`
         vm.expectRevert("ECDSA: invalid signature");
@@ -342,7 +342,6 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -361,12 +360,13 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         // TierProof
         address newInstance = address(0x33);
 
-        bytes32 signedHash = sv.getSignedHash(transition, newInstance, ctx.prover, ctx.metaHash);
+        bytes32 signedHash = sv.getSignedHash(transition, newInstance, ctx.msgSender, ctx.metaHash);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(KNOWN_ADDRESS_PRIV_KEY, signedHash);
         bytes memory signature = abi.encodePacked(r, s, v);
 
         bytes memory data = abi.encodePacked(id, newInstance, signature);
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: data });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 0, data: data });
 
         // `verifyProof()`
         vm.expectRevert(SgxVerifier.SGX_INVALID_INSTANCE.selector);
@@ -383,7 +383,6 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         IVerifier.Context memory ctx = IVerifier.Context({
             metaHash: bytes32("ab"),
             blobHash: bytes32("cd"),
-            prover: Alice,
             msgSender: Alice,
             blockId: 10,
             isContesting: false,
@@ -403,12 +402,13 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         uint32 id = 0;
         address newInstance = address(0x33);
 
-        bytes32 signedHash = sv.getSignedHash(transition, newInstance, ctx.prover, ctx.metaHash);
+        bytes32 signedHash = sv.getSignedHash(transition, newInstance, ctx.msgSender, ctx.metaHash);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(KNOWN_ADDRESS_PRIV_KEY, signedHash);
         bytes memory signature = abi.encodePacked(r, s, v);
 
         bytes memory data = abi.encodePacked(id, newInstance, signature);
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 100, data: data });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ prover: ctx.msgSender, tier: 100, data: data });
 
         // `verifyProof()`
         vm.expectRevert(AddressResolver.RESOLVER_DENIED.selector);


### PR DESCRIPTION
4 tests are still failing.

Also with the contesting and stuff, it's not as clear cut when to use `msg.sender` and the supplied prover... So this might be a more confusing feature than I first thought because there will need to be clear rules when which is used. So not so convinced anymore we should add this.