### PR TITLE
chore(relayer): refactor db migrations for events_canonical_token_symbol

### DIFF
--- a/packages/relayer/migrations/1666650599_create_events_table.sql
+++ b/packages/relayer/migrations/1666650599_create_events_table.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS events (
     kind VARCHAR(255) NOT NULL DEFAULT "",
     data JSON NOT NULL,
     canonical_token_address VARCHAR(255) DEFAULT "",
-    canonical_token_symbol VARCHAR(10) DEFAULT "",
+    canonical_token_symbol VARCHAR(255) DEFAULT "",
     canonical_token_name VARCHAR(255) DEFAULT "",
     canonical_token_decimals int DEFAULT 0,
     amount VARCHAR(255) NOT NULL DEFAULT 0,

--- a/packages/relayer/migrations/1707727779_alert_events_canonical_token_symbol_length.sql
+++ b/packages/relayer/migrations/1707727779_alert_events_canonical_token_symbol_length.sql
@@ -1,9 +1,0 @@
--- +goose Up
--- +goose StatementBegin
-ALTER TABLE `events` MODIFY COLUMN `canonical_token_symbol` VARCHAR(255);
--- +goose StatementEnd
-
--- +goose Down
--- +goose StatementBegin
-ALTER TABLE `events` MODIFY COLUMN `canonical_token_symbol` VARCHAR(10);
--- +goose StatementEnd


### PR DESCRIPTION
We create tables from scratch in alpha-7. It's easier to read the database schema and migrations with the PR. 