### PR TITLE
fix(protocol): verify target address is a contract address in DelegateOwner

### DIFF
--- a/packages/protocol/contracts/L2/DelegateOwner.sol
+++ b/packages/protocol/contracts/L2/DelegateOwner.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.24;
 
 import "../common/EssentialContract.sol";
 import "../common/LibStrings.sol";
+import "../libs/LibAddress.sol";
 import "../libs/LibBytes.sol";
 import "../bridge/IBridge.sol";
 
@@ -41,6 +42,7 @@ contract DelegateOwner is EssentialContract, IMessageInvocable {
 
     error DO_DRYRUN_SUCCEEDED();
     error DO_INVALID_PARAM();
+    error DO_INVALID_TARGET();
     error DO_INVALID_TX_ID();
     error DO_PERMISSION_DENIED();
     error DO_TARGET_CALL_REVERTED();
@@ -105,6 +107,9 @@ contract DelegateOwner is EssentialContract, IMessageInvocable {
         Call memory call = abi.decode(_data, (Call));
 
         if (_verifyTxId && call.txId != nextTxId++) revert DO_INVALID_TX_ID();
+
+        // By design, the target must be a contract address.
+        if (!Address.isContract(call.target)) revert DO_INVALID_TARGET();
 
         (bool success, bytes memory result) = call.isDelegateCall //
             ? call.target.delegatecall(call.txdata)


### PR DESCRIPTION
Fix bug report from OZ: **L-16 Diff-Audit: ‘DelegateOwner’ Does Not Check for Contract Existence**

The [DelegateOwner](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/L2/DelegateOwner.sol) contract is intended to be deployed on L2 and set as the owner of all the other L2 contracts. The DAO on L1 can [then call it through the Bridge contract](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/L2/DelegateOwner.sol#L75-L85) to execute arbitrary calls in its name. This could for example be used by the DAO to execute privileged functions on L2 from the L1. Calls from the DelegateOwner can be either [low-level calls or delegate calls](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/L2/DelegateOwner.sol#L109-L111) based on an [input parameter](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/L2/DelegateOwner.sol#L109C47-L109C66).

However, low-level calls in Solidity do not check for contract existence. Such calls could thus be considered [successful](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/L2/DelegateOwner.sol#L113-L114) if the contract called has not been deployed yet, resulting in silent failures.

Consider adding a validation of the contract's existence if the given [call.txdata](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/L2/DelegateOwner.sol#L111C52-L111C63) is non-empty.