### PR TITLE
feat(protocol): emit CalldataTxList when calldata is used for DA

### DIFF
--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -26,6 +26,11 @@ abstract contract TaikoEvents {
         TaikoData.EthDeposit[] depositsProcessed
     );
 
+    /// @notice Emitted when a block's txList is in the calldata.
+    /// @param blockId The ID of the proposed block.
+    /// @param txList The txList.
+    event CalldataTxList(uint256 indexed blockId, bytes txList);
+
     /// @dev Emitted when a block is verified.
     /// @param blockId The ID of the verified block.
     /// @param prover The prover whose transition is used for verifying the

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -32,6 +32,11 @@ library LibProposing {
         TaikoData.EthDeposit[] depositsProcessed
     );
 
+    /// @notice Emitted when a block's txList is in the calldata.
+    /// @param blockId The ID of the proposed block.
+    /// @param txList The txList.
+    event CalldataTxList(uint256 indexed blockId, bytes txList);
+
     // Warning: Any errors defined here must also be defined in TaikoErrors.sol.
     error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
@@ -130,6 +135,8 @@ library LibProposing {
             ) {
                 revert L1_INVALID_SIG();
             }
+
+            emit CalldataTxList(meta_.id, _txList);
         }
 
         // Following the Merge, the L1 mixHash incorporates the


### PR DESCRIPTION
This is to support using calldata from contract proposers. A [second step]([url](https://github.com/taikoxyz/taiko-mono/pull/17641/files)) will follow to remove the current requirement that only EOA proposers can use calldata. With this PR, the node/client can switch to using this event to fetch the calldata.