### PR TITLE
fix(protocol): allow TaikoL1 to be paused when initialized 

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -43,7 +43,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
     /// @param _addressManager The address of the {AddressManager} contract.
     /// @param _genesisBlockHash The block hash of the genesis block.
-    /// @param _pause true to pause the contract by default
+    /// @param _pause true to pause the contract by default.
     function init(
         address _owner,
         address _addressManager,

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -43,16 +43,19 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
     /// @param _addressManager The address of the {AddressManager} contract.
     /// @param _genesisBlockHash The block hash of the genesis block.
+    /// @param _pause true to pause the contract by default
     function init(
         address _owner,
         address _addressManager,
-        bytes32 _genesisBlockHash
+        bytes32 _genesisBlockHash,
+        bool _pause
     )
         external
         initializer
     {
         __Essential_init(_owner, _addressManager);
         LibVerifying.init(state, getConfig(), _genesisBlockHash);
+        if (_pause) pause();
     }
 
     function init2() external onlyOwner reinitializer(2) {

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -301,7 +301,7 @@ contract DeployOnL1 is DeployCapability {
             name: "taiko",
             impl: address(new TaikoL1()),
             data: abi.encodeCall(
-                TaikoL1.init, (timelock, rollupAddressManager, vm.envBytes32("L2_GENESIS_HASH"))
+                TaikoL1.init, (timelock, rollupAddressManager, vm.envBytes32("L2_GENESIS_HASH"), true)
                 ),
             registerTo: rollupAddressManager
         });

--- a/packages/protocol/test/L1/TaikoL1TestBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestBase.sol
@@ -122,7 +122,7 @@ abstract contract TaikoL1TestBase is TaikoTest {
             })
         );
 
-        L1.init(address(0), address(addressManager), GENESIS_BLOCK_HASH);
+        L1.init(address(0), address(addressManager), GENESIS_BLOCK_HASH, false);
 
         gp.enableTaikoTokenAllowance(true);
         printVariables("init  ");


### PR DESCRIPTION
This enables us to config the rollup without being frontrunned by others with proposeBlock transactions.