### PR TITLE
fix(protocol): reduce MainnetTaikoL1 code size

### DIFF
--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./TaikoData.sol";
+
+/// @title TaikoEvents
+/// @notice This abstract contract provides event declarations for the Taiko
+/// protocol, which are emitted during block proposal, proof, verification, and
+/// Ethereum deposit processes.
+/// @dev The events defined here must match the definitions in the corresponding
+/// L1 libraries.
+/// @custom:security-contact security@taiko.xyz
+abstract contract TaikoEvents {
+    /// @notice Emitted when a block is proposed.
+    /// @param blockId The ID of the proposed block.
+    /// @param assignedProver The address of the assigned prover.
+    /// @param livenessBond The liveness bond of the proposed block.
+    /// @param meta The metadata of the proposed block.
+    /// @param depositsProcessed The EthDeposit array about processed deposits in this proposed
+    /// block.
+    event BlockProposed(
+        uint256 indexed blockId,
+        address indexed assignedProver,
+        uint96 livenessBond,
+        TaikoData.BlockMetadata meta,
+        TaikoData.EthDeposit[] depositsProcessed
+    );
+
+    /// @notice Emitted when a block's txList is in the calldata.
+    /// @param blockId The ID of the proposed block.
+    /// @param txList The txList.
+    event CalldataTxList(uint256 indexed blockId, bytes txList);
+
+    /// @notice Emitted when some state variable values changed.
+    /// @dev This event is currently used by Taiko node/client for block proposal/proving.
+    /// @param slotB The SlotB data structure.
+    event StateVariablesUpdated(TaikoData.SlotB slotB);
+
+    /// @notice Emitted when a transition is proved.
+    /// @param blockId The block ID.
+    /// @param tran The transition data.
+    /// @param prover The prover's address.
+    /// @param validityBond The validity bond amount.
+    /// @param tier The tier of the proof.
+    event TransitionProved(
+        uint256 indexed blockId,
+        TaikoData.Transition tran,
+        address prover,
+        uint96 validityBond,
+        uint16 tier
+    );
+
+    /// @notice Emitted when a transition is contested.
+    /// @param blockId The block ID.
+    /// @param tran The transition data.
+    /// @param contester The contester's address.
+    /// @param contestBond The contest bond amount.
+    /// @param tier The tier of the proof.
+    event TransitionContested(
+        uint256 indexed blockId,
+        TaikoData.Transition tran,
+        address contester,
+        uint96 contestBond,
+        uint16 tier
+    );
+
+    /// @notice Emitted when proving is paused or unpaused.
+    /// @param paused The pause status.
+    event ProvingPaused(bool paused);
+
+    /// @dev Emitted when a block is verified.
+    /// @param blockId The ID of the verified block.
+    /// @param prover The prover whose transition is used for verifying the
+    /// block.
+    /// @param blockHash The hash of the verified block.
+    /// @param stateRoot Deprecated and is always zero.
+    /// @param tier The tier ID of the proof.
+    event BlockVerified(
+        uint256 indexed blockId,
+        address indexed prover,
+        bytes32 blockHash,
+        bytes32 stateRoot,
+        uint16 tier
+    );
+}

--- a/packages/protocol/contracts/L1/TaikoEvents.sol
+++ b/packages/protocol/contracts/L1/TaikoEvents.sol
@@ -11,6 +11,12 @@ import "./TaikoData.sol";
 /// L1 libraries.
 /// @custom:security-contact security@taiko.xyz
 abstract contract TaikoEvents {
+    /// @dev Emitted when token is credited back to a user's bond balance.
+    event BondCredited(address indexed user, uint256 amount);
+
+    /// @dev Emitted when token is debited from a user's bond balance.
+    event BondDebited(address indexed user, uint256 amount);
+
     /// @notice Emitted when a block is proposed.
     /// @param blockId The ID of the proposed block.
     /// @param assignedProver The address of the assigned prover.
@@ -30,11 +36,6 @@ abstract contract TaikoEvents {
     /// @param blockId The ID of the proposed block.
     /// @param txList The txList.
     event CalldataTxList(uint256 indexed blockId, bytes txList);
-
-    /// @notice Emitted when some state variable values changed.
-    /// @dev This event is currently used by Taiko node/client for block proposal/proving.
-    /// @param slotB The SlotB data structure.
-    event StateVariablesUpdated(TaikoData.SlotB slotB);
 
     /// @notice Emitted when a transition is proved.
     /// @param blockId The block ID.
@@ -82,4 +83,9 @@ abstract contract TaikoEvents {
         bytes32 stateRoot,
         uint16 tier
     );
+
+    /// @notice Emitted when some state variable values changed.
+    /// @dev This event is currently used by Taiko node/client for block proposal/proving.
+    /// @param slotB The SlotB data structure.
+    event StateVariablesUpdated(TaikoData.SlotB slotB);
 }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -5,6 +5,7 @@ import "../common/EssentialContract.sol";
 import "./libs/LibProposing.sol";
 import "./libs/LibProving.sol";
 import "./libs/LibVerifying.sol";
+import "./TaikoEvents.sol";
 import "./ITaikoL1.sol";
 
 /// @title TaikoL1
@@ -16,16 +17,11 @@ import "./ITaikoL1.sol";
 /// by the Bridge contract.
 /// @dev Labeled in AddressResolver as "taiko"
 /// @custom:security-contact security@taiko.xyz
-contract TaikoL1 is EssentialContract, ITaikoL1 {
+contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
     /// @notice The TaikoL1 state.
     TaikoData.State public state;
 
     uint256[50] private __gap;
-
-    /// @notice Emitted when some state variable values changed.
-    /// @dev This event is currently used by Taiko node/client for block proposal/proving.
-    /// @param slotB The SlotB data structure.
-    event StateVariablesUpdated(TaikoData.SlotB slotB);
 
     error L1_RECEIVE_DISABLED();
 

--- a/packages/protocol/contracts/L1/libs/LibVerifying.sol
+++ b/packages/protocol/contracts/L1/libs/LibVerifying.sol
@@ -39,7 +39,7 @@ library LibVerifying {
         IAddressResolver _resolver,
         uint64 _maxBlocksToVerify
     )
-        internal
+        public
     {
         if (_maxBlocksToVerify == 0) {
             return;

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 
 import "../contracts/common/LibStrings.sol";
 import "../contracts/tko/TaikoToken.sol";
-import "../contracts/L1/TaikoL1.sol";
+import "../contracts/mainnet/MainnetTaikoL1.sol";
 import "../contracts/L1/provers/GuardianProver.sol";
 import "../contracts/L1/tiers/DevnetTierProvider.sol";
 import "../contracts/L1/tiers/TierProviderV2.sol";
@@ -247,7 +247,7 @@ contract DeployOnL1 is DeployCapability {
 
         deployProxy({
             name: "taiko",
-            impl: address(new TaikoL1()),
+            impl: address(new MainnetTaikoL1()),
             data: abi.encodeCall(
                 TaikoL1.init,
                 (

--- a/packages/protocol/script/DeployOnL1.s.sol
+++ b/packages/protocol/script/DeployOnL1.s.sol
@@ -246,8 +246,22 @@ contract DeployOnL1 is DeployCapability {
         copyRegister(rollupAddressManager, _sharedAddressManager, "bridge");
 
         deployProxy({
-            name: "taiko",
+            name: "mainnet_taiko",
             impl: address(new MainnetTaikoL1()),
+            data: abi.encodeCall(
+                TaikoL1.init,
+                (
+                    owner,
+                    rollupAddressManager,
+                    vm.envBytes32("L2_GENESIS_HASH"),
+                    vm.envBool("PAUSE_TAIKO_L1")
+                )
+            )
+        });
+
+        deployProxy({
+            name: "taiko",
+            impl: address(new TaikoL1()),
             data: abi.encodeCall(
                 TaikoL1.init,
                 (


### PR DESCRIPTION
MainnetTaikoL1's code is too large. In this PR, I changed a library function to public, added back TaikoEvents (otherwise client cannot handle public library events), and changed deploy scripts to test deploying MainnetTaikoL1.