### PR TITLE
chore(relayer): change event repository

### DIFF
--- a/packages/relayer/.golangci.yml
+++ b/packages/relayer/.golangci.yml
@@ -24,7 +24,8 @@ linters:
     - lll
     - unused
     - whitespace
-    - wsl
+    - lll
+    - importas
 
 linters-settings:
   funlen:

--- a/packages/relayer/api/api.go
+++ b/packages/relayer/api/api.go
@@ -13,7 +13,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/taikol2"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/http"
-	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils"
 	"github.com/urfave/cli/v2"
 )
@@ -41,11 +40,6 @@ func InitFromConfig(ctx context.Context, api *API, cfg *Config) (err error) {
 		return err
 	}
 
-	eventRepository, err := repo.NewEventRepository(db)
-	if err != nil {
-		return err
-	}
-
 	srcEthClient, err := ethclient.Dial(cfg.SrcRPCUrl)
 	if err != nil {
 		return err
@@ -62,7 +56,7 @@ func InitFromConfig(ctx context.Context, api *API, cfg *Config) (err error) {
 	}
 
 	srv, err := http.NewServer(http.NewServerOpts{
-		EventRepo:               eventRepository,
+		DB:                      db,
 		Echo:                    echo.New(),
 		CorsOrigins:             cfg.CORSOrigins,
 		SrcEthClient:            srcEthClient,

--- a/packages/relayer/event.go
+++ b/packages/relayer/event.go
@@ -1,7 +1,7 @@
 package relayer
 
 import (
-	"context"
+	"gorm.io/gorm"
 	"math/big"
 	"net/http"
 	"time"
@@ -128,37 +128,38 @@ type FindAllByAddressOpts struct {
 
 // EventRepository is used to interact with events in the store
 type EventRepository interface {
-	Save(ctx context.Context, opts *SaveEventOpts) (*Event, error)
-	UpdateStatus(ctx context.Context, id int, status EventStatus) error
-	UpdateFeesAndProfitability(ctx context.Context, id int, opts *UpdateFeesAndProfitabilityOpts) error
+	Save(db *gorm.DB, opts *SaveEventOpts) (*Event, error)
+	UpdateStatus(db *gorm.DB, id int, status EventStatus) error
+	UpdateFeesAndProfitability(db *gorm.DB, id int, opts *UpdateFeesAndProfitabilityOpts) error
 	FindAllByAddress(
-		ctx context.Context,
+		db *gorm.DB,
 		req *http.Request,
 		opts FindAllByAddressOpts,
 	) (*paginate.Page, error)
 	FirstByMsgHash(
-		ctx context.Context,
+		db *gorm.DB,
 		msgHash string,
 	) (*Event, error)
 	FirstByEventAndMsgHash(
-		ctx context.Context,
+		db *gorm.DB,
 		event string,
 		msgHash string,
 	) (*Event, error)
-	Delete(ctx context.Context, id int) error
+	Delete(db *gorm.DB, id int) error
 	ChainDataSyncedEventByBlockNumberOrGreater(
-		ctx context.Context,
+		db *gorm.DB,
 		srcChainId uint64,
 		syncedChainId uint64,
 		blockNumber uint64,
 	) (*Event, error)
 	LatestChainDataSyncedEvent(
-		ctx context.Context,
+		db *gorm.DB,
 		srcChainId uint64,
 		syncedChainId uint64,
 	) (uint64, error)
-	DeleteAllAfterBlockID(blockID uint64, srcChainID uint64, destChainID uint64) error
+	DeleteAllAfterBlockID(db *gorm.DB, blockID uint64, srcChainID uint64, destChainID uint64) error
 	FindLatestBlockID(
+		db *gorm.DB,
 		event string,
 		srcChainID uint64,
 		destChainID uint64,

--- a/packages/relayer/indexer/handle_chain_data_synced_event.go
+++ b/packages/relayer/indexer/handle_chain_data_synced_event.go
@@ -3,11 +3,13 @@ package indexer
 import (
 	"context"
 	"encoding/json"
+	"gorm.io/gorm"
 
 	"log/slog"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
+
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/signalservice"
 )
@@ -15,6 +17,7 @@ import (
 // handleChainDataSyncedEvent handles an individual ChainDataSynced event
 func (i *Indexer) handleChainDataSyncedEvent(
 	ctx context.Context,
+	dbTx *gorm.DB,
 	event *signalservice.SignalServiceChainDataSynced,
 	waitForConfirmations bool,
 ) error {
@@ -52,7 +55,7 @@ func (i *Indexer) handleChainDataSyncedEvent(
 		return errors.Wrap(err, "json.Marshal(event)")
 	}
 
-	_, err = i.eventRepo.Save(ctx, &relayer.SaveEventOpts{
+	_, err = i.eventRepo.Save(dbTx.WithContext(ctx), &relayer.SaveEventOpts{
 		Name:            relayer.EventNameChainDataSynced,
 		Event:           relayer.EventNameChainDataSynced,
 		Data:            string(marshaled),

--- a/packages/relayer/indexer/handle_message_processed_event.go
+++ b/packages/relayer/indexer/handle_message_processed_event.go
@@ -3,10 +3,12 @@ package indexer
 import (
 	"context"
 	"encoding/json"
+	"gorm.io/gorm"
 	"log/slog"
 	"math/big"
 
 	"github.com/pkg/errors"
+
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
@@ -15,6 +17,7 @@ import (
 // handleMessageProcessedEvent handles an individual MessageProcessed event
 func (i *Indexer) handleMessageProcessedEvent(
 	ctx context.Context,
+	dbTx *gorm.DB,
 	chainID *big.Int,
 	event *bridge.BridgeMessageProcessed,
 	waitForConfirmations bool,
@@ -73,6 +76,7 @@ func (i *Indexer) handleMessageProcessedEvent(
 
 	id, err := i.saveEventToDB(
 		ctx,
+		dbTx,
 		marshaled,
 		"0x",
 		chainID,

--- a/packages/relayer/indexer/handle_message_sent_event.go
+++ b/packages/relayer/indexer/handle_message_sent_event.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"encoding/json"
+	"gorm.io/gorm"
 	"math/big"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
+
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
@@ -24,6 +26,7 @@ var (
 // handleMessageSentEvent handles an individual MessageSent event
 func (i *Indexer) handleMessageSentEvent(
 	ctx context.Context,
+	dbTx *gorm.DB,
 	chainID *big.Int,
 	event *bridge.BridgeMessageSent,
 	waitForConfirmations bool,
@@ -83,6 +86,7 @@ func (i *Indexer) handleMessageSentEvent(
 
 	id, err := i.saveEventToDB(
 		ctx,
+		dbTx,
 		marshaled,
 		common.Hash(event.MsgHash).Hex(),
 		chainID,

--- a/packages/relayer/indexer/set_initial_Indexing_block_by_mode.go
+++ b/packages/relayer/indexer/set_initial_Indexing_block_by_mode.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/pkg/errors"
+
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 )
 
@@ -28,6 +29,7 @@ func (i *Indexer) setInitialIndexingBlockByMode(
 	case Sync:
 		// get most recently processed block height from the DB
 		latest, err := i.eventRepo.FindLatestBlockID(
+			i.db.GormDB().WithContext(i.ctx),
 			i.eventName,
 			chainID.Uint64(),
 			i.destChainId.Uint64(),

--- a/packages/relayer/pkg/http/get_block_info.go
+++ b/packages/relayer/pkg/http/get_block_info.go
@@ -80,6 +80,7 @@ func (srv *Server) GetBlockInfo(c echo.Context) error {
 	}
 
 	latestProcessedSrcBlock, err := srv.eventRepo.FindLatestBlockID(
+		srv.db.GormDB().WithContext(c.Request().Context()),
 		relayer.EventNameMessageSent,
 		srcChainID.Uint64(),
 		destChainID.Uint64(),
@@ -89,6 +90,7 @@ func (srv *Server) GetBlockInfo(c echo.Context) error {
 	}
 
 	latestProcessedDestBlock, err := srv.eventRepo.FindLatestBlockID(
+		srv.db.GormDB().WithContext(c.Request().Context()),
 		relayer.EventNameMessageSent,
 		destChainID.Uint64(),
 		srcChainID.Uint64(),

--- a/packages/relayer/pkg/http/get_events_by_address.go
+++ b/packages/relayer/pkg/http/get_events_by_address.go
@@ -95,7 +95,7 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 	}
 
 	page, err := srv.eventRepo.FindAllByAddress(
-		c.Request().Context(),
+		srv.db.GormDB().WithContext(c.Request().Context()),
 		c.Request(),
 		relayer.FindAllByAddressOpts{
 			Address:   common.HexToAddress(address),
@@ -114,7 +114,7 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 		v := &(*page.Items.(*[]relayer.Event))[i]
 
 		msgProcessedEvent, err := srv.eventRepo.FirstByEventAndMsgHash(
-			c.Request().Context(),
+			srv.db.GormDB().WithContext(c.Request().Context()),
 			relayer.EventNameMessageStatusChanged,
 			v.MsgHash,
 		)

--- a/packages/relayer/pkg/http/server.go
+++ b/packages/relayer/pkg/http/server.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"context"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/db"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
 	"math/big"
 	"net/http"
 	"os"
@@ -42,6 +44,7 @@ type ethClient interface {
 // @host relayer.hekla.taiko.xyz
 // Server represents an relayer http server instance.
 type Server struct {
+	db                      db.DB
 	echo                    *echo.Echo
 	eventRepo               relayer.EventRepository
 	srcEthClient            ethClient
@@ -53,8 +56,8 @@ type Server struct {
 }
 
 type NewServerOpts struct {
+	DB                      db.DB
 	Echo                    *echo.Echo
-	EventRepo               relayer.EventRepository
 	CorsOrigins             []string
 	SrcEthClient            ethClient
 	DestEthClient           ethClient
@@ -67,8 +70,8 @@ func (opts NewServerOpts) Validate() error {
 		return ErrNoHTTPFramework
 	}
 
-	if opts.EventRepo == nil {
-		return relayer.ErrNoEventRepository
+	if opts.DB == nil {
+		return db.ErrNoDB
 	}
 
 	if opts.CorsOrigins == nil {
@@ -102,8 +105,9 @@ func NewServer(opts NewServerOpts) (*Server, error) {
 	}
 
 	srv := &Server{
+		db:                      opts.DB,
 		echo:                    opts.Echo,
-		eventRepo:               opts.EventRepo,
+		eventRepo:               &repo.EventRepository{},
 		srcEthClient:            opts.SrcEthClient,
 		destEthClient:           opts.DestEthClient,
 		processingFeeMultiplier: opts.ProcessingFeeMultiplier,

--- a/packages/relayer/pkg/mock/event_repository.go
+++ b/packages/relayer/pkg/mock/event_repository.go
@@ -1,16 +1,17 @@
 package mock
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
+	"gorm.io/gorm"
 	"math/rand"
 	"net/http"
 	"time"
 
 	"github.com/morkid/paginate"
-	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"gorm.io/datatypes"
+
+	"github.com/taikoxyz/taiko-mono/packages/relayer"
 )
 
 type EventRepository struct {
@@ -22,7 +23,7 @@ func NewEventRepository() *EventRepository {
 		events: make([]*relayer.Event, 0),
 	}
 }
-func (r *EventRepository) Save(ctx context.Context, opts *relayer.SaveEventOpts) (*relayer.Event, error) {
+func (r *EventRepository) Save(db *gorm.DB, opts *relayer.SaveEventOpts) (*relayer.Event, error) {
 	r.events = append(r.events, &relayer.Event{
 		ID:           rand.Int(), // nolint: gosec
 		Data:         datatypes.JSON(opts.Data),
@@ -38,7 +39,7 @@ func (r *EventRepository) Save(ctx context.Context, opts *relayer.SaveEventOpts)
 	return nil, nil
 }
 
-func (r *EventRepository) UpdateStatus(ctx context.Context, id int, status relayer.EventStatus) error {
+func (r *EventRepository) UpdateStatus(db *gorm.DB, id int, status relayer.EventStatus) error {
 	var event *relayer.Event
 
 	var index int
@@ -64,7 +65,7 @@ func (r *EventRepository) UpdateStatus(ctx context.Context, id int, status relay
 }
 
 func (r *EventRepository) UpdateFeesAndProfitability(
-	ctx context.Context,
+	db *gorm.DB,
 	id int, opts *relayer.UpdateFeesAndProfitabilityOpts,
 ) error {
 	var event *relayer.Event
@@ -102,7 +103,7 @@ func (r *EventRepository) UpdateFeesAndProfitability(
 }
 
 func (r *EventRepository) FindAllByAddress(
-	ctx context.Context,
+	db *gorm.DB,
 	req *http.Request,
 	opts relayer.FindAllByAddressOpts,
 ) (*paginate.Page, error) {
@@ -139,7 +140,7 @@ func (r *EventRepository) FindAllByAddress(
 }
 
 func (r *EventRepository) FirstByMsgHash(
-	ctx context.Context,
+	db *gorm.DB,
 	msgHash string,
 ) (*relayer.Event, error) {
 	for _, e := range r.events {
@@ -152,7 +153,7 @@ func (r *EventRepository) FirstByMsgHash(
 }
 
 func (r *EventRepository) FirstByEventAndMsgHash(
-	ctx context.Context,
+	db *gorm.DB,
 	event string,
 	msgHash string,
 ) (*relayer.Event, error) {
@@ -166,7 +167,7 @@ func (r *EventRepository) FirstByEventAndMsgHash(
 }
 
 func (r *EventRepository) Delete(
-	ctx context.Context,
+	db *gorm.DB,
 	id int,
 ) error {
 	for i, e := range r.events {
@@ -179,7 +180,7 @@ func (r *EventRepository) Delete(
 }
 
 func (r *EventRepository) ChainDataSyncedEventByBlockNumberOrGreater(
-	ctx context.Context,
+	db *gorm.DB,
 	srcChainId uint64,
 	syncedChainId uint64,
 	blockNumber uint64,
@@ -191,7 +192,7 @@ func (r *EventRepository) ChainDataSyncedEventByBlockNumberOrGreater(
 }
 
 func (r *EventRepository) LatestChainDataSyncedEvent(
-	ctx context.Context,
+	db *gorm.DB,
 	srcChainId uint64,
 	syncedChainId uint64,
 ) (uint64, error) {
@@ -199,12 +200,18 @@ func (r *EventRepository) LatestChainDataSyncedEvent(
 }
 
 // DeleteAllAfterBlockID is used when a reorg is detected
-func (r *EventRepository) DeleteAllAfterBlockID(blockID uint64, srcChainID uint64, destChainID uint64) error {
+func (r *EventRepository) DeleteAllAfterBlockID(
+	db *gorm.DB,
+	blockID uint64,
+	srcChainID uint64,
+	destChainID uint64,
+) error {
 	return nil
 }
 
 // GetLatestBlockID get latest block id
 func (r *EventRepository) FindLatestBlockID(
+	db *gorm.DB,
 	event string,
 	srcChainID uint64,
 	destChainID uint64,

--- a/packages/relayer/processor/is_profitable.go
+++ b/packages/relayer/processor/is_profitable.go
@@ -59,7 +59,7 @@ func (p *Processor) isProfitable(
 		EstimatedOnchainFee: estimatedOnchainFee,
 	}
 
-	if err := p.eventRepo.UpdateFeesAndProfitability(ctx, id, &opts); err != nil {
+	if err := p.eventRepo.UpdateFeesAndProfitability(p.db.GormDB().WithContext(ctx), id, &opts); err != nil {
 		slog.Error("failed to update event", "error", err)
 	}
 

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
 	"log/slog"
 	"math/big"
 	"os"
@@ -35,9 +36,9 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/quotamanager"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/signalservice"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/taikol2"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/db"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/proof"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
-	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils"
 )
 
@@ -81,6 +82,7 @@ type hop struct {
 type Processor struct {
 	cancel context.CancelFunc
 
+	db        db.DB
 	eventRepo relayer.EventRepository
 
 	queue queue.Queue
@@ -155,11 +157,6 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 	p.cfg = cfg
 
 	db, err := cfg.OpenDBFunc()
-	if err != nil {
-		return err
-	}
-
-	eventRepository, err := repo.NewEventRepository(db)
 	if err != nil {
 		return err
 	}
@@ -334,7 +331,8 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 
 	p.hops = hops
 	p.prover = prover
-	p.eventRepo = eventRepository
+	p.db = db
+	p.eventRepo = &repo.EventRepository{}
 
 	p.srcEthClient = srcEthClient
 	p.destEthClient = destEthClient

--- a/packages/relayer/processor/wait_header_synced.go
+++ b/packages/relayer/processor/wait_header_synced.go
@@ -24,7 +24,7 @@ func (p *Processor) waitHeaderSynced(
 
 	// check once before ticker interval
 	event, err := p.eventRepo.ChainDataSyncedEventByBlockNumberOrGreater(
-		ctx,
+		p.db.GormDB().WithContext(ctx),
 		hopChainId,
 		chainId.Uint64(),
 		blockNum,
@@ -51,7 +51,7 @@ func (p *Processor) waitHeaderSynced(
 			return nil, ctx.Err()
 		case <-ticker.C:
 			event, err := p.eventRepo.ChainDataSyncedEventByBlockNumberOrGreater(
-				ctx,
+				p.db.GormDB().WithContext(ctx),
 				hopChainId,
 				chainId.Uint64(),
 				blockNum,

--- a/packages/relayer/watchdog/watchdog.go
+++ b/packages/relayer/watchdog/watchdog.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/db"
 	"log/slog"
 	"math/big"
 	"sync"
@@ -54,6 +55,7 @@ type ethClient interface {
 type Watchdog struct {
 	cancel context.CancelFunc
 
+	db        db.DB
 	eventRepo relayer.EventRepository
 
 	queue queue.Queue
@@ -101,11 +103,6 @@ func (w *Watchdog) InitFromCli(ctx context.Context, c *cli.Context) error {
 // nolint: funlen
 func InitFromConfig(ctx context.Context, w *Watchdog, cfg *Config) error {
 	db, err := cfg.OpenDBFunc()
-	if err != nil {
-		return err
-	}
-
-	eventRepository, err := repo.NewEventRepository(db)
 	if err != nil {
 		return err
 	}
@@ -172,7 +169,8 @@ func InitFromConfig(ctx context.Context, w *Watchdog, cfg *Config) error {
 		return err
 	}
 
-	w.eventRepo = eventRepository
+	w.db = db
+	w.eventRepo = &repo.EventRepository{}
 
 	w.srcEthClient = srcEthClient
 	w.destEthClient = destEthClient


### PR DESCRIPTION
- Let `*gorm.DB` be a parameter but don't let `db.DB` be the `EventRepository` struct number.
- Based on the above change, fix bug about `EventRepository.Save` operation.