### PR TITLE
chore(repo): remove pip from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,12 +26,3 @@ updates:
       time: "04:20"
       timezone: "America/New_York"
     open-pull-requests-limit: 10
-
-  - package-ecosystem: "pip"
-    directory: "/packages/protocol/simulation"
-    schedule:
-      interval: "monthly"
-      day: "saturday"
-      time: "04:20"
-      timezone: "America/New_York"
-    open-pull-requests-limit: 10


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed a specific package ecosystem configuration from Dependabot settings to adjust pull request scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->