### PR TITLE
feat(relayer): check if txhash is being processed, incase crawler picks up message twice

### DIFF
--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -132,6 +132,9 @@ type Processor struct {
 	txmgr txmgr.TxManager
 
 	maxMessageRetries uint64
+
+	processingTxHashes map[common.Hash]bool
+	processingTxHashMu *sync.Mutex
 }
 
 // InitFromCli creates a new processor from a cli context
@@ -368,6 +371,9 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 	p.targetTxHash = cfg.TargetTxHash
 
 	p.maxMessageRetries = cfg.MaxMessageRetries
+
+	p.processingTxHashes = make(map[common.Hash]bool, 0)
+	p.processingTxHashMu = &sync.Mutex{}
 
 	return nil
 }

--- a/packages/relayer/processor/processor_test.go
+++ b/packages/relayer/processor/processor_test.go
@@ -46,7 +46,9 @@ func newTestProcessor(profitableOnly bool) *Processor {
 		cfg: &Config{
 			DestBridgeAddress: common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
 		},
-		maxMessageRetries: 5,
-		destQuotaManager:  &mock.QuotaManager{},
+		maxMessageRetries:  5,
+		destQuotaManager:   &mock.QuotaManager{},
+		processingTxHashes: make(map[common.Hash]bool, 0),
+		processingTxHashMu: &sync.Mutex{},
 	}
 }


### PR DESCRIPTION
… before we can process it due to backlog, or being retried due to unprofitability.