### PR TITLE
feat(protocol): allow only a specified processor to process message

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -212,9 +212,11 @@ contract Bridge is EssentialContract, IBridge {
     {
         uint256 gasStart = gasleft();
 
-        // If the gas limit is set to zero, only the owner can process the message.
-        if (_message.gasLimit == 0 && msg.sender != _message.destOwner) {
-            revert B_PERMISSION_DENIED();
+        if (msg.sender != _message.destOwner) {
+            if (_message.gasLimit == 0) revert B_PERMISSION_DENIED();
+
+            address processor = resolve(LibStrings.B_BRIDGE_PROCESSOR, true);
+            if (processor != address(0) && msg.sender != processor) revert B_PERMISSION_DENIED();
         }
 
         bytes32 msgHash = hashMessage(_message);

--- a/packages/protocol/contracts/common/LibStrings.sol
+++ b/packages/protocol/contracts/common/LibStrings.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.24;
 /// @title LibStrings
 /// @custom:security-contact security@taiko.xyz
 library LibStrings {
+    bytes32 internal constant B_BRIDGE_PROCESSOR = bytes32("bridge_processor");
     bytes32 internal constant B_CHAIN_WATCHDOG = bytes32("chain_watchdog");
     bytes32 internal constant B_WITHDRAWER = bytes32("withdrawer");
     bytes32 internal constant B_PROPOSER = bytes32("proposer");


### PR DESCRIPTION
Previously a bridged message can be processed by any address on the destination chain unless the specified `message.gasLimit` is 0. 

Now the bridge can be configured with a specific "processor" address, and if `message.gasLimit `is not 0, only the `message.destOwner `and this processor can process the bridged message. This can avoid most racing conditions.

This change is backward compatible, but I actually prefer this change: https://github.com/taikoxyz/taiko-mono/pull/16999. 