### PR TITLE
fix(bridge-ui-v2): facilitate reset of recipient address back to sender address

### DIFF
--- a/packages/bridge-ui-v2/src/components/Bridge/SharedBridgeComponents/RecipientStep/Recipient.svelte
+++ b/packages/bridge-ui-v2/src/components/Bridge/SharedBridgeComponents/RecipientStep/Recipient.svelte
@@ -36,6 +36,14 @@
     addressInput.focus();
     addEscKeyListener();
   }
+  
+  function confirmModal() {
+    if(!ethereumAddressBinding){
+        $recipientAddress = null;
+    }
+    closeModal()
+  }
+
 
   function cancelModal() {
     // Revert change of recipient address
@@ -144,8 +152,8 @@
             </ActionButton>
             <ActionButton
               priority="primary"
-              disabled={invalidAddress || !ethereumAddressBinding}
-              on:click={closeModal}
+              disabled={invalidAddress}
+              on:click={confirmModal}
               onPopup>
               <span class="body-bold">{$t('common.confirm')}</span>
             </ActionButton>


### PR DESCRIPTION
Hey :)

I just changed the bridge interface a bit. You know how sometimes you set a custom recipient address for your tokens and then want to switch back to your sender address? Before, you'd have to copy and paste your own sender address back in which is a bit of a hassle.

Now with this fix if you want to reset the recipient address to your own, just hit the little 'x' in the address field to clear it out, and then click 'Confirm'. It'll automatically set the recipient address back to the default, which is your sender address.

1. Click the 'x' to clear the custom address:
   ![Clear Custom Address](https://github.com/taikoxyz/taiko-mono/assets/150069539/c0759f26-7447-4db5-b12c-2f0849a877f9)
2. Then hit 'Confirm' to reset to your default address:
   ![Confirm Reset](https://github.com/taikoxyz/taiko-mono/assets/150069539/9666a71e-f1d2-4282-ad2b-9da7b4616fd6)
 
 And now you recipient address gets reset!
