### PR TITLE
fix(protocol): allow recall message to fail

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -209,7 +209,6 @@ contract Bridge is EssentialContract, IBridge {
 
         if (block.timestamp >= invocationDelay + receivedAt) {
             delete proofReceipt[msgHash];
-            messageStatus[msgHash] = Status.RECALLED;
 
             // Some cases recall might fail (e.g. USDC shuts down minting allowance)
             bool success = true;
@@ -235,8 +234,10 @@ contract Bridge is EssentialContract, IBridge {
 
             if (success) {
                 emit MessageRecalled(msgHash);
+                messageStatus[msgHash] = Status.RECALLED;
             } else {
                 emit MessageRecallFailed(msgHash, data);
+                messageStatus[msgHash] = Status.RECALL_FAILED;
             }
         } else if (isNewlyProven) {
             emit MessageReceived(msgHash, _message, true);

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -11,7 +11,8 @@ interface IBridge {
         RETRIABLE,
         DONE,
         FAILED,
-        RECALLED
+        RECALLED,
+        RECALL_FAILED
     }
 
     struct Message {

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -79,6 +79,11 @@ interface IBridge {
     /// @param msgHash The hash of the message.
     event MessageRecalled(bytes32 indexed msgHash);
 
+    /// @notice Emitted when a message is about to be recalled, but fails.
+    /// @param msgHash The hash of the message.
+    /// @param data The return data of the low level call.
+    event MessageRecallFailed(bytes32 indexed msgHash, bytes data);
+
     /// @notice Emitted when a message is executed.
     /// @param msgHash The hash of the message.
     event MessageExecuted(bytes32 indexed msgHash);


### PR DESCRIPTION
As per description: https://github.com/code-423n4/2024-03-taiko-findings/issues/279

So first of all, this "less-invasive" solution, than the author proposed is enough, since:
- We will not support USDC right away
- We won't expect recall() to be called oftern
- We won't expect that our bridge allowance - once approved by Circle - would be reduced to 0 (or to an exact numnber).

So investigating why an `onMessageRecalled` via a specific event might be more useful, and later on we can upgrade our contracts to reward the users if their message status is RECALL_FAILED.