### PR TITLE
chore(bridge-ui): fix configuredChains.json validation error for localhost setup

### DIFF
--- a/packages/bridge-ui/config/sample/configuredChains.example
+++ b/packages/bridge-ui/config/sample/configuredChains.example
@@ -2,36 +2,79 @@
   "configuredChains": [
     {
       "123456": {
-        "name": "",
+        "name": "Chain Name 1",
         "type": "L1",
-        "icon": "path/or/url/to/icon",
-        "urls": {
-          "rpc": "",
-          "explorer": ""
+        "icon": "path/or/url/to/icon1",
+        "rpcUrls": {
+          "default": {
+            "http": [
+              "https://rpc.chain1.url"
+            ]
+          }
+        },
+        "nativeCurrency": {
+          "name": "Currency1",
+          "symbol": "SYM1",
+          "decimals": 18
+        },
+        "blockExplorers": {
+          "default": {
+            "name": "Explorer 1",
+            "url": "https://explorer.chain1.url/"
+          }
         }
       }
     },
     {
       "78910": {
-        "name": "",
+        "name": "Chain Name 2",
         "type": "L2",
-        "icon": "path/or/url/to/icon",
-        "urls": {
-          "rpc": "",
-          "explorer": ""
+        "icon": "path/or/url/to/icon2",
+        "rpcUrls": {
+          "default": {
+            "http": [
+              "https://rpc.chain2.url"
+            ]
+          }
+        },
+        "nativeCurrency": {
+          "name": "Currency2",
+          "symbol": "SYM2",
+          "decimals": 18
+        },
+        "blockExplorers": {
+          "default": {
+            "name": "Explorer 2",
+            "url": "https://explorer.chain2.url/"
+          }
         }
       }
     },
     {
       "98765": {
-        "name": "",
+        "name": "Chain Name 3",
         "type": "L3",
-        "icon": "path/or/url/to/icon",
-        "urls": {
-          "rpc": "",
-          "explorer": ""
+        "icon": "path/or/url/to/icon3",
+        "rpcUrls": {
+          "default": {
+            "http": [
+              "https://rpc.chain3.url"
+            ]
+          }
+        },
+        "nativeCurrency": {
+          "name": "Currency3",
+          "symbol": "SYM3",
+          "decimals": 18
+        },
+        "blockExplorers": {
+          "default": {
+            "name": "Explorer 3",
+            "url": "https://explorer.chain3.url/"
+          }
         }
       }
     }
   ]
 }
+


### PR DESCRIPTION
I was setting up the bridge UI to run on localhost and following the steps in the [README.md](https://github.com/taikoxyz/taiko-mono/blob/main/packages/bridge-ui/README.md), but I ran into this error when calling `pnpm dev`:

```sh

error when starting dev server:
Error: encoded configuredChains.json is not valid.
    ...
 ELIFECYCLE  Command failed with exit code 1.
```

I was pretty sure I filled everything out right, like this:

```json
{
  "configuredChains": [
    {
      "167008": {
        "name": "Taiko Katla L2",
        "type": "L2",
        "icon": "",
        "urls": {
          "rpc": "https://rpc.katla.taiko.xyz",
          "explorer": "https://explorer.katla.taiko.xyz/"
        }
      }
    },
    ...
  ]
}
```

But it wasn't working.

So, I checked the schema in `config/schemas/configuredChains.schema.json`, made my config match it, and it started working. Turns out, there was this commit: https://github.com/taikoxyz/taiko-mono/commit/d6ef79eae0836a9dabd481cd0953bc03eea9bf7a that changed the schema but didn't update the sample config, which is why I was getting that error about `configuredChains.json` being invalid after filling it out.
