### PR TITLE
fix(bridge-ui): fix dropdown menu behavior and chevron icon in transactions status-filter-drop-down

### DIFF
--- a/packages/bridge-ui/src/components/Transactions/Filter/StatusFilterDropdown.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Filter/StatusFilterDropdown.svelte
@@ -9,7 +9,6 @@
 
   export let selectedStatus: MessageStatus | null = null;
 
-  let flipped = false;
   let menuOpen = false;
   let uuid = `dropdown-${uid()}`;
 
@@ -17,7 +16,8 @@
 
   const closeMenu = () => {
     menuOpen = false;
-    flipped = false;
+    // Reset the chevron icon to face left when the menu closes
+    iconFlipperComponent.setFlipped(false);
   };
 
   const options = [
@@ -30,12 +30,28 @@
 
   const toggleMenu = () => {
     menuOpen = !menuOpen;
-    flipped = !flipped;
+    // Update the chevron icon state when toggling the menu
+    iconFlipperComponent.setFlipped(menuOpen);
+    // Add or remove event listener for clicks outside the dropdown menu
+    if (menuOpen) {
+      window.addEventListener('click', handleOutsideClick);
+    } else {
+      window.removeEventListener('click', handleOutsideClick);
+    }
   };
+
 
   const select = (option: (typeof options)[0]) => {
     selectedStatus = option.value;
     closeMenu();
+  };
+
+  const handleOutsideClick = (event: MouseEvent) => {
+      const dropdown = document.querySelector('.relative');
+      // Check if the click event target is outside the dropdown menu
+      if (dropdown && !dropdown.contains(event.target as Node)) {
+          closeMenu();
+      }
   };
 
   $: menuClasses = classNames(
@@ -55,12 +71,11 @@
         ? options.find((option) => option.value === selectedStatus)?.label
         : $t('transactions.filter.all')}
     </span>
+    <!-- Use bind to synchronize the icon state -->
     <IconFlipper
-      bind:flipped
       bind:this={iconFlipperComponent}
       iconType1="chevron-left"
       iconType2="chevron-down"
-      selectedDefault="chevron-left"
       size={15} />
   </button>
   {#if menuOpen}


### PR DESCRIPTION
**This pull request:**

1. Fixes the behavior where the dropdown menu did not close upon clicking again, and the chevron icon remained stagnant.
2. Resolves the issue where clicking elsewhere on the page while the dropdown menu was open failed to reverse the chevron icon to its previous state.

**Changes Made:**

1. Added logic to toggle the dropdown menu state and update the chevron icon accordingly.
2. Implemented event listeners to detect clicks outside the dropdown menu, allowing for automatic menu closure.
3. Updated the component behavior to ensure consistent dropdown menu functionality.

**How to Test:**

1. Open the transactions filter component in the application (https://bridge.katla.taiko.xyz/transactions)
2. Click on the dropdown button to open the menu.
3. Verify that the dropdown menu opens and displays the available options.
4. Click on the dropdown button again to close the menu.
5. Ensure that the dropdown menu closes, and the chevron icon reverts to its initial state.
6. Click anywhere outside the dropdown menu to close it.
7. Confirm that the dropdown menu closes, and the chevron icon flips back accordingly.
