### PR TITLE
feat(guardian-prover-health-check): add indexer in MySQL

### DIFF
--- a/packages/guardian-prover-health-check/migrations/1666651003_alter_health_checks_guardian_prover_id_index.sql
+++ b/packages/guardian-prover-health-check/migrations/1666651003_alter_health_checks_guardian_prover_id_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `health_checks` ADD INDEX `health_checks_guardian_prover_id_index` (`guardian_prover_id`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX health_checks_guardian_prover_id_index on health_checks;
+-- +goose StatementEnd

--- a/packages/guardian-prover-health-check/migrations/1666651004_alter_signed_blocks_block_id_index.sql
+++ b/packages/guardian-prover-health-check/migrations/1666651004_alter_signed_blocks_block_id_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `signed_blocks` ADD INDEX `signed_blocks_block_id_index` (`block_id`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX signed_blocks_block_id_index on signed_blocks;
+-- +goose StatementEnd


### PR DESCRIPTION
To optimize these queries which introduce high load based on database monitoring
```
SELECT * FROM `health_checks` WHERE `guardian_prover_id` = ? ORDER BY `created_at` DESC LIMIT ?

SELECT COUNT ( * ) FROM `health_checks` WHERE `guardian_prover_id` = ? AND `created_at` > NOW ( ) - INTERVAL ? SQL_TSI_DAY

SELECT * FROM `signed_blocks` WHERE `block_id` >= ?
```
