### PR TITLE
fix(protocol): ensure onMessageInvocation only callable by the local bridge

### DIFF
--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -36,7 +36,12 @@ abstract contract CrossChainOwned is EssentialContract, IMessageInvocable {
     error XCO_PERMISSION_DENIED();
     error XCO_TX_REVERTED();
 
-    function onMessageInvocation(bytes calldata data) external payable whenNotPaused {
+    function onMessageInvocation(bytes calldata data)
+        external
+        payable
+        whenNotPaused
+        onlyFromNamed("bridge")
+    {
         if (msg.sender != resolve("bridge", false)) revert XCO_PERMISSION_DENIED();
 
         (uint64 txId, bytes memory txdata) = abi.decode(data, (uint64, bytes));

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -84,5 +84,8 @@ interface IRecallableSender {
 /// @title IMessageInvocable
 /// @notice An interface that all bridge message receiver shall implement
 interface IMessageInvocable {
+    /// @notice Called when this contract is the bridge target.
+    /// @param data The data for this contract to interpret.
+    /// @dev This method should be guarded with `onlyFromNamed("bridge")`.
     function onMessageInvocation(bytes calldata data) external payable;
 }

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -93,7 +93,13 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
     }
 
     /// @inheritdoc IMessageInvocable
-    function onMessageInvocation(bytes calldata data) external payable nonReentrant whenNotPaused {
+    function onMessageInvocation(bytes calldata data)
+        external
+        payable
+        nonReentrant
+        whenNotPaused
+        onlyFromNamed("bridge")
+    {
         (
             CanonicalNFT memory ctoken,
             address from,

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -212,7 +212,13 @@ contract ERC20Vault is BaseVault {
     }
 
     /// @inheritdoc IMessageInvocable
-    function onMessageInvocation(bytes calldata data) external payable nonReentrant whenNotPaused {
+    function onMessageInvocation(bytes calldata data)
+        external
+        payable
+        nonReentrant
+        whenNotPaused
+        onlyFromNamed("bridge")
+    {
         (CanonicalERC20 memory ctoken, address from, address to, uint256 amount) =
             abi.decode(data, (CanonicalERC20, address, address, uint256));
 

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -81,7 +81,13 @@ contract ERC721Vault is BaseNFTVault, IERC721ReceiverUpgradeable {
     }
 
     /// @inheritdoc IMessageInvocable
-    function onMessageInvocation(bytes calldata data) external payable nonReentrant whenNotPaused {
+    function onMessageInvocation(bytes calldata data)
+        external
+        payable
+        nonReentrant
+        whenNotPaused
+        onlyFromNamed("bridge")
+    {
         (CanonicalNFT memory ctoken, address from, address to, uint256[] memory tokenIds) =
             abi.decode(data, (CanonicalNFT, address, address, uint256[]));
 


### PR DESCRIPTION
`onMessageInvocation` is designed to be callable by the local bridge, guard each `onMessageInvocation` with `onlyFromNamed("bridge")` make it more explicit. Using `onlyFromNamed("bridge")` also prevents one `onMessageInvocation` from calling another `onMessageInvocation`, which is a security issue.