### PR TITLE
feat(protocol): switch to default EIP1559 implementation post Ontake fork

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -40,7 +40,7 @@ library TaikoData {
         // Group 5: Previous configs in TaikoL2
         // ---------------------------------------------------------------------
         uint8 basefeeSharingPctg;
-        uint32 blockGasTarget;
+        uint8 blockGasTargetMillion;
         // ---------------------------------------------------------------------
         // Group 6: Others
         // ---------------------------------------------------------------------
@@ -71,7 +71,6 @@ library TaikoData {
 
     struct BlockParamsV2 {
         address coinbase;
-        bytes32 extraData;
         bytes32 parentMetaHash;
         uint64 anchorBlockId; // NEW
         uint64 timestamp; // NEW
@@ -123,8 +122,6 @@ library TaikoData {
         uint32 blobTxListOffset;
         uint32 blobTxListLength;
         uint8 blobIndex;
-        uint8 basefeeSharingPctg;
-        uint32 blockGasTarget;
     }
 
     /// @dev Struct representing transition to be proven.

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -39,7 +39,6 @@ library TaikoData {
         // ---------------------------------------------------------------------
         // Group 5: Previous configs in TaikoL2
         // ---------------------------------------------------------------------
-        uint8 basefeeAdjustmentQuotient;
         uint8 basefeeSharingPctg;
         uint32 blockGasIssuance;
         // ---------------------------------------------------------------------
@@ -124,7 +123,6 @@ library TaikoData {
         uint32 blobTxListOffset;
         uint32 blobTxListLength;
         uint8 blobIndex;
-        uint8 basefeeAdjustmentQuotient;
         uint8 basefeeSharingPctg;
         uint32 blockGasIssuance;
     }

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -40,7 +40,7 @@ library TaikoData {
         // Group 5: Previous configs in TaikoL2
         // ---------------------------------------------------------------------
         uint8 basefeeSharingPctg;
-        uint32 blockGasIssuance;
+        uint32 blockGasTarget;
         // ---------------------------------------------------------------------
         // Group 6: Others
         // ---------------------------------------------------------------------
@@ -124,7 +124,7 @@ library TaikoData {
         uint32 blobTxListLength;
         uint8 blobIndex;
         uint8 basefeeSharingPctg;
-        uint32 blockGasIssuance;
+        uint32 blockGasTarget;
     }
 
     /// @dev Struct representing transition to be proven.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -270,7 +270,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
             basefeeSharingPctg: 75,
-            blockGasIssuance: 20_000_000,
+            blockGasTarget: 20_000_000,
             ontakeForkHeight: 374_400 // = 7200 * 52
          });
     }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -269,7 +269,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             livenessBond: 125e18, // 125 Taiko token
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
-            basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
             blockGasIssuance: 20_000_000,
             ontakeForkHeight: 374_400 // = 7200 * 52

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -270,7 +270,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
             basefeeSharingPctg: 75,
-            blockGasTarget: 20_000_000,
+            blockGasTargetMillion: 20,
             ontakeForkHeight: 374_400 // = 7200 * 52
          });
     }

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -18,7 +18,6 @@ library LibData {
     {
         return TaikoData.BlockParamsV2({
             coinbase: _v1.coinbase,
-            extraData: _v1.extraData,
             parentMetaHash: _v1.parentMetaHash,
             anchorBlockId: 0,
             timestamp: 0,
@@ -75,9 +74,7 @@ library LibData {
             proposedIn: 0,
             blobTxListOffset: 0,
             blobTxListLength: 0,
-            blobIndex: 0,
-            basefeeSharingPctg: 0,
-            blockGasTarget: 0
+            blobIndex: 0
         });
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -77,7 +77,7 @@ library LibData {
             blobTxListLength: 0,
             blobIndex: 0,
             basefeeSharingPctg: 0,
-            blockGasIssuance: 0
+            blockGasTarget: 0
         });
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -76,7 +76,6 @@ library LibData {
             blobTxListOffset: 0,
             blobTxListLength: 0,
             blobIndex: 0,
-            basefeeAdjustmentQuotient: 0,
             basefeeSharingPctg: 0,
             blockGasIssuance: 0
         });

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -264,7 +264,7 @@ library LibProposing {
             revert L1_INVALID_PROPOSER();
         }
     }
-    
+
     function _encodeExtraBlockConfigs(
         uint8 _basefeeSharingPctg,
         uint8 _blockGasTargetMillion

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -185,7 +185,7 @@ library LibProposing {
                 blobTxListLength: local.params.blobTxListLength,
                 blobIndex: local.params.blobIndex,
                 basefeeSharingPctg: _config.basefeeSharingPctg,
-                blockGasIssuance: _config.blockGasIssuance
+                blockGasTarget: _config.blockGasTarget
             });
         }
 

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -21,6 +21,7 @@ library LibProposing {
         ITierProvider tierProvider;
         bytes32 parentMetaHash;
         bool postFork;
+        bytes32 extraData;
     }
 
     /// @notice Emitted when a block is proposed.
@@ -106,7 +107,9 @@ library LibProposing {
                 // otherwise use a default BlockParamsV2 with 0 values
             }
         } else {
-            local.params = LibData.blockParamsV1ToV2(abi.decode(_data, (TaikoData.BlockParams)));
+            TaikoData.BlockParams memory paramsV1 = abi.decode(_data, (TaikoData.BlockParams));
+            local.params = LibData.blockParamsV1ToV2(paramsV1);
+            local.extraData = paramsV1.extraData;
         }
 
         if (local.params.coinbase == address(0)) {
@@ -168,7 +171,9 @@ library LibProposing {
                 anchorBlockHash: blockhash(local.params.anchorBlockId),
                 difficulty: keccak256(abi.encode("TAIKO_DIFFICULTY", local.b.numBlocks)),
                 blobHash: 0, // to be initialized below
-                extraData: local.params.extraData,
+                extraData: local.postFork
+                    ? _encodeExtraBlockConfigs(_config.basefeeSharingPctg, _config.blockGasTargetMillion)
+                    : local.extraData,
                 coinbase: local.params.coinbase,
                 id: local.b.numBlocks,
                 gasLimit: _config.blockMaxGasLimit,
@@ -183,9 +188,7 @@ library LibProposing {
                 proposedIn: uint64(block.number),
                 blobTxListOffset: local.params.blobTxListOffset,
                 blobTxListLength: local.params.blobTxListLength,
-                blobIndex: local.params.blobIndex,
-                basefeeSharingPctg: _config.basefeeSharingPctg,
-                blockGasTarget: _config.blockGasTarget
+                blobIndex: local.params.blobIndex
             });
         }
 
@@ -261,5 +264,16 @@ library LibProposing {
                 depositsProcessed: deposits_
             });
         }
+    }
+
+    function _encodeExtraBlockConfigs(
+        uint8 _basefeeSharingPctg,
+        uint8 _blockGasTargetMillion
+    )
+        private
+        pure
+        returns (bytes32)
+    {
+        return bytes32(uint256(_basefeeSharingPctg) << 8 | uint256(_blockGasTargetMillion));
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -184,7 +184,6 @@ library LibProposing {
                 blobTxListOffset: local.params.blobTxListOffset,
                 blobTxListLength: local.params.blobTxListLength,
                 blobIndex: local.params.blobIndex,
-                basefeeAdjustmentQuotient: _config.basefeeAdjustmentQuotient,
                 basefeeSharingPctg: _config.basefeeSharingPctg,
                 blockGasIssuance: _config.blockGasIssuance
             });

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -54,7 +54,6 @@ contract TaikoL2 is EssentialContract {
     /// @param parentHash The hash of the parent block.
     /// @param gasExcess The gas excess value used to calculate the base fee.
     event Anchored(bytes32 parentHash, uint64 gasExcess);
-    event AnchoredV2(bytes32 parentHash);
 
     error L2_BASEFEE_MISMATCH();
     error L2_FORK_ERROR();
@@ -263,8 +262,6 @@ contract TaikoL2 is EssentialContract {
         if (block.number < ONTAKE_FORK_HEIGHT) {
             gasExcess = _gasExcess;
             emit Anchored(_parentHash, _gasExcess);
-        } else {
-            emit AnchoredV2(_parentHash);
         }
     }
 

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -259,6 +259,7 @@ contract TaikoL2 is EssentialContract {
         bytes32 _parentHash = blockhash(parentId);
         l2Hashes[parentId] = _parentHash;
         publicInputHash = publicInputHashNew;
+
         if (block.number < ONTAKE_FORK_HEIGHT) {
             gasExcess = _gasExcess;
             emit Anchored(_parentHash, _gasExcess);

--- a/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
@@ -20,7 +20,6 @@ contract HeklaTaikoL1 is TaikoL1 {
             livenessBond: 125e18, // 125 Taiko token
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
-            basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
             blockGasIssuance: 20_000_000,
             ontakeForkHeight: 720_000 // = 7200 * 100

--- a/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
@@ -21,7 +21,7 @@ contract HeklaTaikoL1 is TaikoL1 {
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
             basefeeSharingPctg: 75,
-            blockGasTarget: 20_000_000,
+            blockGasTargetMillion: 20,
             ontakeForkHeight: 720_000 // = 7200 * 100
          });
     }

--- a/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
@@ -21,7 +21,7 @@ contract HeklaTaikoL1 is TaikoL1 {
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
             basefeeSharingPctg: 75,
-            blockGasIssuance: 20_000_000,
+            blockGasTarget: 20_000_000,
             ontakeForkHeight: 720_000 // = 7200 * 100
          });
     }

--- a/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
@@ -50,7 +50,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
             assertEq(meta.anchorBlockHash, blockhash(block.number - 1));
             assertEq(meta.livenessBond, config.livenessBond);
             assertEq(meta.coinbase, Alice);
-            assertEq(meta.extraData, params.extraData);
 
             TaikoData.Block memory blk = L1.getBlock(i);
             assertEq(blk.blockId, i);
@@ -104,7 +103,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         // Propose the first block with default parameters
         TaikoData.BlockParamsV2 memory params = TaikoData.BlockParamsV2({
             coinbase: address(0),
-            extraData: 0,
             parentMetaHash: 0,
             anchorBlockId: 0,
             timestamp: 0,
@@ -125,7 +123,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         assertEq(meta.livenessBond, config.livenessBond);
         assertEq(meta.coinbase, Alice);
         assertEq(meta.parentMetaHash, bytes32(uint256(1)));
-        assertEq(meta.extraData, params.extraData);
 
         TaikoData.Block memory blk = L1.getBlock(1);
         assertEq(blk.blockId, 1);
@@ -145,7 +142,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
 
         params = TaikoData.BlockParamsV2({
             coinbase: Bob,
-            extraData: bytes32(uint256(123)),
             parentMetaHash: 0,
             anchorBlockId: 90,
             timestamp: uint64(block.timestamp - 100),
@@ -165,7 +161,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         assertEq(meta.livenessBond, config.livenessBond);
         assertEq(meta.coinbase, Bob);
         assertEq(meta.parentMetaHash, blk.metaHash);
-        assertEq(meta.extraData, params.extraData);
 
         blk = L1.getBlock(2);
         assertEq(blk.blockId, 2);


### PR DESCRIPTION
Since block time no longer has any impact on L2's 1559 basefee calculation, we can switch to use the default EIP1559 implementation and relaying on proofs to verify the L2 basefee is correct, without doing it in the L2's anchor function.

@davidtaikocha @smtmfft lets briefly go over it tomorrow.

@k-kaddal if we merge this PR, it means you don't need to learn our own EIP-1559 math at all.
