### PR TITLE
fix(protocol): implicit type-casting in Bridge.sol

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -61,7 +61,7 @@ contract Bridge is EssentialContract, IBridge {
     error B_INVOCATION_TOO_EARLY();
 
     modifier sameChain(uint64 _chainId) {
-        if (_chainId != block.chainid) revert B_INVALID_CHAINID();
+        if (_chainId != uint64(block.chainid)) revert B_INVALID_CHAINID();
         _;
     }
 


### PR DESCRIPTION
message.destChainId is uint64 but block.chainid is uint256. use uint64(block.chainid)  is more safe.

refs: 
- https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1344.md