### PR TITLE
ci(repo): fix dependabot failures for pnpm

### DIFF
--- a/.github/actions/install-pnpm-dependencies/action.yml
+++ b/.github/actions/install-pnpm-dependencies/action.yml
@@ -4,6 +4,11 @@ description: "Install pnpm dependencies"
 runs:
   using: "composite"
   steps:
+    - name: Set up Git to use HTTPS
+      shell: bash
+      run: |
+        git config --global url."https://github.com/".insteadOf "git@github.com:"
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
cherry-picked from https://github.com/taikoxyz/taiko-mono/pull/17338/commits/8761064f0745ebb8cf5dbea32aa3dae5b99fdcd6