### PR TITLE
chore(protocol): add realistic testcase to simulate behavior

### DIFF
--- a/packages/protocol/test/team/TimelockTokenPool.t.sol
+++ b/packages/protocol/test/team/TimelockTokenPool.t.sol
@@ -547,4 +547,125 @@ contract TestTimelockTokenPool is TaikoTest {
         assertEq(tko.balanceOf(Alice), 10_000e18);
         assertEq(usdc.balanceOf(Alice), 1_000_000_000e6 - paidUsdc);
     }
+
+    // Let's calculate at which date, how much is unlocked vs. withdrawable.
+    function test_realistic_scenario() public {
+        // Let's assume Alice started at Taiko 2023.02.01. 00:00:00 -> Unix timestamp is 1675206000
+        uint64 grantStart = 1_675_206_000;
+        // Full grant period of her is 4 years -> So tokens fully owned (but not unlcoked yet!) by
+        // 2027.02.01. 00:00:00
+        uint32 grantPeriod = 4 * 365 days;
+        // Half year is the cliff for "owning" tokens
+        uint64 grantCliff = grantStart + 180 days;
+
+        // 'Unlocking' starts at TGE (but not real withdrawable tokens during 1 year if unblock
+        // cliff is 1 year!!) .
+        // So let's say TGE is at 2024.06.01 (1 years 4 months of grant start - Alice 'started'
+        // 2023.02.01 at Taiko)
+        uint64 TGE = 1_717_192_800; //Equivalent of 2024.06.01
+        // Full unlocking period is 4 years, so the overall token will be available to be unlocked
+        // is 2028.06.01 ( 1 years 4 months of grant start)
+        uint32 unlockPeriod = 4 * 365 days;
+        // 1 year cliff is for unlocking, so during this period there are no withdrawable tokens.
+        uint64 unlockCliff = TGE + 365 days;
+
+        // At TGE we put Alices data into the contracts
+        vm.warp(TGE);
+
+        uint128 alice_grant_amount = 100_000e18; // Alice granted 100.000
+
+        pool.grant(
+            Alice,
+            TimelockTokenPool.Grant(
+                alice_grant_amount,
+                0, // No strike price for now
+                grantStart,
+                grantCliff,
+                grantPeriod,
+                TGE,
+                unlockCliff,
+                unlockPeriod
+            )
+        );
+        vm.prank(Vault);
+        tko.approve(address(pool), 100_000e18);
+
+        // At time of granting, obviously there is no
+        (
+            uint128 amountOwned,
+            uint128 amountUnlocked,
+            uint128 amountWithdrawn,
+            uint128 amountToWithdraw,
+            uint128 costToWithdraw
+        ) = pool.getMyGrantSummary(Alice);
+
+        // So Alice is at the company 1years 4 months -> 16 months. Fully owning is 4 years
+        // (48months).
+        // 48months / 16month  = 3, so by this time Alice owns 100k/3 = 33% owned.
+        // at TGE (2024.06.01)
+        assertEq(amountOwned, 33_284_817_351_598_173_515_981); // Close to 33% owned already, as
+            // 16month elapsed (from 48)
+        assertEq(amountUnlocked, 0); // Nothin is unlocked (withdrawable) yet
+        assertEq(amountWithdrawn, 0);
+        assertEq(amountToWithdraw, 0);
+        assertEq(costToWithdraw, 0);
+
+        // 0.5 year after TGE (2024.12.01), 22 months at company, so 48months / 22 months => cca. 45%
+        // (45K) owned but 0 unlocked yet (due to 1 year TGE cliff)
+        vm.warp(TGE + 182 days);
+        (amountOwned, amountUnlocked, amountWithdrawn, amountToWithdraw, costToWithdraw) =
+            pool.getMyGrantSummary(Alice);
+        assertEq(amountOwned, 45_750_570_776_255_707_762_557);
+        assertEq(amountUnlocked, 0);
+        assertEq(amountWithdrawn, 0);
+        assertEq(amountToWithdraw, 0);
+
+        // 1 year (+1 day) later after TGE. The owned will be 2years 4 months (48/28 months) = 58K
+        // 1/4 of this 58K is unlocked (withdrawable) -> cc 14.5K
+        vm.warp(TGE + 366 days);
+        (amountOwned, amountUnlocked, amountWithdrawn, amountToWithdraw, costToWithdraw) =
+            pool.getMyGrantSummary(Alice);
+        assertEq(amountOwned, 58_353_310_502_283_105_022_831);
+        assertEq(amountUnlocked, 14_628_295_646_462_750_985_175);
+        assertEq(amountWithdrawn, 0);
+        assertEq(amountToWithdraw, 14_628_295_646_462_750_985_175); // Withdrawable - already
+            // withdrawn amount
+
+        // 2 year later after TGE. The owned will be 3years 4 months (48/40 months) = 83K
+        // 1/2 of this 83k is unlocked (withdrawable) -> cc 41.5K
+        vm.warp(TGE + 2 * 365 days);
+        (amountOwned, amountUnlocked, amountWithdrawn, amountToWithdraw, costToWithdraw) =
+            pool.getMyGrantSummary(Alice);
+        assertEq(amountOwned, 83_284_817_351_598_173_515_981);
+        assertEq(amountUnlocked, 41_642_408_675_799_086_757_990);
+        assertEq(amountWithdrawn, 0);
+        assertEq(amountToWithdraw, 41_642_408_675_799_086_757_990);
+
+        // Fast forward to the 4year anniversarys (+1 day) when Alice started 2027.02.02.
+        // Alice owns his 100% allocaiton, but obviously not be able to withdraw all, because it is
+        // still
+        // subject to be fully unlocked - > which will be 2028.06.01.
+        // At this date: 2027.02.02, only unlocked: (2y 8 months since TGE, so 48 / 32) cca 66% of
+        // owned (which is 100K already): 66K
+        vm.warp(grantStart + 4 * 365 days + 1 days);
+        (amountOwned, amountUnlocked, amountWithdrawn, amountToWithdraw, costToWithdraw) =
+            pool.getMyGrantSummary(Alice);
+
+        // @dantaik: You can clearly see here, Alice is owning here 100% on the 4th year anniversary
+        // of her start date, but only some portion of it unlocked (which is calculated since TGE)
+        assertEq(amountOwned, alice_grant_amount); // All 100K owned, but not yet unlocked
+        assertEq(amountUnlocked, 66_783_675_799_086_757_990_867);
+        assertEq(amountWithdrawn, 0);
+        assertEq(amountToWithdraw, 66_783_675_799_086_757_990_867);
+
+        // All will be unlocked 4year post TGE
+        vm.warp(TGE + 4 * 365 days + 1 days);
+        (amountOwned, amountUnlocked, amountWithdrawn, amountToWithdraw, costToWithdraw) =
+            pool.getMyGrantSummary(Alice);
+
+        assertEq(amountOwned, alice_grant_amount);
+        assertEq(amountUnlocked, alice_grant_amount);
+        assertEq(amountWithdrawn, 0);
+        assertEq(amountToWithdraw, alice_grant_amount);
+    }
 }


### PR DESCRIPTION
@dantaik 
This is to address the fear that a token is unlocked (withdrawable) the same time when the grant grants Alice her 100%. No, it all depends on the parameters we supply in, so fully dynamic, but behavior is 100% compliant with grant letters (for labs people and taiko grants too).

Please read the testcase documentation example carefully.

To run the test:
`forge test --match-test test_realistic_scenario -vv`

