### PR TITLE
feat(protocol): remove a few cached addresses

### DIFF
--- a/packages/protocol/contracts/mainnet/L1RollupAddressManager.sol
+++ b/packages/protocol/contracts/mainnet/L1RollupAddressManager.sol
@@ -12,10 +12,13 @@ import "../common/LibStrings.sol";
 contract L1RollupAddressManager is AddressManager {
     /// @notice Gets the address mapped to a specific chainId-name pair.
     /// @dev Sub-contracts can override this method to avoid reading from storage.
-    /// The following names are not cached:
+    /// The following names are not cached as they are not used frequently or its address is likely
+    /// to change:
     /// - B_PROPOSER
     /// - B_PROPOSER_ONE
     /// - B_TIER_PROVIDER
+    /// - B_ASSIGNMENT_HOOK
+    /// - B_AUTOMATA_DCAP_ATTESTATION
     function _getOverride(
         uint64 _chainId,
         bytes32 _name
@@ -49,9 +52,6 @@ contract L1RollupAddressManager is AddressManager {
             }
             if (_name == LibStrings.B_AUTOMATA_DCAP_ATTESTATION) {
                 return 0x8d7C954960a36a7596d7eA4945dDf891967ca8A3;
-            }
-            if (_name == LibStrings.B_ASSIGNMENT_HOOK) {
-                return 0x537a2f0D3a5879b41BCb5A2afE2EA5c4961796F6;
             }
         }
         return address(0);

--- a/packages/protocol/contracts/mainnet/L1RollupAddressManager.sol
+++ b/packages/protocol/contracts/mainnet/L1RollupAddressManager.sol
@@ -12,13 +12,8 @@ import "../common/LibStrings.sol";
 contract L1RollupAddressManager is AddressManager {
     /// @notice Gets the address mapped to a specific chainId-name pair.
     /// @dev Sub-contracts can override this method to avoid reading from storage.
-    /// The following names are not cached as they are not used frequently or its address is likely
-    /// to change:
-    /// - B_PROPOSER
-    /// - B_PROPOSER_ONE
-    /// - B_TIER_PROVIDER
-    /// - B_ASSIGNMENT_HOOK
-    /// - B_AUTOMATA_DCAP_ATTESTATION
+    /// Some names are not cached as they are not used frequently or
+    /// its address is likely to change.
     function _getOverride(
         uint64 _chainId,
         bytes32 _name

--- a/packages/protocol/contracts/mainnet/L1SharedAddressManager.sol
+++ b/packages/protocol/contracts/mainnet/L1SharedAddressManager.sol
@@ -12,12 +12,8 @@ import "../common/LibStrings.sol";
 contract L1SharedAddressManager is AddressManager {
     /// @notice Gets the address mapped to a specific chainId-name pair.
     /// @dev Sub-contracts can override this method to avoid reading from storage.
-    /// The following names are not cached as they are not used frequently or its address is likely
-    /// to change:
-    /// - B_BRIDGE_WATCHDOG
-    /// - B_BRIDGED_ERC20
-    /// - B_BRIDGED_ERC721
-    /// - B_BRIDGED_ERC1155
+    /// Some names are not cached as they are not used frequently or
+    /// its address is likely to change.
     function _getOverride(
         uint64 _chainId,
         bytes32 _name

--- a/packages/protocol/contracts/mainnet/L1SharedAddressManager.sol
+++ b/packages/protocol/contracts/mainnet/L1SharedAddressManager.sol
@@ -12,8 +12,12 @@ import "../common/LibStrings.sol";
 contract L1SharedAddressManager is AddressManager {
     /// @notice Gets the address mapped to a specific chainId-name pair.
     /// @dev Sub-contracts can override this method to avoid reading from storage.
-    /// The following names are not cached:
+    /// The following names are not cached as they are not used frequently or its address is likely
+    /// to change:
     /// - B_BRIDGE_WATCHDOG
+    /// - B_BRIDGED_ERC20
+    /// - B_BRIDGED_ERC721
+    /// - B_BRIDGED_ERC1155
     function _getOverride(
         uint64 _chainId,
         bytes32 _name
@@ -41,15 +45,6 @@ contract L1SharedAddressManager is AddressManager {
             }
             if (_name == LibStrings.B_ERC1155_VAULT) {
                 return 0xaf145913EA4a56BE22E120ED9C24589659881702;
-            }
-            if (_name == LibStrings.B_BRIDGED_ERC20) {
-                return 0x79BC0Aada00fcF6E7AB514Bfeb093b5Fae3653e3;
-            }
-            if (_name == LibStrings.B_BRIDGED_ERC721) {
-                return 0xC3310905E2BC9Cfb198695B75EF3e5B69C6A1Bf7;
-            }
-            if (_name == LibStrings.B_BRIDGED_ERC1155) {
-                return 0x3c90963cFBa436400B0F9C46Aa9224cB379c2c40;
             }
             if (_name == LibStrings.B_QUOTA_MANAGER) {
                 return 0x91f67118DD47d502B1f0C354D0611997B022f29E;


### PR DESCRIPTION
- `B_ASSIGNMENT_HOOK` is only used in  `ProverSet.init`
- `B_AUTOMATA_DCAP_ATTESTATION` is only used in `SgxVerifier.registerInstance`
- `B_BRIDGED_ERC20` and the other two bridged tokens are only used when a new bridged token is deployed, and these are EOAs that may change.