### PR TITLE
ci(repo): add merge gatekeeper

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -1,0 +1,18 @@
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  merge-gatekeeper:
+    runs-on: [taiko-runner]
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -12,7 +12,51 @@ on:
       - "go.sum"
 
 jobs:
-  dummy:
-    runs-on: [taiko-runner]
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
     steps:
-      - run: exit 0
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
+          cache: true
+
+      - name: Lint
+        working-directory: packages/taiko-client
+        run: make lint
+
+  integration_tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
+          cache: true
+
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/install-pnpm-dependencies
+
+      - name: Test
+        working-directory: packages/taiko-client
+        run: make test
+
+      - name: Codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          files: packages/taiko-client/coverage.out

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -12,51 +12,7 @@ on:
       - "go.sum"
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
+  dummy:
+    runs-on: [taiko-runner]
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21
-          cache: true
-
-      - name: Lint
-        working-directory: packages/taiko-client
-        run: make lint
-
-  integration_tests:
-    name: Integration tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21
-          cache: true
-
-      - name: Install pnpm dependencies
-        uses: ./.github/actions/install-pnpm-dependencies
-
-      - name: Test
-        working-directory: packages/taiko-client
-        run: make test
-
-      - name: Codecov.io
-        uses: codecov/codecov-action@v4
-        with:
-          files: packages/taiko-client/coverage.out
+      - run: exit 1

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -15,4 +15,4 @@ jobs:
   dummy:
     runs-on: [taiko-runner]
     steps:
-      - run: exit 1
+      - run: exit 0


### PR DESCRIPTION
This PR adds merge-gatekeeper, which ensured all triggered jobs pass successfully, otherwise merge-gatekeeper will fail. This is useful in our monorepo so we do not need to set repo-wide required checks for our PRs, instead we just need to require "merge-gatekeeper" to pass successfully in our repo settings.