### PR TITLE
fix(relayer): return revert error instead of nil

### DIFF
--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -104,7 +104,7 @@ func (p *Processor) processMessage(
 	}
 
 	if receipt.Status != types.ReceiptStatusSuccessful {
-		return false, msgBody.TimesRetried, err
+		return false, msgBody.TimesRetried, errTxReverted
 	}
 
 	messageStatus, err := p.destBridge.MessageStatus(&bind.CallOpts{


### PR DESCRIPTION
Fixed condition that checks receipt status in function, ensuring revert in case of unsuccessful transactions