### PR TITLE
chore(repo): vercel builds need node v18

### DIFF
--- a/.github/actions/install-pnpm-dependencies/action.yml
+++ b/.github/actions/install-pnpm-dependencies/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Install pnpm
       uses: pnpm/action-setup@v2


### PR DESCRIPTION
this might break something. if it does we can fix it easily, by creating a separate action for v16 and v18.

but for now let's try this, and then the vercel builds will work.