### PR TITLE
feat(protocol): modify L2 gas issuance and base fee calculation

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -39,7 +39,7 @@ library TaikoData {
         // ---------------------------------------------------------------------
         // Group 5: L2 configs
         // ---------------------------------------------------------------------
-        uint32 gasTargetPerL1Block;
+        uint32 gasTargetPerBlock;
         uint8 basefeeAdjustmentQuotient;
         uint8 basefeeSharingPctg;
         // ---------------------------------------------------------------------
@@ -125,7 +125,7 @@ library TaikoData {
         uint32 blobTxListLength;
         uint8 blobIndex;
         // The percentage of base fee sent to block.coinbase on L2.
-        uint32 gasTargetPerL1Block;
+        uint32 gasTargetPerBlock;
         uint8 basefeeAdjustmentQuotient;
         uint8 basefeeSharingPctg;
     }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -37,9 +37,8 @@ library TaikoData {
         uint8 stateRootSyncInternal;
         uint64 maxAnchorHeightOffset;
         // ---------------------------------------------------------------------
-        // Group 5: L2 configs
+        // Group 5: Previous configs in TaikoL2
         // ---------------------------------------------------------------------
-        uint32 gasTargetPerBlock;
         uint8 basefeeAdjustmentQuotient;
         uint8 basefeeSharingPctg;
         // ---------------------------------------------------------------------
@@ -124,8 +123,6 @@ library TaikoData {
         uint32 blobTxListOffset;
         uint32 blobTxListLength;
         uint8 blobIndex;
-        // The percentage of base fee sent to block.coinbase on L2.
-        uint32 gasTargetPerBlock;
         uint8 basefeeAdjustmentQuotient;
         uint8 basefeeSharingPctg;
     }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -265,16 +265,10 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             // their data.
             blockRingBufferSize: 360_000, // = 7200 * 50
             maxBlocksToVerify: 16,
-            // This value is set based on `gasTargetPerBlock = 15_000_000 * 4` in TaikoL2.
-            // We use 8x rather than 4x here to handle the scenario where the average number of
-            // Taiko blocks proposed per Ethereum block is smaller than 1.
-            // There is 250_000 additional gas for the anchor tx. Therefore, on explorers, you'll
-            // read Taiko's gas limit to be 240_250_000.
             blockMaxGasLimit: 240_000_000,
             livenessBond: 125e18, // 125 Taiko token
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
-            gasTargetPerBlock: 30_000_000,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
             ontakeForkHeight: 374_400 // = 7200 * 52

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -265,7 +265,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             // their data.
             blockRingBufferSize: 360_000, // = 7200 * 50
             maxBlocksToVerify: 16,
-            // This value is set based on `gasTargetPerL1Block = 15_000_000 * 4` in TaikoL2.
+            // This value is set based on `gasTargetPerBlock = 15_000_000 * 4` in TaikoL2.
             // We use 8x rather than 4x here to handle the scenario where the average number of
             // Taiko blocks proposed per Ethereum block is smaller than 1.
             // There is 250_000 additional gas for the anchor tx. Therefore, on explorers, you'll
@@ -274,7 +274,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             livenessBond: 125e18, // 125 Taiko token
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
-            gasTargetPerL1Block: 60_000_000,
+            gasTargetPerBlock: 30_000_000,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
             ontakeForkHeight: 374_400 // = 7200 * 52

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -79,7 +79,6 @@ library LibData {
             blobTxListOffset: 0,
             blobTxListLength: 0,
             blobIndex: 0,
-            gasTargetPerBlock: 0,
             basefeeAdjustmentQuotient: 0,
             basefeeSharingPctg: 0
         });

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -79,7 +79,7 @@ library LibData {
             blobTxListOffset: 0,
             blobTxListLength: 0,
             blobIndex: 0,
-            gasTargetPerL1Block: 0,
+            gasTargetPerBlock: 0,
             basefeeAdjustmentQuotient: 0,
             basefeeSharingPctg: 0
         });

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -177,7 +177,7 @@ library LibProposing {
                 blobTxListOffset: params.blobTxListOffset,
                 blobTxListLength: params.blobTxListLength,
                 blobIndex: params.blobIndex,
-                gasTargetPerL1Block: _config.gasTargetPerL1Block,
+                gasTargetPerBlock: _config.gasTargetPerBlock,
                 basefeeAdjustmentQuotient: _config.basefeeAdjustmentQuotient,
                 basefeeSharingPctg: _config.basefeeSharingPctg
             });

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -177,7 +177,6 @@ library LibProposing {
                 blobTxListOffset: params.blobTxListOffset,
                 blobTxListLength: params.blobTxListLength,
                 blobIndex: params.blobIndex,
-                gasTargetPerBlock: _config.gasTargetPerBlock,
                 basefeeAdjustmentQuotient: _config.basefeeAdjustmentQuotient,
                 basefeeSharingPctg: _config.basefeeSharingPctg
             });

--- a/packages/protocol/contracts/L2/Lib1559Math.sol
+++ b/packages/protocol/contracts/L2/Lib1559Math.sol
@@ -15,7 +15,7 @@ library Lib1559Math {
     error EIP1559_INVALID_PARAMS();
 
     function calc1559BaseFee(
-        uint32 _gasTargetPerL1Block,
+        uint32 _gasTarget,
         uint8 _adjustmentQuotient,
         uint64 _gasExcess,
         uint64 _gasIssuance,
@@ -35,7 +35,7 @@ library Lib1559Math {
         // bonding curve, regardless the actual amount of gas used by this
         // block, however, this block's gas used will affect the next
         // block's base fee.
-        basefee_ = basefee(gasExcess_, uint256(_adjustmentQuotient) * _gasTargetPerL1Block);
+        basefee_ = basefee(gasExcess_, uint256(_adjustmentQuotient) * _gasTarget);
 
         // Always make sure basefee is nonzero, this is required by the node.
         if (basefee_ == 0) basefee_ = 1;

--- a/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
@@ -20,7 +20,6 @@ contract HeklaTaikoL1 is TaikoL1 {
             livenessBond: 125e18, // 125 Taiko token
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
-            gasTargetPerBlock: 30_000_000,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
             ontakeForkHeight: 720_000 // = 7200 * 100

--- a/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
@@ -20,7 +20,7 @@ contract HeklaTaikoL1 is TaikoL1 {
             livenessBond: 125e18, // 125 Taiko token
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
-            gasTargetPerL1Block: 60_000_000,
+            gasTargetPerBlock: 30_000_000,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
             ontakeForkHeight: 720_000 // = 7200 * 100


### PR DESCRIPTION
This pull request addresses two key issues related to gas issuance and base fee calculation in our L2 system:

## Anchoring Height Exploitation

Currently, proposers can choose the anchoring height (required by preconfirmation). This allows them to potentially exploit the protocol by always selecting the minimum possible anchoring block height, which can artificially inflate base fees by preventing new gas issuance on L2. 

- [x] Modify gas issuance to occur per L2 block instead of per L1 block.
- [x] Removed block gas target config and use block gas limit / 2 as the target

## Base Fee Prediction

The current protocol only allows for predicting the base fee of the next L2 block. There's a need for predicting base fees for multiple consecutive L2 blocks that haven't been submitted on-chain yet.

- [x] Implement a new function `calculateBaseFee` to predict base fees for multiple L2 blocks; function `getBasefee` will deprecate post Ontake fork.