### PR TITLE
fix(relayer): bounds check for erc20 + nft data

### DIFF
--- a/packages/relayer/indexer/save_event_to_db.go
+++ b/packages/relayer/indexer/save_event_to_db.go
@@ -23,7 +23,7 @@ func (i *Indexer) saveEventToDB(
 ) (int, error) {
 	eventType, canonicalToken, amount, err := relayer.DecodeMessageData(eventData, eventValue)
 	if err != nil {
-		return 0, errors.Wrap(err, "eventTypeAmountAndCanonicalTokenFromEvent(event)")
+		return 0, errors.Wrap(err, "relayer.DecodeMessageData")
 	}
 
 	// check if we have an existing event already. this is mostly likely only true

--- a/packages/relayer/types.go
+++ b/packages/relayer/types.go
@@ -160,6 +160,11 @@ func decodeDataAsERC20(decodedData []byte) (CanonicalToken, *big.Int, error) {
 
 	// Boundary check
 	if startIndex >= int64(len(decodedData)) {
+		slog.Info("startIndex greater than decodedData length",
+			"startIndex", startIndex,
+			"lenDecodedData", int64(len(decodedData)),
+		)
+
 		return token, big.NewInt(0), errors.New("calculated index is out of bounds")
 	}
 
@@ -203,6 +208,11 @@ func decodeDataAsNFT(decodedData []byte) (EventType, CanonicalToken, *big.Int, e
 
 	// Boundary check
 	if startIndex >= int64(len(decodedData)) {
+		slog.Info("startIndex greater than decodedData length",
+			"startIndex", startIndex,
+			"lenDecodedData", int64(len(decodedData)),
+		)
+
 		return EventTypeSendETH, token, big.NewInt(0), errors.New("calculated index is out of bounds")
 	}
 

--- a/packages/relayer/types.go
+++ b/packages/relayer/types.go
@@ -160,7 +160,7 @@ func decodeDataAsERC20(decodedData []byte) (CanonicalToken, *big.Int, error) {
 
 	// Boundary check
 	if startIndex >= int64(len(decodedData)) {
-		slog.Info("startIndex greater than decodedData length",
+		slog.Warn("startIndex greater than decodedData length",
 			"startIndex", startIndex,
 			"lenDecodedData", int64(len(decodedData)),
 		)
@@ -208,7 +208,7 @@ func decodeDataAsNFT(decodedData []byte) (EventType, CanonicalToken, *big.Int, e
 
 	// Boundary check
 	if startIndex >= int64(len(decodedData)) {
-		slog.Info("startIndex greater than decodedData length",
+		slog.Warn("startIndex greater than decodedData length",
 			"startIndex", startIndex,
 			"lenDecodedData", int64(len(decodedData)),
 		)

--- a/packages/relayer/types.go
+++ b/packages/relayer/types.go
@@ -155,7 +155,15 @@ func decodeDataAsERC20(decodedData []byte) (CanonicalToken, *big.Int, error) {
 		return token, big.NewInt(0), errors.New("data for BigInt is invalid")
 	}
 
-	canonicalTokenData := decodedData[offset.Int64()+canonicalTokenDataStartingindex*32:]
+	// Calculate the starting index for canonicalTokenData
+	startIndex := offset.Int64() + canonicalTokenDataStartingindex*32
+
+	// Boundary check
+	if startIndex >= int64(len(decodedData)) {
+		return token, big.NewInt(0), errors.New("calculated index is out of bounds")
+	}
+
+	canonicalTokenData := decodedData[startIndex:]
 
 	types := []string{"uint64", "address", "uint8", "string", "string"}
 	values, err := decodeABI(types, canonicalTokenData)
@@ -190,7 +198,15 @@ func decodeDataAsNFT(decodedData []byte) (EventType, CanonicalToken, *big.Int, e
 		return EventTypeSendETH, token, big.NewInt(0), errors.New("data for BigInt is invalid")
 	}
 
-	canonicalTokenData := decodedData[offset.Int64()+canonicalTokenDataStartingindex*32:]
+	// Calculate the starting index for canonicalTokenData
+	startIndex := offset.Int64() + canonicalTokenDataStartingindex*32
+
+	// Boundary check
+	if startIndex >= int64(len(decodedData)) {
+		return EventTypeSendETH, token, big.NewInt(0), errors.New("calculated index is out of bounds")
+	}
+
+	canonicalTokenData := decodedData[startIndex:]
 
 	types := []string{"uint64", "address", "string", "string"}
 	values, err := decodeABI(types, canonicalTokenData)
@@ -283,6 +299,8 @@ func DecodeMessageData(eventData []byte, value *big.Int) (EventType, CanonicalTo
 
 		if err == nil {
 			return eventType, canonicalToken, amount, nil
+		} else {
+			return EventTypeSendETH, canonicalToken, amount, err
 		}
 	}
 

--- a/packages/relayer/types.go
+++ b/packages/relayer/types.go
@@ -299,8 +299,6 @@ func DecodeMessageData(eventData []byte, value *big.Int) (EventType, CanonicalTo
 
 		if err == nil {
 			return eventType, canonicalToken, amount, nil
-		} else {
-			return EventTypeSendETH, canonicalToken, amount, err
 		}
 	}
 


### PR DESCRIPTION
if a message is not ERC20 or not NFT data, it will not be long enough for the bounds check, so we should check the bounds when indexing the byte array.