### PR TITLE
fix(protocol): remove receive function from Bridge

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -100,9 +100,6 @@ contract Bridge is EssentialContract, IBridge {
         _;
     }
 
-    /// @notice Function to receive Ether.
-    receive() external payable { }
-
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
     /// @param _addressManager The address of the {AddressManager} contract.


### PR DESCRIPTION
OZ's finding: basically people could lock funds by sending ether to this contract. But because we need to seed the liquidity when genesis, we need this functionality first, so:
1. Seed liquidity
2. Merge this and upgrade so noone else can lock funds.

<img width="492" alt="kép" src="https://github.com/taikoxyz/taiko-mono/assets/51912515/80636664-4e55-4c7f-a295-ccfe22ace8c7">
