### PR TITLE
feat(protocol): enforce initializer call with onlyInitializing modifier

### DIFF
--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -15,7 +15,6 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../common/EssentialContract.sol";
 import "../bridge/IBridge.sol";
 
@@ -24,7 +23,7 @@ import "../bridge/IBridge.sol";
 /// signals for transaction approval.
 /// @dev Notice that when sending the message on the owner chain, the gas limit of the message must
 /// not be zero, so on this chain, some EOA can help execute this transaction.
-abstract contract CrossChainOwned is Initializable, EssentialContract, IMessageInvocable {
+abstract contract CrossChainOwned is EssentialContract, IMessageInvocable {
     uint64 public ownerChainId; // slot 1
     uint64 public nextTxId;
     uint256[49] private __gap;

--- a/packages/protocol/contracts/L2/CrossChainOwned.sol
+++ b/packages/protocol/contracts/L2/CrossChainOwned.sol
@@ -15,7 +15,7 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../common/EssentialContract.sol";
 import "../bridge/IBridge.sol";
 
@@ -24,7 +24,7 @@ import "../bridge/IBridge.sol";
 /// signals for transaction approval.
 /// @dev Notice that when sending the message on the owner chain, the gas limit of the message must
 /// not be zero, so on this chain, some EOA can help execute this transaction.
-abstract contract CrossChainOwned is EssentialContract, IMessageInvocable {
+abstract contract CrossChainOwned is Initializable, EssentialContract, IMessageInvocable {
     uint64 public ownerChainId; // slot 1
     uint64 public nextTxId;
     uint256[49] private __gap;
@@ -66,6 +66,7 @@ abstract contract CrossChainOwned is EssentialContract, IMessageInvocable {
     )
         internal
         virtual
+        onlyInitializing
     {
         __Essential_init(_addressManager);
 

--- a/packages/protocol/contracts/common/AddressResolver.sol
+++ b/packages/protocol/contracts/common/AddressResolver.sol
@@ -14,6 +14,7 @@
 
 pragma solidity 0.8.24;
 
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./AddressManager.sol";
 
 /// @title AddressResolver
@@ -25,7 +26,7 @@ import "./AddressManager.sol";
 /// Note that the address manager should be changed using upgradability, there
 /// is no setAddressManager() function go guarantee atomicness across all
 /// contracts that are resolvers.
-abstract contract AddressResolver {
+abstract contract AddressResolver is Initializable {
     address public addressManager;
     uint256[49] private __gap;
 
@@ -93,7 +94,7 @@ abstract contract AddressResolver {
     /// @dev Initialization method for setting up AddressManager reference.
     /// @param _addressManager Address of the AddressManager.
     // solhint-disable-next-line func-name-mixedcase
-    function __AddressResolver_init(address _addressManager) internal virtual {
+    function __AddressResolver_init(address _addressManager) internal virtual onlyInitializing {
         if (block.chainid > type(uint64).max) {
             revert RESOLVER_UNEXPECTED_CHAINID();
         }

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -15,10 +15,11 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./AddressResolver.sol";
 import "./OwnerUUPSUpgradable.sol";
 
-abstract contract Essential1StepContract is OwnerUUPSUpgradable, AddressResolver {
+abstract contract Essential1StepContract is Initializable, OwnerUUPSUpgradable, AddressResolver {
     uint256[50] private __gap;
 
     /// @dev Modifier that ensures the caller is the owner or resolved address of a given name.
@@ -31,14 +32,14 @@ abstract contract Essential1StepContract is OwnerUUPSUpgradable, AddressResolver
     /// @notice Initializes the contract with an address manager.
     /// @param _addressManager The address of the address manager.
     // solhint-disable-next-line func-name-mixedcase
-    function __Essential_init(address _addressManager) internal virtual {
+    function __Essential_init(address _addressManager) internal virtual onlyInitializing {
         __OwnerUUPSUpgradable_init();
         __AddressResolver_init(_addressManager);
     }
 
     /// @notice Initializes the contract without an address manager.
     // solhint-disable-next-line func-name-mixedcase
-    function __Essential_init() internal virtual {
+    function __Essential_init() internal virtual onlyInitializing {
         __Essential_init(address(0));
     }
 }

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -15,11 +15,10 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./AddressResolver.sol";
 import "./OwnerUUPSUpgradable.sol";
 
-abstract contract Essential1StepContract is Initializable, OwnerUUPSUpgradable, AddressResolver {
+abstract contract Essential1StepContract is OwnerUUPSUpgradable, AddressResolver {
     uint256[50] private __gap;
 
     /// @dev Modifier that ensures the caller is the owner or resolved address of a given name.

--- a/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
+++ b/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
@@ -16,13 +16,12 @@ pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /// @title OwnerUUPSUpgradable
 /// @notice This contract serves as the base contract for many core components.
 /// @dev We didn't use OpenZeppelin's PausableUpgradeable and
 /// ReentrancyGuardUpgradeable contract to optimize storage reads.
-abstract contract OwnerUUPSUpgradable is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+abstract contract OwnerUUPSUpgradable is UUPSUpgradeable, OwnableUpgradeable {
     uint8 private constant _FALSE = 1;
     uint8 private constant _TRUE = 2;
 

--- a/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
+++ b/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol
@@ -16,12 +16,13 @@ pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /// @title OwnerUUPSUpgradable
 /// @notice This contract serves as the base contract for many core components.
 /// @dev We didn't use OpenZeppelin's PausableUpgradeable and
 /// ReentrancyGuardUpgradeable contract to optimize storage reads.
-abstract contract OwnerUUPSUpgradable is UUPSUpgradeable, OwnableUpgradeable {
+abstract contract OwnerUUPSUpgradable is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     uint8 private constant _FALSE = 1;
     uint8 private constant _TRUE = 2;
 
@@ -83,7 +84,7 @@ abstract contract OwnerUUPSUpgradable is UUPSUpgradeable, OwnableUpgradeable {
 
     /// @notice Initializes the contract with an address manager.
     // solhint-disable-next-line func-name-mixedcase
-    function __OwnerUUPSUpgradable_init() internal virtual {
+    function __OwnerUUPSUpgradable_init() internal virtual onlyInitializing {
         __Ownable_init();
         _paused = _FALSE;
     }

--- a/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol
+++ b/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol
@@ -15,12 +15,11 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../../common/EssentialContract.sol";
 
 /// @title MerkleClaimable
 /// Contract for managing Taiko token airdrop for eligible users
-abstract contract MerkleClaimable is Initializable, EssentialContract {
+abstract contract MerkleClaimable is EssentialContract {
     mapping(bytes32 => bool) public isClaimed;
     bytes32 public merkleRoot;
     uint64 public claimStart;

--- a/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol
+++ b/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol
@@ -15,11 +15,12 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../../common/EssentialContract.sol";
 
 /// @title MerkleClaimable
 /// Contract for managing Taiko token airdrop for eligible users
-abstract contract MerkleClaimable is EssentialContract {
+abstract contract MerkleClaimable is Initializable, EssentialContract {
     mapping(bytes32 => bool) public isClaimed;
     bytes32 public merkleRoot;
     uint64 public claimStart;
@@ -63,6 +64,7 @@ abstract contract MerkleClaimable is EssentialContract {
         bytes32 _merkleRoot
     )
         internal
+        onlyInitializing
     {
         _setConfig(_claimStart, _claimEnd, _merkleRoot);
     }


### PR DESCRIPTION
This PR strengthens code security by adding the `onlyInitializing` modifier to several `init` methods, ensuring they are called only from functions with an `initializer` modifier. Additionally, it improves code clarity by directly importing `Initializable` rather than relying on child inheritance. These changes enhance contract integrity and maintainability.

The init methods lacking the `onlyInitializing` modifier are as follows:

1. [__AddressResolver_init()](https://github.com/taikoxyz/taiko-mono/blob/bdf61f28fc266610cb8f243b799746197bf13641/packages/protocol/contracts/common/AddressResolver.sol#L96)
2. [__Essential_init()](https://github.com/taikoxyz/taiko-mono/blob/bdf61f28fc266610cb8f243b799746197bf13641/packages/protocol/contracts/common/EssentialContract.sol#L34)
3. [__OwnerUUPSUpgradable_init()](https://github.com/taikoxyz/taiko-mono/blob/bdf61f28fc266610cb8f243b799746197bf13641/packages/protocol/contracts/common/OwnerUUPSUpgradable.sol#L86)
4. [__CrossChainOwned_init()](https://github.com/taikoxyz/taiko-mono/blob/bdf61f28fc266610cb8f243b799746197bf13641/packages/protocol/contracts/L2/CrossChainOwned.sol#L63)
5. [__MerkleClaimable_init()](https://github.com/taikoxyz/taiko-mono/blob/bdf61f28fc266610cb8f243b799746197bf13641/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol#L60)
