### PR TITLE
ci(repo): skip vercel previews on dependabot PRs

### DIFF
--- a/.github/workflows/bridge-ui-preview.yml
+++ b/.github/workflows/bridge-ui-preview.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   Deploy-Preview:
     runs-on: [taiko-runner]
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/fork-diff-preview.yml
+++ b/.github/workflows/fork-diff-preview.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   Deploy-Preview:
     runs-on: [taiko-runner]
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/guardian-prover-health-check-ui-preview.yml
+++ b/.github/workflows/guardian-prover-health-check-ui-preview.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   Deploy-Preview:
     runs-on: [taiko-runner]
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
fixes those dependabot failures.