### PR TITLE
fix(bridge-ui): balance not updating on manual wallet connect

### DIFF
--- a/packages/bridge-ui/src/components/TokenDropdown/TokenDropdown.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/TokenDropdown.svelte
@@ -136,7 +136,7 @@
     destChainId = $destNetwork?.id,
   ) {
     const token = value;
-    if (!token || !srcChainId || !destChainId || !userAddress) return;
+    if (!token || !srcChainId || !userAddress) return;
     $computingBalance = true;
     $errorComputingBalance = false;
 
@@ -175,7 +175,7 @@
   const onNetworkChange = () => {
     const srcChain = $connectedSourceChain;
     const destChain = $destNetwork;
-    if (srcChain && destChain) updateBalance($account?.address, srcChain.id, destChain.id);
+    if (srcChain) updateBalance($account?.address, srcChain.id, destChain ? destChain.id : undefined);
   };
 
   const onAccountChange = (newAccount: Account, prevAccount?: Account) => {


### PR DESCRIPTION
### Issue:

I experienced a lack of balance update when manually connecting my wallet to the bridge interface. The balance should display immediately upon connection, but I saw that "Balance: N/A" remained even after a successful wallet connection. This issue did not occur when the wallet auto-connected, it was only present when I needed to click the 'Connect Wallet' button.

![Connect Wallet Button](https://github.com/taikoxyz/taiko-mono/assets/150457827/8ba7b348-d740-46cc-8b61-2f45526a21a2)

### Cause:

I believe the cause is in the `onNetworkChange` function, which has a condition that both `srcChain` and `destChain` must be present to update the balance. This logic fails to account for cases where a user manually connects their wallet without a previous network change.

![N/A Balance](https://github.com/taikoxyz/taiko-mono/assets/150457827/b63b3f8d-c7fb-4788-8b65-1e67c06c0ea4)

### Resolution:

To solve this, I modified the `onNetworkChange` function so the balance updates even if only the `srcChain` is present, which typically occurs when manually connecting a wallet. The updated logic now checks for the existence of `destChain`, and if absent, proceeds with `undefined`. The functions `getTokenBalance` in [bridge-ui/src/libs/token/fetchBalance.ts](https://github.com/taikoxyz/taiko-mono/blob/main/packages/bridge-ui/src/libs/token/fetchBalance.ts#L20) and `getAddress` in [bridge-ui/src/libs/token/getAddress.ts](https://github.com/taikoxyz/taiko-mono/blob/main/packages/bridge-ui/src/libs/token/getAddress.ts#L17) seem unaffected by these changes since they can handle an `undefined` value for `destChainId`.
