### PR TITLE
fix(relayer): profitability changes

### DIFF
--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Install Git
+        run: sudo apt-get update && sudo apt-get install -y git
+
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -278,7 +278,7 @@ func (i *Indexer) Start() error {
 		return errors.Wrap(err, "i.setInitialIndexingBlockByMode")
 	}
 
-	go i.eventLoop(i.ctx, i.latestIndexedBlockNumber)
+	go i.eventLoop(i.ctx)
 
 	go func() {
 		if err := backoff.Retry(func() error {
@@ -291,7 +291,7 @@ func (i *Indexer) Start() error {
 	return nil
 }
 
-func (i *Indexer) eventLoop(ctx context.Context, startBlockID uint64) {
+func (i *Indexer) eventLoop(ctx context.Context) {
 	i.wg.Add(1)
 	defer i.wg.Done()
 

--- a/packages/relayer/pkg/db/db.go
+++ b/packages/relayer/pkg/db/db.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"database/sql"
+
 	"github.com/cyberhorsey/errors"
 	"gorm.io/gorm"
 )

--- a/packages/relayer/pkg/http/get_events_by_address_test.go
+++ b/packages/relayer/pkg/http/get_events_by_address_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Test_GetEventsByAddress(t *testing.T) {
-	srv := newTestServer("")
+	srv := newTestServer()
 
 	_, err := srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
 		Name:        "name",

--- a/packages/relayer/pkg/http/get_recommended_processing_fees.go
+++ b/packages/relayer/pkg/http/get_recommended_processing_fees.go
@@ -122,14 +122,14 @@ func (srv *Server) GetRecommendedProcessingFees(c echo.Context) error {
 	for _, f := range feeTypes {
 		fees = append(fees, fee{
 			Type:        f.String(),
-			Amount:      srv.getCost(c.Request().Context(), uint64(f), destGasTipCap, destBaseFee, Layer1).String(),
+			Amount:      srv.getCost(uint64(f), destGasTipCap, destBaseFee, Layer1).String(),
 			DestChainID: srcChainID.Uint64(),
 			GasLimit:    strconv.Itoa(int(f)),
 		})
 
 		fees = append(fees, fee{
 			Type:        f.String(),
-			Amount:      srv.getCost(c.Request().Context(), uint64(f), srcGasTipCap, srcBaseFee, Layer2).String(),
+			Amount:      srv.getCost(uint64(f), srcGasTipCap, srcBaseFee, Layer2).String(),
 			DestChainID: destChainID.Uint64(),
 			GasLimit:    strconv.Itoa(int(f)),
 		})
@@ -143,7 +143,6 @@ func (srv *Server) GetRecommendedProcessingFees(c echo.Context) error {
 }
 
 func (srv *Server) getCost(
-	ctx context.Context,
 	gasLimit uint64,
 	gasTipCap *big.Int,
 	baseFee *big.Int,
@@ -151,7 +150,7 @@ func (srv *Server) getCost(
 ) *big.Int {
 	cost := new(big.Int).Mul(
 		new(big.Int).SetUint64(gasLimit),
-		new(big.Int).Add(gasTipCap, baseFee))
+		new(big.Int).Add(gasTipCap, new(big.Int).Mul(baseFee, big.NewInt(2))))
 
 	if destLayer == Layer2 {
 		return cost

--- a/packages/relayer/pkg/http/server_test.go
+++ b/packages/relayer/pkg/http/server_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
 )
 
-func newTestServer(url string) *Server {
+func newTestServer() *Server {
 	_ = godotenv.Load("../.test.env")
 
 	srv := &Server{
@@ -104,7 +104,7 @@ func Test_NewServer(t *testing.T) {
 }
 
 func Test_Health(t *testing.T) {
-	srv := newTestServer("")
+	srv := newTestServer()
 
 	req, _ := http.NewRequest(echo.GET, "/healthz", nil)
 	rec := httptest.NewRecorder()
@@ -117,7 +117,7 @@ func Test_Health(t *testing.T) {
 }
 
 func Test_Root(t *testing.T) {
-	srv := newTestServer("")
+	srv := newTestServer()
 
 	req, _ := http.NewRequest(echo.GET, "/", nil)
 	rec := httptest.NewRecorder()
@@ -130,7 +130,7 @@ func Test_Root(t *testing.T) {
 }
 
 func Test_StartShutdown(t *testing.T) {
-	srv := newTestServer("")
+	srv := newTestServer()
 
 	go func() {
 		_ = srv.Start(":3928")

--- a/packages/relayer/processor/can_process_message.go
+++ b/packages/relayer/processor/can_process_message.go
@@ -16,7 +16,7 @@ import (
 // or its processed, failed, and is in Retriable or Failed state, where the user
 // should finish manually.
 func canProcessMessage(
-	ctx context.Context,
+	_ context.Context,
 	eventStatus relayer.EventStatus,
 	messageOwner common.Address,
 	relayerAddress common.Address,

--- a/packages/relayer/processor/is_profitable.go
+++ b/packages/relayer/processor/is_profitable.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
@@ -51,12 +52,13 @@ func (p *Processor) isProfitable(
 	)
 
 	opts := relayer.UpdateFeesAndProfitabilityOpts{
-		Fee:                 fee,
-		DestChainBaseFee:    destChainBaseFee,
-		GasTipCap:           gasTipCap,
-		GasLimit:            gasLimit,
-		IsProfitable:        shouldProcess,
-		EstimatedOnchainFee: estimatedOnchainFee,
+		Fee:                     fee,
+		DestChainBaseFee:        destChainBaseFee,
+		GasTipCap:               gasTipCap,
+		GasLimit:                gasLimit,
+		IsProfitable:            shouldProcess,
+		EstimatedOnchainFee:     estimatedOnchainFee,
+		IsProfitableEvaluatedAt: time.Now().UTC(),
 	}
 
 	if err := p.eventRepo.UpdateFeesAndProfitability(ctx, id, &opts); err != nil {

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -139,7 +139,7 @@ func (p *Processor) processMessage(
 		return false, msgBody.TimesRetried, nil
 	}
 
-	if err := p.waitForConfirmations(ctx, msgBody.Event.Raw.TxHash, msgBody.Event.Raw.BlockNumber); err != nil {
+	if err := p.waitForConfirmations(ctx, msgBody.Event.Raw.TxHash); err != nil {
 		return false, msgBody.TimesRetried, err
 	}
 
@@ -261,10 +261,6 @@ func (p *Processor) generateEncodedSignalProof(ctx context.Context,
 
 			if err != nil {
 				return nil, errors.Wrap(err, "p.waitHeaderSynced")
-			}
-
-			if err != nil {
-				return nil, errors.Wrap(err, "hop.headerSyncer.GetSyncedSnippet")
 			}
 
 			blockNum = event.SyncedInBlockID

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -443,7 +443,7 @@ func (p *Processor) sendProcessMessageCall(
 	// mul by 1.05 for padding
 	gasLimit := uint64(float64(event.Message.GasLimit))
 
-	var estimatedCost uint64 = 0
+	var estimatedMaxCost uint64
 
 	if bool(p.profitableOnly) {
 		profitable, err := p.isProfitable(
@@ -490,7 +490,7 @@ func (p *Processor) sendProcessMessageCall(
 			return nil, relayer.ErrUnprofitable
 		}
 
-		estimatedCost = gasUsed * (baseFee.Uint64() + gasTipCap.Uint64())
+		estimatedMaxCost = gasUsed * ((baseFee.Uint64() * 2) + gasTipCap.Uint64())
 	}
 
 	// we should check event status one more time, after we have waiting for
@@ -548,10 +548,10 @@ func (p *Processor) sendProcessMessageCall(
 		slog.Info("tx cost", "txHash", hex.EncodeToString(receipt.TxHash.Bytes()),
 			"srcTxHash", event.Raw.TxHash.Hex(),
 			"actualCost", cost,
-			"estimatedCost", estimatedCost,
+			"estimatedMaxCost", estimatedMaxCost,
 		)
 
-		if cost > estimatedCost {
+		if cost > estimatedMaxCost {
 			relayer.UnprofitableMessageAfterTransacting.Inc()
 		} else {
 			relayer.ProfitableMessageAfterTransacting.Inc()

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -257,8 +257,6 @@ func (p *Processor) generateEncodedSignalProof(ctx context.Context,
 		var hopChainID *big.Int
 
 		for _, hop := range p.hops {
-			hop.blockNum = blockNum
-
 			event, err := p.waitHeaderSynced(ctx, hopEthClient, hop.chainID.Uint64(), blockNum)
 
 			if err != nil {
@@ -443,7 +441,7 @@ func (p *Processor) sendProcessMessageCall(
 	}
 
 	// mul by 1.05 for padding
-	gasLimit := uint64(float64(event.Message.GasLimit) * 1.05)
+	gasLimit := uint64(float64(event.Message.GasLimit))
 
 	var estimatedCost uint64 = 0
 

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -66,7 +66,6 @@ type hop struct {
 	taikoAddress         common.Address
 	ethClient            ethClient
 	caller               relayer.Caller
-	blockNum             uint64
 }
 
 // Processor is the main struct which handles message processing and queue

--- a/packages/relayer/processor/wait_for_confirmations.go
+++ b/packages/relayer/processor/wait_for_confirmations.go
@@ -10,7 +10,7 @@ import (
 
 // waitForConfirmations waits for the given transaction to reach N confs
 // before returning
-func (p *Processor) waitForConfirmations(ctx context.Context, txHash common.Hash, blockNumber uint64) error {
+func (p *Processor) waitForConfirmations(ctx context.Context, txHash common.Hash) error {
 	ctx, cancelFunc := context.WithTimeout(ctx, time.Duration(p.confTimeoutInSeconds)*time.Second)
 
 	defer cancelFunc()

--- a/packages/relayer/processor/wait_for_confirmations_test.go
+++ b/packages/relayer/processor/wait_for_confirmations_test.go
@@ -11,6 +11,6 @@ import (
 func Test_waitForConfirmations(t *testing.T) {
 	p := newTestProcessor(true)
 
-	err := p.waitForConfirmations(context.TODO(), mock.SucceedTxHash, uint64(mock.BlockNum))
+	err := p.waitForConfirmations(context.TODO(), mock.SucceedTxHash)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
used to have to multiply by `1.05` for padding, no longer necessary with previous bridge fee changes. Legacy code, now removed.

As well, the optimism txmgr defines it's fee calculation as:
```go
// calcGasFeeCap deterministically computes the recommended gas fee cap given
// the base fee and gasTipCap. The resulting gasFeeCap is equal to:
//
//	gasTipCap + 2*baseFee.
func calcGasFeeCap(baseFee, gasTipCap *big.Int) *big.Int {
	return new(big.Int).Add(
		gasTipCap,
		new(big.Int).Mul(baseFee, two),
	)
```

So we should use `baseFee * 2`, not `baseFee`,when determining profitability.