### PR TITLE
feat(relayer): enable rabbitmq metrics in prometheus in docker-compose

### DIFF
--- a/packages/relayer/docker-compose/docker-compose.yml
+++ b/packages/relayer/docker-compose/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
+      - 15692:15692
     volumes:
       - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
       - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq

--- a/packages/relayer/docker-compose/prometheus.yml
+++ b/packages/relayer/docker-compose/prometheus.yml
@@ -6,3 +6,7 @@ scrape_configs:
     scrape_interval: 15s
     static_configs:
       - targets: ["localhost:9090"]
+
+  - job_name: "rabbitmq"
+    static_configs:
+      - targets: ["host.docker.internal:15692"]


### PR DESCRIPTION
<img width="1508" alt="Screen Shot 2024-03-25 at 12 20 10 AM" src="https://github.com/taikoxyz/taiko-mono/assets/104292916/e8e80700-a2b6-428f-b2ac-89719af12bc1">
