### PR TITLE
chore(protocol): remove uncessary cast

### DIFF
--- a/packages/protocol/contracts/libs/LibTrieProof.sol
+++ b/packages/protocol/contracts/libs/LibTrieProof.sol
@@ -57,10 +57,7 @@ library LibTrieProof {
         }
 
         bool verified = SecureMerkleTrie.verifyInclusionProof(
-            bytes.concat(slot),
-            RLPWriter.writeUint(uint256(value)),
-            storageProof,
-            bytes32(storageRoot)
+            bytes.concat(slot), RLPWriter.writeUint(uint256(value)), storageProof, storageRoot
         );
 
         if (!verified) revert LTP_INVALID_INCLUSION_PROOF();


### PR DESCRIPTION
Within the [LibTrieProof contract](https://github.com/taikoxyz/taiko-mono/blob/e610d1907ef47fb6e25d8bc26e9b7edf3954d886/packages/protocol/contracts/libs/LibTrieProof.sol), the [bytes32(storageRoot)](https://github.com/taikoxyz/taiko-mono/blob/e610d1907ef47fb6e25d8bc26e9b7edf3954d886/packages/protocol/contracts/libs/LibTrieProof.sol#L63) cast was unnecessary.
To improve the overall clarity, intent, and readability of the codebase, consider removing unnecessary casts.