### PR TITLE
feat(protocol): add anchor tx gaslimit to config

### DIFF
--- a/packages/protocol/contracts/layer1/based/TaikoData.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoData.sol
@@ -10,14 +10,8 @@ import "src/shared/data/LibSharedData.sol";
 library TaikoData {
     /// @dev Struct holding Taiko configuration parameters. See {TaikoConfig}.
     struct Config {
-        // ---------------------------------------------------------------------
-        // Group 1: General configs
-        // ---------------------------------------------------------------------
         // The chain ID of the network where Taiko contracts are deployed.
         uint64 chainId;
-        // ---------------------------------------------------------------------
-        // Group 2: Block level configs
-        // ---------------------------------------------------------------------
         // The maximum number of proposals allowed in a single block.
         uint64 blockMaxProposals;
         // Size of the block ring buffer, allowing extra space for proposals.
@@ -27,25 +21,14 @@ library TaikoData {
         uint64 maxBlocksToVerify;
         // The maximum gas limit allowed for a block.
         uint32 blockMaxGasLimit;
-        // ---------------------------------------------------------------------
-        // Group 3: Proof related configs
-        // ---------------------------------------------------------------------
         // The amount of Taiko token as a prover liveness bond
         uint96 livenessBond;
-        // ---------------------------------------------------------------------
-        // Group 4: Cross-chain sync
-        // ---------------------------------------------------------------------
         // The number of L2 blocks between each L2-to-L1 state root sync.
         uint8 stateRootSyncInternal;
         uint64 maxAnchorHeightOffset;
-        // ---------------------------------------------------------------------
-        // Group 5: Previous configs in TaikoL2
-        // ---------------------------------------------------------------------
         LibSharedData.BaseFeeConfig baseFeeConfig;
-        // ---------------------------------------------------------------------
-        // Group 6: Others
-        // ---------------------------------------------------------------------
         uint64 ontakeForkHeight;
+        uint24 anchorTransactionGasLimit;
     }
 
     /// @dev A proof and the tier of proof it belongs to

--- a/packages/protocol/contracts/layer1/based/TaikoL1.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoL1.sol
@@ -305,8 +305,9 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
-            ontakeForkHeight: 374_400 // = 7200 * 52
-         });
+            ontakeForkHeight: 374_400, // = 7200 * 52
+            anchorTransactionGasLimit: 250_000
+        });
     }
 
     /// @dev chain_pauser is supposed to be a cold wallet.

--- a/packages/protocol/contracts/layer1/devnet/DevnetTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetTaikoL1.sol
@@ -25,7 +25,8 @@ contract DevnetTaikoL1 is TaikoL1 {
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000
             }),
-            ontakeForkHeight: 2
+            ontakeForkHeight: 2,
+            anchorTransactionGasLimit: 250_000
         });
     }
 }

--- a/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
@@ -27,7 +27,8 @@ contract HeklaTaikoL1 is TaikoL1 {
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
-            ontakeForkHeight: 840_512
+            ontakeForkHeight: 840_512,
+            anchorTransactionGasLimit: 250_000
         });
     }
 }

--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
@@ -35,7 +35,8 @@ contract MainnetTaikoL1 is TaikoL1, RollupAddressCache {
                 minGasExcess: 1_340_000_000, // correspond to 0.008847185 gwei basefee
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
-            ontakeForkHeight: 538_304
+            ontakeForkHeight: 538_304,
+            anchorTransactionGasLimit: 250_000
         });
     }
 


### PR DESCRIPTION
Suggested by @lorenzoXB from Gattaca:

 > Would it be possible to add the anchor tx gas limit (250k) to the onchain config? i think that's the only param affecting "consensus" that's not onchain currently