### PR TITLE
chore(protocol): fix ETH send issue to EOA

### DIFF
--- a/packages/protocol/contracts/L2/DelegateOwner.sol
+++ b/packages/protocol/contracts/L2/DelegateOwner.sol
@@ -108,8 +108,8 @@ contract DelegateOwner is EssentialContract, IMessageInvocable {
 
         if (_verifyTxId && call.txId != nextTxId++) revert DO_INVALID_TX_ID();
 
-        // By design, the target must be a contract address.
-        if (!Address.isContract(call.target)) revert DO_INVALID_TARGET();
+        // By design, the target must be a contract address if the txdata is not empty
+        if (call.txdata.length != 0 && !Address.isContract(call.target)) revert DO_INVALID_TARGET();
 
         (bool success, bytes memory result) = call.isDelegateCall //
             ? call.target.delegatecall(call.txdata)


### PR DESCRIPTION
Rationale is: only check the target is a contract, in case txdata is not empty (so basically it is a function call of an L2 contract) - otherwise let it send the eth to an EOA.

The rcommendation from OZ:
_Consider adding a validation of the contract's existence **if** the given [call.txdata](https://github.com/taikoxyz/taiko-mono/blob/dd8725f8d27f835102fa3c5a013003090268357d/packages/protocol/contracts/L2/DelegateOwner.sol#L111C52-L111C63) is non-empty._