### PR TITLE
fix(protocol): fix singla service cannot be shared by multiple taiko L1/L2 contracts on the same chain bug

### DIFF
--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -55,8 +55,8 @@ contract SignalService is EssentialContract, ISignalService {
     error SS_INVALID_PARAMS();
     error SS_INVALID_SIGNAL();
     error SS_LOCAL_CHAIN_DATA_NOT_FOUND();
-    error SS_UNSUPPORTED();
     error SS_UNAUTHORIZED();
+    error SS_UNSUPPORTED();
 
     /// @dev Initializer to be called after being deployed behind a proxy.
     function init(address _addressManager) external initializer {

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -39,11 +39,14 @@ contract SignalService is EssentialContract, ISignalService {
         bytes[] storageProof;
     }
 
-    uint256[50] private __gap;
+    mapping(address => bool) public isChainDataRelayerAuthorized;
+    uint256[49] private __gap;
 
     event SnippetRelayed(
         uint64 indexed chainid, bytes32 indexed kind, bytes32 data, bytes32 signal
     );
+
+    event RelayerAuthorized(address indexed addr, bool authrized);
 
     error SS_EMPTY_PROOF();
     error SS_INVALID_APP();
@@ -53,10 +56,20 @@ contract SignalService is EssentialContract, ISignalService {
     error SS_INVALID_SIGNAL();
     error SS_LOCAL_CHAIN_DATA_NOT_FOUND();
     error SS_UNSUPPORTED();
+    error SS_UNAUTHORIZED();
 
     /// @dev Initializer to be called after being deployed behind a proxy.
     function init(address _addressManager) external initializer {
         __Essential_init(_addressManager);
+    }
+
+    /// @dev Authorize or deautohrize an address for calling relayChainData
+    /// @dev Note that addr is supposed to be TaikoL1 and TaikoL1 contracts deployed locally.
+    function authorizeChainDataRelayer(address addr, bool toAuthorize) external onlyOwner {
+        if (isChainDataRelayerAuthorized[addr] == toAuthorize) revert SS_INVALID_PARAMS();
+        isChainDataRelayerAuthorized[addr] = toAuthorize;
+
+        emit RelayerAuthorized(addr, toAuthorize);
     }
 
     /// @inheritdoc ISignalService
@@ -66,9 +79,9 @@ contract SignalService is EssentialContract, ISignalService {
         bytes32 data
     )
         external
-        onlyFromNamed("taiko")
         returns (bytes32 slot)
     {
+        if (!isChainDataRelayerAuthorized[msg.sender]) revert SS_UNAUTHORIZED();
         return _relayChainData(chainId, kind, data);
     }
 

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -39,7 +39,7 @@ contract SignalService is EssentialContract, ISignalService {
         bytes[] storageProof;
     }
 
-    mapping(address => bool) public isChainDataRelayerAuthorized;
+    mapping(address => bool) public isRelayerAuthorized;
     uint256[49] private __gap;
 
     event SnippetRelayed(
@@ -65,9 +65,9 @@ contract SignalService is EssentialContract, ISignalService {
 
     /// @dev Authorize or deautohrize an address for calling relayChainData
     /// @dev Note that addr is supposed to be TaikoL1 and TaikoL1 contracts deployed locally.
-    function authorizeChainDataRelayer(address addr, bool toAuthorize) external onlyOwner {
-        if (isChainDataRelayerAuthorized[addr] == toAuthorize) revert SS_INVALID_PARAMS();
-        isChainDataRelayerAuthorized[addr] = toAuthorize;
+    function authorizeRelayer(address addr, bool toAuthorize) external onlyOwner {
+        if (isRelayerAuthorized[addr] == toAuthorize) revert SS_INVALID_PARAMS();
+        isRelayerAuthorized[addr] = toAuthorize;
 
         emit RelayerAuthorized(addr, toAuthorize);
     }
@@ -81,7 +81,7 @@ contract SignalService is EssentialContract, ISignalService {
         external
         returns (bytes32 slot)
     {
-        if (!isChainDataRelayerAuthorized[msg.sender]) revert SS_UNAUTHORIZED();
+        if (!isRelayerAuthorized[msg.sender]) revert SS_UNAUTHORIZED();
         return _relayChainData(chainId, kind, data);
     }
 

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -116,7 +116,6 @@ contract DeployOnL1 is DeployCapability {
         copyRegister(rollupAddressManager, sharedAddressManager, "taiko_token");
         copyRegister(rollupAddressManager, sharedAddressManager, "signal_service");
         copyRegister(rollupAddressManager, sharedAddressManager, "bridge");
-        copyRegister(sharedAddressManager, rollupAddressManager, "taiko");
 
         address proposer = vm.envAddress("PROPOSER");
         if (proposer != address(0)) {

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -91,6 +91,10 @@ contract DeployOnL1 is DeployCapability {
         addressNotNull(taikoL1Addr, "taikoL1Addr");
         TaikoL1 taikoL1 = TaikoL1(payable(taikoL1Addr));
 
+        if (vm.envAddress("SHARED_ADDRESS_MANAGER") == address(0)) {
+            SignalService(signalServiceAddr).authorizeRelayer(taikoL1Addr, true);
+        }
+
         uint64 l2ChainId = taikoL1.getConfig().chainId;
         require(l2ChainId != block.chainid, "same chainid");
 

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -54,6 +54,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
                 data: abi.encodeCall(SignalService.init, address(addressManager))
             })
         );
+        ss.authorizeChainDataRelayer(address(L1), true);
 
         pv = PseZkVerifier(
             deployProxy({

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -54,7 +54,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
                 data: abi.encodeCall(SignalService.init, address(addressManager))
             })
         );
-        ss.authorizeChainDataRelayer(address(L1), true);
+        ss.authorizeRelayer(address(L1), true);
 
         pv = PseZkVerifier(
             deployProxy({

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -57,7 +57,7 @@ contract TestTaikoL2 is TaikoTest {
 
         L2.setConfigAndExcess(TaikoL2.Config(gasTarget, quotient), gasExcess);
 
-        ss.authorizeChainDataRelayer(address(L2), true);
+        ss.authorizeRelayer(address(L2), true);
 
         gasExcess = 195_420_300_100;
 

--- a/packages/protocol/test/L2/TaikoL2.t.sol
+++ b/packages/protocol/test/L2/TaikoL2.t.sol
@@ -28,13 +28,15 @@ contract TestTaikoL2 is TaikoTest {
             data: abi.encodeCall(AddressManager.init, ())
         });
 
-        deployProxy({
-            name: "signal_service",
-            impl: address(new SignalService()),
-            data: abi.encodeCall(SignalService.init, (addressManager)),
-            registerTo: addressManager,
-            owner: address(0)
-        });
+        SignalService ss = SignalService(
+            deployProxy({
+                name: "signal_service",
+                impl: address(new SignalService()),
+                data: abi.encodeCall(SignalService.init, (addressManager)),
+                registerTo: addressManager,
+                owner: address(0)
+            })
+        );
 
         uint64 gasExcess = 0;
         uint8 quotient = 8;
@@ -54,6 +56,8 @@ contract TestTaikoL2 is TaikoTest {
         );
 
         L2.setConfigAndExcess(TaikoL2.Config(gasTarget, quotient), gasExcess);
+
+        ss.authorizeChainDataRelayer(address(L2), true);
 
         gasExcess = 195_420_300_100;
 

--- a/packages/protocol/test/L2/TaikoL2NoFeeCheck.t.sol
+++ b/packages/protocol/test/L2/TaikoL2NoFeeCheck.t.sol
@@ -27,13 +27,15 @@ contract TestTaikoL2NoFeeCheck is TaikoTest {
             data: abi.encodeCall(AddressManager.init, ())
         });
 
-        deployProxy({
-            name: "signal_service",
-            impl: address(new SignalService()),
-            data: abi.encodeCall(SignalService.init, (addressManager)),
-            registerTo: addressManager,
-            owner: address(0)
-        });
+        SignalService ss = SignalService(
+            deployProxy({
+                name: "signal_service",
+                impl: address(new SignalService()),
+                data: abi.encodeCall(SignalService.init, (addressManager)),
+                registerTo: addressManager,
+                owner: address(0)
+            })
+        );
 
         uint64 gasExcess = 0;
         uint8 quotient = 8;
@@ -54,6 +56,8 @@ contract TestTaikoL2NoFeeCheck is TaikoTest {
         );
 
         L2.setConfigAndExcess(TaikoL2.Config(gasTarget, quotient), gasExcess);
+
+        ss.authorizeChainDataRelayer(address(L2), true);
 
         vm.roll(block.number + 1);
         vm.warp(block.timestamp + 30);

--- a/packages/protocol/test/L2/TaikoL2NoFeeCheck.t.sol
+++ b/packages/protocol/test/L2/TaikoL2NoFeeCheck.t.sol
@@ -57,7 +57,7 @@ contract TestTaikoL2NoFeeCheck is TaikoTest {
 
         L2.setConfigAndExcess(TaikoL2.Config(gasTarget, quotient), gasExcess);
 
-        ss.authorizeChainDataRelayer(address(L2), true);
+        ss.authorizeRelayer(address(L2), true);
 
         vm.roll(block.number + 1);
         vm.warp(block.timestamp + 30);

--- a/packages/protocol/test/signal/SignalService.t.sol
+++ b/packages/protocol/test/signal/SignalService.t.sol
@@ -51,9 +51,7 @@ contract TestSignalService is TaikoTest {
         );
 
         taiko = randAddress();
-
         signalService.authorizeRelayer(taiko, true);
-
         vm.stopPrank();
     }
 

--- a/packages/protocol/test/signal/SignalService.t.sol
+++ b/packages/protocol/test/signal/SignalService.t.sol
@@ -51,7 +51,9 @@ contract TestSignalService is TaikoTest {
         );
 
         taiko = randAddress();
-        addressManager.setAddress(uint64(block.chainid), "taiko", taiko);
+
+        signalService.authorizeChainDataRelayer(taiko, true);
+
         vm.stopPrank();
     }
 
@@ -298,6 +300,13 @@ contract TestSignalService is TaikoTest {
             signal: randBytes32(),
             proof: abi.encode(proofs)
         });
+
+        vm.prank(Alice);
+        signalService.authorizeChainDataRelayer(taiko, false);
+
+        vm.expectRevert(SignalService.SS_UNAUTHORIZED.selector);
+        vm.prank(taiko);
+        signalService.relayChainData(srcChainId, LibSignals.SIGNAL_ROOT, proofs[0].rootHash);
     }
 
     function test_SignalService_proveSignalReceived_one_hop_state_root() public {

--- a/packages/protocol/test/signal/SignalService.t.sol
+++ b/packages/protocol/test/signal/SignalService.t.sol
@@ -52,7 +52,7 @@ contract TestSignalService is TaikoTest {
 
         taiko = randAddress();
 
-        signalService.authorizeChainDataRelayer(taiko, true);
+        signalService.authorizeRelayer(taiko, true);
 
         vm.stopPrank();
     }
@@ -302,7 +302,7 @@ contract TestSignalService is TaikoTest {
         });
 
         vm.prank(Alice);
-        signalService.authorizeChainDataRelayer(taiko, false);
+        signalService.authorizeRelayer(taiko, false);
 
         vm.expectRevert(SignalService.SS_UNAUTHORIZED.selector);
         vm.prank(taiko);

--- a/packages/protocol/utils/generate_genesis/taikoL2.ts
+++ b/packages/protocol/utils/generate_genesis/taikoL2.ts
@@ -461,6 +461,9 @@ async function generateContractConfigs(
                 _owner: ownerSecurityCouncil,
                 // AddressResolver
                 addressManager: addressMap.SharedAddressManager,
+                isRelayerAuthorized: {
+                    [addressMap.TaikoL2]: true,
+                },
             },
             slots: {
                 [IMPLEMENTATION_SLOT]: addressMap.SignalServiceImpl,

--- a/packages/protocol/utils/generate_genesis/taikoL2.ts
+++ b/packages/protocol/utils/generate_genesis/taikoL2.ts
@@ -243,9 +243,6 @@ async function generateContractConfigs(
                 addresses: {
                     [chainId]: {
                         [ethers.utils.hexlify(
-                            ethers.utils.toUtf8Bytes("taiko"),
-                        )]: addressMap.TaikoL2,
-                        [ethers.utils.hexlify(
                             ethers.utils.toUtf8Bytes("bridge"),
                         )]: addressMap.Bridge,
                         [ethers.utils.hexlify(


### PR DESCRIPTION
In Signal Service, we cannot assume there is only one "taiko" address on a chain so  using `onlyFromNamed("taiko")` is incorrect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Implemented a system to manage and authorize chain data relayers in the blockchain protocol.
	- Added an event to track changes in relayer authorization status.
- **Tests**
	- Enhanced test contracts to support new authorization features for chain data relayers.
- **Refactor**
	- Updated existing tests to align with the new relayer authorization system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->