### PR TITLE
fix(bridge-ui): walletconnect not allowing to switch to unconfigured chains

### DIFF
--- a/packages/bridge-ui/config/schemas/configuredChains.schema.json
+++ b/packages/bridge-ui/config/schemas/configuredChains.schema.json
@@ -5,9 +5,6 @@
       "type": "array",
       "items": {
         "type": "object",
-        "propertyNames": {
-          "pattern": "^[0-9]+$"
-        },
         "additionalProperties": {
           "type": "object",
           "properties": {
@@ -20,20 +17,59 @@
             "type": {
               "type": "string"
             },
-            "urls": {
+            "rpcUrls": {
               "type": "object",
               "properties": {
-                "rpc": {
-                  "type": "string"
-                },
-                "explorer": {
-                  "type": "string"
+                "default": {
+                  "type": "object",
+                  "properties": {
+                    "http": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": ["http"]
                 }
               },
-              "required": ["rpc", "explorer"]
+              "required": ["default"]
+            },
+            "nativeCurrency": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "symbol": {
+                  "type": "string"
+                },
+                "decimals": {
+                  "type": "integer"
+                }
+              },
+              "required": ["name", "symbol", "decimals"]
+            },
+            "blockExplorers": {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["name", "url"]
+                }
+              },
+              "required": ["default"]
             }
           },
-          "required": ["name", "icon", "type", "urls"]
+          "required": ["name", "icon", "type", "rpcUrls", "nativeCurrency", "blockExplorers"]
         }
       }
     }

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ReviewStep/ReviewStep.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ReviewStep/ReviewStep.svelte
@@ -97,7 +97,7 @@
               <li>
                 <a
                   class="flex justify-start link"
-                  href={`${chainConfig[currentChain].urls.explorer}/token/${nft.addresses[currentChain]}`}
+                  href={`${chainConfig[currentChain]?.blockExplorers?.default.url}/token/${nft.addresses[currentChain]}`}
                   target="_blank">
                   {shortenAddress(nft.addresses[currentChain], 8, 12)}
                   <!-- <Icon type="arrow-top-right" fillClass="fill-primary-link" /> -->

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ConfirmationStep/ConfirmationStep.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ConfirmationStep/ConfirmationStep.svelte
@@ -58,7 +58,7 @@
     const userAccount = $account?.address;
     if (!currentChain || !destinationChain || !userAccount) return; //TODO error handling
 
-    const explorer = chainConfig[currentChain].urls.explorer;
+    const explorer = chainConfig[currentChain]?.blockExplorers?.default.url;
 
     await pendingTransactions.add(txHash, currentChain);
 
@@ -92,7 +92,7 @@
     const userAccount = $account?.address;
     if (!currentChain || !destinationChain || !userAccount || !$selectedToken) return; //TODO error handling
 
-    const { explorer } = chainConfig[currentChain].urls;
+    const explorer = chainConfig[currentChain]?.blockExplorers?.default.url;
 
     infoToast({
       title: $t('bridge.actions.approve.tx.title'),

--- a/packages/bridge-ui/src/components/Faucet/Faucet.svelte
+++ b/packages/bridge-ui/src/components/Faucet/Faucet.svelte
@@ -64,7 +64,8 @@
 
     try {
       const txHash = await mint(selectedToken, $connectedSourceChain.id);
-      const explorer = chainConfig[$connectedSourceChain.id].urls.explorer;
+
+      const explorer = chainConfig[$connectedSourceChain.id]?.blockExplorers?.default.url;
 
       infoToast({
         title: $t('faucet.mint.tx.title'),

--- a/packages/bridge-ui/src/components/NFTs/NFTInfoDialog.svelte
+++ b/packages/bridge-ui/src/components/NFTs/NFTInfoDialog.svelte
@@ -119,7 +119,7 @@
             {:else if canonicalChain && canonicalAddress}
               <a
                 class="flex justify-start link"
-                href={`${chainConfig[canonicalChain].urls.explorer}/token/${canonicalAddress}`}
+                href={`${chainConfig[canonicalChain]?.blockExplorers?.default.url}/token/${canonicalAddress}`}
                 target="_blank">
                 {shortenAddress(canonicalAddress, 6, 8)}
                 <Icon type="arrow-top-right" fillClass="fill-primary-link" />
@@ -138,7 +138,7 @@
               {#if bridgedChain && bridgedAddress}
                 <a
                   class="flex justify-start link"
-                  href={`${chainConfig[bridgedChain].urls.explorer}/token/${bridgedAddress}`}
+                  href={`${chainConfig[bridgedChain]?.blockExplorers?.default.url}/token/${bridgedAddress}`}
                   target="_blank">
                   {shortenAddress(bridgedAddress, 6, 8)}
                   <Icon type="arrow-top-right" fillClass="fill-primary-link" />

--- a/packages/bridge-ui/src/components/SideNavigation/SideNavigation.svelte
+++ b/packages/bridge-ui/src/components/SideNavigation/SideNavigation.svelte
@@ -105,7 +105,7 @@
             <li>
               <LinkButton
                 href={$connectedSourceChain
-                  ? chainConfig[$connectedSourceChain.id].urls.explorer
+                  ? chainConfig[$connectedSourceChain.id]?.blockExplorers?.default.url
                   : PUBLIC_DEFAULT_EXPLORER}
                 external>
                 <Icon type="explorer" />

--- a/packages/bridge-ui/src/components/Transactions/MobileDetailsDialog.svelte
+++ b/packages/bridge-ui/src/components/Transactions/MobileDetailsDialog.svelte
@@ -144,7 +144,7 @@
                 <div class="f-row min-w-1/2 text-primary-content">
                   <a
                     class="flex justify-start link"
-                    href={`${chainConfig[canonicalChain].urls.explorer}/token/${canonicalAddress}`}
+                    href={`${chainConfig[canonicalChain]?.blockExplorers?.default.url}/token/${canonicalAddress}`}
                     target="_blank">
                     {shortenAddress(canonicalAddress, 6, 8)}
                   </a>
@@ -162,7 +162,7 @@
                   {#if bridgedChain && bridgedAddress}
                     <a
                       class="flex justify-start link"
-                      href={`${chainConfig[bridgedChain].urls.explorer}/token/${bridgedAddress}`}
+                      href={`${chainConfig[bridgedChain]?.blockExplorers?.default.url}/token/${bridgedAddress}`}
                       target="_blank">
                       {shortenAddress(bridgedAddress, 6, 8)}
                       <Icon type="arrow-top-right" fillClass="fill-primary-link" />
@@ -195,7 +195,7 @@
             <h4 class="text-secondary-content">{$t('transactions.header.explorer')}</h4>
             <a
               class="flex justify-start content-center link"
-              href={`${chainConfig[Number(selectedItem.srcChainId)].urls.explorer}/tx/${selectedItem.hash}`}
+              href={`${chainConfig[Number(selectedItem.srcChainId)]?.blockExplorers?.default.url}/tx/${selectedItem.hash}`}
               target="_blank">
               {$t('transactions.link.explorer')}
               <Icon type="arrow-top-right" />

--- a/packages/bridge-ui/src/components/Transactions/Status/Status.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Status/Status.svelte
@@ -112,7 +112,7 @@
       // Step 5: Call claim() method on the bridge
       const txHash = await bridge.claim({ msgHash, message, wallet });
 
-      const { explorer } = chainConfig[Number(bridgeTx.destChainId)].urls;
+      const explorer = chainConfig[Number(bridgeTx.destChainId)]?.blockExplorers?.default.url;
 
       infoToast({
         title: $t('transactions.actions.claim.tx.title'),
@@ -202,7 +202,7 @@
       // Step 4: Call release() method on the bridge
       const txHash = await bridge.release({ msgHash, message, wallet });
 
-      const { explorer } = chainConfig[Number(bridgeTx.srcChainId)].urls;
+      const explorer = chainConfig[Number(bridgeTx.srcChainId)]?.blockExplorers?.default.url;
 
       infoToast({
         title: $t('transactions.actions.release.tx.title'),

--- a/packages/bridge-ui/src/components/Transactions/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Transaction.svelte
@@ -182,7 +182,7 @@
     <div class="hidden md:flex grow py-2 flex flex-col justify-center">
       <a
         class="flex justify-center py-3 link"
-        href={`${chainConfig[Number(item.srcChainId)].urls.explorer}/tx/${item.hash}`}
+        href={`${chainConfig[Number(item.srcChainId)]?.blockExplorers?.default.url}/tx/${item.hash}`}
         target="_blank">
         {$t('transactions.link.explorer')}
         <Icon type="arrow-top-right" fillClass="fill-primary-link" />
@@ -245,7 +245,7 @@
     <div class="hidden md:flex w-1/5 py-2 flex flex-col justify-center">
       <a
         class="flex justify-start py-3 link"
-        href={`${chainConfig[Number(item.srcChainId)].urls.explorer}/tx/${item.hash}`}
+        href={`${chainConfig[Number(item.srcChainId)]?.blockExplorers?.default.url}/tx/${item.hash}`}
         target="_blank">
         {$t('transactions.link.explorer')}
         <Icon type="arrow-top-right" fillClass="fill-primary-link" />

--- a/packages/bridge-ui/src/libs/chain/chains.ts
+++ b/packages/bridge-ui/src/libs/chain/chains.ts
@@ -1,22 +1,16 @@
 import type { Chain } from 'viem';
 
 import { chainConfig } from '$chainConfig';
-import type { ChainConfigMap } from '$libs/chain';
+import type { ChainConfig } from '$libs/chain';
 
-function mapChainConfigToChain(chainId: string, chainConfig: ChainConfigMap[number]): Chain {
+function mapChainConfigToChain(chainId: string, chainConfig: ChainConfig): Chain {
   return {
     id: Number(chainId),
     name: chainConfig.name,
-    nativeCurrency: {
-      name: 'ETH',
-      symbol: 'ETH',
-      decimals: 18,
-    },
-    rpcUrls: {
-      public: { http: [chainConfig.urls.rpc] },
-      default: { http: [chainConfig.urls.rpc] },
-    },
-  } as const satisfies Chain;
+    rpcUrls: chainConfig.rpcUrls,
+    nativeCurrency: chainConfig.nativeCurrency,
+    blockExplorers: chainConfig.blockExplorers,
+  };
 }
 
 export const chainIdToChain = (chainId: number): Chain => {

--- a/packages/bridge-ui/src/libs/chain/types.ts
+++ b/packages/bridge-ui/src/libs/chain/types.ts
@@ -1,3 +1,5 @@
+import type { Chain } from 'viem';
+
 export type ChainID = bigint;
 
 export enum LayerType {
@@ -6,14 +8,7 @@ export enum LayerType {
   L3 = 'L3',
 }
 
-export type Urls = {
-  rpc: string;
-  explorer: string;
-};
-
-export type ChainConfig = {
-  name: string;
-  urls: Urls;
+export type ChainConfig = Omit<Chain, 'id'> & {
   icon: string;
   type: LayerType;
 };


### PR DESCRIPTION
The old version of walletconnect was less strict when adding custom chains, now it expect more info, mainly blockexplorer urls

- Aligned our internal chain config closer to viem's Chain type


fixes:  #16308