### PR TITLE
chore(protocol): explicit revert in vaults in case of insufficient fees

### DIFF
--- a/packages/protocol/contracts/tokenvault/BaseVault.sol
+++ b/packages/protocol/contracts/tokenvault/BaseVault.sol
@@ -31,6 +31,7 @@ abstract contract BaseVault is
 
     uint256[50] private __gap;
 
+    error VAULT_INSURFICIENT_FEE();
     error VAULT_INVALID_TO_ADDR();
     error VAULT_PERMISSION_DENIED();
 

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -47,6 +47,8 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
             revert VAULT_INTERFACE_NOT_SUPPORTED();
         }
 
+        if (msg.value < _op.fee) revert VAULT_INSURFICIENT_FEE();
+
         (bytes memory data, CanonicalNFT memory ctoken) = _handleMessage(_op);
 
         // Create a message to send to the destination chain

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -39,6 +39,8 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
         nonReentrant
         returns (IBridge.Message memory message_)
     {
+        if (msg.value < _op.fee) revert VAULT_INSURFICIENT_FEE();
+
         for (uint256 i; i < _op.amounts.length; ++i) {
             if (_op.amounts[i] == 0) revert VAULT_INVALID_AMOUNT();
         }
@@ -46,8 +48,6 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
         if (!_op.token.supportsInterface(type(IERC1155).interfaceId)) {
             revert VAULT_INTERFACE_NOT_SUPPORTED();
         }
-
-        if (msg.value < _op.fee) revert VAULT_INSURFICIENT_FEE();
 
         (bytes memory data, CanonicalNFT memory ctoken) = _handleMessage(_op);
 

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -230,6 +230,7 @@ contract ERC20Vault is BaseVault {
         if (_op.amount == 0) revert VAULT_INVALID_AMOUNT();
         if (_op.token == address(0)) revert VAULT_INVALID_TOKEN();
         if (btokenBlacklist[_op.token]) revert VAULT_BTOKEN_BLACKLISTED();
+        if (msg.value < _op.fee) revert VAULT_INSURFICIENT_FEE();
 
         (bytes memory data, CanonicalERC20 memory ctoken, uint256 balanceChange) =
             _handleMessage(_op);

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -38,6 +38,8 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
         nonReentrant
         returns (IBridge.Message memory message_)
     {
+        if (msg.value < _op.fee) revert VAULT_INSURFICIENT_FEE();
+
         for (uint256 i; i < _op.tokenIds.length; ++i) {
             if (_op.amounts[i] != 0) revert VAULT_INVALID_AMOUNT();
         }
@@ -45,8 +47,6 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
         if (!_op.token.supportsInterface(type(IERC721).interfaceId)) {
             revert VAULT_INTERFACE_NOT_SUPPORTED();
         }
-
-        if (msg.value < _op.fee) revert VAULT_INSURFICIENT_FEE();
 
         (bytes memory data, CanonicalNFT memory ctoken) = _handleMessage(_op);
 

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -46,6 +46,8 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
             revert VAULT_INTERFACE_NOT_SUPPORTED();
         }
 
+        if (msg.value < _op.fee) revert VAULT_INSURFICIENT_FEE();
+
         (bytes memory data, CanonicalNFT memory ctoken) = _handleMessage(_op);
 
         IBridge.Message memory message = IBridge.Message({

--- a/packages/protocol/test/tokenvault/ERC20Vault.t.sol
+++ b/packages/protocol/test/tokenvault/ERC20Vault.t.sol
@@ -215,7 +215,7 @@ contract TestERC20Vault is TaikoTest {
 
     function test_20Vault_send_erc20_revert_if_allowance_not_set() public {
         vm.startPrank(Alice);
-        vm.expectRevert("ERC20: insufficient allowance");
+        vm.expectRevert(BaseVault.VAULT_INSURFICIENT_FEE.selector);
         erc20Vault.sendToken(
             ERC20Vault.BridgeTransferOp(
                 destChainId, address(0), Bob, 1, address(erc20), 1_000_000, 1 wei


### PR DESCRIPTION
Handling a suggestion from OZ: **L-17 Diff-Audit: Inexplicit Revert**

When a token is bridged through the ERC20Vault, the destination chain message value is derived as [msg.value - _op.fee](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/tokenvault/ERC20Vault.sol#L245). However, this can lead to an underflow revert if the provided fee exceeds the message value. Consider checking the values beforehand, as done in the [Bridge contract](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/bridge/Bridge.sol#L150).