### PR TITLE
fix(protocol): assembly Error fix

### DIFF
--- a/packages/protocol/contracts/automata-attestation/utils/BytesUtils.sol
+++ b/packages/protocol/contracts/automata-attestation/utils/BytesUtils.sol
@@ -270,7 +270,13 @@ library BytesUtils {
 
     function memcpy(uint256 dest, uint256 src, uint256 len) private pure {
         assembly {
-            mcopy(dest, src, len)
+            for {
+                let i := 0
+            } lt(i, len) {
+                i := add(i, 32)
+            } { 
+                mstore(add(dest, i), mload(add(src, i)))
+            }
         }
     }
 


### PR DESCRIPTION
```javascript
Error:
Compiler run failed:
Error (4619): Function "mcopy" not found.
   --> contracts/automata-attestation/utils/BytesUtils.sol:273:13:
    |
273 |             mcopy(dest, src, len)
    |             ^^^^^
````
> We can solve this using :
```javascript
 function memcpy(uint256 dest, uint256 src, uint256 len) private pure {
        assembly {
            for {
                let i := 0
            } lt(i, len) {
                i := add(i, 32)
            } { 
                mstore(add(dest, i), mload(add(src, i)))
            }
        }
    }
 ```
**This loop copies 32 bytes at a time until the specified length is reached. Note that this implementation assumes that the length is a multiple of 32.**