### PR TITLE
chore(relayer): prevent indexing halts and add error monitoring metrics

### DIFF
--- a/packages/relayer/cmd/flags/common.go
+++ b/packages/relayer/cmd/flags/common.go
@@ -105,12 +105,14 @@ var (
 		Usage:    "Retry interval in seconds when there is an error",
 		Category: processorCategory,
 		Value:    12,
+		EnvVars:  []string{"BACKOFF_RETRY_INTERVAL"},
 	}
 	BackOffMaxRetrys = &cli.Uint64Flag{
 		Name:     "backoff.maxRetrys",
 		Usage:    "Max retry times when there is an error",
 		Category: processorCategory,
-		Value:    3,
+		Value:    5,
+		EnvVars:  []string{"BACKOFF_MAX_RETRYS"},
 	}
 )
 

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -384,7 +384,7 @@ func (i *Indexer) filter(ctx context.Context) error {
 		switch i.eventName {
 		case relayer.EventNameMessageSent:
 			if err := i.withRetry(func() error { return i.indexMessageSentEvents(ctx, filterOpts) }); err != nil {
-				return errors.Wrap(err, "i.indexMessageSentEvents")
+				slog.Error("i.indexMessageSentEvents", "error", err)
 			}
 
 			// we dont want to watch for message status changed events
@@ -393,17 +393,17 @@ func (i *Indexer) filter(ctx context.Context) error {
 			// since they are related.
 			if i.watchMode != CrawlPastBlocks {
 				if err := i.withRetry(func() error { return i.indexMessageStatusChangedEvents(ctx, filterOpts) }); err != nil {
-					return errors.Wrap(err, "i.indexMessageStatusChangedEvents")
+					slog.Error("i.indexMessageStatusChangedEvents", "error", err)
 				}
 
 				// we also want to index chain data synced events.
 				if err := i.withRetry(func() error { return i.indexChainDataSyncedEvents(ctx, filterOpts) }); err != nil {
-					return errors.Wrap(err, "i.indexChainDataSyncedEvents")
+					slog.Error("i.indexChainDataSyncedEvents", "error", err)
 				}
 			}
 		case relayer.EventNameMessageProcessed:
 			if err := i.withRetry(func() error { return i.indexMessageProcessedEvents(ctx, filterOpts) }); err != nil {
-				return errors.Wrap(err, "i.indexMessageProcessedEvents")
+				slog.Error("i.indexMessageProcessedEvents", "error", err)
 			}
 		}
 

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -386,6 +386,7 @@ func (i *Indexer) filter(ctx context.Context) error {
 			if err := i.withRetry(func() error { return i.indexMessageSentEvents(ctx, filterOpts) }); err != nil {
 				// We will skip the error after retrying, as we want the indexer to continue.
 				slog.Error("i.indexMessageSentEvents", "error", err)
+				relayer.MessageSentEventsAfterRetryErrorCount.Inc()
 			}
 
 			// we dont want to watch for message status changed events
@@ -395,16 +396,19 @@ func (i *Indexer) filter(ctx context.Context) error {
 			if i.watchMode != CrawlPastBlocks {
 				if err := i.withRetry(func() error { return i.indexMessageStatusChangedEvents(ctx, filterOpts) }); err != nil {
 					slog.Error("i.indexMessageStatusChangedEvents", "error", err)
+					relayer.MessageStatusChangedEventsAfterRetryErrorCount.Inc()
 				}
 
 				// we also want to index chain data synced events.
 				if err := i.withRetry(func() error { return i.indexChainDataSyncedEvents(ctx, filterOpts) }); err != nil {
 					slog.Error("i.indexChainDataSyncedEvents", "error", err)
+					relayer.ChainDataSyncedEventsAfterRetryErrorCount.Inc()
 				}
 			}
 		case relayer.EventNameMessageProcessed:
 			if err := i.withRetry(func() error { return i.indexMessageProcessedEvents(ctx, filterOpts) }); err != nil {
 				slog.Error("i.indexMessageProcessedEvents", "error", err)
+				relayer.MessageProcessedEventsAfterRetryErrorCount.Inc()
 			}
 		}
 

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -384,6 +384,7 @@ func (i *Indexer) filter(ctx context.Context) error {
 		switch i.eventName {
 		case relayer.EventNameMessageSent:
 			if err := i.withRetry(func() error { return i.indexMessageSentEvents(ctx, filterOpts) }); err != nil {
+				// We will skip the error after retrying, as we want the indexer to continue.
 				slog.Error("i.indexMessageSentEvents", "error", err)
 			}
 

--- a/packages/relayer/indexer/save_event_to_db.go
+++ b/packages/relayer/indexer/save_event_to_db.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"math/big"
 
 	"github.com/pkg/errors"
@@ -21,6 +22,9 @@ func (i *Indexer) saveEventToDB(
 	eventValue *big.Int,
 	emittedBlockNumber uint64,
 ) (int, error) {
+
+	slog.Info("saveEventToDB")
+
 	eventType, canonicalToken, amount, err := relayer.DecodeMessageData(eventData, eventValue)
 	if err != nil {
 		return 0, errors.Wrap(err, "eventTypeAmountAndCanonicalTokenFromEvent(event)")

--- a/packages/relayer/indexer/save_event_to_db.go
+++ b/packages/relayer/indexer/save_event_to_db.go
@@ -3,7 +3,6 @@ package indexer
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"math/big"
 
 	"github.com/pkg/errors"
@@ -22,9 +21,6 @@ func (i *Indexer) saveEventToDB(
 	eventValue *big.Int,
 	emittedBlockNumber uint64,
 ) (int, error) {
-
-	slog.Info("saveEventToDB")
-
 	eventType, canonicalToken, amount, err := relayer.DecodeMessageData(eventData, eventValue)
 	if err != nil {
 		return 0, errors.Wrap(err, "eventTypeAmountAndCanonicalTokenFromEvent(event)")

--- a/packages/relayer/prometheus.go
+++ b/packages/relayer/prometheus.go
@@ -130,4 +130,20 @@ var (
 		Name: "unprofitable_message_after_transacting_ops_total",
 		Help: "The total number of processed events that ended up unprofitable",
 	})
+	MessageSentEventsAfterRetryErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "message_sent_events_after_retry_error_count",
+		Help: "The total number of errors logged for MessageSent events after retries",
+	})
+	MessageStatusChangedEventsAfterRetryErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "message_status_changed_events_after_retry_error_count",
+		Help: "The total number of errors logged for MessageStatusChanged events after retries",
+	})
+	ChainDataSyncedEventsAfterRetryErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "chain_data_synced_events_after_retry_error_count",
+		Help: "The total number of errors logged for ChainDataSynced events after retries",
+	})
+	MessageProcessedEventsAfterRetryErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "message_processed_events_after_retry_error_count",
+		Help: "The total number of errors logged for MessageProcessed events after retries",
+	})
 )


### PR DESCRIPTION
Updated error handling in the block indexing code to use slog.Error for logging errors instead of wrapping and returning them.

This ensured that if the indexer encounters an error with a specific transaction, it logs the error after retries and continues processing the remaining transactions. This prevents the indexing process from halting due to individual transaction errors.
