### PR TITLE
fix(protocol): remove the blob-reuse feature

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -75,7 +75,6 @@ library TaikoData {
         address assignedProver;
         address coinbase;
         bytes32 extraData;
-        uint24 txListByteOffset;
         uint24 txListByteSize;
         bytes32 parentMetaHash;
         HookCall[] hookCalls;
@@ -96,7 +95,6 @@ library TaikoData {
         uint32 gasLimit;
         uint64 timestamp;
         uint64 l1Height;
-        uint24 txListByteOffset;
         uint24 txListByteSize;
         uint16 minTier;
         bool blobUsed;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -26,8 +26,6 @@ library TaikoData {
         uint32 blockMaxGasLimit;
         // The maximum allowed bytes for the proposed transaction list calldata.
         uint24 blockMaxTxListBytes;
-        // True if EIP-4844 is enabled for DA
-        bool blobAllowedForDA;
         // ---------------------------------------------------------------------
         // Group 3: Proof related configs
         // ---------------------------------------------------------------------

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -24,8 +24,6 @@ library TaikoData {
         uint64 maxBlocksToVerifyPerProposal;
         // The maximum gas limit allowed for a block.
         uint32 blockMaxGasLimit;
-        // The maximum allowed bytes for the proposed transaction list calldata.
-        uint24 blockMaxTxListBytes;
         // ---------------------------------------------------------------------
         // Group 3: Proof related configs
         // ---------------------------------------------------------------------
@@ -73,7 +71,6 @@ library TaikoData {
         address assignedProver;
         address coinbase;
         bytes32 extraData;
-        uint24 txListByteSize;
         bytes32 parentMetaHash;
         HookCall[] hookCalls;
     }
@@ -93,7 +90,6 @@ library TaikoData {
         uint32 gasLimit;
         uint64 timestamp;
         uint64 l1Height;
-        uint24 txListByteSize;
         uint16 minTier;
         bool blobUsed;
         bytes32 parentMetaHash;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -26,12 +26,8 @@ library TaikoData {
         uint32 blockMaxGasLimit;
         // The maximum allowed bytes for the proposed transaction list calldata.
         uint24 blockMaxTxListBytes;
-        // The max period in seconds that a blob can be reused for DA.
-        uint24 blobExpiry;
         // True if EIP-4844 is enabled for DA
         bool blobAllowedForDA;
-        // True if blob can be reused
-        bool blobReuseEnabled;
         // ---------------------------------------------------------------------
         // Group 3: Proof related configs
         // ---------------------------------------------------------------------
@@ -79,10 +75,8 @@ library TaikoData {
         address assignedProver;
         address coinbase;
         bytes32 extraData;
-        bytes32 blobHash;
         uint24 txListByteOffset;
         uint24 txListByteSize;
-        bool cacheBlobForReuse;
         bytes32 parentMetaHash;
         HookCall[] hookCalls;
     }
@@ -189,10 +183,8 @@ library TaikoData {
             ) transitions;
         // Ring buffer for Ether deposits
         mapping(uint256 depositId_mod_ethDepositRingBufferSize => uint256 depositAmount) ethDeposits;
-        // Reusable blobs
-        mapping(bytes32 blobHash => uint256 since) reusableBlobs;
-        SlotA slotA; // slot 6
-        SlotB slotB; // slot 7
-        uint256[43] __gap;
+        SlotA slotA; // slot 5
+        SlotB slotB; // slot 6
+        uint256[44] __gap;
     }
 }

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -35,7 +35,6 @@ abstract contract TaikoErrors {
     error L1_TOO_MANY_TIERS();
     error L1_TRANSITION_ID_ZERO();
     error L1_TRANSITION_NOT_FOUND();
-    error L1_TXLIST_SIZE();
     error L1_UNAUTHORIZED();
     error L1_UNEXPECTED_PARENT();
     error L1_UNEXPECTED_TRANSITION_ID();

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -14,7 +14,6 @@ abstract contract TaikoErrors {
     error L1_ASSIGNED_PROVER_NOT_ALLOWED();
     error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
-    error L1_BLOB_NOT_REUSABLE();
     error L1_BLOCK_MISMATCH();
     error L1_INVALID_BLOCK_ID();
     error L1_INVALID_CONFIG();

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -12,7 +12,7 @@ abstract contract TaikoErrors {
     error L1_ALREADY_CONTESTED();
     error L1_ALREADY_PROVED();
     error L1_ASSIGNED_PROVER_NOT_ALLOWED();
-    error L1_BLOB_FOR_DA_DISABLED();
+    error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
     error L1_BLOB_NOT_REUSABLE();
     error L1_BLOCK_MISMATCH();

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -15,7 +15,6 @@ abstract contract TaikoErrors {
     error L1_BLOB_FOR_DA_DISABLED();
     error L1_BLOB_NOT_FOUND();
     error L1_BLOB_NOT_REUSABLE();
-    error L1_BLOB_REUSE_DISABLED();
     error L1_BLOCK_MISMATCH();
     error L1_INVALID_BLOCK_ID();
     error L1_INVALID_CONFIG();

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -72,10 +72,6 @@ abstract contract TaikoEvents {
         uint16 tier
     );
 
-    /// @dev Emitted when a blob is cached for reuse.
-    /// @param blobHash The blobHash cached.
-    event BlobCached(bytes32 blobHash);
-
     /// @dev Emitted when proving has been paused
     /// @param paused True if paused, false if unpaused.
     event ProvingPaused(bool paused);

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -133,11 +133,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
         return LibDepositing.canDepositEthToL2(state, getConfig(), _amount);
     }
 
-    /// @notice See {LibProposing-isBlobReusable}.
-    function isBlobReusable(bytes32 _blobHash) public view returns (bool) {
-        return LibProposing.isBlobReusable(state, getConfig(), _blobHash);
-    }
-
     /// @notice Gets the details of a block.
     /// @param _blockId Index of the block.
     /// @return blk_ The block.
@@ -201,9 +196,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
             // and right now txList is still saved in calldata, so we set it
             // to 120KB.
             blockMaxTxListBytes: 120_000,
-            blobExpiry: 24 hours,
             blobAllowedForDA: false,
-            blobReuseEnabled: false,
             livenessBond: 250e18, // 250 Taiko token
             // ETH deposit related.
             ethDepositRingBufferSize: 1024,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -192,10 +192,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
             // Can be overridden by the tier config.
             maxBlocksToVerifyPerProposal: 10,
             blockMaxGasLimit: 15_000_000,
-            // Each go-ethereum transaction has a size limit of 128KB,
-            // and right now txList is still saved in calldata, so we set it
-            // to 120KB.
-            blockMaxTxListBytes: 120_000,
             livenessBond: 250e18, // 250 Taiko token
             // ETH deposit related.
             ethDepositRingBufferSize: 1024,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -196,7 +196,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
             // and right now txList is still saved in calldata, so we set it
             // to 120KB.
             blockMaxTxListBytes: 120_000,
-            blobAllowedForDA: false,
             livenessBond: 250e18, // 250 Taiko token
             // ETH deposit related.
             ethDepositRingBufferSize: 1024,

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -34,7 +34,6 @@ library LibProposing {
     // Warning: Any errors defined here must also be defined in TaikoErrors.sol.
     error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
-    error L1_BLOB_NOT_REUSABLE();
     error L1_INVALID_HOOK();
     error L1_INVALID_PARAM();
     error L1_INVALID_PROVER();

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -37,7 +37,7 @@ library LibProposing {
     );
 
     // Warning: Any errors defined here must also be defined in TaikoErrors.sol.
-    error L1_BLOB_FOR_DA_DISABLED();
+    error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
     error L1_BLOB_NOT_REUSABLE();
     error L1_INVALID_HOOK();
@@ -133,14 +133,13 @@ library LibProposing {
 
         // Update certain meta fields
         if (meta_.blobUsed) {
-            if (!_config.blobAllowedForDA) revert L1_BLOB_FOR_DA_DISABLED();
+            if (block.chainid != 1) revert L1_BLOB_NOT_AVAILABLE();
 
             // Always use the first blob in this transaction. If the
             // proposeBlock functions are called more than once in the same
             // L1 transaction, these multiple L2 blocks will share the same
             // blob.
             meta_.blobHash = blobhash(0);
-
             if (meta_.blobHash == 0) revert L1_BLOB_NOT_FOUND();
 
             // Check that the txList data range is within the max size of a blob

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -249,10 +249,8 @@ library LibVerifying {
             _config.chainId <= 1 || _config.chainId == block.chainid //
                 || _config.blockMaxProposals == 1
                 || _config.blockRingBufferSize <= _config.blockMaxProposals + 1
-                || _config.blockMaxGasLimit == 0 || _config.blockMaxTxListBytes == 0
-                || _config.blockMaxTxListBytes > 128 * 1024 // calldata up to 128K
-                || _config.livenessBond == 0 || _config.ethDepositRingBufferSize <= 1
-                || _config.ethDepositMinCountPerBlock == 0
+                || _config.blockMaxGasLimit == 0 || _config.livenessBond == 0
+                || _config.ethDepositRingBufferSize <= 1 || _config.ethDepositMinCountPerBlock == 0
             // Audit recommendation, and gas tested. Processing 32 deposits (as initially set in
             // TaikoL1.sol) costs 72_502 gas.
             || _config.ethDepositMaxCountPerBlock > 32

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -195,7 +195,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
 
         vm.prank(proposer, proposer);
         (meta, depositsProcessed) = L1.proposeBlock{ value: msgValue }(
-            abi.encode(TaikoData.BlockParams(prover, address(0), 0, 0, 0, hookcalls)),
+            abi.encode(TaikoData.BlockParams(prover, address(0), 0, 0, hookcalls)),
             new bytes(txListSize)
         );
     }

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -195,7 +195,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
 
         vm.prank(proposer, proposer);
         (meta, depositsProcessed) = L1.proposeBlock{ value: msgValue }(
-            abi.encode(TaikoData.BlockParams(prover, address(0), 0, 0, 0, 0, hookcalls)),
+            abi.encode(TaikoData.BlockParams(prover, address(0), 0, 0, 0, hookcalls)),
             new bytes(txListSize)
         );
     }

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -195,7 +195,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
 
         vm.prank(proposer, proposer);
         (meta, depositsProcessed) = L1.proposeBlock{ value: msgValue }(
-            abi.encode(TaikoData.BlockParams(prover, address(0), 0, 0, 0, 0, false, 0, hookcalls)),
+            abi.encode(TaikoData.BlockParams(prover, address(0), 0, 0, 0, 0, hookcalls)),
             new bytes(txListSize)
         );
     }


### PR DESCRIPTION
Based on our discussion in the previous all-hands, it seems reuse-blob is not a feature that we will use.

Also removed the txListSize from Block metadata as it is not necessary and not used by the client at all.


BEGIN_COMMIT_OVERRIDE
fix(protocol): remove the blob-reuse feature
END_COMMIT_OVERRIDE