### PR TITLE
fix(protocol): fix two bridge bugs with additional tests

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -25,7 +25,7 @@ jobs:
         run: rm packages/protocol/package.json
 
       - name: Run Slither
-        uses: crytic/slither-action@v0.3.2
+        uses: crytic/slither-action@v0.4.0
         id: slither
         with:
           target: packages/protocol

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -265,7 +265,6 @@ contract Bridge is EssentialContract, IBridge {
                         (baseFee >= maxFee ? maxFee : (maxFee + baseFee) >> 1).min(_message.fee);
 
                     refundAmount -= fee;
-
                     msg.sender.sendEtherAndVerify(fee, _SEND_ETHER_GAS_LIMIT);
                 }
             }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -94,7 +94,7 @@ contract Bridge is EssentialContract, IBridge {
         _;
     }
 
-    modifier differentChain(uint64 _chainId) {
+    modifier diffChain(uint64 _chainId) {
         if (_chainId == 0 || _chainId == block.chainid) revert B_INVALID_CHAINID();
         _;
     }
@@ -167,7 +167,7 @@ contract Bridge is EssentialContract, IBridge {
     )
         external
         sameChain(_message.srcChainId)
-        differentChain(_message.destChainId)
+        diffChain(_message.destChainId)
         whenNotPaused
         nonReentrant
     {
@@ -214,7 +214,7 @@ contract Bridge is EssentialContract, IBridge {
     )
         external
         sameChain(_message.destChainId)
-        differentChain(_message.srcChainId)
+        diffChain(_message.srcChainId)
         whenNotPaused
         nonReentrant
     {
@@ -283,7 +283,7 @@ contract Bridge is EssentialContract, IBridge {
     )
         external
         sameChain(_message.destChainId)
-        differentChain(_message.srcChainId)
+        diffChain(_message.srcChainId)
         whenNotPaused
         nonReentrant
     {
@@ -318,7 +318,7 @@ contract Bridge is EssentialContract, IBridge {
     function failMessage(Message calldata _message)
         external
         sameChain(_message.destChainId)
-        differentChain(_message.srcChainId)
+        diffChain(_message.srcChainId)
         whenNotPaused
         nonReentrant
     {

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -136,11 +136,9 @@ contract Bridge is EssentialContract, IBridge {
 
         // Verify destination chain and to address.
         if (!destChainEnabled) revert B_INVALID_CHAINID();
-        if (_message.destChainId == block.chainid) revert B_INVALID_CHAINID();
 
         // Ensure the sent value matches the expected amount.
-        uint256 expectedAmount = _message.value + _message.fee;
-        if (expectedAmount != msg.value) revert B_INVALID_VALUE();
+        if (_message.value + _message.fee != msg.value) revert B_INVALID_VALUE();
 
         message_ = _message;
 
@@ -391,8 +389,10 @@ contract Bridge is EssentialContract, IBridge {
         view
         returns (bool enabled_, address destBridge_)
     {
-        destBridge_ = resolve(_chainId, "bridge", true);
-        enabled_ = destBridge_ != address(0);
+        if (_chainId != 0 && _chainId != block.chainid) {
+            destBridge_ = resolve(_chainId, "bridge", true);
+            enabled_ = destBridge_ != address(0);
+        }
     }
 
     /// @notice Gets the current context.

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -90,9 +90,9 @@ contract Bridge is EssentialContract, IBridge {
     error B_SIGNAL_NOT_RECEIVED();
 
     modifier validChainIds(uint64 _localChainId, uint64 _remoteChainId) {
-        if (
-            _localChainId != block.chainid || _remoteChainId == 0 || _remoteChainId == block.chainid
-        ) revert B_INVALID_CHAINID();
+        if (_remoteChainId == 0) revert B_INVALID_CHAINID();
+        if (_remoteChainId == block.chainid) revert B_INVALID_CHAINID();
+        if (_localChainId != block.chainid) revert B_INVALID_CHAINID();
         _;
     }
 
@@ -123,9 +123,8 @@ contract Bridge is EssentialContract, IBridge {
         returns (bytes32 msgHash_, Message memory message_)
     {
         // Ensure the message owner is not null.
-        if (_message.srcOwner == address(0) || _message.destOwner == address(0)) {
-            revert B_INVALID_USER();
-        }
+        if (_message.srcOwner == address(0)) revert B_INVALID_USER();
+        if (_message.destOwner == address(0)) revert B_INVALID_USER();
 
         if (_message.gasLimit == 0) {
             if (_message.fee != 0) revert B_INVALID_FEE();

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -94,6 +94,11 @@ contract Bridge is EssentialContract, IBridge {
         _;
     }
 
+    modifier differentChain(uint64 _chainId) {
+        if (_chainId == 0 || _chainId == block.chainid) revert B_INVALID_CHAINID();
+        _;
+    }
+
     /// @notice Function to receive Ether.
     receive() external payable { }
 
@@ -161,6 +166,7 @@ contract Bridge is EssentialContract, IBridge {
         external
         whenNotPaused
         sameChain(_message.srcChainId)
+        differentChain(_message.destChainId)
         nonReentrant
     {
         bytes32 msgHash = hashMessage(_message);
@@ -208,6 +214,7 @@ contract Bridge is EssentialContract, IBridge {
         external
         whenNotPaused
         sameChain(_message.destChainId)
+        differentChain(_message.srcChainId)
         nonReentrant
     {
         uint256 gasStart = gasleft();
@@ -279,6 +286,7 @@ contract Bridge is EssentialContract, IBridge {
         external
         whenNotPaused
         sameChain(_message.destChainId)
+        differentChain(_message.srcChainId)
         nonReentrant
     {
         bytes32 msgHash = hashMessage(_message);
@@ -313,6 +321,7 @@ contract Bridge is EssentialContract, IBridge {
         external
         whenNotPaused
         sameChain(_message.destChainId)
+        differentChain(_message.srcChainId)
         nonReentrant
     {
         if (msg.sender != _message.destOwner) revert B_PERMISSION_DENIED();

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -606,7 +606,6 @@ contract Bridge is EssentialContract, IBridge {
     {
         if (_message.to == address(0)) return true;
         if (_message.to == address(this)) return true;
-
         if (_message.to == _signalService) return true;
 
         return _message.data.length >= 4

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -128,6 +128,7 @@ contract Bridge is EssentialContract, IBridge {
         override
         nonZeroAddr(_message.srcOwner)
         nonZeroAddr(_message.destOwner)
+        diffChain(_message.destChainId)
         whenNotPaused
         nonReentrant
         returns (bytes32 msgHash_, Message memory message_)
@@ -396,10 +397,8 @@ contract Bridge is EssentialContract, IBridge {
         view
         returns (bool enabled_, address destBridge_)
     {
-        if (_chainId != 0 && _chainId != block.chainid) {
-            destBridge_ = resolve(_chainId, LibStrings.B_BRIDGE, true);
-            enabled_ = destBridge_ != address(0);
-        }
+        destBridge_ = resolve(_chainId, LibStrings.B_BRIDGE, true);
+        enabled_ = destBridge_ != address(0);
     }
 
     /// @notice Gets the current context.

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -9,8 +9,6 @@ import "../signal/ISignalService.sol";
 import "./IBridge.sol";
 import "./IQuotaManager.sol";
 
-import "forge-std/src/console2.sol";
-
 /// @title Bridge
 /// @notice See the documentation for {IBridge}.
 /// @dev Labeled in AddressResolver as "bridge". Additionally, the code hash for the same address on
@@ -233,9 +231,11 @@ contract Bridge is EssentialContract, IBridge {
         if (
             _message.to == address(0) || _message.to == address(this)
                 || _message.to == signalService
-                || _message.data.length >= 4
-                    && bytes4(_message.data) != IMessageInvocable.onMessageInvocation.selector
-                    && _message.to.isContract()
+                || (
+                    _message.data.length >= 4
+                        && bytes4(_message.data) != IMessageInvocable.onMessageInvocation.selector
+                        && _message.to.isContract()
+                )
         ) {
             // Handle special addresses that don't require actual invocation but
             // mark message as DONE
@@ -266,7 +266,6 @@ contract Bridge is EssentialContract, IBridge {
 
                     refundAmount -= fee;
 
-                    console2.log("actual fee:", fee);
                     msg.sender.sendEtherAndVerify(fee, _SEND_ETHER_GAS_LIMIT);
                 }
             }
@@ -461,8 +460,6 @@ contract Bridge is EssentialContract, IBridge {
         private
         returns (bool success_)
     {
-        console2.log("_gasLimit:", _gasLimit);
-
         assert(_message.from != address(this));
 
         if (_gasLimit == 0) return false;

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -123,8 +123,9 @@ contract Bridge is EssentialContract, IBridge {
         returns (bytes32 msgHash_, Message memory message_)
     {
         // Ensure the message owner is not null.
-        if (_message.srcOwner == address(0)) revert B_INVALID_USER();
-        if (_message.destOwner == address(0)) revert B_INVALID_USER();
+        if (_message.srcOwner == address(0) || _message.destOwner == address(0)) {
+            revert B_INVALID_USER();
+        }
 
         if (_message.gasLimit == 0) {
             if (_message.fee != 0) revert B_INVALID_FEE();

--- a/packages/protocol/contracts/libs/LibNetwork.sol
+++ b/packages/protocol/contracts/libs/LibNetwork.sol
@@ -41,7 +41,7 @@ library LibNetwork {
     /// @param _chainId The chain ID.
     /// @return true if the chain ID represents an internal Taiko devnet's base layer, false
     /// otherwise.
-    function isTaikoDevnetL1(uint256 _chainId) internal pure returns (bool) {
+    function isTaikoDevnet(uint256 _chainId) internal pure returns (bool) {
         return _chainId >= 32_300 && _chainId <= 32_400;
     }
 
@@ -51,6 +51,6 @@ library LibNetwork {
     /// @return true if the chain supports Dencun hardfork, false otherwise.
     function isDencunSupported(uint256 _chainId) internal pure returns (bool) {
         return _chainId == LibNetwork.MAINNET || _chainId == LibNetwork.HOLESKY
-            || _chainId == LibNetwork.SEPOLIA || isTaikoDevnetL1(_chainId);
+            || _chainId == LibNetwork.SEPOLIA || isTaikoDevnet(_chainId);
     }
 }

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -324,6 +324,7 @@ contract SignalService is EssentialContract, ISignalService {
         bytes32 signal = _signal;
         bytes32 value = _signal;
         address signalService = resolve(chainId, LibStrings.B_SIGNAL_SERVICE, false);
+        if (signalService == address(this)) revert SS_INVALID_MID_HOP_CHAINID();
 
         HopProof memory hop;
         bytes32 signalRoot;
@@ -349,6 +350,7 @@ contract SignalService is EssentialContract, ISignalService {
                     revert SS_INVALID_MID_HOP_CHAINID();
                 }
                 signalService = resolve(hop.chainId, LibStrings.B_SIGNAL_SERVICE, false);
+                if (signalService == address(this)) revert SS_INVALID_MID_HOP_CHAINID();
             }
 
             isFullProof = hop.accountProof.length != 0;

--- a/packages/protocol/test/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/bridge/Bridge2.t.sol
@@ -64,3 +64,27 @@ contract BridgeTest2 is TaikoTest {
         vm.stopPrank();
     }
 }
+
+contract TestToContract is IMessageInvocable {
+    uint256 public receivedEther;
+    IBridge private bridge;
+    IBridge.Context public ctx;
+
+    constructor(IBridge _bridge) {
+        bridge = _bridge;
+    }
+
+    function onMessageInvocation(bytes calldata _data) external payable {
+        ctx = bridge.context();
+        receivedEther += msg.value;
+    }
+
+    function anotherFunc(bytes calldata _data) external payable {
+        receivedEther += msg.value;
+    }
+
+    fallback() external payable {
+        ctx = bridge.context();
+        receivedEther += msg.value;
+    }
+}

--- a/packages/protocol/test/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/bridge/Bridge2.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "../TaikoTest.sol";
+
+contract BridgeTest2 is TaikoTest { }

--- a/packages/protocol/test/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/bridge/Bridge2.t.sol
@@ -22,6 +22,18 @@ contract BridgeTest2 is TaikoTest {
         vm.stopPrank();
     }
 
+    modifier assertSameTotalBalance() {
+        uint256 totalBalance = getBalanceForAccounts();
+        _;
+        uint256 totalBalance2 = getBalanceForAccounts();
+        assertEq(totalBalance2, totalBalance);
+    }
+
+    modifier dealEther(address addr) {
+        vm.deal(addr, 100 ether);
+        _;
+    }
+
     function setUp() public {
         owner = vm.addr(0x1000);
         remoteChainId = uint64(block.chainid + 1);
@@ -62,6 +74,10 @@ contract BridgeTest2 is TaikoTest {
 
         addressManager.setAddress(remoteChainId, "bridge", remoteBridge);
         vm.stopPrank();
+    }
+
+    function getBalanceForAccounts() public view returns (uint256) {
+        return Alice.balance + Bob.balance + Carol.balance + David.balance + address(bridge).balance;
     }
 }
 

--- a/packages/protocol/test/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/bridge/Bridge2.t.sol
@@ -80,29 +80,3 @@ contract BridgeTest2 is TaikoTest {
         return Alice.balance + Bob.balance + Carol.balance + David.balance + address(bridge).balance;
     }
 }
-
-contract TestToContract is IMessageInvocable {
-    uint256 public receivedEther;
-    IBridge private bridge;
-    IBridge.Context public ctx;
-
-    constructor(IBridge _bridge) {
-        bridge = _bridge;
-    }
-
-    function onMessageInvocation(bytes calldata) external payable {
-        ctx = bridge.context();
-        receivedEther += msg.value;
-    }
-
-    function anotherFunc(bytes calldata) external payable {
-        receivedEther += msg.value;
-    }
-
-    fallback() external payable {
-        ctx = bridge.context();
-        receivedEther += msg.value;
-    }
-
-    receive() external payable { }
-}

--- a/packages/protocol/test/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/bridge/Bridge2.t.sol
@@ -74,12 +74,12 @@ contract TestToContract is IMessageInvocable {
         bridge = _bridge;
     }
 
-    function onMessageInvocation(bytes calldata _data) external payable {
+    function onMessageInvocation(bytes calldata) external payable {
         ctx = bridge.context();
         receivedEther += msg.value;
     }
 
-    function anotherFunc(bytes calldata _data) external payable {
+    function anotherFunc(bytes calldata) external payable {
         receivedEther += msg.value;
     }
 
@@ -87,4 +87,6 @@ contract TestToContract is IMessageInvocable {
         ctx = bridge.context();
         receivedEther += msg.value;
     }
+
+    receive() external payable { }
 }

--- a/packages/protocol/test/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/bridge/Bridge2.t.sol
@@ -27,6 +27,7 @@ contract BridgeTest2 is TaikoTest {
         _;
         uint256 totalBalance2 = getBalanceForAccounts();
         assertEq(totalBalance2, totalBalance);
+        assertEq(address(signalService).balance, 0);
     }
 
     modifier dealEther(address addr) {
@@ -34,13 +35,12 @@ contract BridgeTest2 is TaikoTest {
         _;
     }
 
-    function setUp() public {
+    function setUp() public dealEther(owner) {
         owner = vm.addr(0x1000);
         remoteChainId = uint64(block.chainid + 1);
         remoteBridge = vm.addr(0x2000);
 
         vm.startPrank(owner);
-        vm.deal(owner, 100 ether);
 
         addressManager = AddressManager(
             deployProxy({
@@ -77,6 +77,7 @@ contract BridgeTest2 is TaikoTest {
     }
 
     function getBalanceForAccounts() public view returns (uint256) {
-        return Alice.balance + Bob.balance + Carol.balance + David.balance + address(bridge).balance;
+        return Alice.balance + Bob.balance + Carol.balance + David.balance + address(bridge).balance
+            + owner.balance;
     }
 }

--- a/packages/protocol/test/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/bridge/Bridge2.t.sol
@@ -3,4 +3,59 @@ pragma solidity 0.8.24;
 
 import "../TaikoTest.sol";
 
-contract BridgeTest2 is TaikoTest { }
+contract BridgeTest2 is TaikoTest {
+    address public owner;
+    uint64 public remoteChainId;
+    address public remoteBridge;
+    AddressManager public addressManager;
+    SignalService public signalService;
+    Bridge public bridge;
+
+    modifier transactedBy(address addr) {
+        vm.deal(addr, 100 ether);
+        vm.startPrank(addr);
+
+        _;
+        vm.stopPrank();
+    }
+
+    function setUp() public {
+        owner = vm.addr(0x1000);
+        remoteChainId = uint64(block.chainid + 1);
+        remoteBridge = vm.addr(0x2000);
+
+        vm.startPrank(owner);
+        vm.deal(owner, 100 ether);
+
+        addressManager = AddressManager(
+            deployProxy({
+                name: "address_manager",
+                impl: address(new AddressManager()),
+                data: abi.encodeCall(AddressManager.init, (address(0)))
+            })
+        );
+
+        signalService = SkipProofCheckSignal(
+            deployProxy({
+                name: "signal_service",
+                impl: address(new SkipProofCheckSignal()),
+                data: abi.encodeCall(SignalService.init, (address(0), address(addressManager))),
+                registerTo: address(addressManager)
+            })
+        );
+
+        bridge = Bridge(
+            payable(
+                deployProxy({
+                    name: "bridge",
+                    impl: address(new Bridge()),
+                    data: abi.encodeCall(Bridge.init, (address(0), address(addressManager))),
+                    registerTo: address(addressManager)
+                })
+            )
+        );
+
+        addressManager.setAddress(remoteChainId, "bridge", remoteBridge);
+        vm.stopPrank();
+    }
+}

--- a/packages/protocol/test/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/bridge/Bridge2.t.sol
@@ -4,9 +4,12 @@ pragma solidity 0.8.24;
 import "../TaikoTest.sol";
 
 contract BridgeTest2 is TaikoTest {
+    bytes public constant fakeProof = "";
+
     address public owner;
     uint64 public remoteChainId;
     address public remoteBridge;
+
     AddressManager public addressManager;
     SignalService public signalService;
     Bridge public bridge;
@@ -54,6 +57,8 @@ contract BridgeTest2 is TaikoTest {
                 })
             )
         );
+
+        vm.deal(address(bridge), 10_000 ether);
 
         addressManager.setAddress(remoteChainId, "bridge", remoteBridge);
         vm.stopPrank();

--- a/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
@@ -3,4 +3,50 @@ pragma solidity 0.8.24;
 
 import "./Bridge2.t.sol";
 
-contract BridgeTest2_failMessage is BridgeTest2 { }
+contract TestToContract {
+    function anotherFunc() external { }
+}
+
+contract BridgeTest2_failMessage is BridgeTest2 {
+    function test_bridge2_failMessage_not_by_destOwner() public transactedBy(Carol) {
+        IBridge.Message memory message;
+        message.destChainId = uint64(block.chainid);
+        message.srcChainId = remoteChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 1000;
+        message.value = 2 ether;
+        message.destOwner = Alice;
+        message.to = Bob;
+
+        vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
+        bridge.failMessage(message);
+    }
+
+    function test_bridge2_failMessage_by_destOwner() public transactedBy(Alice) {
+        TestToContract target = new TestToContract();
+
+        IBridge.Message memory message;
+
+        message.destChainId = uint64(block.chainid);
+        message.srcChainId = remoteChainId;
+
+        message.gasLimit = 1_000_000;
+        message.fee = 5_000_000;
+        message.value = 2 ether;
+        message.destOwner = Alice;
+        message.to = address(target);
+        message.data = abi.encodeCall(TestToContract.anotherFunc, ());
+
+        vm.expectRevert(Bridge.B_INVALID_STATUS.selector);
+        bridge.failMessage(message);
+
+        bridge.processMessage(message, fakeProof);
+        bytes32 hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.RETRIABLE);
+
+        bridge.failMessage(message);
+
+        hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.FAILED);
+    }
+}

--- a/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./Bridge2.t.sol";
+
+contract BridgeTest2_failMessage is BridgeTest2 { }

--- a/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
@@ -67,9 +67,6 @@ contract BridgeTest2_failMessage is BridgeTest2 {
         message.destOwner = Alice;
         message.to = David;
 
-        uint256 aliceBalance = Alice.balance;
-        uint256 davidBalance = David.balance;
-
         bridge.processMessage(message, fakeProof);
         bytes32 hash = bridge.hashMessage(message);
         assertTrue(bridge.messageStatus(hash) == IBridge.Status.DONE);

--- a/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
@@ -3,10 +3,6 @@ pragma solidity 0.8.24;
 
 import "./Bridge2.t.sol";
 
-contract TestToContract {
-    function anotherFunc() external { }
-}
-
 contract BridgeTest2_failMessage is BridgeTest2 {
     function test_bridge2_failMessage_not_by_destOwner() public transactedBy(Carol) {
         IBridge.Message memory message;
@@ -23,7 +19,7 @@ contract BridgeTest2_failMessage is BridgeTest2 {
     }
 
     function test_bridge2_failMessage_by_destOwner__message_failed() public transactedBy(Alice) {
-        TestToContract target = new TestToContract();
+        TestToContract target = new TestToContract(bridge);
 
         IBridge.Message memory message;
 
@@ -35,7 +31,7 @@ contract BridgeTest2_failMessage is BridgeTest2 {
         message.value = 2 ether;
         message.destOwner = Alice;
         message.to = address(target);
-        message.data = abi.encodeCall(TestToContract.anotherFunc, ());
+        message.data = abi.encodeCall(TestToContract.anotherFunc, ("hi"));
 
         vm.expectRevert(Bridge.B_INVALID_STATUS.selector);
         bridge.failMessage(message);

--- a/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_failMessage.t.sol
@@ -4,7 +4,11 @@ pragma solidity 0.8.24;
 import "./Bridge2.t.sol";
 
 contract BridgeTest2_failMessage is BridgeTest2 {
-    function test_bridge2_failMessage_not_by_destOwner() public transactedBy(Carol) {
+    function test_bridge2_failMessage_not_by_destOwner()
+        public
+        transactedBy(Carol)
+        assertSameTotalBalance
+    {
         IBridge.Message memory message;
         message.destChainId = uint64(block.chainid);
         message.srcChainId = remoteChainId;
@@ -18,10 +22,12 @@ contract BridgeTest2_failMessage is BridgeTest2 {
         bridge.failMessage(message);
     }
 
-    function test_bridge2_failMessage_by_destOwner__message_retriable() public {
-        vm.deal(Alice, 100 ether);
-        vm.deal(Carol, 100 ether);
-
+    function test_bridge2_failMessage_by_destOwner__message_retriable()
+        public
+        dealEther(Alice)
+        dealEther(Carol)
+        assertSameTotalBalance
+    {
         IBridge.Message memory message;
 
         message.destChainId = uint64(block.chainid);
@@ -55,6 +61,7 @@ contract BridgeTest2_failMessage is BridgeTest2 {
     function test_bridge2_failMessage_by_destOwner__message_processed()
         public
         transactedBy(Alice)
+        assertSameTotalBalance
     {
         IBridge.Message memory message;
 

--- a/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
@@ -3,4 +3,33 @@ pragma solidity 0.8.24;
 
 import "./Bridge2.t.sol";
 
-contract BridgeTest2_processMessage is BridgeTest2 { }
+contract BridgeTest2_processMessage is BridgeTest2 {
+    function test_bridge2_processMessage_basic() public {
+        vm.deal(Alice, 100 ether);
+
+        IBridge.Message memory message;
+
+        vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
+        vm.prank(Alice);
+        bridge.processMessage(message, fakeProof);
+
+        // message.destChainId = uint64(block.chainid);
+        // vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
+        // vm.prank(Alice);
+        // bridge.processMessage(message, fakeProof);
+
+        // message.gasLimit = 1_000_000;
+        // vm.expectRevert(); // RESOLVER_ZERO_ADDR src bridge not registered
+        // vm.prank(Alice);
+        // bridge.processMessage(message, fakeProof);
+
+        // message.srcChainId = remoteChainId;
+        // address srcBridge = vm.addr(0x2000);
+
+        // vm.prank(owner);
+        // addressManager.setAddress(remoteChainId, "bridge", srcBridge);
+
+        // vm.prank(Alice);
+        // bridge.processMessage(message, fakeProof);
+    }
+}

--- a/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
@@ -6,30 +6,62 @@ import "./Bridge2.t.sol";
 contract BridgeTest2_processMessage is BridgeTest2 {
     function test_bridge2_processMessage_basic() public {
         vm.deal(Alice, 100 ether);
+        vm.startPrank(Alice);
 
         IBridge.Message memory message;
 
         vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
-        vm.prank(Alice);
         bridge.processMessage(message, fakeProof);
 
-        // message.destChainId = uint64(block.chainid);
-        // vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
-        // vm.prank(Alice);
-        // bridge.processMessage(message, fakeProof);
+        message.destChainId = uint64(block.chainid);
+        vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
+        bridge.processMessage(message, fakeProof);
 
-        // message.gasLimit = 1_000_000;
-        // vm.expectRevert(); // RESOLVER_ZERO_ADDR src bridge not registered
-        // vm.prank(Alice);
-        // bridge.processMessage(message, fakeProof);
+        message.srcChainId = uint64(block.chainid);
+        vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
+        bridge.processMessage(message, fakeProof);
 
-        // message.srcChainId = remoteChainId;
-        // address srcBridge = vm.addr(0x2000);
+        message.srcChainId = remoteChainId + 1;
+        vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
+        bridge.processMessage(message, fakeProof);
 
-        // vm.prank(owner);
-        // addressManager.setAddress(remoteChainId, "bridge", srcBridge);
+        message.srcChainId = remoteChainId;
+        vm.expectRevert(); // RESOLVER_ZERO_ADDR src bridge not registered
+        bridge.processMessage(message, fakeProof);
 
-        // vm.prank(Alice);
-        // bridge.processMessage(message, fakeProof);
+        message.gasLimit = 1_000_000;
+        bytes32 hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.NEW);
+
+        bridge.processMessage(message, fakeProof);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.DONE);
+
+        vm.stopPrank();
+
+        vm.prank(owner);
+        addressManager.setAddress(message.srcChainId, "bridge", address(0));
+
+        vm.startPrank(Alice);
+
+        message.id += 1;
+        vm.expectRevert(); // RESOLVER_ZERO_ADDR src bridge not registered
+        bridge.processMessage(message, fakeProof);
+
+        vm.stopPrank();
+    }
+
+    function test_bridge2_processMessage_basic2() public transactedBy(Carol) {
+        IBridge.Message memory message;
+
+        message.destChainId = uint64(block.chainid);
+        message.srcChainId = remoteChainId;
+
+        message.gasLimit = 1_000_000;
+        message.fee = 10_000_000;
+        vm.expectRevert(LibAddress.ETH_TRANSFER_FAILED.selector);
+        bridge.processMessage(message, fakeProof);
+
+        message.destOwner = Alice;
+        bridge.processMessage(message, fakeProof);
     }
 }

--- a/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
@@ -3,30 +3,6 @@ pragma solidity 0.8.24;
 
 import "./Bridge2.t.sol";
 
-contract TestToContract is IMessageInvocable {
-    uint256 public receivedEther;
-    IBridge private bridge;
-    IBridge.Context public ctx;
-
-    constructor(IBridge _bridge) {
-        bridge = _bridge;
-    }
-
-    function onMessageInvocation(bytes calldata _data) external payable {
-        ctx = bridge.context();
-        receivedEther += msg.value;
-    }
-
-    function anotherFunc(bytes calldata _data) external payable {
-        receivedEther += msg.value;
-    }
-
-    fallback() external payable {
-        ctx = bridge.context();
-        receivedEther += msg.value;
-    }
-}
-
 contract BridgeTest2_processMessage is BridgeTest2 {
     function test_bridge2_processMessage_basic() public {
         vm.deal(Alice, 100 ether);

--- a/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
@@ -305,15 +305,18 @@ contract BridgeTest2_processMessage is BridgeTest2 {
         message.srcChainId = remoteChainId;
 
         message.gasLimit = 1_000_000;
-        message.fee = 5_000_000;
+        message.fee = 0;
         message.value = 2 ether;
         message.destOwner = Alice;
         message.to = address(target);
         message.data = abi.encodeCall(TestToContract.anotherFunc, (""));
 
+        uint256 aliceBalance = Alice.balance;
         bridge.processMessage(message, fakeProof);
         bytes32 hash = bridge.hashMessage(message);
-        assertTrue(bridge.messageStatus(hash) == IBridge.Status.RETRIABLE);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.DONE);
+        assertEq(Alice.balance, aliceBalance + 2 ether);
+        assertEq(target.receivedEther(), 0 ether);
 
         message.data = "1";
         bridge.processMessage(message, fakeProof);

--- a/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
@@ -285,7 +285,6 @@ contract BridgeTest2_processMessage is BridgeTest2 {
         message.destOwner = Alice;
         message.to = David;
 
-        uint256 aliceBalance = Alice.balance;
         uint256 davidBalance = David.balance;
 
         bridge.processMessage(message, fakeProof);

--- a/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
@@ -50,18 +50,79 @@ contract BridgeTest2_processMessage is BridgeTest2 {
         vm.stopPrank();
     }
 
-    function test_bridge2_processMessage_basic2() public transactedBy(Carol) {
+    function test_bridge2_processMessage_no_invocation_no_fee() public transactedBy(Carol) {
         IBridge.Message memory message;
 
         message.destChainId = uint64(block.chainid);
         message.srcChainId = remoteChainId;
 
         message.gasLimit = 1_000_000;
-        message.fee = 10_000_000;
+        message.value = 2 ether;
+        message.fee = 0;
         vm.expectRevert(LibAddress.ETH_TRANSFER_FAILED.selector);
         bridge.processMessage(message, fakeProof);
 
         message.destOwner = Alice;
+        uint256 aliceBalance = Alice.balance;
         bridge.processMessage(message, fakeProof);
+        assertEq(Alice.balance, aliceBalance + 2 ether);
+
+        message.to = address(bridge);
+        aliceBalance = Alice.balance;
+        bridge.processMessage(message, fakeProof);
+        assertEq(Alice.balance, aliceBalance + 2 ether);
+
+        message.to = address(signalService);
+        aliceBalance = Alice.balance;
+        bridge.processMessage(message, fakeProof);
+        assertEq(Alice.balance, aliceBalance + 2 ether);
+    }
+
+    function test_bridge2_processMessage_invocation_no_fee_nonzero_gaslimi()
+        public
+        transactedBy(Carol)
+    {
+        IBridge.Message memory message;
+
+        message.destChainId = uint64(block.chainid);
+        message.srcChainId = remoteChainId;
+        message.gasLimit = 1_000_000;
+        message.value = 2 ether;
+        message.fee = 0;
+        message.destOwner = Alice;
+        message.to = David;
+
+        uint256 davidBalance = David.balance;
+        bridge.processMessage(message, fakeProof);
+        assertEq(David.balance, davidBalance + 2 ether);
+    }
+
+    function test_bridge2_processMessage_invocation_no_fee_zero_gaslimit() public {
+        vm.deal(Alice, 100 ether);
+        vm.startPrank(Alice);
+
+        IBridge.Message memory message;
+
+        message.destChainId = uint64(block.chainid);
+        message.srcChainId = remoteChainId;
+        message.gasLimit = 0;
+        message.value = 2 ether;
+        message.fee = 0;
+        message.destOwner = Bob;
+        message.to = David;
+
+        vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
+        bridge.processMessage(message, fakeProof);
+        vm.stopPrank();
+
+        vm.deal(Bob, 10 ether);
+        uint256 davidBalance = David.balance;
+
+        vm.prank(Bob);
+        bridge.processMessage(message, fakeProof);
+        assertEq(David.balance, davidBalance);
+
+        bytes32 hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.RETRIABLE);
     }
 }

--- a/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
@@ -50,15 +50,18 @@ contract BridgeTest2_processMessage is BridgeTest2 {
         vm.stopPrank();
     }
 
-    function test_bridge2_processMessage_no_invocation_no_fee() public transactedBy(Carol) {
+    function test_bridge2_processMessage__special_to_address__0_fee__nonezero_gaslimit()
+        public
+        transactedBy(Carol)
+    {
         IBridge.Message memory message;
 
         message.destChainId = uint64(block.chainid);
         message.srcChainId = remoteChainId;
 
         message.gasLimit = 1_000_000;
-        message.value = 2 ether;
         message.fee = 0;
+        message.value = 2 ether;
         vm.expectRevert(LibAddress.ETH_TRANSFER_FAILED.selector);
         bridge.processMessage(message, fakeProof);
 
@@ -76,28 +79,12 @@ contract BridgeTest2_processMessage is BridgeTest2 {
         aliceBalance = Alice.balance;
         bridge.processMessage(message, fakeProof);
         assertEq(Alice.balance, aliceBalance + 2 ether);
+
+        bytes32 hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.DONE);
     }
 
-    function test_bridge2_processMessage_invocation_no_fee_nonzero_gaslimi()
-        public
-        transactedBy(Carol)
-    {
-        IBridge.Message memory message;
-
-        message.destChainId = uint64(block.chainid);
-        message.srcChainId = remoteChainId;
-        message.gasLimit = 1_000_000;
-        message.value = 2 ether;
-        message.fee = 0;
-        message.destOwner = Alice;
-        message.to = David;
-
-        uint256 davidBalance = David.balance;
-        bridge.processMessage(message, fakeProof);
-        assertEq(David.balance, davidBalance + 2 ether);
-    }
-
-    function test_bridge2_processMessage_invocation_no_fee_zero_gaslimit() public {
+    function test_bridge2_processMessage__special_to_address__0_fee__0_gaslimit() public {
         vm.deal(Alice, 100 ether);
         vm.startPrank(Alice);
 
@@ -105,24 +92,161 @@ contract BridgeTest2_processMessage is BridgeTest2 {
 
         message.destChainId = uint64(block.chainid);
         message.srcChainId = remoteChainId;
-        message.gasLimit = 0;
-        message.value = 2 ether;
-        message.fee = 0;
-        message.destOwner = Bob;
-        message.to = David;
 
+        message.gasLimit = 0;
+        message.fee = 0;
+        message.value = 2 ether;
         vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
         bridge.processMessage(message, fakeProof);
-        vm.stopPrank();
 
-        vm.deal(Bob, 10 ether);
-        uint256 davidBalance = David.balance;
-
-        vm.prank(Bob);
+        message.destOwner = Alice;
+        uint256 aliceBalance = Alice.balance;
         bridge.processMessage(message, fakeProof);
-        assertEq(David.balance, davidBalance);
+        assertEq(Alice.balance, aliceBalance + 2 ether);
+
+        message.to = address(bridge);
+        aliceBalance = Alice.balance;
+        bridge.processMessage(message, fakeProof);
+        assertEq(Alice.balance, aliceBalance + 2 ether);
+
+        message.to = address(signalService);
+        aliceBalance = Alice.balance;
+        bridge.processMessage(message, fakeProof);
+        assertEq(Alice.balance, aliceBalance + 2 ether);
 
         bytes32 hash = bridge.hashMessage(message);
-        assertTrue(bridge.messageStatus(hash) == IBridge.Status.RETRIABLE);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.DONE);
+
+        vm.stopPrank();
+
+        message.value = 3 ether;
+        vm.deal(Bob, 100 ether);
+
+        vm.prank(Bob);
+        vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
+        bridge.processMessage(message, fakeProof);
+
+        hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.NEW);
     }
+
+    function test_bridge2_processMessage__special_to_address__nonezero_fee__nonezero_gaslimit()
+        public
+    {
+        vm.deal(Alice, 100 ether);
+        vm.startPrank(Alice);
+
+        IBridge.Message memory message;
+
+        message.destChainId = uint64(block.chainid);
+        message.srcChainId = remoteChainId;
+
+        message.gasLimit = 1;
+        message.fee = 5_000_000;
+        message.value = 2 ether;
+        message.destOwner = Bob;
+
+        uint256 bobBalance = Bob.balance;
+        uint256 aliceBalance = Alice.balance;
+
+        bridge.processMessage(message, fakeProof);
+
+        assertEq(Bob.balance, bobBalance + 2 ether);
+        assertEq(Alice.balance, aliceBalance + 5_000_000);
+
+        bytes32 hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.DONE);
+
+        message.gasLimit = 10_000_000;
+        bobBalance = Bob.balance;
+        aliceBalance = Alice.balance;
+
+        bridge.processMessage(message, fakeProof);
+        assertTrue(Bob.balance > bobBalance + 2 ether);
+        assertTrue(Alice.balance < aliceBalance + 5_000_000);
+
+        vm.stopPrank();
+    }
+
+    function test_bridge2_processMessage__special_to_address__nonezero_fee__0_gaslimit() public { }
+
+    function test_bridge2_processMessage__eoa_address__0_fee__nonezero_gaslimit() public { }
+
+    function test_bridge2_processMessage__eoa_to_address__0_fee__0_gaslimit() public { }
+
+    function test_bridge2_processMessage__eoa_to_address__nonezero_fee__nonezero_gaslimit()
+        public
+    { }
+
+    function test_bridge2_processMessage__eoa_to_address__nonezero_fee__0_gaslimit() public { }
+
+    function test_bridge2_processMessage__onMessageInvocation_address__0_fee__nonezero_gaslimit()
+        public
+    { }
+
+    function test_bridge2_processMessage__onMessageInvocation_to_address__0_fee__0_gaslimit()
+        public
+    { }
+
+    function test_bridge2_processMessage__onMessageInvocation_to_address__nonezero_fee__nonezero_gaslimit(
+    )
+        public
+    { }
+
+    function test_bridge2_processMessage__onMessageInvocation_to_address__nonezero_fee__0_gaslimit()
+        public
+    { }
+
+    // function test_bridge2_processMessage_special_to_address_nonezero_fee()
+    //     public
+    //     transactedBy(Carol)
+    //public  { }
+
+    // function test_bridge2_processMessage_normal_to_address_no_fee_zero_gaslimit() public {
+    //     vm.deal(Alice, 100 ether);
+    //     vm.startPrank(Alice);
+
+    //     IBridge.Message memory message;
+
+    //     message.destChainId = uint64(block.chainid);
+    //     message.srcChainId = remoteChainId;
+    //     message.gasLimit = 0;
+    //     message.value = 2 ether;
+    //     message.fee = 0;
+    //     message.destOwner = Bob;
+    //     message.to = David;
+
+    //     vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
+    //     bridge.processMessage(message, fakeProof);
+    //     vm.stopPrank();
+
+    //     vm.deal(Bob, 10 ether);
+    //     uint256 davidBalance = David.balance;
+
+    //     vm.prank(Bob);
+    //     bridge.processMessage(message, fakeProof);
+    //     assertEq(David.balance, davidBalance);
+
+    //     bytes32 hash = bridge.hashMessage(message);
+    //     assertTrue(bridge.messageStatus(hash) == IBridge.Status.RETRIABLE);
+    // }
+
+    // function test_bridge2_processMessage_normal_to_address_no_fee_nonzero_gaslimi()
+    //     public
+    //     transactedBy(Carol)
+    // {
+    //     IBridge.Message memory message;
+
+    //     message.destChainId = uint64(block.chainid);
+    //     message.srcChainId = remoteChainId;
+    //     message.gasLimit = 1_000_000;
+    //     message.value = 2 ether;
+    //     message.fee = 0;
+    //     message.destOwner = Alice;
+    //     message.to = David;
+
+    //     uint256 davidBalance = David.balance;
+    //     bridge.processMessage(message, fakeProof);
+    //     assertEq(David.balance, davidBalance + 2 ether);
+    // }
 }

--- a/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_processMessage.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./Bridge2.t.sol";
+
+contract BridgeTest2_processMessage is BridgeTest2 { }

--- a/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
@@ -52,6 +52,9 @@ contract BridgeTest2_recallMessage is BridgeTest2 {
         assertEq(address(bridge).balance, bridgeBalance + 1 ether);
 
         bridge.recallMessage(m, fakeProof);
+        bytes32 hash = bridge.hashMessage(m);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.RECALLED);
+
         assertEq(Alice.balance, aliceBalance + 1 ether);
         assertEq(Carol.balance, carolBalance - 1 ether);
         assertEq(address(bridge).balance, bridgeBalance);
@@ -101,6 +104,8 @@ contract BridgeTest2_recallMessage is BridgeTest2 {
 
         vm.prank(address(callableSender));
         bridge.recallMessage(m, fakeProof);
+        bytes32 hash = bridge.hashMessage(m);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.RECALLED);
 
         (bytes32 msgHash, address from, uint64 srcChainId) = callableSender.ctx();
         assertEq(msgHash, mhash);

--- a/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./Bridge2.t.sol";
+
+contract BridgeTest2_recallMessage is BridgeTest2 { }

--- a/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
@@ -22,7 +22,7 @@ contract TestRecallableSender is IRecallableSender, IERC165 {
 }
 
 contract BridgeTest2_recallMessage is BridgeTest2 {
-    function test_bridge2_recallMessage_basic() public transactedBy(Carol) {
+    function test_bridge2_recallMessage_basic() public transactedBy(Carol) assertSameTotalBalance {
         IBridge.Message memory message;
         message.srcOwner = Alice;
         message.destOwner = Bob;
@@ -58,9 +58,11 @@ contract BridgeTest2_recallMessage is BridgeTest2 {
         bridge.recallMessage(m, fakeProof);
     }
 
-    function test_bridge2_recallMessage_missing_local_signal_service() public {
-        vm.deal(Carol, 100 ether);
-
+    function test_bridge2_recallMessage_missing_local_signal_service()
+        public
+        dealEther(Carol)
+        assertSameTotalBalance
+    {
         IBridge.Message memory message;
         message.srcOwner = Alice;
         message.destOwner = Bob;
@@ -79,12 +81,11 @@ contract BridgeTest2_recallMessage is BridgeTest2 {
         bridge.recallMessage(m, fakeProof);
     }
 
-    function test_bridge2_recallMessage_callable_sender() public {
+    function test_bridge2_recallMessage_callable_sender() public dealEther(Carol) {
         TestRecallableSender callableSender = new TestRecallableSender(bridge);
-
         vm.deal(address(callableSender), 100 ether);
 
-        vm.deal(Carol, 100 ether);
+        uint256 totalBalance = getBalanceForAccounts() + address(callableSender).balance;
 
         IBridge.Message memory message;
         message.srcOwner = Alice;
@@ -105,5 +106,8 @@ contract BridgeTest2_recallMessage is BridgeTest2 {
         assertEq(msgHash, mhash);
         assertEq(from, address(bridge));
         assertEq(srcChainId, block.chainid);
+
+        uint256 totalBalance2 = getBalanceForAccounts() + address(callableSender).balance;
+        assertEq(totalBalance2, totalBalance);
     }
 }

--- a/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
@@ -28,7 +28,7 @@ contract TestRecallableSender is IRecallableSender, IERC165 {
 }
 
 contract BridgeTest2_recallMessage is BridgeTest2 {
-    function test_bridge2_recallMessage_1() public transactedBy(Carol) {
+    function test_bridge2_recallMessage_basic() public transactedBy(Carol) {
         IBridge.Message memory message;
         message.srcOwner = Alice;
         message.destOwner = Bob;

--- a/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
@@ -16,13 +16,7 @@ contract TestRecallableSender is IRecallableSender, IERC165 {
             || _interfaceId == type(IERC165Upgradeable).interfaceId;
     }
 
-    function onMessageRecalled(
-        IBridge.Message calldata _message,
-        bytes32 _msgHash
-    )
-        external
-        payable
-    {
+    function onMessageRecalled(IBridge.Message calldata, bytes32) external payable {
         ctx = bridge.context();
     }
 }

--- a/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_recallMessage.t.sol
@@ -3,4 +3,108 @@ pragma solidity 0.8.24;
 
 import "./Bridge2.t.sol";
 
-contract BridgeTest2_recallMessage is BridgeTest2 { }
+contract TestRecallableSender is IRecallableSender, IERC165 {
+    IBridge private bridge;
+    IBridge.Context public ctx;
+
+    constructor(IBridge _bridge) {
+        bridge = _bridge;
+    }
+
+    function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
+        return _interfaceId == type(IRecallableSender).interfaceId
+            || _interfaceId == type(IERC165Upgradeable).interfaceId;
+    }
+
+    function onMessageRecalled(
+        IBridge.Message calldata _message,
+        bytes32 _msgHash
+    )
+        external
+        payable
+    {
+        ctx = bridge.context();
+    }
+}
+
+contract BridgeTest2_recallMessage is BridgeTest2 {
+    function test_bridge2_recallMessage_1() public transactedBy(Carol) {
+        IBridge.Message memory message;
+        message.srcOwner = Alice;
+        message.destOwner = Bob;
+        message.destChainId = remoteChainId;
+        message.value = 1 ether;
+
+        vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
+        bridge.recallMessage(message, fakeProof);
+
+        message.srcChainId = uint64(block.chainid);
+        vm.expectRevert(Bridge.B_MESSAGE_NOT_SENT.selector);
+        bridge.recallMessage(message, fakeProof);
+
+        uint256 aliceBalance = Alice.balance;
+        uint256 carolBalance = Carol.balance;
+        uint256 bridgeBalance = address(bridge).balance;
+
+        (, IBridge.Message memory m) = bridge.sendMessage{ value: 1 ether }(message);
+        assertEq(Alice.balance, aliceBalance);
+        assertEq(Carol.balance, carolBalance - 1 ether);
+        assertEq(address(bridge).balance, bridgeBalance + 1 ether);
+
+        bridge.recallMessage(m, fakeProof);
+        assertEq(Alice.balance, aliceBalance + 1 ether);
+        assertEq(Carol.balance, carolBalance - 1 ether);
+        assertEq(address(bridge).balance, bridgeBalance);
+
+        // recall the same message again
+        vm.expectRevert(Bridge.B_INVALID_STATUS.selector);
+        bridge.recallMessage(m, fakeProof);
+    }
+
+    function test_bridge2_recallMessage_missing_local_signal_service() public {
+        vm.deal(Carol, 100 ether);
+
+        IBridge.Message memory message;
+        message.srcOwner = Alice;
+        message.destOwner = Bob;
+        message.destChainId = remoteChainId;
+        message.value = 1 ether;
+        message.srcChainId = uint64(block.chainid);
+
+        vm.prank(Carol);
+        (, IBridge.Message memory m) = bridge.sendMessage{ value: 1 ether }(message);
+
+        vm.prank(owner);
+        addressManager.setAddress(uint64(block.chainid), "signal_service", address(0));
+
+        vm.prank(Carol);
+        vm.expectRevert();
+        bridge.recallMessage(m, fakeProof);
+    }
+
+    function test_bridge2_recallMessage_callable_sender() public {
+        TestRecallableSender callableSender = new TestRecallableSender(bridge);
+
+        vm.deal(address(callableSender), 100 ether);
+
+        vm.deal(Carol, 100 ether);
+
+        IBridge.Message memory message;
+        message.srcOwner = Alice;
+        message.destOwner = Bob;
+        message.destChainId = remoteChainId;
+        message.value = 1 ether;
+        message.srcChainId = uint64(block.chainid);
+
+        vm.prank(address(callableSender));
+        (bytes32 mhash, IBridge.Message memory m) = bridge.sendMessage{ value: 1 ether }(message);
+
+        vm.prank(address(callableSender));
+        bridge.recallMessage(m, fakeProof);
+
+        (bytes32 msgHash, address from, uint64 srcChainId) = callableSender.ctx();
+        assertEq(msgHash, mhash);
+        assertEq(from, address(bridge));
+        assertEq(srcChainId, block.chainid);
+    }
+}

--- a/packages/protocol/test/bridge/Bridge2_retryMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_retryMessage.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./Bridge2.t.sol";
+
+contract BridgeTest2_retryMessage is BridgeTest2 { }

--- a/packages/protocol/test/bridge/Bridge2_retryMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_retryMessage.t.sol
@@ -4,10 +4,12 @@ pragma solidity 0.8.24;
 import "./Bridge2.t.sol";
 
 contract BridgeTest2_retryMessage is BridgeTest2 {
-    function test_bridge2_retryMessage() public {
-        vm.deal(Alice, 100 ether);
-        vm.deal(Carol, 100 ether);
-
+    function test_bridge2_retryMessage()
+        public
+        dealEther(Alice)
+        dealEther(Carol)
+        assertSameTotalBalance
+    {
         IBridge.Message memory message;
 
         message.destChainId = uint64(block.chainid);

--- a/packages/protocol/test/bridge/Bridge2_retryMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_retryMessage.t.sol
@@ -3,4 +3,38 @@ pragma solidity 0.8.24;
 
 import "./Bridge2.t.sol";
 
-contract BridgeTest2_retryMessage is BridgeTest2 { }
+contract BridgeTest2_retryMessage is BridgeTest2 {
+    function test_bridge2_retryMessage() public {
+        vm.deal(Alice, 100 ether);
+        vm.deal(Carol, 100 ether);
+
+        IBridge.Message memory message;
+
+        message.destChainId = uint64(block.chainid);
+        message.srcChainId = remoteChainId;
+
+        message.fee = 0;
+        message.value = 2 ether;
+        message.destOwner = Alice;
+        message.to = David;
+        message.gasLimit = bridge.getMessageMinGasLimit(0) - 1;
+
+        vm.prank(Carol);
+        bridge.processMessage(message, fakeProof);
+        bytes32 hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.RETRIABLE);
+
+        vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
+        vm.prank(Carol);
+        bridge.retryMessage(message, true);
+
+        vm.expectRevert(Bridge.B_RETRY_FAILED.selector);
+        vm.prank(Carol);
+        bridge.retryMessage(message, false);
+
+        vm.prank(Alice);
+        bridge.retryMessage(message, false);
+        hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.DONE);
+    }
+}

--- a/packages/protocol/test/bridge/Bridge2_retryMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_retryMessage.t.sol
@@ -3,13 +3,28 @@ pragma solidity 0.8.24;
 
 import "./Bridge2.t.sol";
 
+contract Target is IMessageInvocable {
+    bool public toFail;
+
+    function onMessageInvocation(bytes calldata) external payable {
+        if (toFail) revert("failed");
+    }
+
+    function setToFail(bool fail) external {
+        toFail = fail;
+    }
+}
+
 contract BridgeTest2_retryMessage is BridgeTest2 {
-    function test_bridge2_retryMessage()
+    function test_bridge2_retryMessage_1()
         public
         dealEther(Alice)
         dealEther(Carol)
         assertSameTotalBalance
     {
+        Target target = new Target();
+        target.setToFail(true);
+
         IBridge.Message memory message;
 
         message.destChainId = uint64(block.chainid);
@@ -18,8 +33,9 @@ contract BridgeTest2_retryMessage is BridgeTest2 {
         message.fee = 0;
         message.value = 2 ether;
         message.destOwner = Alice;
-        message.to = David;
-        message.gasLimit = bridge.getMessageMinGasLimit(0) - 1;
+        message.to = address(target);
+        message.data = abi.encodeCall(Target.onMessageInvocation, ("hello"));
+        message.gasLimit = 1_000_000;
 
         vm.prank(Carol);
         bridge.processMessage(message, fakeProof);
@@ -34,9 +50,48 @@ contract BridgeTest2_retryMessage is BridgeTest2 {
         vm.prank(Carol);
         bridge.retryMessage(message, false);
 
+        vm.expectRevert(Bridge.B_RETRY_FAILED.selector);
         vm.prank(Alice);
         bridge.retryMessage(message, false);
+
+        vm.prank(Alice);
+        bridge.retryMessage(message, true);
+
+        hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.FAILED);
+    }
+
+    function test_bridge2_retryMessage_2() public dealEther(Alice) dealEther(Carol) {
+        Target target = new Target();
+        target.setToFail(true);
+
+        uint256 totalBalance = getBalanceForAccounts() + address(target).balance;
+        IBridge.Message memory message;
+
+        message.destChainId = uint64(block.chainid);
+        message.srcChainId = remoteChainId;
+
+        message.fee = 0;
+        message.value = 2 ether;
+        message.destOwner = Alice;
+        message.to = address(target);
+        message.data = abi.encodeCall(Target.onMessageInvocation, ("hello"));
+        message.gasLimit = 1_000_000;
+
+        vm.prank(Carol);
+        bridge.processMessage(message, fakeProof);
+        bytes32 hash = bridge.hashMessage(message);
+        assertTrue(bridge.messageStatus(hash) == IBridge.Status.RETRIABLE);
+
+        target.setToFail(false);
+
+        vm.prank(Alice);
+        bridge.retryMessage(message, false);
+
         hash = bridge.hashMessage(message);
         assertTrue(bridge.messageStatus(hash) == IBridge.Status.DONE);
+
+        uint256 totalBalance2 = getBalanceForAccounts() + address(target).balance;
+        assertEq(totalBalance2, totalBalance);
     }
 }

--- a/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
@@ -58,7 +58,6 @@ contract BridgeTest2_sendMessage is BridgeTest2 {
     }
 
     function test_bridge2_sendMessage_invocationGasLimit() public transactedBy(Carol) {
-        // init an all-zero message
         IBridge.Message memory message;
         message.srcOwner = Alice;
         message.destOwner = Bob;

--- a/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
@@ -4,7 +4,11 @@ pragma solidity 0.8.24;
 import "./Bridge2.t.sol";
 
 contract BridgeTest2_sendMessage is BridgeTest2 {
-    function test_bridge2_sendMessage_invalid_message() public transactedBy(Carol) {
+    function test_bridge2_sendMessage_invalid_message()
+        public
+        transactedBy(Carol)
+        assertSameTotalBalance
+    {
         // init an all-zero message
         IBridge.Message memory message;
 
@@ -57,7 +61,11 @@ contract BridgeTest2_sendMessage is BridgeTest2 {
         assertTrue(mhash2 != mhash);
     }
 
-    function test_bridge2_sendMessage_invocationGasLimit() public transactedBy(Carol) {
+    function test_bridge2_sendMessage_invocationGasLimit()
+        public
+        transactedBy(Carol)
+        assertSameTotalBalance
+    {
         IBridge.Message memory message;
         message.srcOwner = Alice;
         message.destOwner = Bob;
@@ -87,9 +95,11 @@ contract BridgeTest2_sendMessage is BridgeTest2 {
         bridge.sendMessage(message);
     }
 
-    function test_bridge2_sendMessage_missing_local_signal_service() public {
-        vm.deal(Alice, 100 ether);
-
+    function test_bridge2_sendMessage_missing_local_signal_service()
+        public
+        dealEther(Alice)
+        assertSameTotalBalance
+    {
         IBridge.Message memory message;
         message.srcOwner = Alice;
         message.destOwner = Bob;

--- a/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
@@ -86,4 +86,23 @@ contract BridgeTest2_sendMessage is BridgeTest2 {
         message.fee = 0;
         bridge.sendMessage(message);
     }
+
+    function test_bridge2_sendMessage_missing_local_signal_service() public {
+        vm.deal(Alice, 100 ether);
+
+        IBridge.Message memory message;
+        message.srcOwner = Alice;
+        message.destOwner = Bob;
+        message.destChainId = remoteChainId;
+
+        vm.prank(Alice);
+        bridge.sendMessage(message);
+
+        vm.prank(owner);
+        addressManager.setAddress(uint64(block.chainid), "signal_service", address(0));
+
+        vm.prank(Alice);
+        vm.expectRevert();
+        bridge.sendMessage(message);
+    }
 }

--- a/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
@@ -41,7 +41,7 @@ contract BridgeTest2_sendMessage is BridgeTest2 {
 
         (bytes32 mhash, IBridge.Message memory m) = bridge.sendMessage{ value: 40_000_000 }(message);
         assertEq(m.id, 1);
-        assertEq(m.srcOwner, Alice);
+        assertEq(m.srcOwner, Alice); // Not Carol
         assertEq(m.srcChainId, block.chainid);
         assertEq(mhash, bridge.hashMessage(m));
 

--- a/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
@@ -3,4 +3,85 @@ pragma solidity 0.8.24;
 
 import "./Bridge2.t.sol";
 
-contract BridgeTest2_sendMessage is BridgeTest2 { }
+contract BridgeTest2_sendMessage is BridgeTest2 {
+    function test_bridge2_sendMessage_invalid_message() public transactedBy(Carol) {
+        // init an all-zero message
+        IBridge.Message memory message;
+
+        vm.expectRevert(Bridge.B_INVALID_USER.selector);
+        bridge.sendMessage(message);
+
+        message.srcOwner = Alice;
+        vm.expectRevert(Bridge.B_INVALID_USER.selector);
+        bridge.sendMessage(message);
+
+        message.destOwner = Bob;
+        vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
+        bridge.sendMessage(message);
+
+        message.destChainId = remoteChainId + 1;
+        vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
+        bridge.sendMessage(message);
+
+        message.destChainId = uint64(block.chainid);
+        vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
+        bridge.sendMessage(message);
+
+        // an bridge has been registered for remoteChainId
+        message.destChainId = remoteChainId;
+        bridge.sendMessage(message); // id = 0
+
+        message.value = 10_000_000;
+        message.gasLimit = 20_000_000;
+        message.fee = 30_000_000;
+        vm.expectRevert(Bridge.B_INVALID_VALUE.selector);
+
+        message.data = "hello";
+        bridge.sendMessage(message);
+
+        (bytes32 mhash, IBridge.Message memory m) = bridge.sendMessage{ value: 40_000_000 }(message);
+        assertEq(m.id, 1);
+        assertEq(m.srcOwner, Alice);
+        assertEq(m.srcChainId, block.chainid);
+        assertEq(mhash, bridge.hashMessage(m));
+
+        m.id = 0;
+        m.from = address(0);
+        m.srcChainId = 0;
+        assertEq(keccak256(abi.encode(message)), keccak256(abi.encode(m)));
+
+        (bytes32 mhash2, IBridge.Message memory m2) =
+            bridge.sendMessage{ value: 40_000_000 }(message);
+
+        assertEq(m2.id, 2);
+        assertTrue(mhash2 != mhash);
+    }
+
+    function test_bridge2_sendMessage_invocationGasLimit() public transactedBy(Carol) {
+        // init an all-zero message
+        IBridge.Message memory message;
+        message.srcOwner = Alice;
+        message.destOwner = Bob;
+        message.destChainId = remoteChainId;
+        message.fee = 1;
+        vm.expectRevert(Bridge.B_INVALID_FEE.selector);
+        bridge.sendMessage(message);
+
+        uint32 minGasLimit = bridge.getMessageMinGasLimit(message.data.length);
+        console2.log("minGasLimit:", minGasLimit);
+
+        message.gasLimit = minGasLimit - 1;
+        vm.expectRevert(Bridge.B_INVALID_GAS_LIMIT.selector);
+        bridge.sendMessage(message);
+
+        message.gasLimit = minGasLimit;
+        vm.expectRevert(Bridge.B_INVALID_GAS_LIMIT.selector);
+        bridge.sendMessage(message);
+
+        message.gasLimit = minGasLimit + 1;
+        vm.expectRevert(Bridge.B_INVALID_VALUE.selector);
+        bridge.sendMessage(message);
+
+        bridge.sendMessage{ value: message.fee }(message);
+    }
+}

--- a/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./Bridge2.t.sol";
+
+contract BridgeTest2_sendMessage is BridgeTest2 { }

--- a/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/bridge/Bridge2_sendMessage.t.sol
@@ -82,5 +82,8 @@ contract BridgeTest2_sendMessage is BridgeTest2 {
         bridge.sendMessage(message);
 
         bridge.sendMessage{ value: message.fee }(message);
+
+        message.fee = 0;
+        bridge.sendMessage(message);
     }
 }


### PR DESCRIPTION
## Bugs

- When `message.destOwner` calls `processMessage`,  `gasleft()` should be used to invoke the message call, not `_invocationGasLimit(_message, true)`.

-  If the following statement is evaluated to be `true`, it will always be `true`, thus `retryMessage` won't work. The fix makes sure we send ether to `message.destOwner` instead.

  ```
   _message.data.length >= 4
  && bytes4(_message.data) != IMessageInvocable.onMessageInvocation.selector
  && _message.to.isContract()
  ```

## Improvements

- checks src and dest chain IDs more carefully