### PR TITLE
chore(protocol): change SGX INSTANCE_EXPIRY to 365 days

### DIFF
--- a/packages/protocol/contracts/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/verifiers/SgxVerifier.sol
@@ -27,7 +27,7 @@ contract SgxVerifier is EssentialContract, IVerifier {
     }
 
     /// @notice The expiry time for the SGX instance.
-    uint64 public constant INSTANCE_EXPIRY = 180 days;
+    uint64 public constant INSTANCE_EXPIRY = 365 days;
 
     /// @notice A security feature, a delay until an instance is enabled when using onchain RA
     /// verification


### PR DESCRIPTION
The idea is still "buy us time" in case we are very busy with other stuff.

@Brechtpd do you think 365 days is acceptable?