### PR TITLE
fix(protocol): fix custom coinbase `transferFrom` issue

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -107,6 +107,7 @@ library TaikoData {
         uint16 minTier;
         bool blobUsed;
         bytes32 parentMetaHash; // slot 8
+        address sender; // slot 9
     }
 
     /// @dev Struct representing transition to be proven.

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -92,22 +92,22 @@ library TaikoData {
     /// `block.prevrandao`, which returns a random number provided by the layer
     /// 1 chain.
     struct BlockMetadata {
-        bytes32 l1Hash; // slot 1
-        bytes32 difficulty; // slot 2
-        bytes32 blobHash; //or txListHash (if Blob not yet supported), // slot 3
-        bytes32 extraData; // slot 4
-        bytes32 depositsHash; // slot 5
-        address coinbase; // L2 coinbase, // slot 6
+        bytes32 l1Hash;
+        bytes32 difficulty;
+        bytes32 blobHash; //or txListHash (if Blob not yet supported)
+        bytes32 extraData;
+        bytes32 depositsHash;
+        address coinbase; // L2 coinbase,
         uint64 id;
         uint32 gasLimit;
-        uint64 timestamp; // slot 7
+        uint64 timestamp;
         uint64 l1Height;
         uint24 txListByteOffset;
         uint24 txListByteSize;
         uint16 minTier;
         bool blobUsed;
-        bytes32 parentMetaHash; // slot 8
-        address sender; // slot 9
+        bytes32 parentMetaHash;
+        address sender;
     }
 
     /// @dev Struct representing transition to be proven.

--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -112,7 +112,7 @@ contract AssignmentHook is EssentialContract, IHook {
         } else {
             // Paying ERC20 tokens
             IERC20(assignment.feeToken).safeTransferFrom(
-                _meta.coinbase, _blk.assignedProver, proverFee
+                _meta.sender, _blk.assignedProver, proverFee
             );
         }
 

--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -99,6 +99,10 @@ contract AssignmentHook is EssentialContract, IHook {
 
         // Send the liveness bond to the Taiko contract
         IERC20 tko = IERC20(resolve("taiko_token", false));
+
+        // Note that we don't have to worry about
+        // https://github.com/crytic/slither/wiki/Detector-Documentation#arbitrary-from-in-transferfrom
+        // as `assignedProver` has provided a signature above to authorize this hook.
         tko.safeTransferFrom(_blk.assignedProver, taikoL1Address, _blk.livenessBond);
 
         // Find the prover fee using the minimal tier

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -133,7 +133,8 @@ library LibProposing {
                 txListByteSize: 0, // to be initialized below
                 minTier: 0, // to be initialized below
                 blobUsed: _txList.length == 0,
-                parentMetaHash: parentMetaHash
+                parentMetaHash: parentMetaHash,
+                sender: msg.sender
             });
         }
 

--- a/packages/protocol/contracts/tokenvault/adapters/USDCAdapter.sol
+++ b/packages/protocol/contracts/tokenvault/adapters/USDCAdapter.sol
@@ -42,6 +42,9 @@ contract USDCAdapter is BridgedERC20Base {
     }
 
     function _burnToken(address _from, uint256 _amount) internal override {
+        // We don't need to worry about
+        // https://github.com/crytic/slither/wiki/Detector-Documentation#arbitrary-from-in-transferfrom
+        // as switching from an old bridged token to a new one can only be performed by the owner.
         usdc.safeTransferFrom(_from, address(this), _amount);
         usdc.burn(_amount);
     }


### PR DESCRIPTION
In AssignmentHook, we have 

```solidity
IERC20(assignment.feeToken).safeTransferFrom(_meta.coinbase,_blk.assignedProver,proverFee)
```

If `meta.coinbase` can be set to any value, then the current block proposer can maliciously consume fee token of another address that have set up the allowance. See  https://github.com/crytic/slither/wiki/Detector-Documentation#arbitrary-from-in-transferfrom
