### PR TITLE
fix(protocol): add uri override

### DIFF
--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -2,15 +2,13 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
-import
-    "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/IERC1155MetadataURIUpgradeable.sol";
 import "../common/EssentialContract.sol";
 import "./LibBridgedToken.sol";
 
 /// @title BridgedERC1155
 /// @notice Contract for bridging ERC1155 tokens across different chains.
 /// @custom:security-contact security@taiko.xyz
-contract BridgedERC1155 is EssentialContract, IERC1155MetadataURIUpgradeable, ERC1155Upgradeable {
+contract BridgedERC1155 is EssentialContract, ERC1155Upgradeable {
     /// @notice Address of the source token contract.
     address public srcToken;
 
@@ -50,6 +48,9 @@ contract BridgedERC1155 is EssentialContract, IERC1155MetadataURIUpgradeable, ER
         // for them instead.
         LibBridgedToken.validateInputs(_srcToken, _srcChainId);
         __Essential_init(_owner, _addressManager);
+
+        // The token URI here is not important as the client will have to read the URI from the
+        // canonical contract to fatch meta data.
         __ERC1155_init(LibBridgedToken.buildURI(_srcToken, _srcChainId));
 
         srcToken = _srcToken;
@@ -130,6 +131,7 @@ contract BridgedERC1155 is EssentialContract, IERC1155MetadataURIUpgradeable, ER
         bytes memory /*_data*/
     )
         internal
+        view
         override
     {
         if (_to == address(this)) revert BTOKEN_CANNOT_RECEIVE();

--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -50,7 +50,7 @@ contract BridgedERC1155 is EssentialContract, ERC1155Upgradeable {
         __Essential_init(_owner, _addressManager);
 
         // The token URI here is not important as the client will have to read the URI from the
-        // canonical contract to fatch meta data.
+        // canonical contract to fetch meta data.
         __ERC1155_init(LibBridgedToken.buildURI(_srcToken, _srcChainId));
 
         srcToken = _srcToken;

--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -122,6 +122,27 @@ contract BridgedERC1155 is EssentialContract, ERC1155Upgradeable {
         return LibBridgedToken.buildSymbol(__symbol);
     }
 
+    /// @notice Gets the source token and source chain ID being bridged.
+    /// @return The source token's address.
+    /// @return The source token's chain ID.
+    function source() public view returns (address, uint256) {
+        return (srcToken, srcChainId);
+    }
+
+    /// @notice Returns the token URI.
+    /// @param _tokenId The token id.
+    /// @return The token URI following EIP-681.
+    function uri(uint256 _tokenId) public view override returns (string memory) {
+        // https://github.com/crytic/slither/wiki/Detector-Documentation#abi-encodePacked-collision
+        // The abi.encodePacked() call below takes multiple dynamic arguments. This is known and
+        // considered acceptable in terms of risk.
+        return string(
+            abi.encodePacked(
+                LibBridgedToken.buildURI(srcToken, srcChainId), Strings.toString(_tokenId)
+            )
+        );
+    }
+
     function _beforeTokenTransfer(
         address, /*_operator*/
         address, /*_from*/

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -121,6 +121,7 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         uint256 /*_batchSize*/
     )
         internal
+        view
         override
     {
         if (_to == address(this)) revert BTOKEN_CANNOT_RECEIVE();


### PR DESCRIPTION
As per code4rena finding too, and hance we dont have any tokenURI information (or even how to find it) for 1155, reusing the erc721 way of consturcting the URI, this way any 3rd party dApps could know where to find the canonical one.