### PR TITLE
feat(protocol): getBlock also returns the transition used to verify the block

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -142,8 +142,18 @@ contract TaikoL1 is EssentialContract, ITaikoL1, ITierProvider, TaikoEvents, Tai
     /// @notice Gets the details of a block.
     /// @param blockId Index of the block.
     /// @return blk The block.
-    function getBlock(uint64 blockId) public view returns (TaikoData.Block memory blk) {
-        return LibUtils.getBlock(state, getConfig(), blockId);
+    /// @return ts The transition used to verify this block.
+    function getBlock(uint64 blockId)
+        public
+        view
+        returns (TaikoData.Block memory blk, TaikoData.TransitionState memory ts)
+    {
+        uint64 slot;
+        (blk, slot) = LibUtils.getBlock(state, getConfig(), blockId);
+
+        if (blk.verifiedTransitionId != 0) {
+            ts = state.transitions[slot][blk.verifiedTransitionId];
+        }
     }
 
     /// @notice Gets the state transition for a specific block.

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -64,9 +64,10 @@ library LibUtils {
     )
         external
         view
-        returns (TaikoData.Block storage blk)
+        returns (TaikoData.Block storage blk, uint64 slot)
     {
-        blk = state.blocks[blockId % config.blockRingBufferSize];
+        slot = blockId % config.blockRingBufferSize;
+        blk = state.blocks[slot];
         if (blk.blockId != blockId) {
             revert L1_INVALID_BLOCK_ID();
         }


### PR DESCRIPTION
This will make it easier for the client to query the data.