### PR TITLE
fix(protocol)!: fix L1 custom coinbase bug - alternative

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -78,6 +78,7 @@ library TaikoData {
     struct BlockParams {
         address assignedProver;
         address coinbase;
+        bytes coinbaseSig;
         bytes32 extraData;
         bytes32 blobHash;
         uint24 txListByteOffset;

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -18,6 +18,7 @@ abstract contract TaikoErrors {
     error L1_BLOB_REUSE_DISABLED();
     error L1_BLOCK_MISMATCH();
     error L1_INVALID_BLOCK_ID();
+    error L1_INVALID_COINBASE();
     error L1_INVALID_CONFIG();
     error L1_INVALID_ETH_DEPOSIT();
     error L1_INVALID_HOOK();

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -86,7 +86,7 @@ library LibProposing {
         if (params.coinbase == address(0)) {
             params.coinbase = msg.sender;
         } else {
-            bytes memory _coinbaseSig = params.coinbaseSig;
+            bytes memory sig = params.coinbaseSig;
 
             // Reset coinbaseSig before hashing
             params.coinbaseSig = "";
@@ -94,7 +94,7 @@ library LibProposing {
                 abi.encode("USE_AS_COINBASE", _config.chainId, address(this), params, _txList)
             );
 
-            if (!params.coinbase.isValidSignature(hash, _coinbaseSig)) {
+            if (ECDSA.recover(hash, sig) != params.coinbase) {
                 revert L1_INVALID_COINBASE();
             }
         }

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -193,7 +193,9 @@ abstract contract TaikoL1TestBase is TaikoTest {
 
         vm.prank(proposer, proposer);
         (meta, depositsProcessed) = L1.proposeBlock{ value: msgValue }(
-            abi.encode(TaikoData.BlockParams(prover, address(0), 0, 0, 0, 0, false, 0, hookcalls)),
+            abi.encode(
+                TaikoData.BlockParams(prover, address(0), "", 0, 0, 0, 0, false, 0, hookcalls)
+            ),
             new bytes(txListSize)
         );
     }


### PR DESCRIPTION
In AssignmentHook, we have 

```solidity
IERC20(assignment.feeToken).safeTransferFrom(_meta.coinbase,_blk.assignedProver,proverFee)
```

If `meta.coinbase` can be set to any value, then the current block proposer can maliciously consume fee token of another address that have set up the allowance. See  https://github.com/crytic/slither/wiki/Detector-Documentation#arbitrary-from-in-transferfrom

We can fix this issue by not allowing the `coinbase` value to be set and always using `msg.sender`; or we can request a signature from `params.coinbase` unless it is address(0). This PR chooses the 2nd approach.


-----

This PR is NOT ready: we need to add more tests and the TaikoL1 contract is too big to be deployed.