### PR TITLE
Fix(Transaction-UI) : toggle menu-change with conditional dropdown and close.

### DIFF
--- a/packages/bridge-ui/src/components/Transactions/Filter/StatusFilterDropdown.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Filter/StatusFilterDropdown.svelte
@@ -27,8 +27,12 @@
     { value: MessageStatus.FAILED, label: $t('transactions.filter.failed') },
   ];
   const toggleMenu = () => {
-    menuOpen = !menuOpen;
-    flipped = !flipped;
+    if (menuOpen) {
+      closeMenu();
+    } else {
+      menuOpen = true;
+      flipped = !flipped;
+    }
   };
 
   const select = (option: (typeof options)[0]) => {


### PR DESCRIPTION
#16429

This PR is the solution to the issue raised in the above link 

"The transaction panel is not reversing in the Bridge UI"
