### PR TITLE
refactor(protocol): improve lib proving logics - 2 (to be tested)

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -31,6 +31,7 @@ library LibProving {
         bool isTopTier;
         bool inProvingWindow;
         bool sameTransition;
+        bool xxx;
     }
 
     // Warning: Any events defined here must also be defined in TaikoEvents.sol.
@@ -162,10 +163,10 @@ library LibProving {
         // Checks if only the assigned prover is permissioned to prove the block.
         // The guardian prover is granted exclusive permission to prove only the first
         // transition.
-        if (
-            local.tier.contestBond != 0 && ts.contester == address(0) && local.tid == 1
-                && ts.tier == 0 && local.inProvingWindow
-        ) {
+
+        local.xxx = local.tier.contestBond != 0 && ts.contester == address(0) && local.tid == 1
+            && ts.tier == 0 && local.inProvingWindow;
+        if (local.xxx) {
             if (msg.sender != local.assignedProver) revert L1_NOT_ASSIGNED_PROVER();
         }
         // We must verify the proof, and any failure in proof verification will
@@ -425,7 +426,7 @@ library LibProving {
             reward = _rewardAfterFriction(_ts.validityBond);
 
             if (_local.livenessBond != 0) {
-                if (_local.assignedProver == msg.sender && _local.inProvingWindow) {
+                if (_local.xxx) {
                     unchecked {
                         reward += _local.livenessBond;
                     }


### PR DESCRIPTION
Address a concern from OZ:

---

Liveness bond return can be triggered in other conditions than first proof by assigned prover

[Location](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/contracts/L1/libs/LibProving.sol#L425-L436) Edit: I rewrote the below a bit to be clearer.
Example 

The liveness bond can be returned when it should not be if tid != 1 or if the transition has already been proven once and the assigned prover contests and proves at the same time (which is unlikely).

For example, let’s imagine a block with SGX as min proof, and the assigned prover `P` missed the proving window for the first transition. He should thus theoretically give up his liveness bond. The correct transition `A` was proven using SGX by someone else at minute [61](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/contracts/L1/tiers/TierProviderV3.sol#L28) after [blk.proposedAt](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/contracts/L1/libs/LibProving.sol#L337) (1 min after end of proving window for SGX). `P` could then prove a transition from a different (random) parent hash using a higher level proof (which has a bigger proving window) just to get his liveness bond back (see 2nd picture below). In this instance for example, he could prove a transition `B` from another parent hash using a zk proof at minute [62](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/contracts/L1/tiers/TierProviderV3.sol#L39) after block proposal (which would be in the proving window). He would get his liveness bond back, but in reality he should not as he missed the SGX proving window for tid == 1.

Essentially the check to return the liveness bond and to filter non-assigned provers should be the same but they are currently different. Cleanest fix would be to store the previous if()’s content as a new variable and pass it to `_overrideWithHigherProof`, though I know you’re short on variables with limited stack depth…