### PR TITLE
feat(protocol): encode basefee params into extraData

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -40,7 +40,7 @@ library TaikoData {
         // Group 5: Previous configs in TaikoL2
         // ---------------------------------------------------------------------
         uint8 basefeeSharingPctg;
-        uint32 blockGasTarget;
+        uint8 blockGasTargetMillion;
         // ---------------------------------------------------------------------
         // Group 6: Others
         // ---------------------------------------------------------------------
@@ -71,7 +71,6 @@ library TaikoData {
 
     struct BlockParamsV2 {
         address coinbase;
-        bytes32 extraData;
         bytes32 parentMetaHash;
         uint64 anchorBlockId; // NEW
         uint64 timestamp; // NEW
@@ -123,8 +122,6 @@ library TaikoData {
         uint32 blobTxListOffset;
         uint32 blobTxListLength;
         uint8 blobIndex;
-        uint8 basefeeSharingPctg;
-        uint32 blockGasTarget;
     }
 
     /// @dev Struct representing transition to be proven.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -270,7 +270,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
             basefeeSharingPctg: 75,
-            blockGasTarget: 20_000_000,
+            blockGasTargetMillion: 20,
             ontakeForkHeight: 374_400 // = 7200 * 52
          });
     }

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -18,7 +18,6 @@ library LibData {
     {
         return TaikoData.BlockParamsV2({
             coinbase: _v1.coinbase,
-            extraData: _v1.extraData,
             parentMetaHash: _v1.parentMetaHash,
             anchorBlockId: 0,
             timestamp: 0,
@@ -75,9 +74,7 @@ library LibData {
             proposedIn: 0,
             blobTxListOffset: 0,
             blobTxListLength: 0,
-            blobIndex: 0,
-            basefeeSharingPctg: 0,
-            blockGasTarget: 0
+            blobIndex: 0
         });
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -274,6 +274,6 @@ library LibProposing {
         pure
         returns (bytes32)
     {
-        return bytes32(uint256(_basefeeSharingPctg) << 248 | uint256(_blockGasTargetMillion) << 240);
+        return bytes32(uint256(_basefeeSharingPctg) << 8 | uint256(_blockGasTargetMillion));
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -172,7 +172,7 @@ library LibProposing {
                 difficulty: keccak256(abi.encode("TAIKO_DIFFICULTY", local.b.numBlocks)),
                 blobHash: 0, // to be initialized below
                 extraData: local.postFork
-                    ? _encodeBaseFeeConfigs(_config.basefeeSharingPctg, _config.blockGasTargetMillion)
+                    ? _encodeExtraBlockConfigs(_config.basefeeSharingPctg, _config.blockGasTargetMillion)
                     : local.extraData,
                 coinbase: local.params.coinbase,
                 id: local.b.numBlocks,
@@ -266,7 +266,7 @@ library LibProposing {
         }
     }
 
-    function _encodeBaseFeeConfigs(
+    function _encodeExtraBlockConfigs(
         uint8 _basefeeSharingPctg,
         uint8 _blockGasTargetMillion
     )

--- a/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
@@ -21,7 +21,7 @@ contract HeklaTaikoL1 is TaikoL1 {
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 64,
             basefeeSharingPctg: 75,
-            blockGasTarget: 20_000_000,
+            blockGasTargetMillion: 20,
             ontakeForkHeight: 720_000 // = 7200 * 100
          });
     }

--- a/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
@@ -50,7 +50,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
             assertEq(meta.anchorBlockHash, blockhash(block.number - 1));
             assertEq(meta.livenessBond, config.livenessBond);
             assertEq(meta.coinbase, Alice);
-            // assertEq(meta.extraData, params.extraData);
 
             TaikoData.Block memory blk = L1.getBlock(i);
             assertEq(blk.blockId, i);

--- a/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
@@ -50,7 +50,7 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
             assertEq(meta.anchorBlockHash, blockhash(block.number - 1));
             assertEq(meta.livenessBond, config.livenessBond);
             assertEq(meta.coinbase, Alice);
-            assertEq(meta.extraData, params.extraData);
+            // assertEq(meta.extraData, params.extraData);
 
             TaikoData.Block memory blk = L1.getBlock(i);
             assertEq(blk.blockId, i);
@@ -104,7 +104,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         // Propose the first block with default parameters
         TaikoData.BlockParamsV2 memory params = TaikoData.BlockParamsV2({
             coinbase: address(0),
-            extraData: 0,
             parentMetaHash: 0,
             anchorBlockId: 0,
             timestamp: 0,
@@ -125,7 +124,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         assertEq(meta.livenessBond, config.livenessBond);
         assertEq(meta.coinbase, Alice);
         assertEq(meta.parentMetaHash, bytes32(uint256(1)));
-        assertEq(meta.extraData, params.extraData);
 
         TaikoData.Block memory blk = L1.getBlock(1);
         assertEq(blk.blockId, 1);
@@ -145,7 +143,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
 
         params = TaikoData.BlockParamsV2({
             coinbase: Bob,
-            extraData: bytes32(uint256(123)),
             parentMetaHash: 0,
             anchorBlockId: 90,
             timestamp: uint64(block.timestamp - 100),
@@ -165,7 +162,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         assertEq(meta.livenessBond, config.livenessBond);
         assertEq(meta.coinbase, Bob);
         assertEq(meta.parentMetaHash, blk.metaHash);
-        assertEq(meta.extraData, params.extraData);
 
         blk = L1.getBlock(2);
         assertEq(blk.blockId, 2);


### PR DESCRIPTION
This will avoid introducing those two params into Ethereum's block data structure which will cause block hash calculation different from Ethereum's. 