### PR TITLE
fix(taiko-client): fix `lastVerifiedBlockHash` fetch

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/beaconsync/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/syncer.go
@@ -85,7 +85,6 @@ func (s *Syncer) TriggerBeaconSync(blockID uint64) error {
 			s.ctx,
 			new(big.Int).SetUint64(stateVars.B.LastVerifiedBlockId),
 		)
-
 		if err != nil {
 			return fmt.Errorf("failed to fetch the last verified block hash: %w", err)
 		}

--- a/packages/taiko-client/driver/chain_syncer/beaconsync/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/syncer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/eth/downloader"
@@ -71,9 +72,25 @@ func (s *Syncer) TriggerBeaconSync(blockID uint64) error {
 		return fmt.Errorf("unexpected NewPayload response status: %s", status.Status)
 	}
 
-	lastVerifiedBlockHash, err := s.rpc.GetLastVerifiedBlockHash(s.ctx)
-	if err != nil {
-		return fmt.Errorf("failed to fetch the last verified block hash: %w", err)
+	var lastVerifiedBlockHash common.Hash
+	if lastVerifiedBlockHash, err = s.rpc.GetLastVerifiedBlockHash(s.ctx); err != nil {
+		log.Debug("Failed to fetch the last verified block hash", "err", err)
+
+		stateVars, err := s.rpc.GetProtocolStateVariables(&bind.CallOpts{Context: s.ctx})
+		if err != nil {
+			return fmt.Errorf("failed to fetch protocol state variables: %w", err)
+		}
+
+		lastVerifiedBlockHeader, err := s.rpc.L2CheckPoint.HeaderByNumber(
+			s.ctx,
+			new(big.Int).SetUint64(stateVars.B.LastVerifiedBlockId),
+		)
+
+		if err != nil {
+			return fmt.Errorf("failed to fetch the last verified block hash: %w", err)
+		}
+
+		lastVerifiedBlockHash = lastVerifiedBlockHeader.Hash()
 	}
 
 	fcRes, err := s.rpc.L2Engine.ForkchoiceUpdate(s.ctx, &engine.ForkchoiceStateV1{

--- a/packages/taiko-client/driver/chain_syncer/blob/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/syncer.go
@@ -409,9 +409,24 @@ func (s *Syncer) insertNewHead(
 		return nil, fmt.Errorf("failed to create execution payloads: %w", err)
 	}
 
-	lastVerifiedBlockHash, err := s.rpc.GetLastVerifiedBlockHash(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch the last verified block hash: %w", err)
+	var lastVerifiedBlockHash common.Hash
+	if lastVerifiedBlockHash, err = s.rpc.GetLastVerifiedBlockHash(ctx); err != nil {
+		log.Debug("Failed to fetch last verified block hash", "error", err)
+
+		stateVars, err := s.rpc.GetProtocolStateVariables(&bind.CallOpts{Context: ctx})
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch protocol state variables: %w", err)
+		}
+
+		lastVerifiedBlockHeader, err := s.rpc.L2.HeaderByNumber(
+			ctx,
+			new(big.Int).SetUint64(stateVars.B.LastVerifiedBlockId),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch last verified block: %w", err)
+		}
+
+		lastVerifiedBlockHash = lastVerifiedBlockHeader.Hash()
 	}
 
 	fc := &engine.ForkchoiceStateV1{


### PR DESCRIPTION
Due the ABI of `TaikoL1.getLastVerifiedBlock()`' in the latest `main` is incompatible with the current mainnet ABI (v1.8.0). 