### PR TITLE
feat(protocol): make sure `init()` covers logics in `init2()`, `init3()`..

### DIFF
--- a/packages/protocol/contracts/layer1/based/TaikoL1.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoL1.sol
@@ -49,7 +49,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
         bool _toPause
     )
         external
-        initializer
+        reinitializer(2)
     {
         __Essential_init(_owner, _rollupAddressManager);
         LibUtils.init(state, getConfig(), _genesisBlockHash);

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -104,7 +104,7 @@ contract Bridge is EssentialContract, IBridge {
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
     /// @param _sharedAddressManager The address of the {AddressManager} contract.
-    function init(address _owner, address _sharedAddressManager) external initializer {
+    function init(address _owner, address _sharedAddressManager) external reinitializer(2) {
         __Essential_init(_owner, _sharedAddressManager);
     }
 

--- a/packages/protocol/contracts/shared/common/AddressManager.sol
+++ b/packages/protocol/contracts/shared/common/AddressManager.sol
@@ -24,10 +24,9 @@ contract AddressManager is EssentialContract, IAddressManager {
     error AM_ADDRESS_ALREADY_SET();
 
     /// @notice Initializes the contract.
-    /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    function init(address _owner) external initializer {
-        __Essential_init(_owner);
-        addressManager = address(this);
+    /// @param _owner The owner of this contract.
+    function init(address _owner) external reinitializer(2) {
+        __Essential_init(_owner, address(this));
     }
 
     function init2() external onlyOwner reinitializer(2) {


### PR DESCRIPTION
In our code `init()` is always called when a contract is deployed, not `init2()` `init3()`,... 
With the modification in this PR, we make sure init() always covers the code in `init2()` and`init3()`,... 