### PR TITLE
fix(bridge-ui): custom and none fee selection overwritten by error fetching recommended fee

### DIFF
--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
@@ -138,7 +138,7 @@
       <span class=" text-primary-content mt-[4px]">
         {#if calculatingRecommendedAmount}
           <LoadingText mask="0.0017730224073" /> ETH
-        {:else if errorCalculatingRecommendedAmount}
+        {:else if errorCalculatingRecommendedAmount && ($processingFeeMethod === ProcessingFeeMethod.RECOMMENDED)}
           <FlatAlert type="warning" message={$t('processing_fee.recommended.error')} />
         {:else}
           {formatEther($processingFee ?? BigInt(0))} ETH {#if $processingFee !== recommendedAmount}
@@ -152,7 +152,7 @@
   <span class="text-primary-content mt-[4px] {$$props.class}">
     {#if calculatingRecommendedAmount}
       <LoadingText mask="0.0017730224073" />
-    {:else if errorCalculatingRecommendedAmount}
+    {:else if errorCalculatingRecommendedAmount && ($processingFeeMethod === ProcessingFeeMethod.RECOMMENDED)}
       <span class="text-warning-sentiment">{$t('processing_fee.recommended.error')}</span>
     {:else}
       {formatEther($processingFee ?? BigInt(0))} ETH {#if $processingFee !== recommendedAmount}
@@ -178,7 +178,7 @@
     <span class="body-small-regular text-secondary-content mt-[4px]">
       {#if calculatingRecommendedAmount}
         <LoadingText mask="0.0001" /> ETH
-      {:else if errorCalculatingRecommendedAmount}
+      {:else if errorCalculatingRecommendedAmount && ($processingFeeMethod === ProcessingFeeMethod.RECOMMENDED)}
         <FlatAlert type="warning" message={$t('processing_fee.recommended.error')} />
       {:else}
         {formatEther($processingFee ?? BigInt(0))} ETH {#if $processingFee !== recommendedAmount}

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
@@ -138,7 +138,7 @@
       <span class=" text-primary-content mt-[4px]">
         {#if calculatingRecommendedAmount}
           <LoadingText mask="0.0017730224073" /> ETH
-        {:else if errorCalculatingRecommendedAmount && ($processingFeeMethod === ProcessingFeeMethod.RECOMMENDED)}
+        {:else if errorCalculatingRecommendedAmount && $processingFeeMethod === ProcessingFeeMethod.RECOMMENDED}
           <FlatAlert type="warning" message={$t('processing_fee.recommended.error')} />
         {:else}
           {formatEther($processingFee ?? BigInt(0))} ETH {#if $processingFee !== recommendedAmount}
@@ -152,7 +152,7 @@
   <span class="text-primary-content mt-[4px] {$$props.class}">
     {#if calculatingRecommendedAmount}
       <LoadingText mask="0.0017730224073" />
-    {:else if errorCalculatingRecommendedAmount && ($processingFeeMethod === ProcessingFeeMethod.RECOMMENDED)}
+    {:else if errorCalculatingRecommendedAmount && $processingFeeMethod === ProcessingFeeMethod.RECOMMENDED}
       <span class="text-warning-sentiment">{$t('processing_fee.recommended.error')}</span>
     {:else}
       {formatEther($processingFee ?? BigInt(0))} ETH {#if $processingFee !== recommendedAmount}
@@ -178,7 +178,7 @@
     <span class="body-small-regular text-secondary-content mt-[4px]">
       {#if calculatingRecommendedAmount}
         <LoadingText mask="0.0001" /> ETH
-      {:else if errorCalculatingRecommendedAmount && ($processingFeeMethod === ProcessingFeeMethod.RECOMMENDED)}
+      {:else if errorCalculatingRecommendedAmount && $processingFeeMethod === ProcessingFeeMethod.RECOMMENDED}
         <FlatAlert type="warning" message={$t('processing_fee.recommended.error')} />
       {:else}
         {formatEther($processingFee ?? BigInt(0))} ETH {#if $processingFee !== recommendedAmount}


### PR DESCRIPTION
When there's an error calculating the recommended fee, the label `Error calculating processing fee, you will need to claim manually!` replaces the value of custom and none fees when these are selected instead of the Recommended fee.

Regardless of the fee type selected, the error message will show up next to the 'Processing Fee' text:
![processingfee](https://github.com/taikoxyz/taiko-mono/assets/150457827/cd89d92f-dee2-406e-9840-30401b0f3581)

With my fix, when selecting a custom fee or none fee, the selected fee amount shows accuratly:

| Description | Screenshot |
| --- | --- |
| When None fee is selected | ![None fee selected](https://github.com/taikoxyz/taiko-mono/assets/150457827/a21f28dd-8bbc-4ef5-b022-ec7131b64d6c) |
| When a custom is selected | ![Custom fee selected](https://github.com/taikoxyz/taiko-mono/assets/150457827/e3584ddc-4a7e-4d60-a5d4-e5173fd75eb9) |
