### PR TITLE
fix(protocol): use IERC721Upgradeable instead of ERC721Upgradeable under ERC721Airdrop

### DIFF
--- a/packages/protocol/contracts/team/airdrop/ERC721Airdrop.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC721Airdrop.sol
@@ -14,7 +14,7 @@
 
 pragma solidity 0.8.24;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
 import "./MerkleClaimable.sol";
 
 /// @title ERC721Airdrop


### PR DESCRIPTION
It's sufficient to import just the ERC721 interface to perform the airdrop