### PR TITLE
feat(protocol): added missing function canonical() in Bridged NFT tokens

### DIFF
--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -121,6 +121,13 @@ contract BridgedERC1155 is EssentialContract, IERC1155MetadataURIUpgradeable, ER
         return LibBridgedToken.buildSymbol(__symbol);
     }
 
+    /// @notice Gets the canonical token's address and chain ID.
+    /// @return The canonical token's address.
+    /// @return The canonical token's chain ID.
+    function canonical() external view returns (address, uint256) {
+        return (srcToken, srcChainId);
+    }
+
     function _beforeTokenTransfer(
         address, /*_operator*/
         address, /*_from*/

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -114,6 +114,13 @@ contract BridgedERC721 is EssentialContract, ERC721Upgradeable {
         );
     }
 
+    /// @notice Gets the canonical token's address and chain ID.
+    /// @return The canonical token's address.
+    /// @return The canonical token's chain ID.
+    function canonical() external view returns (address, uint256) {
+        return (srcToken, srcChainId);
+    }
+
     function _beforeTokenTransfer(
         address, /*_from*/
         address _to,


### PR DESCRIPTION
https://github.com/code-423n4/2024-03-taiko-findings/blob/main/data/MrPotatoMagic-Q.md#n-02-missing-sourcecanonical-function-on-bridgederc115-contract