### PR TITLE
fix(taiko-client): out of range for emptyTxLists

### DIFF
--- a/packages/taiko-client/preconfapi/builder/blob.go
+++ b/packages/taiko-client/preconfapi/builder/blob.go
@@ -177,7 +177,7 @@ func (b *BlobTransactionBuilder) BuildBlocksUnsigned(
 		encodedParams = append(encodedParams, encoded)
 	}
 
-	emptyTxLists := make([][]byte, 0)
+	emptyTxLists := make([][]byte, len(encodedParams))
 
 	for i := range encodedParams {
 		emptyTxLists[i] = []byte{0xff}


### PR DESCRIPTION
When calling /blocks/build, an index out of range error occurs because emptyTxList is initialized with size 0. The logic attempts to populate specific positions in the 2D array, causing the error. This is fixed by initializing emptyTxList with the length of encodedParams.