### PR TITLE
chore(bridge-ui): improve dropdown ux 

### DIFF
--- a/packages/bridge-ui/src/components/ChainSelectors/SelectorDialogs/ChainsDropdown.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/SelectorDialogs/ChainsDropdown.svelte
@@ -45,7 +45,12 @@
   <ul
     role="listbox"
     class="text-primary-content text-sm"
-    use:closeOnClickOrEscape={{ enabled: isOpen, callback: () => (isOpen = false) }}>
+    use:closeOnClickOrEscape={{
+      enabled: isOpen,
+      callback: () => {
+        setTimeout(() => (isOpen = false), 0);
+      },
+    }}>
     {#each chains as chain (chain.id)}
       {@const disabled = (isDestination && chain.id === $connectedSourceChain?.id) || chain.id === value?.id}
       {@const icon = chainConfig[Number(chain.id)]?.icon || 'Unknown Chain'}


### PR DESCRIPTION
- Improve the UX of the `ChainsDropdown`
  - The problem where the dropdown wouldn't disappear when the dropdown is showing has been fixed. This was done by adding a `setTimeout` to the `<ul />` callback, which made the toggle feature work properly again.