### PR TITLE
fix(protocol): fix bridge prove message issue using staticcall

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -572,10 +572,12 @@ contract Bridge is EssentialContract, IBridge {
         bytes calldata _proof
     )
         private
-        returns (bool)
+        returns (bool success_)
     {
-        return ISignalService(_signalService).proveSignalReceived(
-            _chainId, resolve(_chainId, "bridge", false), _signal, _proof
+        bytes memory data = abi.encodeCall(
+            ISignalService.proveSignalReceived,
+            (_chainId, resolve(_chainId, "bridge", false), _signal, _proof)
         );
+        (success_,) = _signalService.sendEther(0, gasleft(), data);
     }
 }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -564,7 +564,7 @@ contract Bridge is EssentialContract, IBridge {
     /// @param _signal The signal.
     /// @param _chainId The ID of the chain the signal is stored on.
     /// @param _proof The merkle inclusion proof.
-    /// @return success_ True if the message was received.
+    /// @return true if the message was received.
     function _proveSignalReceived(
         address _signalService,
         bytes32 _signal,
@@ -572,12 +572,12 @@ contract Bridge is EssentialContract, IBridge {
         bytes calldata _proof
     )
         private
-        returns (bool success_)
+        returns (bool)
     {
         bytes memory data = abi.encodeCall(
             ISignalService.proveSignalReceived,
             (_chainId, resolve(_chainId, "bridge", false), _signal, _proof)
         );
-        (success_,) = _signalService.sendEther(0, gasleft(), data);
+        return _signalService.sendEther(0, gasleft(), data);
     }
 }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -574,7 +574,7 @@ contract Bridge is EssentialContract, IBridge {
         private
         returns (bool)
     {
-        return ISignalServcice(_signalService).proveSignalReceived(
+        return ISignalService(_signalService).proveSignalReceived(
             _chainId, resolve(_chainId, "bridge", false), _signal, _proof
         );
     }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -358,10 +358,7 @@ contract Bridge is EssentialContract, IBridge {
         if (_message.srcChainId != block.chainid) return false;
 
         return _proveSignalReceived(
-            resolve("signal_service", false),
-            signalForFailedMessage(hashMessage(_message)),
-            _message.destChainId,
-            _proof
+            signalForFailedMessage(hashMessage(_message)), _message.destChainId, _proof
         );
     }
 
@@ -377,9 +374,7 @@ contract Bridge is EssentialContract, IBridge {
         returns (bool)
     {
         if (_message.destChainId != block.chainid) return false;
-        return _proveSignalReceived(
-            resolve("signal_service", false), hashMessage(_message), _message.srcChainId, _proof
-        );
+        return _proveSignalReceived(hashMessage(_message), _message.srcChainId, _proof);
     }
 
     /// @notice Checks if the destination chain is enabled.
@@ -560,24 +555,20 @@ contract Bridge is EssentialContract, IBridge {
     }
 
     /// @notice Checks if the signal was received.
-    /// @param _signalService The signal service address.
     /// @param _signal The signal.
     /// @param _chainId The ID of the chain the signal is stored on.
     /// @param _proof The merkle inclusion proof.
     /// @return success_ True if the message was received.
     function _proveSignalReceived(
-        address _signalService,
         bytes32 _signal,
         uint64 _chainId,
         bytes calldata _proof
     )
         private
-        returns (bool success_)
+        returns (bool)
     {
-        bytes memory data = abi.encodeCall(
-            ISignalService.proveSignalReceived,
-            (_chainId, resolve(_chainId, "bridge", false), _signal, _proof)
+        return ISignalService(resolve("signal_service", false)).proveSignalReceived(
+            _chainId, resolve(_chainId, "bridge", false), _signal, _proof
         );
-        success_ = _signalService.sendEther(0, gasleft(), data);
     }
 }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -353,7 +353,6 @@ contract Bridge is EssentialContract, IBridge {
         bytes calldata _proof
     )
         public
-        view
         returns (bool)
     {
         if (_message.srcChainId != block.chainid) return false;
@@ -375,7 +374,6 @@ contract Bridge is EssentialContract, IBridge {
         bytes calldata _proof
     )
         public
-        view
         returns (bool)
     {
         if (_message.destChainId != block.chainid) return false;
@@ -574,13 +572,12 @@ contract Bridge is EssentialContract, IBridge {
         bytes calldata _proof
     )
         private
-        view
         returns (bool success_)
     {
         bytes memory data = abi.encodeCall(
             ISignalService.proveSignalReceived,
             (_chainId, resolve(_chainId, "bridge", false), _signal, _proof)
         );
-        (success_,) = _signalService.staticcall(data);
+        success_ = _signalService.sendEther(0, gasleft(), data);
     }
 }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -358,7 +358,10 @@ contract Bridge is EssentialContract, IBridge {
         if (_message.srcChainId != block.chainid) return false;
 
         return _proveSignalReceived(
-            signalForFailedMessage(hashMessage(_message)), _message.destChainId, _proof
+            resolve("signal_service", false),
+            signalForFailedMessage(hashMessage(_message)),
+            _message.destChainId,
+            _proof
         );
     }
 
@@ -374,7 +377,9 @@ contract Bridge is EssentialContract, IBridge {
         returns (bool)
     {
         if (_message.destChainId != block.chainid) return false;
-        return _proveSignalReceived(hashMessage(_message), _message.srcChainId, _proof);
+        return _proveSignalReceived(
+            resolve("signal_service", false), hashMessage(_message), _message.srcChainId, _proof
+        );
     }
 
     /// @notice Checks if the destination chain is enabled.
@@ -555,11 +560,13 @@ contract Bridge is EssentialContract, IBridge {
     }
 
     /// @notice Checks if the signal was received.
+    /// @param _signalService The signal service address.
     /// @param _signal The signal.
     /// @param _chainId The ID of the chain the signal is stored on.
     /// @param _proof The merkle inclusion proof.
     /// @return success_ True if the message was received.
     function _proveSignalReceived(
+        address _signalService,
         bytes32 _signal,
         uint64 _chainId,
         bytes calldata _proof
@@ -567,7 +574,7 @@ contract Bridge is EssentialContract, IBridge {
         private
         returns (bool)
     {
-        return ISignalService(resolve("signal_service", false)).proveSignalReceived(
+        return ISignalServcice(_signalService).proveSignalReceived(
             _chainId, resolve(_chainId, "bridge", false), _signal, _proof
         );
     }


### PR DESCRIPTION
Previously `proveSignalReceived` in signalService is a `view` function, but now it can cache data so it's no longer a `view` function. Therefore, in Bridge.sol, we can no longer use `staticcall`.