### PR TITLE
feat(protocol): change guardian prover cooldown windows

### DIFF
--- a/packages/protocol/contracts/L1/tiers/TierProviderBase.sol
+++ b/packages/protocol/contracts/L1/tiers/TierProviderBase.sol
@@ -53,7 +53,7 @@ abstract contract TierProviderBase is ITierProvider {
                 verifierName: LibStrings.B_TIER_GUARDIAN_MINORITY,
                 validityBond: 500 ether, // TKO
                 contestBond: 3280 ether, // =500TKO * 6.5625
-                cooldownWindow: 1440, //24 hours
+                cooldownWindow: 360, // 6 hours
                 provingWindow: 2880, // 48 hours
                 maxBlocksToVerifyPerProof: 16
             });
@@ -64,7 +64,7 @@ abstract contract TierProviderBase is ITierProvider {
                 verifierName: LibStrings.B_TIER_GUARDIAN,
                 validityBond: 0, // must be 0 for top tier
                 contestBond: 0, // must be 0 for top tier
-                cooldownWindow: 60, //1 hours
+                cooldownWindow: 1440, // 24 hours
                 provingWindow: 2880, // 48 hours
                 maxBlocksToVerifyPerProof: 16
             });

--- a/packages/protocol/contracts/L1/tiers/TierProviderBase.sol
+++ b/packages/protocol/contracts/L1/tiers/TierProviderBase.sol
@@ -53,7 +53,7 @@ abstract contract TierProviderBase is ITierProvider {
                 verifierName: LibStrings.B_TIER_GUARDIAN_MINORITY,
                 validityBond: 500 ether, // TKO
                 contestBond: 3280 ether, // =500TKO * 6.5625
-                cooldownWindow: 360, // 6 hours
+                cooldownWindow: 240, // 4 hours
                 provingWindow: 2880, // 48 hours
                 maxBlocksToVerifyPerProof: 16
             });

--- a/packages/protocol/deployments/hekla-contract-logs.md
+++ b/packages/protocol/deployments/hekla-contract-logs.md
@@ -120,6 +120,8 @@
 - impl: `0x750D885DCAB712bA808D66D934CF315D0D98d04c.`
 - logs:
   - upgraded on May 14, 2024 at commit `0ef7b8caa`
+- todo:
+  - update tier config in Hekla and mainnet
 
 ### tierRouter
 

--- a/packages/protocol/deployments/mainnet-contract-logs-L1.md
+++ b/packages/protocol/deployments/mainnet-contract-logs-L1.md
@@ -227,6 +227,8 @@
 - logs:
   - deployed on May 1, 2024 @commit`56dddf2b6`
   - deployed on May 15, 2024 @commit`cd5144255`
+- todo:
+  - update tier config in Hekla and mainnet
 
 #### tier_sgx
 


### PR DESCRIPTION
Change guardian minority cooldown window from 24 hours to 4 hours. If one guardian is hacked and his proof is incorrect, guardian majority will override it, and guardian majority's cooldown is changed from 1 hour 24 hours so there will be more time for monitoring and necessary actions.