### PR TITLE
refactor(protocol): use packed encoding of BlockMetadataV2 in `proveBlock`

### DIFF
--- a/packages/protocol/contracts/L1/libs/LibProving.sol
+++ b/packages/protocol/contracts/L1/libs/LibProving.sol
@@ -148,9 +148,9 @@ library LibProving {
         TaikoData.TierProof memory proof;
 
         if (local.postFork) {
-            (meta, tran, proof) = abi.decode(
-                _input, (TaikoData.BlockMetadataV2, TaikoData.Transition, TaikoData.TierProof)
-            );
+            uint256 offset;
+            (meta, offset) = LibData.decodeMetadataPacked(_input);
+            (tran, proof) = abi.decode(_input[offset:], (TaikoData.Transition, TaikoData.TierProof));
         } else {
             TaikoData.BlockMetadata memory meta1;
 

--- a/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
@@ -111,7 +111,7 @@ abstract contract TaikoL1TestGroupBase is TaikoL1TestBase {
         }
     }
 
-    function proveBlock2(
+    function proveBlockV2(
         address prover,
         TaikoData.BlockMetadataV2 memory meta,
         bytes32 parentHash,
@@ -165,7 +165,9 @@ abstract contract TaikoL1TestGroupBase is TaikoL1TestBase {
         } else {
             if (revertReason != "") vm.expectRevert(revertReason);
             vm.prank(prover);
-            L1.proveBlock(meta.id, abi.encode(meta, tran, proof));
+            L1.proveBlock(
+                meta.id, bytes.concat(LibData.encodeMetadataPacked(meta), abi.encode(tran, proof))
+            );
         }
     }
 

--- a/packages/protocol/test/L1/TaikoL1testGroupA1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1testGroupA1.t.sol
@@ -79,7 +79,7 @@ contract TaikoL1TestGroupA1 is TaikoL1TestGroupBase {
 
             mineAndWrap(10 seconds);
 
-            proveBlock2(Alice, meta2, parentHash, blockHash, stateRoot, meta2.minTier, "");
+            proveBlockV2(Alice, meta2, parentHash, blockHash, stateRoot, meta2.minTier, "");
             parentHash = blockHash;
 
             printBlockAndTrans(meta2.id);

--- a/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
@@ -68,7 +68,7 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
 
             mineAndWrap(10 seconds);
 
-            proveBlock2(Alice, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
+            proveBlockV2(Alice, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
             parentHash = blockHash;
 
             printBlockAndTrans(i);

--- a/packages/protocol/test/L1/TestMetadataEncoding.t.sol
+++ b/packages/protocol/test/L1/TestMetadataEncoding.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../TaikoTest.sol";
+
+contract MyContract {
+    function encodeMetadataPacked(TaikoData.BlockMetadataV2 memory metadata_)
+        external
+        pure
+        returns (bytes memory)
+    {
+        return LibData.encodeMetadataPacked(metadata_);
+    }
+
+    function decodeMetadataPacked(bytes calldata _encoded)
+        external
+        pure
+        returns (TaikoData.BlockMetadataV2 memory metadata_, uint256 offset_)
+    {
+        return LibData.decodeMetadataPacked(_encoded);
+    }
+}
+
+contract BlockMetadataTest is TaikoTest {
+    MyContract public target;
+
+    function setUp() public {
+        target = new MyContract();
+    }
+
+    function testMetadataEncodeDecode() public {
+        TaikoData.BlockMetadataV2 memory m1 = TaikoData.BlockMetadataV2({
+            anchorBlockHash: bytes32(uint256(1)),
+            difficulty: bytes32(uint256(2)),
+            blobHash: bytes32(uint256(3)),
+            extraData: bytes32(uint256(4)),
+            coinbase: address(0x1234567890123456789012345678901234567890),
+            id: 5,
+            gasLimit: 6,
+            timestamp: 7,
+            anchorBlockId: 8,
+            minTier: 9,
+            blobUsed: true,
+            parentMetaHash: bytes32(uint256(10)),
+            proposer: address(0x9876543210987654321098765432109876543210),
+            livenessBond: 11,
+            proposedAt: 12,
+            proposedIn: 13,
+            blobTxListOffset: 14,
+            blobTxListLength: 15,
+            blobIndex: 16,
+            basefeeAdjustmentQuotient: 17,
+            basefeeSharingPctg: 18
+        });
+
+        // Encode the struct
+        bytes memory encoded = target.encodeMetadataPacked(m1);
+
+        // Ensure the encoded length is correct
+        assertEq(encoded.length, 270, "Encoded length should be 270 bytes");
+
+        // Decode the encoded data
+        (TaikoData.BlockMetadataV2 memory m2, uint256 offset) = target.decodeMetadataPacked(encoded);
+
+        assertEq(offset, 270, "offset");
+        // Compare the original and decoded structs
+        assertEq(m2.anchorBlockHash, m1.anchorBlockHash, "anchorBlockHash mismatch");
+        assertEq(m2.difficulty, m1.difficulty, "difficulty mismatch");
+        assertEq(m2.blobHash, m1.blobHash, "blobHash mismatch");
+        assertEq(m2.extraData, m1.extraData, "extraData mismatch");
+        assertEq(m2.coinbase, m1.coinbase, "coinbase mismatch");
+        assertEq(m2.id, m1.id, "id mismatch");
+        assertEq(m2.gasLimit, m1.gasLimit, "gasLimit mismatch");
+        assertEq(m2.timestamp, m1.timestamp, "timestamp mismatch");
+        assertEq(m2.anchorBlockId, m1.anchorBlockId, "anchorBlockId mismatch");
+        assertEq(m2.minTier, m1.minTier, "minTier mismatch");
+        assertEq(m2.blobUsed, m1.blobUsed, "blobUsed mismatch");
+        assertEq(m2.parentMetaHash, m1.parentMetaHash, "parentMetaHash mismatch");
+        assertEq(m2.proposer, m1.proposer, "proposer mismatch");
+        assertEq(m2.livenessBond, m1.livenessBond, "livenessBond mismatch");
+        assertEq(m2.proposedAt, m1.proposedAt, "proposedAt mismatch");
+        assertEq(m2.proposedIn, m1.proposedIn, "proposedIn mismatch");
+        assertEq(m2.blobTxListOffset, m1.blobTxListOffset, "blobTxListOffset mismatch");
+        assertEq(m2.blobTxListLength, m1.blobTxListLength, "blobTxListLength mismatch");
+        assertEq(m2.blobIndex, m1.blobIndex, "blobIndex mismatch");
+        assertEq(
+            m2.basefeeAdjustmentQuotient,
+            m1.basefeeAdjustmentQuotient,
+            "basefeeAdjustmentQuotient mismatch"
+        );
+        assertEq(m2.basefeeSharingPctg, m1.basefeeSharingPctg, "basefeeSharingPctg mismatch");
+    }
+}


### PR DESCRIPTION
Previously we use 704 bytes for encoded BlockMetadataV2, but with the new approach we only use 270, that's a `(704-270)*4= 1736` gas saved.