### PR TITLE
feat(protocol): allow msg.sender to customize block proposer addresses

### DIFF
--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -78,6 +78,7 @@ library TaikoData {
     }
 
     struct BlockParamsV2 {
+        address proposer;
         address coinbase;
         bytes32 parentMetaHash;
         uint64 anchorBlockId; // NEW

--- a/packages/protocol/contracts/L1/TaikoL1.sol
+++ b/packages/protocol/contracts/L1/TaikoL1.sol
@@ -71,7 +71,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
     )
         external
         payable
-        onlyFromOptionalNamed(LibStrings.B_BLOCK_PROPOSER)
         whenNotPaused
         nonReentrant
         emitEventForClient
@@ -88,7 +87,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
         bytes calldata _txList
     )
         external
-        onlyFromOptionalNamed(LibStrings.B_BLOCK_PROPOSER)
         whenNotPaused
         nonReentrant
         emitEventForClient
@@ -105,7 +103,6 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
         bytes[] calldata _txListArr
     )
         external
-        onlyFromOptionalNamed(LibStrings.B_BLOCK_PROPOSER)
         whenNotPaused
         nonReentrant
         emitEventForClient

--- a/packages/protocol/contracts/L1/libs/LibData.sol
+++ b/packages/protocol/contracts/L1/libs/LibData.sol
@@ -18,6 +18,7 @@ library LibData {
         returns (TaikoData.BlockParamsV2 memory)
     {
         return TaikoData.BlockParamsV2({
+            proposer: address(0),
             coinbase: _v1.coinbase,
             parentMetaHash: _v1.parentMetaHash,
             anchorBlockId: 0,

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -160,19 +160,19 @@ library LibProposing {
             if (_params.length != 0) {
                 local.params = abi.decode(_params, (TaikoData.BlockParamsV2));
             }
-            if (local.params.proposer == address(0)) {
-                local.params.proposer = msg.sender;
-            } else {
-                require(
-                    local.params.proposer == msg.sender || local.allowCustomProposer,
-                    L1_INVALID_CUSTOM_PROPOSER()
-                );
-            }
         } else {
             TaikoData.BlockParams memory paramsV1 = abi.decode(_params, (TaikoData.BlockParams));
             local.params = LibData.blockParamsV1ToV2(paramsV1);
-            local.params.proposer = msg.sender;
             local.extraData = paramsV1.extraData;
+        }
+
+        if (local.params.proposer == address(0)) {
+            local.params.proposer = msg.sender;
+        } else {
+            require(
+                local.params.proposer == msg.sender || local.allowCustomProposer,
+                L1_INVALID_CUSTOM_PROPOSER()
+            );
         }
 
         if (local.params.coinbase == address(0)) {

--- a/packages/protocol/contracts/L1/libs/LibProposing.sol
+++ b/packages/protocol/contracts/L1/libs/LibProposing.sol
@@ -20,6 +20,7 @@ library LibProposing {
         ITierProvider tierProvider;
         bytes32 parentMetaHash;
         bool postFork;
+        bool allowCustomProposer;
         bytes32 extraData;
     }
 
@@ -51,6 +52,7 @@ library LibProposing {
     error L1_BLOB_NOT_AVAILABLE();
     error L1_BLOB_NOT_FOUND();
     error L1_INVALID_ANCHOR_BLOCK();
+    error L1_INVALID_CUSTOM_PROPOSER();
     error L1_INVALID_PARAMS();
     error L1_INVALID_PROPOSER();
     error L1_INVALID_TIMESTAMP();
@@ -148,19 +150,33 @@ library LibProposing {
             revert L1_TOO_MANY_BLOCKS();
         }
 
+        address permittedProposer = _resolver.resolve(LibStrings.B_BLOCK_PROPOSER, true);
+        if (permittedProposer != address(0)) {
+            require(permittedProposer == msg.sender, L1_INVALID_PROPOSER());
+            local.allowCustomProposer = true;
+        }
+
         if (local.postFork) {
             if (_params.length != 0) {
                 local.params = abi.decode(_params, (TaikoData.BlockParamsV2));
-                // otherwise use a default BlockParamsV2 with 0 values
+            }
+            if (local.params.proposer == address(0)) {
+                local.params.proposer = msg.sender;
+            } else {
+                require(
+                    local.params.proposer == msg.sender || local.allowCustomProposer,
+                    L1_INVALID_CUSTOM_PROPOSER()
+                );
             }
         } else {
             TaikoData.BlockParams memory paramsV1 = abi.decode(_params, (TaikoData.BlockParams));
             local.params = LibData.blockParamsV1ToV2(paramsV1);
+            local.params.proposer = msg.sender;
             local.extraData = paramsV1.extraData;
         }
 
         if (local.params.coinbase == address(0)) {
-            local.params.coinbase = msg.sender;
+            local.params.coinbase = local.params.proposer;
         }
 
         if (!local.postFork || local.params.anchorBlockId == 0) {
@@ -232,7 +248,7 @@ library LibProposing {
                 minTier: 0, // to be initialized below
                 blobUsed: _txList.length == 0,
                 parentMetaHash: local.params.parentMetaHash,
-                proposer: msg.sender,
+                proposer: local.params.proposer,
                 livenessBond: _config.livenessBond,
                 proposedAt: uint64(block.timestamp),
                 proposedIn: uint64(block.number),
@@ -294,7 +310,7 @@ library LibProposing {
             ++_state.slotB.numBlocks;
         }
 
-        LibBonds.debitBond(_state, _resolver, msg.sender, _config.livenessBond);
+        LibBonds.debitBond(_state, _resolver, local.params.proposer, _config.livenessBond);
 
         // Bribe the block builder. Unlike 1559-tips, this tip is only made
         // if this transaction succeeds.
@@ -307,7 +323,7 @@ library LibProposing {
         } else {
             emit BlockProposed({
                 blockId: metaV1_.id,
-                assignedProver: msg.sender,
+                assignedProver: local.params.proposer,
                 livenessBond: _config.livenessBond,
                 meta: metaV1_,
                 depositsProcessed: new TaikoData.EthDeposit[](0)

--- a/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
@@ -30,6 +30,7 @@ abstract contract TaikoL1TestGroupBase is TaikoL1TestBase {
         TaikoData.HookCall[] memory hookcalls = new TaikoData.HookCall[](0);
         bytes memory txList = new bytes(10);
 
+        console2.log("in test: proposer", proposer);
         vm.prank(proposer);
         if (revertReason != "") vm.expectRevert(revertReason);
         (meta,) = L1.proposeBlock{ value: 3 ether }(

--- a/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
+++ b/packages/protocol/test/L1/TaikoL1TestGroupBase.sol
@@ -30,7 +30,6 @@ abstract contract TaikoL1TestGroupBase is TaikoL1TestBase {
         TaikoData.HookCall[] memory hookcalls = new TaikoData.HookCall[](0);
         bytes memory txList = new bytes(10);
 
-        console2.log("in test: proposer", proposer);
         vm.prank(proposer);
         if (revertReason != "") vm.expectRevert(revertReason);
         (meta,) = L1.proposeBlock{ value: 3 ether }(

--- a/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
@@ -35,7 +35,7 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
 
         bytes32 parentHash = GENESIS_BLOCK_HASH;
 
-        proposeBlock(Alice, TaikoL1.L1_FORK_ERROR.selector);
+        proposeBlock(Alice, LibProposing.L1_INVALID_CUSTOM_PROPOSER.selector);
 
         TaikoData.BlockParamsV2 memory params;
         for (uint64 i = 1; i <= 5; ++i) {

--- a/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
+++ b/packages/protocol/test/L1/TaikoL1testGroupA2.t.sol
@@ -102,6 +102,7 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
 
         // Propose the first block with default parameters
         TaikoData.BlockParamsV2 memory params = TaikoData.BlockParamsV2({
+            proposer: address(0),
             coinbase: address(0),
             parentMetaHash: 0,
             anchorBlockId: 0,
@@ -141,6 +142,7 @@ contract TaikoL1TestGroupA2 is TaikoL1TestGroupBase {
         // Propose the second block with custom parameters
 
         params = TaikoData.BlockParamsV2({
+            proposer: address(0),
             coinbase: Bob,
             parentMetaHash: 0,
             anchorBlockId: 90,


### PR DESCRIPTION
This is necessary for [PreconfTaskManager](https://github.com/NethermindEth/Taiko-Preconf-AVS/blob/master/SmartContracts/src/avs/PreconfTaskManager.sol) to assign the actual preconfers as the block proposers, not using the `PreconfTaskManager` contract itself.