### PR TITLE
feat(protocol): allow first block proposer to skip EOA check signature

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -140,7 +140,7 @@ library LibProposing {
             // We cannot rely on `msg.sender != tx.origin` for EOA check, as it will break after EIP
             // 7645: Alias ORIGIN to SENDER
             if (
-                _checkEOAForCalldataDA
+                _checkEOAForCalldataDA && meta_.id != 1
                     && ECDSA.recover(meta_.blobHash, params.signature) != msg.sender
             ) {
                 revert L1_INVALID_SIG();


### PR DESCRIPTION
This is to avoid the first block proposer (you know who) having to sign the txList to avoid unnecessary interaction.