### PR TITLE
feat(protocol): improve `TransitionProved` event to include previous prover and contester

### DIFF
--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -48,13 +48,17 @@ abstract contract TaikoEvents {
     /// @dev Emitted when a block transition is proved or re-proved.
     /// @param blockId The ID of the proven block.
     /// @param tran The verified transition.
+    /// @param prevProver The previous prover address.
+    /// @param prevContester The previous contester address.
     /// @param prover The prover address.
     /// @param validityBond The validity bond amount.
     /// @param tier The tier ID of the proof.
     event TransitionProved(
         uint256 indexed blockId,
         TaikoData.Transition tran,
-        address prover,
+        address indexed prevProver,
+        address prevContester,
+        address indexed prover,
         uint96 validityBond,
         uint16 tier
     );


### PR DESCRIPTION
This improvement will allow us to subscribe to `TransitionProved` to monitor provers of interest.