### PR TITLE
feat(relayer): only publish messages with new status

### DIFF
--- a/packages/relayer/indexer/handle_message_sent_event.go
+++ b/packages/relayer/indexer/handle_message_sent_event.go
@@ -86,6 +86,12 @@ func (i *Indexer) handleMessageSentEvent(
 		return errors.Wrap(err, "svc.eventStatusFromMsgHash")
 	}
 
+	// only add messages with new status to queue
+	if eventStatus != relayer.EventStatusNew {
+		slog.Info("event status is not new, skipping")
+		return nil
+	}
+
 	marshaled, err := json.Marshal(event)
 	if err != nil {
 		return errors.Wrap(err, "json.Marshal(event)")

--- a/packages/relayer/watchdog/watchdog.go
+++ b/packages/relayer/watchdog/watchdog.go
@@ -148,7 +148,10 @@ func InitFromConfig(ctx context.Context, w *Watchdog, cfg *Config) error {
 
 	watchdogAddr := crypto.PubkeyToAddress(*publicKeyECDSA)
 
-	var q queue.Queue
+	q, err := cfg.OpenQueueFunc()
+	if err != nil {
+		return err
+	}
 
 	w.eventRepo = eventRepository
 	w.suspendedTxRepo = suspendedTxRepo


### PR DESCRIPTION
will reduce spam on the queues for the crawler, this was removed post-refactor, also a watchdog queue fix.