### PR TITLE
feat(protocol): allow L2 contracts to read L2's parent block timestamp

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -49,6 +49,12 @@ contract TaikoL2 is CrossChainOwned {
     /// @notice The last synced L1 block height.
     uint64 public lastSyncedBlock;
 
+    /// @notice The parent block's timestamp.
+    uint64 public parentTimestamp;
+
+    /// @notice The current block's timestamp.
+    uint64 private __currentBlockTimestamp;
+
     uint256[47] private __gap;
 
     /// @notice Emitted when the latest L1 block details are anchored to L2.
@@ -95,6 +101,7 @@ contract TaikoL2 is CrossChainOwned {
 
         gasExcess = _gasExcess;
         (publicInputHash,) = _calcPublicInputHash(block.number);
+        __currentBlockTimestamp = uint64(block.timestamp);
     }
 
     /// @notice Anchors the latest L1 block details to L2 for cross-layer
@@ -153,6 +160,9 @@ contract TaikoL2 is CrossChainOwned {
         // Update state variables
         l2Hashes[parentId] = blockhash(parentId);
         publicInputHash = publicInputHashNew;
+
+        parentTimestamp = __currentBlockTimestamp;
+        __currentBlockTimestamp = uint64(block.timestamp);
 
         emit Anchored(blockhash(parentId), gasExcess);
     }


### PR DESCRIPTION
This is a small feature but it may be very useful for us to incentivize block proposers for liveness. For example, we can [allow a fair-mint token](https://github.com/taikoxyz/taiko-mono/pull/16408) that only can be minted by `block.coinbase` for each L2 block but only when the L2's block is x seconds later than the parent's block timestamp. Without being able to read the parent L2 block's timestamp, this is impossible.

This tiny feature imposes a very small amount of additional gas cost.