### PR TITLE
fix: remove unnecessary exit() command

### DIFF
--- a/packages/protocol/script/eip1559_util.py
+++ b/packages/protocol/script/eip1559_util.py
@@ -105,7 +105,6 @@ gas_excess_issued = MAX_EXP_INPUT * ADJUSTMENT_FACTOR // SCALE
 print("spot basefee             [fix point]2 : ", calc_spot_basefee())
 
 
-exit()
 gas_excess_issued = bkup
 # one L2 block per L1 block vs multiple L2 blocks per L1 block
 x1 = []


### PR DESCRIPTION
This pull request removes an unnecessary exit() command from the end of the script, allowing the graph plotting code to execute properly. The changes ensure that the script functions as intended without any hindrance to its execution flow.