### PR TITLE
fix(protocol): fix parent metahash check for the first block

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -85,9 +85,10 @@ library LibProposing {
         bytes32 parentMetaHash =
             _state.blocks[(b.numBlocks - 1) % _config.blockRingBufferSize].metaHash;
 
-        // Check if parent block has the right meta hash
-        // This is to allow the proposer to make sure the block builds on the expected latest chain
-        // state
+        assert(parentMetaHash != 0);
+
+        // Check if parent block has the right meta hash. This is to allow the proposer to make sure
+        // the block builds on the expected latest chain state.
         if (params.parentMetaHash != 0 && parentMetaHash != params.parentMetaHash) {
             revert L1_UNEXPECTED_PARENT();
         }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -84,8 +84,7 @@ library LibProposing {
 
         bytes32 parentMetaHash =
             _state.blocks[(b.numBlocks - 1) % _config.blockRingBufferSize].metaHash;
-
-        assert(parentMetaHash != 0);
+        // assert(parentMetaHash != 0);
 
         // Check if parent block has the right meta hash. This is to allow the proposer to make sure
         // the block builds on the expected latest chain state.

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -68,6 +68,7 @@ library LibVerifying {
         blk.nextTransitionId = 2;
         blk.proposedAt = uint64(block.timestamp);
         blk.verifiedTransitionId = 1;
+        blk.metaHash = bytes32(uint256(1)); // Give the genesis metahash a non-zero value.
 
         // Init the first state transition
         TaikoData.TransitionState storage ts = _state.transitions[0][1];


### PR DESCRIPTION
The check didn't work for block 1 as the genesis block's metahash is 0.

Inspired by https://github.com/code-423n4/2024-03-taiko-findings/issues/218 