### PR TITLE
fix(gp-ui): update status banner to remove fake critical error

### DIFF
--- a/packages/guardian-prover-health-check-ui/src/components/StatusBanner/StatusBanner.svelte
+++ b/packages/guardian-prover-health-check-ui/src/components/StatusBanner/StatusBanner.svelte
@@ -14,7 +14,9 @@
 	$: configuredCorrectly = $guardianProvers && $totalGuardianProvers !== 0;
 
 	$: healthy = configuredCorrectly && proverStatusesAlive === $totalGuardianProvers;
-	$: unhealthy = configuredCorrectly && proverStatusesAlive === $totalGuardianProvers - 1;
+	$: unhealthy = configuredCorrectly && 
+              proverStatusesAlive < $totalGuardianProvers && 
+              proverStatusesAlive >= $minGuardianRequirement;
 	$: critical = configuredCorrectly && proverStatusesAlive <= $minGuardianRequirement;
 
 	$: statusType =


### PR DESCRIPTION
Fix this:
<img width="1723" alt="image" src="https://github.com/taikoxyz/taiko-mono/assets/162329697/35394923-cd68-4394-843d-4f878255b4e8">
