### PR TITLE
feat(protocol): use Ownable2StepUpgradeable for better security

### DIFF
--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -44,6 +44,8 @@ abstract contract Essential1StepContract is OwnerUUPSUpgradable, AddressResolver
 }
 
 abstract contract EssentialContract is Essential1StepContract, Ownable2StepUpgradeable {
+    uint256[50] private __gap;
+
     function transferOwnership(address newOwner)
         public
         virtual

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -14,10 +14,11 @@
 
 pragma solidity 0.8.24;
 
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "./AddressResolver.sol";
 import "./OwnerUUPSUpgradable.sol";
 
-abstract contract EssentialContract is OwnerUUPSUpgradable, AddressResolver {
+abstract contract Essential1StepContract is OwnerUUPSUpgradable, AddressResolver {
     uint256[50] private __gap;
 
     /// @dev Modifier that ensures the caller is the owner or resolved address of a given name.
@@ -39,5 +40,23 @@ abstract contract EssentialContract is OwnerUUPSUpgradable, AddressResolver {
     // solhint-disable-next-line func-name-mixedcase
     function __Essential_init() internal virtual {
         __Essential_init(address(0));
+    }
+}
+
+abstract contract EssentialContract is Essential1StepContract, Ownable2StepUpgradeable {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(Ownable2StepUpgradeable, OwnableUpgradeable)
+    {
+        Ownable2StepUpgradeable.transferOwnership(newOwner);
+    }
+
+    function _transferOwnership(address newOwner)
+        internal
+        virtual
+        override(Ownable2StepUpgradeable, OwnableUpgradeable)
+    {
+        Ownable2StepUpgradeable._transferOwnership(newOwner);
     }
 }

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -48,7 +48,6 @@ abstract contract EssentialContract is Essential1StepContract, Ownable2StepUpgra
 
     function transferOwnership(address newOwner)
         public
-        virtual
         override(Ownable2StepUpgradeable, OwnableUpgradeable)
     {
         Ownable2StepUpgradeable.transferOwnership(newOwner);
@@ -56,7 +55,6 @@ abstract contract EssentialContract is Essential1StepContract, Ownable2StepUpgra
 
     function _transferOwnership(address newOwner)
         internal
-        virtual
         override(Ownable2StepUpgradeable, OwnableUpgradeable)
     {
         Ownable2StepUpgradeable._transferOwnership(newOwner);

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -48,14 +48,14 @@ abstract contract EssentialContract is Essential1StepContract, Ownable2StepUpgra
 
     function transferOwnership(address newOwner)
         public
-        override(Ownable2StepUpgradeable, OwnableUpgradeable)
+        override(OwnableUpgradeable, Ownable2StepUpgradeable)
     {
         Ownable2StepUpgradeable.transferOwnership(newOwner);
     }
 
     function _transferOwnership(address newOwner)
         internal
-        override(Ownable2StepUpgradeable, OwnableUpgradeable)
+        override(OwnableUpgradeable, Ownable2StepUpgradeable)
     {
         Ownable2StepUpgradeable._transferOwnership(newOwner);
     }

--- a/packages/protocol/contracts/tokenvault/BaseVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseVault.sol
@@ -21,7 +21,7 @@ import "../libs/LibAddress.sol";
 import "../libs/LibDeploy.sol";
 
 abstract contract BaseVault is
-    Essential1StepContract,
+    EssentialContract,
     IRecallableSender,
     IMessageInvocable,
     IERC165Upgradeable

--- a/packages/protocol/contracts/tokenvault/BaseVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseVault.sol
@@ -21,7 +21,7 @@ import "../libs/LibAddress.sol";
 import "../libs/LibDeploy.sol";
 
 abstract contract BaseVault is
-    EssentialContract,
+    Essential1StepContract,
     IRecallableSender,
     IMessageInvocable,
     IERC165Upgradeable

--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -25,7 +25,7 @@ import "./LibBridgedToken.sol";
 /// @title BridgedERC1155
 /// @notice Contract for bridging ERC1155 tokens across different chains.
 contract BridgedERC1155 is
-    EssentialContract,
+    Essential1StepContract,
     IERC1155Upgradeable,
     IERC1155MetadataURIUpgradeable,
     ERC1155Upgradeable

--- a/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
@@ -18,7 +18,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "../common/EssentialContract.sol";
 import "./IBridgedERC20.sol";
 
-abstract contract BridgedERC20Base is EssentialContract, IBridgedERC20 {
+abstract contract BridgedERC20Base is Essential1StepContract, IBridgedERC20 {
     address public migratingAddress; // slot 1
     bool public migratingInbound;
     uint256[49] private __gap;

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -21,7 +21,7 @@ import "./LibBridgedToken.sol";
 
 /// @title BridgedERC721
 /// @notice Contract for bridging ERC721 tokens across different chains.
-contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
+contract BridgedERC721 is Essential1StepContract, ERC721Upgradeable {
     address public srcToken; // Address of the source token contract.
     uint256 public srcChainId; // Source chain ID where the token originates.
 

--- a/packages/protocol/test/common/EssentialContract.t.sol
+++ b/packages/protocol/test/common/EssentialContract.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 
-contract Target1 is EssentialContract {
+contract Target1 is Essential1StepContract {
     uint256 public count;
 
     function init() external initializer {


### PR DESCRIPTION
This is to address the findings from Quill Audit:

## Description: 
Using single step ownership transfer is not secure, the existing owner can assign any new address as owner, and lose the ownership if the assigned address is incorrect address which can’t perform actions.
[Ownable2StepUpgradable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/access/Ownable2StepUpgradeable.sol) provides added safety where the pending owner can accept the ownership due to its two-step process to transfer the ownership.

## Recommendation(s): 
Consider using Ownable2StepUpgradable instead of OwnableUpgradable.