### PR TITLE
chore(repo): add release please PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,12 +1,18 @@
+name: release-please
+
 on:
   push:
     branches:
       - main
-name: release-please
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:
-          command: manifest
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
this is so that the release-please PR tag will trigger the deployment / release workflow. github_token is not sufficient.

this is using my personal account for now for testing, and will be "taiko kitty" once we add him.