### PR TITLE
fix(protocol): fix guardian prover

### DIFF
--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -35,7 +35,7 @@ contract GuardianProver is Guardians {
     /// @param _meta The block's metadata.
     /// @param _tran The valid transition.
     /// @param _proof The tier proof.
-    /// @return approved_ True if the minimum number of approval is aquired, false otherwise.
+    /// @return approved_ True if the minimum number of approval is acquired, false otherwise.
     function approve(
         TaikoData.BlockMetadata calldata _meta,
         TaikoData.Transition calldata _tran,

--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -19,7 +19,7 @@ contract GuardianProver is Guardians {
     event GuardianApproval(
         address indexed addr,
         uint256 indexed blockId,
-        bytes32 blockHash,
+        bytes32 indexed blockHash,
         bool approved,
         bytes proofData
     );
@@ -50,7 +50,7 @@ contract GuardianProver is Guardians {
             revert INVALID_PROOF();
         }
 
-        bytes32 hash = keccak256(abi.encode(_meta, _tran, _proof));
+        bytes32 hash = keccak256(abi.encode(_meta, _tran, _proof.data));
         approved_ = approve(_meta.id, hash);
 
         emit GuardianApproval(msg.sender, _meta.id, _tran.blockHash, approved_, _proof.data);

--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -15,8 +15,13 @@ contract GuardianProver is Guardians {
     /// @param blockId The block ID.
     /// @param blockHash The block hash.
     /// @param approved If the proof is approved.
+    /// @param proofData The proof data.
     event GuardianApproval(
-        address indexed addr, uint256 indexed blockId, bytes32 blockHash, bool approved
+        address indexed addr,
+        uint256 indexed blockId,
+        bytes32 blockHash,
+        bool approved,
+        bytes proofData
     );
 
     /// @notice Initializes the contract.
@@ -45,10 +50,10 @@ contract GuardianProver is Guardians {
             revert INVALID_PROOF();
         }
 
-        bytes32 hash = keccak256(abi.encode(_meta, _tran));
+        bytes32 hash = keccak256(abi.encode(_meta, _tran, _proof));
         approved_ = approve(_meta.id, hash);
 
-        emit GuardianApproval(msg.sender, _meta.id, _tran.blockHash, approved_);
+        emit GuardianApproval(msg.sender, _meta.id, _tran.blockHash, approved_, _proof.data);
 
         if (approved_) {
             deleteApproval(hash);

--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -41,7 +41,7 @@ contract GuardianProver is Guardians {
         nonReentrant
         returns (bool approved_)
     {
-        if (_proof.tier != LibTiers.TIER_GUARDIAN || _proof.data.length != 0) {
+        if (_proof.tier != LibTiers.TIER_GUARDIAN) {
             revert INVALID_PROOF();
         }
 

--- a/packages/protocol/contracts/verifiers/GuardianVerifier.sol
+++ b/packages/protocol/contracts/verifiers/GuardianVerifier.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import "../common/EssentialContract.sol";
+import "../L1/tiers/ITierProvider.sol";
 import "./IVerifier.sol";
 
 /// @title GuardianVerifier
@@ -9,7 +10,8 @@ import "./IVerifier.sol";
 contract GuardianVerifier is EssentialContract, IVerifier {
     uint256[50] private __gap;
 
-    error PERMISSION_DENIED();
+    error GV_INVALID_PROOF();
+    error GV_PERMISSION_DENIED();
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
@@ -22,13 +24,17 @@ contract GuardianVerifier is EssentialContract, IVerifier {
     function verifyProof(
         Context calldata _ctx,
         TaikoData.Transition calldata,
-        TaikoData.TierProof calldata
+        TaikoData.TierProof calldata _proof
     )
         external
         view
     {
+        if (_proof.tier != LibTiers.TIER_GUARDIAN || _proof.data.length != 0) {
+            revert GV_INVALID_PROOF();
+        }
+
         if (_ctx.msgSender != resolve("guardian_prover", false)) {
-            revert PERMISSION_DENIED();
+            revert GV_PERMISSION_DENIED();
         }
     }
 }

--- a/packages/protocol/contracts/verifiers/GuardianVerifier.sol
+++ b/packages/protocol/contracts/verifiers/GuardianVerifier.sol
@@ -29,7 +29,7 @@ contract GuardianVerifier is EssentialContract, IVerifier {
         external
         view
     {
-        if (_proof.tier != LibTiers.TIER_GUARDIAN || _proof.data.length != 0) {
+        if (_proof.tier != LibTiers.TIER_GUARDIAN) {
             revert GV_INVALID_PROOF();
         }
 

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -624,7 +624,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                 blockHash,
                 stateRoot,
                 LibTiers.TIER_GUARDIAN,
-                GuardianVerifier.PERMISSION_DENIED.selector
+                GuardianVerifier.GV_PERMISSION_DENIED.selector
             );
 
             vm.roll(block.number + 15 * 12);

--- a/packages/protocol/test/verifiers/GuardianVerifier.t.sol
+++ b/packages/protocol/test/verifiers/GuardianVerifier.t.sol
@@ -37,7 +37,8 @@ contract TestGuardianVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: "" });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ tier: LibTiers.TIER_GUARDIAN, data: "" });
 
         // `verifyProof()`
         gv.verifyProof(ctx, transition, proof);
@@ -65,10 +66,11 @@ contract TestGuardianVerifier is TaikoL1TestBase {
         });
 
         // TierProof
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: "" });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ tier: LibTiers.TIER_GUARDIAN, data: "" });
 
         // `verifyProof()` with invalid ctx.prover
-        vm.expectRevert(GuardianVerifier.PERMISSION_DENIED.selector);
+        vm.expectRevert(GuardianVerifier.GV_PERMISSION_DENIED.selector);
         gv.verifyProof(ctx, transition, proof);
     }
 }

--- a/packages/protocol/test/verifiers/SgxVerifier.t.sol
+++ b/packages/protocol/test/verifiers/SgxVerifier.t.sol
@@ -255,7 +255,8 @@ contract TestSgxVerifier is TaikoL1TestBase, AttestationBase {
         });
 
         // TierProof
-        TaikoData.TierProof memory proof = TaikoData.TierProof({ tier: 0, data: "" });
+        TaikoData.TierProof memory proof =
+            TaikoData.TierProof({ tier: LibTiers.TIER_GUARDIAN, data: "" });
 
         // `verifyProof()`
         sv.verifyProof(ctx, transition, proof);


### PR DESCRIPTION
https://github.com/code-423n4/2024-03-taiko-findings/issues/248

Previous approvals are accumulated per ` bytes32 hash = keccak256(abi.encode(_meta, _tran))`, and proof.data is totally ignored. Now we calculate hash as `keccak256(abi.encode(_meta, _tran, _proof.data))`, this will enfore provers must have the same proof.data to decide if bonds are returned ( if `bytes32(_proof.data) == RETURN_LIVENESS_BOND`).