### PR TITLE
feat(protocol): remove and clear `proposedIn` from TaikoData.Block

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -127,7 +127,7 @@ library TaikoData {
         uint96 livenessBond;
         uint64 blockId; // slot 3
         uint64 proposedAt; // timestamp
-        uint64 proposedIn; // L1 block number
+        uint64 __reserved1;
         uint32 nextTransitionId;
         uint32 verifiedTransitionId;
     }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -158,7 +158,7 @@ library LibProposing {
             livenessBond: _config.livenessBond,
             blockId: b.numBlocks,
             proposedAt: meta_.timestamp,
-            proposedIn: uint64(block.number),
+            __reserved1: 0,
             // For a new block, the next transition ID is always 1, not 0.
             nextTransitionId: 1,
             // For unverified block, its verifiedTransitionId is always 0.


### PR DESCRIPTION
This `proposedIn` value is useless so I remove it and zero the field. The same slot can be used for other purposes in the future.