### PR TITLE
feat(relayer): add indexer for MAX() in MySQL

### DIFF
--- a/packages/relayer/migrations/1708366661_alert_processed_blocks_chain_id_event_name_block_height_index.sql
+++ b/packages/relayer/migrations/1708366661_alert_processed_blocks_chain_id_event_name_block_height_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `processed_blocks` ADD INDEX `processed_blocks_chain_id_event_name_block_height_index` (`chain_id`, `event_name`, `block_height`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX processed_blocks_chain_id_event_name_block_height_index on processed_blocks;
+-- +goose StatementEnd


### PR DESCRIPTION
It's to optimize the query
```
SELECT `id`, `block_height`, `hash`, `event_name`, `chain_id`
FROM `processed_blocks`
WHERE `block_height` = (
  SELECT MAX(`block_height`)
  FROM `processed_blocks`
  WHERE `chain_id` = ? AND `event_name` = ?
)
```

The subquery filters rows based on ```chain_id``` and ```event_name``` and then finds the maximum block_height. An index that includes these three columns can significantly improve the performance of the subquery by allowing MySQL to quickly locate the rows that match the given ```chain_id``` and ```event_name```, and then efficiently determine the maximum ```block_height``` among those rows.