### PR TITLE
feat(protocol): reduce gas cost by skipping reading storage for `delegates()`

### DIFF
--- a/packages/protocol/contracts/tko/TaikoToken.sol
+++ b/packages/protocol/contracts/tko/TaikoToken.sol
@@ -27,9 +27,9 @@ contract TaikoToken is TaikoTokenBase {
         _mint(_recipient, 1_000_000_000 ether);
     }
 
-    function delegates(address account) public view virtual returns (address) {
+    function delegates(address account) public view virtual override returns (address) {
         // Special check to avoid reading from storage slots
         if (account == _TAIKO_L1 || account == _ERC20_VAULT) return address(0);
-        else return _delegates[account];
+        else return super.delegates(account);
     }
 }

--- a/packages/protocol/contracts/tko/TaikoToken.sol
+++ b/packages/protocol/contracts/tko/TaikoToken.sol
@@ -12,6 +12,8 @@ import "./TaikoTokenBase.sol";
 /// @custom:security-contact security@taiko.xyz
 contract TaikoToken is TaikoTokenBase {
     address private constant _TAIKO_L1 = 0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a;
+    address private constant _ERC20_VAULT = 0x996282cA11E5DEb6B5D122CC3B9A1FcAAD4415Ab;
+
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
     /// @param _recipient The address to receive initial token minting.
@@ -25,11 +27,9 @@ contract TaikoToken is TaikoTokenBase {
         _mint(_recipient, 1_000_000_000 ether);
     }
 
-    /**
-     * @dev Get the address `account` is currently delegating to.
-     */
     function delegates(address account) public view virtual returns (address) {
-        if (account == _TAIKO_L1) return address(0);
+        // Special check to avoid reading from storage slots
+        if (account == _TAIKO_L1 || account == _ERC20_VAULT) return address(0);
         else return _delegates[account];
     }
 }

--- a/packages/protocol/contracts/tko/TaikoToken.sol
+++ b/packages/protocol/contracts/tko/TaikoToken.sol
@@ -11,9 +11,11 @@ import "./TaikoTokenBase.sol";
 /// 0x10dea67478c5F8C5E2D90e5E9B26dBe60c54d800 (token.taiko.eth)
 /// @custom:security-contact security@taiko.xyz
 contract TaikoToken is TaikoTokenBase {
+    address private constant _TAIKO_L1 = 0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a;
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
     /// @param _recipient The address to receive initial token minting.
+
     function init(address _owner, address _recipient) public initializer {
         __Essential_init(_owner);
         __ERC20_init("Taiko Token", "TKO");
@@ -21,5 +23,13 @@ contract TaikoToken is TaikoTokenBase {
         __ERC20Permit_init("Taiko Token");
         // Mint 1 billion tokens
         _mint(_recipient, 1_000_000_000 ether);
+    }
+
+    /**
+     * @dev Get the address `account` is currently delegating to.
+     */
+    function delegates(address account) public view virtual returns (address) {
+        if (account == _TAIKO_L1) return address(0);
+        else return _delegates[account];
     }
 }

--- a/packages/protocol/contracts/tko/TaikoToken.sol
+++ b/packages/protocol/contracts/tko/TaikoToken.sol
@@ -28,7 +28,7 @@ contract TaikoToken is TaikoTokenBase {
     }
 
     function delegates(address account) public view virtual override returns (address) {
-        // Special check to avoid reading from storage slots
+        // Special checks to avoid reading from storage slots
         if (account == _TAIKO_L1 || account == _ERC20_VAULT) return address(0);
         else return super.delegates(account);
     }


### PR DESCRIPTION
<img width="1418" alt="Screenshot 2024-06-05 at 16 42 46" src="https://github.com/taikoxyz/taiko-mono/assets/99078276/e8c0b49a-0aa1-429c-bbd5-05a8fea7d1cf">

As you can see from the image above, for everyone TAIKO transfer, this function is always called:

<img width="600" alt="Screenshot 2024-06-05 at 16 43 48" src="https://github.com/taikoxyz/taiko-mono/assets/99078276/1817b582-55b4-4412-9e76-a1d5e78c77dc">


Reading `delegates(from)` and `delegates(to)` cost 2100 each, which sucks. This PR make sure  `delegates` always return 0 for two special address: TaikoL1 and ERC20Vault to reduce gas cost, as these addresses never delegate.

A better but my trouble "fix" is to wrap TAIKO into a BOND token which is a pure ERC20 token for bonds.