### PR TITLE
feat(relayer): add indexer in MySQL

### DIFF
--- a/packages/relayer/migrations/1708366658_alert_processed_blocks_block_height_index.sql
+++ b/packages/relayer/migrations/1708366658_alert_processed_blocks_block_height_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `processed_blocks` ADD INDEX `processed_blocks_block_height_index` (`block_height`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX processed_blocks_block_height_index on processed_blocks;
+-- +goose StatementEnd

--- a/packages/relayer/migrations/1708366659_alert_processed_blocks_chain_id_event_name_index.sql
+++ b/packages/relayer/migrations/1708366659_alert_processed_blocks_chain_id_event_name_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `processed_blocks` ADD INDEX `processed_blocks_chain_id_event_name_index` (`chain_id`, `event_name`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX processed_blocks_chain_id_event_name_index on processed_blocks;
+-- +goose StatementEnd

--- a/packages/relayer/migrations/1708366660_alert_processed_blocks_block_height_chain_id_index.sql
+++ b/packages/relayer/migrations/1708366660_alert_processed_blocks_block_height_chain_id_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `processed_blocks` ADD INDEX `processed_blocks_block_height_chain_id_index` (`block_height`, `chain_id`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX processed_blocks_block_height_chain_id_index on processed_blocks;
+-- +goose StatementEnd


### PR DESCRIPTION
In https://github.com/taikoxyz/taiko-mono/blob/main/packages/relayer/pkg/repo/block.go#L49
```
func (r *BlockRepository) GetLatestBlockProcessedForEvent(eventName string, chainID *big.Int) (*relayer.Block, error) {
	b := &relayer.Block{}
	if err := r.
		startQuery().
		Raw(`SELECT id, block_height, hash, event_name, chain_id 
		FROM processed_blocks 
		WHERE block_height = 
		( SELECT MAX(block_height) from processed_blocks 
		WHERE chain_id = ? AND event_name = ? )`, chainID.Int64(), eventName).
		FirstOrInit(b).Error; err != nil {
		return nil, err
	}

	return b, nil
}
```
The database query scans rows in processed_blocks and it's being used heavily based on the database monitoring. 

Other query is
```
SELECT * FROM `processed_blocks` WHERE `block_height` = ? AND `chain_id` = ? ORDER BY `processed_blocks` . `id` LIMIT ?
```

The PR is to add indexer to optimize the database performance. 
