### PR TITLE
fix(protocol): add address manager to taiko token

### DIFF
--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -22,16 +22,18 @@ contract TaikoToken is EssentialContract, ERC20SnapshotUpgradeable, ERC20VotesUp
     /// @param _name The name of the token.
     /// @param _symbol The symbol of the token.
     /// @param _recipient The address to receive initial token minting.
+    /// @param _addressManager The AddressManager address.
     function init(
         address _owner,
         string calldata _name,
         string calldata _symbol,
-        address _recipient
+        address _recipient,
+        address _addressManager
     )
         public
         initializer
     {
-        __Essential_init(_owner);
+        __Essential_init(_owner, _addressManager);
         __ERC20_init(_name, _symbol);
         __ERC20Snapshot_init();
         __ERC20Votes_init();

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -195,7 +195,8 @@ contract DeployOnL1 is DeployCapability {
                     timelock,
                     vm.envString("TAIKO_TOKEN_NAME"),
                     vm.envString("TAIKO_TOKEN_SYMBOL"),
-                    vm.envAddress("TAIKO_TOKEN_PREMINT_RECIPIENT")
+                    vm.envAddress("TAIKO_TOKEN_PREMINT_RECIPIENT"),
+                    address(sharedAddressManager)
                 )
                 ),
             registerTo: sharedAddressManager

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -124,7 +124,8 @@ abstract contract TaikoL1TestBase is TaikoTest {
                 name: "taiko_token",
                 impl: address(new TaikoToken()),
                 data: abi.encodeCall(
-                    TaikoToken.init, (address(0), "Taiko Token", "TTKOk", address(this))
+                    TaikoToken.init,
+                    (address(0), "Taiko Token", "TTKOk", address(this), address(addressManager))
                     ),
                 registerTo: address(addressManager)
             })

--- a/packages/protocol/test/tokenvault/ERC20Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC20Vault.t.sol
@@ -85,21 +85,22 @@ contract TestERC20Vault is TaikoTest {
         vm.deal(Carol, 1 ether);
         vm.deal(Bob, 1 ether);
 
-        tko = TaikoToken(
-            deployProxy({
-                name: "taiko_token",
-                impl: address(new TaikoToken()),
-                data: abi.encodeCall(
-                    TaikoToken.init, (address(0), "Taiko Token", "TTKOk", address(this))
-                    )
-            })
-        );
-
         addressManager = AddressManager(
             deployProxy({
                 name: "address_manager",
                 impl: address(new AddressManager()),
                 data: abi.encodeCall(AddressManager.init, (address(0)))
+            })
+        );
+
+        tko = TaikoToken(
+            deployProxy({
+                name: "taiko_token",
+                impl: address(new TaikoToken()),
+                data: abi.encodeCall(
+                    TaikoToken.init,
+                    (address(0), "Taiko Token", "TTKOk", address(this), address(addressManager))
+                    )
             })
         );
 


### PR DESCRIPTION
Without this, for example the function `function snapshot() public onlyFromOwnerOrNamed("snapshooter")` is not interpretable, since there is no address manager to look the address up.