### PR TITLE
fix(protocol): fix permission in ComposeVerifier

### DIFF
--- a/packages/protocol/contracts/layer1/verifiers/compose/ComposeVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/compose/ComposeVerifier.sol
@@ -78,7 +78,7 @@ abstract contract ComposeVerifier is EssentialContract, IVerifier {
         TaikoData.TierProof calldata _proof
     )
         external
-        onlyFromNamed(LibStrings.B_TAIKO)
+        onlyAuthorizedCaller
         nonReentrant
     {
         (address[] memory verifiers, uint256 numSubProofs_) = getSubVerifiersAndThreshold();


### PR DESCRIPTION
The verifyProof function of the ComposeVerifier contract [uses the onlyAuthorizedCaller](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/verifiers/compose/ComposeVerifier.sol#L47) modifier, which allows descendant contracts to [introduce additional authorized callers](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/verifiers/compose/TeeAnyVerifier.sol#L15). However, the verifyBatchProof function [must be called by the TaikoL1 contract](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/verifiers/compose/ComposeVerifier.sol#L81). This means that the verifyBatchProof function of the [ZkAndTeeVerifier](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/verifiers/compose/ZkAndTeeVerifier.sol#L9) is not authorized to [invoke the sub-verifiers](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/verifiers/compose/ComposeVerifier.sol#L103) and is therefore non-functional.

Consider using the onlyAuthorizedCaller modifier in both of the aforementioned cases.