### PR TITLE
feat(protocol): use CREATE2 for shorter addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ __pycache__/
 .vscode/launch.json
 packages/protocol/config.js
 .vercel
+packages/protocol/script/*.txt

--- a/packages/protocol/script/compute_addr.py
+++ b/packages/protocol/script/compute_addr.py
@@ -29,7 +29,7 @@ def find_smallest_address(deployer_address, keccak256_bytecode, shared_state, lo
         salt_hex = Web3.to_hex(current_salt)
         new_address = compute_create2_address(deployer_address, salt_hex, keccak256_bytecode)
         if count % 100000 == 0:  # Report every 100000 iterations
-            print(f"Process {os.getpid()}: Checking salt {salt_hex}, current smallest: {shared_state[0]}")
+            print(f"Process {os.getpid()}: current salt {salt_hex}, current smallest: {shared_state[0]}")
         with lock:
             smallest_address, smallest_salt = shared_state[0], shared_state[1]
             if new_address < smallest_address:

--- a/packages/protocol/script/compute_addr.py
+++ b/packages/protocol/script/compute_addr.py
@@ -1,0 +1,65 @@
+import os
+import multiprocessing
+from web3 import Web3
+
+def compute_create2_address(deployer_address, salt, keccak256_bytecode):
+    deployer_address_bytes = Web3.to_bytes(hexstr=deployer_address)
+    salt_bytes = Web3.to_bytes(hexstr=salt)
+    bytecode_hash_bytes = Web3.to_bytes(hexstr=keccak256_bytecode)
+    combined = b'\xff' + deployer_address_bytes + salt_bytes + bytecode_hash_bytes
+    address_hash = Web3.keccak(combined)
+    return '0x' + address_hash[-20:].hex()
+
+def load_state(file_path):
+    if os.path.exists(file_path):
+        with open(file_path, 'r') as file:
+            data = file.read().split(',')
+            return int(data[0], 16), data[1]
+    return None, '0x0'
+
+def save_state(file_path, salt, address, lock):
+    with lock:
+        with open(file_path, 'w') as file:
+            file.write(f"{salt},{address}")
+
+def find_smallest_address(deployer_address, keccak256_bytecode, file_path, lock, range_start, range_end):
+    initial_salt, smallest_address = load_state(file_path)
+
+    current_salt = range_start
+    while current_salt < range_end:
+        salt_hex = Web3.to_hex(current_salt)
+        new_address = compute_create2_address(deployer_address, salt_hex, keccak256_bytecode)
+        if smallest_address == '0x0' or new_address < smallest_address:
+            smallest_address = new_address
+            save_state(file_path, salt_hex, smallest_address, lock)
+            print(f"Thread {os.getpid()}: New smallest address: {smallest_address} with salt {salt_hex}")
+        current_salt += 1
+
+def main():
+    deployer_address = '0x1234567890123456789012345678901234567890'
+
+    keccak256_bytecode = '0xd1d246dd74f52e9a2b7590b717f82d7a9ccaff0705acda80552d3e3a5f3b8f03'
+
+    file_path = keccak256_bytecode[0:10] + ".txt"
+    num_processes = multiprocessing.cpu_count()
+
+    # Creating a lock for file operations
+    lock = multiprocessing.Lock()
+
+    # Calculate the range of salts each process will handle
+    salt_start = 0
+    salt_range = 2**64 // num_processes
+
+    processes = []
+    for i in range(num_processes):
+        process_range_start = salt_start + i * salt_range
+        process_range_end = process_range_start + salt_range
+        process = multiprocessing.Process(target=find_smallest_address, args=(deployer_address, keccak256_bytecode, file_path, lock, process_range_start, process_range_end))
+        processes.append(process)
+        process.start()
+
+    for process in processes:
+        process.join()
+
+if __name__ == "__main__":
+    main()

--- a/packages/protocol/script/compute_addr.py
+++ b/packages/protocol/script/compute_addr.py
@@ -8,7 +8,7 @@ def compute_create2_address(deployer_address, salt, keccak256_bytecode):
     bytecode_hash_bytes = Web3.to_bytes(hexstr=keccak256_bytecode)
     combined = b'\xff' + deployer_address_bytes + salt_bytes + bytecode_hash_bytes
     address_hash = Web3.keccak(combined)
-    return '0x' + address_hash[-20:].hex()
+    return address_hash[-20:].hex()
 
 def load_state(file_path):
     if os.path.exists(file_path):

--- a/packages/protocol/script/compute_addr.py
+++ b/packages/protocol/script/compute_addr.py
@@ -8,58 +8,64 @@ def compute_create2_address(deployer_address, salt, keccak256_bytecode):
     bytecode_hash_bytes = Web3.to_bytes(hexstr=keccak256_bytecode)
     combined = b'\xff' + deployer_address_bytes + salt_bytes + bytecode_hash_bytes
     address_hash = Web3.keccak(combined)
-    return address_hash[-20:].hex()
+    return '0x' + address_hash[-20:].hex()
 
 def load_state(file_path):
     if os.path.exists(file_path):
         with open(file_path, 'r') as file:
             data = file.read().split(',')
-            return int(data[0], 16), data[1]
-    return None, '0x0'
+            return data[0], data[1]
+    return '0xffffffffffffffffffffffffffffffffffffffff', '0x0'  # Default to highest possible address and zero salt
 
-def save_state(file_path, salt, address, lock):
-    with lock:
-        with open(file_path, 'w') as file:
-            file.write(f"{salt},{address}")
+def save_state(file_path, salt, address):
+    with open(file_path, 'w') as file:
+        file.write(f"{salt},{address}")
 
-def find_smallest_address(deployer_address, keccak256_bytecode, file_path, lock, range_start, range_end):
-    initial_salt, smallest_address = load_state(file_path)
-
+def find_smallest_address(deployer_address, keccak256_bytecode, shared_state, lock, range_start, range_end):
+    print(f"Process {os.getpid()} starting from {range_start} to {range_end}")  # Diagnostic print
     current_salt = range_start
+    count = 0  # Add a counter to periodically report progress
     while current_salt < range_end:
         salt_hex = Web3.to_hex(current_salt)
         new_address = compute_create2_address(deployer_address, salt_hex, keccak256_bytecode)
-        if smallest_address == '0x0' or new_address < smallest_address:
-            smallest_address = new_address
-            save_state(file_path, salt_hex, smallest_address, lock)
-            print(f"Thread {os.getpid()}: New smallest address: {smallest_address} with salt {salt_hex}")
+        if count % 100000 == 0:  # Report every 100000 iterations
+            print(f"Process {os.getpid()}: Checking salt {salt_hex}, current smallest: {shared_state[0]}")
+        with lock:
+            smallest_address, smallest_salt = shared_state[0], shared_state[1]
+            if new_address < smallest_address:
+                shared_state[0] = new_address
+                shared_state[1] = salt_hex
+                print(f"Process {os.getpid()}: New smallest address: {new_address} with salt {salt_hex}")
         current_salt += 1
+        count += 1
+
 
 def main():
     deployer_address = '0x1234567890123456789012345678901234567890'
-
-    keccak256_bytecode = '0xd1d246dd74f52e9a2b7590b717f82d7a9ccaff0705acda80552d3e3a5f3b8f03'
-
+    keccak256_bytecode = '0xd1d346dd74f52e9a2b7590b717f82d7a9ccaff0705acda80552d3e3a5f3b8f03'
     file_path = keccak256_bytecode[0:10] + ".txt"
+
     num_processes = multiprocessing.cpu_count()
-
-    # Creating a lock for file operations
-    lock = multiprocessing.Lock()
-
-    # Calculate the range of salts each process will handle
-    salt_start = 0
-    salt_range = 2**64 // num_processes
+    manager = multiprocessing.Manager()
+    shared_state = manager.list(load_state(file_path))  # Load initial state or default
+    lock = manager.Lock()
 
     processes = []
+    salt_range = 2**24  # Smaller salt range for faster processing
+    salt_start = 0
+
     for i in range(num_processes):
         process_range_start = salt_start + i * salt_range
         process_range_end = process_range_start + salt_range
-        process = multiprocessing.Process(target=find_smallest_address, args=(deployer_address, keccak256_bytecode, file_path, lock, process_range_start, process_range_end))
+        process = multiprocessing.Process(target=find_smallest_address, args=(deployer_address, keccak256_bytecode, shared_state, lock, process_range_start, process_range_end))
         processes.append(process)
         process.start()
 
     for process in processes:
         process.join()
+
+    # Save the final state once all processes have finished
+    save_state(file_path, shared_state[1], shared_state[0])
 
 if __name__ == "__main__":
     main()

--- a/packages/protocol/test/DeployCapability.sol
+++ b/packages/protocol/test/DeployCapability.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
 
 import "forge-std/src/console2.sol";
 import "forge-std/src/Script.sol";
@@ -18,12 +19,18 @@ abstract contract DeployCapability is Script {
         string memory name,
         address impl,
         bytes memory data,
-        address registerTo
+        address registerTo,
+        bytes32 salt
     )
         internal
         returns (address proxy)
     {
-        proxy = address(new ERC1967Proxy(impl, data));
+        bytes memory bytecode =
+            abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(impl, data));
+
+        proxy = address(Create2.deploy(0, salt, bytecode));
+
+        // proxy = address(new ERC1967Proxy(impl, data));
 
         if (registerTo != address(0)) {
             AddressManager(registerTo).setAddress(
@@ -37,6 +44,7 @@ abstract contract DeployCapability is Script {
         console2.log("  owner      :", OwnableUpgradeable(proxy).owner());
         console2.log("  msg.sender :", msg.sender);
         console2.log("  this       :", address(this));
+        console2.logBytes32(keccak256(bytecode));
 
         vm.writeJson(
             vm.serializeAddress("deployment", name, proxy),
@@ -47,12 +55,24 @@ abstract contract DeployCapability is Script {
     function deployProxy(
         string memory name,
         address impl,
+        bytes memory data,
+        address registerTo
+    )
+        internal
+        returns (address proxy)
+    {
+        return deployProxy(name, impl, data, registerTo, 0);
+    }
+
+    function deployProxy(
+        string memory name,
+        address impl,
         bytes memory data
     )
         internal
         returns (address proxy)
     {
-        return deployProxy(name, impl, data, address(0));
+        return deployProxy(name, impl, data, address(0), 0);
     }
 
     function register(address registerTo, string memory name, address addr) internal {


### PR DESCRIPTION
Also added a python script to compute salt so we can create shorter addresses for contracts on L1.