### PR TITLE
fix(repo): typos

### DIFF
--- a/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
+++ b/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
@@ -147,7 +147,7 @@ End game: multiple zkVMs (Guardians removed)
 
 There are a few risks associated with the protocol:
 
-- The protocol does not have a robust on-chain fee estimation mechanism. On calling the on-chain functions, the relayers should provide the contracts with upto date prices for users or atleast maintain a default amount of gas to send across.
+- The protocol does not have a robust on-chain fee estimation mechanism. On calling the on-chain functions, the relayers should provide the contracts with up to date prices for users or at least maintain a default amount of gas to send across.
 - The protocol would not work perfectly with swapping protocols. This is because the bridge includes invocation delays which can cause swaps to go outdated.
 - There is an issue related to custom coinbase transfers which can create a risk among block proposers.
 

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -119,7 +119,7 @@ func (p *Processor) processMessage(
 	slog.Info(
 		"updating message status",
 		"status", relayer.EventStatus(messageStatus).String(),
-		"occuredtxHash", msgBody.Event.Raw.TxHash.Hex(),
+		"occurredtxHash", msgBody.Event.Raw.TxHash.Hex(),
 	)
 
 	if messageStatus == uint8(relayer.EventStatusRetriable) {


### PR DESCRIPTION
### Description

This pull request addresses several typographical errors found across different files in the project. The corrections made include:

- Changed "ocured" to "occurred".
- Split "upto" into "up to".
- Split "atleast" into "at least".

### Type of change

This PR involves text corrections which are aimed at improving the readability and accuracy of the project's documentation or comments in the code. These changes are non-functional and purely cosmetic.

### How Has This Been Tested?

Given that the modifications are strictly textual and non-functional, no new tests are necessary. The changes were reviewed manually to ensure that only the intended text modifications were made, without altering any actual code logic or functionality.

### Checklist:

- [x] My changes are limited to typo fixes and do not alter the functionality of the code.
- [x] I have manually reviewed the edited text to verify correctness and consistency.

### Additional Notes

Correcting these typos enhances the professionalism and clarity of the project's documentation and code comments. These improvements help maintain the quality and readability of the codebase. No further actions are required unless additional typographical errors are found.