### PR TITLE
fix(protocol): refine EIP-1559 basefee calculation and gas excess adjustment in TaikoL2

### DIFF
--- a/packages/protocol/contract_layout.md
+++ b/packages/protocol/contract_layout.md
@@ -35,10 +35,10 @@
 | __gap           | uint256[49]                 | 202  | 0      | 1568  | contracts/L2/TaikoL2.sol:TaikoL2 |
 | l2Hashes        | mapping(uint256 => bytes32) | 251  | 0      | 32    | contracts/L2/TaikoL2.sol:TaikoL2 |
 | publicInputHash | bytes32                     | 252  | 0      | 32    | contracts/L2/TaikoL2.sol:TaikoL2 |
-| gasExcess       | uint64                      | 253  | 0      | 8     | contracts/L2/TaikoL2.sol:TaikoL2 |
+| parentGasExcess | uint64                      | 253  | 0      | 8     | contracts/L2/TaikoL2.sol:TaikoL2 |
 | lastSyncedBlock | uint64                      | 253  | 8      | 8     | contracts/L2/TaikoL2.sol:TaikoL2 |
 | parentTimestamp | uint64                      | 253  | 16     | 8     | contracts/L2/TaikoL2.sol:TaikoL2 |
-| __deprecated2   | uint64                      | 253  | 24     | 8     | contracts/L2/TaikoL2.sol:TaikoL2 |
+| parentGasTarget | uint64                      | 253  | 24     | 8     | contracts/L2/TaikoL2.sol:TaikoL2 |
 | l1ChainId       | uint64                      | 254  | 0      | 8     | contracts/L2/TaikoL2.sol:TaikoL2 |
 | __gap           | uint256[46]                 | 255  | 0      | 1472  | contracts/L2/TaikoL2.sol:TaikoL2 |
 

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -41,7 +41,7 @@ library TaikoData {
         // ---------------------------------------------------------------------
         uint8 basefeeAdjustmentQuotient;
         uint8 basefeeSharingPctg;
-        uint32 gasTargetPerL1Block;
+        uint32 gasIssuancePerSecond;
         // ---------------------------------------------------------------------
         // Group 6: Others
         // ---------------------------------------------------------------------
@@ -126,7 +126,7 @@ library TaikoData {
         uint8 blobIndex;
         uint8 basefeeAdjustmentQuotient;
         uint8 basefeeSharingPctg;
-        uint32 gasTargetPerL1Block;
+        uint32 gasIssuancePerSecond;
     }
 
     /// @dev Struct representing transition to be proven.

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -287,7 +287,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             maxAnchorHeightOffset: 64,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
-            gasIssuancePerSecond: 2_000_000,
+            gasIssuancePerSecond: 5_000_000,
             ontakeForkHeight: 374_400 // = 7200 * 52
          });
     }

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -287,7 +287,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
             maxAnchorHeightOffset: 64,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
-            gasTargetPerL1Block: 60_000_000,
+            gasIssuancePerSecond: 2_000_000,
             ontakeForkHeight: 374_400 // = 7200 * 52
          });
     }

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -78,7 +78,7 @@ library LibData {
             blobIndex: 0,
             basefeeAdjustmentQuotient: 0,
             basefeeSharingPctg: 0,
-            gasTargetPerL1Block: 0
+            gasIssuancePerSecond: 0
         });
     }
 }

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -176,7 +176,7 @@ library LibProposing {
                 blobIndex: local.params.blobIndex,
                 basefeeAdjustmentQuotient: _config.basefeeAdjustmentQuotient,
                 basefeeSharingPctg: _config.basefeeSharingPctg,
-                gasTargetPerL1Block: _config.gasTargetPerL1Block
+                gasIssuancePerSecond: _config.gasIssuancePerSecond
             });
         }
 

--- a/packages/protocol/contracts/L2/Lib1559Math.sol
+++ b/packages/protocol/contracts/L2/Lib1559Math.sol
@@ -57,7 +57,7 @@ library Lib1559Math {
             ratio = f * _newGasTarget / _gasTarget;
         }
 
-        if (ratio > type(int256).max) revert EIP1559_INVALID_PARAMS();
+        if (ratio > uint256(type(int256).max)) revert EIP1559_INVALID_PARAMS();
 
         int256 lnRatio = LibFixedPointMath.ln(int256(ratio));
 

--- a/packages/protocol/contracts/L2/Lib1559Math.sol
+++ b/packages/protocol/contracts/L2/Lib1559Math.sol
@@ -36,9 +36,6 @@ library Lib1559Math {
         // block, however, this block's gas used will affect the next
         // block's base fee.
         basefee_ = basefee(gasExcess_, uint256(_adjustmentQuotient) * _gasTarget);
-
-        // Always make sure basefee is nonzero, this is required by the node.
-        if (basefee_ == 0) basefee_ = 1;
     }
 
     /// @dev eth_qty(excess_gas_issued) / (TARGET * ADJUSTMENT_QUOTIENT)
@@ -46,7 +43,8 @@ library Lib1559Math {
     /// @param _target The product of gasTarget and adjustmentQuotient
     function basefee(uint256 _gasExcess, uint256 _target) internal pure returns (uint256) {
         if (_target == 0) revert EIP1559_INVALID_PARAMS();
-        return ethQty(_gasExcess, _target) / _target;
+        uint256 fee = ethQty(_gasExcess, _target) / _target;
+        return fee == 0 ? 1 : fee;
     }
 
     /// @dev exp(_gasExcess / _target)

--- a/packages/protocol/contracts/L2/Lib1559Math.sol
+++ b/packages/protocol/contracts/L2/Lib1559Math.sol
@@ -43,34 +43,18 @@ library Lib1559Math {
 
     /// @dev eth_qty(excess_gas_issued) / (TARGET * ADJUSTMENT_QUOTIENT)
     /// @param _gasExcess The gas excess value
-    /// @param _adjustmentFactor The product of gasTarget and adjustmentQuotient
-    function basefee(
-        uint256 _gasExcess,
-        uint256 _adjustmentFactor
-    )
-        internal
-        pure
-        returns (uint256)
-    {
-        if (_adjustmentFactor == 0) {
-            revert EIP1559_INVALID_PARAMS();
-        }
-        return _ethQty(_gasExcess, _adjustmentFactor) / LibFixedPointMath.SCALING_FACTOR;
+    /// @param _target The product of gasTarget and adjustmentQuotient
+    function basefee(uint256 _gasExcess, uint256 _target) internal pure returns (uint256) {
+        if (_target == 0) revert EIP1559_INVALID_PARAMS();
+        return ethQty(_gasExcess, _target) / _target;
     }
 
-    /// @dev exp(gas_qty / TARGET / ADJUSTMENT_QUOTIENT)
-    function _ethQty(
-        uint256 _gasExcess,
-        uint256 _adjustmentFactor
-    )
-        private
-        pure
-        returns (uint256)
-    {
-        uint256 input = _gasExcess * LibFixedPointMath.SCALING_FACTOR / _adjustmentFactor;
+    /// @dev exp(_gasExcess / _target)
+    function ethQty(uint256 _gasExcess, uint256 _target) internal pure returns (uint256) {
+        uint256 input = _gasExcess * LibFixedPointMath.SCALING_FACTOR / _target;
         if (input > LibFixedPointMath.MAX_EXP_INPUT) {
             input = LibFixedPointMath.MAX_EXP_INPUT;
         }
-        return uint256(LibFixedPointMath.exp(int256(input)));
+        return uint256(LibFixedPointMath.exp(int256(input))) / LibFixedPointMath.SCALING_FACTOR;
     }
 }

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -199,8 +199,7 @@ contract TaikoL2 is EssentialContract {
         LibL2Config.Config memory config = getConfig();
 
         (basefee_, parentGasExcess_) = Lib1559Math.calc1559BaseFee(
-            config.gasTargetPerL1Block,
-            config.basefeeAdjustmentQuotient,
+            uint256(config.gasTargetPerL1Block) * config.basefeeAdjustmentQuotient,
             parentGasExcess,
             uint64(_anchorBlockId - lastSyncedBlock) * config.gasTargetPerL1Block,
             _parentGasUsed
@@ -254,8 +253,7 @@ contract TaikoL2 is EssentialContract {
         returns (uint256 basefee_, uint64 parentGasExcess_)
     {
         return Lib1559Math.calc1559BaseFee(
-            _gasIssuancePerSecond,
-            _adjustmentQuotient,
+            uint256(_gasIssuancePerSecond) * _adjustmentQuotient,
             _parentGasExcess,
             _blocktime * _gasIssuancePerSecond,
             _parentGasUsed

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -104,7 +104,7 @@ contract TaikoL2 is EssentialContract {
     /// - _initialGasExcess = 274*5_000_000 => basefee =0.01 gwei
     /// - _initialGasExcess = 282*5_000_000 => basefee =0.05 gwei
     /// - _initialGasExcess = 288*5_000_000 => basefee =0.1 gwei
-    function init2(uint64 _initialGasExcess) external reinitializer(2) {
+    function init2(uint64 _initialGasExcess) external onlyOwner reinitializer(2) {
         parentGasExcess = _initialGasExcess;
         parentTimestamp = uint64(block.timestamp);
         parentGasTarget = 0;

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -325,7 +325,7 @@ contract TaikoL2 is EssentialContract {
         publicInputHash = newPublicInputHash;
         parentGasExcess = newGasExcess;
         parentTimestamp = uint64(block.timestamp);
-        parentGasTarget = newGasExcess;
+        parentGasTarget = newGasTarget;
 
         emit Anchored(parentHash, newGasExcess);
     }

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -289,9 +289,10 @@ contract TaikoL2 is EssentialContract {
         // Check if the gas settings has changed
         uint64 newGasTarget = uint64(_gasIssuancePerSecond) * _basefeeAdjustmentQuotient;
         if (newGasTarget < parentGasTarget) {
-            // Reset parentGasExcess to avoid sudden increase of basefee. See
-            // test_change_of_quotient_and_gips in Lib1559Math.t.sol.
-            parentGasExcess = 0;
+            // adjust parentGasExcess to keep the basefee unchanged. Note that due to math
+            // calculation precision, the basefee may change slightly.
+            parentGasExcess =
+                Lib1559Math.adjustExcess(parentGasExcess, parentGasTarget, newGasTarget);
         }
 
         // Verify the base fee per gas is correct

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -65,12 +65,12 @@ contract TaikoL2 is EssentialContract {
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
     /// @param _rollupAddressManager The address of the {AddressManager} contract.
     /// @param _l1ChainId The ID of the base layer.
-    /// @param _parentGasExcess The initial parentGasExcess.
+    /// @param _initialGasExcess The initial parentGasExcess.
     function init(
         address _owner,
         address _rollupAddressManager,
         uint64 _l1ChainId,
-        uint64 _parentGasExcess
+        uint64 _initialGasExcess
     )
         external
         initializer
@@ -95,12 +95,12 @@ contract TaikoL2 is EssentialContract {
         }
 
         l1ChainId = _l1ChainId;
-        parentGasExcess = _parentGasExcess;
+        parentGasExcess = _initialGasExcess;
         (publicInputHash,) = _calcPublicInputHash(block.number);
     }
 
-    function init2() external reinitializer(2) {
-        parentGasExcess = 0;
+    function init2(uint64 _initialGasExcess) external reinitializer(2) {
+        parentGasExcess = _initialGasExcess;
         parentTimestamp = uint64(block.timestamp);
         parentGasTarget = 0;
     }

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -288,7 +288,7 @@ contract TaikoL2 is EssentialContract {
 
         // Check if the gas settings has changed
         uint64 newGasTarget = uint64(_gasIssuancePerSecond) * _basefeeAdjustmentQuotient;
-        if (newGasTarget < parentGasTarget) {
+        if (newGasTarget != parentGasTarget) {
             // adjust parentGasExcess to keep the basefee unchanged. Note that due to math
             // calculation precision, the basefee may change slightly.
             parentGasExcess =

--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -99,6 +99,11 @@ contract TaikoL2 is EssentialContract {
         (publicInputHash,) = _calcPublicInputHash(block.number);
     }
 
+    /// @dev Reinitialize some state variables.
+    /// We may want to init the basefee to a default value using one of the following values.
+    /// - _initialGasExcess = 274*5_000_000 => basefee =0.01 gwei
+    /// - _initialGasExcess = 282*5_000_000 => basefee =0.05 gwei
+    /// - _initialGasExcess = 288*5_000_000 => basefee =0.1 gwei
     function init2(uint64 _initialGasExcess) external reinitializer(2) {
         parentGasExcess = _initialGasExcess;
         parentTimestamp = uint64(block.timestamp);

--- a/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
@@ -22,7 +22,7 @@ contract HeklaTaikoL1 is TaikoL1 {
             maxAnchorHeightOffset: 64,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
-            gasTargetPerL1Block: 60_000_000,
+            gasIssuancePerSecond: 2_000_000,
             ontakeForkHeight: 720_000 // = 7200 * 100
          });
     }

--- a/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/hekla/HeklaTaikoL1.sol
@@ -22,7 +22,7 @@ contract HeklaTaikoL1 is TaikoL1 {
             maxAnchorHeightOffset: 64,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
-            gasIssuancePerSecond: 2_000_000,
+            gasIssuancePerSecond: 5_000_000,
             ontakeForkHeight: 720_000 // = 7200 * 100
          });
     }

--- a/packages/protocol/contracts/mainnet/MainnetTaikoL1.sol
+++ b/packages/protocol/contracts/mainnet/MainnetTaikoL1.sol
@@ -32,7 +32,7 @@ contract MainnetTaikoL1 is TaikoL1 {
             maxAnchorHeightOffset: 64,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
-            gasTargetPerL1Block: 60_000_000,
+            gasIssuancePerSecond: 2_000_000,
             ontakeForkHeight: 374_400 // = 7200 * 52
          });
     }

--- a/packages/protocol/contracts/mainnet/MainnetTaikoL1.sol
+++ b/packages/protocol/contracts/mainnet/MainnetTaikoL1.sol
@@ -32,7 +32,7 @@ contract MainnetTaikoL1 is TaikoL1 {
             maxAnchorHeightOffset: 64,
             basefeeAdjustmentQuotient: 8,
             basefeeSharingPctg: 75,
-            gasIssuancePerSecond: 2_000_000,
+            gasIssuancePerSecond: 5_000_000,
             ontakeForkHeight: 374_400 // = 7200 * 52
          });
     }

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -32,19 +32,19 @@ contract TestLib1559Math is TaikoTest {
         uint256 basefee = Lib1559Math.basefee(excess, 2_000_000 * 4) / 10_000_000;
         console2.log("basefee (uint 0.01gwei) with quotient = 4: ", basefee);
 
-        // basefee will decrease if gas issued per second or quotient increased.
+        /// basefee will decrease if (gas_issued_per_second * quotient) increases.
         basefee = Lib1559Math.basefee(excess, 2_000_000 * 8) / 10_000_000;
         console2.log("basefee (uint 0.01gwei) with quotient = 8: ", basefee);
         basefee = Lib1559Math.basefee(excess, 4_000_000 * 4) / 10_000_000;
         console2.log("basefee (uint 0.01gwei) with gips = 4_000_000: ", basefee);
 
-        // basefee will increase if gas issued per second or quotient decreased.
+        // basefee will increase if (gas_issued_per_second * quotient) decreases.
         basefee = Lib1559Math.basefee(excess, 2_000_000 * 2) / 10_000_000;
         console2.log("basefee (uint 0.01gwei) with quotient = 2: ", basefee);
         basefee = Lib1559Math.basefee(excess, 1_000_000 * 4) / 10_000_000;
         console2.log("basefee (uint 0.01gwei) with gips = 1_000_000: ", basefee);
 
-        // basefee will be the same if gas issued per second * quotient decreased remains same
+        /// basefee will remain the same if (gas_issued_per_second * quotient) remains the same.
         basefee = Lib1559Math.basefee(excess, 4_000_000 * 2) / 10_000_000;
         console2.log("basefee (uint 0.01gwei) ", basefee);
     }

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -6,8 +6,41 @@ import "../TaikoTest.sol";
 contract TestLib1559Math is TaikoTest {
     using LibMath for uint256;
 
+    uint256 public constant gips = 2_000_000; // gas issuance per second
+    uint256 public constant quotient = 4;
+    uint256 public constant target = gips * quotient;
+
+    function test_ethQty() external {
+        assertEq(Lib1559Math.ethQty(0, 60_000_000 / 8), 1);
+        assertEq(Lib1559Math.ethQty(60_000_000, 60_000_000 / 8), 2980);
+        assertEq(Lib1559Math.ethQty(60_000_000 * 2, 60_000_000 / 8), 8_886_110);
+        assertEq(Lib1559Math.ethQty(60_000_000 * 3, 60_000_000 / 8), 26_489_122_129);
+        assertEq(Lib1559Math.ethQty(60_000_000 * 4, 60_000_000 / 8), 78_962_960_182_680);
+        assertEq(
+            Lib1559Math.ethQty(60_000_000 * 10, 60_000_000 / 8),
+            55_406_223_843_935_100_525_863_115_942_268_902
+        );
+        assertEq(
+            Lib1559Math.ethQty(60_000_000 * 100, 60_000_000 / 8),
+            57_896_044_618_658_097_650_144_101_621_524_338_577_433_870_140_581_303_254_786
+        );
+    }
+
+    function test_basefee() external {
+        uint256 basefee;
+        for (uint256 i; basefee <= 5000;) {
+            // uint 0.01 gwei
+            basefee = Lib1559Math.basefee(i * gips, target) / 10_000_000;
+            if (basefee != 0) {
+                console2.log("basefee (uint 0.01gwei) after", i, "seconds:", basefee);
+            }
+            i += 12;
+        }
+    }
+
     function test_eip1559_math() external pure {
         LibL2Config.Config memory config = LibL2Config.get();
+
         uint256 adjustmentFactor = config.gasTargetPerL1Block * config.basefeeAdjustmentQuotient;
 
         uint256 baseFee;

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -6,66 +6,46 @@ import "../TaikoTest.sol";
 contract TestLib1559Math is TaikoTest {
     using LibMath for uint256;
 
-    uint256 public constant gips = 2_000_000; // gas issuance per second
-    uint256 public constant quotient = 4;
-    uint256 public constant target = gips * quotient;
-
     function test_ethQty() external {
-        assertEq(Lib1559Math.ethQty(0, 60_000_000 / 8), 1);
-        assertEq(Lib1559Math.ethQty(60_000_000, 60_000_000 / 8), 2980);
-        assertEq(Lib1559Math.ethQty(60_000_000 * 2, 60_000_000 / 8), 8_886_110);
-        assertEq(Lib1559Math.ethQty(60_000_000 * 3, 60_000_000 / 8), 26_489_122_129);
-        assertEq(Lib1559Math.ethQty(60_000_000 * 4, 60_000_000 / 8), 78_962_960_182_680);
-        assertEq(
-            Lib1559Math.ethQty(60_000_000 * 10, 60_000_000 / 8),
-            55_406_223_843_935_100_525_863_115_942_268_902
-        );
-        assertEq(
-            Lib1559Math.ethQty(60_000_000 * 100, 60_000_000 / 8),
-            57_896_044_618_658_097_650_144_101_621_524_338_577_433_870_140_581_303_254_786
-        );
+        assertEq(Lib1559Math.ethQty(0, 60_000_000 * 8), 1);
+        assertEq(Lib1559Math.ethQty(60_000_000, 60_000_000 * 8), 1);
+        assertEq(Lib1559Math.ethQty(60_000_000 * 100, 60_000_000 * 8), 268_337);
+        assertEq(Lib1559Math.ethQty(60_000_000 * 200, 60_000_000 * 8), 72_004_899_337);
     }
 
     function test_basefee() external {
         uint256 basefee;
         for (uint256 i; basefee <= 5000;) {
             // uint 0.01 gwei
-            basefee = Lib1559Math.basefee(i * gips, target) / 10_000_000;
+            basefee = Lib1559Math.basefee(i * 2_000_000, 2_000_000 * 4) / 10_000_000;
             if (basefee != 0) {
                 console2.log("basefee (uint 0.01gwei) after", i, "seconds:", basefee);
             }
-            i += 12;
+            i += 1;
         }
     }
 
-    function test_eip1559_math() external pure {
-        LibL2Config.Config memory config = LibL2Config.get();
+    function test_change_of_quotient_and_gips() public {
+        uint256 excess = 150 * 2_000_000;
 
-        uint256 adjustmentFactor = config.gasTargetPerL1Block * config.basefeeAdjustmentQuotient;
+        // uint 0.01 gwei
+        uint256 basefee = Lib1559Math.basefee(excess, 2_000_000 * 4) / 10_000_000;
+        console2.log("basefee (uint 0.01gwei) with quotient = 4: ", basefee);
 
-        uint256 baseFee;
-        uint256 i;
-        uint256 target = 0.01 gwei;
+        // basefee will decrease if gas issued per second or quotient increased.
+        basefee = Lib1559Math.basefee(excess, 2_000_000 * 8) / 10_000_000;
+        console2.log("basefee (uint 0.01gwei) with quotient = 8: ", basefee);
+        basefee = Lib1559Math.basefee(excess, 4_000_000 * 4) / 10_000_000;
+        console2.log("basefee (uint 0.01gwei) with gips = 4_000_000: ", basefee);
 
-        for (uint256 k; k < 5; ++k) {
-            for (; baseFee < target; ++i) {
-                baseFee = Lib1559Math.basefee(config.gasTargetPerL1Block * i, adjustmentFactor);
-            }
-            console2.log("base fee:", baseFee);
-            console2.log("    gasExcess:", config.gasTargetPerL1Block * i);
-            console2.log("    i:", i);
-            target *= 10;
-        }
-    }
+        // basefee will increase if gas issued per second or quotient decreased.
+        basefee = Lib1559Math.basefee(excess, 2_000_000 * 2) / 10_000_000;
+        console2.log("basefee (uint 0.01gwei) with quotient = 2: ", basefee);
+        basefee = Lib1559Math.basefee(excess, 1_000_000 * 4) / 10_000_000;
+        console2.log("basefee (uint 0.01gwei) with gips = 1_000_000: ", basefee);
 
-    function test_eip1559_math_max() external pure {
-        LibL2Config.Config memory config = LibL2Config.get();
-        uint256 adjustmentFactor = config.gasTargetPerL1Block * config.basefeeAdjustmentQuotient;
-
-        uint256 gasExcess = type(uint64).max;
-        uint256 baseFee = Lib1559Math.basefee(gasExcess, adjustmentFactor);
-
-        console2.log("base fee (gwei):", baseFee / 1 gwei);
-        console2.log("    gasExcess:", gasExcess);
+        // basefee will be the same if gas issued per second * quotient decreased remains same
+        basefee = Lib1559Math.basefee(excess, 4_000_000 * 2) / 10_000_000;
+        console2.log("basefee (uint 0.01gwei) ", basefee);
     }
 }

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -17,7 +17,7 @@ contract TestLib1559Math is TaikoTest {
         uint256 basefee;
         for (uint256 i; basefee <= 5000;) {
             // uint 0.01 gwei
-            basefee = Lib1559Math.basefee(i * 2_000_000, 2_000_000 * 4) / 10_000_000;
+            basefee = Lib1559Math.basefee(i * 5_000_000, 5_000_000 * 8) / 10_000_000;
             if (basefee != 0) {
                 console2.log("basefee (uint 0.01gwei) after", i, "seconds:", basefee);
             }

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -13,7 +13,7 @@ contract TestLib1559Math is TaikoTest {
         assertEq(Lib1559Math.ethQty(60_000_000 * 200, 60_000_000 * 8), 72_004_899_337);
     }
 
-    function test_basefee() external {
+    function test_basefee() external pure {
         uint256 basefee;
         for (uint256 i; basefee <= 5000;) {
             // uint 0.01 gwei
@@ -25,7 +25,7 @@ contract TestLib1559Math is TaikoTest {
         }
     }
 
-    function test_change_of_quotient_and_gips() public {
+    function test_change_of_quotient_and_gips() public pure {
         uint256 excess = 150 * 2_000_000;
 
         // uint 0.01 gwei

--- a/packages/protocol/test/L2/Lib1559Math.t.sol
+++ b/packages/protocol/test/L2/Lib1559Math.t.sol
@@ -45,6 +45,7 @@ contract TestLib1559Math is TaikoTest {
             uint64 newTarget = 5 * 2_000_000;
             uint64 newExcess = Lib1559Math.adjustExcess(excess, target, newTarget);
             basefee = Lib1559Math.basefee(newExcess, newTarget) / unit;
+            console2.log("old gas excess: ", excess);
             console2.log("new gas excess: ", newExcess);
             console2.log("basefee: ", basefee);
             assertEq(baselineBasefee, basefee);
@@ -55,6 +56,7 @@ contract TestLib1559Math is TaikoTest {
             uint64 newTarget = 3 * 2_000_000;
             uint64 newExcess = Lib1559Math.adjustExcess(excess, target, newTarget);
             basefee = Lib1559Math.basefee(newExcess, newTarget) / unit;
+            console2.log("old gas excess: ", excess);
             console2.log("new gas excess: ", newExcess);
             console2.log("basefee: ", basefee);
             assertEq(baselineBasefee, basefee);

--- a/packages/protocol/test/L2/TaikoL2EIP1559Configurable.sol
+++ b/packages/protocol/test/L2/TaikoL2EIP1559Configurable.sol
@@ -34,7 +34,7 @@ contract TaikoL2EIP1559Configurable is TaikoL2 {
         if (_newConfig.basefeeAdjustmentQuotient == 0) revert L2_INVALID_CONFIG();
 
         customConfig = _newConfig;
-        gasExcess = _newGasExcess;
+        parentGasExcess = _newGasExcess;
 
         emit ConfigAndExcessChanged(_newConfig, _newGasExcess);
     }

--- a/packages/protocol/utils/generate_genesis/taikoL2.ts
+++ b/packages/protocol/utils/generate_genesis/taikoL2.ts
@@ -515,7 +515,7 @@ async function generateContractConfigs(
                 // TaikoL2 => CrossChainOwned
                 l1ChainId,
                 // TaikoL2
-                gasExcess: param1559.gasExcess,
+                parentGasExcess: param1559.gasExcess,
                 publicInputHash: `${ethers.utils.solidityKeccak256(
                     ["bytes32[256]"],
                     [


### PR DESCRIPTION
This PR introduces two changes to improve our implementation of the EIP-1559. 

### 1. Refined EIP-1559 Base Fee Calculation

   - Previous: `basefee = eth_qty(excess_gas_issued)`
   - New: `basefee = eth_qty(excess_gas_issued) / (TARGET * ADJUSTMENT_QUOTIENT)`

   This modification aligns our implementation more closely with Vitalik Buterin's proposal. While both approaches are functional, the new calculation allows for a more gradual adjustment of the base fee.

### 2. Gas Excess Adjustment in TaikoL2

   Implemented a gas excess adjustment mechanism  when `TARGET * ADJUSTMENT_QUOTIENT` in a block changes to keep the base fee the same. Without this mechanism, the base fee may spike, as demonstrated in the `test_change_of_quotient_and_gips` test.

### 3. Set 5m gas per second

   Configured the L2 to issue 5 million gas per second (Ethereum issues 2.5 million gas per second which translates into 2.5*12=30 million block gas target).