### PR TITLE
chore(protocol): enable Aragon's contracts to depend on our contract code directly

### DIFF
--- a/packages/protocol/contracts/layer1/automata-attestation/AutomataDcapV3Attestation.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/AutomataDcapV3Attestation.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import { V3Struct } from "./lib/QuoteV3Auth/V3Struct.sol";
 import { V3Parser } from "./lib/QuoteV3Auth/V3Parser.sol";

--- a/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestation.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/interfaces/IAttestation.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import { V3Struct } from "../lib/QuoteV3Auth/V3Struct.sol";
 

--- a/packages/protocol/contracts/layer1/automata-attestation/interfaces/ISigVerifyLib.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/interfaces/ISigVerifyLib.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title ISigVerifyLib
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/layer1/automata-attestation/lib/EnclaveIdStruct.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/lib/EnclaveIdStruct.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title EnclaveIdStruct
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/layer1/automata-attestation/lib/PEMCertChainLib.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/lib/PEMCertChainLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import { LibString } from "solady/src/utils/LibString.sol";
 import { Asn1Decode, NodePtr } from "../utils/Asn1Decode.sol";

--- a/packages/protocol/contracts/layer1/automata-attestation/lib/QuoteV3Auth/V3Parser.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/lib/QuoteV3Auth/V3Parser.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import { Base64 } from "solady/src/utils/Base64.sol";
 import { BytesUtils } from "../../utils/BytesUtils.sol";

--- a/packages/protocol/contracts/layer1/automata-attestation/lib/QuoteV3Auth/V3Struct.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/lib/QuoteV3Auth/V3Struct.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title V3Struct
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/layer1/automata-attestation/lib/TCBInfoStruct.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/lib/TCBInfoStruct.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title TCBInfoStruct
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/layer1/automata-attestation/lib/interfaces/IPEMCertChainLib.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/lib/interfaces/IPEMCertChainLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IPEMCertChainLib
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/layer1/automata-attestation/utils/Asn1Decode.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/utils/Asn1Decode.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Original source: https://github.com/JonahGroendal/asn1-decode
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 // Inspired by PufferFinance/rave - Apache-2.0 license
 // https://github.com/JonahGroendal/asn1-decode/blob/5c2d1469fc678513753786acb441e597969192ec/contracts/Asn1Decode.sol

--- a/packages/protocol/contracts/layer1/automata-attestation/utils/BytesUtils.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/utils/BytesUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD 2-Clause License
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 // Inspired by ensdomains/dnssec-oracle - BSD-2-Clause license
 // https://github.com/ensdomains/dnssec-oracle/blob/master/contracts/BytesUtils.sol

--- a/packages/protocol/contracts/layer1/automata-attestation/utils/SHA1.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/utils/SHA1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD 2-Clause License
 
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 // Inspired by ensdomains/solsha1 - BSD 2-Clause License
 // https://github.com/ensdomains/solsha1/blob/master/contracts/SHA1.sol

--- a/packages/protocol/contracts/layer1/automata-attestation/utils/SigVerifyLib.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/utils/SigVerifyLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../interfaces/ISigVerifyLib.sol";
 import "./BytesUtils.sol";

--- a/packages/protocol/contracts/layer1/automata-attestation/utils/X509DateUtils.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/utils/X509DateUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title X509DateUtils
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/layer1/based/ITaikoL1.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoL1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoData.sol";
 
@@ -81,6 +81,35 @@ interface ITaikoL1 {
     /// @param _blockId The index of the block.
     /// @return The prover's address. If the block is not verified yet, address(0) will be returned.
     function getVerifiedBlockProver(uint64 _blockId) external view returns (address);
+
+    /// @notice Returns information about the last verified block.
+    /// @return blockId_ The last verified block's ID.
+    /// @return blockHash_ The last verified block's blockHash.
+    /// @return stateRoot_ The last verified block's stateRoot.
+    /// @return verifiedAt_ The timestamp this block is verified at.
+    function getLastVerifiedBlock()
+        external
+        view
+        returns (uint64 blockId_, bytes32 blockHash_, bytes32 stateRoot_, uint64 verifiedAt_);
+
+    /// @notice Returns information about the last synchronized block.
+    /// @return blockId_ The last verified block's ID.
+    /// @return blockHash_ The last verified block's blockHash.
+    /// @return stateRoot_ The last verified block's stateRoot.
+    /// @return verifiedAt_ The timestamp this block is verified at.
+    function getLastSyncedBlock()
+        external
+        view
+        returns (uint64 blockId_, bytes32 blockHash_, bytes32 stateRoot_, uint64 verifiedAt_);
+
+    /// @notice Gets the state variables of the TaikoL1 contract.
+    /// @dev This method can be deleted once node/client stops using it.
+    /// @return State variables stored at SlotA.
+    /// @return State variables stored at SlotB.
+    function getStateVariables()
+        external
+        view
+        returns (TaikoData.SlotA memory, TaikoData.SlotB memory);
 
     /// @notice Gets the configuration of the TaikoL1 contract.
     /// @return Config struct containing configuration parameters.

--- a/packages/protocol/contracts/layer1/based/LibBonds.sol
+++ b/packages/protocol/contracts/layer1/based/LibBonds.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/protocol/contracts/layer1/based/LibData.sol
+++ b/packages/protocol/contracts/layer1/based/LibData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../verifiers/IVerifier.sol";
 import "./TaikoData.sol";

--- a/packages/protocol/contracts/layer1/based/LibProposing.sol
+++ b/packages/protocol/contracts/layer1/based/LibProposing.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../shared/common/LibAddress.sol";
 import "../../shared/common/LibNetwork.sol";

--- a/packages/protocol/contracts/layer1/based/LibProving.sol
+++ b/packages/protocol/contracts/layer1/based/LibProving.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../verifiers/IVerifier.sol";
 import "./LibBonds.sol";

--- a/packages/protocol/contracts/layer1/based/LibUtils.sol
+++ b/packages/protocol/contracts/layer1/based/LibUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/protocol/contracts/layer1/based/LibVerifying.sol
+++ b/packages/protocol/contracts/layer1/based/LibVerifying.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../shared/signal/ISignalService.sol";
 import "./LibBonds.sol";

--- a/packages/protocol/contracts/layer1/based/TaikoData.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../shared/data/LibSharedData.sol";
 

--- a/packages/protocol/contracts/layer1/based/TaikoEvents.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoEvents.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoData.sol";
 

--- a/packages/protocol/contracts/layer1/based/TaikoL1.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoL1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../shared/common/EssentialContract.sol";
 import "./LibData.sol";
@@ -243,12 +243,8 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
     {
         return LibUtils.getTransition(state, getConfig(), _blockId, _tid);
     }
+    /// @inheritdoc ITaikoL1
 
-    /// @notice Returns information about the last verified block.
-    /// @return blockId_ The last verified block's ID.
-    /// @return blockHash_ The last verified block's blockHash.
-    /// @return stateRoot_ The last verified block's stateRoot.
-    /// @return verifiedAt_ The timestamp this block is verified at.
     function getLastVerifiedBlock()
         external
         view
@@ -258,11 +254,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
         (blockHash_, stateRoot_, verifiedAt_) = LibUtils.getBlockInfo(state, getConfig(), blockId_);
     }
 
-    /// @notice Returns information about the last synchronized block.
-    /// @return blockId_ The last verified block's ID.
-    /// @return blockHash_ The last verified block's blockHash.
-    /// @return stateRoot_ The last verified block's stateRoot.
-    /// @return verifiedAt_ The timestamp this block is verified at.
+    /// @inheritdoc ITaikoL1
     function getLastSyncedBlock()
         external
         view
@@ -272,10 +264,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
         (blockHash_, stateRoot_, verifiedAt_) = LibUtils.getBlockInfo(state, getConfig(), blockId_);
     }
 
-    /// @notice Gets the state variables of the TaikoL1 contract.
-    /// @dev This method can be deleted once node/client stops using it.
-    /// @return State variables stored at SlotA.
-    /// @return State variables stored at SlotB.
+    /// @inheritdoc ITaikoL1
     function getStateVariables()
         external
         view

--- a/packages/protocol/contracts/layer1/devnet/DevnetTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetTaikoL1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../based/TaikoL1.sol";
 

--- a/packages/protocol/contracts/layer1/devnet/DevnetTierProvider.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetTierProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../tiers/TierProviderBase.sol";
 import "../tiers/ITierRouter.sol";

--- a/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../based/TaikoL1.sol";
 

--- a/packages/protocol/contracts/layer1/hekla/HeklaTaikoToken.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaTaikoToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20SnapshotUpgradeable.sol";

--- a/packages/protocol/contracts/layer1/hekla/HeklaTierProvider.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaTierProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../tiers/TierProviderBase.sol";
 import "../tiers/ITierRouter.sol";

--- a/packages/protocol/contracts/layer1/mainnet/addrcache/AddressCache.sol
+++ b/packages/protocol/contracts/layer1/mainnet/addrcache/AddressCache.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title AddressCache
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/layer1/mainnet/addrcache/RollupAddressCache.sol
+++ b/packages/protocol/contracts/layer1/mainnet/addrcache/RollupAddressCache.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/common/LibStrings.sol";
 import "../../../shared/common/LibNetwork.sol";

--- a/packages/protocol/contracts/layer1/mainnet/addrcache/SharedAddressCache.sol
+++ b/packages/protocol/contracts/layer1/mainnet/addrcache/SharedAddressCache.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/common/LibStrings.sol";
 import "../../../shared/common/LibNetwork.sol";

--- a/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetBridge.sol
+++ b/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/bridge/Bridge.sol";
 import "../addrcache/SharedAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetERC1155Vault.sol
+++ b/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetERC1155Vault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/tokenvault/ERC1155Vault.sol";
 import "../addrcache/SharedAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetERC20Vault.sol
+++ b/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetERC20Vault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/tokenvault/ERC20Vault.sol";
 import "../addrcache/SharedAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetERC721Vault.sol
+++ b/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetERC721Vault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/tokenvault/ERC721Vault.sol";
 import "../addrcache/SharedAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetSharedAddressManager.sol
+++ b/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetSharedAddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/common/AddressManager.sol";
 import "../../../shared/common/LibStrings.sol";

--- a/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetSignalService.sol
+++ b/packages/protocol/contracts/layer1/mainnet/multirollup/MainnetSignalService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/signal/SignalService.sol";
 import "../addrcache/SharedAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/reentrylock/LibFasterReentryLock.sol
+++ b/packages/protocol/contracts/layer1/mainnet/reentrylock/LibFasterReentryLock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title LibFasterReentryLock
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetGuardianProver.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetGuardianProver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../layer1/provers/GuardianProver.sol";
 import "../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetProverSet.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetProverSet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../provers/ProverSet.sol";
 import "../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetRollupAddressManager.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetRollupAddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/common/AddressManager.sol";
 import "../../../shared/common/LibStrings.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../based/TaikoL1.sol";
 import "../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTierRouter.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTierRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../tiers/ITierRouter.sol";
 

--- a/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetRisc0Verifier.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetRisc0Verifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../verifiers/Risc0Verifier.sol";
 import "../../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetSP1Verifier.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetSP1Verifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../verifiers/SP1Verifier.sol";
 import "../../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetSgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetSgxVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../verifiers/SgxVerifier.sol";
 import "../../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetTeeAnyVerifier.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetTeeAnyVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../verifiers/compose/TeeAnyVerifier.sol";
 import "../../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetZkAndTeeVerifier.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetZkAndTeeVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../verifiers/compose/ZkAndTeeVerifier.sol";
 import "../../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetZkAnyVerifier.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/verifiers/MainnetZkAnyVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../verifiers/compose/ZkAnyVerifier.sol";
 import "../../addrcache/RollupAddressCache.sol";

--- a/packages/protocol/contracts/layer1/provers/GuardianProver.sol
+++ b/packages/protocol/contracts/layer1/provers/GuardianProver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/protocol/contracts/layer1/provers/ProverSet.sol
+++ b/packages/protocol/contracts/layer1/provers/ProverSet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import "@openzeppelin/contracts/interfaces/IERC1271.sol";

--- a/packages/protocol/contracts/layer1/team/airdrop/ERC20Airdrop.sol
+++ b/packages/protocol/contracts/layer1/team/airdrop/ERC20Airdrop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/protocol/contracts/layer1/team/airdrop/MerkleClaimable.sol
+++ b/packages/protocol/contracts/layer1/team/airdrop/MerkleClaimable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "../../../shared/common/EssentialContract.sol";

--- a/packages/protocol/contracts/layer1/team/tokenunlock/TokenUnlock.sol
+++ b/packages/protocol/contracts/layer1/team/tokenunlock/TokenUnlock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/packages/protocol/contracts/layer1/tiers/ITierProvider.sol
+++ b/packages/protocol/contracts/layer1/tiers/ITierProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title ITierProvider
 /// @notice Defines interface to return tier configuration.

--- a/packages/protocol/contracts/layer1/tiers/ITierRouter.sol
+++ b/packages/protocol/contracts/layer1/tiers/ITierRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title ITierRouter
 /// @notice Defines interface to return an ITierProvider

--- a/packages/protocol/contracts/layer1/tiers/LibTiers.sol
+++ b/packages/protocol/contracts/layer1/tiers/LibTiers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title LibTiers
 /// @dev Tier ID cannot be zero and must be unique.

--- a/packages/protocol/contracts/layer1/tiers/TierProviderBase.sol
+++ b/packages/protocol/contracts/layer1/tiers/TierProviderBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../shared/common/LibStrings.sol";
 import "./ITierProvider.sol";

--- a/packages/protocol/contracts/layer1/tiers/TierProviderV2.sol
+++ b/packages/protocol/contracts/layer1/tiers/TierProviderV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TierProviderBase.sol";
 

--- a/packages/protocol/contracts/layer1/token/TaikoToken.sol
+++ b/packages/protocol/contracts/layer1/token/TaikoToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../shared/token/TaikoTokenBase.sol";
 

--- a/packages/protocol/contracts/layer1/verifiers/IVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/IVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../based/TaikoData.sol";
 

--- a/packages/protocol/contracts/layer1/verifiers/LibPublicInput.sol
+++ b/packages/protocol/contracts/layer1/verifiers/LibPublicInput.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../layer1/based/TaikoData.sol";
 

--- a/packages/protocol/contracts/layer1/verifiers/Risc0Verifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/Risc0Verifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@risc0/contracts/IRiscZeroVerifier.sol";
 import "../../shared/common/EssentialContract.sol";

--- a/packages/protocol/contracts/layer1/verifiers/SP1Verifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/SP1Verifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@sp1-contracts/src/ISP1Verifier.sol";
 import "../../shared/common/EssentialContract.sol";

--- a/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "../../shared/common/EssentialContract.sol";

--- a/packages/protocol/contracts/layer1/verifiers/compose/ComposeVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/compose/ComposeVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/common/EssentialContract.sol";
 import "../../../shared/common/LibStrings.sol";

--- a/packages/protocol/contracts/layer1/verifiers/compose/TeeAnyVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/compose/TeeAnyVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/common/LibStrings.sol";
 import "./ComposeVerifier.sol";

--- a/packages/protocol/contracts/layer1/verifiers/compose/ZkAndTeeVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/compose/ZkAndTeeVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/common/LibStrings.sol";
 import "./ComposeVerifier.sol";

--- a/packages/protocol/contracts/layer1/verifiers/compose/ZkAnyVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/compose/ZkAnyVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/common/LibStrings.sol";
 import "./ComposeVerifier.sol";

--- a/packages/protocol/contracts/layer2/DelegateOwner.sol
+++ b/packages/protocol/contracts/layer2/DelegateOwner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../shared/common/EssentialContract.sol";
 import "../shared/common/LibStrings.sol";

--- a/packages/protocol/contracts/layer2/based/IBlockHash.sol
+++ b/packages/protocol/contracts/layer2/based/IBlockHash.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IBlockHash
 /// @notice Interface for retrieving block hashes.

--- a/packages/protocol/contracts/layer2/based/Lib1559Math.sol
+++ b/packages/protocol/contracts/layer2/based/Lib1559Math.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@solady/src/utils/FixedPointMathLib.sol";
 import "../../shared/common/LibMath.sol";

--- a/packages/protocol/contracts/layer2/based/LibL2Config.sol
+++ b/packages/protocol/contracts/layer2/based/LibL2Config.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title LibL2Config
 library LibL2Config {

--- a/packages/protocol/contracts/layer2/based/TaikoL2.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoL2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/protocol/contracts/layer2/devnet/DevnetTaikoL2.sol
+++ b/packages/protocol/contracts/layer2/devnet/DevnetTaikoL2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../based/TaikoL2.sol";
 

--- a/packages/protocol/contracts/layer2/hekla/HeklaTaikoL2.sol
+++ b/packages/protocol/contracts/layer2/hekla/HeklaTaikoL2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../based/TaikoL2.sol";
 

--- a/packages/protocol/contracts/layer2/mainnet/MainnetTaikoL2.sol
+++ b/packages/protocol/contracts/layer2/mainnet/MainnetTaikoL2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../based/TaikoL2.sol";
 

--- a/packages/protocol/contracts/layer2/token/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/token/BridgedTaikoToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../shared/tokenvault/IBridgedERC20.sol";
 import "../../shared/token/TaikoTokenBase.sol";

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import "../common/EssentialContract.sol";

--- a/packages/protocol/contracts/shared/bridge/IBridge.sol
+++ b/packages/protocol/contracts/shared/bridge/IBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IBridge
 /// @notice The bridge used in conjunction with the {ISignalService}.

--- a/packages/protocol/contracts/shared/bridge/IQuotaManager.sol
+++ b/packages/protocol/contracts/shared/bridge/IQuotaManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IQuotaManager
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/shared/bridge/QuotaManager.sol
+++ b/packages/protocol/contracts/shared/bridge/QuotaManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../common/EssentialContract.sol";
 import "../common/LibStrings.sol";

--- a/packages/protocol/contracts/shared/common/AddressManager.sol
+++ b/packages/protocol/contracts/shared/common/AddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./EssentialContract.sol";
 

--- a/packages/protocol/contracts/shared/common/AddressResolver.sol
+++ b/packages/protocol/contracts/shared/common/AddressResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./IAddressManager.sol";

--- a/packages/protocol/contracts/shared/common/EssentialContract.sol
+++ b/packages/protocol/contracts/shared/common/EssentialContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/packages/protocol/contracts/shared/common/IAddressManager.sol
+++ b/packages/protocol/contracts/shared/common/IAddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IAddressManager
 /// @notice Manages a mapping of (chainId, name) pairs to Ethereum addresses.

--- a/packages/protocol/contracts/shared/common/IAddressResolver.sol
+++ b/packages/protocol/contracts/shared/common/IAddressResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IAddressResolver
 /// @notice This contract acts as a bridge for name-to-address resolution.

--- a/packages/protocol/contracts/shared/common/LibAddress.sol
+++ b/packages/protocol/contracts/shared/common/LibAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/packages/protocol/contracts/shared/common/LibBytes.sol
+++ b/packages/protocol/contracts/shared/common/LibBytes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 library LibBytes {
     error INNER_ERROR(bytes innerError);

--- a/packages/protocol/contracts/shared/common/LibMath.sol
+++ b/packages/protocol/contracts/shared/common/LibMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title LibMath
 /// @dev This library offers additional math functions for uint256.

--- a/packages/protocol/contracts/shared/common/LibNetwork.sol
+++ b/packages/protocol/contracts/shared/common/LibNetwork.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title LibNetwork
 library LibNetwork {

--- a/packages/protocol/contracts/shared/common/LibStrings.sol
+++ b/packages/protocol/contracts/shared/common/LibStrings.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title LibStrings
 /// @custom:security-contact security@taiko.xyz

--- a/packages/protocol/contracts/shared/common/LibTrieProof.sol
+++ b/packages/protocol/contracts/shared/common/LibTrieProof.sol
@@ -4,7 +4,7 @@
 //   | |/ _` | | / / _ \ | |__/ _` | '_ (_-<
 //   |_|\__,_|_|_\_\___/ |____\__,_|_.__/__/
 
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@optimism/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol";
 import "@optimism/packages/contracts-bedrock/src/libraries/rlp/RLPWriter.sol";

--- a/packages/protocol/contracts/shared/data/LibSharedData.sol
+++ b/packages/protocol/contracts/shared/data/LibSharedData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 library LibSharedData {
     /// @dev Struct that represents L2 basefee configurations

--- a/packages/protocol/contracts/shared/signal/ISignalService.sol
+++ b/packages/protocol/contracts/shared/signal/ISignalService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title ISignalService
 /// @notice The SignalService contract serves as a secure cross-chain message

--- a/packages/protocol/contracts/shared/signal/SignalService.sol
+++ b/packages/protocol/contracts/shared/signal/SignalService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../common/EssentialContract.sol";
 import "../common/LibStrings.sol";

--- a/packages/protocol/contracts/shared/token/TaikoTokenBase.sol
+++ b/packages/protocol/contracts/shared/token/TaikoTokenBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import "../common/EssentialContract.sol";

--- a/packages/protocol/contracts/shared/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BaseNFTVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./BaseVault.sol";
 

--- a/packages/protocol/contracts/shared/tokenvault/BaseVault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BaseVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/packages/protocol/contracts/shared/tokenvault/BridgedERC1155.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BridgedERC1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import "../common/EssentialContract.sol";

--- a/packages/protocol/contracts/shared/tokenvault/BridgedERC20.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BridgedERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";

--- a/packages/protocol/contracts/shared/tokenvault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BridgedERC20V2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/interfaces/IERC5267Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20PermitUpgradeable.sol";

--- a/packages/protocol/contracts/shared/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BridgedERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "../common/EssentialContract.sol";

--- a/packages/protocol/contracts/shared/tokenvault/ERC1155Vault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/ERC1155Vault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/utils/ERC1155ReceiverUpgradeable.sol";

--- a/packages/protocol/contracts/shared/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/ERC20Vault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";

--- a/packages/protocol/contracts/shared/tokenvault/ERC721Vault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/ERC721Vault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";

--- a/packages/protocol/contracts/shared/tokenvault/IBridgedERC1155.sol
+++ b/packages/protocol/contracts/shared/tokenvault/IBridgedERC1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IBridgedERC1155
 /// @notice Contract for bridging ERC1155 tokens across different chains.

--- a/packages/protocol/contracts/shared/tokenvault/IBridgedERC20.sol
+++ b/packages/protocol/contracts/shared/tokenvault/IBridgedERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IBridgedERC20
 /// @notice Interface for all bridged tokens.

--- a/packages/protocol/contracts/shared/tokenvault/IBridgedERC721.sol
+++ b/packages/protocol/contracts/shared/tokenvault/IBridgedERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title IBridgedERC721
 /// @notice Contract for bridging ERC721 tokens across different chains.

--- a/packages/protocol/contracts/shared/tokenvault/LibBridgedToken.sol
+++ b/packages/protocol/contracts/shared/tokenvault/LibBridgedToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
 

--- a/packages/protocol/script/layer1/AddSGXVerifierInstances.s.sol
+++ b/packages/protocol/script/layer1/AddSGXVerifierInstances.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 import "../../contracts/layer1/verifiers/SgxVerifier.sol";

--- a/packages/protocol/script/layer1/DeployERC20Airdrop.s.sol
+++ b/packages/protocol/script/layer1/DeployERC20Airdrop.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 import "../../contracts/layer1/team/airdrop/ERC20Airdrop.sol";

--- a/packages/protocol/script/layer1/DeployLabsProverPool.s.sol
+++ b/packages/protocol/script/layer1/DeployLabsProverPool.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 import "../../contracts/layer1/provers/ProverSet.sol";

--- a/packages/protocol/script/layer1/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/DeployProtocolOnL1.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@risc0/contracts/groth16/RiscZeroGroth16Verifier.sol";

--- a/packages/protocol/script/layer1/DeployProverSet.s.sol
+++ b/packages/protocol/script/layer1/DeployProverSet.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../contracts/layer1/provers/ProverSet.sol";
 import "../../test/shared/DeployCapability.sol";

--- a/packages/protocol/script/layer1/DeployQuotaManager.s.sol
+++ b/packages/protocol/script/layer1/DeployQuotaManager.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 import "../../contracts/shared/bridge/QuotaManager.sol";

--- a/packages/protocol/script/layer1/DeployRisc0Verifier.s.sol
+++ b/packages/protocol/script/layer1/DeployRisc0Verifier.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@risc0/contracts/groth16/RiscZeroGroth16Verifier.sol";
 import "../../test/shared/DeployCapability.sol";

--- a/packages/protocol/script/layer1/DeploySP1Verifier.s.sol
+++ b/packages/protocol/script/layer1/DeploySP1Verifier.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import { SP1Verifier as SP1Verifier200rc } from "@sp1-contracts/src/v2.0.0/SP1VerifierPlonk.sol";
 import "../../test/shared/DeployCapability.sol";

--- a/packages/protocol/script/layer1/DeployTaikoToken.s.sol
+++ b/packages/protocol/script/layer1/DeployTaikoToken.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 import "../../contracts/layer1/token/TaikoToken.sol";

--- a/packages/protocol/script/layer1/SendMessageToDelegateOwner.s.sol
+++ b/packages/protocol/script/layer1/SendMessageToDelegateOwner.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/Script.sol";
 import "../../contracts/shared/bridge/IBridge.sol";

--- a/packages/protocol/script/layer1/SetDcapParams.s.sol
+++ b/packages/protocol/script/layer1/SetDcapParams.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/Script.sol";
 import "forge-std/src/console2.sol";

--- a/packages/protocol/script/layer1/UpgradeHeklaOntakeL1.s.sol
+++ b/packages/protocol/script/layer1/UpgradeHeklaOntakeL1.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "../../test/shared/DeployCapability.sol";

--- a/packages/protocol/script/layer1/UpgradeHeklaOntakeL2.s.sol
+++ b/packages/protocol/script/layer1/UpgradeHeklaOntakeL2.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "../../test/shared/DeployCapability.sol";

--- a/packages/protocol/script/layer1/tokenunlock/Deploy.s.sol
+++ b/packages/protocol/script/layer1/tokenunlock/Deploy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../test/shared/DeployCapability.sol";
 import "../../../contracts/layer1/team/tokenunlock/TokenUnlock.sol";

--- a/packages/protocol/script/layer1/tokenunlock/Vest.s.sol
+++ b/packages/protocol/script/layer1/tokenunlock/Vest.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/Script.sol";
 import "forge-std/src/console2.sol";

--- a/packages/protocol/script/layer2/DeployDelegateOwner.s.sol
+++ b/packages/protocol/script/layer2/DeployDelegateOwner.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 import "../../contracts/layer2/DelegateOwner.sol";

--- a/packages/protocol/script/layer2/PostGenesisConfig.s.sol
+++ b/packages/protocol/script/layer2/PostGenesisConfig.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/Script.sol";
 import "forge-std/src/console2.sol";

--- a/packages/protocol/script/layer2/PostGenesisQuery.s.sol
+++ b/packages/protocol/script/layer2/PostGenesisQuery.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 import "../../contracts/shared/common/AddressManager.sol";

--- a/packages/protocol/script/shared/AuthorizeTaikoForMultihop.s.sol
+++ b/packages/protocol/script/shared/AuthorizeTaikoForMultihop.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 import "../../contracts/shared/signal/SignalService.sol";

--- a/packages/protocol/script/shared/SetAddress.s.sol
+++ b/packages/protocol/script/shared/SetAddress.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/Script.sol";
 import "forge-std/src/console2.sol";

--- a/packages/protocol/script/shared/SetRemoteBridgeSuites.s.sol
+++ b/packages/protocol/script/shared/SetRemoteBridgeSuites.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../test/shared/DeployCapability.sol";
 

--- a/packages/protocol/test/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/test/genesis/GenerateGenesis.g.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/console2.sol";
 import "forge-std/src/StdJson.sol";

--- a/packages/protocol/test/layer1/TaikoL1Test.sol
+++ b/packages/protocol/test/layer1/TaikoL1Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../contracts/layer1/based/TaikoL1.sol";
 import "../../contracts/layer1/token/TaikoToken.sol";

--- a/packages/protocol/test/layer1/automata-attestation/AutomataDcapV3AttestationTest.t.sol
+++ b/packages/protocol/test/layer1/automata-attestation/AutomataDcapV3AttestationTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/Test.sol";
 import "forge-std/src/console.sol";

--- a/packages/protocol/test/layer1/automata-attestation/common/AttestationBase.t.sol
+++ b/packages/protocol/test/layer1/automata-attestation/common/AttestationBase.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/Test.sol";
 import "forge-std/src/console.sol";

--- a/packages/protocol/test/layer1/automata-attestation/utils/DcapTestUtils.t.sol
+++ b/packages/protocol/test/layer1/automata-attestation/utils/DcapTestUtils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import { TCBInfoStruct } from
     "../../../../contracts/layer1/automata-attestation/lib/TCBInfoStruct.sol";

--- a/packages/protocol/test/layer1/automata-attestation/utils/V3QuoteParseUtils.t.sol
+++ b/packages/protocol/test/layer1/automata-attestation/utils/V3QuoteParseUtils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import { V3Struct } from
     "../../../../contracts/layer1/automata-attestation/lib/QuoteV3Auth/V3Struct.sol";

--- a/packages/protocol/test/layer1/based/GuardianProver1.t.sol
+++ b/packages/protocol/test/layer1/based/GuardianProver1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../contracts/layer1/provers/GuardianProver.sol";
 import "../../shared/TaikoTest.sol";

--- a/packages/protocol/test/layer1/based/GuardianProver2.t.sol
+++ b/packages/protocol/test/layer1/based/GuardianProver2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../contracts/layer1/provers/GuardianProver.sol";
 import "./TaikoL1TestBase.sol";

--- a/packages/protocol/test/layer1/based/TaikoL1.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1LibProvingWithTiers.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1LibProvingWithTiers.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestBase.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoL1Test.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup1.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup10.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup10.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup2.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup3.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup3.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup4.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup4.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup5.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup5.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup6.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup6.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup7.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup7.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup8.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup8.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroup9.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroup9.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1TestGroupBase.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1TestGroupBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1testGroupA1.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1testGroupA1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TaikoL1testGroupA2.t.sol
+++ b/packages/protocol/test/layer1/based/TaikoL1testGroupA2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL1TestGroupBase.sol";
 

--- a/packages/protocol/test/layer1/based/TestTierProvider.sol
+++ b/packages/protocol/test/layer1/based/TestTierProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../contracts/shared/common/LibStrings.sol";
 import "../../../contracts/layer1/tiers/ITierProvider.sol";

--- a/packages/protocol/test/layer1/team/airdrop/ERC20Airdrop.t.sol
+++ b/packages/protocol/test/layer1/team/airdrop/ERC20Airdrop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "../../TaikoL1Test.sol";

--- a/packages/protocol/test/layer1/team/airdrop/MerkleClaimable.t.sol
+++ b/packages/protocol/test/layer1/team/airdrop/MerkleClaimable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../TaikoL1Test.sol";
 

--- a/packages/protocol/test/layer1/team/tokenunlock/TokenUnlock.t.sol
+++ b/packages/protocol/test/layer1/team/tokenunlock/TokenUnlock.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 import "../../../shared/TaikoTest.sol";

--- a/packages/protocol/test/layer1/verifiers/MockPlonkVerifier.sol
+++ b/packages/protocol/test/layer1/verifiers/MockPlonkVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@optimism/packages/contracts-bedrock/src/libraries/Bytes.sol";
 

--- a/packages/protocol/test/layer1/verifiers/Risc0Verifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/Risc0Verifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../based/TaikoL1TestBase.sol";
 

--- a/packages/protocol/test/layer1/verifiers/RiscZeroGroth16Verifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/RiscZeroGroth16Verifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@risc0/contracts/groth16/RiscZeroGroth16Verifier.sol";
 import "@risc0/contracts/groth16/ControlID.sol";

--- a/packages/protocol/test/layer1/verifiers/SP1PlonkVerifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/SP1PlonkVerifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import { SP1Verifier as SP1PlonkVerifier } from "@sp1-contracts/src/v2.0.0/SP1VerifierPlonk.sol";
 import "../based/TaikoL1TestBase.sol";

--- a/packages/protocol/test/layer1/verifiers/SP1Verifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/SP1Verifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../based/TaikoL1TestBase.sol";
 

--- a/packages/protocol/test/layer1/verifiers/SgxVerifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/SgxVerifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../automata-attestation/common/AttestationBase.t.sol";
 import "../based/TaikoL1TestBase.sol";

--- a/packages/protocol/test/layer1/verifiers/compose/ComposeVerifeir.t.sol
+++ b/packages/protocol/test/layer1/verifiers/compose/ComposeVerifeir.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../shared/TaikoTest.sol";
 import "../../../../contracts/layer1/verifiers/compose/ComposeVerifier.sol";

--- a/packages/protocol/test/layer2/DelegateOwner.t.sol
+++ b/packages/protocol/test/layer2/DelegateOwner.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../shared/thirdparty/Multicall3.sol";
 import "./TaikoL2Test.sol";

--- a/packages/protocol/test/layer2/Lib1559Math.t.sol
+++ b/packages/protocol/test/layer2/Lib1559Math.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL2Test.sol";
 

--- a/packages/protocol/test/layer2/LibL2Signer.sol
+++ b/packages/protocol/test/layer2/LibL2Signer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../shared/thirdparty/LibUint512Math.sol";
 

--- a/packages/protocol/test/layer2/TaikoL2.t.sol
+++ b/packages/protocol/test/layer2/TaikoL2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL2Test.sol";
 

--- a/packages/protocol/test/layer2/TaikoL2EIP1559Configurable.sol
+++ b/packages/protocol/test/layer2/TaikoL2EIP1559Configurable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../contracts/layer2/based/TaikoL2.sol";
 

--- a/packages/protocol/test/layer2/TaikoL2NoFeeCheck.t.sol
+++ b/packages/protocol/test/layer2/TaikoL2NoFeeCheck.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./TaikoL2Test.sol";
 

--- a/packages/protocol/test/layer2/TaikoL2Test.sol
+++ b/packages/protocol/test/layer2/TaikoL2Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../contracts/layer2/DelegateOwner.sol";
 import "../layer2/TaikoL2EIP1559Configurable.sol";

--- a/packages/protocol/test/shared/DeployCapability.sol
+++ b/packages/protocol/test/shared/DeployCapability.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/packages/protocol/test/shared/HelperContracts.sol
+++ b/packages/protocol/test/shared/HelperContracts.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../contracts/shared/bridge/Bridge.sol";
 import "../../contracts/shared/signal/SignalService.sol";

--- a/packages/protocol/test/shared/TaikoTest.sol
+++ b/packages/protocol/test/shared/TaikoTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "forge-std/src/Test.sol";
 

--- a/packages/protocol/test/shared/bridge/Bridge.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/shared/bridge/Bridge2.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/shared/bridge/Bridge2_failMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_failMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./Bridge2.t.sol";
 

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./Bridge2.t.sol";
 

--- a/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./Bridge2.t.sol";
 

--- a/packages/protocol/test/shared/bridge/Bridge2_retryMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_retryMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./Bridge2.t.sol";
 

--- a/packages/protocol/test/shared/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_sendMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "./Bridge2.t.sol";
 

--- a/packages/protocol/test/shared/bridge/QuotaManager.t.sol
+++ b/packages/protocol/test/shared/bridge/QuotaManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/shared/common/AddressManager.t.sol
+++ b/packages/protocol/test/shared/common/AddressManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/shared/common/AddressResolver.t.sol
+++ b/packages/protocol/test/shared/common/AddressResolver.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/shared/common/EssentialContract.t.sol
+++ b/packages/protocol/test/shared/common/EssentialContract.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/shared/common/LibAddress.t.sol
+++ b/packages/protocol/test/shared/common/LibAddress.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 import "../../../contracts/shared/common/LibAddress.sol";

--- a/packages/protocol/test/shared/common/LibTrieProof.t.sol
+++ b/packages/protocol/test/shared/common/LibTrieProof.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../../../contracts/shared/common/LibTrieProof.sol";
 import "../TaikoTest.sol";

--- a/packages/protocol/test/shared/signal/SignalService.t.sol
+++ b/packages/protocol/test/shared/signal/SignalService.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 import "forge-std/src/console2.sol";

--- a/packages/protocol/test/shared/thirdparty/LibUint512Math.sol
+++ b/packages/protocol/test/shared/thirdparty/LibUint512Math.sol
@@ -23,7 +23,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title LibUint512Math
 library LibUint512Math {

--- a/packages/protocol/test/shared/thirdparty/Multicall3.sol
+++ b/packages/protocol/test/shared/thirdparty/Multicall3.sol
@@ -3,7 +3,7 @@
  */
 
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 /// @title Multicall3
 /// @notice Aggregate results from multiple function calls

--- a/packages/protocol/test/shared/token/FreeMintERC20.sol
+++ b/packages/protocol/test/shared/token/FreeMintERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/protocol/test/shared/token/MayFailFreeMintERC20.sol
+++ b/packages/protocol/test/shared/token/MayFailFreeMintERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/protocol/test/shared/token/RegularERC20.sol
+++ b/packages/protocol/test/shared/token/RegularERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/protocol/test/shared/tokenvault/BridgedERC20V2.t.sol
+++ b/packages/protocol/test/shared/tokenvault/BridgedERC20V2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/shared/tokenvault/ERC1155Vault.t.sol
+++ b/packages/protocol/test/shared/tokenvault/ERC1155Vault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import "../TaikoTest.sol";

--- a/packages/protocol/test/shared/tokenvault/ERC20Vault.t.sol
+++ b/packages/protocol/test/shared/tokenvault/ERC20Vault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "../TaikoTest.sol";
 

--- a/packages/protocol/test/shared/tokenvault/ERC721Vault.t.sol
+++ b/packages/protocol/test/shared/tokenvault/ERC721Vault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "../TaikoTest.sol";


### PR DESCRIPTION
Aragon's code uses `pragma solidity ^0.8.17;`