### PR TITLE
chore(relayer): upgrade event db operation

### DIFF
--- a/packages/relayer/event.go
+++ b/packages/relayer/event.go
@@ -159,6 +159,7 @@ type EventRepository interface {
 	) (uint64, error)
 	DeleteAllAfterBlockID(blockID uint64, srcChainID uint64, destChainID uint64) error
 	FindLatestBlockID(
+		ctx context.Context,
 		event string,
 		srcChainID uint64,
 		destChainID uint64,

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -474,7 +474,7 @@ func (i *Indexer) indexMessageSentEvents(ctx context.Context,
 }
 
 func (i *Indexer) checkReorg(ctx context.Context, emittedInBlockNumber uint64) error {
-	n, err := i.eventRepo.FindLatestBlockID(i.eventName, i.srcChainId.Uint64(), i.destChainId.Uint64())
+	n, err := i.eventRepo.FindLatestBlockID(ctx, i.eventName, i.srcChainId.Uint64(), i.destChainId.Uint64())
 	if err != nil {
 		return err
 	}

--- a/packages/relayer/indexer/set_initial_Indexing_block_by_mode.go
+++ b/packages/relayer/indexer/set_initial_Indexing_block_by_mode.go
@@ -28,6 +28,7 @@ func (i *Indexer) setInitialIndexingBlockByMode(
 	case Sync:
 		// get most recently processed block height from the DB
 		latest, err := i.eventRepo.FindLatestBlockID(
+			i.ctx,
 			i.eventName,
 			chainID.Uint64(),
 			i.destChainId.Uint64(),

--- a/packages/relayer/pkg/http/get_block_info.go
+++ b/packages/relayer/pkg/http/get_block_info.go
@@ -80,6 +80,7 @@ func (srv *Server) GetBlockInfo(c echo.Context) error {
 	}
 
 	latestProcessedSrcBlock, err := srv.eventRepo.FindLatestBlockID(
+		c.Request().Context(),
 		relayer.EventNameMessageSent,
 		srcChainID.Uint64(),
 		destChainID.Uint64(),
@@ -89,6 +90,7 @@ func (srv *Server) GetBlockInfo(c echo.Context) error {
 	}
 
 	latestProcessedDestBlock, err := srv.eventRepo.FindLatestBlockID(
+		c.Request().Context(),
 		relayer.EventNameMessageSent,
 		destChainID.Uint64(),
 		srcChainID.Uint64(),

--- a/packages/relayer/pkg/mock/event_repository.go
+++ b/packages/relayer/pkg/mock/event_repository.go
@@ -205,6 +205,7 @@ func (r *EventRepository) DeleteAllAfterBlockID(blockID uint64, srcChainID uint6
 
 // GetLatestBlockID get latest block id
 func (r *EventRepository) FindLatestBlockID(
+	ctx context.Context,
 	event string,
 	srcChainID uint64,
 	destChainID uint64,

--- a/packages/relayer/pkg/repo/event.go
+++ b/packages/relayer/pkg/repo/event.go
@@ -73,6 +73,7 @@ func (r *EventRepository) UpdateFeesAndProfitability(
 	if err := tx.Count(&count).Error; err != nil {
 		return errors.Wrap(err, "r.db.Count")
 	}
+
 	if count == 0 {
 		return gorm.ErrRecordNotFound
 	}
@@ -104,6 +105,7 @@ func (r *EventRepository) UpdateStatus(ctx context.Context, id int, status relay
 	if err := tx.Count(&count).Error; err != nil {
 		return errors.Wrap(err, "r.db.Count")
 	}
+
 	if count == 0 {
 		return gorm.ErrRecordNotFound
 	}

--- a/packages/relayer/pkg/repo/event.go
+++ b/packages/relayer/pkg/repo/event.go
@@ -2,10 +2,8 @@ package repo
 
 import (
 	"context"
-	"strings"
-	"time"
-
 	"net/http"
+	"strings"
 
 	"github.com/morkid/paginate"
 	"github.com/pkg/errors"
@@ -54,7 +52,7 @@ func (r *EventRepository) Save(ctx context.Context, opts *relayer.SaveEventOpts)
 		EmittedBlockID:         opts.EmittedBlockID,
 	}
 
-	if err := r.db.GormDB().Create(e).Error; err != nil {
+	if err := r.db.GormDB().WithContext(ctx).Create(e).Error; err != nil {
 		return nil, errors.Wrap(err, "r.db.Create")
 	}
 
@@ -66,36 +64,31 @@ func (r *EventRepository) UpdateFeesAndProfitability(
 	id int,
 	opts *relayer.UpdateFeesAndProfitabilityOpts,
 ) error {
-	e := &relayer.Event{}
-	if err := r.db.GormDB().Where("id = ?", id).First(e).Error; err != nil {
-		return errors.Wrap(err, "r.db.First")
+	tx := r.db.GormDB().WithContext(ctx)
+	tx = tx.Model(&relayer.Event{})
+	tx = tx.Where("id = ?", id)
+	err := tx.Updates(map[string]interface{}{
+		"fee":                        opts.Fee,
+		"dest_chain_base_fee":        opts.DestChainBaseFee,
+		"gas_tip_cap":                opts.GasTipCap,
+		"gas_limit":                  opts.GasLimit,
+		"is_profitable":              opts.IsProfitable,
+		"estimated_onchain_fee":      opts.EstimatedOnchainFee,
+		"is_profitable_evaluated_at": opts.IsProfitableEvaluatedAt,
+	}).Error
+	if err != nil {
+		return errors.Wrap(err, "r.db.Commit")
 	}
-
-	e.Fee = &opts.Fee
-	e.DestChainBaseFee = &opts.DestChainBaseFee
-	e.GasTipCap = &opts.GasTipCap
-	e.GasLimit = &opts.GasLimit
-	e.IsProfitable = &opts.IsProfitable
-	e.EstimatedOnchainFee = &opts.EstimatedOnchainFee
-	currentTime := time.Now().UTC()
-	e.IsProfitableEvaluatedAt = &currentTime
-
-	if err := r.db.GormDB().Save(e).Error; err != nil {
-		return errors.Wrap(err, "r.db.Save")
-	}
-
 	return nil
 }
 
 func (r *EventRepository) UpdateStatus(ctx context.Context, id int, status relayer.EventStatus) error {
-	e := &relayer.Event{}
-	if err := r.db.GormDB().Where("id = ?", id).First(e).Error; err != nil {
-		return errors.Wrap(err, "r.db.First")
-	}
-
-	e.Status = status
-	if err := r.db.GormDB().Save(e).Error; err != nil {
-		return errors.Wrap(err, "r.db.Save")
+	tx := r.db.GormDB().WithContext(ctx)
+	tx = tx.Model(&relayer.Event{})
+	tx = tx.Where("id = ?", id)
+	err := tx.Update("status", status).Error
+	if err != nil {
+		return errors.Wrap(err, "tx.Commit")
 	}
 
 	return nil
@@ -107,7 +100,7 @@ func (r *EventRepository) FirstByMsgHash(
 ) (*relayer.Event, error) {
 	e := &relayer.Event{}
 	// find all message sent events
-	if err := r.db.GormDB().Where("msg_hash = ?", msgHash).
+	if err := r.db.GormDB().WithContext(ctx).Where("msg_hash = ?", msgHash).
 		First(&e).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
@@ -126,7 +119,7 @@ func (r *EventRepository) FirstByEventAndMsgHash(
 ) (*relayer.Event, error) {
 	e := &relayer.Event{}
 	// find all message sent events
-	if err := r.db.GormDB().Where("msg_hash = ?", msgHash).
+	if err := r.db.GormDB().WithContext(ctx).Where("msg_hash = ?", msgHash).
 		Where("event = ?", event).
 		First(&e).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -148,7 +141,7 @@ func (r *EventRepository) FindAllByAddress(
 		DefaultSize: 100,
 	})
 
-	q := r.db.GormDB().
+	q := r.db.GormDB().WithContext(ctx).
 		Model(&relayer.Event{}).
 		Where(
 			"dest_owner_json = ? OR message_owner = ?",
@@ -186,7 +179,7 @@ func (r *EventRepository) Delete(
 	ctx context.Context,
 	id int,
 ) error {
-	return r.db.GormDB().Delete(relayer.Event{}, id).Error
+	return r.db.GormDB().WithContext(ctx).Delete(relayer.Event{}, id).Error
 }
 
 func (r *EventRepository) ChainDataSyncedEventByBlockNumberOrGreater(
@@ -197,7 +190,7 @@ func (r *EventRepository) ChainDataSyncedEventByBlockNumberOrGreater(
 ) (*relayer.Event, error) {
 	e := &relayer.Event{}
 	// find all message sent events
-	if err := r.db.GormDB().Where("name = ?", relayer.EventNameChainDataSynced).
+	if err := r.db.GormDB().WithContext(ctx).Where("name = ?", relayer.EventNameChainDataSynced).
 		Where("chain_id = ?", srcChainId).
 		Where("synced_chain_id = ?", syncedChainId).
 		Where("block_id >= ?", blockNumber).
@@ -221,7 +214,7 @@ func (r *EventRepository) LatestChainDataSyncedEvent(
 ) (uint64, error) {
 	blockID := 0
 	// find all message sent events
-	if err := r.db.GormDB().Table("events").
+	if err := r.db.GormDB().WithContext(ctx).Table("events").
 		Where("chain_id = ?", srcChainId).
 		Where("synced_chain_id = ?", syncedChainId).
 		Select("COALESCE(MAX(block_id), 0)").
@@ -247,6 +240,7 @@ WHERE block_id >= ? AND chain_id = ? AND dest_chain_id = ?`
 
 // GetLatestBlockID get latest block id
 func (r *EventRepository) FindLatestBlockID(
+	ctx context.Context,
 	event string,
 	srcChainID uint64,
 	destChainID uint64,
@@ -256,7 +250,7 @@ func (r *EventRepository) FindLatestBlockID(
 
 	var b uint64
 
-	if err := r.db.GormDB().Table("events").Raw(q, srcChainID, destChainID, event).Scan(&b).Error; err != nil {
+	if err := r.db.GormDB().WithContext(ctx).Table("events").Raw(q, srcChainID, destChainID, event).Scan(&b).Error; err != nil {
 		return 0, err
 	}
 

--- a/packages/relayer/pkg/repo/event.go
+++ b/packages/relayer/pkg/repo/event.go
@@ -67,6 +67,16 @@ func (r *EventRepository) UpdateFeesAndProfitability(
 	tx := r.db.GormDB().WithContext(ctx)
 	tx = tx.Model(&relayer.Event{})
 	tx = tx.Where("id = ?", id)
+
+	// check if existed.
+	var count int64
+	if err := tx.Count(&count).Error; err != nil {
+		return errors.Wrap(err, "r.db.Count")
+	}
+	if count == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
 	err := tx.Updates(map[string]interface{}{
 		"fee":                        opts.Fee,
 		"dest_chain_base_fee":        opts.DestChainBaseFee,
@@ -88,9 +98,17 @@ func (r *EventRepository) UpdateStatus(ctx context.Context, id int, status relay
 	tx := r.db.GormDB().WithContext(ctx)
 	tx = tx.Model(&relayer.Event{})
 	tx = tx.Where("id = ?", id)
-	err := tx.Update("status", status).Error
 
-	if err != nil {
+	// check if existed.
+	var count int64
+	if err := tx.Count(&count).Error; err != nil {
+		return errors.Wrap(err, "r.db.Count")
+	}
+	if count == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
+	if err := tx.Update("status", status).Error; err != nil {
 		return errors.Wrap(err, "tx.Commit")
 	}
 

--- a/packages/relayer/pkg/repo/event.go
+++ b/packages/relayer/pkg/repo/event.go
@@ -76,9 +76,11 @@ func (r *EventRepository) UpdateFeesAndProfitability(
 		"estimated_onchain_fee":      opts.EstimatedOnchainFee,
 		"is_profitable_evaluated_at": opts.IsProfitableEvaluatedAt,
 	}).Error
+
 	if err != nil {
 		return errors.Wrap(err, "r.db.Commit")
 	}
+
 	return nil
 }
 
@@ -87,6 +89,7 @@ func (r *EventRepository) UpdateStatus(ctx context.Context, id int, status relay
 	tx = tx.Model(&relayer.Event{})
 	tx = tx.Where("id = ?", id)
 	err := tx.Update("status", status).Error
+
 	if err != nil {
 		return errors.Wrap(err, "tx.Commit")
 	}
@@ -250,7 +253,8 @@ func (r *EventRepository) FindLatestBlockID(
 
 	var b uint64
 
-	if err := r.db.GormDB().WithContext(ctx).Table("events").Raw(q, srcChainID, destChainID, event).Scan(&b).Error; err != nil {
+	if err := r.db.GormDB().WithContext(ctx).Table("events").
+		Raw(q, srcChainID, destChainID, event).Scan(&b).Error; err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
- Use `ctx` during event db operation.
- Only store the data that needs to be modified instead of selecting and saving all the struct fields.