### PR TITLE
fix(protocol): take calldata into account when calculating gas charge

### DIFF
--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -286,7 +286,11 @@ contract Bridge is EssentialContract, IBridge {
                     // - need to have a buffer/small revenue to the realyer since it consumes
                     // maintenance and infra costs to operate
                     uint256 refund = stats.numCacheOps * _GAS_REFUND_PER_CACHE_OPERATION;
-                    stats.gasUsedInFeeCalc = uint32(GAS_OVERHEAD + gasStart - gasleft());
+                    // Taking into account the encoded message calldata cost, and can count with 16
+                    // gas per bytes (vs. checking each and every byte if zero or non-zero)
+                    uint32 msgCalldataGas = uint32(abi.encode(_message).length) << 4;
+                    stats.gasUsedInFeeCalc =
+                        uint32(GAS_OVERHEAD + gasStart + msgCalldataGas - gasleft());
                     uint256 gasCharged = refund.max(stats.gasUsedInFeeCalc) - refund;
                     uint256 maxFee = gasCharged * _message.fee / _message.gasLimit;
                     uint256 baseFee = gasCharged * block.basefee;

--- a/packages/protocol/deployments/mainnet-contract-logs-L1.md
+++ b/packages/protocol/deployments/mainnet-contract-logs-L1.md
@@ -67,6 +67,8 @@
 - proxy: `0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC`
 - impl: `0x3c326483EBFabCf3252205f26dF632FE83d11108`
 - owner: `admin.taiko.eth`
+- todo:
+  - upgrade the contract
 - logs:
   - deployed on May 1, 2024 @commit`56dddf2b6`
   - admin.taiko.eth accepted the ownership @tx`0x0ed114fee6de4e3e2206cea44e6632ec0c4588f73648d98d8df5dc0183b07885`

--- a/packages/protocol/deployments/mainnet-contract-logs-L2.md
+++ b/packages/protocol/deployments/mainnet-contract-logs-L2.md
@@ -48,6 +48,7 @@
 - owner: `0xCa5b76Cc7A38b86Db11E5aE5B1fc9740c3bA3DE8`
 - todo:
   - change owner to DelegateOwner
+  - upgrade the contract
 - logs:
   - deployed on May 1, 2024 @commit`56dddf2b6`
   - redeployed on May 22, 2024 @commit`b955e0e`


### PR DESCRIPTION
As Maxim wrote + Seppi reminded:
(It is a rounded-up approach, favoring the relayer/processor a bit, by not checking which byte is 0 which not, but assuming non-zero.. This way relayer can have a bit more buffer).

<img width="777" alt="kép" src="https://github.com/taikoxyz/taiko-mono/assets/51912515/3a6a49d5-602e-45f8-b4dc-5b72476eeb0d">
