### PR TITLE
fix(relayer): remove unnecessary FindLatestBlockID

### DIFF
--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -299,13 +299,6 @@ func (i *Indexer) eventLoop(ctx context.Context, startBlockID uint64) {
 
 // filter is the main function run by Start in the indexer
 func (i *Indexer) filter(ctx context.Context) error {
-	n, err := i.eventRepo.FindLatestBlockID(i.eventName, i.srcChainId.Uint64(), i.destChainId.Uint64())
-	if err != nil {
-		return err
-	}
-
-	i.latestIndexedBlockNumber = n
-
 	// get the latest header
 	header, err := i.srcEthClient.HeaderByNumber(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
https://github.com/taikoxyz/taiko-mono/blob/main/packages/relayer/indexer/set_initial_Indexing_block_by_mode.go#L13 should be the one to set ```i.latestIndexedBlockNumber```

Otherwise, ```Resync``` mode doesn't have the correct ```i.latestIndexedBlockNumber```.