### PR TITLE
fix(protocol): fix encode eth deposit check

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibDepositing.sol
+++ b/packages/protocol/contracts/L1/libs/LibDepositing.sol
@@ -153,7 +153,7 @@ library LibDepositing {
     /// @param amount The amount of the deposit.
     /// @return The encoded deposit.
     function _encodeEthDeposit(address addr, uint256 amount) private pure returns (uint256) {
-        if (amount >= type(uint96).max) revert L1_INVALID_ETH_DEPOSIT();
+        if (amount > type(uint96).max) revert L1_INVALID_ETH_DEPOSIT();
         return (uint256(uint160(addr)) << 96) | amount;
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -99,9 +99,9 @@ library LibVerifying {
                 || config.ethDepositMaxCountPerBlock < config.ethDepositMinCountPerBlock
                 || config.ethDepositMinAmount == 0
                 || config.ethDepositMaxAmount <= config.ethDepositMinAmount
-                || config.ethDepositMaxAmount >= type(uint96).max || config.ethDepositGas == 0
+                || config.ethDepositMaxAmount > type(uint96).max || config.ethDepositGas == 0
                 || config.ethDepositMaxFee == 0
-                || config.ethDepositMaxFee >= type(uint96).max / config.ethDepositMaxCountPerBlock
+                || config.ethDepositMaxFee > type(uint96).max / config.ethDepositMaxCountPerBlock
         ) return false;
 
         return true;


### PR DESCRIPTION
The function should still `amount == type(uint96).max` since `type(uint96).max` is still < 2^96 so encoding should still be valid.

```solidity
function _encodeEthDeposit(address addr, uint256 amount) private pure returns (uint256) {
        if (amount >= type(uint96).max) revert L1_INVALID_ETH_DEPOSIT();
        return (uint256(uint160(addr)) << 96) | amount;
    }
```