### PR TITLE
feat(protocol): allow GuardianProver set TKO allowance for TaikoL1

### DIFF
--- a/packages/protocol/contracts/L1/TaikoToken.sol
+++ b/packages/protocol/contracts/L1/TaikoToken.sol
@@ -10,7 +10,9 @@ import "../common/LibStrings.sol";
 /// We use this contract to take 50 more slots to remove `ERC20SnapshotUpgradeable` from the parent
 /// contract list.
 /// We can simplify the code since we no longer need to maintain upgradability with Hekla.
+// solhint-disable contract-name-camelcase
 abstract contract EssentialContract_ is EssentialContract {
+    // solhint-disable var-name-mixedcase
     uint256[50] private __slots_previously_used_by_ERC20SnapshotUpgradeable;
 }
 

--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import "../../common/LibStrings.sol";
 import "../../verifiers/IVerifier.sol";
 import "../tiers/ITierProvider.sol";
@@ -12,6 +14,8 @@ import "./Guardians.sol";
 /// This prover uses itself as the verifier.
 /// @custom:security-contact security@taiko.xyz
 contract GuardianProver is IVerifier, Guardians {
+    using SafeERC20 for IERC20;
+
     error GV_PERMISSION_DENIED();
     error GV_ZERO_ADDRESS();
 
@@ -43,7 +47,7 @@ contract GuardianProver is IVerifier, Guardians {
     function enableTaikoTokenAllowance(bool _enable) external onlyOwner {
         address tko = resolve(LibStrings.B_TAIKO_TOKEN, false);
         address taiko = resolve(LibStrings.B_TAIKO, false);
-        IERC20(tko).approve(taiko, _enable ? type(uint256).max : 0);
+        IERC20(tko).safeApprove(taiko, _enable ? type(uint256).max : 0);
     }
 
     /// @dev Withdraws Taiko Token to a given address.
@@ -54,7 +58,7 @@ contract GuardianProver is IVerifier, Guardians {
 
         IERC20 tko = IERC20(resolve(LibStrings.B_TAIKO_TOKEN, false));
         uint256 amount = _amount == 0 ? tko.balanceOf(address(this)) : _amount;
-        tko.transfer(_to, amount);
+        tko.safeTransfer(_to, amount);
     }
 
     /// @dev Called by guardians to approve a guardian proof

--- a/packages/protocol/contracts/tokenvault/BridgedERC20.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20.sol
@@ -9,7 +9,9 @@ import "./BridgedERC20Base.sol";
 /// We use this contract to take 50 more slots to remove `ERC20SnapshotUpgradeable` from the parent
 /// contract list.
 /// We can simplify the code since we no longer need to maintain upgradability with Hekla.
+// solhint-disable contract-name-camelcase
 abstract contract BridgedERC20Base_ is BridgedERC20Base {
+    // solhint-disable var-name-mixedcase
     uint256[50] private __slots_previously_used_by_ERC20SnapshotUpgradeable;
 }
 

--- a/packages/protocol/script/DeployTaikoToken.s.sol
+++ b/packages/protocol/script/DeployTaikoToken.s.sol
@@ -20,13 +20,6 @@ contract DeployTaikoToken is DeployCapability {
     }
 
     function run() external broadcast {
-        // Deploy the shared address manager at first.
-        address sharedAddressManager = deployProxy({
-            name: "shared_address_manager",
-            impl: address(new AddressManager()),
-            data: abi.encodeCall(AddressManager.init, (address(0)))
-        });
-
         // Deploy the TaikoToken contract, use securityCouncil address as the owner.
         deployProxy({
             name: "taiko_token",

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -123,6 +123,8 @@ abstract contract TaikoL1TestBase is TaikoTest {
         );
 
         L1.init(address(0), address(addressManager), GENESIS_BLOCK_HASH);
+
+        gp.enableTaikoTokenAllowance(true);
         printVariables("init  ");
     }
 


### PR DESCRIPTION
When GuardianProver's tier is `TIER_GUARDIAN_MINORITY`, it will need to place validity bond by holding TKO and allow the TaikoL1 contract to transfer TKO out.

@davidtaikocha  if we deploy GuardianProver for tier `TIER_GUARDIAN_MINORITY`, we should call `enableTaikoTokenAllowance(true)` on it.