### PR TITLE
Fix(GitHub) : spell-env fixes in the workflow files.

### DIFF
--- a/.github/workflows/bridge-ui.yml
+++ b/.github/workflows/bridge-ui.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build Svelte app
         env:
-          SKIP_ENV_VALDIATION: "true"
+          SKIP_ENV_VALIDATION: "true"
         working-directory: ./packages/bridge-ui
         run: pnpm build
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Unit tests
         env:
-          SKIP_ENV_VALDIATION: "true"
+          SKIP_ENV_VALIDATION: "true"
         working-directory: ./packages/bridge-ui
         run: pnpm test:unit
 

--- a/packages/bridge-ui/scripts/vite-plugins/generateBridgeConfig.ts
+++ b/packages/bridge-ui/scripts/vite-plugins/generateBridgeConfig.ts
@@ -14,7 +14,7 @@ dotenv.config();
 const pluginName = 'generateBridgeConfig';
 const logger = new PluginLogger(pluginName);
 
-const skip = process.env.SKIP_ENV_VALDIATION === 'true';
+const skip = process.env.SKIP_ENV_VALIDATION === 'true';
 
 const currentDir = path.resolve(new URL(import.meta.url).pathname);
 

--- a/packages/bridge-ui/scripts/vite-plugins/generateChainConfig.ts
+++ b/packages/bridge-ui/scripts/vite-plugins/generateChainConfig.ts
@@ -15,7 +15,7 @@ dotenv.config();
 const pluginName = 'generateChainConfig';
 const logger = new PluginLogger(pluginName);
 
-const skip = process.env.SKIP_ENV_VALDIATION === 'true';
+const skip = process.env.SKIP_ENV_VALIDATION === 'true';
 
 const currentDir = path.resolve(new URL(import.meta.url).pathname);
 

--- a/packages/bridge-ui/scripts/vite-plugins/generateCustomTokenConfig.ts
+++ b/packages/bridge-ui/scripts/vite-plugins/generateCustomTokenConfig.ts
@@ -14,7 +14,7 @@ dotenv.config();
 const pluginName = 'generateTokens';
 const logger = new PluginLogger(pluginName);
 
-const skip = process.env.SKIP_ENV_VALDIATION === 'true';
+const skip = process.env.SKIP_ENV_VALIDATION === 'true';
 
 const currentDir = path.resolve(new URL(import.meta.url).pathname);
 

--- a/packages/bridge-ui/scripts/vite-plugins/generateEventIndexerConfig.ts
+++ b/packages/bridge-ui/scripts/vite-plugins/generateEventIndexerConfig.ts
@@ -16,7 +16,7 @@ dotenv.config();
 const pluginName = 'generateEventIndexerConfig';
 const logger = new PluginLogger(pluginName);
 
-const skip = process.env.SKIP_ENV_VALDIATION === 'true';
+const skip = process.env.SKIP_ENV_VALIDATION === 'true';
 
 const currentDir = path.resolve(new URL(import.meta.url).pathname);
 

--- a/packages/bridge-ui/scripts/vite-plugins/generateRelayerConfig.ts
+++ b/packages/bridge-ui/scripts/vite-plugins/generateRelayerConfig.ts
@@ -16,7 +16,7 @@ dotenv.config();
 const pluginName = 'generateRelayerConfig';
 const logger = new PluginLogger(pluginName);
 
-const skip = process.env.SKIP_ENV_VALDIATION === 'true';
+const skip = process.env.SKIP_ENV_VALIDATION === 'true';
 
 const currentDir = path.resolve(new URL(import.meta.url).pathname);
 


### PR DESCRIPTION
Spelling issue in the code
     
     SKIP_ENV_VALDIATION: "true" 
Changed to 
          SKIP_ENV_VALIDATION: "true"

"VALIDATION" being the misspelt word

