### PR TITLE
feat(protocol): enable EIP712 signature for TimelockTokenPool

### DIFF
--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -84,7 +84,7 @@ abstract contract EssentialContract is UUPSUpgradeable, Ownable2StepUpgradeable,
     }
 
     /// @notice Returns true if the contract is paused, and false otherwise.
-    /// @return True if paused, false otherwise.
+    /// @return true if paused, false otherwise.
     function paused() public view returns (bool) {
         return __paused == _TRUE;
     }

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -176,6 +176,9 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
         _withdraw(recipient, _to);
     }
 
+    /// @notice Gets the hash to be signed to authorize an withdrawal.
+    /// @param _to The destination address.
+    /// @return The hash to be signed.
     function getWithdrawalHash(address _to) public view returns (bytes32) {
         return _hashTypedDataV4(keccak256(abi.encode(TYPED_HASH, _to)));
     }

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -179,6 +179,7 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
 
         bytes32 typed = keccak256("Withdrawal(address to)");
         bytes32 hash = _hashTypedDataV4(keccak256(abi.encode(typed, _to)));
+
         address recipient = hash.recover(_sig);
         if (recipient == address(0)) revert INVALID_SIGNATURE();
 

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -24,7 +24,7 @@ import "../common/EssentialContract.sol";
 /// - grant program grantees
 /// @custom:security-contact security@taiko.xyz
 contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
-    using ECDSAUpgradeable for bytes32;
+    using ECDSA for bytes32;
     using SafeERC20 for IERC20;
 
     struct Grant {

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -142,7 +142,7 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
     /// This transaction should happen on a regular basis, e.g., quarterly.
     /// @param _recipient The grant recipient address.
     /// @param _grant The grant struct.
-    function grant(address _recipient, Grant memory _grant) external onlyOwner {
+    function grant(address _recipient, Grant memory _grant) external onlyOwner nonReentrant {
         if (_recipient == address(0)) revert INVALID_PARAM();
         if (recipients[_recipient].grant.amount != 0) revert ALREADY_GRANTED();
 
@@ -157,7 +157,7 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
     /// granted to the recipient will NOT be voided but are subject to the
     /// original unlock schedule.
     /// @param _recipient The grant recipient address.
-    function void(address _recipient) external onlyOwner {
+    function void(address _recipient) external onlyOwner nonReentrant {
         Recipient storage r = recipients[_recipient];
         uint128 amountVoided = _voidGrant(r.grant);
 
@@ -168,14 +168,14 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
     }
 
     /// @notice Withdraws all withdrawable tokens.
-    function withdraw() external {
+    function withdraw() external nonReentrant {
         _withdraw(msg.sender, msg.sender);
     }
 
     /// @notice Withdraws all withdrawable tokens to a designated address.
     /// @param _to The address where the granted and unlocked tokens shall be sent to.
     /// @param _sig Signature provided by the recipient.
-    function withdraw(address _recipient, address _to, bytes memory _sig) external {
+    function withdraw(address _recipient, address _to, bytes memory _sig) external nonReentrant {
         if (_to == address(0)) revert INVALID_PARAM();
         if (!verifySignature(Withdrawal(_recipient, _to), _sig)) revert INVALID_SIGNATURE();
 

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -126,7 +126,7 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
         initializer
     {
         __Essential_init(_owner);
-        __EIP712_init("Taiko Timelock Token Pool", "1");
+        __EIP712_init("Taiko TimelockTokenPool", "1");
 
         if (_taikoToken == address(0)) revert INVALID_PARAM();
         taikoToken = _taikoToken;

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -173,7 +173,7 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
 
     /// @notice Withdraws all withdrawable tokens to a designated address.
     /// @param _to The address where the granted and unlocked tokens shall be sent to.
-    /// @param _sig Signature provided by the recipient.
+    /// @param _sig Signature provided by the grant recipient.
     function withdraw(address _to, bytes memory _sig) external nonReentrant {
         if (_to == address(0)) revert INVALID_PARAM();
 

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -176,9 +176,12 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
     /// @param _sig Signature provided by the grant recipient.
     function withdraw(address _to, bytes memory _sig) external nonReentrant {
         if (_to == address(0)) revert INVALID_PARAM();
-        bytes32 hash = _hashTypedDataV4(keccak256(abi.encode(TYPED_HASH, _to)));
-        address recipient = ECDSA.recover(hash, _sig);
+        address recipient = ECDSA.recover(getWithdrawalHash(_to), _sig);
         _withdraw(recipient, _to);
+    }
+
+    function getWithdrawalHash(address _to) public view returns (bytes32) {
+        return _hashTypedDataV4(keccak256(abi.encode(TYPED_HASH, _to)));
     }
 
     /// @notice Returns the summary of the grant for a given recipient.

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -60,7 +60,7 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
         address to;
     }
 
-    bytes32 public TYPED_HASH = keccak256("Withdrawal(address to)");
+    bytes32 public constant TYPED_HASH = keccak256("Withdrawal(address to)");
 
     /// @notice The Taiko token address.
     address public taikoToken;

--- a/packages/protocol/contracts/team/TimelockTokenPool.sol
+++ b/packages/protocol/contracts/team/TimelockTokenPool.sol
@@ -56,10 +56,6 @@ contract TimelockTokenPool is EssentialContract, EIP712Upgradeable {
         Grant grant;
     }
 
-    struct Withdrawal {
-        address to;
-    }
-
     bytes32 public constant TYPED_HASH = keccak256("Withdrawal(address to)");
 
     /// @notice The Taiko token address.

--- a/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
@@ -87,7 +87,7 @@ contract ERC20Airdrop2 is MerkleClaimable {
 
     /// @notice External withdraw function
     /// @param user User address
-    function withdraw(address user) external ongoingWithdrawals {
+    function withdraw(address user) external ongoingWithdrawals nonReentrant {
         (, uint256 amount) = getBalance(user);
         withdrawnAmount[user] += amount;
         IERC20(token).safeTransferFrom(vault, user, amount);


### PR DESCRIPTION
This allows grantees to sign the withdrawal transactions with clear info rather than a random hash.