### PR TITLE
chore(docs-site): updates outdated client link in docs

### DIFF
--- a/packages/docs-site/src/content/docs/core-concepts/taiko-nodes.md
+++ b/packages/docs-site/src/content/docs/core-concepts/taiko-nodes.md
@@ -22,7 +22,7 @@ You can see all the changes made in the `taiko-geth` fork at [geth.taiko.xyz](ht
 
 ## taiko-client
 
-The [taiko-client](https://github.com/taikoxyz/taiko-client) software replaces the consensus client piece of an Ethereum mainnet node. It connects to `taiko-geth`, and the compiled binary includes three sub-commands:
+The [taiko-client](https://github.com/taikoxyz/taiko-mono/tree/main/packages/taiko-client) software replaces the consensus client piece of an Ethereum mainnet node. It connects to `taiko-geth`, and the compiled binary includes three sub-commands:
 
 ### `driver`
 


### PR DESCRIPTION
- links now to client in our mono repo