### PR TITLE
feat(relayer): flags for processing and indexing minimum amounts

### DIFF
--- a/packages/relayer/cmd/flags/indexer.go
+++ b/packages/relayer/cmd/flags/indexer.go
@@ -103,7 +103,7 @@ var (
 	MinFeeToIndex = &cli.Uint64Flag{
 		Name:     "minFeeToIndex",
 		Usage:    "Minimum fee to index and add to the queue (will still be saved to database)",
-		Category: processorCategory,
+		Category: indexerCategory,
 		Value:    0,
 		EnvVars:  []string{"MIN_FEE_TO_INDEX"},
 	}

--- a/packages/relayer/cmd/flags/indexer.go
+++ b/packages/relayer/cmd/flags/indexer.go
@@ -100,6 +100,13 @@ var (
 		Category: indexerCategory,
 		EnvVars:  []string{"TARGET_BLOCK_NUMBER"},
 	}
+	MinFeeToIndex = &cli.Uint64Flag{
+		Name:     "minFeeToIndex",
+		Usage:    "Minimum fee to index and add to the queue (will still be saved to database)",
+		Category: processorCategory,
+		Value:    0,
+		EnvVars:  []string{"MIN_FEE_TO_INDEX"},
+	}
 )
 
 var IndexerFlags = MergeFlags(CommonFlags, QueueFlags, []cli.Flag{
@@ -115,5 +122,6 @@ var IndexerFlags = MergeFlags(CommonFlags, QueueFlags, []cli.Flag{
 	NumLatestBlocksEndWhenCrawling,
 	NumLatestBlocksStartWhenCrawling,
 	EventName,
+	MinFeeToIndex,
 	TargetBlockNumber,
 })

--- a/packages/relayer/cmd/flags/processor.go
+++ b/packages/relayer/cmd/flags/processor.go
@@ -143,6 +143,13 @@ var (
 		Required: false,
 		EnvVars:  []string{"DEST_QUOTA_MANAGER_ADDRESS"},
 	}
+	MinFeeToProcess = &cli.Uint64Flag{
+		Name:     "minFeeToProcess",
+		Usage:    "Minimum fee to process",
+		Category: processorCategory,
+		Value:    0,
+		EnvVars:  []string{"MIN_FEE_TO_PROCESS"},
+	}
 )
 
 var ProcessorFlags = MergeFlags(CommonFlags, QueueFlags, TxmgrFlags, []cli.Flag{
@@ -166,5 +173,6 @@ var ProcessorFlags = MergeFlags(CommonFlags, QueueFlags, TxmgrFlags, []cli.Flag{
 	CacheOption,
 	UnprofitableMessageQueueExpiration,
 	MaxMessageRetries,
+	MinFeeToProcess,
 	DestQuotaManagerAddress,
 })

--- a/packages/relayer/indexer/config.go
+++ b/packages/relayer/indexer/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	TargetBlockNumber                *uint64
 	BackOffRetryInterval             time.Duration
 	BackOffMaxRetries                uint64
+	MinFeeToIndex                    uint64
 	OpenQueueFunc                    func() (queue.Queue, error)
 	OpenDBFunc                       func() (DB, error)
 }
@@ -85,6 +86,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		EventName:                        c.String(flags.EventName.Name),
 		BackOffMaxRetries:                c.Uint64(flags.BackOffMaxRetrys.Name),
 		BackOffRetryInterval:             c.Duration(flags.BackOffRetryInterval.Name),
+		MinFeeToIndex:                    c.Uint64(flags.MinFeeToIndex.Name),
 		TargetBlockNumber: func() *uint64 {
 			if c.IsSet(flags.TargetBlockNumber.Name) {
 				value := c.Uint64(flags.TargetBlockNumber.Name)

--- a/packages/relayer/indexer/handle_message_sent_event.go
+++ b/packages/relayer/indexer/handle_message_sent_event.go
@@ -108,6 +108,13 @@ func (i *Indexer) handleMessageSentEvent(
 		return nil
 	}
 
+	if i.minFeeToIndex != 0 && event.Message.Fee < i.minFeeToIndex {
+		slog.Warn("Fee is less than minFeeToIndex, not adding to queue",
+			"fee", event.Message.Fee,
+			"minFeeToIndex", i.minFeeToIndex,
+		)
+	}
+
 	msg := queue.QueueMessageSentBody{
 		ID:    id,
 		Event: event,

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -245,6 +245,8 @@ func InitFromConfig(ctx context.Context, i *Indexer, cfg *Config) (err error) {
 
 	i.minFeeToIndex = i.cfg.MinFeeToIndex
 
+	slog.Info("minFeeToIndex", "minFeeToIndex", i.minFeeToIndex)
+
 	return nil
 }
 

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -125,6 +125,8 @@ type Indexer struct {
 
 	eventName string
 
+	minFeeToIndex uint64
+
 	cfg *Config
 }
 
@@ -240,6 +242,8 @@ func InitFromConfig(ctx context.Context, i *Indexer, cfg *Config) (err error) {
 	i.cfg = cfg
 
 	i.ctx = ctx
+
+	i.minFeeToIndex = i.cfg.MinFeeToIndex
 
 	return nil
 }

--- a/packages/relayer/processor/config.go
+++ b/packages/relayer/processor/config.go
@@ -86,6 +86,7 @@ type Config struct {
 	TxmgrConfigs *txmgr.CLIConfig
 
 	MaxMessageRetries uint64
+	MinFeeToProcess   uint64
 }
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
@@ -176,6 +177,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			c,
 		),
 		MaxMessageRetries: c.Uint64(flags.MaxMessageRetries.Name),
+		MinFeeToProcess:   c.Uint64(flags.MinFeeToProcess.Name),
 		OpenDBFunc: func() (DB, error) {
 			return db.OpenDBConnection(db.DBConnectionOpts{
 				Name:            c.String(flags.DatabaseUsername.Name),

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -117,10 +117,7 @@ func (p *Processor) processMessage(
 		return false, msgBody.TimesRetried, nil
 	}
 
-	if err := p.waitForConfirmations(ctx, msgBody.Event.Raw.TxHash, msgBody.Event.Raw.BlockNumber); err != nil {
-		return false, msgBody.TimesRetried, err
-	}
-
+	// check message process eligibility before waiting for confirmations to process
 	eventStatus, err := p.eventStatusFromMsgHash(ctx, msgBody.Event.MsgHash)
 	if err != nil {
 		return false, msgBody.TimesRetried, errors.Wrap(err, "p.eventStatusFromMsgHash")
@@ -134,6 +131,10 @@ func (p *Processor) processMessage(
 		uint64(msgBody.Event.Message.GasLimit),
 	) {
 		return false, msgBody.TimesRetried, nil
+	}
+
+	if err := p.waitForConfirmations(ctx, msgBody.Event.Raw.TxHash, msgBody.Event.Raw.BlockNumber); err != nil {
+		return false, msgBody.TimesRetried, err
 	}
 
 	// check paused status

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -117,6 +117,7 @@ func (p *Processor) processMessage(
 		slog.Warn("minFeeToProcess not met",
 			"minFeeToProcess", p.minFeeToProcess,
 			"fee", msgBody.Event.Message.Fee,
+			"srcTxHash", msgBody.Event.Raw.TxHash.Hex(),
 		)
 
 		return false, msgBody.TimesRetried, nil

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -114,6 +114,11 @@ func (p *Processor) processMessage(
 	// we never want to process messages below a certain fee, if set.
 	// return a nil error, and we will successfully acknowledge this.
 	if p.minFeeToProcess != 0 && msgBody.Event.Message.Fee < p.minFeeToProcess {
+		slog.Warn("minFeeToProcess not met",
+			"minFeeToProcess", p.minFeeToProcess,
+			"fee", msgBody.Event.Message.Fee,
+		)
+
 		return false, msgBody.TimesRetried, nil
 	}
 

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -111,6 +111,12 @@ func (p *Processor) processMessage(
 		return false, msgBody.TimesRetried, nil
 	}
 
+	// we never want to process messages below a certain fee, if set.
+	// return a nil error, and we will successfully acknowledge this.
+	if p.minFeeToProcess != 0 && msgBody.Event.Message.Fee < p.minFeeToProcess {
+		return false, msgBody.TimesRetried, nil
+	}
+
 	if err := p.waitForConfirmations(ctx, msgBody.Event.Raw.TxHash, msgBody.Event.Raw.BlockNumber); err != nil {
 		return false, msgBody.TimesRetried, err
 	}

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -136,6 +136,8 @@ type Processor struct {
 
 	processingTxHashes map[common.Hash]bool
 	processingTxHashMu sync.Mutex
+
+	minFeeToProcess uint64
 }
 
 // InitFromCli creates a new processor from a cli context
@@ -372,6 +374,8 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 	p.maxMessageRetries = cfg.MaxMessageRetries
 
 	p.processingTxHashes = make(map[common.Hash]bool, 0)
+
+	p.minFeeToProcess = p.cfg.MinFeeToProcess
 
 	return nil
 }

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -510,10 +511,18 @@ func (p *Processor) eventLoop(ctx context.Context) {
 				}
 
 				if shouldRequeue {
-					// we want to negatively acknowledge the message and make sure
-					// we requeue it
+					// we want to negatively acknowledge the message
 					if err := p.queue.Nack(ctx, m, true); err != nil {
 						slog.Error("Err nacking message", "err", err.Error())
+					}
+
+					marshalledMsg, err := json.Marshal(msg)
+					if err != nil {
+						slog.Error("err marshaling queue message", "err", err.Error())
+					} else {
+						if err := p.queue.Publish(ctx, p.queueName(), marshalledMsg, nil, nil); err != nil {
+							slog.Error("err publishing to queue", "err", err.Error())
+						}
 					}
 				} else {
 					// otherwise if no error, we can acknowledge it successfully.

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -377,6 +377,8 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 
 	p.minFeeToProcess = p.cfg.MinFeeToProcess
 
+	slog.Info("minFeeToProcess", "minFeeToProcess", p.minFeeToProcess)
+
 	return nil
 }
 


### PR DESCRIPTION
This will let us filter out permanently from being added to the queue, messages where:
- a fee is set but it will *never* be profitable
- a fee is set at a low gas price, and our minimum is now bumped
- a unprofitable message that has circulated the queue too long and is being re-crawled by our crawler over and over

this PR also handles context.Cancelled shutdown error correctly, by doing nothing with the message, instead of Nacking it. Now it will automatically go to a diff consumer.