### PR TITLE
feat(protocol): extend SignalService interface 

### DIFF
--- a/packages/protocol/contracts/signal/ISignalService.sol
+++ b/packages/protocol/contracts/signal/ISignalService.sol
@@ -122,21 +122,4 @@ interface ISignalService {
         external
         pure
         returns (bytes32 signal);
-
-    /// @notice Returns true if a signal root is ached. If storage slot value is not bytes32(0),
-    /// than signal root is cached, so no need for account proof.
-    /// @dev If return values _cahced false and _blockId 0, it means there is no cached signal
-    /// service root with give chainId).
-    /// @param chainId Indenitifer of the chain for we are quering it's cached signal service root.
-    /// @param blockId The block id in question. If 0, indicates the query is targetting the latest
-    /// synced height.
-    /// @return _blockId blockId or highest synced block id.
-    /// @return _cached True if cached, false if not.
-    function isSignalRootCached(
-        uint64 chainId,
-        uint64 blockId
-    )
-        external
-        view
-        returns (uint64 _blockId, bool _cached);
 }

--- a/packages/protocol/contracts/signal/ISignalService.sol
+++ b/packages/protocol/contracts/signal/ISignalService.sol
@@ -93,6 +93,7 @@ interface ISignalService {
         returns (bool);
 
     /// @notice Returns the given block's  chain data.
+    /// @param chainId Indenitifer of the chainId.
     /// @param kind A value to mark the data type.
     /// @param blockId The chain data's corresponding block id. If this value is 0, use the top
     /// block id.
@@ -106,4 +107,34 @@ interface ISignalService {
         external
         view
         returns (uint64 _blockId, bytes32 _chainData);
+
+    /// @notice Returns the data to be used for caching slot generation.
+    /// @param chainId Indenitifer of the chainId.
+    /// @param kind A value to mark the data type.
+    /// @param blockId The chain data's corresponding block id. If this value is 0, use the top
+    /// block id.
+    /// @return signal The signal used for caching slot creation.
+    function signalForChainData(
+        uint64 chainId,
+        bytes32 kind,
+        uint64 blockId
+    )
+        external
+        view
+        returns (bytes32 signal);
+
+    /// @notice Returns true if a signal root is ached. If storage slot value is not bytes32(0),
+    /// than signal root is cached, so no need for account proof.
+    /// @param chainId Indenitifer of the chain for we are quering it's cached signal service root.
+    /// @param blockId The block id in question. If 0, indicates the query is targetting the latest
+    /// synced height.
+    /// @return _blockId blockId or highest syned block id.
+    /// @return _cached True if cached, false if not.
+    function isSignalRootCached(
+        uint64 chainId,
+        uint64 blockId
+    )
+        external
+        view
+        returns (uint64 _blockId, bool _cached);
 }

--- a/packages/protocol/contracts/signal/ISignalService.sol
+++ b/packages/protocol/contracts/signal/ISignalService.sol
@@ -120,7 +120,7 @@ interface ISignalService {
         uint64 blockId
     )
         external
-        view
+        pure
         returns (bytes32 signal);
 
     /// @notice Returns true if a signal root is ached. If storage slot value is not bytes32(0),

--- a/packages/protocol/contracts/signal/ISignalService.sol
+++ b/packages/protocol/contracts/signal/ISignalService.sol
@@ -125,10 +125,12 @@ interface ISignalService {
 
     /// @notice Returns true if a signal root is ached. If storage slot value is not bytes32(0),
     /// than signal root is cached, so no need for account proof.
+    /// @dev If return values _cahced false and _blockId 0, it means there is no cached signal
+    /// service root with give chainId).
     /// @param chainId Indenitifer of the chain for we are quering it's cached signal service root.
     /// @param blockId The block id in question. If 0, indicates the query is targetting the latest
     /// synced height.
-    /// @return _blockId blockId or highest syned block id.
+    /// @return _blockId blockId or highest synced block id.
     /// @return _cached True if cached, false if not.
     function isSignalRootCached(
         uint64 chainId,

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -194,6 +194,24 @@ contract SignalService is EssentialContract, ISignalService {
         }
     }
 
+    /// @inheritdoc ISignalService
+    function isSignalRootCached(
+        uint64 chainId,
+        uint64 blockId
+    )
+        public
+        view
+        returns (uint64 _blockId, bool _cached)
+    {
+        _blockId = blockId != 0 ? blockId : topBlockId[chainId][LibSignals.SIGNAL_ROOT];
+
+        bytes32 signal = signalForChainData(chainId, LibSignals.SIGNAL_ROOT, _blockId);
+        if (_loadSignalValue(address(this), signal) != 0) {
+            _cached = true;
+        }
+    }
+
+    /// @inheritdoc ISignalService
     function signalForChainData(
         uint64 chainId,
         bytes32 kind,

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -195,23 +195,6 @@ contract SignalService is EssentialContract, ISignalService {
     }
 
     /// @inheritdoc ISignalService
-    function isSignalRootCached(
-        uint64 chainId,
-        uint64 blockId
-    )
-        public
-        view
-        returns (uint64 _blockId, bool _cached)
-    {
-        _blockId = blockId != 0 ? blockId : topBlockId[chainId][LibSignals.SIGNAL_ROOT];
-
-        bytes32 signal = signalForChainData(chainId, LibSignals.SIGNAL_ROOT, _blockId);
-        if (_loadSignalValue(address(this), signal) != 0) {
-            _cached = true;
-        }
-    }
-
-    /// @inheritdoc ISignalService
     function signalForChainData(
         uint64 chainId,
         bytes32 kind,

--- a/packages/protocol/test/signal/SignalService.t.sol
+++ b/packages/protocol/test/signal/SignalService.t.sol
@@ -517,6 +517,17 @@ contract TestSignalService is TaikoTest {
             proofs[7].chainId, LibSignals.STATE_ROOT, proofs[8].blockId, proofs[8].rootHash
         );
 
+        // proofs[0] we do need full proof
+        (uint64 blockId, bool cached) =
+            signalService.isSignalRootCached(proofs[0].chainId, proofs[0].blockId);
+        assertEq(blockId, proofs[0].blockId);
+        assertEq(cached, false);
+
+        // proofs[7] we do not need full proof (only signal service storage proof) bc. it is cached
+        (blockId, cached) = signalService.isSignalRootCached(proofs[7].chainId, 0);
+        assertEq(blockId, proofs[8].blockId);
+        assertEq(cached, true);
+
         signalService.proveSignalReceived({
             chainId: srcChainId,
             app: randAddress(),

--- a/packages/protocol/test/signal/SignalService.t.sol
+++ b/packages/protocol/test/signal/SignalService.t.sol
@@ -517,17 +517,6 @@ contract TestSignalService is TaikoTest {
             proofs[7].chainId, LibSignals.STATE_ROOT, proofs[8].blockId, proofs[8].rootHash
         );
 
-        // proofs[0] we do need full proof
-        (uint64 blockId, bool cached) =
-            signalService.isSignalRootCached(proofs[0].chainId, proofs[0].blockId);
-        assertEq(blockId, proofs[0].blockId);
-        assertEq(cached, false);
-
-        // proofs[7] we do not need full proof (only signal service storage proof) bc. it is cached
-        (blockId, cached) = signalService.isSignalRootCached(proofs[7].chainId, 0);
-        assertEq(blockId, proofs[8].blockId);
-        assertEq(cached, true);
-
         signalService.proveSignalReceived({
             chainId: srcChainId,
             app: randAddress(),

--- a/packages/protocol/test/team/airdrop/ERC20Airdrop.t.sol
+++ b/packages/protocol/test/team/airdrop/ERC20Airdrop.t.sol
@@ -91,7 +91,7 @@ contract TestERC20Airdrop is TaikoTest {
 
         // 2. Need to add it to the AddressManager (below here i'm just mocking it) so that we can
         // mint TKO. Basically this step only required in this test. Only thing we need to be sure
-        // on testnet/mainnet. Vault (which Aridrop transfers from) HAVE tokens.
+        // on testnet/mainnet. Vault (which Airdrop transfers from) HAVE tokens.
         addressManager = new MockAddressManager(address(vault));
 
         // 3. Deploy a bridged TKO token (but on mainnet it will be just a bridged token from L1 to


### PR DESCRIPTION
@KorbinianK @cyberhorsey 
You can query if we need to have ful proof or not if calling:

`getSyncedChainData`(`cahinId`, **`LibSignals.SIGNAL_ROOT`**, `blockId`)

If you supply 0 for blockId, it will return you the `topBlockId` where the **`LibSignals.SIGNAL_ROOT`** was cached and you dont need to have full proof (for that block height!).

If you supply non-0 for blockId, it will specifically search for that block id and revert if not cached.