### PR TITLE
fix(bridge-ui): update disabled for chainselector

### DIFF
--- a/packages/bridge-ui/src/components/ChainSelectors/ChainPill/ChainPill.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/ChainPill/ChainPill.svelte
@@ -9,10 +9,10 @@
   import { classNames } from '$libs/util/classNames';
   import { truncateString } from '$libs/util/truncateString';
   import { uid } from '$libs/util/uid';
+  import { account } from '$stores';
 
   export let value: Maybe<Chain> | null = null;
   export let label = '';
-  export let readOnly = false;
   export let selectChain: (event: CustomEvent<{ chain: Chain; switchWallet: boolean }>) => Promise<void>;
 
   export let switchWallet = false;
@@ -34,6 +34,8 @@
       modalOpen = true;
     }
   };
+
+  $: disabled = !$account || !$account.isConnected;
 </script>
 
 <div class={classes}>
@@ -44,7 +46,7 @@
     <button
       id={buttonId}
       type="button"
-      disabled={readOnly}
+      {disabled}
       aria-haspopup="dialog"
       aria-controls={dialogId}
       aria-expanded={modalOpen}

--- a/packages/bridge-ui/src/components/ChainSelectors/ChainPill/ChainPill.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/ChainPill/ChainPill.svelte
@@ -13,6 +13,7 @@
 
   export let value: Maybe<Chain> | null = null;
   export let label = '';
+  export let readOnly = false;
   export let selectChain: (event: CustomEvent<{ chain: Chain; switchWallet: boolean }>) => Promise<void>;
 
   export let switchWallet = false;

--- a/packages/bridge-ui/src/components/ChainSelectors/ChainPill/ChainPill.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/ChainPill/ChainPill.svelte
@@ -36,7 +36,7 @@
     }
   };
 
-  $: disabled = !$account || !$account.isConnected;
+  $: disabled = !$account || !$account.isConnected || readOnly;
 </script>
 
 <div class={classes}>

--- a/packages/bridge-ui/src/components/Faucet/Faucet.svelte
+++ b/packages/bridge-ui/src/components/Faucet/Faucet.svelte
@@ -188,7 +188,7 @@
         direction={ChainSelectorDirection.SOURCE}
         label={$t('chain_selector.currently_on')}
         switchWallet />
-      <TokenDropdown {disabled} tokens={mintableTokens} {onlyMintable} bind:value={selectedToken} />
+      <TokenDropdown tokens={mintableTokens} {onlyMintable} bind:value={selectedToken} />
     </div>
 
     {#if alertMessage}

--- a/packages/bridge-ui/src/components/Faucet/Faucet.svelte
+++ b/packages/bridge-ui/src/components/Faucet/Faucet.svelte
@@ -188,7 +188,7 @@
         direction={ChainSelectorDirection.SOURCE}
         label={$t('chain_selector.currently_on')}
         switchWallet />
-      <TokenDropdown tokens={mintableTokens} {onlyMintable} bind:value={selectedToken} />
+      <TokenDropdown {disabled} tokens={mintableTokens} {onlyMintable} bind:value={selectedToken} />
     </div>
 
     {#if alertMessage}


### PR DESCRIPTION
**Select error before connecting the wallet.**

Before update:
Select opens but the change is not active which looks like a bug.
Any actions are not active until the wallet is connected.
I think it's not supposed to work like that - https://www.youtube.com/watch?v=1GyqVcW-Xuc

<img width="519" alt="image" src="https://github.com/taikoxyz/taiko-mono/assets/96314649/68a2e0f5-6648-4586-a30e-c455b4ffd2a9">




After the update:
Select is active only after the wallet is connected.
<img width="429" alt="image" src="https://github.com/taikoxyz/taiko-mono/assets/96314649/52226c74-6482-4ae6-b671-d10d5a79ac16">
