### PR TITLE
feat(protocol): allow disabling block reuse

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -42,6 +42,8 @@ library TaikoData {
         uint24 blobExpiry;
         // True if EIP-4844 is enabled for DA
         bool blobAllowedForDA;
+        // True if blob can be reused
+        bool blobReuseEnabled;
         // ---------------------------------------------------------------------
         // Group 3: Proof related configs
         // ---------------------------------------------------------------------

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -28,6 +28,7 @@ abstract contract TaikoErrors {
     error L1_BLOB_NOT_FOUND();
     error L1_BLOB_NOT_REUSEABLE();
     error L1_BLOB_NOT_USED();
+    error L1_BLOB_REUSE_DISALBED();
     error L1_BLOCK_MISMATCH();
     error L1_CHAIN_DATA_NOT_RELAYED();
     error L1_INVALID_BLOCK_ID();

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -219,6 +219,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, ITierProvider, TaikoEvents, Tai
             blockMaxTxListBytes: 120_000,
             blobExpiry: 24 hours,
             blobAllowedForDA: false,
+            blobReuseEnabled: false,
             livenessBond: 250e18, // 250 Taiko token
             // ETH deposit related.
             ethDepositRingBufferSize: 1024,

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -46,6 +46,7 @@ library LibProposing {
     error L1_BLOB_FOR_DA_DISABLED();
     error L1_BLOB_NOT_FOUND();
     error L1_BLOB_NOT_REUSEABLE();
+    error L1_BLOB_REUSE_DISALBED();
     error L1_INVALID_HOOK();
     error L1_INVALID_PARAM();
     error L1_INVALID_PROVER();
@@ -139,6 +140,8 @@ library LibProposing {
             if (!config.blobAllowedForDA) revert L1_BLOB_FOR_DA_DISABLED();
 
             if (params.blobHash != 0) {
+                if (!config.blobReuseEnabled) revert L1_BLOB_REUSE_DISALBED();
+
                 // We try to reuse an old blob
                 if (!isBlobReusable(state, config, params.blobHash)) {
                     revert L1_BLOB_NOT_REUSEABLE();
@@ -156,7 +159,7 @@ library LibProposing {
                 // Depends on the blob data price, it may not make sense to
                 // cache the blob which costs 20,000 (sstore) + 631 (event)
                 // extra gas.
-                if (params.cacheBlobForReuse) {
+                if (config.blobReuseEnabled && params.cacheBlobForReuse) {
                     state.reusableBlobs[meta.blobHash] = block.timestamp;
                     emit BlobCached(meta.blobHash);
                 }


### PR DESCRIPTION
To launch an internal devnet with blob ASAP, it's necessary to introduce support for disabling blob reuse. The existing implementation lacks this capability. 