### PR TITLE
fix(protocol): Require amount=1 when transferring ERC721 instead of 0

### DIFF
--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -18,6 +18,16 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
 
     uint256[50] private __gap;
 
+    /// @notice Helper function to create array of ones with specified length
+    /// @param length array length to create
+    function createArrayOfOnes(uint256 length) private pure returns (uint256[] memory) {
+        uint256[] memory ones = new uint256[](length);
+        for (uint256 i; i < length; ++i) {
+            ones[i] = 1;
+        }
+        return ones;
+    }
+
     /// @notice Transfers ERC721 tokens to this vault and sends a message to the
     /// destination chain so the user can receive the same (bridged) tokens
     /// by invoking the message call.
@@ -32,7 +42,7 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
         returns (IBridge.Message memory message_)
     {
         for (uint256 i; i < _op.tokenIds.length; ++i) {
-            if (_op.amounts[i] != 0) revert VAULT_INVALID_AMOUNT();
+            if (_op.amounts[i] != 1) revert VAULT_INVALID_AMOUNT();
         }
 
         if (!_op.token.supportsInterface(ERC721_INTERFACE_ID)) {
@@ -102,7 +112,7 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
             ctoken: ctoken.addr,
             token: token,
             tokenIds: tokenIds,
-            amounts: new uint256[](tokenIds.length)
+            amounts: createArrayOfOnes(tokenIds.length)
         });
     }
 
@@ -134,7 +144,7 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
             ctoken: ctoken.addr,
             token: token,
             tokenIds: tokenIds,
-            amounts: new uint256[](tokenIds.length)
+            amounts: createArrayOfOnes(tokenIds.length)
         });
     }
 

--- a/packages/protocol/test/tokenvault/ERC721Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC721Vault.t.sol
@@ -236,7 +236,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
@@ -285,7 +285,7 @@ contract ERC721VaultTest is TaikoTest {
         erc721Vault.sendToken{ value: 140_000 }(sendOpts);
     }
 
-    function test_721Vault_sendToken_with_1_tokens_but_erc721_amount_1_invalid() public {
+    function test_721Vault_sendToken_with_1_tokens_but_erc721_amount_0_invalid() public {
         vm.prank(Alice, Alice);
         canonicalToken721.approve(address(erc721Vault), 1);
 
@@ -295,7 +295,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 1;
+        amounts[0] = 0;
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
             address(0),
@@ -326,7 +326,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
@@ -379,7 +379,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
@@ -427,7 +427,7 @@ contract ERC721VaultTest is TaikoTest {
 
         tokenIds[0] = 2;
 
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
@@ -469,7 +469,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         uint256 etherValue = 0.1 ether;
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
@@ -529,7 +529,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
@@ -569,8 +569,8 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[1] = 2;
 
         uint256[] memory amounts = new uint256[](2);
-        amounts[0] = 0;
-        amounts[1] = 0;
+        amounts[0] = 1;
+        amounts[1] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
@@ -625,7 +625,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
@@ -724,7 +724,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,
@@ -808,7 +808,7 @@ contract ERC721VaultTest is TaikoTest {
         tokenIds[0] = 1;
 
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 0;
+        amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
             destChainId,


### PR DESCRIPTION
This change is in response with #15898. Transferring ERC721 should require the amount to be 1 instead of 0, so the transfer will not be ambiguous for offchain tracking. While it may cost slightly more gas to require amount=1 instead of 0, but I still think it makes sense to do so.