### PR TITLE
ci(repo): add more dependabot actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,37 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "04:20"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "04:20"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "04:20"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "pip"
+    directory: "/packages/protocol/simulation"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "04:20"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "saturday"
       time: "04:20"
       timezone: "America/New_York"
@@ -30,7 +30,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/packages/protocol/simulation"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "saturday"
       time: "04:20"
       timezone: "America/New_York"


### PR DESCRIPTION
1. I've enabled grouped security updates to reduce dependabot noise:
    <img width="766" alt="image" src="https://github.com/taikoxyz/taiko-mono/assets/13951458/8c581f34-017d-48b6-8ff1-2187593f6d2d">
2. I've added more dependabot updates, we will **manually merge these now**, but we will configure auto-merging soon for bug fixes (maybe using mergify).
3. I set it to early morning EST on saturday because this is when the codebase is low-traffic, reducing the probability of collisions with main and easier to auto-merge in.