### PR TITLE
fix(relayer): revert func `WaitConfirmations` should not wait forever for ethereum.NotFound

### DIFF
--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -84,7 +84,6 @@ func (p *Processor) processMessage(
 
 	slog.Info("waiting for confirmations",
 		"msgHash", common.BytesToHash(msgBody.Event.MsgHash[:]).Hex(),
-		"txHash", msgBody.Event.Raw.TxHash,
 	)
 
 	if err := p.waitForConfirmations(ctx, msgBody.Event.Raw.TxHash, msgBody.Event.Raw.BlockNumber); err != nil {


### PR DESCRIPTION
Reverts taikoxyz/taiko-mono#16547

Synced with @cyberhorsey  offline. 
```
The context has a timeout
It will hit the case <-ctx.Done(): and return, after the contet's timeout
not the ethereum RPC's timeout.
ctx, cancelFunc := context.WithTimeout(ctx, time.Duration(p.confTimeoutInSeconds)*time.Second)
```
