### PR TITLE
chore(repo): grammatical errors and typos in can_process_message.go

### DIFF
--- a/packages/relayer/processor/can_process_message.go
+++ b/packages/relayer/processor/can_process_message.go
@@ -10,11 +10,11 @@ import (
 )
 
 // canProcessMessage determines whether a message is processable by the relayer.
-// there are several conditions which it would not be processable, which include:
+// There are several conditions under which it would not be processable, including:
 // - the event status is New, and the GasLimit is 0, which means only the user who
 // sent the message can process it.
 // - the event status is not New, which means it is either already processed and succeeded,
-// or its processed, failed, and is in Retriable or Failed state, where the user
+// or it is processed, failed, and is in Retriable or Failed state, where the user
 // should finish manually.
 func canProcessMessage(
 	ctx context.Context,
@@ -23,7 +23,7 @@ func canProcessMessage(
 	relayerAddress common.Address,
 	gasLimit *big.Int,
 ) bool {
-	// we can not process, exit early
+	// We cannot process, exit early.
 	if eventStatus == relayer.EventStatusNew && gasLimit == nil || gasLimit.Cmp(common.Big0) == 0 {
 		if messageOwner != relayerAddress {
 			slog.Info("gasLimit == 0 and owner is not the current relayer key, can not process.")


### PR DESCRIPTION
There are grammatical errors and typos in the comments.