### PR TITLE
refactor(protocol): improve block liveness bond handling

### DIFF
--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -33,7 +33,6 @@ abstract contract TaikoErrors {
     error L1_TRANSITION_ID_ZERO();
     error L1_TRANSITION_NOT_FOUND();
     error L1_UNAUTHORIZED();
-    error L1_UNEXPECTED_LIVENESS_BOND();
     error L1_UNEXPECTED_PARENT();
     error L1_UNEXPECTED_TRANSITION_ID();
 }

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -33,6 +33,7 @@ abstract contract TaikoErrors {
     error L1_TRANSITION_ID_ZERO();
     error L1_TRANSITION_NOT_FOUND();
     error L1_UNAUTHORIZED();
+    error L1_UNEXPECTED_LIVENESS_BOND();
     error L1_UNEXPECTED_PARENT();
     error L1_UNEXPECTED_TRANSITION_ID();
 }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -457,7 +457,7 @@ library LibProving {
         pure
         returns (bool)
     {
-        return _local.inProvingWindow
+        return _local.inProvingWindow && _local.tid == 1
             || _local.isTopTier && _proofData.length == 32
                 && bytes32(_proofData) == LibStrings.H_RETURN_LIVENESS_BOND;
     }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -384,7 +384,7 @@ library LibProving {
         uint256 reward; // reward to the new (current) prover
 
         if (_ts.contester != address(0)) {
-            assert(_blk.livenessBond == 0);
+            // assert(_blk.livenessBond == 0);
 
             if (_local.sameTransition) {
                 // The contested transition is proven to be valid, contester loses the game

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -446,6 +446,7 @@ library LibProving {
         return _amount == 0 ? 0 : (_amount * 7) >> 3;
     }
 
+    /// @dev Returns if the liveness bond shall be returned.
     function _returnLivenessBond(
         Local memory _local,
         bytes memory _proofData

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -409,6 +409,8 @@ library LibProving {
 
             uint256 livenessBond = _blk.livenessBond;
             if (livenessBond != 0) {
+                // After the first proof, the block's liveness bond will always be reset to 0.
+                // This means liveness bond will be handled only once for any given block.
                 _blk.livenessBond = 0;
 
                 if (_returnLivenessBond(_local, _proof.data)) {

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -75,7 +75,6 @@ library LibProving {
     error L1_INVALID_TIER();
     error L1_INVALID_TRANSITION();
     error L1_NOT_ASSIGNED_PROVER();
-    error L1_UNEXPECTED_LIVENESS_BOND();
 
     /// @notice Pauses or unpauses the proving process.
     /// @param _state Current TaikoData.State.

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -23,7 +23,6 @@ library LibProving {
         ITierProvider.Tier tier;
         bytes32 metaHash;
         address assignedProver;
-        uint96 livenessBond;
         uint64 slot;
         uint64 blockId;
         uint32 tid;
@@ -409,7 +408,7 @@ library LibProving {
             uint256 livenessBond = _blk.livenessBond;
             if (livenessBond != 0) {
                 if (
-                    _local.assignedProver == msg.sender && _local.inProvingWindow
+                    _local.inProvingWindow && _local.assignedProver == msg.sender
                         || _local.isTopTier && _returnLivenessBond(_proof.data)
                 ) {
                     unchecked {

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -411,11 +411,7 @@ library LibProving {
             if (livenessBond != 0) {
                 _blk.livenessBond = 0;
 
-                if (
-                    _local.inProvingWindow
-                        || _local.isTopTier && _proof.data.length == 32
-                            && bytes32(_proof.data) == LibStrings.H_RETURN_LIVENESS_BOND
-                ) {
+                if (_returnLivenessBond(_local, _proof.data)) {
                     if (_blk.assignedProver == msg.sender) {
                         reward += livenessBond;
                     } else {
@@ -448,5 +444,18 @@ library LibProving {
     /// @dev Returns the reward after applying 12.5% friction.
     function _rewardAfterFriction(uint256 _amount) private pure returns (uint256) {
         return _amount == 0 ? 0 : (_amount * 7) >> 3;
+    }
+
+    function _returnLivenessBond(
+        Local memory _local,
+        bytes memory _proofData
+    )
+        private
+        pure
+        returns (bool)
+    {
+        return _local.inProvingWindow
+            || _local.isTopTier && _proofData.length == 32
+                && bytes32(_proofData) == LibStrings.H_RETURN_LIVENESS_BOND;
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -76,6 +76,7 @@ library LibProving {
     error L1_INVALID_TIER();
     error L1_INVALID_TRANSITION();
     error L1_NOT_ASSIGNED_PROVER();
+    error L1_UNEXPECTED_LIVENESS_BOND();
 
     /// @notice Pauses or unpauses the proving process.
     /// @param _state Current TaikoData.State.

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -201,11 +201,11 @@ library LibProving {
         }
 
         local.isTopTier = local.tier.contestBond == 0;
+        local.livenessBond = blk.livenessBond;
         local.sameTransition = _tran.blockHash == ts.blockHash && _tran.stateRoot == ts.stateRoot;
         IERC20 tko = IERC20(_resolver.resolve(LibStrings.B_TAIKO_TOKEN, false));
 
         if (_proof.tier > ts.tier) {
-            local.livenessBond = blk.livenessBond;
             if (local.isTopTier && local.livenessBond != 0) {
                 if (
                     local.inProvingWindow

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -201,11 +201,12 @@ library LibProving {
         }
 
         local.isTopTier = local.tier.contestBond == 0;
+        local.sameTransition = _tran.blockHash == ts.blockHash && _tran.stateRoot == ts.stateRoot;
         IERC20 tko = IERC20(_resolver.resolve(LibStrings.B_TAIKO_TOKEN, false));
 
-        local.livenessBond = blk.livenessBond;
-        if (local.isTopTier) {
-            if (local.livenessBond != 0) {
+        if (_proof.tier > ts.tier) {
+            local.livenessBond = blk.livenessBond;
+            if (local.isTopTier && local.livenessBond != 0) {
                 if (
                     local.inProvingWindow
                         || (
@@ -218,11 +219,7 @@ library LibProving {
                 blk.livenessBond = 0;
                 local.livenessBond = 0;
             }
-        }
 
-        local.sameTransition = _tran.blockHash == ts.blockHash && _tran.stateRoot == ts.stateRoot;
-
-        if (_proof.tier > ts.tier) {
             // Handles the case when an incoming tier is higher than the current transition's tier.
             // Reverts when the incoming proof tries to prove the same transition
             // (L1_ALREADY_PROVED).

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -206,16 +206,11 @@ library LibProving {
         IERC20 tko = IERC20(_resolver.resolve(LibStrings.B_TAIKO_TOKEN, false));
 
         if (_proof.tier > ts.tier) {
-            if (local.isTopTier && local.livenessBond != 0) {
-                if (
-                    local.inProvingWindow
-                        || (
-                            _proof.data.length == 32
-                                && bytes32(_proof.data) == LibStrings.H_RETURN_LIVENESS_BOND
-                        )
-                ) {
+            if (local.livenessBond != 0) {
+                if (local.inProvingWindow || local.isTopTier && _returnLivenessBond(_proof.data)) {
                     tko.safeTransfer(local.assignedProver, local.livenessBond);
                 }
+                // Always set liveness bond to zero
                 blk.livenessBond = 0;
                 local.livenessBond = 0;
             }
@@ -455,5 +450,10 @@ library LibProving {
     /// @dev Returns the reward after applying 12.5% friction.
     function _rewardAfterFriction(uint256 _amount) private pure returns (uint256) {
         return _amount == 0 ? 0 : (_amount * 7) >> 3;
+    }
+
+    // @dev Returns if the liveness bond shall be returned
+    function _returnLivenessBond(bytes memory _proofData) private pure returns (bool) {
+        return _proofData.length == 32 && bytes32(_proofData) == LibStrings.H_RETURN_LIVENESS_BOND;
     }
 }


### PR DESCRIPTION
This PR is based on some feedback from OZ.

In this PR, the liveness bond handling logic is unified into one single section of code. When the block is proven for the first time, the liveness bond value associated with the block will be set to 0, regardless if it is returned to the assigned prover. 