### PR TITLE
fix(bridge-ui): remove erroneous numeric expression

### DIFF
--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
@@ -10,7 +10,6 @@
   import { AddressInputState } from '$components/Bridge/SharedBridgeComponents/AddressInput/state';
   import { enteredAmount, selectedNFTs, selectedToken, tokenBalance } from '$components/Bridge/state';
   import { importDone } from '$components/Bridge/state';
-  1;
   import { detectContractType, type NFT, TokenType } from '$libs/token';
   import { checkOwnership } from '$libs/token/checkOwnership';
   import { getTokenWithInfoFromAddress } from '$libs/token/getTokenWithInfoFromAddress';


### PR DESCRIPTION
## What does this PR do?

This PR removes an erroneous `1;` expression that was inadvertently added in a previous commit. This change helps to clean up the codebase and improve its readability.

## Notes

- No functional changes are introduced.