### PR TITLE
feat(bridge-ui): update usdc wording, add minimum fee check

### DIFF
--- a/packages/bridge-ui/src/app.config.ts
+++ b/packages/bridge-ui/src/app.config.ts
@@ -28,7 +28,7 @@ export const bridgeTransactionPoller = {
 };
 
 export const claimConfig = {
-  minimumEthToClaim: 0.001,
+  minimumEthToClaim: 0.0015, // 1M gas * 1.5 gwei (lowest gasPrice)
 };
 
 export const transactionConfig = {

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/NoneOption.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/NoneOption.svelte
@@ -2,6 +2,7 @@
   import type { Address } from 'viem';
 
   import { destNetwork, selectedToken } from '$components/Bridge/state';
+  import { claimConfig } from '$config';
   import { recommendProcessingFee } from '$libs/fee';
   import { fetchBalance, type NFT, type Token } from '$libs/token';
   import { account, connectedSourceChain } from '$stores';
@@ -28,11 +29,16 @@
       });
 
       // Calculate the recommended amount of ETH needed for processMessage call
-      const recommendedAmount = await recommendProcessingFee({
+      let recommendedAmount = await recommendProcessingFee({
         token,
         destChainId: destChain,
         srcChainId: srcChain,
       });
+
+      if (recommendedAmount <= claimConfig.minimumEthToClaim) {
+        // should the fee be very small, set it to at least the minimum
+        recommendedAmount = BigInt(claimConfig.minimumEthToClaim);
+      }
 
       // Does the user have enough ETH to claim manually on the destination chain?
       enoughEth = destBalance ? destBalance?.value >= recommendedAmount : false;

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -41,7 +41,7 @@
     "alerts": {
       "slow_bridging": "Please note: Bridging to L1 will take around 24hrs!",
       "smart_contract_wallet": "It seems you are using a smart contract wallet. Please double check that the recipient matches your wallet on the destination or change it accordingly.",
-      "stable_coin": "You are bridging a stable coin. Currently we are not supporting a native 1:1 conversion. Please use the <a href=\"https://stargate.finance/transfer\" class=\"link\">Stargate Bridge</a> instead. Your bridged asset might not be of any use.",
+      "stable_coin": "You are bridging a stable coin. For USDC, we are currently partnering with <a target=\"_blank\" href=\"https://stargate.finance/transfer\" class=\"link\">Stargate Bridge</a> for liquidity. Consider using their bridge, as the ecosystem partners are likely using their bridged version",
       "wrapped_eth": "You are bridging wrapped ETH. Please be aware that un-wrapping will only work on the original chain of the token, <span class=\"font-bold\">NOT</span> on the destination."
     },
     "button": {


### PR DESCRIPTION
- make the message clearer
- no longer allows the user to switch to "none" for processing fee if they have less than 0.0015 ETH on the destination 

Calculation: 1M gas for self claim (rounded up from ~850k) * 1.5 gwei (default minimum in MM)