### PR TITLE
ci(repo): revert and fix workflow triggers

### DIFF
--- a/.github/workflows/blobstorage.yml
+++ b/.github/workflows/blobstorage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "packages/blobstorage/**"
+  pull_request:
+    paths:
+      - "packages/blobstorage/**"
 
 jobs:
   test-blobstorage:

--- a/.github/workflows/bridge-ui.yml
+++ b/.github/workflows/bridge-ui.yml
@@ -2,11 +2,6 @@ name: Bridge UI CI/CD
 
 on:
   push:
-    branches-ignore:
-      - main
-      - release-please-*
-    paths:
-      - "packages/bridge-ui/**"
     tags:
       - "bridge-ui-v*"
   pull_request:

--- a/.github/workflows/bridge-ui.yml
+++ b/.github/workflows/bridge-ui.yml
@@ -9,6 +9,9 @@ on:
       - "packages/bridge-ui/**"
     tags:
       - "bridge-ui-v*"
+  pull_request:
+    paths:
+      - "packages/bridge-ui/**"
 
 jobs:
   build-and-test:

--- a/.github/workflows/eventindexer.yml
+++ b/.github/workflows/eventindexer.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "packages/eventindexer/**"
+  pull_request:
+    paths:
+      - "packages/eventindexer/**"
       - "go.mod"
       - "go.sum"
 

--- a/.github/workflows/guardian-prover-health-check-ui.yml
+++ b/.github/workflows/guardian-prover-health-check-ui.yml
@@ -2,10 +2,8 @@ name: Guardians UI CI/CD
 
 on:
   push:
-    branches-ignore:
-      - release-please-*
-    paths:
-      - "packages/guardian-prover-health-check-ui/**"
+    tags:
+      - "bridge-ui-v*"
   pull_request:
     paths:
       - "packages/guardian-prover-health-check-ui/**"
@@ -40,7 +38,7 @@ jobs:
       vercel_token: ${{ secrets.VERCEL_TOKEN }}
 
   deploy_guardians-ui_hekla_production:
-    if: ${{ github.ref_name == 'main' && contains(github.ref, 'refs/tags/guardians-ui-') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/guardians-ui-v') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:

--- a/.github/workflows/guardian-prover-health-check-ui.yml
+++ b/.github/workflows/guardian-prover-health-check-ui.yml
@@ -6,6 +6,9 @@ on:
       - release-please-*
     paths:
       - "packages/guardian-prover-health-check-ui/**"
+  pull_request:
+    paths:
+      - "packages/guardian-prover-health-check-ui/**"
 
 jobs:
   build-and-test:

--- a/.github/workflows/guardian-prover-health-check.yml
+++ b/.github/workflows/guardian-prover-health-check.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "packages/guardian-prover-health-check/**"
+  pull_request:
+    paths:
+      - "packages/guardian-prover-health-check/**"
       - "go.mod"
       - "go.sum"
 

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "packages/relayer/**"
+  pull_request:
+    paths:
+      - "packages/relayer/**"
       - "go.mod"
       - "go.sum"
 

--- a/.github/workflows/snaefell-ui.yml
+++ b/.github/workflows/snaefell-ui.yml
@@ -2,10 +2,8 @@ name: Snaefell UI CI/CD
 
 on:
   push:
-    branches-ignore:
-      - release-please-*
-    paths:
-      - "packages/snaefell-ui/**"
+    tags:
+      - "snaefull-ui-v*"
   pull_request:
     paths:
       - "packages/snaefell-ui/**"
@@ -28,7 +26,7 @@ jobs:
       vercel_token: ${{ secrets.VERCEL_TOKEN }}
 
   deploy_snaefell-ui_mainnet_production:
-    if: ${{ github.ref_name == 'main' && contains(github.ref, 'refs/tags/snaefell-ui-') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/snaefull-ui-v') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "packages/taiko-client/**"
+  pull_request:
+    paths:
+      - "packages/taiko-client/**"
       - "go.mod"
       - "go.sum"
 

--- a/.github/workflows/taikoon-ui.yml
+++ b/.github/workflows/taikoon-ui.yml
@@ -2,10 +2,8 @@ name: Taikoon UI CI/CD
 
 on:
   push:
-    branches-ignore:
-      - release-please-*
-    paths:
-      - "packages/taikoon-ui/**"
+    tags:
+      - "taikoon-ui-v*"
   pull_request:
     paths:
       - "packages/taikoon-ui/**"
@@ -28,7 +26,7 @@ jobs:
       vercel_token: ${{ secrets.VERCEL_TOKEN }}
 
   deploy_taikoon-ui_mainnet_production:
-    if: ${{ github.ref_name == 'main' && contains(github.ref, 'refs/tags/taikoon-ui-') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/taikoon-ui-v') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:

--- a/.github/workflows/taikoon-ui.yml
+++ b/.github/workflows/taikoon-ui.yml
@@ -6,6 +6,9 @@ on:
       - release-please-*
     paths:
       - "packages/taikoon-ui/**"
+  pull_request:
+    paths:
+      - "packages/taikoon-ui/**"
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This reverts my change [here](https://github.com/taikoxyz/taiko-mono/pull/17247) to remove the pull_request event trigger and makes it better.

@davidtaikocha would you prefer that we build a docker image on PR commits for taiko-client as well? This is the way it is set up in the eventindexer and relayer. if you would want this change, I can add it, but it will increase the amount of pushes to the docker registry, I don't know what the limit is or if this is preferred.

Right now it's as it was before, only on main, and integration tests on PR.