### PR TITLE
docs(protocol): transfer Hekla ownerships

### DIFF
--- a/packages/protocol/deployments/hekla-contract-logs.md
+++ b/packages/protocol/deployments/hekla-contract-logs.md
@@ -10,64 +10,71 @@
 
 - proxy: `0x7D3338FD5e654CAC5B10028088624CA1D64e74f7`
 - impl: `0x27ef4e7b101e822Dd107FF14Ca2540e89cea8E3e`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ### taiko_token
 
 - proxy: `0x6490E12d480549D333499236fF2Ba6676C296011`
 - impl: `0x01BB2fD6D80942CE95B43c1322530fe690F2bc0e`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - deployed on Mar 29, 2024 at commit `b341a68d5`
   - upgraded on Jun 18, 2024, added `batchTransfer` method.
+  - transfered ownership on Jul 8, 2024
 
 ### signal_service
 
 - proxy: `0x6Fc2fe9D9dd0251ec5E0727e826Afbb0Db2CBe0D`
 - impl: `0xE6371B30e500ff38ec809a652fdFE98174011B2D`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ### bridge
 
 - proxy: `0xA098b76a3Dd499D3F6D58D8AcCaFC8efBFd06807`
 - impl: `0x339F4C5320a5C697EA10b4f35d546C330AB43d8D`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ### erc20_vault
 
 - proxy: `0x2259662ed5dE0E09943Abe701bc5f5a108eABBAa`
 - impl: `0x1bf437b2f6e5959fe167210Ee2221ADa09a66846`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ### erc721_vault
 
 - proxy: `0x046b82D9010b534c716742BE98ac3FEf3f2EC99f`
 - impl: `0x06467bab46598b887240044309A6ffE261A0E2e3`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ### erc1155_vault
 
 - proxy: `0x9Ae5945Ab34f6182F75E16B73e037421F341fEe3`
 - impl: `0xBFCff65554d6e89A1aC280eE1E9f87764124B833`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ### bridged_erc20
 
@@ -91,16 +98,17 @@
 
 - proxy: `0x1F027871F286Cf4B7F898B21298E7B3e090a8403`
 - impl: `0x68570e85Ca54bAE1B6f608d0929665146BA66B39`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `13ad99d`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ### taikoL1
 
 - proxy: `0x79C9109b764609df928d16fC4a91e9081F7e87DB`
 - impl: `0xf44269ab814F86d0d0d483325E0fAA08205e772D.`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 10, 2024 at [PR #17532](https://github.com/taikoxyz/taiko-mono/pull/17532)
@@ -109,15 +117,17 @@
   - upgraded on Jun 14, 2024 at [PR #17553](https://github.com/taikoxyz/taiko-mono/pull/17553) @commit `baed5b5`
   - upgraded on Jun 19, 2024 at commit `b7e12e3`
   - upgraded on Jun 20, 2024 at commit `6e07ab5`
+  - transfered ownership on Jul 8, 2024
 
 ### assignmentHook
 
 - proxy: `0x9e640a6aadf4f664CF467B795c31332f44AcBe6c`
 - impl: `0xfcb5B945dbd08AfdB08e6C358193B23b0E6eFa23`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 12, 2024 at commit `04bb81e`
+  - transfered ownership on Jul 8, 2024
 
 ### tierProvider
 
@@ -155,19 +165,21 @@
 
 - proxy: `0x92F195a8702da2104aE8E3E10779176E7C35d6BC`
 - impl: `0x23bDb18995266c1Ac4c1BDBF69aE977A2DCE0750`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - upgraded on May 10, 2024 at commit `4903bec`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ### guardian_minority
 
 - proxy: `0x31d4d27da5c299d4b6CE19c869B8891C0002795d`
 - impl: `0x7eA0a9d62cF26Bd81D62AEf6D6D67a86A580aFA3`
-- owner: `0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`
+- owner: `0x1D2D1bb9D180541E88a6a682aCf3f61c1605B190`
 - logs:
   - deployed on May 20, 2024 at commit `6e56475`
   - upgraded on Jun 10, 2024 at commit `d5965bb`
+  - transfered ownership on Jul 8, 2024
 
 ## L2 Contracts
 
@@ -260,7 +272,3 @@
 - impl: `0xb190786090Fc4308c4C40808f3bEB55c4463c152`
 - logs:
   - deployed on May 10, 2024 at commit `4903bec`
-
-## Other EOAs/Contracts
-
-- Holesky `TimelockController`:`0x13cfc60c900a927C48f5c2a4923Ec9771a3A2805`


### PR DESCRIPTION
Transferred all Hekla L1 contracts' ownership from `TimeLock` to an EOA, same as the L2 contracts owner.