### PR TITLE
ci(protocol): avoid installing `netcat` in action

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Prepare environment
         continue-on-error: true
-        run: sudo apt-get update && sudo apt-get install -y git netcat wget
+        run: sudo apt-get update && sudo apt-get install -y git wget
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
         timeout-minutes: 2
         run: |
           anvil --hardfork cancun &
-          while ! nc -z localhost 8545; do
+          until cast chain-id --rpc-url "http://localhost:8545" 2> /dev/null; do
             sleep 1
           done
           pnpm test:deploy:l1

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,3 @@ __pycache__/
 
 # Idea
 .idea/
-
-# pnpm lock file
-pnpm-lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ __pycache__/
 
 # Idea
 .idea/
+
+# pnpm lock file
+pnpm-lock.yaml

--- a/packages/taiko-client/.golangci.yml
+++ b/packages/taiko-client/.golangci.yml
@@ -3,22 +3,10 @@
 run:
   timeout: 20m
   tests: true
-  skip-dirs-use-default: true
-  skip-files:
-    - bindings/gen_taiko_l1.go
-    - bindings/gen_taiko_l2.go
-    - bindings/encoding/struct.go
 
 issues:
-  # List of regexps of issue texts to exclude.
-  #
-  # But independently of this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`.
-  # To list all excluded by default patterns execute `golangci-lint run --help`
-  #
-  # Default: https://golangci-lint.run/usage/false-positives/#default-exclusions
-  exclude:
-    - abcdef
+  exclude-dirs:
+    - bindings
 
 linters:
   disable-all: true
@@ -43,7 +31,8 @@ linters:
     - makezero
     - misspell
     - misspell
-    - megacheck
+    - gosimple
+    - staticcheck
     - revive
     - staticcheck
     - sqlclosecheck


### PR DESCRIPTION
- Avoid installing netcat cmd.
- Ignore pnpm-lock.yml file.
- Update golangci.yml config to match the `v1.60.0` version.