### PR TITLE
fix(protocol): fix ERC20Airdrop2.sol with an extended withdrawal window

### DIFF
--- a/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
@@ -14,6 +14,8 @@ contract ERC20Airdrop2 is MerkleClaimable {
     using LibMath for uint256;
     using SafeERC20 for IERC20;
 
+    uint256 public constant WITHDRAWAL_GRACE_PERIOD = 30 days;
+
     /// @notice The address of the token contract.
     address public token;
 
@@ -39,7 +41,10 @@ contract ERC20Airdrop2 is MerkleClaimable {
     error WITHDRAWALS_NOT_ONGOING();
 
     modifier ongoingWithdrawals() {
-        if (claimEnd > block.timestamp || claimEnd + withdrawalWindow < block.timestamp) {
+        if (
+            claimEnd > block.timestamp
+                || claimEnd + withdrawalWindow + WITHDRAWAL_GRACE_PERIOD < block.timestamp
+        ) {
             revert WITHDRAWALS_NOT_ONGOING();
         }
         _;

--- a/packages/protocol/test/team/airdrop/ERC20Airdrop2.t.sol
+++ b/packages/protocol/test/team/airdrop/ERC20Airdrop2.t.sol
@@ -137,9 +137,9 @@ contract TestERC20Airdrop2 is TaikoTest {
         vm.expectRevert(ERC20Airdrop2.WITHDRAWALS_NOT_ONGOING.selector);
         airdrop2.withdraw(Alice);
 
-        // Roll 11 day after
+        // Roll 31 day after
         vm.roll(block.number + 200);
-        vm.warp(claimEnd + 11 days);
+        vm.warp(claimEnd + 10 days + 30 days + 1); // withdrawal window + grace period + 1sec
 
         (uint256 balance, uint256 withdrawable) = airdrop2.getBalance(Alice);
 


### PR DESCRIPTION
https://github.com/code-423n4/2024-03-taiko-findings/issues/245

@adaki2004 Dani, please take a look at the bug report above...

OR we simply delete this contract if ERC20Airdrop is to be used by genesis airdop.