### PR TITLE
chore(bridge-ui): suggest stable coin message change

### DIFF
--- a/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/ReviewStep/ReviewStep.svelte
+++ b/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/ReviewStep/ReviewStep.svelte
@@ -30,7 +30,7 @@
 
   $: wrappedAssetWarning = $t('bridge.alerts.wrapped_eth');
 
-  $: stableCoinWarning = $t('bridge.alerts.stable_coin');
+  $: stableCoinWarning = $t('bridge.alerts.usdc_token');
 
   $: if (wrapped || unsupportedStableCoin) {
     needsManualConfirmation = true;

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -40,7 +40,7 @@
     },
     "alerts": {
       "slow_bridging": "Please note: Bridging to L1 will take around 24hrs!",
-      "stable_coin": "You are bridging a stable coin. Currently we are not supporting a native 1:1 conversion. Please use the <a href=\"https://stargate.finance/transfer\" class=\"link\">Stargate Bridge</a> instead. Your bridged asset might not be of any use.",
+      "usdc_token": "You are bridging USDC. If you would like to participate in our XXX campaign (link), please use the <a href=\"https://stargate.finance/transfer\" class=\"link\">Stargate Bridge</a> instead.",
       "wrapped_eth": "You are bridging wrapped ETH. Please be aware that un-wrapping will only work on the original chain of the token, <span class=\"font-bold\">NOT</span> on the destination."
     },
     "button": {


### PR DESCRIPTION
Joaquin, our liquidity campaign with startgate is only related to USDC or it also include USDT?

@KorbinianK In case it's USDC, I think we should only display this warning for USDC. I also think we should change the message as I suggested. "Currently we are not supporting a native 1:1 conversion" is confusing and kind of scary.