### PR TITLE
feat(guardian-prover-health-check): add indexer in MySQL

### DIFF
--- a/packages/guardian-prover-health-check/migrations/1666651005_alter_health_checks_guardian_prover_id_created_at_index.sql
+++ b/packages/guardian-prover-health-check/migrations/1666651005_alter_health_checks_guardian_prover_id_created_at_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `health_checks` ADD INDEX `health_checks_guardian_prover_id_created_at_index` (`guardian_prover_id`, `created_at`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX health_checks_guardian_prover_id_created_at_index on health_checks;
+-- +goose StatementEnd


### PR DESCRIPTION
It's to to optimize these queries:
```
SELECT * FROM `health_checks` WHERE `guardian_prover_id` = ? ORDER BY `created_at` DESC LIMIT ?

SELECT COUNT ( * ) FROM `health_checks` WHERE `guardian_prover_id` = ? AND `created_at` > NOW ( ) - INTERVAL ? SQL_TSI_DAY
```