### PR TITLE
docs(protocol): add `hekla-contract-logs.md`

### DIFF
--- a/packages/protocol/contracts/L1/tiers/DevnetTierProvider.sol
+++ b/packages/protocol/contracts/L1/tiers/DevnetTierProvider.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import "../../common/EssentialContract.sol";
+import "../../common/LibStrings.sol";
 import "./ITierProvider.sol";
 
 /// @title DevnetTierProvider
@@ -31,7 +32,7 @@ contract DevnetTierProvider is EssentialContract, ITierProvider {
 
         if (_tierId == LibTiers.TIER_GUARDIAN) {
             return ITierProvider.Tier({
-                verifierName: "tier_guardian",
+                verifierName: LibStrings.B_TIER_GUARDIAN,
                 validityBond: 0, // must be 0 for top tier
                 contestBond: 0, // must be 0 for top tier
                 cooldownWindow: 60, //1 hours

--- a/packages/protocol/contracts/L1/tiers/HeklaTierProvider.sol
+++ b/packages/protocol/contracts/L1/tiers/HeklaTierProvider.sol
@@ -5,10 +5,10 @@ import "../../common/EssentialContract.sol";
 import "../../common/LibStrings.sol";
 import "./ITierProvider.sol";
 
-/// @title TierProviderHekla
+/// @title HeklaTierProvider
 /// @dev Labeled in AddressResolver as "tier_provider"
 /// @custom:security-contact security@taiko.xyz
-contract TierProviderHekla is EssentialContract, ITierProvider {
+contract HeklaTierProvider is EssentialContract, ITierProvider {
     uint256[50] private __gap;
 
     /// @notice Initializes the contract.

--- a/packages/protocol/contracts/L1/tiers/TierProviderHekla.sol
+++ b/packages/protocol/contracts/L1/tiers/TierProviderHekla.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "../../common/EssentialContract.sol";
+import "../../common/LibStrings.sol";
+import "./ITierProvider.sol";
+
+/// @title TierProviderHekla
+/// @dev Labeled in AddressResolver as "tier_provider"
+/// @custom:security-contact security@taiko.xyz
+contract TierProviderHekla is EssentialContract, ITierProvider {
+    uint256[50] private __gap;
+
+    /// @notice Initializes the contract.
+    /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
+    function init(address _owner) external initializer {
+        __Essential_init(_owner);
+    }
+
+    /// @inheritdoc ITierProvider
+    function getTier(uint16 _tierId) public pure override returns (ITierProvider.Tier memory) {
+        if (_tierId == LibTiers.TIER_OPTIMISTIC) {
+            return ITierProvider.Tier({
+                verifierName: "",
+                validityBond: 250 ether, // TKO
+                contestBond: 500 ether, // TKO
+                cooldownWindow: 1440, //24 hours
+                provingWindow: 30, // 0.5 hours
+                maxBlocksToVerifyPerProof: 12
+            });
+        }
+
+        if (_tierId == LibTiers.TIER_SGX) {
+            return ITierProvider.Tier({
+                verifierName: LibStrings.B_TIER_SGX,
+                validityBond: 250 ether, // TKO
+                contestBond: 1640 ether, // =250TKO * 6.5625
+                cooldownWindow: 1440, //24 hours
+                provingWindow: 60, // 1 hours
+                maxBlocksToVerifyPerProof: 8
+            });
+        }
+
+        if (_tierId == LibTiers.TIER_GUARDIAN) {
+            return ITierProvider.Tier({
+                verifierName: LibStrings.B_TIER_GUARDIAN,
+                validityBond: 0, // must be 0 for top tier
+                contestBond: 0, // must be 0 for top tier
+                cooldownWindow: 60, //1 hours
+                provingWindow: 2880, // 48 hours
+                maxBlocksToVerifyPerProof: 16
+            });
+        }
+
+        revert TIER_NOT_FOUND();
+    }
+
+    /// @inheritdoc ITierProvider
+    function getTierIds() public pure override returns (uint16[] memory tiers_) {
+        tiers_ = new uint16[](3);
+        tiers_[0] = LibTiers.TIER_OPTIMISTIC;
+        tiers_[1] = LibTiers.TIER_SGX;
+        tiers_[2] = LibTiers.TIER_GUARDIAN;
+    }
+
+    /// @inheritdoc ITierProvider
+    function getMinTier(uint256 _rand) public pure override returns (uint16) {
+        // 50% will be selected to require SGX proofs.
+        if (_rand % 2 == 0) return LibTiers.TIER_SGX;
+        // Other blocks are optimistic, without validity proofs.
+        return LibTiers.TIER_OPTIMISTIC;
+    }
+}

--- a/packages/protocol/deployments/hekla-contract-logs.md
+++ b/packages/protocol/deployments/hekla-contract-logs.md
@@ -1,0 +1,211 @@
+# Taiko Hekla network Contract Logs
+
+## Notes
+
+1. Code used on Hekla must correspond to a commit on the main branch of the official repo: https://github.com/taikoxyz/taiko-mono.
+
+## L1 Contracts
+
+### shared_address_manager
+
+- proxy: `0x7D3338FD5e654CAC5B10028088624CA1D64e74f7`
+- impl: `0x1B71F7014DB583Dc354d97608FAFe81e1a611c03`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### taiko_token
+
+- proxy: `0x6490E12d480549D333499236fF2Ba6676C296011`
+- impl: `0x087f33bf5141033bbf7a2acef5d8fadce9204eca`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - deployed on Mar 29, 2024 at commit `b341a68d5`
+
+### signal_service
+
+- proxy: `0x6Fc2fe9D9dd0251ec5E0727e826Afbb0Db2CBe0D`
+- impl: `0x7c20d41c2573A1225B361A3B2F667fe1F021A83B`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### bridge
+
+- proxy: `0xA098b76a3Dd499D3F6D58D8AcCaFC8efBFd06807`
+- impl: `0x74baa4826B22F7746EfEeCEc178FFbb77A2567C3`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### erc20_vault
+
+- proxy: `0x2259662ed5dE0E09943Abe701bc5f5a108eABBAa`
+- impl: `0xbE1101ED567020581127Ad065461c69c2C3A6115`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### erc721_vault
+
+- proxy: `0x046b82D9010b534c716742BE98ac3FEf3f2EC99f`
+- impl: `0xBEBD9B63dED7eC68F00f98495b60FC5eEE7f154E`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### erc1155_vault
+
+- proxy: `0x9Ae5945Ab34f6182F75E16B73e037421F341fEe3`
+- impl: `0xE1A60fD257De1A304a5b5d1EfDa38aFe52c0f910`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### bridged_erc20
+
+- impl: `0x2E062eA9f7f2D777eb67a32710BFDcE42c655B18`
+- logs:
+  - deployed on May 10, 2024 at commit `4903bec`
+
+### bridged_erc721
+
+- impl: `0xbD832CAf65c8a73609EFd62E2A4FCB1292e4c9C1`
+- logs:
+  - deployed on May 10, 2024 at commit `4903bec`
+
+### bridged_erc1155
+
+- impl: `0x0B5B063dc89EcfCedf8aF570d82598F72a7dfF35`
+- logs:
+  - deployed on May 10, 2024 at commit `4903bec`
+
+### rollup_address_manager
+
+- proxy: `0x1F027871F286Cf4B7F898B21298E7B3e090a8403`
+- impl: `0xDd39Ad18E6B8A2696394C310D5F95700dB643D27`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `13ad99d`
+
+### taikoL1
+
+- proxy: `0x79C9109b764609df928d16fC4a91e9081F7e87DB`
+- impl: `0x168FEe80cD2Cc496b504A0844aBB4eA9ec32f787`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### assignmentHook
+
+- proxy: `0x9e640a6aadf4f664CF467B795c31332f44AcBe6c`
+- impl: `0xA35ed4FAD13C038C05aC4c8FD3353B3d90d15ea5`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### tierProvider
+
+- impl: `0x02932D1c8C9EBf283aA809E7591A070c82b1696D`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### guardian_prover_minority
+
+- proxy: ``
+- impl: ``
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### guardian_prover
+
+- proxy: `0x92F195a8702da2104aE8E3E10779176E7C35d6BC`
+- impl: `0x3D351Ab46F79805e579E24E5cD94362758a99eb5`
+- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+## L2 Contracts
+
+### bridge
+
+- proxy: `0x1670090000000000000000000000000000000001`
+- impl: `0x8CC29961a0329D033C6A5fF5Ab915cceB53aEDce`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### erc20_vault
+
+- proxy: `0x1670090000000000000000000000000000000002`
+- impl: `0xFefDE79d88264E26fb1fea40f83b8C549d09075E`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### erc721_vault
+
+- proxy: `0x1670090000000000000000000000000000000003`
+- impl: `0x598Ee9B7EdbB2A838156823Ae28E2Ca98c0b5BB7`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### erc1155_vault
+
+- proxy: `0x1670090000000000000000000000000000000004`
+- impl: `0x63Ff7f4Fac6275a598DF5d86cC5e1278Db2D7346`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### signal_service
+
+- proxy: `0x1670090000000000000000000000000000000005`
+- impl: `0x6EFDeff4E88a24063aAaeF6f50470E3305eCf1Ce`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### shared_address_manager
+
+- proxy: `0x1670090000000000000000000000000000000006`
+- impl: `0x38969CEc9C1524D81264dE493b18988920C1f74b`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### taikoL2
+
+- proxy: `0x1670090000000000000000000000000000010001`
+- impl: `0x5b927DF807f84D6A993BD04f6EC0C17f7fa4cEFb`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### rollup_address_manager
+
+- proxy: `0x1670090000000000000000000000000000010002`
+- impl: `0xF74340b7E8816FA0351be5AF5fDF91b28495B99A`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
+- logs:
+  - upgraded on May 10, 2024 at commit `4903bec`
+
+### bridged_erc20
+
+- impl: `0x62Acda3Ad15B382C32B2fB21BEAc9DfB95bbb02F`
+- logs:
+  - deployed on May 10, 2024 at commit `4903bec`
+
+### bridged_erc721
+
+- impl: `0x45327BDbe23c1a3F0b437C78a19E813f9b11E566`
+- logs:
+  - deployed on May 10, 2024 at commit `4903bec`
+
+### bridged_erc1155
+
+- impl: `0xb190786090Fc4308c4C40808f3bEB55c4463c152`
+- logs:
+  - deployed on May 10, 2024 at commit `4903bec`

--- a/packages/protocol/deployments/hekla-contract-logs.md
+++ b/packages/protocol/deployments/hekla-contract-logs.md
@@ -209,3 +209,7 @@
 - impl: `0xb190786090Fc4308c4C40808f3bEB55c4463c152`
 - logs:
   - deployed on May 10, 2024 at commit `4903bec`
+
+## Other EOAs/Contracts
+
+- Holesky `TimelockController`:`0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`


### PR DESCRIPTION
You can add `0xBB02244f0906100aF99cd487fEBE49883cF97CdD` as the future owner of all L1 contracts