### PR TITLE
feat(protocol): add blockId to bond events

### DIFF
--- a/packages/protocol/contracts/layer1/based/LibBonds.sol
+++ b/packages/protocol/contracts/layer1/based/LibBonds.sol
@@ -74,10 +74,10 @@ library LibBonds {
             unchecked {
                 _state.bondBalance[_user] = balance - _amount;
             }
-            emit BondDebited(_user, _blockId, _amount);
         } else {
             _tko(_resolver).transferFrom(_user, address(this), _amount);
         }
+        emit BondDebited(_user, _blockId, _amount);
     }
 
     /// @dev Credits TAIKO tokens to a user's bond balance.

--- a/packages/protocol/contracts/layer1/based/LibBonds.sol
+++ b/packages/protocol/contracts/layer1/based/LibBonds.sol
@@ -13,13 +13,15 @@ import "./TaikoData.sol";
 library LibBonds {
     /// @dev Emitted when a token is credited back to a user's bond balance.
     /// @param user The address of the user whose bond balance is credited.
+    /// @param blockId The ID of the block to credit for.
     /// @param amount The amount of tokens credited.
-    event BondCredited(address indexed user, uint256 amount);
+    event BondCredited(address indexed user, uint256 blockId, uint256 amount);
 
     /// @dev Emitted when a token is debited from a user's bond balance.
     /// @param user The address of the user whose bond balance is debited.
+    /// @param blockId The ID of the block to debit for.
     /// @param amount The amount of tokens debited.
-    event BondDebited(address indexed user, uint256 amount);
+    event BondDebited(address indexed user, uint256 blockId, uint256 amount);
 
     /// @dev Deposits TAIKO tokens to be used as bonds.
     /// @param _state The current state of TaikoData.
@@ -55,11 +57,13 @@ library LibBonds {
     /// @param _state The current state of TaikoData.
     /// @param _resolver The address resolver interface.
     /// @param _user The address of the user to debit.
+    /// @param _blockId The ID of the block to debit for.
     /// @param _amount The amount of tokens to debit.
     function debitBond(
         TaikoData.State storage _state,
         IAddressResolver _resolver,
         address _user,
+        uint256 _blockId,
         uint256 _amount
     )
         internal
@@ -70,7 +74,7 @@ library LibBonds {
             unchecked {
                 _state.bondBalance[_user] = balance - _amount;
             }
-            emit BondDebited(_user, _amount);
+            emit BondDebited(_user, _blockId, _amount);
         } else {
             _tko(_resolver).transferFrom(_user, address(this), _amount);
         }
@@ -79,10 +83,11 @@ library LibBonds {
     /// @dev Credits TAIKO tokens to a user's bond balance.
     /// @param _state The current state of TaikoData.
     /// @param _user The address of the user to credit.
+    /// @param _blockId The ID of the block to credit for.
     /// @param _amount The amount of tokens to credit.
-    function creditBond(TaikoData.State storage _state, address _user, uint256 _amount) internal {
+    function creditBond(TaikoData.State storage _state, address _user, uint256 _blockId, uint256 _amount) internal {
         _state.bondBalance[_user] += _amount;
-        emit BondCredited(_user, _amount);
+        emit BondCredited(_user, _blockId, _amount);
     }
 
     /// @dev Gets a user's current TAIKO token bond balance.

--- a/packages/protocol/contracts/layer1/based/LibBonds.sol
+++ b/packages/protocol/contracts/layer1/based/LibBonds.sol
@@ -68,8 +68,9 @@ library LibBonds {
     )
         internal
     {
-        uint256 balance = _state.bondBalance[_user];
+        if (_amount == 0) return;
 
+        uint256 balance = _state.bondBalance[_user];
         if (balance >= _amount) {
             unchecked {
                 _state.bondBalance[_user] = balance - _amount;
@@ -93,6 +94,7 @@ library LibBonds {
     )
         internal
     {
+        if (_amount == 0) return;
         unchecked {
             _state.bondBalance[_user] += _amount;
         }

--- a/packages/protocol/contracts/layer1/based/LibBonds.sol
+++ b/packages/protocol/contracts/layer1/based/LibBonds.sol
@@ -85,8 +85,17 @@ library LibBonds {
     /// @param _user The address of the user to credit.
     /// @param _blockId The ID of the block to credit for.
     /// @param _amount The amount of tokens to credit.
-    function creditBond(TaikoData.State storage _state, address _user, uint256 _blockId, uint256 _amount) internal {
-        _state.bondBalance[_user] += _amount;
+    function creditBond(
+        TaikoData.State storage _state,
+        address _user,
+        uint256 _blockId,
+        uint256 _amount
+    )
+        internal
+    {
+        unchecked {
+            _state.bondBalance[_user] += _amount;
+        }
         emit BondCredited(_user, _blockId, _amount);
     }
 

--- a/packages/protocol/contracts/layer1/based/LibProposing.sol
+++ b/packages/protocol/contracts/layer1/based/LibProposing.sol
@@ -269,7 +269,7 @@ library LibProposing {
             ++_state.slotB.numBlocks;
         }
 
-        LibBonds.debitBond(_state, _resolver, local.params.proposer, _config.livenessBond);
+        LibBonds.debitBond(_state, _resolver, local.params.proposer, meta_.id, _config.livenessBond);
 
         emit BlockProposedV2(meta_.id, meta_);
     }

--- a/packages/protocol/contracts/layer1/based/LibProving.sol
+++ b/packages/protocol/contracts/layer1/based/LibProving.sol
@@ -515,10 +515,11 @@ library LibProving {
                 // The contested transition is proven to be invalid, contester wins the game.
                 // Contester gets 3/4 of reward, the new prover gets 1/4.
                 reward = _rewardAfterFriction(_ts.validityBond) >> 2;
-
-                LibBonds.creditBond(
-                    _state, _ts.contester, _local.blockId, _ts.contestBond + reward * 3
-                );
+                unchecked {
+                    LibBonds.creditBond(
+                        _state, _ts.contester, _local.blockId, _ts.contestBond + reward * 3
+                    );
+                }
             }
         } else {
             if (_local.sameTransition) revert L1_ALREADY_PROVED();
@@ -536,7 +537,9 @@ library LibProving {
 
                 if (_returnLivenessBond(_local, _proof.data)) {
                     if (_local.assignedProver == msg.sender) {
-                        reward += _local.livenessBond;
+                        unchecked {
+                            reward += _local.livenessBond;
+                        }
                     } else {
                         LibBonds.creditBond(
                             _state, _local.assignedProver, _local.blockId, _local.livenessBond

--- a/packages/protocol/contracts/layer1/based/LibProving.sol
+++ b/packages/protocol/contracts/layer1/based/LibProving.sol
@@ -377,7 +377,9 @@ library LibProving {
 
                 // _checkIfContestable(/*_state,*/ tier.cooldownWindow, ts.timestamp);
                 // Burn the contest bond from the prover.
-                LibBonds.debitBond(_state, _resolver, msg.sender, local.blockId, local.tier.contestBond);
+                LibBonds.debitBond(
+                    _state, _resolver, msg.sender, local.blockId, local.tier.contestBond
+                );
 
                 // We retain the contest bond within the transition, just in
                 // case this configuration is altered to a different value
@@ -514,7 +516,9 @@ library LibProving {
                 // Contester gets 3/4 of reward, the new prover gets 1/4.
                 reward = _rewardAfterFriction(_ts.validityBond) >> 2;
 
-                LibBonds.creditBond(_state, _ts.contester, _local.blockId, _ts.contestBond + reward * 3);
+                LibBonds.creditBond(
+                    _state, _ts.contester, _local.blockId, _ts.contestBond + reward * 3
+                );
             }
         } else {
             if (_local.sameTransition) revert L1_ALREADY_PROVED();
@@ -534,7 +538,9 @@ library LibProving {
                     if (_local.assignedProver == msg.sender) {
                         reward += _local.livenessBond;
                     } else {
-                        LibBonds.creditBond(_state, _local.assignedProver, _local.blockId, _local.livenessBond);
+                        LibBonds.creditBond(
+                            _state, _local.assignedProver, _local.blockId, _local.livenessBond
+                        );
                     }
                 }
             }
@@ -542,9 +548,13 @@ library LibProving {
 
         unchecked {
             if (reward > _local.tier.validityBond) {
-                LibBonds.creditBond(_state, msg.sender, _local.blockId, reward - _local.tier.validityBond);
+                LibBonds.creditBond(
+                    _state, msg.sender, _local.blockId, reward - _local.tier.validityBond
+                );
             } else if (reward < _local.tier.validityBond) {
-                LibBonds.debitBond(_state, _resolver, msg.sender, _local.blockId, _local.tier.validityBond - reward);
+                LibBonds.debitBond(
+                    _state, _resolver, msg.sender, _local.blockId, _local.tier.validityBond - reward
+                );
             }
         }
 

--- a/packages/protocol/contracts/layer1/based/LibProving.sol
+++ b/packages/protocol/contracts/layer1/based/LibProving.sol
@@ -377,7 +377,7 @@ library LibProving {
 
                 // _checkIfContestable(/*_state,*/ tier.cooldownWindow, ts.timestamp);
                 // Burn the contest bond from the prover.
-                LibBonds.debitBond(_state, _resolver, msg.sender, local.tier.contestBond);
+                LibBonds.debitBond(_state, _resolver, msg.sender, local.blockId, local.tier.contestBond);
 
                 // We retain the contest bond within the transition, just in
                 // case this configuration is altered to a different value
@@ -508,13 +508,13 @@ library LibProving {
                 reward = _rewardAfterFriction(_ts.contestBond);
 
                 // We return the validity bond back, but the original prover doesn't get any reward.
-                LibBonds.creditBond(_state, _ts.prover, _ts.validityBond);
+                LibBonds.creditBond(_state, _ts.prover, _local.blockId, _ts.validityBond);
             } else {
                 // The contested transition is proven to be invalid, contester wins the game.
                 // Contester gets 3/4 of reward, the new prover gets 1/4.
                 reward = _rewardAfterFriction(_ts.validityBond) >> 2;
 
-                LibBonds.creditBond(_state, _ts.contester, _ts.contestBond + reward * 3);
+                LibBonds.creditBond(_state, _ts.contester, _local.blockId, _ts.contestBond + reward * 3);
             }
         } else {
             if (_local.sameTransition) revert L1_ALREADY_PROVED();
@@ -534,7 +534,7 @@ library LibProving {
                     if (_local.assignedProver == msg.sender) {
                         reward += _local.livenessBond;
                     } else {
-                        LibBonds.creditBond(_state, _local.assignedProver, _local.livenessBond);
+                        LibBonds.creditBond(_state, _local.assignedProver, _local.blockId, _local.livenessBond);
                     }
                 }
             }
@@ -542,9 +542,9 @@ library LibProving {
 
         unchecked {
             if (reward > _local.tier.validityBond) {
-                LibBonds.creditBond(_state, msg.sender, reward - _local.tier.validityBond);
+                LibBonds.creditBond(_state, msg.sender, _local.blockId, reward - _local.tier.validityBond);
             } else if (reward < _local.tier.validityBond) {
-                LibBonds.debitBond(_state, _resolver, msg.sender, _local.tier.validityBond - reward);
+                LibBonds.debitBond(_state, _resolver, msg.sender, _local.blockId, _local.tier.validityBond - reward);
             }
         }
 

--- a/packages/protocol/contracts/layer1/based/LibVerifying.sol
+++ b/packages/protocol/contracts/layer1/based/LibVerifying.sol
@@ -119,7 +119,7 @@ library LibVerifying {
                 local.blockHash = ts.blockHash;
                 local.prover = ts.prover;
 
-                LibBonds.creditBond(_state, local.prover, ts.validityBond);
+                LibBonds.creditBond(_state, local.prover, local.blockId, ts.validityBond);
 
                 // Note: We exclusively address the bonds linked to the
                 // transition used for verification. While there may exist

--- a/packages/protocol/contracts/layer1/based/TaikoEvents.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoEvents.sol
@@ -12,10 +12,10 @@ import "./TaikoData.sol";
 /// @custom:security-contact security@taiko.xyz
 abstract contract TaikoEvents {
     /// @dev Emitted when token is credited back to a user's bond balance.
-    event BondCredited(address indexed user, uint256 amount);
+    event BondCredited(address indexed user, uint256 blockId, uint256 amount);
 
     /// @dev Emitted when token is debited from a user's bond balance.
-    event BondDebited(address indexed user, uint256 amount);
+    event BondDebited(address indexed user, uint256 blockId, uint256 amount);
 
     /// @dev DEPRECATED but used by node/client for syncing old blocks
     /// @notice Emitted when a block is proposed.


### PR DESCRIPTION
Proposers and provers may want to track their bonds, but without blockIds in `BondCredited` and `BondDebited` event, it's really hard to track for which blocks their bonds are burned.