### PR TITLE
chore(main): update CI to ignore checks in audit files

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -12,4 +12,5 @@ extend-exclude = [
   "packages/protocol/contracts/automata-attestation/**",
   "packages/protocol/contracts/thirdparty/**",
   "packages/protocol/contracts/compiled/**",
+  "packages/protocol/audit/**",
 ]


### PR DESCRIPTION
### Description

This PR makes changes to the typo checking setup by adding the external audits folder `"packages/protocol/audit/**"` to the exclude list, otherwise these will be flagged in every PR as in #16652.

I'm assuming it's better not to fix typos in the audit files because altering them could compromise their (legal?) integrity, and those typos don't show up in any of the products or docs.






