### PR TITLE
fix(bridge-ui): enable continue button for scanned nft imports

### DIFF
--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
   import { t } from 'svelte-i18n';
 
   import { enteredAmount, selectedNFTs } from '$components/Bridge/state';
@@ -61,10 +60,6 @@
   } else {
     canProceed = false;
   }
-
-  onDestroy(() => {
-    $selectedNFTs = [];
-  });
 </script>
 
 {$selectedNFTs?.length} <br />

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
@@ -40,6 +40,7 @@
   };
 
   function onManualImportClick() {
+    $selectedNFTs = [];
     $selectedImportMethod = ImportMethod.MANUAL;
   }
   $: isERC1155 = $selectedNFTs ? $selectedNFTs.some((nft) => nft.type === 'ERC1155') : false;

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/StepNavigation/StepNavigation.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/StepNavigation/StepNavigation.svelte
@@ -39,7 +39,10 @@
   };
 
   const handlePreviousStep = () => {
-    if (activeStep === BridgeSteps.REVIEW) {
+    if (activeStep === BridgeSteps.IMPORT) {
+      $selectedNFTs = [];
+      $selectedImportMethod = ImportMethod.NONE;
+    } else if (activeStep === BridgeSteps.REVIEW) {
       activeStep = BridgeSteps.IMPORT;
     } else if (activeStep === BridgeSteps.CONFIRM) {
       activeStep = BridgeSteps.REVIEW;
@@ -65,7 +68,9 @@
           <span class="body-bold">{nextStepButtonText}</span>
         </ActionButton>
 
-        <StepBack on:click={() => ($selectedImportMethod = ImportMethod.NONE)}>{$t('common.back')}</StepBack>
+        <StepBack on:click={() => handlePreviousStep()}>
+          {$t('common.back')}
+        </StepBack>
       {/if}
     {/if}
     {#if activeStep === BridgeSteps.REVIEW}

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/StepNavigation/StepNavigation.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/StepNavigation/StepNavigation.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
 
-  import { importDone } from '$components/Bridge/state';
+  import { selectedNFTs } from '$components/Bridge/state';
   import { BridgeSteps, BridgingStatus, ImportMethod } from '$components/Bridge/types';
   import { ActionButton } from '$components/Button';
 
@@ -59,7 +59,7 @@
       {#if $selectedImportMethod !== ImportMethod.NONE}
         <ActionButton
           priority="primary"
-          disabled={!$importDone}
+          disabled={!$selectedNFTs || $selectedNFTs.length === 0}
           loading={validatingImport}
           on:click={() => handleNextStep()}>
           <span class="body-bold">{nextStepButtonText}</span>


### PR DESCRIPTION
Fixes https://github.com/taikoxyz/taiko-mono/issues/16064

* Continue button is disabled when trying to bridge scanned NFTs

Before

![image](https://github.com/taikoxyz/taiko-mono/assets/105874219/8b20f33b-818d-4e7a-9dd8-fd7a4e6baca8)

After

![image](https://github.com/taikoxyz/taiko-mono/assets/105874219/8e223cb9-2952-4870-8a3d-7a94eeb34fab)
