### PR TITLE
fix(protocol): fix permission bugs

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -117,9 +117,18 @@ contract TaikoL1 is
     }
 
     /// @notice Pause block proving.
-    /// @param pause True if paused.
-    function pauseProving(bool pause) external onlyOwner {
-        LibProving.pauseProving(state, pause);
+    /// @param toPause True if to pause the contract.
+    function pauseProving(bool toPause) external onlyFromOwnerOrNamed("pauser") {
+        LibProving.pauseProving(state, toPause);
+    }
+
+    function pause(bool toPause) external whenNotPaused onlyFromOwnerOrNamed("pauser") {
+        if (toPause) {
+            super._pause();
+        } else {
+            super._unpause();
+            state.slotB.lastUnpausedAt = uint64(block.timestamp);
+        }
     }
 
     /// @notice Deposits Ether to Layer 2.
@@ -127,11 +136,6 @@ contract TaikoL1 is
     /// Layer 2.
     function depositEtherToL2(address recipient) external payable nonReentrant whenNotPaused {
         LibDepositing.depositEtherToL2(state, getConfig(), AddressResolver(this), recipient);
-    }
-
-    function unpause() public override {
-        OwnerUUPSUpgradable.unpause();
-        state.slotB.lastUnpausedAt = uint64(block.timestamp);
     }
 
     /// @notice Checks if Ether deposit is allowed for Layer 2.

--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -57,7 +57,7 @@ contract TaikoToken is EssentialContract, ERC20SnapshotUpgradeable, ERC20VotesUp
     }
 
     /// @notice Creates a new token snapshot.
-    function snapshot() public onlyOwner {
+    function snapshot() public onlyFromOwnerOrNamed("snapshooter") {
         _snapshot();
     }
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -164,7 +164,15 @@ contract TaikoL2 is CrossChainOwned, ICrossChainSync {
     }
 
     /// @notice Withdraw token or Ether from this address
-    function withdraw(address token, address to) external onlyOwner nonReentrant whenNotPaused {
+    function withdraw(
+        address token,
+        address to
+    )
+        external
+        onlyFromOwnerOrNamed("withdrawer")
+        nonReentrant
+        whenNotPaused
+    {
         if (to == address(0)) revert L2_INVALID_PARAM();
         if (token == address(0)) {
             to.sendEther(address(this).balance);

--- a/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
+++ b/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
@@ -62,20 +62,20 @@ abstract contract OwnerUUPSUpgradable is UUPSUpgradeable, OwnableUpgradeable {
         _disableInitializers();
     }
 
-    function pause() public virtual whenNotPaused {
+    function paused() public view returns (bool) {
+        return _paused == _TRUE;
+    }
+
+    function _pause() internal virtual whenNotPaused {
         _paused = _TRUE;
         emit Paused(msg.sender);
         _authorizePause(msg.sender);
     }
 
-    function unpause() public virtual whenPaused {
+    function _unpause() internal virtual whenPaused {
         _paused = _FALSE;
         emit Unpaused(msg.sender);
         _authorizePause(msg.sender);
-    }
-
-    function paused() public view returns (bool) {
-        return _paused == _TRUE;
     }
 
     function _authorizeUpgrade(address) internal virtual override onlyOwner { }

--- a/packages/protocol/contracts/tokenvault/BridgedERC20.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20.sol
@@ -33,19 +33,11 @@ contract BridgedERC20 is
     address public srcToken; // slot 1
     uint8 private srcDecimals;
     uint256 public srcChainId; // slot 2
-    address public snapshooter; // slot 3
 
-    uint256[47] private __gap;
+    uint256[48] private __gap;
 
     error BTOKEN_CANNOT_RECEIVE();
-    error BTOKEN_UNAUTHORIZED();
 
-    modifier onlyOwnerOrSnapshooter() {
-        if (msg.sender != owner() && msg.sender != snapshooter) {
-            revert BTOKEN_UNAUTHORIZED();
-        }
-        _;
-    }
     /// @notice Initializes the contract.
     /// @dev Different BridgedERC20 Contract is deployed per unique _srcToken
     /// (e.g., one for USDC, one for USDT, etc.).
@@ -83,13 +75,8 @@ contract BridgedERC20 is
         srcDecimals = _decimals;
     }
 
-    /// @notice Set the snapshoter address.
-    function setSnapshoter(address _snapshooter) external onlyOwner {
-        snapshooter = _snapshooter;
-    }
-
     /// @notice Creates a new token snapshot.
-    function snapshot() external onlyOwnerOrSnapshooter {
+    function snapshot() external onlyFromOwnerOrNamed("snapshooter") {
         _snapshot();
     }
 

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -117,7 +117,7 @@ contract ERC20Vault is BaseVault {
         external
         nonReentrant
         whenNotPaused
-        onlyOwner
+        onlyFromOwnerOrNamed("token_upgrader")
         returns (address btokenOld)
     {
         if (btokenNew == address(0) || bridgedToCanonical[btokenNew].addr != address(0)) {


### PR DESCRIPTION
- `OwnerUUPSUpgradable.pause()` and `OwnerUUPSUpgradable.unpause()` are not permission-checked. Now they are internal functions.
- `TaikoL1.unpause()` was not permission checked, fixed.
- Allow certain `onlyOwner` function to use `onlyFromOwnerOrNamed` in case we get rid of the security council earlier but would like to keep special named roles for special operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security and functionality in contract operations with improved access control and reentrancy protection.
	- Added conditional logic for pausing and unpausing operations in contracts.
- **Refactor**
	- Consolidated pause and unpause functionality into a single method across multiple contracts.
	- Updated function signatures and access modifiers for clarity and security.
	- Removed redundant code and variables to streamline contract efficiency.
- **Chores**
	- Increased internal storage array size in the `BridgedERC20` contract for future compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->