### PR TITLE
fix(protocol): fix isSignalSent bug

### DIFF
--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -81,7 +81,7 @@ contract SignalService is EssentialContract, ISignalService {
 
     /// @inheritdoc ISignalService
     function sendSignal(bytes32 signal) external returns (bytes32 slot) {
-        return _sendSignal(msg.sender, signal, signal);
+        return _sendSignal(msg.sender, signal, 1);
     }
 
     /// @inheritdoc ISignalService

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -44,7 +44,7 @@ contract SignalService is EssentialContract, ISignalService {
     mapping(address => bool) public isAuthorized;
     uint256[49] private __gap;
 
-    event SignalSent(address app, bytes32 signal, bytes32 value);
+    event SignalSent(address app, bytes32 signal, bytes32 slot, bytes32 value);
     event Authorized(address indexed addr, bool authrized);
 
     error SS_EMPTY_PROOF();
@@ -282,7 +282,7 @@ contract SignalService is EssentialContract, ISignalService {
         assembly {
             sstore(slot, value)
         }
-        emit SignalSent(app, signal, value);
+        emit SignalSent(app, signal, slot, value);
     }
 
     function _cacheChainData(

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -81,7 +81,7 @@ contract SignalService is EssentialContract, ISignalService {
 
     /// @inheritdoc ISignalService
     function sendSignal(bytes32 signal) external returns (bytes32 slot) {
-        return _sendSignal(msg.sender, signal, bytes32(uint(1)));
+        return _sendSignal(msg.sender, signal, bytes32(uint256(1)));
     }
 
     /// @inheritdoc ISignalService

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -82,7 +82,7 @@ contract SignalService is EssentialContract, ISignalService {
 
     /// @inheritdoc ISignalService
     function sendSignal(bytes32 signal) external returns (bytes32 slot) {
-        return _sendSignal(msg.sender, signal, bytes32(uint256(1)));
+        return _sendSignal(msg.sender, signal, signal);
     }
 
     /// @inheritdoc ISignalService

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -44,6 +44,7 @@ contract SignalService is EssentialContract, ISignalService {
     mapping(address => bool) public isAuthorized;
     uint256[49] private __gap;
 
+    event SignalSent(address app, bytes32 signal, bytes32 value);
     event Authorized(address indexed addr, bool authrized);
 
     error SS_EMPTY_PROOF();
@@ -281,6 +282,7 @@ contract SignalService is EssentialContract, ISignalService {
         assembly {
             sstore(slot, value)
         }
+        emit SignalSent(app, signal, value);
     }
 
     function _cacheChainData(

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -81,7 +81,7 @@ contract SignalService is EssentialContract, ISignalService {
 
     /// @inheritdoc ISignalService
     function sendSignal(bytes32 signal) external returns (bytes32 slot) {
-        return _sendSignal(msg.sender, signal, 1);
+        return _sendSignal(msg.sender, signal, bytes32(uint(1)));
     }
 
     /// @inheritdoc ISignalService
@@ -172,7 +172,7 @@ contract SignalService is EssentialContract, ISignalService {
 
     /// @inheritdoc ISignalService
     function isSignalSent(address app, bytes32 signal) public view returns (bool) {
-        return _loadSignalValue(app, signal) == signal;
+        return _loadSignalValue(app, signal) != 0;
     }
 
     /// @inheritdoc ISignalService


### PR DESCRIPTION
When checking if a signal is sent, we should check if the value written is non-zero rather than the signal itself -- for relayed chain data, the signal value is the chain data ,not the signal.