### PR TITLE
chore(main): updated tokenomics documentation

### DIFF
--- a/packages/protocol/docs/tokenomics-whitepaper.tex
+++ b/packages/protocol/docs/tokenomics-whitepaper.tex
@@ -52,7 +52,7 @@ The total supply of Taiko Tokens, "TKO", is fixed at 1 billion, with 18 decimals
     \item \href{https://ethereum.org/en/developers/docs/layer-2-scaling/}{Ethereum Layer 1 and Layer 2 Integration}
     \item \href{https://ethereum.org/en/governance/}{Ethereum Governance Documentation}
     \item \href{https://ethereum.org/en/whitepaper/}{Ethereum Whitepaper}
-    \item \href{https://docs.soliditylang.org/en/v0.8.3/}{Solidity Documentation}
+    \item \href{https://docs.soliditylang.org/en/v0.8.25/}{Solidity Documentation}
     \item \href{https://consensys.net/blog/blockchain-explained/what-is-a-dao-and-how-do-they-work/}{Understanding DAOs in Ethereum}
 \end{enumerate}
 \end{document}


### PR DESCRIPTION
The link to the official solidity documentation is updated to the latest version. This update is to resolve the issue https://github.com/taikoxyz/taiko-mono/issues/16598.
