### PR TITLE
fix(taiko-client): dont check l1heightInAnchor vs l1Height when detecting reorg

### DIFF
--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -683,16 +683,6 @@ func (c *Client) checkSyncedL1SnippetFromAnchor(
 		return false, err
 	}
 
-	if l1HeightInAnchor+1 != l1Height {
-		log.Info(
-			"Reorg detected due to L1 height mismatch",
-			"blockID", blockID,
-			"l1HeightInAnchor", l1HeightInAnchor,
-			"l1Height", l1Height,
-		)
-		return true, nil
-	}
-
 	if parentGasUsed != uint32(parent.GasUsed()) {
 		log.Info(
 			"Reorg detected due to parent gas used mismatch",


### PR DESCRIPTION
Now that any block 64 blocks or older can be passed in to `proposeBlock` via the `anchorBlockId` parameter, this check is no longer valid or necessary, and will break the taiko-client on a reorg loop if a manual anchor block is passed in that isnt `latest`, post-ontake fork.