### PR TITLE
fix(eventindexer): slow md indexing

### DIFF
--- a/packages/eventindexer/AssignmentHook.json
+++ b/packages/eventindexer/AssignmentHook.json
@@ -1,0 +1,860 @@
+[
+  {
+    "type": "function",
+    "name": "MAX_GAS_PAYING_PROVER",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addressManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hashAssignment",
+    "inputs": [
+      {
+        "name": "_assignment",
+        "type": "tuple",
+        "internalType": "struct AssignmentHook.ProverAssignment",
+        "components": [
+          {
+            "name": "feeToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "expiry",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "maxBlockId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "maxProposedIn",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "metaHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "parentMetaHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "tierFees",
+            "type": "tuple[]",
+            "internalType": "struct TaikoData.TierFee[]",
+            "components": [
+              {
+                "name": "tier",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "fee",
+                "type": "uint128",
+                "internalType": "uint128"
+              }
+            ]
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "_taikoL1Address",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_blockProposer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_assignedProver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_blobHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "impl",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "inNonReentrant",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "init",
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_addressManager",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "lastUnpausedAt",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "onBlockProposed",
+    "inputs": [
+      {
+        "name": "_blk",
+        "type": "tuple",
+        "internalType": "struct TaikoData.Block",
+        "components": [
+          {
+            "name": "metaHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "assignedProver",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "livenessBond",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "blockId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "proposedAt",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "proposedIn",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextTransitionId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "verifiedTransitionId",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      },
+      {
+        "name": "_meta",
+        "type": "tuple",
+        "internalType": "struct TaikoData.BlockMetadata",
+        "components": [
+          {
+            "name": "l1Hash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "difficulty",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "blobHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "extraData",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "depositsHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "coinbase",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "timestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l1Height",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "minTier",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "blobUsed",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "parentMetaHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "sender",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      },
+      {
+        "name": "_data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "resolve",
+    "inputs": [
+      {
+        "name": "_chainId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "_name",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "_allowZeroAddress",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address payable"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "resolve",
+    "inputs": [
+      {
+        "name": "_name",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "_allowZeroAddress",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address payable"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeTo",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "AdminChanged",
+    "inputs": [
+      {
+        "name": "previousAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BeaconUpgraded",
+    "inputs": [
+      {
+        "name": "beacon",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlockAssigned",
+    "inputs": [
+      {
+        "name": "assignedProver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "meta",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct TaikoData.BlockMetadata",
+        "components": [
+          {
+            "name": "l1Hash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "difficulty",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "blobHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "extraData",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "depositsHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "coinbase",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "timestamp",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l1Height",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "minTier",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "blobUsed",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "parentMetaHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "sender",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      },
+      {
+        "name": "assignment",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct AssignmentHook.ProverAssignment",
+        "components": [
+          {
+            "name": "feeToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "expiry",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "maxBlockId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "maxProposedIn",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "metaHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "parentMetaHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "tierFees",
+            "type": "tuple[]",
+            "internalType": "struct TaikoData.TierFee[]",
+            "components": [
+              {
+                "name": "tier",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "fee",
+                "type": "uint128",
+                "internalType": "uint128"
+              }
+            ]
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EtherPaymentFailed",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "maxGas",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ETH_TRANSFER_FAILED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FUNC_NOT_IMPLEMENTED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "HOOK_ASSIGNMENT_EXPIRED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "HOOK_ASSIGNMENT_INVALID_SIG",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "HOOK_TIER_NOT_FOUND",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "INVALID_PAUSE_STATUS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "REENTRANT_CALL",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RESOLVER_DENIED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RESOLVER_INVALID_MANAGER",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RESOLVER_UNEXPECTED_CHAINID",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RESOLVER_ZERO_ADDR",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "name",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZERO_ADDRESS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZERO_VALUE",
+    "inputs": []
+  }
+]

--- a/packages/eventindexer/Bridge.json
+++ b/packages/eventindexer/Bridge.json
@@ -1,0 +1,1637 @@
+[
+  {
+    "type": "function",
+    "name": "GAS_OVERHEAD",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "GAS_RESERVE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "RELAYER_MAX_PROOF_BYTES",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addressManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "context",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "ctx_",
+        "type": "tuple",
+        "internalType": "struct IBridge.Context",
+        "components": [
+          {
+            "name": "msgHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "failMessage",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getMessageMinGasLimit",
+    "inputs": [
+      {
+        "name": "dataLength",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "hashMessage",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "impl",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "inNonReentrant",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "init",
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_addressManager",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "init2",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isDestChainEnabled",
+    "inputs": [
+      {
+        "name": "_chainId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "enabled_",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "destBridge_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isMessageFailed",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "_proof",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isMessageReceived",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "_proof",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isMessageSent",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lastUnpausedAt",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "messageStatus",
+    "inputs": [
+      {
+        "name": "msgHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "status",
+        "type": "uint8",
+        "internalType": "enum IBridge.Status"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nextMessageId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "processMessage",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "_proof",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "status_",
+        "type": "uint8",
+        "internalType": "enum IBridge.Status"
+      },
+      {
+        "name": "reason_",
+        "type": "uint8",
+        "internalType": "enum IBridge.StatusReason"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "recallMessage",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "_proof",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "resolve",
+    "inputs": [
+      {
+        "name": "_chainId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "_name",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "_allowZeroAddress",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address payable"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "resolve",
+    "inputs": [
+      {
+        "name": "_name",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "_allowZeroAddress",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address payable"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "retryMessage",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "_isLastAttempt",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "selfDelegate",
+    "inputs": [
+      {
+        "name": "_anyToken",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendMessage",
+    "inputs": [
+      {
+        "name": "_message",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "msgHash_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "message_",
+        "type": "tuple",
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "signalForFailedMessage",
+    "inputs": [
+      {
+        "name": "_msgHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeTo",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "AdminChanged",
+    "inputs": [
+      {
+        "name": "previousAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BeaconUpgraded",
+    "inputs": [
+      {
+        "name": "beacon",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MessageProcessed",
+    "inputs": [
+      {
+        "name": "msgHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "message",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "stats",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct Bridge.ProcessingStats",
+        "components": [
+          {
+            "name": "gasUsedInFeeCalc",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "proofSize",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "numCacheOps",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "processedByRelayer",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MessageSent",
+    "inputs": [
+      {
+        "name": "msgHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "message",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IBridge.Message",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "gasLimit",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "from",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "srcChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "srcOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "destChainId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "destOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MessageStatusChanged",
+    "inputs": [
+      {
+        "name": "msgHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "status",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum IBridge.Status"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "B_INSUFFICIENT_GAS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_INVALID_CHAINID",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_INVALID_CONTEXT",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_INVALID_FEE",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_INVALID_GAS_LIMIT",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_INVALID_STATUS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_INVALID_VALUE",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_MESSAGE_NOT_SENT",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_OUT_OF_ETH_QUOTA",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_PERMISSION_DENIED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_PROOF_TOO_LARGE",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_RETRY_FAILED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "B_SIGNAL_NOT_RECEIVED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ETH_TRANSFER_FAILED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FUNC_NOT_IMPLEMENTED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "INVALID_PAUSE_STATUS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "REENTRANT_CALL",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RESOLVER_DENIED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RESOLVER_INVALID_MANAGER",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RESOLVER_UNEXPECTED_CHAINID",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RESOLVER_ZERO_ADDR",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "name",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZERO_ADDRESS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZERO_VALUE",
+    "inputs": []
+  }
+]

--- a/packages/eventindexer/indexer/fetch_nft_metadata.go
+++ b/packages/eventindexer/indexer/fetch_nft_metadata.go
@@ -127,11 +127,10 @@ func resolveMetadataURL(tokenURI string) string {
 	}
 
 	if isBase64(tokenURI) {
-		// Extract the actual base64 part
 		parts := strings.Split(tokenURI, "base64,")
 
-		// Check if the part after "base64," is valid base64
 		decodedTokenURI, _ := base64.StdEncoding.DecodeString(parts[1])
+
 		return string(decodedTokenURI)
 	}
 

--- a/packages/eventindexer/indexer/fetch_nft_metadata.go
+++ b/packages/eventindexer/indexer/fetch_nft_metadata.go
@@ -60,7 +60,8 @@ func (i *Indexer) fetchNFTMetadata(
 			slog.Warn("Invalid metadata URI",
 				"contractAddress", contractAddress,
 				"tokenID", tokenID.Int64(),
-				"chainID", chainID.String())
+				"chainID", chainID.String(),
+				"tokenURI", tokenURI)
 
 			return nil, nil
 		}

--- a/packages/eventindexer/indexer/index_erc20_transfers.go
+++ b/packages/eventindexer/indexer/index_erc20_transfers.go
@@ -157,10 +157,6 @@ func (i *Indexer) saveERC20Transfer(ctx context.Context, chainID *big.Int, vLog 
 		if err != nil {
 			return errors.Wrap(err, "i.erc20BalanceRepo.CreateMetadata")
 		}
-
-		slog.Info("metadata created", "pk", pk, "symbol", symbol, "decimals", decimals, "contractAddress", vLog.Address.Hex())
-	} else {
-		slog.Info("metadata found", "pk", pk, "symbol", md.Symbol, "decimals", md.Decimals, "contractAddress", vLog.Address.Hex())
 	}
 
 	// increment To address's balance

--- a/packages/eventindexer/indexer/index_nft_transfers.go
+++ b/packages/eventindexer/indexer/index_nft_transfers.go
@@ -158,6 +158,7 @@ func (i *Indexer) saveERC721Transfer(ctx context.Context, chainID *big.Int, vLog
 				return errors.Wrap(err, "i.nftMetadataRepo.SaveNFTMetadata")
 			}
 		}
+
 		pk = metadata.ID
 	}
 

--- a/packages/eventindexer/indexer/index_nft_transfers.go
+++ b/packages/eventindexer/indexer/index_nft_transfers.go
@@ -60,7 +60,7 @@ func (i *Indexer) indexNFTTransfers(
 }
 
 // isERC1155Transfer determines whether a given log is a valid ERC1155 transfer event
-func (i *Indexer) isERC1155Transfer(ctx context.Context, vLog types.Log) bool {
+func (i *Indexer) isERC1155Transfer(_ context.Context, vLog types.Log) bool {
 	// malformed event
 	if len(vLog.Topics) == 0 {
 		return false
@@ -152,18 +152,13 @@ func (i *Indexer) saveERC721Transfer(ctx context.Context, chainID *big.Int, vLog
 				TokenID:         tokenID,
 				Name:            "invalid_metadata",
 			}
-		}
 
-		metadata, err = i.nftMetadataRepo.SaveNFTMetadata(ctx, metadata)
-		if err != nil {
-			return errors.Wrap(err, "i.nftMetadataRepo.SaveNFTMetadata")
+			metadata, err = i.nftMetadataRepo.SaveNFTMetadata(ctx, metadata)
+			if err != nil {
+				return errors.Wrap(err, "i.nftMetadataRepo.SaveNFTMetadata")
+			}
 		}
-
 		pk = metadata.ID
-
-		slog.Info("metadata created", "contractAddress", vLog.Address.Hex(), "tokenId", metadata.TokenID)
-	} else {
-		slog.Info("metadata found", "contractAddress", vLog.Address.Hex(), "tokenId", metadata.TokenID)
 	}
 
 	// increment To address's balance
@@ -257,18 +252,14 @@ func (i *Indexer) saveERC1155Transfer(ctx context.Context, chainID *big.Int, vLo
 					TokenID:         t.Id.Int64(),
 					Name:            "invalid_metadata",
 				}
-			}
 
-			metadata, err = i.nftMetadataRepo.SaveNFTMetadata(ctx, metadata)
-			if err != nil {
-				return errors.Wrap(err, "i.nftMetadataRepo.SaveNFTMetadata")
+				metadata, err = i.nftMetadataRepo.SaveNFTMetadata(ctx, metadata)
+				if err != nil {
+					return errors.Wrap(err, "i.nftMetadataRepo.SaveNFTMetadata")
+				}
 			}
 
 			pk = metadata.ID
-
-			slog.Info("metadata created", "contractAddress", vLog.Address.Hex(), "tokenId", metadata.TokenID)
-		} else {
-			slog.Info("metadata found", "contractAddress", vLog.Address.Hex(), "tokenId", metadata.TokenID)
 		}
 
 		increaseOpts := eventindexer.UpdateNFTBalanceOpts{
@@ -300,8 +291,6 @@ func (i *Indexer) saveERC1155Transfer(ctx context.Context, chainID *big.Int, vLo
 			return err
 		}
 	} else if vLog.Topics[0].Hex() == transferBatchSignatureHash.Hex() {
-		slog.Info("erc1155 transfer batch")
-
 		type TransferBatchEvent struct {
 			Operator common.Address
 			From     common.Address
@@ -320,7 +309,6 @@ func (i *Indexer) saveERC1155Transfer(ctx context.Context, chainID *big.Int, vLo
 		for idx, id := range t.Ids {
 			var pk int = 0
 
-			slog.Info("ERC1155 BATCH:", "", pk)
 			// Check if metadata already exists in db, if not fetch and store
 			metadata, err := i.nftMetadataRepo.GetNFTMetadata(ctx, vLog.Address.Hex(), id.Int64(), chainID.Int64())
 			if err != nil {
@@ -344,18 +332,14 @@ func (i *Indexer) saveERC1155Transfer(ctx context.Context, chainID *big.Int, vLo
 						TokenID:         id.Int64(),
 						Name:            "invalid_metadata",
 					}
-				}
 
-				metadata, err = i.nftMetadataRepo.SaveNFTMetadata(ctx, metadata)
-				if err != nil {
-					return errors.Wrap(err, "i.nftMetadataRepo.SaveNFTMetadata")
+					metadata, err = i.nftMetadataRepo.SaveNFTMetadata(ctx, metadata)
+					if err != nil {
+						return errors.Wrap(err, "i.nftMetadataRepo.SaveNFTMetadata")
+					}
 				}
 
 				pk = metadata.ID
-
-				slog.Info("metadata created", "contractAddress", vLog.Address.Hex(), "tokenId", metadata.TokenID)
-			} else {
-				slog.Info("metadata found", "contractAddress", vLog.Address.Hex(), "tokenId", metadata.TokenID)
 			}
 
 			increaseOpts := eventindexer.UpdateNFTBalanceOpts{

--- a/packages/eventindexer/indexer/index_nft_transfers.go
+++ b/packages/eventindexer/indexer/index_nft_transfers.go
@@ -162,6 +162,8 @@ func (i *Indexer) saveERC721Transfer(ctx context.Context, chainID *big.Int, vLog
 		pk = metadata.ID
 	}
 
+	slog.Info("metadata pk", "pk", pk)
+
 	// increment To address's balance
 	// decrement From address's balance
 	increaseOpts := eventindexer.UpdateNFTBalanceOpts{

--- a/packages/eventindexer/indexer/index_nft_transfers.go
+++ b/packages/eventindexer/indexer/index_nft_transfers.go
@@ -162,6 +162,11 @@ func (i *Indexer) saveERC721Transfer(ctx context.Context, chainID *big.Int, vLog
 		pk = metadata.ID
 	}
 
+	if pk == 0 {
+		slog.Warn("unable to create or fetch md", "contractAddress", vLog.Address.Hex())
+		return nil
+	}
+
 	slog.Info("metadata pk", "pk", pk)
 
 	// increment To address's balance

--- a/packages/eventindexer/migrations/20270906208850_alter_nft_metadata_addtl_indexes.sql
+++ b/packages/eventindexer/migrations/20270906208850_alter_nft_metadata_addtl_indexes.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `nft_metadata` ADD INDEX `nft_metadata_contract_address_token_id_chain_id_index` (`contract_address`, `token_id`, `chain_id`),
+ADD INDEX `nft_metadata_contract_address_index` (`contract_address`)
+;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE nft_metadata DROP INDEX nft_metadata_contract_address_token_id_chain_id_index,
+  DROP INDEX nft_metadata_contract_address;
+-- +goose StatementEnd

--- a/packages/eventindexer/migrations/20270906208851_alter_nft_balances_addtl_indexes.sql
+++ b/packages/eventindexer/migrations/20270906208851_alter_nft_balances_addtl_indexes.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `nft_balances` ADD INDEX `nft_balances_address_chain_id_amount_index` (`address`, `chain_id`, `amount`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE nft_balances
+  DROP INDEX nft_balances_address_chain_id_amount_index
+-- +goose StatementEnd

--- a/packages/eventindexer/migrations/20270906208852_alter_erc20_balances_addtl_indexes.sql
+++ b/packages/eventindexer/migrations/20270906208852_alter_erc20_balances_addtl_indexes.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `erc20_balances` ADD INDEX `erc20_balances_contract_address_address_chain_id_index` (`contract_address`, `address`, `chain_id`);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE erc20_balances DROP INDEX erc20_balances_contract_address_address_chain_id_index,
+  DROP INDEX erc20_balances_contract_address-- +goose StatementEnd

--- a/packages/eventindexer/migrations/20270906208852_alter_erc20_balances_addtl_indexes.sql
+++ b/packages/eventindexer/migrations/20270906208852_alter_erc20_balances_addtl_indexes.sql
@@ -7,3 +7,4 @@ ALTER TABLE `erc20_balances` ADD INDEX `erc20_balances_contract_address_address_
 -- +goose StatementBegin
 ALTER TABLE erc20_balances DROP INDEX erc20_balances_contract_address_address_chain_id_index,
   DROP INDEX erc20_balances_contract_address-- +goose StatementEnd
+-- +goose StatementEnd

--- a/packages/eventindexer/pkg/repo/nft_balance.go
+++ b/packages/eventindexer/pkg/repo/nft_balance.go
@@ -60,7 +60,7 @@ func (r *NFTBalanceRepository) increaseBalanceInDB(
 	b.Amount += opts.Amount
 
 	// update the row to reflect new balance
-	if err := db.WithContext(ctx).Save(b).Error; err != nil {
+	if err := db.Save(b).Error; err != nil {
 		return nil, errors.Wrap(err, "r.db.Save")
 	}
 
@@ -81,7 +81,7 @@ func (r *NFTBalanceRepository) decreaseBalanceInDB(
 		ChainID:         opts.ChainID,
 	}
 
-	err := db.WithContext(ctx).
+	err := db.
 		Where("contract_address = ?", opts.ContractAddress).
 		Where("token_id = ?", opts.TokenID).
 		Where("address = ?", opts.Address).


### PR DESCRIPTION
Indexing is unusably slow with the addition of metadata indexing, due to the lack of indices on the correct column combinations. This speeds it up.