### PR TITLE
fix(relayer): func WaitConfirmations should not wait forever for ethereum.NotFound

### DIFF
--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -84,6 +84,7 @@ func (p *Processor) processMessage(
 
 	slog.Info("waiting for confirmations",
 		"msgHash", common.BytesToHash(msgBody.Event.MsgHash[:]).Hex(),
+		"txHash", msgBody.Event.Raw.TxHash,
 	)
 
 	if err := p.waitForConfirmations(ctx, msgBody.Event.Raw.TxHash, msgBody.Event.Raw.BlockNumber); err != nil {

--- a/packages/relayer/types.go
+++ b/packages/relayer/types.go
@@ -68,7 +68,10 @@ var (
 
 // WaitConfirmations won't return before N blocks confirmations have been seen
 // on destination chain, or context is cancelled.
+// txHash is from Raw.TxHash in event or SignalServiceChainDataSynced.
 func WaitConfirmations(ctx context.Context, confirmer confirmer, confirmations uint64, txHash common.Hash) error {
+	notFoundCount := 0
+
 	checkConfs := func() error {
 		receipt, err := confirmer.TransactionReceipt(ctx, txHash)
 		if err != nil {
@@ -83,7 +86,7 @@ func WaitConfirmations(ctx context.Context, confirmer confirmer, confirmations u
 		want := receipt.BlockNumber.Uint64() + confirmations
 
 		if latest < want {
-			slog.Info("waiting for confirmations", "latestBlockNum", latest, "wantBlockNum", want)
+			slog.Info("waiting for confirmations", "latestBlockNum", latest, "wantBlockNum", want, "txHash", txHash.Hex())
 
 			return errStillWaiting
 		}
@@ -107,7 +110,14 @@ func WaitConfirmations(ctx context.Context, confirmer confirmer, confirmations u
 			return ctx.Err()
 		case <-ticker.C:
 			if err := checkConfs(); err != nil {
-				if err == ethereum.NotFound || err == errStillWaiting {
+				if err == ethereum.NotFound {
+					notFoundCount++
+					if notFoundCount >= 10 {
+						return err
+					}
+
+					continue
+				} else if err == errStillWaiting {
 					continue
 				}
 


### PR DESCRIPTION
WaitConfirmations used in processor should not wait forever for ethereum.NotFound. It will cause the processor stuck.