### PR TITLE
fix(protocol): revert Hekla ring buffer size changes

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1Hekla.sol
+++ b/packages/protocol/contracts/L1/TaikoL1Hekla.sol
@@ -12,7 +12,8 @@ contract TaikoL1Hekla is TaikoL1 {
         return TaikoData.Config({
             chainId: LibNetwork.TAIKO_HEKLA,
             blockMaxProposals: 324_000, // Never change this value as ring buffer is being reused!!!
-            blockRingBufferSize: 324_512, // Never change this value as ring buffer is being reused!!!
+            blockRingBufferSize: 324_512, // Never change this value as ring buffer is being
+                // reused!!!
             maxBlocksToVerify: 16,
             blockMaxGasLimit: 240_000_000,
             livenessBond: 125e18, // 125 Taiko token

--- a/packages/protocol/contracts/L1/TaikoL1Hekla.sol
+++ b/packages/protocol/contracts/L1/TaikoL1Hekla.sol
@@ -11,8 +11,8 @@ contract TaikoL1Hekla is TaikoL1 {
     function getConfig() public pure override returns (TaikoData.Config memory) {
         return TaikoData.Config({
             chainId: LibNetwork.TAIKO_HEKLA,
-            blockMaxProposals: 504_000, // = 7200 * 70
-            blockRingBufferSize: 540_000, // = 7200 * 75
+            blockMaxProposals: 324_000, // = 45*86400/12, 45 days, 12 seconds avg block time
+            blockRingBufferSize: 324_512,
             maxBlocksToVerify: 16,
             blockMaxGasLimit: 240_000_000,
             livenessBond: 125e18, // 125 Taiko token

--- a/packages/protocol/contracts/L1/TaikoL1Hekla.sol
+++ b/packages/protocol/contracts/L1/TaikoL1Hekla.sol
@@ -11,8 +11,8 @@ contract TaikoL1Hekla is TaikoL1 {
     function getConfig() public pure override returns (TaikoData.Config memory) {
         return TaikoData.Config({
             chainId: LibNetwork.TAIKO_HEKLA,
-            blockMaxProposals: 324_000, // = 45*86400/12, 45 days, 12 seconds avg block time
-            blockRingBufferSize: 324_512,
+            blockMaxProposals: 324_000, // Never change this value as ring buffer is being reused!!!
+            blockRingBufferSize: 324_512, // Never change this value as ring buffer is being reused!!!
             maxBlocksToVerify: 16,
             blockMaxGasLimit: 240_000_000,
             livenessBond: 125e18, // 125 Taiko token

--- a/packages/protocol/script/upgrade/UpgradeTaikoL1.s.sol
+++ b/packages/protocol/script/upgrade/UpgradeTaikoL1.s.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.24;
 
 import "forge-std/src/Script.sol";
 import "forge-std/src/console2.sol";
-import "../../contracts/L1/TaikoL1.sol";
+import "../../contracts/L1/TaikoL1Hekla.sol";
 import "./UpgradeScript.s.sol";
 
 contract UpgradeTaikoL1 is UpgradeScript {
     function run() external setUp {
-        upgrade("TaikoL1", address(new TaikoL1()));
+        upgrade("TaikoL1", address(new TaikoL1Hekla()));
     }
 }


### PR DESCRIPTION
The ring buffer in Hekla has been reused, so we shouldn't update it.