### PR TITLE
fix(protocol): fix liveness bond related tokenomics issue

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -103,7 +103,6 @@ library TaikoData {
         uint96 contestBond;
         uint64 timestamp; // slot 6 (90 bits)
         uint16 tier;
-        uint8 contestations;
     }
 
     /// @dev Struct containing data required for verifying a block.

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -103,6 +103,7 @@ library TaikoData {
         uint96 contestBond;
         uint64 timestamp; // slot 6 (90 bits)
         uint16 tier;
+        uint8 __reserved1;
     }
 
     /// @dev Struct containing data required for verifying a block.

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -11,7 +11,6 @@ pragma solidity 0.8.24;
 abstract contract TaikoErrors {
     error L1_ALREADY_CONTESTED();
     error L1_ALREADY_PROVED();
-    error L1_ASSIGNED_PROVER_NOT_ALLOWED();
     error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
     error L1_BLOCK_MISMATCH();

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -15,6 +15,7 @@ abstract contract TaikoErrors {
     error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
     error L1_BLOCK_MISMATCH();
+    error L1_CANNOT_CONTEST();
     error L1_INVALID_BLOCK_ID();
     error L1_INVALID_CONFIG();
     error L1_INVALID_GENESIS_HASH();

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -27,21 +27,17 @@ abstract contract TaikoEvents {
     );
     /// @dev Emitted when a block is verified.
     /// @param blockId The ID of the verified block.
-    /// @param assignedProver The block's assigned prover.
     /// @param prover The prover whose transition is used for verifying the
     /// block.
     /// @param blockHash The hash of the verified block.
     /// @param stateRoot The block's state root.
     /// @param tier The tier ID of the proof.
-    /// @param contestations Number of total contestations.
     event BlockVerified(
         uint256 indexed blockId,
-        address indexed assignedProver,
         address indexed prover,
         bytes32 blockHash,
         bytes32 stateRoot,
-        uint16 tier,
-        uint8 contestations
+        uint16 tier
     );
 
     /// @notice Emitted when some state variable values changed.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -138,18 +138,8 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
     /// @notice Gets the details of a block.
     /// @param _blockId Index of the block.
     /// @return blk_ The block.
-    /// @return ts_ The transition used to verify this block.
-    function getBlock(uint64 _blockId)
-        public
-        view
-        returns (TaikoData.Block memory blk_, TaikoData.TransitionState memory ts_)
-    {
-        uint64 slot;
-        (blk_, slot) = LibUtils.getBlock(state, getConfig(), _blockId);
-
-        if (blk_.verifiedTransitionId != 0) {
-            ts_ = state.transitions[slot][blk_.verifiedTransitionId];
-        }
+    function getBlock(uint64 _blockId) public view returns (TaikoData.Block memory blk_) {
+        (blk_,) = LibUtils.getBlock(state, getConfig(), _blockId);
     }
 
     /// @notice Gets the state transition for a specific block.
@@ -167,10 +157,25 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
         return LibUtils.getTransition(state, getConfig(), _blockId, _parentHash);
     }
 
+    /// @notice Gets the state transition for a specific block.
+    /// @param _blockId Index of the block.
+    /// @param _tid The transition id.
+    /// @return The state transition data of the block.
+    function getTransition(
+        uint64 _blockId,
+        uint32 _tid
+    )
+        public
+        view
+        returns (TaikoData.TransitionState memory)
+    {
+        return LibUtils.getTransition(state, getConfig(), _blockId, _tid);
+    }
     /// @notice Gets the state variables of the TaikoL1 contract.
     /// @dev This method can be deleted once node/client stops using it.
     /// @return State variables stored at SlotA.
     /// @return State variables stored at SlotB.
+
     function getStateVariables()
         public
         view

--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -5,13 +5,13 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import "../common/EssentialContract.sol";
+
 /// @title TaikoToken
 /// @notice The TaikoToken (TKO), in the protocol is used for prover collateral
 /// in the form of bonds. It is an ERC20 token with 18 decimal places of
 /// precision.
 /// @dev Labeled in AddressResolver as "taiko_token"
 /// @custom:security-contact security@taiko.xyz
-
 contract TaikoToken is EssentialContract, ERC20SnapshotUpgradeable, ERC20VotesUpgradeable {
     uint256[50] private __gap;
 

--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -5,13 +5,13 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import "../common/EssentialContract.sol";
-
 /// @title TaikoToken
 /// @notice The TaikoToken (TKO), in the protocol is used for prover collateral
 /// in the form of bonds. It is an ERC20 token with 18 decimal places of
 /// precision.
 /// @dev Labeled in AddressResolver as "taiko_token"
 /// @custom:security-contact security@taiko.xyz
+
 contract TaikoToken is EssentialContract, ERC20SnapshotUpgradeable, ERC20VotesUpgradeable {
     uint256[50] private __gap;
 

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -306,6 +306,7 @@ library LibProving {
             ts_.contestBond = 1; // to save gas
             ts_.timestamp = _blk.proposedAt;
             ts_.tier = 0;
+            ts_.__reserved1 = 0;
 
             if (tid_ == 1) {
                 // This approach serves as a cost-saving technique for the

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -371,7 +371,6 @@ library LibProving {
     {
         // Higher tier proof overwriting lower tier proof
         uint256 reward; // reward to the new (current) prover
-        uint96 livenessBondToValidityBond;
 
         if (_ts.contester != address(0)) {
             if (_sameTransition) {
@@ -397,7 +396,9 @@ library LibProving {
             uint96 livenessBond = _blk.livenessBond;
             if (livenessBond != 0) {
                 if (_blk.assignedProver == msg.sender) {
-                    livenessBondToValidityBond = livenessBond;
+                    unchecked {
+                        reward += livenessBond;
+                    }
                 }
                 _blk.livenessBond = 0;
             }
@@ -411,7 +412,7 @@ library LibProving {
             }
         }
 
-        _ts.validityBond = _tier.validityBond + livenessBondToValidityBond;
+        _ts.validityBond = _tier.validityBond;
         _ts.contestBond = 1; // to save gas
         _ts.contester = address(0);
         _ts.prover = msg.sender;

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -390,6 +390,10 @@ library LibProving {
         } else {
             if (_sameTransition) revert L1_ALREADY_PROVED();
 
+            // Contest the existing transition and prove it to be invalid. The new prover get all
+            // rewards.
+            reward = _rewardAfterFriction(_ts.validityBond);
+
             uint96 livenessBond = _blk.livenessBond;
             if (livenessBond != 0) {
                 if (_blk.assignedProver == msg.sender) {
@@ -397,16 +401,12 @@ library LibProving {
                 }
                 _blk.livenessBond = 0;
             }
-
-            // Contest the existing transition and prove it to be invalid. The new prover get all
-            // rewards.
-            reward = _rewardAfterFriction(_ts.validityBond);
         }
 
         unchecked {
             if (reward > _tier.validityBond) {
                 _tko.safeTransfer(msg.sender, reward - _tier.validityBond);
-            } else {
+            } else if (reward < _tier.validityBond) {
                 _tko.safeTransferFrom(msg.sender, address(this), _tier.validityBond - reward);
             }
         }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -16,9 +16,6 @@ library LibProving {
     using LibMath for uint256;
     using SafeERC20 for IERC20;
 
-    /// @notice Keccak hash of the string "RETURN_LIVENESS_BOND".
-    bytes32 public constant RETURN_LIVENESS_BOND = keccak256("RETURN_LIVENESS_BOND");
-
     /// @notice The tier name for optimistic proofs.
     bytes32 private constant TIER_OP = bytes32("tier_optimistic");
 
@@ -188,13 +185,11 @@ library LibProving {
         IERC20 tko = IERC20(_resolver.resolve("taiko_token", false));
 
         if (isTopTier) {
-            // A special return value from the top tier prover can signal this
-            // contract to return all liveness bond.
-            bool returnLivenessBond = blk.livenessBond != 0 && _proof.data.length == 32
-                && bytes32(_proof.data) == RETURN_LIVENESS_BOND;
-
-            if (returnLivenessBond) {
-                tko.safeTransfer(blk.assignedProver, blk.livenessBond);
+            uint96 livenessBond = blk.livenessBond;
+            if (livenessBond != 0) {
+                if (!LibUtils.isPostDeadline(ts.timestamp, b.lastUnpausedAt, tier.provingWindow)) {
+                    tko.safeTransfer(blk.assignedProver, livenessBond);
+                }
                 blk.livenessBond = 0;
             }
         }
@@ -205,7 +200,7 @@ library LibProving {
             // Handles the case when an incoming tier is higher than the current transition's tier.
             // Reverts when the incoming proof tries to prove the same transition
             // (L1_ALREADY_PROVED).
-            _overrideWithHigherProof(ts, _tran, _proof, tier, tko, sameTransition);
+            _overrideWithHigherProof(blk, ts, _tran, _proof, tier, tko, sameTransition);
 
             emit TransitionProved({
                 blockId: blk.blockId,
@@ -257,7 +252,6 @@ library LibProving {
                 // doesn't have any significance.
                 ts.contestBond = tier.contestBond;
                 ts.contester = msg.sender;
-                ts.contestations += 1;
 
                 emit TransitionContested({
                     blockId: blk.blockId,
@@ -312,7 +306,6 @@ library LibProving {
             ts_.contestBond = 1; // to save gas
             ts_.timestamp = _blk.proposedAt;
             ts_.tier = 0;
-            ts_.contestations = 0;
 
             if (tid_ == 1) {
                 // This approach serves as a cost-saving technique for the
@@ -365,6 +358,7 @@ library LibProving {
     // validity bond `V` ratio is `C/V = 21/(32*r)`, and if `r` set at 10%, the C/V ratio will be
     // 6.5625.
     function _overrideWithHigherProof(
+        TaikoData.Block storage _blk,
         TaikoData.TransitionState storage _ts,
         TaikoData.Transition memory _tran,
         TaikoData.TierProof memory _proof,
@@ -376,6 +370,7 @@ library LibProving {
     {
         // Higher tier proof overwriting lower tier proof
         uint256 reward; // reward to the new (current) prover
+        uint96 livenessBondToValidityBond;
 
         if (_ts.contester != address(0)) {
             if (_sameTransition) {
@@ -393,10 +388,18 @@ library LibProving {
             }
         } else {
             if (_sameTransition) revert L1_ALREADY_PROVED();
+
+            uint96 livenessBond = _blk.livenessBond;
+            if (livenessBond != 0) {
+                if (_blk.assignedProver == msg.sender) {
+                    livenessBondToValidityBond = livenessBond;
+                }
+                _blk.livenessBond = 0;
+            }
+
             // Contest the existing transition and prove it to be invalid. The new prover get all
             // rewards.
             reward = _rewardAfterFriction(_ts.validityBond);
-            _ts.contestations += 1;
         }
 
         unchecked {
@@ -407,7 +410,7 @@ library LibProving {
             }
         }
 
-        _ts.validityBond = _tier.validityBond;
+        _ts.validityBond = _tier.validityBond + livenessBondToValidityBond;
         _ts.contestBond = 1; // to save gas
         _ts.contester = address(0);
         _ts.prover = msg.sender;
@@ -432,6 +435,9 @@ library LibProving {
     {
         // The highest tier proof can always submit new proofs
         if (_tier.contestBond == 0) return;
+
+        // If the transition is contested, anyone can prove
+        if (_ts.contester != address(0)) return;
 
         bool isAssignedProver = msg.sender == _blk.assignedProver;
 

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -457,6 +457,6 @@ library LibProving {
 
     /// @dev Returns the reward after applying 12.5% friction.
     function _rewardAfterFriction(uint256 _amount) private pure returns (uint256) {
-        return (_amount * 7) >> 3;
+        return _amount == 0 ? 0 : (_amount * 7) >> 3;
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -389,8 +389,9 @@ library LibProving {
         } else {
             if (_sameTransition) revert L1_ALREADY_PROVED();
 
-            // Contest the existing transition and prove it to be invalid. The new prover get all
-            // rewards.
+            // The code below will be executed if
+            // - 1) the transition is proved for the fist time, or
+            // - 2) the transition is contested.
             reward = _rewardAfterFriction(_ts.validityBond);
 
             uint96 livenessBond = _blk.livenessBond;

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -16,6 +16,9 @@ library LibProving {
     using LibMath for uint256;
     using SafeERC20 for IERC20;
 
+    /// @notice Keccak hash of the string "RETURN_LIVENESS_BOND".
+    bytes32 public constant RETURN_LIVENESS_BOND = keccak256("RETURN_LIVENESS_BOND");
+
     /// @notice The tier name for optimistic proofs.
     bytes32 private constant TIER_OP = bytes32("tier_optimistic");
 
@@ -187,7 +190,10 @@ library LibProving {
         if (isTopTier) {
             uint96 livenessBond = blk.livenessBond;
             if (livenessBond != 0) {
-                if (!LibUtils.isPostDeadline(ts.timestamp, b.lastUnpausedAt, tier.provingWindow)) {
+                if (
+                    !LibUtils.isPostDeadline(ts.timestamp, b.lastUnpausedAt, tier.provingWindow)
+                        || (_proof.data.length == 32 && bytes32(_proof.data) == RETURN_LIVENESS_BOND)
+                ) {
                     tko.safeTransfer(blk.assignedProver, livenessBond);
                 }
                 blk.livenessBond = 0;

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -16,6 +16,22 @@ library LibProving {
     using LibMath for uint256;
     using SafeERC20 for IERC20;
 
+    // A struct to get around stack too deep issue and to cache state variables for multiple reads.
+    struct Local {
+        TaikoData.SlotB b;
+        ITierProvider.Tier tier;
+        bytes32 metaHash;
+        address assignedProver;
+        uint96 livenessBond;
+        uint64 slot;
+        uint64 blockId;
+        uint32 tid;
+        bool lastUnpausedAt;
+        bool isTopTier;
+        bool inProvingWindow;
+        bool sameTransition;
+    }
+
     /// @notice Keccak hash of the string "RETURN_LIVENESS_BOND".
     bytes32 public constant RETURN_LIVENESS_BOND = keccak256("RETURN_LIVENESS_BOND");
 
@@ -60,7 +76,6 @@ library LibProving {
     // Warning: Any errors defined here must also be defined in TaikoErrors.sol.
     error L1_ALREADY_CONTESTED();
     error L1_ALREADY_PROVED();
-    error L1_ASSIGNED_PROVER_NOT_ALLOWED();
     error L1_BLOCK_MISMATCH();
     error L1_INVALID_BLOCK_ID();
     error L1_INVALID_PAUSE_STATUS();
@@ -109,28 +124,34 @@ library LibProving {
             revert L1_INVALID_TRANSITION();
         }
 
+        Local memory local;
+        local.b = _state.slotB;
+
         // Check that the block has been proposed but has not yet been verified.
-        TaikoData.SlotB memory b = _state.slotB;
-        if (_meta.id <= b.lastVerifiedBlockId || _meta.id >= b.numBlocks) {
+        if (_meta.id <= local.b.lastVerifiedBlockId || _meta.id >= local.b.numBlocks) {
             revert L1_INVALID_BLOCK_ID();
         }
 
-        uint64 slot = _meta.id % _config.blockRingBufferSize;
-        TaikoData.Block storage blk = _state.blocks[slot];
+        local.slot = _meta.id % _config.blockRingBufferSize;
+        TaikoData.Block storage blk = _state.blocks[local.slot];
+
+        local.blockId = blk.blockId;
+        local.assignedProver = blk.assignedProver;
+        local.metaHash = blk.metaHash;
 
         // Check the integrity of the block data. It's worth noting that in
         // theory, this check may be skipped, but it's included for added
         // caution.
-        if (blk.blockId != _meta.id || blk.metaHash != keccak256(abi.encode(_meta))) {
+        if (local.blockId != _meta.id || local.metaHash != keccak256(abi.encode(_meta))) {
             revert L1_BLOCK_MISMATCH();
         }
 
-        // Each transition is uniquely identified by the parentHash, with the blockHash and
-        // stateRoot open for later updates as higher-tier proofs become available. In cases where a
-        // transition with the specified parentHash does not exist, the transition ID (tid) is 0,
-        // but after receiving a unique transition it is set to 1.
-        (uint32 tid, TaikoData.TransitionState storage ts) =
-            _fetchOrCreateTransition(_state, blk, _tran, slot);
+        // Each transition is uniquely identified by the parentHash, with the
+        // blockHash and stateRoot open for later updates as higher-tier proofs
+        // become available. In cases where a transition with the specified
+        // parentHash does not exist, the transition ID (tid) will be set to 0.
+        TaikoData.TransitionState storage ts;
+        (local.tid, ts) = _fetchOrCreateTransition(_state, blk, _tran, local);
 
         // The new proof must meet or exceed the minimum tier required by the
         // block or the previous proof; it cannot be on a lower tier.
@@ -140,12 +161,20 @@ library LibProving {
 
         // Retrieve the tier configurations. If the tier is not supported, the
         // subsequent action will result in a revert.
-        ITierProvider.Tier memory tier =
-            ITierProvider(_resolver.resolve("tier_provider", false)).getTier(_proof.tier);
+        local.tier = ITierProvider(_resolver.resolve("tier_provider", false)).getTier(_proof.tier);
 
-        // Check if this prover is allowed to submit a proof for this block
-        _checkProverPermission(blk, ts, tid, tier, b.lastUnpausedAt);
+        local.inProvingWindow =
+            !LibUtils.isPostDeadline(ts.timestamp, local.b.lastUnpausedAt, local.tier.provingWindow);
 
+        // Checks if only the assigned prover is permissioned to prove the block.
+        // The guardian prover is granted exclusive permission to prove only the first
+        // transition.
+        if (
+            local.tier.contestBond != 0 && ts.contester == address(0) && local.tid == 1
+                && ts.tier == 0 && local.inProvingWindow
+        ) {
+            if (msg.sender != local.assignedProver) revert L1_NOT_ASSIGNED_PROVER();
+        }
         // We must verify the proof, and any failure in proof verification will
         // result in a revert.
         //
@@ -161,24 +190,24 @@ library LibProving {
         // It's obvious that proof verification is entirely decoupled from
         // Taiko's core protocol.
         {
-            address verifier = _resolver.resolve(tier.verifierName, true);
+            address verifier = _resolver.resolve(local.tier.verifierName, true);
 
             if (verifier != address(0)) {
-                bool isContesting = _proof.tier == ts.tier && tier.contestBond != 0;
+                bool isContesting = _proof.tier == ts.tier && local.tier.contestBond != 0;
 
                 IVerifier.Context memory ctx = IVerifier.Context({
-                    metaHash: blk.metaHash,
+                    metaHash: local.metaHash,
                     blobHash: _meta.blobHash,
                     // Separate msgSender to allow the prover to be any address in the future.
                     prover: msg.sender,
                     msgSender: msg.sender,
-                    blockId: blk.blockId,
+                    blockId: local.blockId,
                     isContesting: isContesting,
                     blobUsed: _meta.blobUsed
                 });
 
                 IVerifier(verifier).verifyProof(ctx, _tran, _proof);
-            } else if (tier.verifierName != TIER_OP) {
+            } else if (local.tier.verifierName != TIER_OP) {
                 // The verifier can be address-zero, signifying that there are no
                 // proof checks for the tier. In practice, this only applies to
                 // optimistic proofs.
@@ -186,45 +215,46 @@ library LibProving {
             }
         }
 
-        bool isTopTier = tier.contestBond == 0;
+        local.isTopTier = local.tier.contestBond == 0;
         IERC20 tko = IERC20(_resolver.resolve("taiko_token", false));
 
-        if (isTopTier) {
-            uint96 livenessBond = blk.livenessBond;
-            if (livenessBond != 0) {
+        local.livenessBond = blk.livenessBond;
+        if (local.isTopTier) {
+            if (local.livenessBond != 0) {
                 if (
-                    !LibUtils.isPostDeadline(ts.timestamp, b.lastUnpausedAt, tier.provingWindow)
+                    local.inProvingWindow
                         || (_proof.data.length == 32 && bytes32(_proof.data) == RETURN_LIVENESS_BOND)
                 ) {
-                    tko.safeTransfer(blk.assignedProver, livenessBond);
+                    tko.safeTransfer(local.assignedProver, local.livenessBond);
                 }
                 blk.livenessBond = 0;
+                local.livenessBond = 0;
             }
         }
 
-        bool sameTransition = _tran.blockHash == ts.blockHash && _tran.stateRoot == ts.stateRoot;
+        local.sameTransition = _tran.blockHash == ts.blockHash && _tran.stateRoot == ts.stateRoot;
 
         if (_proof.tier > ts.tier) {
             // Handles the case when an incoming tier is higher than the current transition's tier.
             // Reverts when the incoming proof tries to prove the same transition
             // (L1_ALREADY_PROVED).
-            _overrideWithHigherProof(blk, ts, _tran, _proof, tier, tko, sameTransition);
+            _overrideWithHigherProof(blk, ts, _tran, _proof, local, tko);
 
             emit TransitionProved({
-                blockId: blk.blockId,
+                blockId: local.blockId,
                 tran: _tran,
                 prover: msg.sender,
-                validityBond: tier.validityBond,
+                validityBond: local.tier.validityBond,
                 tier: _proof.tier
             });
         } else {
             // New transition and old transition on the same tier - and if this transaction tries to
             // prove the same, it reverts
-            if (sameTransition) revert L1_ALREADY_PROVED();
+            if (local.sameTransition) revert L1_ALREADY_PROVED();
 
-            if (isTopTier) {
+            if (local.isTopTier) {
                 // The top tier prover re-proves.
-                assert(tier.validityBond == 0);
+                assert(local.tier.validityBond == 0);
                 assert(ts.validityBond == 0 && ts.contester == address(0));
 
                 ts.prover = msg.sender;
@@ -232,7 +262,7 @@ library LibProving {
                 ts.stateRoot = _tran.stateRoot;
 
                 emit TransitionProved({
-                    blockId: blk.blockId,
+                    blockId: local.blockId,
                     tran: _tran,
                     prover: msg.sender,
                     validityBond: 0,
@@ -244,13 +274,17 @@ library LibProving {
 
                 // Making it a non-sliding window, relative when ts.timestamp was registered (or to
                 // lastUnpaused if that one is bigger)
-                if (LibUtils.isPostDeadline(ts.timestamp, b.lastUnpausedAt, tier.cooldownWindow)) {
+                if (
+                    LibUtils.isPostDeadline(
+                        ts.timestamp, local.b.lastUnpausedAt, local.tier.cooldownWindow
+                    )
+                ) {
                     revert L1_CANNOT_CONTEST();
                 }
 
                 // _checkIfContestable(/*_state,*/ tier.cooldownWindow, ts.timestamp);
                 // Burn the contest bond from the prover.
-                tko.safeTransferFrom(msg.sender, address(this), tier.contestBond);
+                tko.safeTransferFrom(msg.sender, address(this), local.tier.contestBond);
 
                 // We retain the contest bond within the transition, just in
                 // case this configuration is altered to a different value
@@ -258,21 +292,21 @@ library LibProving {
                 //
                 // It's worth noting that the previous value of ts.contestBond
                 // doesn't have any significance.
-                ts.contestBond = tier.contestBond;
+                ts.contestBond = local.tier.contestBond;
                 ts.contester = msg.sender;
 
                 emit TransitionContested({
-                    blockId: blk.blockId,
+                    blockId: local.blockId,
                     tran: _tran,
                     contester: msg.sender,
-                    contestBond: tier.contestBond,
+                    contestBond: local.tier.contestBond,
                     tier: _proof.tier
                 });
             }
         }
 
         ts.timestamp = uint64(block.timestamp);
-        return tier.maxBlocksToVerifyPerProof;
+        return local.tier.maxBlocksToVerifyPerProof;
     }
 
     /// @dev Handle the transition initialization logic
@@ -280,12 +314,12 @@ library LibProving {
         TaikoData.State storage _state,
         TaikoData.Block storage _blk,
         TaikoData.Transition memory _tran,
-        uint64 slot
+        Local memory _local
     )
         private
         returns (uint32 tid_, TaikoData.TransitionState storage ts_)
     {
-        tid_ = LibUtils.getTransitionId(_state, _blk, slot, _tran.parentHash);
+        tid_ = LibUtils.getTransitionId(_state, _blk, _local.slot, _tran.parentHash);
 
         if (tid_ == 0) {
             // In cases where a transition with the provided parentHash is not
@@ -306,7 +340,7 @@ library LibProving {
             // Keep in mind that state.transitions are also reusable storage
             // slots, so it's necessary to reinitialize all transition fields
             // below.
-            ts_ = _state.transitions[slot][tid_];
+            ts_ = _state.transitions[_local.slot][tid_];
             ts_.blockHash = 0;
             ts_.stateRoot = 0;
             ts_.validityBond = 0;
@@ -334,7 +368,7 @@ library LibProving {
                 //
                 // While alternative implementations are possible, introducing
                 // such changes would require additional if-else logic.
-                ts_.prover = _blk.assignedProver;
+                ts_.prover = _local.assignedProver;
             } else {
                 // In scenarios where this transition is not the first one, we
                 // straightforwardly reset the transition prover to address
@@ -346,13 +380,13 @@ library LibProving {
                 // reusable. However, given that the majority of blocks will
                 // only possess one transition — the correct one — we don't need
                 // to be concerned about the cost in this case.
-                _state.transitionIds[_blk.blockId][_tran.parentHash] = tid_;
+                _state.transitionIds[_local.blockId][_tran.parentHash] = tid_;
 
                 // There is no need to initialize ts.key here because it's only used when tid == 1
             }
         } else {
             // A transition with the provided parentHash has been located.
-            ts_ = _state.transitions[slot][tid_];
+            ts_ = _state.transitions[_local.slot][tid_];
         }
     }
 
@@ -372,9 +406,8 @@ library LibProving {
         TaikoData.TransitionState storage _ts,
         TaikoData.Transition memory _tran,
         TaikoData.TierProof memory _proof,
-        ITierProvider.Tier memory _tier,
-        IERC20 _tko,
-        bool _sameTransition
+        Local memory _local,
+        IERC20 _tko
     )
         private
     {
@@ -382,7 +415,7 @@ library LibProving {
         uint256 reward; // reward to the new (current) prover
 
         if (_ts.contester != address(0)) {
-            if (_sameTransition) {
+            if (_local.sameTransition) {
                 // The contested transition is proven to be valid, contester loses the game
                 reward = _rewardAfterFriction(_ts.contestBond);
 
@@ -396,73 +429,41 @@ library LibProving {
                 _tko.safeTransfer(_ts.contester, _ts.contestBond + reward * 3);
             }
         } else {
-            if (_sameTransition) revert L1_ALREADY_PROVED();
+            if (_local.sameTransition) revert L1_ALREADY_PROVED();
 
             // The code below will be executed if
             // - 1) the transition is proved for the fist time, or
             // - 2) the transition is contested.
             reward = _rewardAfterFriction(_ts.validityBond);
 
-            uint96 livenessBond = _blk.livenessBond;
-            if (livenessBond != 0) {
-                if (_blk.assignedProver == msg.sender) {
+            if (_local.livenessBond != 0) {
+                if (_local.assignedProver == msg.sender && _local.inProvingWindow) {
                     unchecked {
-                        reward += livenessBond;
+                        reward += _local.livenessBond;
                     }
                 }
                 _blk.livenessBond = 0;
+                _local.livenessBond = 0;
             }
         }
 
         unchecked {
-            if (reward > _tier.validityBond) {
-                _tko.safeTransfer(msg.sender, reward - _tier.validityBond);
-            } else if (reward < _tier.validityBond) {
-                _tko.safeTransferFrom(msg.sender, address(this), _tier.validityBond - reward);
+            if (reward > _local.tier.validityBond) {
+                _tko.safeTransfer(msg.sender, reward - _local.tier.validityBond);
+            } else if (reward < _local.tier.validityBond) {
+                _tko.safeTransferFrom(msg.sender, address(this), _local.tier.validityBond - reward);
             }
         }
 
-        _ts.validityBond = _tier.validityBond;
+        _ts.validityBond = _local.tier.validityBond;
         _ts.contestBond = 1; // to save gas
         _ts.contester = address(0);
         _ts.prover = msg.sender;
         _ts.tier = _proof.tier;
 
-        if (!_sameTransition) {
+        if (!_local.sameTransition) {
             _ts.blockHash = _tran.blockHash;
             _ts.stateRoot = _tran.stateRoot;
-        }
-    }
-
-    /// @dev Check the msg.sender (the new prover) against the block's assigned prover.
-    function _checkProverPermission(
-        TaikoData.Block storage _blk,
-        TaikoData.TransitionState storage _ts,
-        uint32 _tid,
-        ITierProvider.Tier memory _tier,
-        uint64 _lastUnpausedAt
-    )
-        private
-        view
-    {
-        // The highest tier proof can always submit new proofs
-        if (_tier.contestBond == 0) return;
-
-        // If the transition is contested, anyone can prove
-        if (_ts.contester != address(0)) return;
-
-        bool isAssignedProver = msg.sender == _blk.assignedProver;
-
-        // The assigned prover can only submit the very first transition.
-        if (
-            _tid == 1 && _ts.tier == 0
-                && !LibUtils.isPostDeadline(_ts.timestamp, _lastUnpausedAt, _tier.provingWindow)
-        ) {
-            if (!isAssignedProver) revert L1_NOT_ASSIGNED_PROVER();
-        } else {
-            // Disallow the same address to prove the block so that we can detect that the
-            // assigned prover should not receive his liveness bond back
-            if (isAssignedProver) revert L1_ASSIGNED_PROVER_NOT_ALLOWED();
         }
     }
 

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -33,19 +33,37 @@ library LibUtils {
         view
         returns (TaikoData.TransitionState storage)
     {
-        TaikoData.SlotB memory b = _state.slotB;
-        if (_blockId < b.lastVerifiedBlockId || _blockId >= b.numBlocks) {
-            revert L1_INVALID_BLOCK_ID();
-        }
-
-        uint64 slot = _blockId % _config.blockRingBufferSize;
-        TaikoData.Block storage blk = _state.blocks[slot];
-        if (blk.blockId != _blockId) revert L1_BLOCK_MISMATCH();
+        _checkBlockId(_state, _blockId);
+        (TaikoData.Block storage blk, uint64 slot) = getBlock(_state, _config, _blockId);
 
         uint32 tid = getTransitionId(_state, blk, slot, _parentHash);
         if (tid == 0) revert L1_TRANSITION_NOT_FOUND();
 
         return _state.transitions[slot][tid];
+    }
+
+    /// @notice This function will revert if the transition is not found.
+    /// @dev Retrieves the transition with a given parentHash.
+    /// @param _state Current TaikoData.State.
+    /// @param _config Actual TaikoData.Config.
+    /// @param _blockId Id of the block.
+    /// @param _tid The transition id.
+    /// @return The state transition data of the block.
+    function getTransition(
+        TaikoData.State storage _state,
+        TaikoData.Config memory _config,
+        uint64 _blockId,
+        uint32 _tid
+    )
+        internal
+        view
+        returns (TaikoData.TransitionState storage)
+    {
+        _checkBlockId(_state, _blockId);
+        (TaikoData.Block storage blk, uint64 slot) = getBlock(_state, _config, _blockId);
+
+        if (_tid == 0 || _tid >= blk.nextTransitionId) revert L1_TRANSITION_NOT_FOUND();
+        return _state.transitions[slot][_tid];
     }
 
     /// @dev Retrieves a block based on its ID.
@@ -101,6 +119,13 @@ library LibUtils {
         unchecked {
             uint256 deadline = _tsTimestamp.max(_lastUnpausedAt) + _windowMinutes * 60;
             return block.timestamp >= deadline;
+        }
+    }
+
+    function _checkBlockId(TaikoData.State storage _state, uint64 _blockId) private view {
+        TaikoData.SlotB memory b = _state.slotB;
+        if (_blockId < b.lastVerifiedBlockId || _blockId >= b.numBlocks) {
+            revert L1_INVALID_BLOCK_ID();
         }
     }
 }

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -57,13 +57,13 @@ contract TaikoL1Test is TaikoL1TestBase {
 
             bytes32 blockHash = bytes32(1e10 + blockId);
             bytes32 stateRoot = bytes32(1e9 + blockId);
-            proveBlock(Bob, Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
             vm.roll(block.number + 15 * 12);
 
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
             parentHash = blockHash;
         }
         printVariables("");
@@ -90,17 +90,17 @@ contract TaikoL1Test is TaikoL1TestBase {
             bytes32 blockHash = bytes32(1e10 + blockId);
             bytes32 stateRoot = bytes32(1e9 + blockId);
 
-            proveBlock(Bob, Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
             vm.roll(block.number + 15 * 12);
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Alice, 2);
+            verifyBlock(2);
 
-            (TaikoData.Block memory blk, TaikoData.TransitionState memory ts) = L1.getBlock(meta.id);
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
             assertEq(meta.id, blk.blockId);
 
-            ts = L1.getTransition(meta.id, parentHash);
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, parentHash);
             assertEq(ts.prover, Bob);
 
             parentHash = blockHash;
@@ -128,14 +128,14 @@ contract TaikoL1Test is TaikoL1TestBase {
             bytes32 blockHash = bytes32(1e10 + blockId);
             bytes32 stateRoot = bytes32(1e9 + blockId);
 
-            proveBlock(Bob, Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
             parentHash = blockHash;
         }
 
         vm.roll(block.number + 15 * 12);
-        verifyBlock(Alice, conf.blockMaxProposals - 1);
+        verifyBlock(conf.blockMaxProposals - 1);
         printVariables("after verify");
-        verifyBlock(Alice, conf.blockMaxProposals);
+        verifyBlock(conf.blockMaxProposals);
         printVariables("after verify");
     }
 
@@ -151,7 +151,6 @@ contract TaikoL1Test is TaikoL1TestBase {
         (meta,) = proposeBlock(Alice, Bob, 1_000_000, 1024);
         // Proving is not, so supply the revert reason to proveBlock
         proveBlock(
-            Bob,
             Bob,
             meta,
             GENESIS_BLOCK_HASH,

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -367,50 +367,6 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
         printVariables("");
     }
 
-    function test_L1_assignedProverCannotProveAfterHisWindowElapsed() external {
-        giveEthAndTko(Alice, 1e8 ether, 100 ether);
-        // This is a very weird test (code?) issue here.
-        // If this line (or Bob's query balance) is uncommented,
-        // Alice/Bob has no balance.. (Causing reverts !!!)
-        console2.log("Alice balance:", tko.balanceOf(Alice));
-        giveEthAndTko(Bob, 1e8 ether, 100 ether);
-        console2.log("Bob balance:", tko.balanceOf(Bob));
-        giveEthAndTko(Carol, 1e8 ether, 100 ether);
-        // Bob
-        vm.prank(Bob, Bob);
-
-        bytes32 parentHash = GENESIS_BLOCK_HASH;
-
-        for (uint256 blockId = 1; blockId < 10; blockId++) {
-            //printVariables("before propose");
-            (TaikoData.BlockMetadata memory meta,) = proposeBlock(Alice, Bob, 1_000_000, 1024);
-            //printVariables("after propose");
-            mine(1);
-
-            bytes32 blockHash = bytes32(1e10 + blockId);
-            bytes32 stateRoot = bytes32(1e9 + blockId);
-
-            vm.roll(block.number + 15 * 12);
-
-            uint16 minTier = meta.minTier;
-            vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
-
-            proveBlock(
-                Bob,
-                meta,
-                parentHash,
-                blockHash,
-                stateRoot,
-                meta.minTier,
-                TaikoErrors.L1_ASSIGNED_PROVER_NOT_ALLOWED.selector
-            );
-
-            verifyBlock(1);
-            parentHash = blockHash;
-        }
-        printVariables("");
-    }
-
     function test_L1_GuardianProverCanAlwaysOverwriteTheProof() external {
         giveEthAndTko(Alice, 1e7 ether, 1000 ether);
         giveEthAndTko(Carol, 1e7 ether, 1000 ether);

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -46,7 +46,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
         } else if (minTier == LibTiers.TIER_SGX) {
             tierToProveWith = LibTiers.TIER_GUARDIAN;
         }
-        proveBlock(Carol, Carol, meta, parentHash, blockHash, stateRoot, tierToProveWith, "");
+        proveBlock(Carol, meta, parentHash, blockHash, stateRoot, tierToProveWith, "");
     }
 
     function test_L1_ContestingWithSameProof() external {
@@ -73,11 +73,10 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             bytes32 stateRoot = bytes32(1e9 + blockId);
             // This proof cannot be verified obviously because of
             // blockhash:blockId
-            proveBlock(Bob, Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
 
             // Try to contest - but should revert with L1_ALREADY_PROVED
             proveBlock(
-                Carol,
                 Carol,
                 meta,
                 parentHash,
@@ -92,7 +91,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -125,17 +124,17 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             // stateRoot instead of blockHash
             uint16 minTier = meta.minTier;
 
-            proveBlock(Bob, Bob, meta, parentHash, stateRoot, stateRoot, minTier, "");
+            proveBlock(Bob, meta, parentHash, stateRoot, stateRoot, minTier, "");
 
             // Try to contest
-            proveBlock(Carol, Carol, meta, parentHash, blockHash, stateRoot, minTier, "");
+            proveBlock(Carol, meta, parentHash, blockHash, stateRoot, minTier, "");
 
             vm.roll(block.number + 15 * 12);
 
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
             // Cannot verify block because it is contested..
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             proveHigherTierProof(meta, parentHash, stateRoot, blockHash, minTier);
 
@@ -145,7 +144,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             );
             // Now can verify
             console2.log("Probalom verify-olni");
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -177,17 +176,17 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             // This proof cannot be verified obviously because of
             // stateRoot instead of blockHash
             uint16 minTier = meta.minTier;
-            proveBlock(Bob, Bob, meta, parentHash, stateRoot, stateRoot, minTier, "");
+            proveBlock(Bob, meta, parentHash, stateRoot, stateRoot, minTier, "");
 
             // Try to contest
-            proveBlock(Carol, Carol, meta, parentHash, blockHash, stateRoot, minTier, "");
+            proveBlock(Carol, meta, parentHash, blockHash, stateRoot, minTier, "");
 
             vm.roll(block.number + 15 * 12);
 
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
             // Cannot verify block because it is contested..
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             proveHigherTierProof(meta, parentHash, stateRoot, blockHash, minTier);
 
@@ -197,7 +196,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                     + 1
             );
             // Now can verify
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -230,21 +229,21 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             // stateRoot instead of blockHash
             uint16 minTier = meta.minTier;
 
-            proveBlock(Bob, Bob, meta, parentHash, blockHash, stateRoot, minTier, "");
+            proveBlock(Bob, meta, parentHash, blockHash, stateRoot, minTier, "");
 
             if (minTier == LibTiers.TIER_OPTIMISTIC) {
                 // Try to contest
-                proveBlock(Carol, Carol, meta, parentHash, stateRoot, stateRoot, minTier, "");
+                proveBlock(Carol, meta, parentHash, stateRoot, stateRoot, minTier, "");
 
                 vm.roll(block.number + 15 * 12);
 
                 vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
                 // Cannot verify block because it is contested..
-                verifyBlock(Carol, 1);
+                verifyBlock(1);
 
                 proveBlock(
-                    Carol, Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, ""
+                    Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, ""
                 );
             }
 
@@ -254,7 +253,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                     + 1
             );
             // Now can verify
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -286,11 +285,11 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             // This proof cannot be verified obviously because of
             // stateRoot instead of blockHash
             uint16 minTier = meta.minTier;
-            proveBlock(Bob, Bob, meta, parentHash, stateRoot, stateRoot, minTier, "");
+            proveBlock(Bob, meta, parentHash, stateRoot, stateRoot, minTier, "");
 
             if (minTier == LibTiers.TIER_OPTIMISTIC) {
                 // Try to contest
-                proveBlock(Carol, Carol, meta, parentHash, blockHash, stateRoot, minTier, "");
+                proveBlock(Carol, meta, parentHash, blockHash, stateRoot, minTier, "");
 
                 vm.roll(block.number + 15 * 12);
 
@@ -300,10 +299,9 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                 );
 
                 // Cannot verify block because it is contested..
-                verifyBlock(Carol, 1);
+                verifyBlock(1);
 
                 proveBlock(
-                    Carol,
                     Carol,
                     meta,
                     parentHash,
@@ -320,7 +318,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                     + 1
             );
             // Now can verify
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -351,7 +349,6 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             bytes32 stateRoot = bytes32(1e9 + blockId);
             proveBlock(
                 Carol,
-                Carol,
                 meta,
                 parentHash,
                 blockHash,
@@ -364,7 +361,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
             parentHash = blockHash;
         }
         printVariables("");
@@ -400,7 +397,6 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
 
             proveBlock(
                 Bob,
-                Bob,
                 meta,
                 parentHash,
                 blockHash,
@@ -409,7 +405,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                 TaikoErrors.L1_ASSIGNED_PROVER_NOT_ALLOWED.selector
             );
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
             parentHash = blockHash;
         }
         printVariables("");
@@ -442,25 +438,18 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
 
             (, TaikoData.SlotB memory b) = L1.getStateVariables();
             uint64 lastVerifiedBlockBefore = b.lastVerifiedBlockId;
-            proveBlock(Bob, Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
             console2.log("mintTier is:", meta.minTier);
             // Try to contest
             proveBlock(
-                Carol,
-                Carol,
-                meta,
-                parentHash,
-                bytes32(uint256(1)),
-                bytes32(uint256(1)),
-                meta.minTier,
-                ""
+                Carol, meta, parentHash, bytes32(uint256(1)), bytes32(uint256(1)), meta.minTier, ""
             );
             vm.roll(block.number + 15 * 12);
 
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             (, b) = L1.getStateVariables();
             uint64 lastVerifiedBlockAfter = b.lastVerifiedBlockId;
@@ -470,9 +459,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             assertEq(lastVerifiedBlockAfter, lastVerifiedBlockBefore);
 
             // Guardian can prove with the original (good) hashes.
-            proveBlock(
-                Carol, Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, ""
-            );
+            proveBlock(Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, "");
 
             vm.roll(block.number + 15 * 12);
             vm.warp(
@@ -480,7 +467,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
                     + 1
             );
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
             parentHash = blockHash;
         }
         printVariables("");
@@ -510,11 +497,10 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             bytes32 stateRoot = bytes32(1e9 + blockId);
             // This proof cannot be verified obviously because of
             // blockhash:blockId
-            proveBlock(Bob, Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
 
             // Try to contest - but should revert with L1_ALREADY_PROVED
             proveBlock(
-                Carol,
                 Carol,
                 meta,
                 parentHash,
@@ -529,7 +515,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -560,31 +546,22 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             bytes32 stateRoot = bytes32(1e9 + blockId);
             // This proof cannot be verified obviously because of
             // blockhash:blockId
-            proveBlock(Bob, Bob, meta, parentHash, stateRoot, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, stateRoot, stateRoot, meta.minTier, "");
 
             // Prove as guardian
             proveBlock(
-                Carol,
-                Carol,
-                meta,
-                parentHash,
-                blockHash,
-                bytes32(uint256(1)),
-                LibTiers.TIER_GUARDIAN,
-                ""
+                Carol, meta, parentHash, blockHash, bytes32(uint256(1)), LibTiers.TIER_GUARDIAN, ""
             );
 
             // Prove as guardian again
-            proveBlock(
-                Carol, Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, ""
-            );
+            proveBlock(Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, "");
 
             vm.roll(block.number + 15 * 12);
 
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -617,11 +594,10 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             bytes32 stateRoot = bytes32(1e9 + blockId);
             // This proof cannot be verified obviously because of
             // blockhash:blockId
-            proveBlock(Bob, Bob, meta, parentHash, stateRoot, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, stateRoot, stateRoot, meta.minTier, "");
 
             // Prove as guardian but in reality not a guardian
             proveBlock(
-                Carol,
                 Carol,
                 meta,
                 parentHash,
@@ -636,7 +612,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -670,7 +646,6 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
 
             meta.id = 100;
             proveBlock(
-                Carol,
                 Carol,
                 meta,
                 parentHash,
@@ -714,7 +689,6 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             meta.l1Height = 200;
             proveBlock(
                 Bob,
-                Bob,
                 meta,
                 parentHash,
                 blockHash,
@@ -752,16 +726,13 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             bytes32 stateRoot = bytes32(1e9 + blockId);
             // This proof cannot be verified obviously because of blockhash is
             // exchanged with stateRoot
-            proveBlock(Bob, Bob, meta, parentHash, stateRoot, stateRoot, meta.minTier, "");
+            proveBlock(Bob, meta, parentHash, stateRoot, stateRoot, meta.minTier, "");
 
             // Prove as guardian
-            proveBlock(
-                Carol, Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, ""
-            );
+            proveBlock(Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, "");
 
             // Try to re-prove but reverts
             proveBlock(
-                Bob,
                 Bob,
                 meta,
                 parentHash,
@@ -776,77 +747,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
             uint16 minTier = meta.minTier;
             vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
 
-            verifyBlock(Carol, 1);
-
-            parentHash = blockHash;
-        }
-        printVariables("");
-    }
-
-    function test_L1_GuardianCanReturnBondIfBlockUnprovable() external {
-        giveEthAndTko(Alice, 1e7 ether, 1000 ether);
-        giveEthAndTko(Carol, 1e7 ether, 1000 ether);
-        console2.log("Alice balance:", tko.balanceOf(Alice));
-        // This is a very weird test (code?) issue here.
-        // If this line is uncommented,
-        // Alice/Bob has no balance.. (Causing reverts !!!)
-        // Current investigations are ongoing with foundry team
-        giveEthAndTko(Bob, 1e7 ether, 100 ether);
-        console2.log("Bob balance:", tko.balanceOf(Bob));
-        // Bob
-        vm.prank(Bob, Bob);
-
-        bytes32 parentHash = GENESIS_BLOCK_HASH;
-        for (uint256 blockId = 1; blockId < conf.blockMaxProposals * 3; blockId++) {
-            printVariables("before propose");
-            (TaikoData.BlockMetadata memory meta,) = proposeBlock(Alice, Bob, 1_000_000, 1024);
-            //printVariables("after propose");
-            mine(1);
-
-            bytes32 blockHash = bytes32(1e10 + blockId);
-            bytes32 stateRoot = bytes32(1e9 + blockId);
-            // This proof cannot be verified obviously because of blockhash is
-            // exchanged with stateRoot
-            proveBlock(Bob, Bob, meta, parentHash, stateRoot, stateRoot, meta.minTier, "");
-
-            // Let's say the 10th block is unprovable so prove accordingly
-            if (blockId == 10) {
-                TaikoData.Transition memory tran = TaikoData.Transition({
-                    parentHash: parentHash,
-                    blockHash: blockHash,
-                    stateRoot: stateRoot,
-                    graffiti: 0x0
-                });
-
-                TaikoData.TierProof memory proof;
-                proof.tier = LibTiers.TIER_GUARDIAN;
-                proof.data = bytes.concat(keccak256("RETURN_LIVENESS_BOND"));
-
-                uint256 balanceBeforeReimbursement = tko.balanceOf(Bob);
-
-                vm.prank(David, David);
-                gp.approve(meta, tran, proof);
-                vm.prank(Emma, Emma);
-                gp.approve(meta, tran, proof);
-                vm.prank(Frank, Frank);
-                gp.approve(meta, tran, proof);
-
-                // // Credited back the bond (not transferred to the user
-                // wallet,
-                // // but in-contract account credited only.)
-                assertEq(tko.balanceOf(Bob) - balanceBeforeReimbursement, 1 ether);
-            } else {
-                // Prove as guardian
-                proveBlock(
-                    Carol, Carol, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, ""
-                );
-            }
-            vm.roll(block.number + 15 * 12);
-
-            uint16 minTier = meta.minTier;
-            vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
-
-            verifyBlock(Carol, 1);
+            verifyBlock(1);
 
             parentHash = blockHash;
         }
@@ -874,11 +775,10 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
 
         bytes32 blockHash = bytes32(uint256(1));
         bytes32 stateRoot = bytes32(uint256(1));
-        proveBlock(Bob, Bob, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, "");
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, "");
 
         // Try to contest with a lower tier proof- but should revert with L1_INVALID_TIER
         proveBlock(
-            Carol,
             Carol,
             meta,
             parentHash,

--- a/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
@@ -154,21 +154,8 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
         bytes32 blockHash = bytes32(uint256(10));
         bytes32 stateRoot = bytes32(uint256(11));
 
-        mineAndWrap(7 days);
-
-        console2.log("====== Bob cannot prove the block out of the proving window");
-        proveBlock(
-            Bob,
-            meta,
-            parentHash,
-            blockHash,
-            stateRoot,
-            meta.minTier,
-            TaikoErrors.L1_ASSIGNED_PROVER_NOT_ALLOWED.selector
-        );
-
         console2.log("====== Taylor proves the block");
-        mineAndWrap(10 seconds);
+        mineAndWrap(7 days);
         proveBlock(Taylor, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
 
         uint256 provenAt;
@@ -384,6 +371,104 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
 
             assertEq(tko.balanceOf(Bob), 10_000 ether - L1.getConfig().livenessBond);
             assertEq(tko.balanceOf(Taylor), 10_000 ether);
+        }
+    }
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob proves the block outside the proving window, using the correct parent hash.
+    // 3. Bob's proof is used to verify the block.
+
+    function test_taikoL1_group_1_case_6() external {
+        vm.warp(1_000_000);
+        printBlockAndTrans(0);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+        uint256 proposedAt;
+        {
+            printBlockAndTrans(meta.id);
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(meta.minTier, LibTiers.TIER_OPTIMISTIC);
+
+            assertEq(blk.nextTransitionId, 1);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, block.timestamp);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, livenessBond);
+
+            proposedAt = blk.proposedAt;
+
+            assertEq(tko.balanceOf(Alice), 10_000 ether);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+        }
+
+        // Prove the block
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        console2.log("====== Bob proves the block outside the proving window");
+        mineAndWrap(7 days);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        uint256 provenAt;
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.timestamp, block.timestamp);
+
+            provenAt = ts.timestamp;
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+        }
+
+        console2.log("====== Verify block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.timestamp, provenAt);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
         }
     }
 }

--- a/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
@@ -79,12 +79,12 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
             assertEq(ts.contester, address(0));
             assertEq(ts.contestBond, 1); // not zero
             assertEq(ts.prover, Bob);
-            assertEq(ts.validityBond, tierOp.validityBond + livenessBond);
+            assertEq(ts.validityBond, tierOp.validityBond);
             assertEq(ts.timestamp, block.timestamp);
 
             provenAt = ts.timestamp;
 
-            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond - tierOp.validityBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
         }
 
         console2.log("====== Verify block");
@@ -107,7 +107,7 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
             assertEq(ts.contester, address(0));
             assertEq(ts.contestBond, 1); // not zero
             assertEq(ts.prover, Bob);
-            assertEq(ts.validityBond, tierOp.validityBond + livenessBond);
+            assertEq(ts.validityBond, tierOp.validityBond);
             assertEq(ts.timestamp, provenAt);
 
             assertEq(tko.balanceOf(Bob), 10_000 ether);
@@ -275,9 +275,7 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
             assertEq(ts.prover, Taylor);
             assertEq(ts.validityBond, tierOp.validityBond);
 
-            assertEq(
-                tko.balanceOf(Bob), 10_000 ether - L1.getConfig().livenessBond - tierOp.validityBond
-            );
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
             assertEq(tko.balanceOf(Taylor), 10_000 ether);
         }
     }
@@ -328,7 +326,7 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
             assertEq(ts.contester, address(0));
             assertEq(ts.contestBond, 1); // not zero
             assertEq(ts.prover, Bob);
-            assertEq(ts.validityBond, tierOp.validityBond + L1.getConfig().livenessBond);
+            assertEq(ts.validityBond, tierOp.validityBond);
 
             assertEq(tko.balanceOf(Bob), 10_000 ether);
             assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.validityBond);

--- a/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestGroupBase.sol";
+
+contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob proves the block within the proving window, using the correct parent hash.
+    // 3. Bob's proof is used to verify the block.
+    function test_taikoL1_group_1_case_1() external {
+        vm.warp(1_000_000);
+        printBlockAndTrans(0);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+        uint256 proposedAt;
+        {
+            printBlockAndTrans(meta.id);
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(meta.minTier, LibTiers.TIER_OPTIMISTIC);
+
+            assertEq(blk.nextTransitionId, 1);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, block.timestamp);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, livenessBond);
+
+            proposedAt = blk.proposedAt;
+
+            assertEq(tko.balanceOf(Alice), 10_000 ether);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+        }
+
+        // Prove the block
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        console2.log("====== Taylor cannot prove the block in the proving window");
+        mineAndWrap(10 seconds);
+        proveBlock(
+            Taylor,
+            meta,
+            parentHash,
+            blockHash,
+            stateRoot,
+            meta.minTier,
+            TaikoErrors.L1_NOT_ASSIGNED_PROVER.selector
+        );
+
+        console2.log("====== Bob proves the block");
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        uint256 provenAt;
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond + livenessBond);
+            assertEq(ts.timestamp, block.timestamp);
+
+            provenAt = ts.timestamp;
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond - tierOp.validityBond);
+        }
+
+        console2.log("====== Verify block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond + livenessBond);
+            assertEq(ts.timestamp, provenAt);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Taylor proposes the block outside the proving window.
+    // 3. Taylor's proof is used to verify the block.
+    function test_taikoL1_group_1_case_2() external {
+        vm.warp(1_000_000);
+        printBlockAndTrans(0);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+        uint256 proposedAt;
+        {
+            printBlockAndTrans(meta.id);
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(meta.minTier, LibTiers.TIER_OPTIMISTIC);
+
+            assertEq(blk.nextTransitionId, 1);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, block.timestamp);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, livenessBond);
+
+            proposedAt = blk.proposedAt;
+
+            assertEq(tko.balanceOf(Alice), 10_000 ether);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+        }
+
+        // Prove the block
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(7 days);
+
+        console2.log("====== Bob cannot prove the block out of the proving window");
+        proveBlock(
+            Bob,
+            meta,
+            parentHash,
+            blockHash,
+            stateRoot,
+            meta.minTier,
+            TaikoErrors.L1_ASSIGNED_PROVER_NOT_ALLOWED.selector
+        );
+
+        console2.log("====== Taylor proves the block");
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        uint256 provenAt;
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Taylor);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.timestamp, block.timestamp);
+
+            provenAt = ts.timestamp;
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.validityBond);
+        }
+
+        console2.log("====== Verify block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Taylor);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.timestamp, provenAt);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob proves the block within the proving window.
+    // 3. Taylor proves the block outside the proving window.
+    // 4. Taylor's proof is used to verify the block.
+    function test_taikoL1_group_1_case_3() external {
+        vm.warp(1_000_000);
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        // Prove the block
+        bytes32 parentHash1 = bytes32(uint256(9));
+        bytes32 parentHash2 = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+
+        console2.log("====== Bob proves the block first");
+        proveBlock(Bob, meta, parentHash1, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor proves the block later");
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash2, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Verify block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 3);
+            assertEq(blk.verifiedTransitionId, 2);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 2);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Taylor);
+            assertEq(ts.validityBond, tierOp.validityBond);
+
+            assertEq(
+                tko.balanceOf(Bob), 10_000 ether - L1.getConfig().livenessBond - tierOp.validityBond
+            );
+            assertEq(tko.balanceOf(Taylor), 10_000 ether);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob proves the block within the proving window.
+    // 3. Taylor proves the block outside the proving window.
+    // 4. Bob's proof is used to verify the block.
+    function test_taikoL1_group_1_case_4() external {
+        vm.warp(1_000_000);
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        // Prove the block
+        bytes32 parentHash1 = GENESIS_BLOCK_HASH;
+        bytes32 parentHash2 = bytes32(uint256(9));
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+
+        console2.log("====== Bob proves the block first");
+        proveBlock(Bob, meta, parentHash1, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor proves the block later");
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash2, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Verify block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 3);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond + L1.getConfig().livenessBond);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.validityBond);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. William proves the block outside the proving window.
+    // 3. Taylor also proves the block outside the proving window.
+    // 4. Taylor's proof is used to verify the block.
+    function test_taikoL1_group_1_case_5() external {
+        vm.warp(1_000_000);
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        // Prove the block
+        bytes32 parentHash1 = bytes32(uint256(9));
+        bytes32 parentHash2 = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(7 days);
+
+        console2.log("====== William proves the block first");
+        proveBlock(William, meta, parentHash1, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor proves the block later");
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash2, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Verify block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 3);
+            assertEq(blk.verifiedTransitionId, 2);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 2);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Taylor);
+            assertEq(ts.validityBond, tierOp.validityBond);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - L1.getConfig().livenessBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether);
+        }
+    }
+}

--- a/packages/protocol/test/L1/TaikoL1TestGroup2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup2.t.sol
@@ -23,8 +23,6 @@ contract TaikoL1TestGroup2 is TaikoL1TestGroupBase {
         console2.log("====== Alice propose a block with bob as the assigned prover");
         TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
 
-        uint96 livenessBond = L1.getConfig().livenessBond;
-
         console2.log("====== Bob proves the block as the assigned prover");
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         bytes32 blockHash = bytes32(uint256(10));
@@ -54,11 +52,11 @@ contract TaikoL1TestGroup2 is TaikoL1TestGroupBase {
             assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
             assertEq(ts.contester, Taylor);
             assertEq(ts.contestBond, tierOp.contestBond);
-            assertEq(ts.validityBond, tierOp.validityBond + livenessBond);
+            assertEq(ts.validityBond, tierOp.validityBond);
             assertEq(ts.prover, Bob);
             assertEq(ts.timestamp, block.timestamp);
 
-            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
             assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
         }
 
@@ -136,8 +134,6 @@ contract TaikoL1TestGroup2 is TaikoL1TestGroupBase {
         console2.log("====== Alice propose a block with bob as the assigned prover");
         TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
 
-        uint96 livenessBond = L1.getConfig().livenessBond;
-
         console2.log("====== Bob proves the block as the assigned prover");
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         bytes32 blockHash = bytes32(uint256(10));
@@ -167,11 +163,11 @@ contract TaikoL1TestGroup2 is TaikoL1TestGroupBase {
             assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
             assertEq(ts.contester, Taylor);
             assertEq(ts.contestBond, tierOp.contestBond);
-            assertEq(ts.validityBond, tierOp.validityBond + livenessBond);
+            assertEq(ts.validityBond, tierOp.validityBond);
             assertEq(ts.prover, Bob);
             assertEq(ts.timestamp, block.timestamp);
 
-            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
             assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
         }
 
@@ -198,9 +194,9 @@ contract TaikoL1TestGroup2 is TaikoL1TestGroupBase {
             assertEq(ts.prover, William);
             assertEq(ts.timestamp, block.timestamp);
 
-            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
 
-            uint256 quarterReward = (tierOp.validityBond + livenessBond) * 7 / 8 / 4;
+            uint256 quarterReward = tierOp.validityBond * 7 / 8 / 4;
             assertEq(tko.balanceOf(Taylor), 10_000 ether + quarterReward * 3);
             assertEq(tko.balanceOf(William), 10_000 ether - tierSgx.validityBond + quarterReward);
         }
@@ -226,9 +222,9 @@ contract TaikoL1TestGroup2 is TaikoL1TestGroupBase {
             assertEq(ts.validityBond, tierSgx.validityBond);
             assertEq(ts.prover, William);
 
-            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
 
-            uint256 quarterReward = (tierOp.validityBond + livenessBond) * 7 / 8 / 4;
+            uint256 quarterReward = tierOp.validityBond * 7 / 8 / 4;
             assertEq(tko.balanceOf(Taylor), 10_000 ether + quarterReward * 3);
             assertEq(tko.balanceOf(William), 10_000 ether + quarterReward);
         }

--- a/packages/protocol/test/L1/TaikoL1TestGroup2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup2.t.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestGroupBase.sol";
+
+contract TaikoL1TestGroup2 is TaikoL1TestGroupBase {
+    // Test summary:
+    // 1. Alice proposes a block, Bob as the prover.
+    // 2. Bob proves the block within the proving window, with correct parent hash.
+    // 3. Taylor contests Bob's proof.
+    // 4. William proves Bob is correct and Taylor is wrong.
+    // 5. William's proof is used to verify the block.
+    function test_taikoL1_group_2_case_1() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+        ITierProvider.Tier memory tierSgx = TierProviderV1(cp).getTier(LibTiers.TIER_SGX);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+
+        console2.log("====== Bob proves the block as the assigned prover");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor contests Bob");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash, blockHash2, stateRoot2, meta.minTier, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, Taylor);
+            assertEq(ts.contestBond, tierOp.contestBond);
+            assertEq(ts.validityBond, tierOp.validityBond + livenessBond);
+            assertEq(ts.prover, Bob);
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
+        }
+
+        console2.log("====== William proves Bob is right");
+        mineAndWrap(10 seconds);
+        proveBlock(William, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_SGX, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, William);
+            assertEq(ts.timestamp, block.timestamp); // not zero
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
+            assertEq(
+                tko.balanceOf(William),
+                10_000 ether - tierSgx.validityBond + tierOp.contestBond * 7 / 8
+            );
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            // assertEq(blk.livenessBond, livenessBond);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.prover, William);
+
+            assertEq(tko.balanceOf(William), 10_000 ether + tierOp.contestBond * 7 / 8);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, Bob as the prover.
+    // 2. Bob proves the block within the proving window, with correct parent hash.
+    // 3. Taylor contests Bob's proof.
+    // 4. William proves Taylor is correct and Bob is wrong.
+    // 5. William's proof is used to verify the block.
+    function test_taikoL1_group_2_case_2() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+        ITierProvider.Tier memory tierSgx = TierProviderV1(cp).getTier(LibTiers.TIER_SGX);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+
+        console2.log("====== Bob proves the block as the assigned prover");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor contests Bob");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash, blockHash2, stateRoot2, meta.minTier, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, Taylor);
+            assertEq(ts.contestBond, tierOp.contestBond);
+            assertEq(ts.validityBond, tierOp.validityBond + livenessBond);
+            assertEq(ts.prover, Bob);
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
+        }
+
+        console2.log("====== William proves Tayler is right");
+        mineAndWrap(10 seconds);
+        proveBlock(William, meta, parentHash, blockHash2, stateRoot2, LibTiers.TIER_SGX, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, William);
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+
+            uint256 quarterReward = (tierOp.validityBond + livenessBond) * 7 / 8 / 4;
+            assertEq(tko.balanceOf(Taylor), 10_000 ether + quarterReward * 3);
+            assertEq(tko.balanceOf(William), 10_000 ether - tierSgx.validityBond + quarterReward);
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, William);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+
+            uint256 quarterReward = (tierOp.validityBond + livenessBond) * 7 / 8 / 4;
+            assertEq(tko.balanceOf(Taylor), 10_000 ether + quarterReward * 3);
+            assertEq(tko.balanceOf(William), 10_000 ether + quarterReward);
+        }
+    }
+}

--- a/packages/protocol/test/L1/TaikoL1TestGroup3.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup3.t.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestGroupBase.sol";
+
+contract TaikoL1TestGroup3 is TaikoL1TestGroupBase {
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. James proves the block outside the proving window, using the correct parent hash.
+    // 3. Taylor contests James' proof.
+    // 4. William proves James is correct and Taylor is wrong.
+    // 5. William's proof is used to verify the block.
+    function test_taikoL1_group_3_case_1() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(James, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+        ITierProvider.Tier memory tierSgx = TierProviderV1(cp).getTier(LibTiers.TIER_SGX);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+
+        console2.log("====== James proves the block");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(7 days);
+        proveBlock(James, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor contests James");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash, blockHash2, stateRoot2, meta.minTier, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, Taylor);
+            assertEq(ts.contestBond, tierOp.contestBond);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.prover, James);
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(James), 10_000 ether - tierOp.validityBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
+        }
+
+        console2.log("====== William proves James is right");
+        mineAndWrap(10 seconds);
+        proveBlock(William, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_SGX, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, William);
+            assertEq(ts.timestamp, block.timestamp); // not zero
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
+            assertEq(
+                tko.balanceOf(William),
+                10_000 ether - tierSgx.validityBond + tierOp.contestBond * 7 / 8
+            );
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            // assertEq(blk.livenessBond, livenessBond);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.prover, William);
+
+            assertEq(tko.balanceOf(William), 10_000 ether + tierOp.contestBond * 7 / 8);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, Bob as the prover.
+    // 2. James proves the block outside the proving window, with correct parent hash.
+    // 3. Taylor contests James' proof.
+    // 4. William proves Taylor is correct and James is wrong.
+    // 5. William's proof is used to verify the block.
+    function test_taikoL1_group_3_case_2() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(James, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+        ITierProvider.Tier memory tierSgx = TierProviderV1(cp).getTier(LibTiers.TIER_SGX);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+
+        console2.log("====== James proves the block");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(7 days);
+        proveBlock(James, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor contests James");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash, blockHash2, stateRoot2, meta.minTier, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, Taylor);
+            assertEq(ts.contestBond, tierOp.contestBond);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.prover, James);
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(James), 10_000 ether - tierOp.validityBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
+        }
+
+        console2.log("====== William proves Tayler is right");
+        mineAndWrap(10 seconds);
+        proveBlock(William, meta, parentHash, blockHash2, stateRoot2, LibTiers.TIER_SGX, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, William);
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(James), 10_000 ether - tierOp.validityBond);
+
+            uint256 quarterReward = tierOp.validityBond * 7 / 8 / 4;
+            assertEq(tko.balanceOf(Taylor), 10_000 ether + quarterReward * 3);
+            assertEq(tko.balanceOf(William), 10_000 ether - tierSgx.validityBond + quarterReward);
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, William);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+
+            uint256 quarterReward = tierOp.validityBond * 7 / 8 / 4;
+            assertEq(tko.balanceOf(James), 10_000 ether - tierOp.validityBond);
+            assertEq(tko.balanceOf(Taylor), 10_000 ether + quarterReward * 3);
+            assertEq(tko.balanceOf(William), 10_000 ether + quarterReward);
+        }
+    }
+}

--- a/packages/protocol/test/L1/TaikoL1TestGroup4.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup4.t.sol
@@ -7,7 +7,8 @@ contract TaikoL1TestGroup4 is TaikoL1TestGroupBase {
     // Test summary:
     // 1. Alice proposes a block, Bob is the prover.
     // 2. Bob proves the block within the proving window, using the correct parent hash.
-    // 3. Taylor disproves Bob with a higher-tier proof.
+    // 3. Taylor contests then proves Bob is wrong  in the same transaction with a higher-tier
+    // proof.
     // 4. Taylor's proof is used to verify the block.
     function test_taikoL1_group_4_case_1() external {
         vm.warp(1_000_000);
@@ -92,7 +93,8 @@ contract TaikoL1TestGroup4 is TaikoL1TestGroupBase {
     // Test summary:
     // 1. Alice proposes a block, assigning Bob as the prover.
     // 2. David proves the block outside the proving window, using the correct parent hash.
-    // 3. Taylor disproves David with a higher-tier proof.
+    // 3. Taylor contests then proves David is wrong in the same transaction with a higher-tier
+    // proof.
     // 4. Taylor's proof is used to verify the block.
     function test_taikoL1_group_4_case_2() external {
         vm.warp(1_000_000);

--- a/packages/protocol/test/L1/TaikoL1TestGroup4.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup4.t.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestGroupBase.sol";
+
+contract TaikoL1TestGroup4 is TaikoL1TestGroupBase {
+    // Test summary:
+    // 1. Alice proposes a block, Bob is the prover.
+    // 2. Bob proves the block within the proving window, using the correct parent hash.
+    // 3. Taylor disproves Bob with a higher-tier proof.
+    // 4. Taylor's proof is used to verify the block.
+    function test_taikoL1_group_4_case_1() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+        ITierProvider.Tier memory tierSgx = TierProviderV1(cp).getTier(LibTiers.TIER_SGX);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+
+        console2.log("====== Bob proves the block as the assigned prover");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor contests Bob with a higher tier proof");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash, blockHash2, stateRoot2, LibTiers.TIER_SGX, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, Taylor);
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(
+                tko.balanceOf(Taylor),
+                10_000 ether - tierSgx.validityBond + (tierOp.validityBond + livenessBond) * 7 / 8
+            );
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            // assertEq(blk.livenessBond, livenessBond);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.prover, Taylor);
+
+            assertEq(
+                tko.balanceOf(Taylor), 10_000 ether + (tierOp.validityBond + livenessBond) * 7 / 8
+            );
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. David proves the block outside the proving window, using the correct parent hash.
+    // 3. Taylor disproves David with a higher-tier proof.
+    // 4. Taylor's proof is used to verify the block.
+    function test_taikoL1_group_4_case_2() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(David, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+        ITierProvider.Tier memory tierSgx = TierProviderV1(cp).getTier(LibTiers.TIER_SGX);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+
+        console2.log("====== Bob proves the block as the assigned prover");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(7 days);
+        proveBlock(David, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor contests David with a higher tier proof");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash, blockHash2, stateRoot2, LibTiers.TIER_SGX, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, Taylor);
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(David), 10_000 ether - tierOp.validityBond);
+            assertEq(
+                tko.balanceOf(Taylor),
+                10_000 ether - tierSgx.validityBond + tierOp.validityBond * 7 / 8
+            );
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.prover, Taylor);
+
+            assertEq(tko.balanceOf(Taylor), 10_000 ether + tierOp.validityBond * 7 / 8);
+        }
+    }
+}

--- a/packages/protocol/test/L1/TaikoL1TestGroup4.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup4.t.sol
@@ -21,8 +21,6 @@ contract TaikoL1TestGroup4 is TaikoL1TestGroupBase {
         console2.log("====== Alice propose a block with bob as the assigned prover");
         TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
 
-        uint96 livenessBond = L1.getConfig().livenessBond;
-
         console2.log("====== Bob proves the block as the assigned prover");
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         bytes32 blockHash = bytes32(uint256(10));
@@ -56,10 +54,10 @@ contract TaikoL1TestGroup4 is TaikoL1TestGroupBase {
             assertEq(ts.prover, Taylor);
             assertEq(ts.timestamp, block.timestamp);
 
-            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
             assertEq(
                 tko.balanceOf(Taylor),
-                10_000 ether - tierSgx.validityBond + (tierOp.validityBond + livenessBond) * 7 / 8
+                10_000 ether - tierSgx.validityBond + tierOp.validityBond * 7 / 8
             );
         }
 
@@ -83,9 +81,7 @@ contract TaikoL1TestGroup4 is TaikoL1TestGroupBase {
             assertEq(ts.contestBond, 1);
             assertEq(ts.prover, Taylor);
 
-            assertEq(
-                tko.balanceOf(Taylor), 10_000 ether + (tierOp.validityBond + livenessBond) * 7 / 8
-            );
+            assertEq(tko.balanceOf(Taylor), 10_000 ether + tierOp.validityBond * 7 / 8);
         }
     }
 

--- a/packages/protocol/test/L1/TaikoL1TestGroup5.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup5.t.sol
@@ -7,9 +7,9 @@ contract TaikoL1TestGroup5 is TaikoL1TestGroupBase {
     // Test summary:
     // 1. Alice proposes a block, assigning Bob as the prover.
     // 2. Guardian prover directly proves the block.
-    // 3. Guardian prover re-proves the same transition.
+    // 3. Guardian prover re-proves the same transition and fails.
     // 4. Guardian prover proves the block again with a different transition.
-    // 5. William contests using a lower-tier proof.
+    // 5. William contests the guardian prover using a lower-tier proof and fails.
     function test_taikoL1_group_5_case_1() external {
         vm.warp(1_000_000);
 
@@ -132,9 +132,9 @@ contract TaikoL1TestGroup5 is TaikoL1TestGroupBase {
     // Test summary:
     // 1. Alice proposes a block, Bob is the prover.
     // 2. Bob proves the block.
-    // 3. Guardian prover re-proves the same transition.
+    // 3. Guardian prover re-proves the same transition and fails.
     // 4. Guardian prover proves the block with a different transition.
-    // 5. William contests using a lower-tier proof.
+    // 5. William contests the guardian prover using a lower-tier proof and fails.
     function test_taikoL1_group_5_case_2() external {
         vm.warp(1_000_000);
 
@@ -225,9 +225,9 @@ contract TaikoL1TestGroup5 is TaikoL1TestGroupBase {
     // Test summary:
     // 1. Alice proposes a block, assigning Bob as the prover.
     // 2. David proves the block outside the proving window.
-    // 3. Guardian prover re-proves the same transition.
+    // 3. Guardian prover re-proves the same transition and fails.
     // 4. Guardian prover proves the block with a different transition.
-    // 5. William contests using a lower-tier proof.
+    // 5. William contests the guardian prover using a lower-tier proof and fails.
     function test_taikoL1_group_5_case_3() external {
         vm.warp(1_000_000);
 

--- a/packages/protocol/test/L1/TaikoL1TestGroup5.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup5.t.sol
@@ -146,8 +146,6 @@ contract TaikoL1TestGroup5 is TaikoL1TestGroupBase {
         console2.log("====== Alice propose a block with bob as the assigned prover");
         TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
 
-        uint96 livenessBond = L1.getConfig().livenessBond;
-
         console2.log("====== Bob proves the block");
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         bytes32 blockHash = bytes32(uint256(10));
@@ -193,7 +191,7 @@ contract TaikoL1TestGroup5 is TaikoL1TestGroupBase {
             assertEq(ts.prover, address(gp));
             assertEq(ts.timestamp, block.timestamp);
 
-            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
             assertEq(tko.balanceOf(William), 10_000 ether);
         }
 
@@ -217,7 +215,7 @@ contract TaikoL1TestGroup5 is TaikoL1TestGroupBase {
             assertEq(ts.contestBond, 1);
             assertEq(ts.prover, address(gp));
 
-            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond);
             assertEq(tko.balanceOf(William), 10_000 ether);
         }
     }

--- a/packages/protocol/test/L1/TaikoL1TestGroup5.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup5.t.sol
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestGroupBase.sol";
+
+contract TaikoL1TestGroup5 is TaikoL1TestGroupBase {
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Guardian prover directly proves the block.
+    // 3. Guardian prover re-proves the same transition.
+    // 4. Guardian prover proves the block again with a different transition.
+    // 5. William contests using a lower-tier proof.
+    function test_taikoL1_group_5_case_1() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        console2.log("====== Guardian prover proves");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+        proveBlock(William, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_GUARDIAN);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.validityBond, 0);
+            assertEq(ts.prover, address(gp));
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether);
+            assertEq(tko.balanceOf(William), 10_000 ether);
+        }
+
+        console2.log("====== Guardian re-approve with the same transition");
+        mineAndWrap(10 seconds);
+        proveBlock(
+            William,
+            meta,
+            parentHash,
+            blockHash,
+            stateRoot,
+            LibTiers.TIER_GUARDIAN,
+            TaikoErrors.L1_ALREADY_PROVED.selector
+        );
+
+        console2.log("====== Guardian re-approve with a different transition");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(William, meta, parentHash, blockHash2, stateRoot2, LibTiers.TIER_GUARDIAN, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_GUARDIAN);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.validityBond, 0);
+            assertEq(ts.prover, address(gp));
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether);
+            assertEq(tko.balanceOf(William), 10_000 ether);
+        }
+
+        console2.log("====== William contests with a lower tier proof");
+        mineAndWrap(10 seconds);
+        proveBlock(
+            William,
+            meta,
+            parentHash,
+            blockHash,
+            stateRoot,
+            LibTiers.TIER_SGX,
+            TaikoErrors.L1_INVALID_TIER.selector
+        );
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_GUARDIAN);
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.prover, address(gp));
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether);
+            assertEq(tko.balanceOf(William), 10_000 ether);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, Bob is the prover.
+    // 2. Bob proves the block.
+    // 3. Guardian prover re-proves the same transition.
+    // 4. Guardian prover proves the block with a different transition.
+    // 5. William contests using a lower-tier proof.
+    function test_taikoL1_group_5_case_2() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+
+        console2.log("====== Bob proves the block");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Guardian re-approve with the same transition");
+        mineAndWrap(10 seconds);
+        proveBlock(
+            William,
+            meta,
+            parentHash,
+            blockHash,
+            stateRoot,
+            LibTiers.TIER_GUARDIAN,
+            TaikoErrors.L1_ALREADY_PROVED.selector
+        );
+
+        console2.log("====== Guardian re-approve with a different transition");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(William, meta, parentHash, blockHash2, stateRoot2, LibTiers.TIER_GUARDIAN, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_GUARDIAN);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.validityBond, 0);
+            assertEq(ts.prover, address(gp));
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(William), 10_000 ether);
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_GUARDIAN);
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.prover, address(gp));
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+            assertEq(tko.balanceOf(William), 10_000 ether);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. David proves the block outside the proving window.
+    // 3. Guardian prover re-proves the same transition.
+    // 4. Guardian prover proves the block with a different transition.
+    // 5. William contests using a lower-tier proof.
+    function test_taikoL1_group_5_case_3() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(David, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+
+        console2.log("====== David proves the block");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(7 days);
+        proveBlock(David, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Guardian re-approve with the same transition");
+        mineAndWrap(10 seconds);
+        proveBlock(
+            William,
+            meta,
+            parentHash,
+            blockHash,
+            stateRoot,
+            LibTiers.TIER_GUARDIAN,
+            TaikoErrors.L1_ALREADY_PROVED.selector
+        );
+
+        console2.log("====== Guardian re-approve with a different transition");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(William, meta, parentHash, blockHash2, stateRoot2, LibTiers.TIER_GUARDIAN, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_GUARDIAN);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.validityBond, 0);
+            assertEq(ts.prover, address(gp));
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(David), 10_000 ether - tierOp.validityBond);
+            assertEq(tko.balanceOf(William), 10_000 ether);
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash2);
+            assertEq(ts.stateRoot, stateRoot2);
+            assertEq(ts.tier, LibTiers.TIER_GUARDIAN);
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.prover, address(gp));
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+            assertEq(tko.balanceOf(David), 10_000 ether - tierOp.validityBond);
+            assertEq(tko.balanceOf(William), 10_000 ether);
+        }
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Guardian prover directly proves the block out of proving window
+    function test_taikoL1_group_5_case_4() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        console2.log("====== Guardian prover proves");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(7 days);
+        proveBlock(William, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_GUARDIAN, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_GUARDIAN);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.validityBond, 0);
+            assertEq(ts.prover, address(gp));
+            assertEq(ts.timestamp, block.timestamp);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - L1.getConfig().livenessBond);
+            assertEq(tko.balanceOf(William), 10_000 ether);
+        }
+    }
+}

--- a/packages/protocol/test/L1/TaikoL1TestGroup6.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup6.t.sol
@@ -8,7 +8,7 @@ contract TaikoL1TestGroup6 is TaikoL1TestGroupBase {
     // 1. Alice proposes a block, assigning Bob as the prover.
     // 2. Bob proves the block within the proving window, using the correct parent hash.
     // 3. Taylor contests Bob's proof.
-    // 4. Bob defends his proof, showing Taylor is incorrect.
+    // 4. Bob re-proves his proof, showing Taylor is incorrect.
     // 5. Bob's proof is validated and used to verify the block.
     function test_taikoL1_group_6_case_1() external {
         vm.warp(1_000_000);

--- a/packages/protocol/test/L1/TaikoL1TestGroup6.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup6.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestGroupBase.sol";
+
+contract TaikoL1TestGroup6 is TaikoL1TestGroupBase {
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob proves the block within the proving window, using the correct parent hash.
+    // 3. Taylor contests Bob's proof.
+    // 4. Bob defends his proof, showing Taylor is incorrect.
+    // 5. Bob's proof is validated and used to verify the block.
+    function test_taikoL1_group_6_case_1() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+        ITierProvider.Tier memory tierSgx = TierProviderV1(cp).getTier(LibTiers.TIER_SGX);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        console2.log("====== Bob proves the block as the assigned prover");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        console2.log("====== Taylor contests Bob");
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        mineAndWrap(10 seconds);
+        proveBlock(Taylor, meta, parentHash, blockHash2, stateRoot2, meta.minTier, "");
+
+        console2.log("====== Bob cannot proves himself is right");
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, LibTiers.TIER_SGX, "");
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.validityBond, tierSgx.validityBond);
+            assertEq(ts.prover, Bob);
+            assertEq(ts.timestamp, block.timestamp); // not zero
+
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
+            assertEq(
+                tko.balanceOf(Bob), 10_000 ether - tierSgx.validityBond + tierOp.contestBond * 7 / 8
+            );
+        }
+
+        console2.log("====== Verify the block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_SGX);
+            assertEq(ts.contestBond, 1);
+            assertEq(ts.prover, Bob);
+
+            assertEq(tko.balanceOf(Taylor), 10_000 ether - tierOp.contestBond);
+            assertEq(tko.balanceOf(Bob), 10_000 ether + tierOp.contestBond * 7 / 8);
+        }
+    }
+}

--- a/packages/protocol/test/L1/TaikoL1TestGroup7.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup7.t.sol
@@ -6,9 +6,8 @@ import "./TaikoL1TestGroupBase.sol";
 contract TaikoL1TestGroup7 is TaikoL1TestGroupBase {
     // Test summary:
     // 1. Alice proposes a block, assigning Bob as the prover.
-    // 2. Bob successfully proves the block within the proving window, using the correct parent
-    // hash.
-    // 3. After the cooldown window, Taylor contests Bob's proof.
+    // 2. Bob proves the block within the proving window, using the correct parent hash.
+    // 3. After the cooldown window, Taylor contests Bob's proof, and fails.
     function test_taikoL1_group_7_case_1() external {
         vm.warp(1_000_000);
 

--- a/packages/protocol/test/L1/TaikoL1TestGroup7.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup7.t.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestGroupBase.sol";
+
+contract TaikoL1TestGroup7 is TaikoL1TestGroupBase {
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob successfully proves the block within the proving window, using the correct parent
+    // hash.
+    // 3. After the cooldown window, Taylor contests Bob's proof.
+    function test_taikoL1_group_7_case_1() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        console2.log("====== Bob proves the block as the assigned prover");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        mineAndWrap(tierOp.cooldownWindow * 60);
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        proveBlock(
+            Taylor,
+            meta,
+            parentHash,
+            blockHash2,
+            stateRoot2,
+            meta.minTier,
+            TaikoErrors.L1_CANNOT_CONTEST.selector
+        );
+        printBlockAndTrans(meta.id);
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob proves the block within the proving window, using the correct parent hash.
+    // 3. Taylor contests Bob's proof.
+    // 4. William attempts but fails to contest Bob again.
+    function test_taikoL1_group_7_case_2() external {
+        vm.warp(1_000_000);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        giveEthAndTko(William, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        console2.log("====== Bob proves the block as the assigned prover");
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        mineAndWrap(10 seconds);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        mineAndWrap(tierOp.cooldownWindow * 60 - 1);
+        bytes32 blockHash2 = bytes32(uint256(20));
+        bytes32 stateRoot2 = bytes32(uint256(21));
+        proveBlock(Taylor, meta, parentHash, blockHash2, stateRoot2, meta.minTier, "");
+
+        bytes32 blockHash3 = bytes32(uint256(30));
+        bytes32 stateRoot3 = bytes32(uint256(31));
+        proveBlock(
+            William,
+            meta,
+            parentHash,
+            blockHash3,
+            stateRoot3,
+            meta.minTier,
+            TaikoErrors.L1_ALREADY_CONTESTED.selector
+        );
+
+        printBlockAndTrans(meta.id);
+    }
+}

--- a/packages/protocol/test/L1/TaikoL1TestGroup8.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup8.t.sol
@@ -105,8 +105,8 @@ contract TaikoL1TestGroup8 is TaikoL1TestGroupBase {
     }
 
     // Test summary:
-    // 1. Get a block that doesn't exist
-    // 2. Get a transition by ID & hash that doesn't exist.
+    // 1. Gets a block that doesn't exist
+    // 2. Gets a transition by ID & hash that doesn't exist.
     function test_taikoL1_group_8_case_3() external {
         vm.expectRevert(TaikoErrors.L1_INVALID_BLOCK_ID.selector);
         L1.getBlock(2);

--- a/packages/protocol/test/L1/TaikoL1TestGroup8.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup8.t.sol
@@ -44,7 +44,7 @@ contract TaikoL1TestGroup8 is TaikoL1TestGroupBase {
         console2.log("====== Alice tries to propose another block after L1 paused");
         proposeBlock(Alice, Bob, EssentialContract.INVALID_PAUSE_STATUS.selector);
 
-        console2.log("====== Unause TaikoL1");
+        console2.log("====== Unpause TaikoL1");
         mineAndWrap(10 seconds);
         vm.prank(L1.owner());
         L1.unpause();
@@ -95,7 +95,7 @@ contract TaikoL1TestGroup8 is TaikoL1TestGroupBase {
         console2.log("====== Alice tries to propose another block after L1 proving paused");
         proposeBlock(Alice, Bob, "");
 
-        console2.log("====== Unause TaikoL1 proving");
+        console2.log("====== Unpause TaikoL1 proving");
         mineAndWrap(10 seconds);
         vm.prank(L1.owner());
         L1.pauseProving(false);

--- a/packages/protocol/test/L1/TaikoL1TestGroup8.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup8.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestGroupBase.sol";
+
+contract TaikoL1TestGroup8 is TaikoL1TestGroupBase {
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. TaikoL1 is paused.
+    // 3. Bob attempts to prove the block within the proving window.
+    // 4. Alice tries to propose another block.
+    // 5. TaikoL1 is unpaused.
+    // 6. Bob attempts again to prove the first block within the proving window.
+    // 7. Alice tries to propose another block.
+    function test_taikoL1_group_8_case_1() external {
+        vm.warp(1_000_000);
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        console2.log("====== Pause TaikoL1");
+        mineAndWrap(10 seconds);
+        vm.prank(L1.owner());
+        L1.pause();
+
+        console2.log("====== Bob proves the block first after L1 paused");
+
+        bytes32 parentHash1 = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+        proveBlock(
+            Bob,
+            meta,
+            parentHash1,
+            blockHash,
+            stateRoot,
+            meta.minTier,
+            EssentialContract.INVALID_PAUSE_STATUS.selector
+        );
+
+        console2.log("====== Alice tries to propose another block after L1 paused");
+        proposeBlock(Alice, Bob, EssentialContract.INVALID_PAUSE_STATUS.selector);
+
+        console2.log("====== Unause TaikoL1");
+        mineAndWrap(10 seconds);
+        vm.prank(L1.owner());
+        L1.unpause();
+
+        console2.log("====== Bob proves the block first after L1 unpaused");
+        proveBlock(Bob, meta, parentHash1, blockHash, stateRoot, meta.minTier, "");
+        console2.log("====== Alice tries to propose another block after L1 unpaused");
+        proposeBlock(Alice, Bob, "");
+    }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. TaikoL1 proving is paused.
+    // 3. Bob attempts to prove the block within the proving window.
+    // 4. Alice tries to propose another block.
+    // 5. TaikoL1 proving is unpaused.
+    // 6. Bob attempts again to prove the first block within the proving window.
+    // 7. Alice tries to propose another block.
+    function test_taikoL1_group_8_case_2() external {
+        vm.warp(1_000_000);
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        console2.log("====== Pause TaikoL1 proving");
+        mineAndWrap(10 seconds);
+        vm.prank(L1.owner());
+        L1.pauseProving(true);
+
+        console2.log("====== Bob proves the block first after L1 proving paused");
+
+        bytes32 parentHash1 = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+        proveBlock(
+            Bob,
+            meta,
+            parentHash1,
+            blockHash,
+            stateRoot,
+            meta.minTier,
+            TaikoErrors.L1_PROVING_PAUSED.selector
+        );
+
+        console2.log("====== Alice tries to propose another block after L1 proving paused");
+        proposeBlock(Alice, Bob, "");
+
+        console2.log("====== Unause TaikoL1 proving");
+        mineAndWrap(10 seconds);
+        vm.prank(L1.owner());
+        L1.pauseProving(false);
+
+        console2.log("====== Bob proves the block first after L1 proving unpaused");
+        proveBlock(Bob, meta, parentHash1, blockHash, stateRoot, meta.minTier, "");
+    }
+
+    // Test summary:
+    // 1. Get a block that doesn't exist
+    // 2. Get a transition by ID & hash that doesn't exist.
+    function test_taikoL1_group_8_case_3() external {
+        vm.expectRevert(TaikoErrors.L1_INVALID_BLOCK_ID.selector);
+        L1.getBlock(2);
+
+        vm.expectRevert(TaikoErrors.L1_TRANSITION_NOT_FOUND.selector);
+        L1.getTransition(0, 2);
+
+        vm.expectRevert(TaikoErrors.L1_TRANSITION_NOT_FOUND.selector);
+        L1.getTransition(0, randBytes32());
+
+        vm.expectRevert(TaikoErrors.L1_INVALID_BLOCK_ID.selector);
+        L1.getTransition(3, randBytes32());
+    }
+}

--- a/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
@@ -48,7 +48,7 @@ abstract contract TaikoL1TestGroupBase is TaikoL1TestBase {
 
         bytes memory txList = new bytes(10);
         assignment.signature =
-            _signAssignment(assignedProver, assignment, address(L1), keccak256(txList));
+            _signAssignment(assignedProver, assignment, address(L1), proposer, keccak256(txList));
 
         TaikoData.HookCall[] memory hookcalls = new TaikoData.HookCall[](1);
         hookcalls[0] = TaikoData.HookCall(address(assignmentHook), abi.encode(assignment));

--- a/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoL1TestBase.sol";
+
+contract TaikoL1New is TaikoL1 {
+    function getConfig() public view override returns (TaikoData.Config memory config) {
+        config = TaikoL1.getConfig();
+        config.maxBlocksToVerifyPerProposal = 0;
+        config.blockMaxProposals = 10;
+        config.blockRingBufferSize = 20;
+    }
+
+    function _checkEOAForCalldataDA() internal pure override returns (bool) {
+        return true;
+    }
+}
+
+abstract contract TaikoL1TestGroupBase is TaikoL1TestBase {
+    function deployTaikoL1() internal override returns (TaikoL1) {
+        return TaikoL1(
+            payable(deployProxy({ name: "taiko", impl: address(new TaikoL1New()), data: "" }))
+        );
+    }
+
+    function proposeBlock(
+        address proposer,
+        address assignedProver,
+        bytes4 revertReason
+    )
+        internal
+        returns (TaikoData.BlockMetadata memory meta)
+    {
+        TaikoData.TierFee[] memory tierFees = new TaikoData.TierFee[](2);
+        tierFees[0] = TaikoData.TierFee(LibTiers.TIER_OPTIMISTIC, 1 ether);
+        tierFees[1] = TaikoData.TierFee(LibTiers.TIER_SGX, 2 ether);
+
+        AssignmentHook.ProverAssignment memory assignment = AssignmentHook.ProverAssignment({
+            feeToken: address(0),
+            tierFees: tierFees,
+            expiry: uint64(block.timestamp + 60 minutes),
+            maxBlockId: 0,
+            maxProposedIn: 0,
+            metaHash: 0,
+            parentMetaHash: 0,
+            signature: new bytes(0)
+        });
+
+        bytes memory txList = new bytes(10);
+        assignment.signature =
+            _signAssignment(assignedProver, assignment, address(L1), keccak256(txList));
+
+        TaikoData.HookCall[] memory hookcalls = new TaikoData.HookCall[](1);
+        hookcalls[0] = TaikoData.HookCall(address(assignmentHook), abi.encode(assignment));
+
+        bytes memory eoaSig;
+        {
+            uint256 privateKey;
+            if (proposer == Alice) {
+                privateKey = 0x1;
+            } else if (proposer == Bob) {
+                privateKey = 0x2;
+            } else if (proposer == Carol) {
+                privateKey = 0x3;
+            } else {
+                revert("unexpected");
+            }
+
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, keccak256(txList));
+            eoaSig = abi.encodePacked(r, s, v);
+        }
+
+        vm.prank(proposer);
+        if (revertReason != "") vm.expectRevert(revertReason);
+        (meta,) = L1.proposeBlock{ value: 3 ether }(
+            abi.encode(TaikoData.BlockParams(assignedProver, address(0), 0, 0, hookcalls, eoaSig)),
+            txList
+        );
+    }
+
+    function proveBlock(
+        address prover,
+        TaikoData.BlockMetadata memory meta,
+        bytes32 parentHash,
+        bytes32 blockHash,
+        bytes32 stateRoot,
+        uint16 tier,
+        bytes4 revertReason
+    )
+        internal
+        override
+    {
+        TaikoData.Transition memory tran = TaikoData.Transition({
+            parentHash: parentHash,
+            blockHash: blockHash,
+            stateRoot: stateRoot,
+            graffiti: 0x0
+        });
+
+        TaikoData.TierProof memory proof;
+        proof.tier = tier;
+        address newInstance;
+
+        // Keep changing the pub key associated with an instance to avoid
+        // attacks,
+        // obviously just a mock due to 2 addresses changing all the time.
+        (newInstance,) = sv.instances(0);
+        if (newInstance == SGX_X_0) {
+            newInstance = SGX_X_1;
+        } else {
+            newInstance = SGX_X_0;
+        }
+
+        if (tier == LibTiers.TIER_SGX) {
+            bytes memory signature =
+                createSgxSignatureProof(tran, newInstance, prover, keccak256(abi.encode(meta)));
+
+            proof.data = bytes.concat(bytes4(0), bytes20(newInstance), signature);
+        }
+
+        if (tier == LibTiers.TIER_GUARDIAN) {
+            proof.data = "";
+
+            // Grant 2 signatures, 3rd might be a revert
+            vm.prank(David, David);
+            gp.approve(meta, tran, proof);
+            vm.prank(Emma, Emma);
+            gp.approve(meta, tran, proof);
+
+            if (revertReason != "") vm.expectRevert(revertReason);
+            vm.prank(Frank);
+            gp.approve(meta, tran, proof);
+        } else {
+            if (revertReason != "") vm.expectRevert(revertReason);
+            vm.prank(prover);
+            L1.proveBlock(meta.id, abi.encode(meta, tran, proof));
+        }
+    }
+
+    function printBlockAndTrans(uint64 blockId) internal view {
+        TaikoData.Block memory blk = L1.getBlock(blockId);
+        printBlock(blk);
+
+        for (uint32 i = 1; i < blk.nextTransitionId; ++i) {
+            printTran(i, L1.getTransition(blockId, i));
+        }
+    }
+
+    function printBlock(TaikoData.Block memory blk) internal view {
+        TaikoData.SlotB memory b = L1.slotB();
+        console2.log("---CHAIN:");
+        console2.log(" | lastVerifiedBlockId:", b.lastVerifiedBlockId);
+        console2.log(" | numBlocks:", b.numBlocks);
+        console2.log(" | timestamp:", block.timestamp);
+        console2.log("---BLOCK#", blk.blockId);
+        console2.log(" | assignedProver:", blk.assignedProver);
+        console2.log(" | livenessBond:", blk.livenessBond);
+        console2.log(" | proposedAt:", blk.proposedAt);
+        console2.log(" | metaHash:", vm.toString(blk.metaHash));
+        console2.log(" | nextTransitionId:", blk.nextTransitionId);
+        console2.log(" | verifiedTransitionId:", blk.verifiedTransitionId);
+    }
+
+    function printTran(uint64 tid, TaikoData.TransitionState memory ts) internal pure {
+        console2.log(" |---TRANSITION#", tid);
+        console2.log("   | tier:", ts.tier);
+        console2.log("   | prover:", ts.prover);
+        console2.log("   | validityBond:", ts.validityBond);
+        console2.log("   | contester:", ts.contester);
+        console2.log("   | contestBond:", ts.contestBond);
+        console2.log("   | timestamp:", ts.timestamp);
+        console2.log("   | blockHash:", vm.toString(ts.blockHash));
+        console2.log("   | stateRoot:", vm.toString(ts.stateRoot));
+    }
+
+    function mineAndWrap(uint256 value) internal {
+        vm.warp(block.timestamp + value);
+    }
+}


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(protocol): return liveness bond only to assigned prover
feat(protocol): allow assigned prover to prove blocks outside proving window (liveness bond not returned)
feat(protocol): remove `contestations` from `TransitionState` and events (it's buggy)
feat(protocol): add `TaikoL1.getTransition(blockId, transitionID)` function
refactor(protocol): use a `Local` struct in LibProving to cache state variables and get around of stack-too-deep error
test(protocol): add more tests to verify bonds are handled correctly
END_COMMIT_OVERRIDE

---

## The liveness bug
The bug was identified by([OpenZeppelin](https://defender.openzeppelin.com/v2/#/audit/306ca593-6cb7-4b7f-92d4-ba1e41ac9e56/issues/L-06)) and [Code4rena](https://github.com/code-423n4/2024-03-taiko-findings/issues/227).

### Scenario (quoted from the bug report)

- Henry is assigned to prove a block, and sends 250 TKO as liveness bond to the TaikoL1 contract. He correctly proves the state transition with an SGX proof, providing another 250 TKO as validity bond.
- Mallory contests the state transition, providing 500 TKO as contest bond to the TaikoL1 contract.
- In the same transaction, Mallory re-proves the block and confirms Henry's transition using a zk proof. In doing so, Henry earns 1/4 * contestBond = 125 TKO, and gets his original validity bond of 250 TKO back. Mallory gets 1/4 * contestBond = 125 TKO as she is the new prover. She provides a new validity bond of 500 TKO.
- The block is verified, and Mallory as the final prover gets back half of the liveness bond as well as her validity bond, 1/2*250 + 500 = 625 TKO in total.

As a result of the above, Henry has lost his initial liveness bond but got 1/4th of the contest bond, a net loss of 125 TKO. Mallory has lost 3/4th of her contest bond but got back half of the liveness bond, a net loss of 250 TKO.


### Result
- Henry incurs a net loss of 125 TKO, losing the liveness bond but gaining a quarter of the contest bond.
- Mallory incurs a net loss of 250 TKO, losing three-quarters of her contest bond but regaining half of the liveness bond.

### Fix

The bug was in the handling of the liveness bond, which was returned to `ts.prover` instead of `blk.assignedProver`. The liveness bond was returned upon block verification, and only if the assigned prover created and used the first transition to finalize the block.

Now, the liveness bond is returned to the assigned prover immediately upon the creation of the first transition, provided it's done before the proving window expires. Otherwise, `ts.livenessBond` is set to `0`.  `test_taikoL1_group_2_case_1` covers the scenario above.


