### PR TITLE
fix(protocol):  fix chainid check to allow the case where `chainid = type(uint64).max` to still be valid, per the implied intention of type downcasting

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -78,7 +78,7 @@ contract TaikoL2 is CrossChainOwned, ICrossChainSync {
     {
         __CrossChainOwned_init(_addressManager, _l1ChainId);
 
-        if (block.chainid <= 1 || block.chainid >= type(uint64).max) {
+        if (block.chainid <= 1 || block.chainid > type(uint64).max) {
             revert L2_INVALID_CHAIN_ID();
         }
 

--- a/packages/protocol/contracts/common/AddressResolver.sol
+++ b/packages/protocol/contracts/common/AddressResolver.sol
@@ -94,7 +94,7 @@ abstract contract AddressResolver {
     /// @param _addressManager Address of the AddressManager.
     // solhint-disable-next-line func-name-mixedcase
     function __AddressResolver_init(address _addressManager) internal virtual {
-        if (block.chainid >= type(uint64).max) {
+        if (block.chainid > type(uint64).max) {
             revert RESOLVER_UNEXPECTED_CHAINID();
         }
         addressManager = _addressManager;


### PR DESCRIPTION

My assumption is that from the casting in `resolve` function, the chainid gets downcasted to `uint64`, so to prevent any possible attack on duplicate chainid due to downcasting, the chainid check is done. However, the check should still be allowed for when `chainid == type(uint64).max`.

```solidity
function resolve(
        uint64 chainId,
        bytes32 name,
        bool allowZeroAddress
    )
        public
        view
        virtual
        returns (address payable addr)
    {
        return _resolve(chainId, name, allowZeroAddress);
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Updated the chain ID checking logic in the Address Resolver to enhance compatibility with future chain IDs.
  - Made a semantic change in the validation of chain ID comparison logic in the TaikoL2 contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->