### PR TITLE
fix(protocol): add _basefeeSharingPctg to `anchorV2`

### DIFF
--- a/packages/protocol/contracts/L2/TaikoL2.sol
+++ b/packages/protocol/contracts/L2/TaikoL2.sol
@@ -145,11 +145,14 @@ contract TaikoL2 is EssentialContract {
         bytes32 _anchorStateRoot,
         uint32 _parentGasUsed,
         uint32 _gasIssuancePerSecond,
-        uint8 _basefeeAdjustmentQuotient
+        uint8 _basefeeAdjustmentQuotient,
+        uint8 _basefeeSharingPctg // needed for client
     )
         external
         nonReentrant
     {
+        if (_basefeeSharingPctg > 100) revert L2_INVALID_PARAM();
+
         if (block.number < ontakeForkHeight()) revert L2_FORK_ERROR();
         _anchor(
             _anchorBlockId,


### PR DESCRIPTION
Adding `config.basefeeSharingPctg` as an input for `anchorV2` transaction so the client can extract the value to calculate basefee distribution.