### PR TITLE
fix(bridge-ui): manual import not resetting correctly

### DIFF
--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/AddressInput/AddressInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/AddressInput/AddressInput.svelte
@@ -49,7 +49,7 @@
 
   // Clear the input field
   export const clearAddress = (): void => {
-    inputElement.value = '';
+    if(inputElement) inputElement.value = '';
     ethereumAddress = '';
     state = State.DEFAULT;
   };


### PR DESCRIPTION
**Observed behavior:**

When you manually add a NFT and go back to the start, the contract address input remains
<img width="588" alt="image" src="https://github.com/taikoxyz/taiko-mono/assets/162104816/5b21ce74-4950-421a-aaa2-c87894c5d0b1">
This blocks the UI, making interactions impossible without refresh!

**Console output:**
```
Uncaught (in promise) TypeError: Cannot set properties of undefined (setting 'value')
    at clearAddress (AddressInput.svelte:52:18)
    at AddressInput.svelte:73:5
    at run (chunk-4BDLA4GE.js?v=b5783581:30:10)
    at Array.forEach (<anonymous>)
    at run_all (chunk-4BDLA4GE.js?v=b5783581:36:7)
    at destroy_component (chunk-4BDLA4GE.js?v=b5783581:2150:5)
    at Object.destroy [as d] (ManualImport.svelte:192:39)
    at destroy_component (chunk-4BDLA4GE.js?v=b5783581:2151:32)
    at Object.destroy [as d] (ImportStep.svelte:16:40)
    at chunk-4BDLA4GE.js?v=b5783581:1408:17
```

**Solution:**
`onDestroy()` calls `clearAddress()`, but when it is not loaded it cannot reset the `inputElement`. So you should check if it exists.
Simple fix!

Go Taiko!! 🥁 