### PR TITLE
fix(protocol): support multicall context in `DelegateOwner` 

### DIFF
--- a/packages/protocol/contracts/L2/DelegateOwner.sol
+++ b/packages/protocol/contracts/L2/DelegateOwner.sol
@@ -104,7 +104,10 @@ contract DelegateOwner is EssentialContract, IMessageInvocable {
     /// @dev Updates the admin address.
     /// @param _admin The new admin address.
     function setAdmin(address _admin) external {
-        if (msg.sender != owner() && msg.sender != admin) revert DO_PERMISSION_DENIED();
+        IBridge.Context memory ctx = IBridge(msg.sender).context();
+        if (msg.sender != owner() && msg.sender != admin && ctx.from != realOwner) {
+            revert DO_PERMISSION_DENIED();
+        }
         if (admin == _admin) revert DO_INVALID_PARAM();
 
         emit AdminUpdated(admin, _admin);


### PR DESCRIPTION
In `DelegateOwner` we have the `setAdmin` function, which works as expected if we call it in a "normal", but currently does not support `multicall3` way of calling itself.

So in case of this scenario for example:

`onMessageInvocation` (through the bridge) by calling `aggregate3` on `multicall3`, to perform 2 inner transactions:
- one of them is to set this `DelegateOwner`'s admin address to a new value
- the other is to call an owned contract to perform a upgrade

So the path of calling would be this:
Bridge -> DelegateOwner -> Multicall -> 1. DelegateOwner (setAdmin)
                                                               -> 2. Another contract to upgrade the impl contract.
 
 The problem with the 1st path is, that the `msg.sender` in `setAdmin`, will be DelegateOwner contract address - in this `multicall3` way.                    