### PR TITLE
feat(protocol): pause ERC20Vault by default on L2 so owner can deploy native USDC

### DIFF
--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -155,7 +155,6 @@ contract ERC20Vault is BaseVault {
         address _btokenNew
     )
         external
-        whenNotPaused
         onlyOwner
         nonReentrant
         returns (address btokenOld_)

--- a/packages/protocol/utils/generate_genesis/taikoL2.ts
+++ b/packages/protocol/utils/generate_genesis/taikoL2.ts
@@ -336,7 +336,7 @@ async function generateContractConfigs(
             variables: {
                 // EssentialContract
                 __reentry: 1, // _FALSE
-                __paused: 1, // _FALSE
+                __paused: 2, // _TRUE
                 // EssentialContract => UUPSUpgradeable => Initializable
                 _initialized: 1,
                 _initializing: false,


### PR DESCRIPTION
After a business conversation with Circle, we decided to deploy native USDC right after L2 genesis. This can be done by deploying the native USDC then call `changeBridgedToken` immediately after L2 genesis, then call `unpause`.