### PR TITLE
feat(protocol): add `lastSyncedBlockId ` for L2 DAO vote aggregation

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -135,7 +135,7 @@ library TaikoData {
     struct SlotA {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
-        uint64 lastSyncedBlocKId;
+        uint64 lastSyncedBlockId;
         uint64 __reservedA2;
     }
 

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -134,7 +134,7 @@ library TaikoData {
     struct SlotA {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
-        uint64 __reservedA1;
+        uint64 lastSyncedAt;
         uint64 __reservedA2;
     }
 

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -136,7 +136,7 @@ library TaikoData {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
         uint64 lastSyncedBlockId;
-        uint64 __reservedA2;
+        uint64 lastSynecdAt;
     }
 
     struct SlotB {

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -135,8 +135,8 @@ library TaikoData {
     struct SlotA {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
-        uint64 lastSyncedAt;
         uint64 lastSyncedBlocKId;
+        uint64 __reservedA2;
     }
 
     struct SlotB {

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -136,7 +136,7 @@ library TaikoData {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
         uint64 lastSyncedAt;
-        uint64 __reservedA2;
+        uint64 lastSyncedBlocKId;
     }
 
     struct SlotB {

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -135,7 +135,7 @@ library TaikoData {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
         uint64 lastSyncedAt;
-        uint64 __reservedA2;
+        uint64 lastVerifiedAt;
     }
 
     struct SlotB {

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -136,7 +136,7 @@ library TaikoData {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
         uint64 lastSyncedAt;
-        uint64 lastVerifiedAt;
+        uint64 __reservedA2;
     }
 
     struct SlotB {

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -57,6 +57,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
 
     function init2() external onlyOwner reinitializer(2) {
         // reset some previously used slots for future reuse
+        state.slotA.__reservedA2 = 0;
         state.slotB.__reservedB1 = 0;
         state.slotB.__reservedB2 = 0;
         state.slotB.__reservedB3 = 0;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -57,7 +57,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
 
     function init2() external reinitializer(2) {
         // reset some previously used slots for future reuse
-        state.slotA.__reservedA1 = 0;
         state.slotA.__reservedA2 = 0;
         state.slotB.__reservedB1 = 0;
         state.slotB.__reservedB2 = 0;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -168,15 +168,27 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
     }
 
     /// @notice Gets the state variables of the TaikoL1 contract.
-    /// @return a_ State variables stored at SlotA.
-    /// @return b_ State variables stored at SlotB.
+    /// @dev This method can be deleted once node/client stops using it.
+    /// @return State variables stored at SlotA.
+    /// @return State variables stored at SlotB.
     function getStateVariables()
         public
         view
-        returns (TaikoData.SlotA memory a_, TaikoData.SlotB memory b_)
+        returns (TaikoData.SlotA memory, TaikoData.SlotB memory)
     {
-        a_ = state.slotA;
-        b_ = state.slotB;
+        return (state.slotA, state.slotB);
+    }
+
+    /// @notice Gets SlotA
+    /// @return  State variables stored at SlotA.
+    function slotA() public view returns (TaikoData.SlotA memory) {
+        return state.slotA;
+    }
+
+    /// @notice Gets SlotB
+    /// @return  State variables stored at SlotB.
+    function slotB() public view returns (TaikoData.SlotB memory) {
+        return state.slotB;
     }
 
     /// @inheritdoc ITaikoL1

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -57,7 +57,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
 
     function init2() external onlyOwner reinitializer(2) {
         // reset some previously used slots for future reuse
-        state.slotA.__reservedA2 = 0;
         state.slotB.__reservedB1 = 0;
         state.slotB.__reservedB2 = 0;
         state.slotB.__reservedB3 = 0;

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -57,7 +57,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
 
     function init2() external reinitializer(2) {
         // reset some previously used slots for future reuse
-        state.slotA.__reservedA2 = 0;
         state.slotB.__reservedB1 = 0;
         state.slotB.__reservedB2 = 0;
         state.slotB.__reservedB3 = 0;

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -256,6 +256,7 @@ library LibVerifying {
 
         if (_lastVerifiedBlockId > lastSyncedBlock + _config.blockSyncThreshold) {
             _state.slotA.lastSyncedBlockId = _lastVerifiedBlockId;
+            _state.slotA.lastSynecdAt = uint64(block.timestamp);
 
             signalService.syncChainData(
                 _config.chainId, LibSignals.STATE_ROOT, _lastVerifiedBlockId, _stateRoot

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -254,6 +254,7 @@ library LibVerifying {
         );
 
         if (_lastVerifiedBlockId > lastSyncedBlock + _config.blockSyncThreshold) {
+            _state.slotA.lastSyncedAt = uint64(block.timestamp);
             signalService.syncChainData(
                 _config.chainId, LibSignals.STATE_ROOT, _lastVerifiedBlockId, _stateRoot
             );

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -255,7 +255,6 @@ library LibVerifying {
         );
 
         if (_lastVerifiedBlockId > lastSyncedBlock + _config.blockSyncThreshold) {
-            _state.slotA.lastSyncedAt = uint64(block.timestamp);
             _state.slotA.lastSyncedBlocKId = _lastVerifiedBlockId;
 
             signalService.syncChainData(

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -225,12 +225,11 @@ library LibVerifying {
             if (numBlocksVerified != 0) {
                 uint64 lastVerifiedBlockId = b.lastVerifiedBlockId + numBlocksVerified;
 
-                // Update protocol level state variables
-                _state.slotB.lastVerifiedBlockId = lastVerifiedBlockId;
-                _state.slotA.lastVerifiedAt = uint64(block.timestamp);
-
                 // sync chain data
                 _syncChainData(_state, _config, _resolver, lastVerifiedBlockId, stateRoot);
+
+                // Update protocol level state variables
+                _state.slotB.lastVerifiedBlockId = lastVerifiedBlockId;
             }
         }
     }

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -225,11 +225,11 @@ library LibVerifying {
             if (numBlocksVerified != 0) {
                 uint64 lastVerifiedBlockId = b.lastVerifiedBlockId + numBlocksVerified;
 
-                // sync chain data
-                _syncChainData(_state, _config, _resolver, lastVerifiedBlockId, stateRoot);
-
                 // Update protocol level state variables
                 _state.slotB.lastVerifiedBlockId = lastVerifiedBlockId;
+
+                // sync chain data
+                _syncChainData(_state, _config, _resolver, lastVerifiedBlockId, stateRoot);
             }
         }
     }

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -228,7 +228,7 @@ library LibVerifying {
                 // Update protocol level state variables
                 _state.slotB.lastVerifiedBlockId = lastVerifiedBlockId;
 
-                // sync chain data
+                // Sync chain data
                 _syncChainData(_state, _config, _resolver, lastVerifiedBlockId, stateRoot);
             }
         }

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -223,13 +223,13 @@ library LibVerifying {
             }
 
             if (numBlocksVerified != 0) {
+                // sync chain data
                 uint64 lastVerifiedBlockId = b.lastVerifiedBlockId + numBlocksVerified;
+                _syncChainData(_state, _config, _resolver, lastVerifiedBlockId, stateRoot);
 
                 // Update protocol level state variables
                 _state.slotB.lastVerifiedBlockId = lastVerifiedBlockId;
-
-                // sync chain data
-                _syncChainData(_config, _resolver, lastVerifiedBlockId, stateRoot);
+                _state.slotA.lastVerifiedAt = uint64(block.timestamp);
             }
         }
     }
@@ -240,6 +240,7 @@ library LibVerifying {
     }
 
     function _syncChainData(
+        TaikoData.State storage _state,
         TaikoData.Config memory _config,
         IAddressResolver _resolver,
         uint64 _lastVerifiedBlockId,

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -256,6 +256,8 @@ library LibVerifying {
 
         if (_lastVerifiedBlockId > lastSyncedBlock + _config.blockSyncThreshold) {
             _state.slotA.lastSyncedAt = uint64(block.timestamp);
+            _state.slotA.lastSyncedBlocKId = _lastVerifiedBlockId;
+
             signalService.syncChainData(
                 _config.chainId, LibSignals.STATE_ROOT, _lastVerifiedBlockId, _stateRoot
             );

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -223,13 +223,14 @@ library LibVerifying {
             }
 
             if (numBlocksVerified != 0) {
-                // sync chain data
                 uint64 lastVerifiedBlockId = b.lastVerifiedBlockId + numBlocksVerified;
-                _syncChainData(_state, _config, _resolver, lastVerifiedBlockId, stateRoot);
 
                 // Update protocol level state variables
                 _state.slotB.lastVerifiedBlockId = lastVerifiedBlockId;
                 _state.slotA.lastVerifiedAt = uint64(block.timestamp);
+
+                // sync chain data
+                _syncChainData(_state, _config, _resolver, lastVerifiedBlockId, stateRoot);
             }
         }
     }

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -255,7 +255,7 @@ library LibVerifying {
         );
 
         if (_lastVerifiedBlockId > lastSyncedBlock + _config.blockSyncThreshold) {
-            _state.slotA.lastSyncedBlocKId = _lastVerifiedBlockId;
+            _state.slotA.lastSyncedBlockId = _lastVerifiedBlockId;
 
             signalService.syncChainData(
                 _config.chainId, LibSignals.STATE_ROOT, _lastVerifiedBlockId, _stateRoot


### PR DESCRIPTION
This small feature is added to support future DAO. The DAO will aggregate votes/vetos on L2 which will be bridged to L1. Suppose a DAO proposal has passed its voting period on L1. We need to wait for L2-to-L1 synchronization to happen for at least once before the proposal's state can be finalized. If for some reason L2 blocks is no longer verified, then all DAO proposals will have to wait.