### PR TITLE
chore(protocol): fix commenting copy paste

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -473,11 +473,11 @@ contract Bridge is EssentialContract, IBridge {
         );
     }
 
-    /// @notice Checks if a msgHash has failed on its destination chain.
+    /// @notice Checks if a msgHash has been received on its source chain.
     /// This is the 'readonly' version of proveMessageReceived.
     /// @param _message The message.
     /// @param _proof The merkle inclusion proof.
-    /// @return true if the message has failed, false otherwise.
+    /// @return true if the message has been received, false otherwise.
     function isMessageReceived(
         Message calldata _message,
         bytes calldata _proof


### PR DESCRIPTION
As per title, there was an issue with copy-pasting function commenting.