### PR TITLE
fix(protocol): call _disableInitializers in AddressResolver's constructor.

### DIFF
--- a/packages/protocol/contracts/common/AddressResolver.sol
+++ b/packages/protocol/contracts/common/AddressResolver.sol
@@ -26,6 +26,10 @@ abstract contract AddressResolver is IAddressResolver, Initializable {
         _;
     }
 
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @inheritdoc IAddressResolver
     function resolve(
         bytes32 _name,


### PR DESCRIPTION
Based on this report from OZ's automated report:

https://defender.openzeppelin.com/v2/#/code/report-details/16655bd8-e1e1-4dbf-bedb-d450f0fa7c29