### PR TITLE
fix(bridge-ui): fix ETH self claiming

### DIFF
--- a/packages/bridge-ui/src/components/TokenDropdown/TokenDropdown.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/TokenDropdown.svelte
@@ -231,7 +231,7 @@
               <svelte:component this={Erc20} size={20} />
             </i>
           {/if}
-          <span class={textClass}>{truncateString(value.symbol, 5)}</span>
+          <span class={textClass}>{truncateString(value.symbol, 6)}</span>
         </div>
       {/if}
     </div>

--- a/packages/bridge-ui/src/components/Transactions/Transaction.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Transaction.svelte
@@ -51,7 +51,7 @@
   };
 
   const openDetails = () => {
-    if (isDesktopOrLarger) {
+    if (!isDesktopOrLarger) {
       detailsOpen = true;
     }
   };

--- a/packages/bridge-ui/src/libs/bridge/isTransactionProcessable.ts
+++ b/packages/bridge-ui/src/libs/bridge/isTransactionProcessable.ts
@@ -1,4 +1,5 @@
 import { getBlock, readContract } from '@wagmi/core';
+import { hexToBigInt } from 'viem';
 
 import { crossChainSyncABI } from '$abi';
 import { routingContractsMap } from '$bridgeConfig';
@@ -18,6 +19,7 @@ export async function isTransactionProcessable(bridgeTx: BridgeTransaction) {
   // Any other status that's not NEW we assume this bridge tx
   // has already been processed (was processable)
   // TODO: do better job here as this is to make the UI happy
+
   if (status !== MessageStatus.NEW) return true;
 
   const destCrossChainSyncAddress = routingContractsMap[Number(destChainId)][Number(srcChainId)].crossChainSyncAddress;
@@ -31,7 +33,7 @@ export async function isTransactionProcessable(bridgeTx: BridgeTransaction) {
       abi: crossChainSyncABI,
       functionName: 'getSyncedSnippet',
       args: [BigInt(0)],
-      chainId: Number(srcChainId),
+      chainId: Number(destChainId),
     });
 
     const srcBlock = await getBlock(config, {
@@ -39,7 +41,7 @@ export async function isTransactionProcessable(bridgeTx: BridgeTransaction) {
       chainId: Number(srcChainId),
     });
 
-    return srcBlock.number !== null && receipt.blockNumber <= srcBlock.number;
+    return srcBlock.number !== null && hexToBigInt(receipt.blockNumber) <= srcBlock.number;
   } catch (error) {
     return false;
   }

--- a/packages/bridge-ui/src/libs/bridge/types.ts
+++ b/packages/bridge-ui/src/libs/bridge/types.ts
@@ -57,6 +57,9 @@ export type RelayerMessage = {
   Memo: string;
 };
 
+// viem expects a bigint, but the receipt.blockNumber is a hex string
+export type ModifiedTransactionReceipt = Omit<TransactionReceipt, 'blockNumber'> & { blockNumber: Hex };
+
 export type BridgeTransaction = {
   hash: Hash;
   from: Address;
@@ -71,7 +74,7 @@ export type BridgeTransaction = {
   timestamp?: number;
 
   status?: MessageStatus;
-  receipt?: TransactionReceipt;
+  receipt?: ModifiedTransactionReceipt;
   msgHash?: Hash;
   message?: Message;
 };

--- a/packages/bridge-ui/src/libs/util/balance.ts
+++ b/packages/bridge-ui/src/libs/util/balance.ts
@@ -9,7 +9,7 @@ export function renderBalance(balance: Maybe<GetBalanceReturnType>) {
   if (!balance) return '0.00';
   // if (typeof balance === 'bigint') return balance.toString();
   const maxlength = Number(balance.formatted) < 0.000001 ? balance.decimals : 6;
-  return `${truncateString(balance.formatted, maxlength, '')} ${truncateString(balance.symbol, 5)}`;
+  return `${truncateString(balance.formatted, maxlength, '')} ${truncateString(balance.symbol, 7)}`;
 }
 
 export function renderEthBalance(balance: bigint, maxlength = 8): string {

--- a/packages/bridge-ui/src/libs/util/fetchTransactionReceipt.ts
+++ b/packages/bridge-ui/src/libs/util/fetchTransactionReceipt.ts
@@ -4,7 +4,7 @@ import { chains } from '$libs/chain';
 
 export async function fetchTransactionReceipt(transactionHash: Hash, chainId: number) {
   try {
-    const nodeUrl = chains.find((c) => c.id === chainId)?.rpcUrls?.public?.http[0];
+    const nodeUrl = chains.find((c) => c.id === chainId)?.rpcUrls?.default?.http[0];
     if (!nodeUrl) {
       throw new Error('Node URL not found');
     }


### PR DESCRIPTION
- Transaction receipts in viem are using bigint instead of hex, which caused some comparisons to be invalid
- fixed a bug when checking if a transaction was processable
- minor bugfixes for truncating