### PR TITLE
fix(protocol): add 1 to _REENTRY_SLOT in EssentialContract

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -16,10 +16,10 @@ contract Bridge is EssentialContract, IBridge {
     using LibAddress for address;
     using LibAddress for address payable;
 
-    /// @dev The slot in transient storage of the call context.
-    /// keccak256("bridge.ctx_slot") + 1
+    /// @dev The slot in transient storage of the call context. This is the keccak256 hash
+    /// of "bridge.ctx_slot"
     bytes32 private constant _CTX_SLOT =
-        0xe4ece82196de19aabe639620d7f716c433d1348f96ce727c9989a982dbadc2ba;
+        0xe4ece82196de19aabe639620d7f716c433d1348f96ce727c9989a982dbadc2b9;
 
     /// @dev Place holder value when not using transient storage
     uint256 internal constant PLACEHOLDER = type(uint256).max;

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -16,10 +16,10 @@ contract Bridge is EssentialContract, IBridge {
     using LibAddress for address;
     using LibAddress for address payable;
 
-    /// @dev The slot in transient storage of the call context. This is the keccak256 hash
-    /// of "bridge.ctx_slot"
+    /// @dev The slot in transient storage of the call context.
+    /// keccak256("bridge.ctx_slot") + 1
     bytes32 private constant _CTX_SLOT =
-        0xe4ece82196de19aabe639620d7f716c433d1348f96ce727c9989a982dbadc2b9;
+        0xe4ece82196de19aabe639620d7f716c433d1348f96ce727c9989a982dbadc2ba;
 
     /// @dev Place holder value when not using transient storage
     uint256 internal constant PLACEHOLDER = type(uint256).max;

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -13,10 +13,13 @@ abstract contract EssentialContract is UUPSUpgradeable, Ownable2StepUpgradeable,
 
     uint8 private constant _TRUE = 2;
 
-    /// @dev The slot in transient storage of the reentry lock. This is the keccak256 hash
-    /// of "ownerUUPS.reentry_slot"
+    /// @dev The slot in transient storage of the reentry lock.
+    /// This is the result of keccak256("ownerUUPS.reentry_slot") plus 1. The addition aims to
+    /// prevent hash collisions with slots defined in EIP-1967, where slots are derived by
+    /// keccak256("something") - 1, and with slots in SignalService, calculated directly with
+    /// keccak256("something").
     bytes32 private constant _REENTRY_SLOT =
-        0xa5054f728453d3dbe953bdc43e4d0cb97e662ea32d7958190f3dc2da31d9721a;
+        0xa5054f728453d3dbe953bdc43e4d0cb97e662ea32d7958190f3dc2da31d9721b;
 
     /// @dev Slot 1.
     uint8 private __reentry;


### PR DESCRIPTION
Change _REENTRY_SLOT from `0xa5054f728453d3dbe953bdc43e4d0cb97e662ea32d7958190f3dc2da31d9721a` to `0xa5054f728453d3dbe953bdc43e4d0cb97e662ea32d7958190f3dc2da31d9721a + 1`

Based on https://github.com/code-423n4/2024-03-taiko-findings/issues/11