### PR TITLE
refactor(protocol): name address manager param clearer

### DIFF
--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -42,19 +42,19 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
+    /// @param _rollupAddressManager The address of the {AddressManager} contract.
     /// @param _genesisBlockHash The block hash of the genesis block.
     /// @param _toPause true to pause the contract by default.
     function init(
         address _owner,
-        address _addressManager,
+        address _rollupAddressManager,
         bytes32 _genesisBlockHash,
         bool _toPause
     )
         external
         initializer
     {
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _rollupAddressManager);
         LibUtils.init(state, _genesisBlockHash);
         if (_toPause) _pause();
     }

--- a/packages/protocol/contracts/L1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/L1/provers/GuardianProver.sol
@@ -92,9 +92,9 @@ contract GuardianProver is IVerifier, EssentialContract {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
-    function init(address _owner, address _addressManager) external initializer {
-        __Essential_init(_owner, _addressManager);
+    /// @param _rollupAddressManager The address of the {AddressManager} contract.
+    function init(address _owner, address _rollupAddressManager) external initializer {
+        __Essential_init(_owner, _rollupAddressManager);
     }
 
     /// @notice Set the set of guardians

--- a/packages/protocol/contracts/L2/DelegateOwner.sol
+++ b/packages/protocol/contracts/L2/DelegateOwner.sol
@@ -64,11 +64,11 @@ contract DelegateOwner is EssentialContract, IMessageInvocable {
     /// @param _remoteOwner The real owner on L1 that can send a cross-chain message to invoke
     /// `onMessageInvocation`.
     /// @param _remoteChainId The L1 chain's ID.
-    /// @param _addressManager The address of the {AddressManager} contract.
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
     /// @param _admin The admin address.
     function init(
         address _remoteOwner,
-        address _addressManager,
+        address _sharedAddressManager,
         uint64 _remoteChainId,
         address _admin
     )
@@ -76,7 +76,7 @@ contract DelegateOwner is EssentialContract, IMessageInvocable {
         initializer
     {
         // This contract's owner will be itself.
-        __Essential_init(address(this), _addressManager);
+        __Essential_init(address(this), _sharedAddressManager);
 
         if (_remoteOwner == address(0) || _remoteChainId == 0 || _remoteChainId == block.chainid) {
             revert DO_INVALID_PARAM();

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -63,19 +63,19 @@ contract TaikoL2 is EssentialContract {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
     /// @param _l1ChainId The ID of the base layer.
     /// @param _gasExcess The initial gasExcess.
     function init(
         address _owner,
-        address _addressManager,
+        address _sharedAddressManager,
         uint64 _l1ChainId,
         uint64 _gasExcess
     )
         external
         initializer
     {
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _sharedAddressManager);
 
         if (_l1ChainId == 0 || _l1ChainId == block.chainid) {
             revert L2_INVALID_L1_CHAIN_ID();

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -63,19 +63,19 @@ contract TaikoL2 is EssentialContract {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _sharedAddressManager The address of the {AddressManager} contract.
+    /// @param _rollupAddressManager The address of the {AddressManager} contract.
     /// @param _l1ChainId The ID of the base layer.
     /// @param _gasExcess The initial gasExcess.
     function init(
         address _owner,
-        address _sharedAddressManager,
+        address _rollupAddressManager,
         uint64 _l1ChainId,
         uint64 _gasExcess
     )
         external
         initializer
     {
-        __Essential_init(_owner, _sharedAddressManager);
+        __Essential_init(_owner, _rollupAddressManager);
 
         if (_l1ChainId == 0 || _l1ChainId == block.chainid) {
             revert L2_INVALID_L1_CHAIN_ID();

--- a/packages/protocol/contracts/bridge/Bridge.sol
+++ b/packages/protocol/contracts/bridge/Bridge.sol
@@ -107,9 +107,9 @@ contract Bridge is EssentialContract, IBridge {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
-    function init(address _owner, address _addressManager) external initializer {
-        __Essential_init(_owner, _addressManager);
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
+    function init(address _owner, address _sharedAddressManager) external initializer {
+        __Essential_init(_owner, _sharedAddressManager);
     }
 
     function init2() external onlyOwner reinitializer(2) {

--- a/packages/protocol/contracts/bridge/QuotaManager.sol
+++ b/packages/protocol/contracts/bridge/QuotaManager.sol
@@ -31,17 +31,17 @@ contract QuotaManager is EssentialContract, IQuotaManager {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
     /// @param _quotaPeriod The time required to restore all quota.
     function init(
         address _owner,
-        address _addressManager,
+        address _sharedAddressManager,
         uint24 _quotaPeriod
     )
         external
         initializer
     {
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _sharedAddressManager);
         _setQuotaPeriod(_quotaPeriod);
     }
 

--- a/packages/protocol/contracts/signal/SignalService.sol
+++ b/packages/protocol/contracts/signal/SignalService.sol
@@ -41,9 +41,9 @@ contract SignalService is EssentialContract, ISignalService {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
-    function init(address _owner, address _addressManager) external initializer {
-        __Essential_init(_owner, _addressManager);
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
+    function init(address _owner, address _sharedAddressManager) external initializer {
+        __Essential_init(_owner, _sharedAddressManager);
     }
 
     /// @dev Authorize or deauthorize an address for calling syncChainData.

--- a/packages/protocol/contracts/team/proving/ProverSet.sol
+++ b/packages/protocol/contracts/team/proving/ProverSet.sol
@@ -47,13 +47,13 @@ contract ProverSet is EssentialContract, IERC1271 {
     function init(
         address _owner,
         address _admin,
-        address _addressManager
+        address _rollupAddressManager
     )
         external
         nonZeroAddr(_admin)
         initializer
     {
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _rollupAddressManager);
         admin = _admin;
         IERC20(tkoToken()).approve(taikoL1(), type(uint256).max);
     }

--- a/packages/protocol/contracts/team/tokenunlock/TokenUnlock.sol
+++ b/packages/protocol/contracts/team/tokenunlock/TokenUnlock.sol
@@ -68,12 +68,12 @@ contract TokenUnlock is EssentialContract {
 
     /// @notice Initializes the contract.
     /// @param _owner The contract owner address.
-    /// @param _addressManager The rollup address manager.
+    /// @param _rollupAddressManager The rollup address manager.
     /// @param _recipient Who will be the grantee for this contract.
     /// @param _tgeTimestamp The token generation event timestamp.
     function init(
         address _owner,
-        address _addressManager,
+        address _rollupAddressManager,
         address _recipient,
         uint64 _tgeTimestamp
     )
@@ -84,7 +84,7 @@ contract TokenUnlock is EssentialContract {
     {
         if (_owner == _recipient) revert INVALID_PARAM();
 
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _rollupAddressManager);
 
         recipient = _recipient;
         tgeTimestamp = _tgeTimestamp;

--- a/packages/protocol/contracts/tko/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/tko/BridgedTaikoToken.sol
@@ -11,9 +11,9 @@ import "./TaikoTokenBase.sol";
 contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20 {
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address manager address.
-    function init(address _owner, address _addressManager) external initializer {
-        __Essential_init(_owner, _addressManager);
+    /// @param _sharedAddressManager The address manager address.
+    function init(address _owner, address _sharedAddressManager) external initializer {
+        __Essential_init(_owner, _sharedAddressManager);
         __ERC20_init("Taiko Token", "TKO");
         __ERC20Votes_init();
         __ERC20Permit_init("Taiko Token");

--- a/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC1155.sol
@@ -35,7 +35,7 @@ contract BridgedERC1155 is
     /// @inheritdoc IBridgedERC1155Initializable
     function init(
         address _owner,
-        address _addressManager,
+        address _sharedAddressManager,
         address _srcToken,
         uint256 _srcChainId,
         string calldata _symbol,
@@ -48,7 +48,7 @@ contract BridgedERC1155 is
         // The symbol and the name can be empty for ERC1155 tokens so we use some placeholder data
         // for them instead.
         LibBridgedToken.validateInputs(_srcToken, _srcChainId);
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _sharedAddressManager);
 
         // The token URI here is not important as the client will have to read the URI from the
         // canonical contract to fetch meta data.

--- a/packages/protocol/contracts/tokenvault/BridgedERC20.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC20.sol
@@ -60,7 +60,7 @@ contract BridgedERC20 is
     /// @inheritdoc IBridgedERC20Initializable
     function init(
         address _owner,
-        address _addressManager,
+        address _sharedAddressManager,
         address _srcToken,
         uint256 _srcChainId,
         uint8 _decimals,
@@ -72,7 +72,7 @@ contract BridgedERC20 is
     {
         // Check if provided parameters are valid
         LibBridgedToken.validateInputs(_srcToken, _srcChainId);
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _sharedAddressManager);
         __ERC20_init(_name, _symbol);
 
         // Set contract properties

--- a/packages/protocol/contracts/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/BridgedERC721.sol
@@ -30,7 +30,7 @@ contract BridgedERC721 is
     /// @inheritdoc IBridgedERC721Initializable
     function init(
         address _owner,
-        address _addressManager,
+        address _sharedAddressManager,
         address _srcToken,
         uint256 _srcChainId,
         string calldata _symbol,
@@ -41,7 +41,7 @@ contract BridgedERC721 is
     {
         // Check if provided parameters are valid
         LibBridgedToken.validateInputs(_srcToken, _srcChainId);
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _sharedAddressManager);
         __ERC721_init(_name, _symbol);
 
         srcToken = _srcToken;

--- a/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC1155Vault.sol
@@ -20,9 +20,9 @@ contract ERC1155Vault is BaseNFTVault, ERC1155ReceiverUpgradeable {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
-    function init(address _owner, address _addressManager) external initializer {
-        __Essential_init(_owner, _addressManager);
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
+    function init(address _owner, address _sharedAddressManager) external initializer {
+        __Essential_init(_owner, _sharedAddressManager);
         __ERC1155Receiver_init();
     }
     /// @notice Transfers ERC1155 tokens to this vault and sends a message to

--- a/packages/protocol/contracts/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC20Vault.sol
@@ -160,9 +160,9 @@ contract ERC20Vault is BaseVault {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
-    function init(address _owner, address _addressManager) external initializer {
-        __Essential_init(_owner, _addressManager);
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
+    function init(address _owner, address _sharedAddressManager) external initializer {
+        __Essential_init(_owner, _sharedAddressManager);
     }
 
     /// @notice Change bridged token.

--- a/packages/protocol/contracts/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/tokenvault/ERC721Vault.sol
@@ -20,9 +20,9 @@ contract ERC721Vault is BaseNFTVault, IERC721Receiver {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
-    function init(address _owner, address _addressManager) external initializer {
-        __Essential_init(_owner, _addressManager);
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
+    function init(address _owner, address _sharedAddressManager) external initializer {
+        __Essential_init(_owner, _sharedAddressManager);
     }
 
     /// @notice Transfers ERC721 tokens to this vault and sends a message to the

--- a/packages/protocol/contracts/tokenvault/IBridgedERC1155.sol
+++ b/packages/protocol/contracts/tokenvault/IBridgedERC1155.sol
@@ -32,14 +32,14 @@ interface IBridgedERC1155 {
 interface IBridgedERC1155Initializable {
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
     /// @param _srcToken Address of the source token.
     /// @param _srcChainId Source chain ID.
     /// @param _symbol Symbol of the bridged token.
     /// @param _name Name of the bridged token.
     function init(
         address _owner,
-        address _addressManager,
+        address _sharedAddressManager,
         address _srcToken,
         uint256 _srcChainId,
         string calldata _symbol,

--- a/packages/protocol/contracts/tokenvault/IBridgedERC20.sol
+++ b/packages/protocol/contracts/tokenvault/IBridgedERC20.sol
@@ -52,7 +52,7 @@ interface IBridgedERC20Migratable {
 interface IBridgedERC20Initializable {
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
     /// @param _srcToken The source token address.
     /// @param _srcChainId The source chain ID.
     /// @param _decimals The number of decimal places of the source token.
@@ -60,7 +60,7 @@ interface IBridgedERC20Initializable {
     /// @param _name The name of the token.
     function init(
         address _owner,
-        address _addressManager,
+        address _sharedAddressManager,
         address _srcToken,
         uint256 _srcChainId,
         uint8 _decimals,

--- a/packages/protocol/contracts/tokenvault/IBridgedERC721.sol
+++ b/packages/protocol/contracts/tokenvault/IBridgedERC721.sol
@@ -25,14 +25,14 @@ interface IBridgedERC721 {
 interface IBridgedERC721Initializable {
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
+    /// @param _sharedAddressManager The address of the {AddressManager} contract.
     /// @param _srcToken Address of the source token.
     /// @param _srcChainId Source chain ID.
     /// @param _symbol Symbol of the bridged token.
     /// @param _name Name of the bridged token.
     function init(
         address _owner,
-        address _addressManager,
+        address _sharedAddressManager,
         address _srcToken,
         uint256 _srcChainId,
         string calldata _symbol,

--- a/packages/protocol/contracts/verifiers/RiscZeroVerifier.sol
+++ b/packages/protocol/contracts/verifiers/RiscZeroVerifier.sol
@@ -29,17 +29,17 @@ contract RiscZeroVerifier is EssentialContract, IVerifier {
 
     /// @notice Initializes the contract with the provided address manager.
     /// @param _owner The address of the owner.
-    /// @param _addressManager The address of the AddressManager.
+    /// @param _rollupAddressManager The address of the AddressManager.
     /// @param _receiptVerifier The address of the risc zero receipt verifier contract.
     function init(
         address _owner,
-        address _addressManager,
+        address _rollupAddressManager,
         address _receiptVerifier
     )
         external
         initializer
     {
-        __Essential_init(_owner, _addressManager);
+        __Essential_init(_owner, _rollupAddressManager);
         receiptVerifier = IRiscZeroReceiptVerifier(_receiptVerifier);
     }
 

--- a/packages/protocol/contracts/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/verifiers/SgxVerifier.sol
@@ -80,9 +80,9 @@ contract SgxVerifier is EssentialContract, IVerifier {
 
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    /// @param _addressManager The address of the {AddressManager} contract.
-    function init(address _owner, address _addressManager) external initializer {
-        __Essential_init(_owner, _addressManager);
+    /// @param _rollupAddressManager The address of the {AddressManager} contract.
+    function init(address _owner, address _rollupAddressManager) external initializer {
+        __Essential_init(_owner, _rollupAddressManager);
     }
 
     /// @notice Adds trusted SGX instances to the registry.

--- a/packages/protocol/deployments/mainnet-contract-logs-L1.md
+++ b/packages/protocol/deployments/mainnet-contract-logs-L1.md
@@ -173,8 +173,6 @@
   - tier_guardian: `0xE3D777143Ea25A6E031d1e921F396750885f43aC`
   - automata_dcap_attestation: `0x8d7C954960a36a7596d7eA4945dDf891967ca8A3`
   - prover_set: `0x518845daA8870bE2C59E49620Fc262AD48953C9a`
-  - proposer_one: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045` vitalik.eth
-  - proposer: `0x000000633b68f5d8d3a86593ebb815b4663bcbe0`
   - chain_watchdog: `0xE3D777143Ea25A6E031d1e921F396750885f43aC`
 - logs:
   - deployed on May 1, 2024 @commit`56dddf2b6`
@@ -214,16 +212,6 @@
   - Upgrade to `0xB9E1E58bcF33B79CcfF99c298963546a6c334388` @commit`d907359` @tx`0xdb5e926c96d112ce1389da77a927fba6c7d04a711839b9e14777530ebcf83914`
   - Upgrade to `0x5fc54737ECC1de49D58AE1195d4A296257F1E31b` @commit`04d8c87` @tx`0x13f54109cb7f7507ad03562b06ea8d8b472043186e44252302583bc64acfb20b`
   - Upgrade to `0xcEe590fACd976B9BDE87BC1B7620B284c5edD2C3` @commit`2dd30ab` @tx`0xc1f91c375713f601b99cf6d2cdb80c129e036a7c9ec5f75871c4d13216dbbb5c`
-
-#### assignment_hook
-
-- proxy: `0x537a2f0D3a5879b41BCb5A2afE2EA5c4961796F6`
-- impl: `0xf77CBFAfE15Df84E6638dF267D25d1AF8e5e53f2`
-- owner: `admin.taiko.eth`
-- logs:
-  - deployed on May 1, 2024 @commit`56dddf2b6`
-  - Upgraded from `0x4f664222C3fF6207558A745648B568D095dDA170` to `0xe226fAd08E2f0AE68C32Eb5d8210fFeDB736Fb0d` @commit`b90b932` @tx`0x416560cd96dc75ccffebe889e8d1ab3e08b33f814dc4a2bf7c6f9555071d1f6f`
-  - Upgraded from `0xe226fAd08E2f0AE68C32Eb5d8210fFeDB736Fb0d` to `0xf77CBFAfE15Df84E6638dF267D25d1AF8e5e53f2` @commit`2b483de` @tx`0x0bbf7d1258c646f41a02a92a55825b1ebfd3659577d0f2b57b462f8895e23a04`
 
 #### tier_provider
 


### PR DESCRIPTION
Given that we have two address manages (shared and rollup), naming parameters this way is less confusing.