### PR TITLE
feat(protocol): allows assigned prover to do more

### DIFF
--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -11,7 +11,6 @@ pragma solidity 0.8.24;
 abstract contract TaikoErrors {
     error L1_ALREADY_CONTESTED();
     error L1_ALREADY_PROVED();
-    error L1_ASSIGNED_PROVER_NOT_ALLOWED();
     error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
     error L1_BLOCK_MISMATCH();

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -215,11 +215,14 @@ library LibProving {
 
         local.isTopTier = local.tier.contestBond == 0;
         IERC20 tko = IERC20(_resolver.resolve("taiko_token", false));
-        
+
         local.livenessBond = blk.livenessBond;
         if (local.isTopTier) {
             if (local.livenessBond != 0) {
-                if (local.inProvingWindow || (_proof.data.length == 32 && bytes32(_proof.data) == RETURN_LIVENESS_BOND)) {
+                if (
+                    local.inProvingWindow
+                        || (_proof.data.length == 32 && bytes32(_proof.data) == RETURN_LIVENESS_BOND)
+                ) {
                     tko.safeTransfer(local.assignedProver, local.livenessBond);
                 }
                 blk.livenessBond = 0;

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -24,8 +24,8 @@ library LibProving {
         address assignedProver;
         uint96 livenessBond;
         uint64 slot;
-        uint32 tid;
         uint64 blockId;
+        uint32 tid;
         bool lastUnpausedAt;
         bool isTopTier;
         bool inProvingWindow;

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -367,50 +367,6 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
         printVariables("");
     }
 
-    function test_L1_assignedProverCannotProveAfterHisWindowElapsed() external {
-        giveEthAndTko(Alice, 1e8 ether, 100 ether);
-        // This is a very weird test (code?) issue here.
-        // If this line (or Bob's query balance) is uncommented,
-        // Alice/Bob has no balance.. (Causing reverts !!!)
-        console2.log("Alice balance:", tko.balanceOf(Alice));
-        giveEthAndTko(Bob, 1e8 ether, 100 ether);
-        console2.log("Bob balance:", tko.balanceOf(Bob));
-        giveEthAndTko(Carol, 1e8 ether, 100 ether);
-        // Bob
-        vm.prank(Bob, Bob);
-
-        bytes32 parentHash = GENESIS_BLOCK_HASH;
-
-        for (uint256 blockId = 1; blockId < 10; blockId++) {
-            //printVariables("before propose");
-            (TaikoData.BlockMetadata memory meta,) = proposeBlock(Alice, Bob, 1_000_000, 1024);
-            //printVariables("after propose");
-            mine(1);
-
-            bytes32 blockHash = bytes32(1e10 + blockId);
-            bytes32 stateRoot = bytes32(1e9 + blockId);
-
-            vm.roll(block.number + 15 * 12);
-
-            uint16 minTier = meta.minTier;
-            vm.warp(block.timestamp + tierProvider().getTier(minTier).cooldownWindow * 60 + 1);
-
-            proveBlock(
-                Bob,
-                meta,
-                parentHash,
-                blockHash,
-                stateRoot,
-                meta.minTier,
-                TaikoErrors.L1_ASSIGNED_PROVER_NOT_ALLOWED.selector
-            );
-
-            verifyBlock(1);
-            parentHash = blockHash;
-        }
-        printVariables("");
-    }
-
     function test_L1_GuardianProverCanAlwaysOverwriteTheProof() external {
         giveEthAndTko(Alice, 1e7 ether, 1000 ether);
         giveEthAndTko(Carol, 1e7 ether, 1000 ether);

--- a/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroup1.t.sol
@@ -154,21 +154,8 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
         bytes32 blockHash = bytes32(uint256(10));
         bytes32 stateRoot = bytes32(uint256(11));
 
-        mineAndWrap(7 days);
-
-        console2.log("====== Bob cannot prove the block out of the proving window");
-        proveBlock(
-            Bob,
-            meta,
-            parentHash,
-            blockHash,
-            stateRoot,
-            meta.minTier,
-            TaikoErrors.L1_ASSIGNED_PROVER_NOT_ALLOWED.selector
-        );
-
         console2.log("====== Taylor proves the block");
-        mineAndWrap(10 seconds);
+        mineAndWrap(7 days);
         proveBlock(Taylor, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
 
         uint256 provenAt;
@@ -384,6 +371,104 @@ contract TaikoL1TestGroup1 is TaikoL1TestGroupBase {
 
             assertEq(tko.balanceOf(Bob), 10_000 ether - L1.getConfig().livenessBond);
             assertEq(tko.balanceOf(Taylor), 10_000 ether);
+        }
+    }
+    // Test summary:
+    // 1. Alice proposes a block, assigning Bob as the prover.
+    // 2. Bob proves the block outside the proving window, using the correct parent hash.
+    // 3. Bob's proof is used to verify the block.
+
+    function test_taikoL1_group_1_case_6() external {
+        vm.warp(1_000_000);
+        printBlockAndTrans(0);
+
+        giveEthAndTko(Alice, 10_000 ether, 1000 ether);
+        giveEthAndTko(Bob, 10_000 ether, 1000 ether);
+        giveEthAndTko(Taylor, 10_000 ether, 1000 ether);
+        ITierProvider.Tier memory tierOp = TierProviderV1(cp).getTier(LibTiers.TIER_OPTIMISTIC);
+
+        console2.log("====== Alice propose a block with bob as the assigned prover");
+        TaikoData.BlockMetadata memory meta = proposeBlock(Alice, Bob, "");
+
+        uint96 livenessBond = L1.getConfig().livenessBond;
+        uint256 proposedAt;
+        {
+            printBlockAndTrans(meta.id);
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(meta.minTier, LibTiers.TIER_OPTIMISTIC);
+
+            assertEq(blk.nextTransitionId, 1);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, block.timestamp);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, livenessBond);
+
+            proposedAt = blk.proposedAt;
+
+            assertEq(tko.balanceOf(Alice), 10_000 ether);
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
+        }
+
+        // Prove the block
+        bytes32 parentHash = GENESIS_BLOCK_HASH;
+        bytes32 blockHash = bytes32(uint256(10));
+        bytes32 stateRoot = bytes32(uint256(11));
+
+        console2.log("====== Bob proves the block outside the proving window");
+        mineAndWrap(7 days);
+        proveBlock(Bob, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+
+        uint256 provenAt;
+
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 0);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.timestamp, block.timestamp);
+
+            provenAt = ts.timestamp;
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - tierOp.validityBond - livenessBond);
+        }
+
+        console2.log("====== Verify block");
+        mineAndWrap(7 days);
+        verifyBlock(1);
+        {
+            printBlockAndTrans(meta.id);
+
+            TaikoData.Block memory blk = L1.getBlock(meta.id);
+            assertEq(blk.nextTransitionId, 2);
+            assertEq(blk.verifiedTransitionId, 1);
+            assertEq(blk.proposedAt, proposedAt);
+            assertEq(blk.assignedProver, Bob);
+            assertEq(blk.livenessBond, 0);
+
+            TaikoData.TransitionState memory ts = L1.getTransition(meta.id, 1);
+            assertEq(ts.blockHash, blockHash);
+            assertEq(ts.stateRoot, stateRoot);
+            assertEq(ts.tier, LibTiers.TIER_OPTIMISTIC);
+            assertEq(ts.contester, address(0));
+            assertEq(ts.contestBond, 1); // not zero
+            assertEq(ts.prover, Bob);
+            assertEq(ts.validityBond, tierOp.validityBond);
+            assertEq(ts.timestamp, provenAt);
+
+            assertEq(tko.balanceOf(Bob), 10_000 ether - livenessBond);
         }
     }
 }


### PR DESCRIPTION
Previously, the assigned prover can only submit the very first proof (to create the verify first transition) within the proving window. It is disallowed to contest/prove blocks in any other situations.

This PR enables the assigned prover to perform actions that all other address can. This means if the assigned prover submits a valid proof right after the proving window expires, its proof will be accepted, but its liveness bond won't be returned.

This PR also introduce a struct to cache state variables.