### PR TITLE
ci(repo): fix merge gatekeeper

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+  merge_group: # Trigger in merge queue to pass the required status check
 
 jobs:
   merge-gatekeeper:
+    if: github.event_name == 'pull_request'
     runs-on: [taiko-runner]
     permissions:
       checks: read

--- a/.github/workflows/repo--validate-pr-title.yml
+++ b/.github/workflows/repo--validate-pr-title.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - release-please-* # Trigger for release-please PRs, but skip the job
-  merge_group: # Trigger in the merge queue, but skip the job
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
merge gatekeeper is hanging in the merge queue, this is a necessary trigger.

after this will need to enable merge gatekeeper as a required status check.