### PR TITLE
fix(protocol): fix LibAddress.supportsInterface to handle undecodeable return data

### DIFF
--- a/packages/protocol/contracts/shared/common/LibAddress.sol
+++ b/packages/protocol/contracts/shared/common/LibAddress.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
@@ -74,10 +73,12 @@ library LibAddress {
         view
         returns (bool result_)
     {
-        if (!Address.isContract(_addr)) return false;
-
-        try IERC165(_addr).supportsInterface(_interfaceId) returns (bool _result) {
-            result_ = _result;
-        } catch { }
+        (bool success, bytes memory data) =
+            _addr.staticcall(abi.encodeCall(IERC165.supportsInterface, (_interfaceId)));
+        if (success && data.length == 32) {
+            result_ = abi.decode(data, (bool));
+        } else {
+            result_ = false;
+        }
     }
 }

--- a/packages/protocol/contracts/shared/common/LibAddress.sol
+++ b/packages/protocol/contracts/shared/common/LibAddress.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
 /// @title LibAddress
 /// @dev Provides utilities for address-related operations.

--- a/packages/protocol/contracts/shared/common/LibAddress.sol
+++ b/packages/protocol/contracts/shared/common/LibAddress.sol
@@ -77,8 +77,6 @@ library LibAddress {
             _addr.staticcall(abi.encodeCall(IERC165.supportsInterface, (_interfaceId)));
         if (success && data.length == 32) {
             result_ = abi.decode(data, (bool));
-        } else {
-            result_ = false;
         }
     }
 }


### PR DESCRIPTION
Identified by Nike:

> The [`supportsInterface` utility function](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/shared/common/LibAddress.sol#L69) wraps a `supportsInterface` call in a `try-catch` block to ensure it returns false if the contract does not implement a `supportsInterface` function. However, it doesn't handle the case where the target contract implements a `supportsInterface` function that doesn't return anything (which will revert outside the `try-catch` block when attempting to decode the `_result`). I'm not sure if you care about this but if so, you could do a low-level call and check the return size.