### PR TITLE
chore(blobstorage): fix blobstorage-down-migrations

### DIFF
--- a/packages/blobstorage/migrations/16667_create_blob_hashes_table.sql
+++ b/packages/blobstorage/migrations/16667_create_blob_hashes_table.sql
@@ -14,5 +14,6 @@ CREATE TABLE IF NOT EXISTS blob_hashes (
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
+DROP TABLE IF EXISTS blocks_meta;
 DROP TABLE blob_hashes;
 -- +goose StatementEnd

--- a/packages/blobstorage/migrations/16667_create_blob_hashes_table.sql
+++ b/packages/blobstorage/migrations/16667_create_blob_hashes_table.sql
@@ -15,5 +15,5 @@ CREATE TABLE IF NOT EXISTS blob_hashes (
 -- +goose Down
 -- +goose StatementBegin
 DROP TABLE IF EXISTS blocks_meta;
-DROP TABLE blob_hashes;
+DROP TABLE IF EXISTS blob_hashes;
 -- +goose StatementEnd

--- a/packages/blobstorage/migrations/16667_create_blob_hashes_table.sql
+++ b/packages/blobstorage/migrations/16667_create_blob_hashes_table.sql
@@ -12,8 +12,8 @@ CREATE TABLE IF NOT EXISTS blob_hashes (
 );
 
 -- +goose StatementEnd
+
 -- +goose Down
--- +goose StatementBegin
 DROP TABLE IF EXISTS blocks_meta;
+
 DROP TABLE IF EXISTS blob_hashes;
--- +goose StatementEnd

--- a/packages/blobstorage/migrations/16669_add_blob_hash_index.sql
+++ b/packages/blobstorage/migrations/16669_add_blob_hash_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `blob_hashes` ADD INDEX `blob_hash_index` (`blob_hash`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX blob_hash_index on blob_hashes;
+-- +goose StatementEnd

--- a/packages/blobstorage/migrations/16669_add_blob_hash_index.sql
+++ b/packages/blobstorage/migrations/16669_add_blob_hash_index.sql
@@ -1,9 +1,0 @@
--- +goose Up
--- +goose StatementBegin
-ALTER TABLE `blob_hashes` ADD INDEX `blob_hash_index` (`blob_hash`);
-
--- +goose StatementEnd
--- +goose Down
--- +goose StatementBegin
-DROP INDEX blob_hash_index on blob_hashes;
--- +goose StatementEnd

--- a/packages/blobstorage/migrations/16670_create_blocks_meta_table.sql
+++ b/packages/blobstorage/migrations/16670_create_blocks_meta_table.sql
@@ -16,11 +16,9 @@ FROM blob_hashes;
 
 -- update indexes
 DROP INDEX block_id_index on blob_hashes;
-ALTER TABLE blocks_meta ADD INDEX `block_id_index` (`block_id`);
 
 -- +goose Down
 -- reverse indexes
-DROP INDEX block_id_index on blocks_meta;
 ALTER TABLE blob_hashes ADD INDEX `block_id_index` (`block_id`);
 
 -- drop blocks_meta table

--- a/packages/blobstorage/migrations/16670_create_blocks_meta_table.sql
+++ b/packages/blobstorage/migrations/16670_create_blocks_meta_table.sql
@@ -18,8 +18,5 @@ FROM blob_hashes;
 DROP INDEX block_id_index on blob_hashes;
 
 -- +goose Down
--- reverse indexes
-ALTER TABLE blob_hashes ADD INDEX `block_id_index` (`block_id`);
-
 -- drop blocks_meta table
 DROP TABLE IF EXISTS blocks_meta;

--- a/packages/blobstorage/migrations/16671_create_unique_blob_hashes_table.sql
+++ b/packages/blobstorage/migrations/16671_create_unique_blob_hashes_table.sql
@@ -60,8 +60,7 @@ UPDATE blocks_meta bm
 JOIN blob_hashes_temp bh ON bm.blob_hash = bh.blob_hash
 SET bm.blob_hash = bh.blob_hash;
 
--- create blob_hash_index
-ALTER TABLE `blob_hashes_temp` ADD INDEX `blob_hash_index` (`blob_hash`);
+DROP `blob_hash_index` on blob_hashes_temp;
 
 -- make blob_hashes_temp the new blob_hashes
 DROP TABLE IF EXISTS blob_hashes;

--- a/packages/blobstorage/migrations/16671_create_unique_blob_hashes_table.sql
+++ b/packages/blobstorage/migrations/16671_create_unique_blob_hashes_table.sql
@@ -19,8 +19,6 @@ UPDATE blocks_meta bm
 JOIN blob_hashes_temp bh ON bm.blob_hash = bh.blob_hash
 SET bm.blob_hash = bh.blob_hash;
 
-ALTER TABLE blocks_meta DROP FOREIGN KEY blocks_meta_ibfk_1;
-
 ALTER TABLE `blob_hashes_temp` ADD INDEX `blob_hash_index` (`blob_hash`);
 
 -- make blob_hashes_temp the new blob_hashes
@@ -60,7 +58,8 @@ UPDATE blocks_meta bm
 JOIN blob_hashes_temp bh ON bm.blob_hash = bh.blob_hash
 SET bm.blob_hash = bh.blob_hash;
 
-DROP INDEX `blob_hash_index` on blob_hashes_temp;
+-- create blob_hash_index
+ALTER TABLE `blob_hashes_temp` ADD INDEX `blob_hash_index` (`blob_hash`);
 
 -- make blob_hashes_temp the new blob_hashes
 DROP TABLE IF EXISTS blob_hashes;

--- a/packages/blobstorage/migrations/16671_create_unique_blob_hashes_table.sql
+++ b/packages/blobstorage/migrations/16671_create_unique_blob_hashes_table.sql
@@ -60,7 +60,7 @@ UPDATE blocks_meta bm
 JOIN blob_hashes_temp bh ON bm.blob_hash = bh.blob_hash
 SET bm.blob_hash = bh.blob_hash;
 
-DROP `blob_hash_index` on blob_hashes_temp;
+DROP INDEX `blob_hash_index` on blob_hashes_temp;
 
 -- make blob_hashes_temp the new blob_hashes
 DROP TABLE IF EXISTS blob_hashes;


### PR DESCRIPTION
Getting an error in blobstorage-down-migrations

```
2024/05/01 06:08:16 goose run: failed to db-down: ERROR 16669_add_blob_hash_index.sql: failed to run SQL migration: failed to execute SQL query "DROP INDEX blob_hash_index on blob_hashes;": Error 1553 (HY000): Cannot drop index 'blob_hash_index': needed in a foreign key constraint
```
- Foreign keys in MySQL automatically create an index on the table. So we don't need ```16669_add_blob_hash_index.sql```
- No need to create index for the primary key
- DROP INDEX `blob_hash_index` in down migration