### PR TITLE
fix(relayer): fix a panic in relayer-api

### DIFF
--- a/packages/relayer/api/api.go
+++ b/packages/relayer/api/api.go
@@ -85,6 +85,7 @@ func InitFromConfig(ctx context.Context, api *API, cfg *Config) (err error) {
 	api.httpPort = cfg.HTTPPort
 	api.ctx = ctx
 	api.wg = &sync.WaitGroup{}
+	api.srcEthClient = srcEthClient
 
 	return nil
 }


### PR DESCRIPTION
```api.srcEthClient``` is being used in
https://github.com/taikoxyz/taiko-mono/blob/main/packages/relayer/api/api.go#L114

If it's not set, then it will get the error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc02c24]

goroutine 108 [running]:
github.com/ethereum/go-ethereum/ethclient.(*Client).SubscribeNewHead(0x0?, {0x15aa3f0, 0xc0001c0b90}, 0x1?)
	/go/pkg/mod/github.com/taikoxyz/taiko-geth@v0.0.0-20240320072400-5db50bce3e8e/ethclient/ethclient.go:338 +0x24
github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils.ScanBlocks({0x15aa3f0, 0xc0001c0b90}, {0x15a0720, 0x0}, 0xc0008531e0)
	/taiko-mono/packages/relayer/pkg/utils/scan_blocks.go:25 +0xe2
github.com/taikoxyz/taiko-mono/packages/relayer/api.(*API).Start.func2.1()
	/taiko-mono/packages/relayer/api/api.go:114 +0x2e
github.com/cenkalti/backoff.RetryNotify(0xc0007f6fa0, {0x15a44a8, 0xc0006b9060}, 0x0)
	/go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0x164
github.com/cenkalti/backoff.Retry(...)
	/go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:24
github.com/taikoxyz/taiko-mono/packages/relayer/api.(*API).Start.func2()
	/taiko-mono/packages/relayer/api/api.go:113 +0x66
created by github.com/taikoxyz/taiko-mono/packages/relayer/api.(*API).Start in goroutine 1
	/taiko-mono/packages/relayer/api/api.go:112 +0x96
```