### PR TITLE
feat(protocol): delete equivalent Bridge events 

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -156,7 +156,6 @@ contract Bridge is EssentialContract, IBridge {
         msgHash_ = hashMessage(message_);
 
         emit MessageSent(msgHash_, message_);
-
         ISignalService(resolve(LibStrings.B_SIGNAL_SERVICE, false)).sendSignal(msgHash_);
     }
 

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -319,11 +319,12 @@ contract Bridge is EssentialContract, IBridge {
         if (msg.sender != _message.destOwner) revert B_PERMISSION_DENIED();
 
         bytes32 msgHash = hashMessage(_message);
-        if (messageStatus[msgHash] != Status.RETRIABLE) {
-            revert B_NON_RETRIABLE();
-        }
+        if (messageStatus[msgHash] != Status.RETRIABLE) revert B_NON_RETRIABLE();
 
-        _updateMessageStatus(msgHash, Status.RECALLED);
+        _updateMessageStatus(msgHash, Status.FAILED);
+        ISignalService(resolve(LibStrings.B_SIGNAL_SERVICE, false)).sendSignal(
+            signalForFailedMessage(msgHash)
+        );
     }
 
     /// @inheritdoc IBridge

--- a/packages/protocol/contracts/bridge/IBridge.sol
+++ b/packages/protocol/contracts/bridge/IBridge.sol
@@ -59,18 +59,6 @@ interface IBridge {
     /// @param message The message.
     event MessageSent(bytes32 indexed msgHash, Message message);
 
-    /// @notice Emitted when a message is recalled.
-    /// @param msgHash The hash of the message.
-    event MessageRecalled(bytes32 indexed msgHash);
-
-    /// @notice Emitted when a message is executed.
-    /// @param msgHash The hash of the message.
-    event MessageExecuted(bytes32 indexed msgHash);
-
-    /// @notice Emitted when a message is marked failed.
-    /// @param msgHash The hash of the message.
-    event MessageFailed(bytes32 indexed msgHash);
-
     /// @notice Emitted when the status of a message changes.
     /// @param msgHash The hash of the message.
     /// @param status The new status of the message.


### PR DESCRIPTION
Deleted the following events:

```
- event MessageRecalled(bytes32 indexed msgHash)
-  event MessageExecuted(bytes32 indexed msgHash)
-  event MessageFailed(bytes32 indexed msgHash)
```

@cyberhorsey @KorbinianK are you guys using the these events or `MessageStatusChanged` instead?