### PR TITLE
feat(protocol): avoid proving-fee payment if amount is 0

### DIFF
--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -112,7 +112,6 @@ contract AssignmentHook is EssentialContract, IHook {
 
         // The proposer irrevocably pays a fee to the assigned prover, either in
         // Ether or ERC20 tokens.
-
         if (assignment.feeToken == address(0)) {
             // Paying Ether
             // Note that this payment may fail if it cost more gas

--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -112,18 +112,17 @@ contract AssignmentHook is EssentialContract, IHook {
 
         // The proposer irrevocably pays a fee to the assigned prover, either in
         // Ether or ERC20 tokens.
-        if (proverFee != 0) {
-            if (assignment.feeToken == address(0)) {
-                // Paying Ether
-                // Note that this payment may fail if it cost more gas
-                bool success = _blk.assignedProver.sendEther(proverFee, MAX_GAS_PAYING_PROVER, "");
-                if (!success) emit EtherPaymentFailed(_blk.assignedProver, MAX_GAS_PAYING_PROVER);
-            } else {
-                // Paying ERC20 tokens
-                IERC20(assignment.feeToken).safeTransferFrom(
-                    _meta.sender, _blk.assignedProver, proverFee
-                );
-            }
+
+        if (assignment.feeToken == address(0)) {
+            // Paying Ether
+            // Note that this payment may fail if it cost more gas
+            bool success = _blk.assignedProver.sendEther(proverFee, MAX_GAS_PAYING_PROVER, "");
+            if (!success) emit EtherPaymentFailed(_blk.assignedProver, MAX_GAS_PAYING_PROVER);
+        } else if (proverFee != 0) {
+            // Paying ERC20 tokens
+            IERC20(assignment.feeToken).safeTransferFrom(
+                _meta.sender, _blk.assignedProver, proverFee
+            );
         }
 
         // block.coinbase can be address(0) in tests

--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -112,16 +112,18 @@ contract AssignmentHook is EssentialContract, IHook {
 
         // The proposer irrevocably pays a fee to the assigned prover, either in
         // Ether or ERC20 tokens.
-        if (assignment.feeToken == address(0)) {
-            // Paying Ether
-            // Note that this payment may fail if it cost more gas
-            bool success = _blk.assignedProver.sendEther(proverFee, MAX_GAS_PAYING_PROVER, "");
-            if (!success) emit EtherPaymentFailed(_blk.assignedProver, MAX_GAS_PAYING_PROVER);
-        } else {
-            // Paying ERC20 tokens
-            IERC20(assignment.feeToken).safeTransferFrom(
-                _meta.sender, _blk.assignedProver, proverFee
-            );
+        if (proverFee != 0) {
+            if (assignment.feeToken == address(0)) {
+                // Paying Ether
+                // Note that this payment may fail if it cost more gas
+                bool success = _blk.assignedProver.sendEther(proverFee, MAX_GAS_PAYING_PROVER, "");
+                if (!success) emit EtherPaymentFailed(_blk.assignedProver, MAX_GAS_PAYING_PROVER);
+            } else {
+                // Paying ERC20 tokens
+                IERC20(assignment.feeToken).safeTransferFrom(
+                    _meta.sender, _blk.assignedProver, proverFee
+                );
+            }
         }
 
         // block.coinbase can be address(0) in tests


### PR DESCRIPTION
This is mainly for gas optimization.