### PR TITLE
feat(relayer): only index messages with non zero gas limit

### DIFF
--- a/packages/relayer/indexer/handle_message_sent_event.go
+++ b/packages/relayer/indexer/handle_message_sent_event.go
@@ -101,6 +101,13 @@ func (i *Indexer) handleMessageSentEvent(
 		return nil
 	}
 
+	// we shouldnt add messages to the queue that will be determined
+	// unprocessable.
+	if event.Message.GasLimit == 0 {
+		slog.Warn("Zero gaslimit message found, will be unprocessable")
+		return nil
+	}
+
 	msg := queue.QueueMessageSentBody{
 		ID:    id,
 		Event: event,


### PR DESCRIPTION
Currently this check is in the processor only, but we can avoid unnecessary messages being picked up by the processor or added to the queue at all by adding this check to the indexer. Nice optimization.