### PR TITLE
chore(protocol): remove unnecessary reserved slots

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -127,7 +127,6 @@ library TaikoData {
         bytes32 blockHash;
         bytes32 stateRoot;
         bytes32 graffiti;
-        bytes32[2] __reserved;
     }
 
     /// @dev Struct representing state transition data.

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -790,8 +790,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                     parentHash: parentHash,
                     blockHash: blockHash,
                     stateRoot: stateRoot,
-                    graffiti: 0x0,
-                    __reserved: [bytes32(0), bytes32(0)]
+                    graffiti: 0x0
                 });
 
                 TaikoData.TierProof memory proof;

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -243,8 +243,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
             parentHash: parentHash,
             blockHash: blockHash,
             stateRoot: stateRoot,
-            graffiti: 0x0,
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: 0x0
         });
 
         bytes32 instance =

--- a/packages/protocol/test/verifiers/GuardianVerifier.t.sol
+++ b/packages/protocol/test/verifiers/GuardianVerifier.t.sol
@@ -33,8 +33,7 @@ contract TestGuardianVerifier is TaikoL1TestBase {
             parentHash: bytes32(0),
             blockHash: bytes32(0),
             stateRoot: bytes32(0),
-            graffiti: bytes32(0),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32(0)
         });
 
         // TierProof
@@ -62,8 +61,7 @@ contract TestGuardianVerifier is TaikoL1TestBase {
             parentHash: bytes32(0),
             blockHash: bytes32(0),
             stateRoot: bytes32(0),
-            graffiti: bytes32(0),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32(0)
         });
 
         // TierProof

--- a/packages/protocol/test/verifiers/PseZkVerifier.t.sol
+++ b/packages/protocol/test/verifiers/PseZkVerifier.t.sol
@@ -51,8 +51,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32(0),
             blockHash: bytes32(0),
             stateRoot: bytes32(0),
-            graffiti: bytes32(0),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32(0)
         });
 
         // TierProof
@@ -80,8 +79,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32(0),
             blockHash: bytes32(0),
             stateRoot: bytes32(0),
-            graffiti: bytes32(0),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32(0)
         });
 
         // TierProof
@@ -133,8 +131,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof
@@ -172,8 +169,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof
@@ -203,8 +199,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof
@@ -243,8 +238,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof
@@ -282,8 +276,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof
@@ -318,8 +311,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof
@@ -361,8 +353,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof
@@ -404,8 +395,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof
@@ -444,8 +434,7 @@ contract TestPseZkVerifier is TaikoL1TestBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("23"),
             stateRoot: bytes32("34"),
-            graffiti: bytes32("1234"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("1234")
         });
 
         // TierProof

--- a/packages/protocol/test/verifiers/SgxVerifier.t.sol
+++ b/packages/protocol/test/verifiers/SgxVerifier.t.sol
@@ -196,8 +196,7 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("34"),
             stateRoot: bytes32("56"),
-            graffiti: bytes32("78"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("78")
         });
 
         // TierProof
@@ -246,8 +245,7 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("34"),
             stateRoot: bytes32("56"),
-            graffiti: bytes32("78"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("78")
         });
 
         // TierProof
@@ -279,8 +277,7 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("34"),
             stateRoot: bytes32("56"),
-            graffiti: bytes32("78"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("78")
         });
 
         // TierProof
@@ -314,8 +311,7 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("34"),
             stateRoot: bytes32("56"),
-            graffiti: bytes32("78"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("78")
         });
 
         // TierProof
@@ -354,8 +350,7 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("34"),
             stateRoot: bytes32("56"),
-            graffiti: bytes32("78"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("78")
         });
 
         // TierProof
@@ -395,8 +390,7 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
             parentHash: bytes32("12"),
             blockHash: bytes32("34"),
             stateRoot: bytes32("56"),
-            graffiti: bytes32("78"),
-            __reserved: [bytes32(0), bytes32(0)]
+            graffiti: bytes32("78")
         });
 
         // TierProof


### PR DESCRIPTION
`Transition` struct is never persisted on chain.