### PR TITLE
feat(protocol): allow owner to update recipient in TokenUnlock

### DIFF
--- a/packages/protocol/contracts/layer1/team/tokenunlock/TokenUnlock.sol
+++ b/packages/protocol/contracts/layer1/team/tokenunlock/TokenUnlock.sol
@@ -66,6 +66,11 @@ contract TokenUnlock is EssentialContract {
         _;
     }
 
+    modifier onlyRecipientOrOwner() {
+        if (msg.sender != recipient && msg.sender != owner()) revert PERMISSION_DENIED();
+        _;
+    }
+
     /// @notice Initializes the contract.
     /// @param _owner The contract owner address.
     /// @param _rollupAddressManager The rollup address manager.
@@ -151,7 +156,7 @@ contract TokenUnlock is EssentialContract {
         IERC20(resolve(LibStrings.B_TAIKO_TOKEN, false)).safeTransfer(recipient, amount);
     }
 
-    function changeRecipient(address _newRecipient) external onlyRecipient {
+    function changeRecipient(address _newRecipient) external onlyRecipientOrOwner {
         if (_newRecipient == address(0) || _newRecipient == recipient) {
             revert INVALID_PARAM();
         }

--- a/packages/protocol/script/layer1/tokenunlock/exercise1.data.json
+++ b/packages/protocol/script/layer1/tokenunlock/exercise1.data.json
@@ -501,7 +501,7 @@
   },
   {
     "proxy": "0x2Da30e14dE6a5fcE16a5Ea72199De76cebDC876C",
-    "recipient": "0x9c0c06ddbb72f70820d7e55b6b77db175d400fba",
+    "recipient": "0xf7a0cd60e3b6ab4523a5f54e9a410258895b138d",
     "vestAmount": 4013867
   },
   {


### PR DESCRIPTION
@davidtaikocha We need to upgrade the implementation of `0x2Da30e14dE6a5fcE16a5Ea72199De76cebDC876C` and then change the recipient from `0x9c0c06ddbb72f70820d7e55b6b77db175d400fba` to `0xf7a0cd60e3b6ab4523a5f54e9a410258895b138d`.

---
<img width="653" alt="Screenshot 2024-09-27 at 15 47 42" src="https://github.com/user-attachments/assets/f4e77580-2bf6-4a88-a3ba-0e9c487257c6">
