### PR TITLE
fix(protocol): use block header's extraData for `basefeeSharingPctg`

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -72,7 +72,6 @@ library TaikoData {
 
     struct BlockParamsV2 {
         address coinbase;
-        bytes32 extraData;
         bytes32 parentMetaHash;
         uint64 anchorBlockId; // NEW
         uint64 timestamp; // NEW
@@ -125,7 +124,6 @@ library TaikoData {
         uint32 blobTxListLength;
         uint8 blobIndex;
         uint8 basefeeAdjustmentQuotient;
-        uint8 basefeeSharingPctg;
         uint32 gasIssuancePerSecond;
     }
 

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -18,7 +18,6 @@ library LibData {
     {
         return TaikoData.BlockParamsV2({
             coinbase: _v1.coinbase,
-            extraData: _v1.extraData,
             parentMetaHash: _v1.parentMetaHash,
             anchorBlockId: 0,
             timestamp: 0,
@@ -77,7 +76,6 @@ library LibData {
             blobTxListLength: 0,
             blobIndex: 0,
             basefeeAdjustmentQuotient: 0,
-            basefeeSharingPctg: 0,
             gasIssuancePerSecond: 0
         });
     }

--- a/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
@@ -50,7 +50,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
             assertEq(meta.anchorBlockHash, blockhash(block.number - 1));
             assertEq(meta.livenessBond, config.livenessBond);
             assertEq(meta.coinbase, Alice);
-            assertEq(meta.extraData, params.extraData);
 
             TaikoData.Block memory blk = L1.getBlock(i);
             assertEq(blk.blockId, i);
@@ -104,7 +103,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         // Propose the first block with default parameters
         TaikoData.BlockParamsV2 memory params = TaikoData.BlockParamsV2({
             coinbase: address(0),
-            extraData: 0,
             parentMetaHash: 0,
             anchorBlockId: 0,
             timestamp: 0,
@@ -125,7 +123,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         assertEq(meta.livenessBond, config.livenessBond);
         assertEq(meta.coinbase, Alice);
         assertEq(meta.parentMetaHash, bytes32(uint256(1)));
-        assertEq(meta.extraData, params.extraData);
 
         TaikoData.Block memory blk = L1.getBlock(1);
         assertEq(blk.blockId, 1);
@@ -145,7 +142,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
 
         params = TaikoData.BlockParamsV2({
             coinbase: Bob,
-            extraData: bytes32(uint256(123)),
             parentMetaHash: 0,
             anchorBlockId: 90,
             timestamp: uint64(block.timestamp - 100),
@@ -165,7 +161,6 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         assertEq(meta.livenessBond, config.livenessBond);
         assertEq(meta.coinbase, Bob);
         assertEq(meta.parentMetaHash, blk.metaHash);
-        assertEq(meta.extraData, params.extraData);
 
         blk = L1.getBlock(2);
         assertEq(blk.blockId, 2);


### PR DESCRIPTION
According to David C, the client implementation is much easier this way compared to https://github.com/taikoxyz/taiko-mono/pull/17888