### PR TITLE
ci(repo): publish github releases in draft mode

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "draft": true,
   "packages": {
     "packages/branding": {},
     "packages/bridge-ui": {},


### PR DESCRIPTION
## summary

This will tell @taiko-kitty to open github releases in draft mode, so we can add some fun / important message descriptions for out releases.