### PR TITLE
feat(relayer): requeue messages when networking error is cause of failure

### DIFF
--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -497,7 +497,9 @@ func (p *Processor) eventLoop(ctx context.Context) {
 						if err := p.queue.Nack(ctx, m, true); err != nil {
 							slog.Error("Err nacking message", "err", err.Error())
 						}
-					case strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "i/o") || strings.Contains(err.Error(), "connect"):
+					case strings.Contains(err.Error(), "timeout") ||
+						strings.Contains(err.Error(), "i/o") ||
+						strings.Contains(err.Error(), "connect"):
 						slog.Error("process message failed due to networking issue", "err", err.Error())
 
 						// we want to negatively acknowledge the message and make sure

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math/big"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -490,6 +491,14 @@ func (p *Processor) eventLoop(ctx context.Context) {
 						}
 					case errors.Is(err, context.Canceled):
 						slog.Error("process message failed due to context cancel", "err", err.Error())
+
+						// we want to negatively acknowledge the message and make sure
+						// we requeue it
+						if err := p.queue.Nack(ctx, m, true); err != nil {
+							slog.Error("Err nacking message", "err", err.Error())
+						}
+					case strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "i/o") || strings.Contains(err.Error(), "connect"):
+						slog.Error("process message failed due to networking issue", "err", err.Error())
 
 						// we want to negatively acknowledge the message and make sure
 						// we requeue it


### PR DESCRIPTION
For instance, RPC connectivity issues, or i/o timeouts, like during airdrop day where our RPCs failed to respond. Now, the relayer will add the message back to the queue ,rather than treat it as an actual error.