### PR TITLE
feat(protocol): remove two step processing

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -105,6 +105,13 @@ contract Bridge is EssentialContract, IBridge {
         __Essential_init(_owner, _addressManager);
     }
 
+    function init2() external onlyOwner reinitializer(2) {
+        // reset some previously used slots for future reuse
+        __reserved1 = 0;
+        __reserved2 = 0;
+        __reserved3 = 0;
+    }
+
     /// @inheritdoc IBridge
     function sendMessage(Message calldata _message)
         external

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -29,9 +29,8 @@ contract Bridge is EssentialContract, IBridge {
     /// @dev The amount of gas not to charge fee per cache operation.
     uint256 private constant _GAS_REFUND_PER_CACHE_OPERATION = 20_000;
 
-    /// @dev The gas overhead for both receiving and invoking a message if the message is processed
-    /// in a single step. We added 20_000 more gas on top of a measured value.
-    uint32 private constant _GAS_OVERHEAD = 53_000 + 20_000;
+    /// @dev The gas overhead for both receiving and invoking a message.
+    uint32 private constant _GAS_OVERHEAD = 60_000;
 
     /// @dev The slot in transient storage of the call context. This is the keccak256 hash
     /// of "bridge.ctx_slot"
@@ -403,12 +402,8 @@ contract Bridge is EssentialContract, IBridge {
     /// @return The minimal gas limit required for sending this message.
     function getMessageMinGasLimit(Message calldata _message) public pure returns (uint32) {
         unchecked {
-            // The message struct takes 7 slots in total.
-            // For each byte, we reserve 16 gas, but since a message can be processed in
-            // two steps, we need to reserve 32 gas per byte (>>5).
-            uint256 calldataCost = (_message.data.length + 6 * 32) >> 5;
-
-            return uint32((_GAS_RESERVE + calldataCost + 1).min(type(uint32).max));
+            uint256 calldataCost = (_message.data.length + 192) >> 4;
+            return uint32(_GAS_RESERVE + calldataCost + 1);
         }
     }
 

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -76,13 +76,10 @@ contract Bridge is EssentialContract, IBridge {
     error B_INVALID_USER();
     error B_INVALID_VALUE();
     error B_INSUFFICIENT_GAS();
-    error B_INVOCATION_TOO_EARLY();
     error B_MESSAGE_FAILED();
     error B_MESSAGE_NOT_PROVEN();
     error B_MESSAGE_NOT_SENT();
-    error B_MESSAGE_NOT_SUSPENDED();
     error B_MESSAGE_SUSPENDED();
-    error B_NON_EMPTY_PROOF();
     error B_NON_RETRIABLE();
     error B_NOT_FAILED();
     error B_NOT_RECEIVED();

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -399,11 +399,10 @@ contract Bridge is EssentialContract, IBridge {
     /// @return The minimal gas limit required for sending this message.
     function getMessageMinGasLimit(Message calldata _message) public pure returns (uint32) {
         unchecked {
-            // The message struct takes 8 slots in total.
+            // The message struct takes 7 slots in total.
             // For each byte, we reserve 16 gas, but since a message can be processed in
             // two steps, we need to reserve 32 gas per byte (>>5).
-            uint256 calldataCost =
-                (_message.data.length + bytes(_message.memo).length + 6 * 32) >> 5;
+            uint256 calldataCost = (_message.data.length + 6 * 32) >> 5;
 
             return uint32((_GAS_RESERVE + calldataCost + 1).min(type(uint32).max));
         }

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -76,11 +76,6 @@ interface IBridge {
     /// @param status The new status of the message.
     event MessageStatusChanged(bytes32 indexed msgHash, Status status);
 
-    /// @notice Emitted when an address is banned or unbanned.
-    /// @param addr The address to ban or unban.
-    /// @param banned True if the address is banned.
-    event AddressBanned(address indexed addr, bool banned);
-
     /// @notice Sends a message to the destination chain and takes custody
     /// of Ether required in this contract.
     /// @param _message The message to be sent.

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -16,23 +16,7 @@ interface IBridge {
 
     struct Message {
         // Message ID whose value is automatically assigned.
-        uint128 id;
-        // The address, EOA or contract, that interacts with this bridge.
-        // The value is automatically assigned.
-        address from;
-        // Source chain ID whose value is automatically assigned.
-        uint64 srcChainId;
-        // Destination chain ID where the `to` address lives.
-        uint64 destChainId;
-        // The owner of the message on the source chain.
-        address srcOwner;
-        // The owner of the message on the destination chain.
-        address destOwner;
-        // The destination address on the destination chain.
-        address to;
-        address refundTo; // deprecated and ignored
-        // value to invoke on the destination chain.
-        uint256 value;
+        uint64 id;
         // The max processing fee for the relayer. This fee has 3 parts:
         // - the fee for message calldata.
         // - the minimal fee reserve for general processing, excluding function call.
@@ -40,23 +24,29 @@ interface IBridge {
         // Any unpaid fee will be refunded to the destOwner on the destination chain.
         // Note that fee must be 0 if gasLimit is 0, or large enough to make the invocation fee
         // non-zero.
-        uint256 fee;
+        uint64 fee;
         // gasLimit that the processMessage call must have.
-        uint256 gasLimit;
+        uint32 gasLimit;
+        // The address, EOA or contract, that interacts with this bridge.
+        // The value is automatically assigned.
+        address from;
+        // Source chain ID whose value is automatically assigned.
+        uint64 srcChainId;
+        // The owner of the message on the source chain.
+        address srcOwner;
+        // Destination chain ID where the `to` address lives.
+        uint64 destChainId;
+        // The owner of the message on the destination chain.
+        address destOwner;
+        // The destination address on the destination chain.
+        address to;
+        address refundTo; // deprecated and ignored
+        // value to invoke on the destination chain.
+        uint256 value;
         // callData to invoke on the destination chain.
         bytes data;
         // Optional memo.
         string memo;
-    }
-
-    // Note that this struct shall take only 1 slot to minimize gas cost
-    struct ProofReceipt {
-        // The time a message is marked as received on the destination chain
-        uint64 receivedAt;
-        // The amount of gas paid for receiving the message.
-        uint32 gasUsed;
-        // The Ether fee paid for gasUsed, up to 18.44 Ether
-        uint64 feePaid;
     }
 
     // Struct representing the context of a bridge operation.
@@ -71,12 +61,6 @@ interface IBridge {
     /// @param msgHash The hash of the message.
     /// @param message The message.
     event MessageSent(bytes32 indexed msgHash, Message message);
-
-    /// @notice Emitted when a message is received.
-    /// @param msgHash The hash of the message.
-    /// @param message The message.
-    /// @param isRecall True if the message is a recall.
-    event MessageReceived(bytes32 indexed msgHash, Message message, bool isRecall);
 
     /// @notice Emitted when a message is recalled.
     /// @param msgHash The hash of the message.
@@ -94,12 +78,6 @@ interface IBridge {
     /// @param msgHash The hash of the message.
     /// @param status The new status of the message.
     event MessageStatusChanged(bytes32 indexed msgHash, Status status);
-
-    /// @notice Emitted when a message is suspended or unsuspended.
-    /// @param msgHash The hash of the message.
-    /// @param suspended True if the message is suspended.
-    /// @param receivedAt The received-at timestamp, 0 if suspended is true.
-    event MessageSuspended(bytes32 msgHash, bool suspended, uint64 receivedAt);
 
     /// @notice Emitted when an address is banned or unbanned.
     /// @param addr The address to ban or unban.

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -40,13 +40,10 @@ interface IBridge {
         address destOwner;
         // The destination address on the destination chain.
         address to;
-        address refundTo; // deprecated and ignored
         // value to invoke on the destination chain.
         uint256 value;
         // callData to invoke on the destination chain.
         bytes data;
-        // Optional memo.
-        string memo;
     }
 
     // Struct representing the context of a bridge operation.

--- a/packages/protocol/contracts/bridge/README.md
+++ b/packages/protocol/contracts/bridge/README.md
@@ -38,9 +38,6 @@ If user wants to bridge ether, he/she will initiate a bridge transaction with `s
         address destOwner;
         // The destination address on the destination chain.
         address to;
-        // Alternate address to send any refund on the destination chain.
-        // If blank, defaults to destOwner.
-        address refundTo;
         // value to invoke on the destination chain.
         uint256 value;
         // Processing fee for the relayer.
@@ -73,7 +70,6 @@ In case of ERC20 the transaction can be initiated by initializing a struct (belo
         uint256 amount;
         uint256 gasLimit;
         uint256 fee;
-        address refundTo;
         string memo;
     }
 ```
@@ -89,7 +85,6 @@ struct BridgeTransferOp {
         uint256[] amounts;
         uint256 gasLimit;
         uint256 fee;
-        address refundTo;
         string memo;
     }
 ```

--- a/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
@@ -19,7 +19,8 @@ abstract contract BaseNFTVault is BaseVault {
         string name;
     }
 
-    // Struct representing the details of a bridged token transfer operation.
+    /// @devStruct representing the details of a bridged token transfer operation.
+    /// 5 slots
     struct BridgeTransferOp {
         // Destination chain ID.
         uint64 destChainId;

--- a/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
@@ -37,9 +37,6 @@ abstract contract BaseNFTVault is BaseVault {
         uint256[] tokenIds;
         // Amounts of tokens to transfer.
         uint256[] amounts;
-        address refundTo; // deprecated and ignored
-        // Optional memo.
-        string memo;
     }
 
     /// @notice ERC1155 interface ID.

--- a/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseNFTVault.sol
@@ -27,16 +27,16 @@ abstract contract BaseNFTVault is BaseVault {
         address destOwner;
         // Recipient address.
         address to;
+        // Processing fee for the relayer.
+        uint64 fee;
         // Address of the token.
         address token;
+        // Gas limit for the operation.
+        uint32 gasLimit;
         // IDs of the tokens to transfer.
         uint256[] tokenIds;
         // Amounts of tokens to transfer.
         uint256[] amounts;
-        // Gas limit for the operation.
-        uint256 gasLimit;
-        // Processing fee for the relayer.
-        uint256 fee;
         address refundTo; // deprecated and ignored
         // Optional memo.
         string memo;

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -70,12 +70,10 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
             srcOwner: msg.sender,
             destOwner: _op.destOwner != address(0) ? _op.destOwner : msg.sender,
             to: resolve(_op.destChainId, name(), false),
-            refundTo: _op.refundTo,
             value: msg.value - _op.fee,
             fee: _op.fee,
             gasLimit: _op.gasLimit,
-            data: data,
-            memo: _op.memo
+            data: data
         });
 
         // Send the message and obtain the message hash

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -43,7 +43,7 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
     /// @param _op Option for sending the ERC1155 token.
     /// @return message_ The constructed message.
 
-    function sendToken(BridgeTransferOp memory _op)
+    function sendToken(BridgeTransferOp calldata _op)
         external
         payable
         whenNotPaused

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -36,8 +36,6 @@ contract ERC20Vault is BaseVault {
         address token;
         uint32 gasLimit;
         uint256 amount;
-        address refundTo; // deprecated and ignored
-        string memo;
     }
 
     /// @notice Mappings from bridged tokens to their canonical tokens.
@@ -232,12 +230,10 @@ contract ERC20Vault is BaseVault {
             srcOwner: msg.sender,
             destOwner: _op.destOwner != address(0) ? _op.destOwner : msg.sender,
             to: resolve(_op.destChainId, name(), false),
-            refundTo: _op.refundTo,
             value: msg.value - _op.fee,
             fee: _op.fee,
             gasLimit: _op.gasLimit,
-            data: data,
-            memo: _op.memo
+            data: data
         });
 
         bytes32 msgHash;

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -28,6 +28,7 @@ contract ERC20Vault is BaseVault {
     }
 
     /// @dev Represents an operation to send tokens to another chain.
+    /// 4 slots
     struct BridgeTransferOp {
         uint64 destChainId;
         address destOwner;

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -32,10 +32,10 @@ contract ERC20Vault is BaseVault {
         uint64 destChainId;
         address destOwner;
         address to;
+        uint64 fee;
         address token;
+        uint32 gasLimit;
         uint256 amount;
-        uint256 gasLimit;
-        uint256 fee;
         address refundTo; // deprecated and ignored
         string memo;
     }

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -55,12 +55,10 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
             srcOwner: msg.sender,
             destOwner: _op.destOwner != address(0) ? _op.destOwner : msg.sender,
             to: resolve(_op.destChainId, name(), false),
-            refundTo: _op.refundTo,
             value: msg.value - _op.fee,
             fee: _op.fee,
             gasLimit: _op.gasLimit,
-            data: data,
-            memo: _op.memo
+            data: data
         });
 
         bytes32 msgHash;

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -29,7 +29,7 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
     /// by invoking the message call.
     /// @param _op Option for sending the ERC721 token.
     /// @return message_ The constructed message.
-    function sendToken(BridgeTransferOp memory _op)
+    function sendToken(BridgeTransferOp calldata _op)
         external
         payable
         whenNotPaused

--- a/packages/protocol/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/genesis/GenerateGenesis.g.sol
@@ -167,8 +167,7 @@ contract TestGenerateGenesis is Test, AddressResolver {
                 value: 0,
                 fee: 0,
                 gasLimit: 0,
-                data: "",
-                memo: ""
+                data: ""
             }),
             ""
         );

--- a/packages/protocol/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/genesis/GenerateGenesis.g.sol
@@ -164,7 +164,6 @@ contract TestGenerateGenesis is Test, AddressResolver {
                 srcOwner: address(0),
                 destOwner: address(0),
                 to: address(0),
-                refundTo: address(0),
                 value: 0,
                 fee: 0,
                 gasLimit: 0,
@@ -190,12 +189,10 @@ contract TestGenerateGenesis is Test, AddressResolver {
                 srcOwner: address(0),
                 destOwner: address(0),
                 to: address(0),
-                refundTo: address(0),
                 value: 0,
                 fee: 0,
                 gasLimit: 0,
-                data: "",
-                memo: ""
+                data: ""
             }),
             ""
         );

--- a/packages/protocol/test/bridge/Bridge.t.sol
+++ b/packages/protocol/test/bridge/Bridge.t.sol
@@ -150,12 +150,10 @@ contract BridgeTest is TaikoTest {
             srcOwner: Alice,
             destOwner: Alice,
             to: Alice,
-            refundTo: Alice,
             value: 10_000,
             fee: 1000,
             gasLimit: 1_000_000,
-            data: "",
-            memo: ""
+            data: ""
         });
         // Mocking proof - but obviously it needs to be created in prod
         // corresponding to the message
@@ -190,12 +188,10 @@ contract BridgeTest is TaikoTest {
             srcOwner: Alice,
             destOwner: Alice,
             to: address(goodReceiver),
-            refundTo: Alice,
             value: 10_000,
             fee: 1000,
             gasLimit: 1_000_000,
-            data: "",
-            memo: ""
+            data: ""
         });
         // Mocking proof - but obviously it needs to be created in prod
         // corresponding to the message
@@ -229,12 +225,10 @@ contract BridgeTest is TaikoTest {
             srcOwner: Alice,
             destOwner: Alice,
             to: address(goodReceiver),
-            refundTo: Alice,
             value: 1000,
             fee: 1000,
             gasLimit: 1_000_000,
-            data: abi.encodeCall(GoodReceiver.onMessageInvocation, abi.encode(Carol)),
-            memo: ""
+            data: abi.encodeCall(GoodReceiver.onMessageInvocation, abi.encode(Carol))
         });
         // Mocking proof - but obviously it needs to be created in prod
         // corresponding to the message
@@ -593,12 +587,10 @@ contract BridgeTest is TaikoTest {
             srcOwner: Alice,
             destOwner: Alice,
             to: address(nonmaliciousContract1),
-            refundTo: Alice,
             value: 1000,
             fee: 1000,
             gasLimit: 1_000_000,
-            data: "",
-            memo: ""
+            data: ""
         });
 
         bytes memory proof = hex"00";
@@ -623,12 +615,10 @@ contract BridgeTest is TaikoTest {
             srcOwner: Alice,
             destOwner: Alice,
             to: address(maliciousContract2),
-            refundTo: Alice,
             value: 1000,
             fee: 1000,
             gasLimit: 1_000_000,
-            data: "",
-            memo: ""
+            data: ""
         });
 
         bytes memory proof = hex"00";
@@ -699,12 +689,10 @@ contract BridgeTest is TaikoTest {
             srcOwner: 0xDf08F82De32B8d460adbE8D72043E3a7e25A3B39,
             destOwner: 0xDf08F82De32B8d460adbE8D72043E3a7e25A3B39,
             to: 0x200708D76eB1B69761c23821809d53F65049939e,
-            refundTo: 0x10020FCb72e27650651B05eD2CEcA493bC807Ba4,
             value: 1000,
             fee: 1000,
             gasLimit: 1_000_000,
-            data: "",
-            memo: ""
+            data: ""
         });
 
         bytes memory proof =
@@ -735,10 +723,8 @@ contract BridgeTest is TaikoTest {
             id: 0, // placeholder, will be overwritten
             from: owner, // placeholder, will be overwritten
             srcChainId: uint64(block.chainid), // will be overwritten
-            refundTo: owner,
             gasLimit: gasLimit,
-            data: "",
-            memo: ""
+            data: ""
         });
     }
 
@@ -759,12 +745,10 @@ contract BridgeTest is TaikoTest {
                 // want to send ether
             destOwner: Alice,
             to: address(delegateOwner),
-            refundTo: Alice,
             value: 0,
             fee: 0,
             gasLimit: 1_000_000,
-            data: encodedCall,
-            memo: ""
+            data: encodedCall
         });
     }
 }

--- a/packages/protocol/test/bridge/Bridge.t.sol
+++ b/packages/protocol/test/bridge/Bridge.t.sol
@@ -19,12 +19,6 @@ contract UntrustedSendMessageRelayer {
     }
 }
 
-contract TwoStepBridge is Bridge {
-    function getInvocationDelay() public pure override returns (uint256) {
-        return 10 hours;
-    }
-}
-
 // A malicious contract that attempts to exhaust gas
 contract MaliciousContract2 {
     fallback() external payable {
@@ -43,7 +37,6 @@ contract BridgeTest is TaikoTest {
     GoodReceiver goodReceiver;
     Bridge bridge;
     Bridge destChainBridge;
-    TwoStepBridge dest2StepBridge;
     SignalService signalService;
     SkipProofCheckSignal mockProofSignalService;
     UntrustedSendMessageRelayer untrustedSenderContract;
@@ -89,16 +82,6 @@ contract BridgeTest is TaikoTest {
             )
         );
 
-        dest2StepBridge = TwoStepBridge(
-            payable(
-                deployProxy({
-                    name: "2_step_bridge",
-                    impl: address(new TwoStepBridge()),
-                    data: abi.encodeCall(Bridge.init, (address(0), address(addressManager)))
-                })
-            )
-        );
-
         // "Deploy" on L2 only
         uint64 l1ChainId = uint64(block.chainid);
         vm.chainId(destChainId);
@@ -135,7 +118,6 @@ contract BridgeTest is TaikoTest {
         );
 
         vm.deal(address(destChainBridge), 100 ether);
-        vm.deal(address(dest2StepBridge), 100 ether);
 
         untrustedSenderContract = new UntrustedSendMessageRelayer();
         vm.deal(address(untrustedSenderContract), 10 ether);
@@ -195,62 +177,6 @@ contract BridgeTest is TaikoTest {
         assertTrue(Alice.balance >= 100 ether + 10_000);
         assertTrue(Alice.balance <= 100 ether + 10_000 + 1000);
         assertTrue(Bob.balance >= 0 && Bob.balance <= 1000);
-    }
-
-    function test_Bridge_processMessage_with_2_steps() public {
-        IBridge.Message memory message = IBridge.Message({
-            id: 0,
-            from: address(bridge),
-            srcChainId: uint64(block.chainid),
-            destChainId: destChainId,
-            srcOwner: Alice,
-            destOwner: Alice,
-            to: Alice,
-            refundTo: Alice,
-            value: 10_000,
-            fee: 1000,
-            gasLimit: 1_000_000,
-            data: "",
-            memo: ""
-        });
-        // Mocking proof - but obviously it needs to be created in prod
-        // corresponding to the message
-        bytes memory proof = hex"00";
-
-        bytes32 msgHash = dest2StepBridge.hashMessage(message);
-
-        vm.chainId(destChainId);
-        // This in is the first transaction setting the proofReceipt
-        vm.prank(Bob, Bob);
-        dest2StepBridge.processMessage(message, proof);
-
-        IBridge.Status status = dest2StepBridge.messageStatus(msgHash);
-        // Still new ! Because of the delay, no processing happened
-        assertEq(status == IBridge.Status.NEW, true);
-        // Alice has 100 ether
-        assertEq(Alice.balance, 100 ether);
-
-        // Go in the future, 5 hours, still not processable
-        vm.warp(block.timestamp + 5 hours);
-
-        vm.expectRevert(Bridge.B_INVOCATION_TOO_EARLY.selector);
-        vm.prank(Bob, Bob);
-        dest2StepBridge.processMessage(message, "");
-
-        // Go in the future, +6 hours, all in all 11 hours from first processing
-        // Carol cannot process (as not preferred executor)
-        vm.warp(block.timestamp + 6 hours);
-
-        // Not too early for Bob
-
-        uint256 bobBalance = Bob.balance;
-
-        vm.prank(Bob, Bob);
-        dest2StepBridge.processMessage(message, "");
-
-        assertTrue(Bob.balance < bobBalance + 1000);
-        assertTrue(Alice.balance > 100 ether + 1000);
-        assertTrue(Alice.balance < 100 ether + 11_000);
     }
 
     function test_Bridge_send_ether_to_contract_with_value_simple() public {
@@ -497,7 +423,7 @@ contract BridgeTest is TaikoTest {
 
     function test_Bridge_send_message_ether_with_processing_fee() public {
         uint256 amount = 0 wei;
-        uint256 fee = 1_000_000 wei;
+        uint64 fee = 1_000_000 wei;
         IBridge.Message memory message = newMessage({
             owner: Alice,
             to: Alice,
@@ -513,7 +439,7 @@ contract BridgeTest is TaikoTest {
 
     function test_Bridge_recall_message_ether() public {
         uint256 amount = 1 ether;
-        uint256 fee = 0 wei;
+        uint64 fee = 0 wei;
         IBridge.Message memory message = newMessage({
             owner: Alice,
             to: Alice,
@@ -538,56 +464,13 @@ contract BridgeTest is TaikoTest {
         assertEq(Alice.balance, (starterBalanceAlice - fee));
     }
 
-    function test_Bridge_recall_message_ether_with_2_steps() public {
-        uint256 amount = 1 ether;
-        uint256 fee = 0 wei;
-        IBridge.Message memory message = newMessage({
-            owner: Alice,
-            to: Alice,
-            value: amount,
-            gasLimit: 0,
-            fee: fee,
-            destChain: destChainId
-        });
-
-        uint256 starterBalanceVault = address(dest2StepBridge).balance;
-        uint256 starterBalanceAlice = Alice.balance;
-
-        vm.prank(Alice, Alice);
-        (, IBridge.Message memory _message) =
-            dest2StepBridge.sendMessage{ value: amount + fee }(message);
-        assertEq(dest2StepBridge.isMessageSent(_message), true);
-
-        assertEq(address(dest2StepBridge).balance, (starterBalanceVault + amount + fee));
-        assertEq(Alice.balance, (starterBalanceAlice - (amount + fee)));
-
-        vm.prank(Bob, Bob);
-        dest2StepBridge.recallMessage(message, "");
-        // Go in the future, 5 hours, still not processable
-        vm.warp(block.timestamp + 5 hours);
-
-        vm.expectRevert(Bridge.B_INVOCATION_TOO_EARLY.selector);
-        vm.prank(Bob, Bob);
-        dest2StepBridge.recallMessage(message, "");
-
-        // Go in the future, +6 hours, all in all 11 hours from first processing
-        vm.warp(block.timestamp + 6 hours);
-
-        // Not too early anymore
-        vm.prank(Bob, Bob);
-        dest2StepBridge.recallMessage(message, "");
-
-        assertEq(address(dest2StepBridge).balance, (starterBalanceVault + fee));
-        assertEq(Alice.balance, (starterBalanceAlice - fee));
-    }
-
     function test_Bridge_recall_message_but_not_supports_recall_interface() public {
         // In this test we expect that the 'message value is still refundable,
         // just not via
         // ERCXXTokenVault (message.from) but directly from the Bridge
 
         uint256 amount = 1 ether;
-        uint256 fee = 0 wei;
+        uint64 fee = 0 wei;
         IBridge.Message memory message = newMessage({
             owner: Alice,
             to: Alice,
@@ -610,7 +493,7 @@ contract BridgeTest is TaikoTest {
 
     function test_Bridge_send_message_ether_with_processing_fee_invalid_amount() public {
         uint256 amount = 0 wei;
-        uint256 fee = 1_000_000 wei;
+        uint64 fee = 1_000_000 wei;
         IBridge.Message memory message = newMessage({
             owner: Alice,
             to: Alice,
@@ -641,78 +524,6 @@ contract BridgeTest is TaikoTest {
 
         IBridge.Status status = destChainBridge.messageStatus(msgHash);
 
-        assertEq(status == IBridge.Status.DONE, true);
-    }
-
-    function test_Bridge_suspend_messages() public {
-        IBridge.Message memory message = IBridge.Message({
-            id: 0,
-            from: address(bridge),
-            srcChainId: uint64(block.chainid),
-            destChainId: destChainId,
-            srcOwner: Alice,
-            destOwner: Alice,
-            to: Alice,
-            refundTo: Alice,
-            value: 1000,
-            fee: 1000,
-            gasLimit: 1_000_000,
-            data: "",
-            memo: ""
-        });
-        // Mocking proof - but obviously it needs to be created in prod
-        // corresponding to the message
-        bytes memory proof = hex"00";
-
-        vm.chainId(destChainId);
-        // This in is the first transaction setting the proofReceipt
-
-        bytes32 msgHash = dest2StepBridge.hashMessage(message);
-        bytes32[] memory messageHashes = new bytes32[](1);
-        messageHashes[0] = msgHash;
-
-        // Unsuspend a msg that has not been suspended will revert
-        vm.prank(dest2StepBridge.owner());
-        vm.expectRevert(Bridge.B_MESSAGE_NOT_SUSPENDED.selector);
-        dest2StepBridge.suspendMessages(messageHashes, false);
-
-        // Suspend that will revert
-        vm.prank(dest2StepBridge.owner());
-        vm.expectRevert(Bridge.B_MESSAGE_NOT_PROVEN.selector);
-        dest2StepBridge.suspendMessages(messageHashes, true);
-
-        vm.prank(Bob);
-        dest2StepBridge.processMessage(message, proof);
-
-        // Suspend
-        vm.prank(dest2StepBridge.owner());
-        dest2StepBridge.suspendMessages(messageHashes, true);
-
-        // Suspend again will revert
-        vm.prank(dest2StepBridge.owner());
-        vm.expectRevert(Bridge.B_MESSAGE_SUSPENDED.selector);
-        dest2StepBridge.suspendMessages(messageHashes, true);
-
-        // Try to process the message
-        vm.prank(Alice);
-        vm.expectRevert(Bridge.B_MESSAGE_SUSPENDED.selector);
-        dest2StepBridge.processMessage(message, proof);
-
-        // Unsuspend
-        vm.prank(dest2StepBridge.owner());
-        dest2StepBridge.suspendMessages(messageHashes, false);
-
-        vm.prank(Alice);
-        vm.expectRevert(Bridge.B_INVOCATION_TOO_EARLY.selector);
-        dest2StepBridge.processMessage(message, "");
-
-        // Go in the future and try again
-        vm.warp(block.timestamp + 30 days);
-
-        vm.prank(Alice);
-        dest2StepBridge.processMessage(message, "");
-
-        IBridge.Status status = dest2StepBridge.messageStatus(msgHash);
         assertEq(status == IBridge.Status.DONE, true);
     }
 
@@ -906,8 +717,8 @@ contract BridgeTest is TaikoTest {
         address owner,
         address to,
         uint256 value,
-        uint256 gasLimit,
-        uint256 fee,
+        uint32 gasLimit,
+        uint64 fee,
         uint64 destChain
     )
         internal

--- a/packages/protocol/test/tokenvault/ERC1155Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC1155Vault.t.sol
@@ -232,16 +232,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 2;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -264,16 +255,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 2;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(0),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(0), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         vm.expectRevert(BaseNFTVault.VAULT_INVALID_TOKEN.selector);
@@ -294,16 +276,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 0;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         vm.expectRevert(BaseNFTVault.VAULT_INVALID_AMOUNT.selector);
@@ -327,16 +300,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 2;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -391,16 +355,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 2;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -444,16 +399,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 1;
 
         sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -498,16 +444,7 @@ contract ERC1155VaultTest is TaikoTest {
         uint256 etherValue = 0.1 ether;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            David,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), David, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: etherValue }(sendOpts);
@@ -561,16 +498,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 2;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
 
         vm.prank(Alice, Alice);
@@ -605,16 +533,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[1] = 5;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -670,16 +589,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -729,16 +639,7 @@ contract ERC1155VaultTest is TaikoTest {
         ERC1155(deployedContract).setApprovalForAll(address(destChainErc1155Vault), true);
 
         sendOpts = BaseNFTVault.BridgeTransferOp(
-            chainId,
-            address(0),
-            Bob,
-            address(deployedContract),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Bob,
-            ""
+            chainId, address(0), Bob, 500_000, address(deployedContract), 500_000, tokenIds, amounts
         );
 
         vm.prank(Bob, Bob);
@@ -784,16 +685,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 1;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -846,13 +738,11 @@ contract ERC1155VaultTest is TaikoTest {
             chainId,
             address(0),
             Alice,
+            500_000,
             address(deployedContract),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Bob,
-            ""
+            amounts
         );
 
         vm.prank(Alice, Alice);
@@ -874,16 +764,7 @@ contract ERC1155VaultTest is TaikoTest {
         amounts[0] = 2;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(ctoken1155),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(ctoken1155), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         erc1155Vault.sendToken{ value: 500_000 }(sendOpts);

--- a/packages/protocol/test/tokenvault/ERC20Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC20Vault.t.sol
@@ -32,7 +32,7 @@ contract PrankDestBridge {
         ERC20Vault.CanonicalERC20 calldata canonicalToken,
         address from,
         address to,
-        uint256 amount,
+        uint64 amount,
         bytes32 msgHash,
         address srcChainERC20Vault,
         uint64 srcChainId,
@@ -182,7 +182,7 @@ contract TestERC20Vault is TaikoTest {
     function test_20Vault_send_erc20_no_processing_fee() public {
         vm.startPrank(Alice);
 
-        uint256 amount = 2 wei;
+        uint64 amount = 2 wei;
         erc20.approve(address(erc20Vault), amount);
 
         uint256 aliceBalanceBefore = erc20.balanceOf(Alice);
@@ -204,7 +204,7 @@ contract TestERC20Vault is TaikoTest {
     function test_20Vault_send_erc20_processing_fee_reverts_if_msg_value_too_low() public {
         vm.startPrank(Alice);
 
-        uint256 amount = 2 wei;
+        uint64 amount = 2 wei;
         erc20.approve(address(erc20Vault), amount);
 
         vm.expectRevert();
@@ -218,7 +218,7 @@ contract TestERC20Vault is TaikoTest {
     function test_20Vault_send_erc20_processing_fee() public {
         vm.startPrank(Alice);
 
-        uint256 amount = 2 wei;
+        uint64 amount = 2 wei;
         erc20.approve(address(erc20Vault), amount);
 
         uint256 aliceBalanceBefore = erc20.balanceOf(Alice);
@@ -248,7 +248,7 @@ contract TestERC20Vault is TaikoTest {
     function test_20Vault_send_erc20_reverts_invalid_amount() public {
         vm.startPrank(Alice);
 
-        uint256 amount = 0;
+        uint64 amount = 0;
 
         vm.expectRevert(ERC20Vault.VAULT_INVALID_AMOUNT.selector);
         erc20Vault.sendToken(
@@ -261,7 +261,7 @@ contract TestERC20Vault is TaikoTest {
     function test_20Vault_send_erc20_reverts_invalid_token_address() public {
         vm.startPrank(Alice);
 
-        uint256 amount = 1;
+        uint64 amount = 1;
 
         vm.expectRevert(ERC20Vault.VAULT_INVALID_TOKEN.selector);
         erc20Vault.sendToken(
@@ -280,7 +280,7 @@ contract TestERC20Vault is TaikoTest {
 
         erc20.mint(address(erc20Vault));
 
-        uint256 amount = 1;
+        uint64 amount = 1;
         address to = Bob;
 
         uint256 erc20VaultBalanceBefore = erc20.balanceOf(address(erc20Vault));
@@ -311,7 +311,7 @@ contract TestERC20Vault is TaikoTest {
 
         erc20.mint(address(erc20Vault));
 
-        uint256 amount = 1;
+        uint64 amount = 1;
         uint256 etherAmount = 0.1 ether;
         address to = David;
 
@@ -345,7 +345,7 @@ contract TestERC20Vault is TaikoTest {
 
         vm.chainId(destChainId);
 
-        uint256 amount = 1;
+        uint64 amount = 1;
 
         destChainIdBridge.setERC20Vault(address(destChainIdERC20Vault));
 
@@ -393,7 +393,7 @@ contract TestERC20Vault is TaikoTest {
 
         vm.chainId(destChainId);
 
-        uint256 amount = 1;
+        uint64 amount = 1;
 
         destChainIdBridge.setERC20Vault(address(destChainIdERC20Vault));
 
@@ -440,7 +440,7 @@ contract TestERC20Vault is TaikoTest {
     function test_20Vault_onMessageRecalled_20() public {
         vm.startPrank(Alice);
 
-        uint256 amount = 2 wei;
+        uint64 amount = 2 wei;
         erc20.approve(address(erc20Vault), amount);
 
         uint256 aliceBalanceBefore = erc20.balanceOf(Alice);

--- a/packages/protocol/test/tokenvault/ERC20Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC20Vault.t.sol
@@ -174,7 +174,7 @@ contract TestERC20Vault is TaikoTest {
         vm.expectRevert("ERC20: insufficient allowance");
         erc20Vault.sendToken(
             ERC20Vault.BridgeTransferOp(
-                destChainId, address(0), Bob, address(erc20), 1 wei, 1_000_000, 1, Bob, ""
+                destChainId, address(0), Bob, 1, address(erc20), 1_000_000, 1 wei
             )
         );
     }
@@ -190,7 +190,7 @@ contract TestERC20Vault is TaikoTest {
 
         erc20Vault.sendToken(
             ERC20Vault.BridgeTransferOp(
-                destChainId, address(0), Bob, address(erc20), amount, 1_000_000, 0, Bob, ""
+                destChainId, address(0), Bob, 0, address(erc20), 1_000_000, amount
             )
         );
 
@@ -210,7 +210,7 @@ contract TestERC20Vault is TaikoTest {
         vm.expectRevert();
         erc20Vault.sendToken(
             ERC20Vault.BridgeTransferOp(
-                destChainId, address(0), Bob, address(erc20), amount, 1_000_000, amount - 1, Bob, ""
+                destChainId, address(0), Bob, amount - 1, address(erc20), 1_000_000, amount
             )
         );
     }
@@ -229,12 +229,10 @@ contract TestERC20Vault is TaikoTest {
                 destChainId,
                 address(0),
                 Bob,
-                address(erc20),
-                amount - 1, // value: (msg.value - fee)
-                1_000_000,
                 amount - 1,
-                Bob,
-                ""
+                address(erc20),
+                1_000_000,
+                amount - 1 // value: (msg.value - fee)
             )
         );
 
@@ -253,7 +251,7 @@ contract TestERC20Vault is TaikoTest {
         vm.expectRevert(ERC20Vault.VAULT_INVALID_AMOUNT.selector);
         erc20Vault.sendToken(
             ERC20Vault.BridgeTransferOp(
-                destChainId, address(0), Bob, address(erc20), amount, 1_000_000, 0, Bob, ""
+                destChainId, address(0), Bob, 0, address(erc20), 1_000_000, amount
             )
         );
     }
@@ -266,7 +264,7 @@ contract TestERC20Vault is TaikoTest {
         vm.expectRevert(ERC20Vault.VAULT_INVALID_TOKEN.selector);
         erc20Vault.sendToken(
             ERC20Vault.BridgeTransferOp(
-                destChainId, address(0), Bob, address(0), amount, 1_000_000, 0, Bob, ""
+                destChainId, address(0), Bob, 0, address(0), 1_000_000, amount
             )
         );
     }
@@ -448,7 +446,7 @@ contract TestERC20Vault is TaikoTest {
 
         IBridge.Message memory _messageToSimulateFail = erc20Vault.sendToken(
             ERC20Vault.BridgeTransferOp(
-                destChainId, address(0), Bob, address(erc20), amount, 1_000_000, 0, Bob, ""
+                destChainId, address(0), Bob, 0, address(erc20), 1_000_000, amount
             )
         );
 

--- a/packages/protocol/test/tokenvault/ERC721Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC721Vault.t.sol
@@ -242,13 +242,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts, // With ERC721 still need to specify 1
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts // With ERC721 still need to specify 1
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -269,16 +267,7 @@ contract ERC721VaultTest is TaikoTest {
         amounts[0] = 0;
 
         BaseNFTVault.BridgeTransferOp memory sendOpts = BaseNFTVault.BridgeTransferOp(
-            destChainId,
-            address(0),
-            Alice,
-            address(0),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            destChainId, address(0), Alice, 500_000, address(0), 500_000, tokenIds, amounts
         );
         vm.prank(Alice, Alice);
         vm.expectRevert(BaseNFTVault.VAULT_INVALID_TOKEN.selector);
@@ -300,13 +289,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         vm.expectRevert(BaseNFTVault.VAULT_INVALID_AMOUNT.selector);
@@ -332,13 +319,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -385,13 +370,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -433,13 +416,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -476,13 +457,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             David,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: etherValue }(sendOpts);
@@ -535,13 +514,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
 
         vm.prank(Alice, Alice);
@@ -576,13 +553,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -631,13 +606,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -679,16 +652,7 @@ contract ERC721VaultTest is TaikoTest {
         ERC721(deployedContract).approve(address(destChainErc721Vault), 1);
 
         sendOpts = BaseNFTVault.BridgeTransferOp(
-            chainId,
-            address(0),
-            Bob,
-            address(deployedContract),
-            tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Bob,
-            ""
+            chainId, address(0), Bob, 500_000, address(deployedContract), 500_000, tokenIds, amounts
         );
 
         vm.prank(Bob, Bob);
@@ -730,13 +694,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: 500_000 }(sendOpts);
@@ -782,13 +744,11 @@ contract ERC721VaultTest is TaikoTest {
             chainId,
             address(0),
             Alice,
+            500_000,
             address(deployedContract),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Bob,
-            ""
+            amounts
         );
 
         vm.prank(Alice, Alice);
@@ -814,13 +774,11 @@ contract ERC721VaultTest is TaikoTest {
             destChainId,
             address(0),
             Alice,
+            500_000,
             address(canonicalToken721),
+            500_000,
             tokenIds,
-            amounts,
-            500_000,
-            500_000,
-            Alice,
-            ""
+            amounts
         );
         vm.prank(Alice, Alice);
         erc721Vault.sendToken{ value: 500_000 }(sendOpts);


### PR DESCRIPTION
- removed "refundTo" and "memo" from messages and vaults.
- reordered field in bridge messagen and vault's op structs to make it use fewer slots.