### PR TITLE
fix(bridge-ui): fix token balance display

### DIFF
--- a/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/ImportStep/TokenInput/TokenInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/ImportStep/TokenInput/TokenInput.svelte
@@ -161,12 +161,11 @@
     if ($account && $account.address && $account?.isConnected) {
       validateAmount($selectedToken);
       refreshUserBalance();
-      if ($selectedToken && $selectedToken.type !== TokenType.ETH)
-        $tokenBalance = await fetchBalance({
-          userAddress: $account.address,
-          token: $selectedToken,
-          srcChainId: $connectedSourceChain?.id,
-        });
+      $tokenBalance = await fetchBalance({
+        userAddress: $account.address,
+        token: $selectedToken,
+        srcChainId: $connectedSourceChain?.id,
+      });
 
       previousSelectedToken = $selectedToken;
     } else {


### PR DESCRIPTION
There's a token balance displaying incorrectly when bridging following the step below
1. Select a token (TTKOk or Horse)
2. Select tab NFT
3. Select tab Token
4. Switch chain
5. The balance will display incorrectly
![Screenshot 2567-04-01 at 22 43 34](https://github.com/taikoxyz/taiko-mono/assets/46973077/12d92c7b-498e-4af8-b016-a3c1df02d499)

So that I found that `tokenBalance` is not changed in `reset()`