### PR TITLE
feat(supplementary-contracts): allow any users to withdraw to recipient

### DIFF
--- a/packages/supplementary-contracts/contracts/tokenUnlocking/TokenUnlocking.sol
+++ b/packages/supplementary-contracts/contracts/tokenUnlocking/TokenUnlocking.sol
@@ -93,12 +93,16 @@ contract TokenUnlocking is OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
     /// @notice Withdraws all withdrawable tokens.
     /// @param _to The address the token will be sent to.
-    function withdraw(address _to) external onlyRecipient nonReentrant {
+    function withdraw(address _to) external nonReentrant {
         uint256 amount = amountWithdrawable();
         if (amount == 0) revert NOT_WITHDRAWABLE();
 
-        amountWithdrawn += amount;
         address to = _to == address(0) ? recipient : _to;
+        if (to != recipient && msg.sender != recipient) {
+            revert PERMISSION_DENIED();
+        }
+
+        amountWithdrawn += amount;
         emit TokenWithdrawn(to, amount);
 
         IERC20(taikoToken).safeTransfer(to, amount);


### PR DESCRIPTION
This change is made for VCs. Some of them are not comfortable to give their private keys to internal personale to perform the withdrawal. This change will allow any address to withdraw tokens to the recipient address.