### PR TITLE
feat(protocol): allows assigned prover to do more

### DIFF
--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -11,7 +11,6 @@ pragma solidity 0.8.24;
 abstract contract TaikoErrors {
     error L1_ALREADY_CONTESTED();
     error L1_ALREADY_PROVED();
-    error L1_ASSIGNED_PROVER_NOT_ALLOWED();
     error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
     error L1_BLOCK_MISMATCH();

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -138,7 +138,7 @@ library LibProving {
             ITierProvider(_resolver.resolve("tier_provider", false)).getTier(_proof.tier);
 
         // Checks if only the assigned prover is permissioned to prove the block.
-        // The guardian prover is granted exclusive permisison to prove only the first
+        // The guardian prover is granted exclusive permission to prove only the first
         // transition.
         if (
             tier.contestBond != 0 && ts.contester == address(0) && tid == 1 && ts.tier == 0
@@ -205,11 +205,15 @@ library LibProving {
         bool sameTransition = _tran.blockHash == ts.blockHash && _tran.stateRoot == ts.stateRoot;
 
         if (_proof.tier > ts.tier) {
-            // Handles the case when an incoming tier is higher than the current transition's tier.
-            // Reverts when the incoming proof tries to prove the same transition
-            // (L1_ALREADY_PROVED).
-
-            // Higher tier proof overwriting lower tier proof
+            // Handles what happens when there is a higher proof incoming. Assume Alice is the
+            // initial prover, Bob is the contester, and Cindy is the subsequent prover. The
+            // validity bond `V` is set at 100, and the contestation bond `C` at 500. If Bob
+            // successfully contests, he receives a reward of 65.625, calculated as 3/4 of 7/8 of
+            // 100. Cindy receives 21.875, which is 1/4 of 7/8 of 100, while the protocol retains
+            // 12.5 as friction. Bob's Return on Investment (ROI) is 13.125%, calculated from 65.625
+            // divided by 500. To establish the expected ROI `r` for valid contestations, where the
+            // contestation bond `C` to validity bond `V` ratio is `C/V = 21/(32*r)`, and if `r` set
+            // at 10%, the C/V ratio will be 6.5625.
             {
                 uint256 reward; // reward to the new (current) prover
 

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -367,50 +367,6 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
         printVariables("");
     }
 
-    function test_L1_assignedProverCannotProveAfterHisWindowElapsed() external {
-        giveEthAndTko(Alice, 1e8 ether, 100 ether);
-        // This is a very weird test (code?) issue here.
-        // If this line (or Bob's query balance) is uncommented,
-        // Alice/Bob has no balance.. (Causing reverts !!!)
-        console2.log("Alice balance:", tko.balanceOf(Alice));
-        giveEthAndTko(Bob, 1e8 ether, 100 ether);
-        console2.log("Bob balance:", tko.balanceOf(Bob));
-        giveEthAndTko(Carol, 1e8 ether, 100 ether);
-        // Bob
-        vm.prank(Bob, Bob);
-
-        bytes32 parentHash = GENESIS_BLOCK_HASH;
-
-        for (uint256 blockId = 1; blockId < 10; blockId++) {
-            //printVariables("before propose");
-            (TaikoData.BlockMetadata memory meta,) = proposeBlock(Alice, Bob, 1_000_000, 1024);
-            //printVariables("after propose");
-            mine(1);
-
-            bytes32 blockHash = bytes32(1e10 + blockId);
-            bytes32 stateRoot = bytes32(1e9 + blockId);
-
-            vm.roll(block.number + 15 * 12);
-
-            uint16 minTier = meta.minTier;
-            vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
-
-            proveBlock(
-                Bob,
-                meta,
-                parentHash,
-                blockHash,
-                stateRoot,
-                meta.minTier,
-                TaikoErrors.L1_ASSIGNED_PROVER_NOT_ALLOWED.selector
-            );
-
-            verifyBlock(1);
-            parentHash = blockHash;
-        }
-        printVariables("");
-    }
-
     function test_L1_GuardianProverCanAlwaysOverwriteTheProof() external {
         giveEthAndTko(Alice, 1e7 ether, 1000 ether);
         giveEthAndTko(Carol, 1e7 ether, 1000 ether);

--- a/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
@@ -374,4 +374,102 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
             assertEq(tko.balanceOf(Taylor), 10_000 ether);
         }
     }
+
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob proves the block outside the proving window, using the correct parent hash.
+    // 3. Bob's proof is used to verify the block.
+    function test_taikoL1_group_1_case_6() external {
+        vm.warp(1_000_000);
+        printBlockAndTrans(0);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+        uint256 proposedAt;
+        {
+            printBlockAndTrans(meta.id);
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(meta.minTier, LibTiers.TIER_OPTIMISTIC);
+
+            assertEq(blk.nextTransitionId, 1);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, block.timestamp);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, livenessBond);
+
+            proposedAt = blk.proposedAt;
+
+            assertEq(tko.balanceOf(Alice), 10_000 ether);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+        }
+
+        // Prove the block
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        console2.log("====== Bob proves the block outside the proving window");
+        mineAndWrap(7 days);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        uint256 provenAt;
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.timestamp, block.timestamp);
+
+            provenAt = ts.timestamp;
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+        }
+
+        console2.log("====== Verify block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.timestamp, provenAt);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+        }
+    }
 }

--- a/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
@@ -155,18 +155,6 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
         bytes32 stateRoot = bytes32(uint256(11));
 
         mineAndWrap(7 days);
-
-        console2.log("====== Bob cannot prove the block out of the proving window");
-        proveBlock(
-            Bob,
-            meta,
-            parentHash,
-            blockHash,
-            stateRoot,
-            meta.minTier,
-            TaikoErrors.L1_ASSIGNED_PROVER_NOT_ALLOWED.selector
-        );
-
         console2.log("====== Taylor proves the block");
         mineAndWrap(10 seconds);
         proveBlock(Taylor, meta, parentHash, blockHash, stateRoot, meta.minTier, "");


### PR DESCRIPTION
Previously, the assigned prover can only submit the very first proof (to create the verify first transition) within the proving window. It is disallowed to contest/prove blocks in any other situations.

This PR enables the assigned prover to perform actions that all other address can. This means if the assigned prover submits a valid proof right after the proving window expires, its proof will be accepted, but its liveness bond won't be returned.

Note that I inlined two methods `_overrideWithHigherProof` and `_checkProverPermission` to resolve stack a too deep issue.