### PR TITLE
chore: fix typos

### DIFF
--- a/packages/protocol/test/team/airdrop/ERC20Airdrop.t.sol
+++ b/packages/protocol/test/team/airdrop/ERC20Airdrop.t.sol
@@ -110,7 +110,7 @@ contract TestERC20Airdrop is TaikoTest {
         vm.stopPrank();
 
         // 5. Mint (AKA transfer) to the vault. This step on mainnet will be done by Taiko Labs. For
-        // testing on A6 the imporatnt thing is: HAVE tokens in this vault!
+        // testing on A6 the important thing is: HAVE tokens in this vault!
         vm.prank(address(vault), owner);
         BridgedERC20(token).mint(address(vault), 1_000_000_000e18);
 

--- a/packages/protocol/test/team/airdrop/ERC721Airdrop.t.sol
+++ b/packages/protocol/test/team/airdrop/ERC721Airdrop.t.sol
@@ -119,7 +119,7 @@ contract TestERC721Airdrop is TaikoTest {
         vm.startPrank(address(vault));
         // 5. Mint 5 NFTs token ids from 0 - 4 to the vault. This step on mainnet will be done by
         // Taiko Labs. For
-        // testing on A6 the imporatnt thing is: HAVE tokens in this vault!
+        // testing on A6 the important thing is: HAVE tokens in this vault!
         for (uint256 i; i != mintSupply; ++i) {
             BridgedERC721(token).mint(address(vault), i);
         }


### PR DESCRIPTION
fix a typo: `imporatnt`->`important`