### PR TITLE
chore(protocol): index more events

### DIFF
--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -77,9 +77,11 @@ abstract contract TaikoEvents {
         uint16 tier
     );
 
-    /// @dev Emitted when proving has been paused
-    /// @param paused True if paused, false if unpaused.
-    event ProvingPaused(bool paused);
+    /// @notice Emitted when proving is paused or unpaused.
+    /// @param lastVerifiedBlockId The last verified block.
+    /// @param numBlocks The number of blocks.
+    /// @param paused The pause status.
+    event ProvingPaused(uint64 indexed lastVerifiedBlockId, uint64 numBlocks, bool paused);
 
     /// @dev Emitted when an Ethereum deposit is made.
     /// @param deposit The Ethereum deposit information including recipient,

--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -31,7 +31,7 @@ contract AssignmentHook is EssentialContract, IHook {
         uint256 tip; // A tip to L1 block builder
     }
 
-    event EtherPaymentFailed(address to, uint256 maxGas);
+    event EtherPaymentFailed(address indexed to, uint256 maxGas);
 
     /// @notice Max gas paying the prover.
     /// @dev This should be large enough to prevent the worst cases for the prover.

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -52,8 +52,10 @@ library LibProving {
     );
 
     /// @notice Emitted when proving is paused or unpaused.
+    /// @param lastVerifiedBlockId The last verified block.
+    /// @param numBlocks The number of blocks.
     /// @param paused The pause status.
-    event ProvingPaused(bool paused);
+    event ProvingPaused(uint64 indexed lastVerifiedBlockId, uint64 numBlocks, bool paused);
 
     // Warning: Any errors defined here must also be defined in TaikoErrors.sol.
     error L1_ALREADY_CONTESTED();
@@ -78,7 +80,7 @@ library LibProving {
         if (!_pause) {
             _state.slotB.lastUnpausedAt = uint64(block.timestamp);
         }
-        emit ProvingPaused(_pause);
+        emit ProvingPaused(_state.slotB.lastVerifiedBlockId, _state.slotB.numBlocks, _pause);
     }
 
     /// @dev Proves or contests a block transition.

--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -16,7 +16,7 @@ contract GuardianProver is Guardians {
     /// @param blockHash The block hash.
     /// @param approved If the proof is approved.
     event GuardianApproval(
-        address indexed addr, uint256 indexed blockId, bytes32 blockHash, bool approved
+        address indexed addr, uint256 indexed blockId, bytes32 indexed blockHash, bool approved
     );
 
     /// @notice Initializes the contract.

--- a/packages/protocol/contracts/L1/provers/Guardians.sol
+++ b/packages/protocol/contracts/L1/provers/Guardians.sol
@@ -31,7 +31,7 @@ abstract contract Guardians is EssentialContract {
     /// @notice Emitted when the set of guardians is updated
     /// @param version The new version
     /// @param guardians The new set of guardians
-    event GuardiansUpdated(uint32 version, address[] guardians);
+    event GuardiansUpdated(uint32 indexed version, address[] guardians);
 
     /// @notice Emitted when an approval is made
     /// @param operationId The operation ID

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -54,7 +54,7 @@ contract TaikoL2 is EssentialContract {
     /// @notice Emitted when the latest L1 block details are anchored to L2.
     /// @param parentHash The hash of the parent block.
     /// @param gasExcess The gas excess value used to calculate the base fee.
-    event Anchored(bytes32 parentHash, uint64 gasExcess);
+    event Anchored(bytes32 indexed parentHash, uint64 gasExcess);
 
     error L2_BASEFEE_MISMATCH();
     error L2_INVALID_L1_CHAIN_ID();

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -96,7 +96,7 @@ interface IBridge {
     /// @param msgHash The hash of the message.
     /// @param suspended True if the message is suspended.
     /// @param receivedAt The received-at timestamp, 0 if suspended is true.
-    event MessageSuspended(bytes32 msgHash, bool suspended, uint64 receivedAt);
+    event MessageSuspended(bytes32 indexed msgHash, bool suspended, uint64 receivedAt);
 
     /// @notice Emitted when an address is banned or unbanned.
     /// @param addr The address to ban or unban.

--- a/packages/protocol/contracts/common/AddressManager.sol
+++ b/packages/protocol/contracts/common/AddressManager.sol
@@ -18,7 +18,7 @@ contract AddressManager is EssentialContract, IAddressManager {
     /// @param newAddress The new address.
     /// @param oldAddress The old address.
     event AddressSet(
-        uint64 indexed chainId, bytes32 indexed name, address newAddress, address oldAddress
+        uint64 indexed chainId, bytes32 indexed name, address indexed newAddress, address oldAddress
     );
 
     error AM_INVALID_PARAMS();

--- a/packages/protocol/contracts/common/EssentialContract.sol
+++ b/packages/protocol/contracts/common/EssentialContract.sol
@@ -27,11 +27,11 @@ abstract contract EssentialContract is UUPSUpgradeable, Ownable2StepUpgradeable,
 
     /// @notice Emitted when the contract is paused.
     /// @param account The account that paused the contract.
-    event Paused(address account);
+    event Paused(address indexed account);
 
     /// @notice Emitted when the contract is unpaused.
     /// @param account The account that unpaused the contract.
-    event Unpaused(address account);
+    event Unpaused(address indexed account);
 
     error REENTRANT_CALL();
     error INVALID_PAUSE_STATUS();

--- a/packages/protocol/contracts/signal/ISignalService.sol
+++ b/packages/protocol/contracts/signal/ISignalService.sol
@@ -63,7 +63,7 @@ interface ISignalService {
     /// @param signal The signal (message) that was sent.
     /// @param slot The location in storage where this signal is stored.
     /// @param value The value of the signal.
-    event SignalSent(address app, bytes32 signal, bytes32 slot, bytes32 value);
+    event SignalSent(address indexed app, bytes32 indexed signal, bytes32 slot, bytes32 value);
 
     /// @notice Emitted when an address is authorized or deauthorized.
     /// @param addr The address to be authorized or deauthorized.

--- a/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
+++ b/packages/protocol/contracts/team/airdrop/ERC20Airdrop2.sol
@@ -34,7 +34,7 @@ contract ERC20Airdrop2 is MerkleClaimable {
     /// @notice Event emitted when a user withdraws their tokens.
     /// @param user The address of the user.
     /// @param amount The amount of tokens withdrawn.
-    event Withdrawn(address user, uint256 amount);
+    event Withdrawn(address indexed user, uint256 amount);
 
     error WITHDRAWALS_NOT_ONGOING();
 

--- a/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol
+++ b/packages/protocol/contracts/team/airdrop/MerkleClaimable.sol
@@ -24,7 +24,7 @@ abstract contract MerkleClaimable is EssentialContract {
 
     /// @notice Event emitted when a claim is made
     /// @param hash Hash of the claim
-    event Claimed(bytes32 hash);
+    event Claimed(bytes32 indexed hash);
 
     error CLAIM_NOT_ONGOING();
     error CLAIMED_ALREADY();

--- a/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20Base.sol
@@ -18,7 +18,7 @@ abstract contract BridgedERC20Base is EssentialContract, IBridgedERC20 {
     /// @notice Emitted when the migration status is changed.
     /// @param addr The address migrating 'to' or 'from'.
     /// @param inbound If false then signals migrating 'from', true if migrating 'into'.
-    event MigrationStatusChanged(address addr, bool inbound);
+    event MigrationStatusChanged(address indexed addr, bool inbound);
 
     /// @notice Emitted when tokens are migrated to or from the bridged token.
     /// @param fromToken The address of the bridged token.

--- a/packages/protocol/contracts/verifiers/RiscZeroVerifier.sol
+++ b/packages/protocol/contracts/verifiers/RiscZeroVerifier.sol
@@ -21,7 +21,7 @@ contract RiscZeroVerifier is EssentialContract, IVerifier {
     /// @dev Emitted when a trusted image is set / unset.
     /// @param imageId The id of the image
     /// @param trusted The block's assigned prover.
-    event ImageTrusted(bytes32 imageId, bool trusted);
+    event ImageTrusted(bytes32 indexed imageId, bool trusted);
 
     error RISC_ZERO_INVALID_IMAGE_ID();
     error RISC_ZERO_INVALID_PROOF();


### PR DESCRIPTION
Based on a report from code4rena - https://github.com/code-423n4/2024-03-taiko-findings/blob/main/data/0x11singh99-Q.md#n-11-event-is-missing-indexed-fields


> Index event fields make the field more quickly accessible to off-chain tools that parse events. However, note that each index field costs extra gas during emission, so it's not necessarily best to index the maximum allowed per event (three fields). Each event should use three indexed fields if there are three or more fields, and gas usage is not particularly of concern for the events in question. If there are fewer than three fields, all of the fields should be indexed.