### PR TITLE
feat(protocol): update mainnet `ontakeForkHeight` config

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
@@ -35,7 +35,7 @@ contract MainnetTaikoL1 is TaikoL1, RollupAddressCache {
                 minGasExcess: 1_340_000_000, // correspond to 0.008847185 gwei basefee
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
-            ontakeForkHeight: 538_256
+            ontakeForkHeight: 538_304
         });
     }
 

--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
@@ -35,8 +35,8 @@ contract MainnetTaikoL1 is TaikoL1, RollupAddressCache {
                 minGasExcess: 1_340_000_000, // correspond to 0.008847185 gwei basefee
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
-            ontakeForkHeight: 576_000 // = 7200 * 80
-         });
+            ontakeForkHeight: 538_256
+        });
     }
 
     function _getAddress(uint64 _chainId, bytes32 _name) internal view override returns (address) {


### PR DESCRIPTION
Assume the block time is 35s, then the chain height will be around `538_256` on 15th Nov.

<img width="798" alt="image" src="https://github.com/user-attachments/assets/9c391f50-ae81-4b4d-b566-daf530ec2196">
