### PR TITLE
feat(protocol): add GuardianApproval event to GuardianProver

### DIFF
--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -20,6 +20,10 @@ import "./Guardians.sol";
 
 /// @title GuardianProver
 contract GuardianProver is Guardians {
+    event GuardianApproval(
+        address indexed addr, uint256 indexed blockId, bytes32 blockHash, bool approved
+    );
+
     /// @notice Initializes the contract with the provided address manager.
     /// @param _addressManager The address of the address manager contract.
     function init(address _addressManager) external initializer {
@@ -45,5 +49,7 @@ contract GuardianProver is Guardians {
             deleteApproval(hash);
             ITaikoL1(resolve("taiko", false)).proveBlock(meta.id, abi.encode(meta, tran, proof));
         }
+
+        emit GuardianApproval(msg.sender, meta.id, tran.blockHash, approved);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The system now emits a `GuardianApproval` event when a guardian approves a block, including details such as the guardian's address, block ID, block hash, and approval status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->