### PR TITLE
chore(protocol): enforce using safeTransfer/safeTransferFrom

### DIFF
--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -99,7 +99,7 @@ contract AssignmentHook is EssentialContract, IHook {
 
         // Send the liveness bond to the Taiko contract
         IERC20 tko = IERC20(resolve("taiko_token", false));
-        tko.transferFrom(_blk.assignedProver, taikoL1Address, _blk.livenessBond);
+        tko.safeTransferFrom(_blk.assignedProver, taikoL1Address, _blk.livenessBond);
 
         // Find the prover fee using the minimal tier
         uint256 proverFee = _getProverFee(assignment.tierFees, _meta.minTier);

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../../common/IAddressResolver.sol";
 import "../../libs/LibMath.sol";
 import "../../signal/ISignalService.sol";
@@ -15,6 +16,7 @@ import "./LibUtils.sol";
 /// @custom:security-contact security@taiko.xyz
 library LibVerifying {
     using LibMath for uint256;
+    using SafeERC20 for IERC20;
 
     // Warning: Any events defined here must also be defined in TaikoEvents.sol.
     /// @notice Emitted when a block is verified.
@@ -186,7 +188,7 @@ library LibVerifying {
                 }
 
                 IERC20 tko = IERC20(_resolver.resolve("taiko_token", false));
-                tko.transfer(ts.prover, bondToReturn);
+                tko.safeTransfer(ts.prover, bondToReturn);
 
                 // Note: We exclusively address the bonds linked to the
                 // transition used for verification. While there may exist

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -193,7 +193,8 @@ contract TimelockTokenPool is EssentialContract {
         amountToWithdraw = amountUnlocked - amountWithdrawn;
 
         // Note: precision is maintained at the token level rather than the wei level, otherwise,
-        // `costPaid` must be a uint256.
+        // `costPaid` must be a uint256. Therefore, please ignore
+        // https://github.com/crytic/slither/wiki/Detector-Documentation#divide-before-multiply
         uint128 _amountUnlocked = amountUnlocked / 1e18; // divide first
         costToWithdraw = _amountUnlocked * r.grant.costPerToken - r.costPaid;
     }

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -216,7 +216,7 @@ contract TimelockTokenPool is EssentialContract {
         totalAmountWithdrawn += amountToWithdraw;
         totalCostPaid += costToWithdraw;
 
-        IERC20(taikoToken).transferFrom(sharedVault, _to, amountToWithdraw);
+        IERC20(taikoToken).safeTransferFrom(sharedVault, _to, amountToWithdraw);
         IERC20(costToken).safeTransferFrom(_recipient, sharedVault, costToWithdraw);
 
         emit Withdrawn(_recipient, _to, amountToWithdraw, costToWithdraw);

--- a/packages/protocol/contracts/team/airdrop/ERC20Airdrop.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC20Airdrop.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import "./MerkleClaimable.sol";
 
@@ -9,6 +10,8 @@ import "./MerkleClaimable.sol";
 /// @notice Contract for managing Taiko token airdrop for eligible users.
 /// @custom:security-contact security@taiko.xyz
 contract ERC20Airdrop is MerkleClaimable {
+    using SafeERC20 for IERC20;
+
     /// @notice The address of the token contract.
     address public token;
 
@@ -60,7 +63,7 @@ contract ERC20Airdrop is MerkleClaimable {
         _verifyClaim(abi.encode(user, amount), proof);
 
         // Transfer the tokens
-        IERC20(token).transferFrom(vault, user, amount);
+        IERC20(token).safeTransferFrom(vault, user, amount);
 
         // Delegate the voting power to delegatee.
         // Note that the signature (v,r,s) may not correspond to the user address,

--- a/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../../libs/LibMath.sol";
 import "./MerkleClaimable.sol";
 
@@ -11,6 +12,7 @@ import "./MerkleClaimable.sol";
 /// @custom:security-contact security@taiko.xyz
 contract ERC20Airdrop2 is MerkleClaimable {
     using LibMath for uint256;
+    using SafeERC20 for IERC20;
 
     /// @notice The address of the token contract.
     address public token;
@@ -88,7 +90,7 @@ contract ERC20Airdrop2 is MerkleClaimable {
     function withdraw(address user) external ongoingWithdrawals {
         (, uint256 amount) = getBalance(user);
         withdrawnAmount[user] += amount;
-        IERC20(token).transferFrom(vault, user, amount);
+        IERC20(token).safeTransferFrom(vault, user, amount);
 
         emit Withdrawn(user, amount);
     }

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -105,6 +105,9 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
     /// @param _tokenId The token id.
     /// @return The token URI following EIP-681.
     function tokenURI(uint256 _tokenId) public view virtual override returns (string memory) {
+        // https://github.com/crytic/slither/wiki/Detector-Documentation#abi-encodePacked-collision
+        // The abi.encodePacked() call below takes multiple dynamic arguments. This is known and
+        // considered acceptable in terms of risk.
         return string(
             abi.encodePacked(
                 LibBridgedToken.buildURI(srcToken, srcChainId), Strings.toString(_tokenId)

--- a/packages/protocol/contracts/tokenvault/adapters/USDCAdapter.sol
+++ b/packages/protocol/contracts/tokenvault/adapters/USDCAdapter.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../BridgedERC20Base.sol";
 
 /// @title IUSDC
 /// @custom:security-contact security@taiko.xyz
-interface IUSDC {
+interface IUSDC is IERC20 {
     /// @notice Burns a specific amount of tokens.
     /// @param _amount The amount of token to be burned.
     function burn(uint256 _amount) external;
@@ -14,18 +16,13 @@ interface IUSDC {
     /// @param _to The address that will receive the minted tokens.
     /// @param _amount The amount of tokens to mint.
     function mint(address _to, uint256 _amount) external;
-
-    /// @notice Transfers tokens from one address to another.
-    /// @param from The address which you want to send tokens from.
-    /// @param _to The address which you want to transfer to.
-    /// @param _amount The amount of tokens to be transferred.
-    /// @return true if the transfer was successful, otherwise false.
-    function transferFrom(address from, address _to, uint256 _amount) external returns (bool);
 }
 
 /// @title USDCAdapter
 /// @custom:security-contact security@taiko.xyz
 contract USDCAdapter is BridgedERC20Base {
+    using SafeERC20 for IUSDC;
+
     /// @notice The USDC instance.
     /// @dev Slot 1.
     IUSDC public usdc;
@@ -45,7 +42,7 @@ contract USDCAdapter is BridgedERC20Base {
     }
 
     function _burnToken(address _from, uint256 _amount) internal override {
-        usdc.transferFrom(_from, address(this), _amount);
+        usdc.safeTransferFrom(_from, address(this), _amount);
         usdc.burn(_amount);
     }
 }


### PR DESCRIPTION
Although in a few contracts it is safe to use `transfer` and `transferFrom` for Taiko token, but to avoid having to explain this to auditors and other reviews, I think it's a good idea to enforce using `safeTransfer` and `safeTransferFrom`.