### PR TITLE
fix(protocol): scale up basefee by `GAS_TARGET * ADJUSTMENT_QUOTIENT`

### DIFF
--- a/packages/protocol/contracts/L2/Lib1559Math.sol
+++ b/packages/protocol/contracts/L2/Lib1559Math.sol
@@ -22,12 +22,8 @@ library Lib1559Math {
         pure
         returns (uint256)
     {
-        if (_adjustmentFactor == 0) {
-            revert EIP1559_INVALID_PARAMS();
-        }
-
-        return _ethQty(_gasExcess, _adjustmentFactor) / LibFixedPointMath.SCALING_FACTOR
-            / _adjustmentFactor;
+        if (_adjustmentFactor == 0) revert EIP1559_INVALID_PARAMS();
+        return _ethQty(_gasExcess, _adjustmentFactor) / LibFixedPointMath.SCALING_FACTOR;
     }
 
     /// @dev exp(gas_qty / TARGET / ADJUSTMENT_QUOTIENT)

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -12,17 +12,18 @@ contract TestLib1559Math is TaikoTest {
         uint256 adjustmentFactor = gasTarget * adjustmentQuotient;
         // The expected values are calculated in eip1559_util.py
 
-        uint256 baseFee =
-            Lib1559Math.basefee({ _gasExcess: 49_954_623_777, _adjustmentFactor: adjustmentFactor });
-        _assertAmostEq(baseFee, 1_199_999_900_175_871_825);
-
-        baseFee = Lib1559Math.basefee({
-            _gasExcess: LibFixedPointMath.MAX_EXP_INPUT * adjustmentFactor
-                / LibFixedPointMath.SCALING_FACTOR,
-            _adjustmentFactor: adjustmentFactor
-        });
         _assertAmostEq(
-            baseFee, 57_896_044_586_242_203_305_830_093_650_308_530_112_287_501_933_378_291_142_596
+            1_199_999_900_175_871_825,
+            Lib1559Math.basefee({ _gasExcess: 49_954_623_777, _adjustmentFactor: adjustmentFactor })
+        );
+
+        _assertAmostEq(
+            57_896_044_586_242_203_305_830_093_650_308_530_112_287_501_933_378_291_142_596,
+            Lib1559Math.basefee({
+                _gasExcess: LibFixedPointMath.MAX_EXP_INPUT * adjustmentFactor
+                    / LibFixedPointMath.SCALING_FACTOR,
+                _adjustmentFactor: adjustmentFactor
+            })
         );
     }
 

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -11,12 +11,12 @@ contract TestLib1559Math is TaikoTest {
         uint256 adjustmentQuotient = 8;
         uint256 adjustmentFactor = gasTarget * adjustmentQuotient;
         // The expected values are calculated in eip1559_util.py
-        _assertAmostEq(
-            999_999_916,
-            Lib1559Math.basefee({ _gasExcess: 49_954_623_777, _adjustmentFactor: adjustmentFactor })
-        );
 
-        uint256 baseFee = Lib1559Math.basefee({
+        uint256 baseFee =
+            Lib1559Math.basefee({ _gasExcess: 49_954_623_777, _adjustmentFactor: adjustmentFactor });
+        _assertAmostEq(baseFee, 1_199_999_900_175_871_825);
+
+        baseFee = Lib1559Math.basefee({
             _gasExcess: LibFixedPointMath.MAX_EXP_INPUT * adjustmentFactor
                 / LibFixedPointMath.SCALING_FACTOR,
             _adjustmentFactor: adjustmentFactor

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -16,13 +16,13 @@ contract TestLib1559Math is TaikoTest {
             Lib1559Math.basefee({ _gasExcess: 49_954_623_777, _adjustmentFactor: adjustmentFactor })
         );
 
+        uint256 baseFee = Lib1559Math.basefee({
+            _gasExcess: LibFixedPointMath.MAX_EXP_INPUT * adjustmentFactor
+                / LibFixedPointMath.SCALING_FACTOR,
+            _adjustmentFactor: adjustmentFactor
+        });
         _assertAmostEq(
-            48_246_703_821_869_050_543_408_253_349_256_099_602_613_005_189_120,
-            Lib1559Math.basefee({
-                _gasExcess: LibFixedPointMath.MAX_EXP_INPUT * adjustmentFactor
-                    / LibFixedPointMath.SCALING_FACTOR,
-                _adjustmentFactor: adjustmentFactor
-            })
+            baseFee, 57_896_044_586_242_203_305_830_093_650_308_530_112_287_501_933_378_291_142_596
         );
     }
 


### PR DESCRIPTION
Not a guru on math, this PR simply tris to follow OZ's suggestion to scale up the basefee by `GAS_TARGET * ADJUSTMENT_QUOTIENT`.

Based on the test result in _test_eip1559_math_, the basefee is scaled by 1200000000 times, since in our testnet, we see basefee is almost always 1wei (maybe even much smaller than 1wei), with 1200000000x scaled up, 1200000000wei is 1.2 gwei, seems to be a reasonable number.

@Brechtpd you may have the best knowledge to make the call.

