### PR TITLE
feat(protocol): expose a `willSyncStateRoot(blockID)` function in TaikoL1

### DIFF
--- a/packages/protocol/contracts/L1/ITaikoL1.sol
+++ b/packages/protocol/contracts/L1/ITaikoL1.sol
@@ -36,5 +36,5 @@ interface ITaikoL1 {
 
     /// @notice Gets the configuration of the TaikoL1 contract.
     /// @return Config struct containing configuration parameters.
-    function getConfig() external view returns (TaikoData.Config memory);
+    function getConfig() external pure returns (TaikoData.Config memory);
 }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -222,7 +222,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
     }
 
     /// @inheritdoc ITaikoL1
-    function getConfig() public view virtual override returns (TaikoData.Config memory) {
+    function getConfig() public pure virtual override returns (TaikoData.Config memory) {
         // All hard-coded configurations:
         // - treasury: the actual TaikoL2 address.
         // - anchorGasLimit: 250_000 (based on internal devnet, its ~220_000
@@ -244,6 +244,10 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents, TaikoErrors {
             stateRootSyncInternal: 16,
             checkEOAForCalldataDA: true
         });
+    }
+
+    function willSyncStateRoot(uint64 _blockId) public pure returns (bool) {
+        return LibUtils.willSyncStateRoot(getConfig().stateRootSyncInternal, _blockId);
     }
 
     /// @dev chain_pauser is supposed to be a cold wallet.

--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -127,7 +127,7 @@ library LibProving {
 
         local.blockId = blk.blockId;
 
-        if (LibUtils.shouldSyncStateRoot(_config.stateRootSyncInternal, local.blockId)) {
+        if (LibUtils.willSyncStateRoot(_config.stateRootSyncInternal, local.blockId)) {
             local.stateRoot = _tran.stateRoot;
         }
 

--- a/packages/protocol/contracts/L1/libs/LibUtils.sol
+++ b/packages/protocol/contracts/L1/libs/LibUtils.sol
@@ -230,7 +230,7 @@ library LibUtils {
         return _blockId % segmentSize == (_isBlockProposed ? 0 : segmentSize >> 1);
     }
 
-    function shouldSyncStateRoot(
+    function willSyncStateRoot(
         uint256 _stateRootSyncInternal,
         uint256 _blockId
     )

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -139,7 +139,7 @@ library LibVerifying {
                     tier: local.tier
                 });
 
-                if (LibUtils.shouldSyncStateRoot(_config.stateRootSyncInternal, local.blockId)) {
+                if (LibUtils.willSyncStateRoot(_config.stateRootSyncInternal, local.blockId)) {
                     local.stateRoot = ts.stateRoot;
                     local.syncBlockId = local.blockId;
                 }

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -685,7 +685,9 @@ contract Bridge is EssentialContract, IBridge {
     }
 
     /// @dev Suggested by OpenZeppelin and copied from
-    /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/83c7e45092dac350b070c421cd2bf7105616cf1a/contracts/metatx/ERC2771Forwarder.sol#L327C1-L370C6
+    /// https://github.com/OpenZeppelin/openzeppelin-contracts/
+    /// blob/83c7e45092dac350b070c421cd2bf7105616cf1a/contracts/
+    /// metatx/ERC2771Forwarder.sol#L327C1-L370C6
     ///
     /// @dev Checks if the requested gas was correctly forwarded to the callee.
     /// As a consequence of https://eips.ethereum.org/EIPS/eip-150[EIP-150]:

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.24;
 import "./TaikoL1TestBase.sol";
 
 contract TaikoL1_NoCooldown is TaikoL1 {
-    function getConfig() public view override returns (TaikoData.Config memory config) {
+    function getConfig() public pure override returns (TaikoData.Config memory config) {
         config = TaikoL1.getConfig();
         // over-write the following
         config.maxBlocksToVerify = 0;

--- a/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/L1/TaikoL1LibProvingWithTiers.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.24;
 import "./TaikoL1TestBase.sol";
 
 contract TaikoL1Tiers is TaikoL1 {
-    function getConfig() public view override returns (TaikoData.Config memory config) {
+    function getConfig() public pure override returns (TaikoData.Config memory config) {
         config = TaikoL1.getConfig();
 
         config.maxBlocksToVerify = 0;
@@ -423,7 +423,7 @@ contract TaikoL1LibProvingWithTiers is TaikoL1TestBase {
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
         for (uint256 blockId = 1; blockId < conf.blockMaxProposals * 3; blockId++) {
-            bool storeStateRoot = LibUtils.shouldSyncStateRoot(syncInternal, blockId);
+            bool storeStateRoot = LibUtils.willSyncStateRoot(syncInternal, blockId);
             console2.log("blockId:", blockId);
             console2.log("storeStateRoot:", storeStateRoot);
 

--- a/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.24;
 import "./TaikoL1TestBase.sol";
 
 contract TaikoL1New is TaikoL1 {
-    function getConfig() public view override returns (TaikoData.Config memory config) {
+    function getConfig() public pure override returns (TaikoData.Config memory config) {
         config = TaikoL1.getConfig();
         config.maxBlocksToVerify = 0;
         config.blockMaxProposals = 10;


### PR DESCRIPTION
If `willSyncStateRoot(blockId)` returns false, block provers should not care the block's transition's `stateRoot` values for contestation, otherwise, they should.