### PR TITLE
fix(bridge-ui): move label to i18n, fix some typos

### DIFF
--- a/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -222,7 +222,7 @@
       </div>
     {/if}
   </div>
-  <!-- We catch key events aboe -->
+  <!-- We catch key events above -->
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <div role="button" tabindex="0" class="overlay-backdrop" on:click={closeModalIfClickedOutside} />
 </dialog>

--- a/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -206,7 +206,7 @@
 
     {#if customTokens.length > 0}
       <div class="flex h-full w-full flex-col justify-between mt-6">
-        <h3 class="title-body-bold mb-7">Your imported tokens:</h3>
+        <h3 class="title-body-bold mb-7">{$t('token_dropdown.imported_tokens')}</h3>
         {#each customTokens as ct (ct.symbol)}
           <div class="flex items-center justify-between">
             <div class="flex items-center m-2 space-x-2">

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -402,7 +402,8 @@
       "description": "You can add your own token by entering the contract address below. Make sure you are on the chain where the token is deployed.",
       "title": "Add your own token"
     },
-    "label": "Select token"
+    "label": "Select token",
+    "imported_tokens": "Your imported tokens:"
   },
   "transactions": {
     "actions": {


### PR DESCRIPTION
**Changes:**

- Move label content into i18n. Move the label "**_Your imported token:_**" to the **en.json** file
- Fix spelling in some code comments. aboe -> above