### PR TITLE
refactor(protocol): optimize signature verification in AssignmentHook

### DIFF
--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -97,7 +97,7 @@ contract AssignmentHook is EssentialContract, IHook {
             }
         } else {
             (address recovered, ECDSA.RecoverError error) =
-                ECDSA.recover(hash, assignment.signature);
+                ECDSA.tryRecover(hash, assignment.signature);
             if (recovered != _blk.assignedProver || error != ECDSA.RecoverError.NoError) {
                 revert HOOK_ASSIGNMENT_INVALID_SIG();
             }

--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -96,7 +96,9 @@ contract AssignmentHook is EssentialContract, IHook {
                 revert HOOK_ASSIGNMENT_INVALID_SIG();
             }
         } else {
-            if (_blk.assignedProver != ECDSA.recover(hash, assignment.signature)) {
+            (address recovered, ECDSA.RecoverError error) =
+                ECDSA.recover(hash, assignment.signature);
+            if (recovered != _blk.assignedProver || error != ECDSA.RecoverError.NoError) {
                 revert HOOK_ASSIGNMENT_INVALID_SIG();
             }
         }

--- a/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
+++ b/packages/protocol/contracts/L1/hooks/AssignmentHook.sol
@@ -96,9 +96,7 @@ contract AssignmentHook is EssentialContract, IHook {
                 revert HOOK_ASSIGNMENT_INVALID_SIG();
             }
         } else {
-            (address recovered, ECDSA.RecoverError error) =
-                ECDSA.tryRecover(hash, assignment.signature);
-            if (recovered != _blk.assignedProver || error != ECDSA.RecoverError.NoError) {
+            if (_blk.assignedProver != ECDSA.recover(hash, assignment.signature)) {
                 revert HOOK_ASSIGNMENT_INVALID_SIG();
             }
         }

--- a/packages/protocol/contracts/team/proving/ProverSet.sol
+++ b/packages/protocol/contracts/team/proving/ProverSet.sol
@@ -99,8 +99,7 @@ contract ProverSet is EssentialContract, IERC1271 {
         view
         returns (bytes4 magicValue_)
     {
-        (address recovered, ECDSA.RecoverError error) = ECDSA.tryRecover(_hash, _signature);
-        if (error == ECDSA.RecoverError.NoError && isProver[recovered]) {
+        if (isProver[ECDSA.recover(_hash, _signature)]) {
             magicValue_ = _EIP1271_MAGICVALUE;
         }
     }

--- a/packages/protocol/contracts/team/proving/ProverSet.sol
+++ b/packages/protocol/contracts/team/proving/ProverSet.sol
@@ -99,7 +99,8 @@ contract ProverSet is EssentialContract, IERC1271 {
         view
         returns (bytes4 magicValue_)
     {
-        if (isProver[ECDSA.recover(_hash, _signature)]) {
+        (address recovered, ECDSA.RecoverError error) = ECDSA.tryRecover(_hash, _signature);
+        if (error == ECDSA.RecoverError.NoError && isProver[recovered]) {
             magicValue_ = _EIP1271_MAGICVALUE;
         }
     }

--- a/packages/protocol/deployments/mainnet-contract-logs-L1.md
+++ b/packages/protocol/deployments/mainnet-contract-logs-L1.md
@@ -203,7 +203,7 @@
   - deployed on May 1, 2024 @commit`56dddf2b6`
   - Upgraded from `0x4f664222C3fF6207558A745648B568D095dDA170` to `0xe226fAd08E2f0AE68C32Eb5d8210fFeDB736Fb0d` @commit`b90b932` @tx`0x416560cd96dc75ccffebe889e8d1ab3e08b33f814dc4a2bf7c6f9555071d1f6f`
 - todo:
-  - upgrade assignment hook
+  - upgrade assignment hook again for signature check improvement
 
 #### tier_provider
 

--- a/packages/protocol/deployments/mainnet-contract-logs-L1.md
+++ b/packages/protocol/deployments/mainnet-contract-logs-L1.md
@@ -203,7 +203,7 @@
   - deployed on May 1, 2024 @commit`56dddf2b6`
   - Upgraded from `0x4f664222C3fF6207558A745648B568D095dDA170` to `0xe226fAd08E2f0AE68C32Eb5d8210fFeDB736Fb0d` @commit`b90b932` @tx`0x416560cd96dc75ccffebe889e8d1ab3e08b33f814dc4a2bf7c6f9555071d1f6f`
 - todo:
-  - upgrade assignment hook for signature check improvement
+  - upgrade assignment hook
 
 #### tier_provider
 
@@ -326,8 +326,6 @@
   - enabled two provers (`0x000000629FBCf27A347d1AEbA658435230D74a5f` and `0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`) @tx`0xa0b1565473849bc753d395abd982e6899ecdd9e754014eebed67b69edadb61c5`
   - upgraded from `0x68d30f47F19c07bCCEf4Ac7FAE2Dc12FCa3e0dC9` to `0x500735343372Dd6c9B84dBc7a75babf4479742B9` @commit`fa481c1` @tx`0x02ed558762eae5f0a930ba4a1047a02d4a793ea48890268c32df04e882f138ff`
   - disable a prover (`0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`) on May 28 @commit`b335b70` @tx`0x27c84a1dbf80d88948f96f1536c244816543fb780c81a04ba485c4c156431112`
-- todo:
-  - upgrade prover_set for signature check
 
 ### labcontester.taiko.eth
 
@@ -338,5 +336,3 @@
   - `0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`
 - logs:
   - enabled a prover (`0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`) on May 28 @commit`b335b70` @tx`0x27c84a1dbf80d88948f96f1536c244816543fb780c81a04ba485c4c156431112`
-- todo:
-  - upgrade prover_set for signature check

--- a/packages/protocol/deployments/mainnet-contract-logs-L1.md
+++ b/packages/protocol/deployments/mainnet-contract-logs-L1.md
@@ -203,7 +203,7 @@
   - deployed on May 1, 2024 @commit`56dddf2b6`
   - Upgraded from `0x4f664222C3fF6207558A745648B568D095dDA170` to `0xe226fAd08E2f0AE68C32Eb5d8210fFeDB736Fb0d` @commit`b90b932` @tx`0x416560cd96dc75ccffebe889e8d1ab3e08b33f814dc4a2bf7c6f9555071d1f6f`
 - todo:
-  - upgrade assignment hook
+  - upgrade assignment hook for signature check improvement
 
 #### tier_provider
 
@@ -326,6 +326,8 @@
   - enabled two provers (`0x000000629FBCf27A347d1AEbA658435230D74a5f` and `0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`) @tx`0xa0b1565473849bc753d395abd982e6899ecdd9e754014eebed67b69edadb61c5`
   - upgraded from `0x68d30f47F19c07bCCEf4Ac7FAE2Dc12FCa3e0dC9` to `0x500735343372Dd6c9B84dBc7a75babf4479742B9` @commit`fa481c1` @tx`0x02ed558762eae5f0a930ba4a1047a02d4a793ea48890268c32df04e882f138ff`
   - disable a prover (`0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`) on May 28 @commit`b335b70` @tx`0x27c84a1dbf80d88948f96f1536c244816543fb780c81a04ba485c4c156431112`
+- todo:
+  - upgrade prover_set for signature check
 
 ### labcontester.taiko.eth
 
@@ -336,3 +338,5 @@
   - `0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`
 - logs:
   - enabled a prover (`0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`) on May 28 @commit`b335b70` @tx`0x27c84a1dbf80d88948f96f1536c244816543fb780c81a04ba485c4c156431112`
+- todo:
+  - upgrade prover_set for signature check


### PR DESCRIPTION
<img width="1423" alt="Screenshot 2024-06-05 at 15 57 45" src="https://github.com/taikoxyz/taiko-mono/assets/99078276/4318c750-9d87-4f5f-98e8-afbe1ebc5e65">

The previous implementation always try an `ecrecover` (3433 gas) even if the prover is a contract. The new implementation checks if the prover is a contract (703 gas) first.