### PR TITLE
refactor(guardian-prover-health-check-ui):  use reduce to avoid for in loop and eliminate temporary variables.

### DIFF
--- a/packages/guardian-prover-health-check-ui/src/lib/blocks/getGuardianProverIdsPerBlockNumber.ts
+++ b/packages/guardian-prover-health-check-ui/src/lib/blocks/getGuardianProverIdsPerBlockNumber.ts
@@ -1,11 +1,11 @@
-import type { GuardianProverIdsMap, SignedBlock, SignedBlocks } from '$lib/types';
+import type { GuardianProverIdsMap, SignedBlocks } from '$lib/types';
 
 export const getGuardianProverIdsPerBlockNumber = (blocks: SignedBlocks): GuardianProverIdsMap => {
-	const result: GuardianProverIdsMap = {};
-
-	for (const blockNumber in blocks) {
-		result[blockNumber] = blocks[blockNumber].map((block: SignedBlock) => block.guardianProverID);
-	}
-
-	return result;
+  const blockNumbers = Object.keys(blocks);
+  return blockNumbers.reduce((prev, blockNumber) => {
+    return {
+      ...prev,
+      [blockNumber]: blocks[blockNumber].map(block => block.guardianProverID)
+    }
+  }, {});
 };

--- a/packages/guardian-prover-health-check-ui/src/lib/blocks/signedBlocksPerGuardian.ts
+++ b/packages/guardian-prover-health-check-ui/src/lib/blocks/signedBlocksPerGuardian.ts
@@ -1,17 +1,14 @@
 import { get } from 'svelte/store';
 import { signedBlocks } from '$stores';
-import type { SignedBlock, SortedSignedBlocks } from '$lib/types';
+import type { SortedSignedBlocks } from '$lib/types';
 
 export function signedBlocksPerGuardian(guardianProverId: number): number {
 	const allSortedSignedBlocks: SortedSignedBlocks = get(signedBlocks);
-	let count = 0;
-	allSortedSignedBlocks.forEach((blockGroup) => {
-		blockGroup.blocks.forEach((block: SignedBlock) => {
-			if (block.guardianProverID === Number(guardianProverId)) {
-				count++;
-			}
-		});
-	});
+  const targetId = Number(guardianProverId);
 
-	return count;
+  return allSortedSignedBlocks
+    .reduce((total, blockGroup) => {
+      const matchingBlocks = blockGroup.blocks.filter(block => block.guardianProverID === targetId);
+      return total + matchingBlocks.length;
+    }, 0);
 }


### PR DESCRIPTION
### Description

`getGuardianProverIdsPerBlockNumber.ts`:  avoid ` for in ` loop ,  use Object.keys to obtain the keys of the blocks object, ensuring that is processed in the order of insertion.

`signedBlocksPerGuardian.ts`:   eliminate temporary variables , `count` can be removed and avoid using the increment operator.