### PR TITLE
refactor(protocol): simplify some protocol code based on OpenZeppelin's recommendation

### DIFF
--- a/packages/protocol/contracts/layer1/based/LibProposing.sol
+++ b/packages/protocol/contracts/layer1/based/LibProposing.sol
@@ -228,35 +228,31 @@ library LibProposing {
         // the block data to be stored on-chain for future integrity checks.
         // If we choose to persist all data fields in the metadata, it will
         // require additional storage slots.
-        unchecked {
-            meta_ = TaikoData.BlockMetadataV2({
-                anchorBlockHash: blockhash(local.params.anchorBlockId),
-                difficulty: keccak256(abi.encode("TAIKO_DIFFICULTY", local.b.numBlocks)),
-                blobHash: 0, // to be initialized below
-                // To make sure each L2 block can be exexucated deterministiclly by the client
-                // without referering to its metadata on Ethereum, we need to encode
-                // config.sharingPctg into the extraData.
-                extraData: local.postFork
-                    ? _encodeBaseFeeConfig(_config.baseFeeConfig)
-                    : local.extraData,
-                coinbase: local.params.coinbase,
-                id: local.b.numBlocks,
-                gasLimit: _config.blockMaxGasLimit,
-                timestamp: local.params.timestamp,
-                anchorBlockId: local.params.anchorBlockId,
-                minTier: 0, // to be initialized below
-                blobUsed: _txList.length == 0,
-                parentMetaHash: local.params.parentMetaHash,
-                proposer: local.params.proposer,
-                livenessBond: _config.livenessBond,
-                proposedAt: uint64(block.timestamp),
-                proposedIn: uint64(block.number),
-                blobTxListOffset: local.params.blobTxListOffset,
-                blobTxListLength: local.params.blobTxListLength,
-                blobIndex: local.params.blobIndex,
-                baseFeeConfig: _config.baseFeeConfig
-            });
-        }
+        meta_ = TaikoData.BlockMetadataV2({
+            anchorBlockHash: blockhash(local.params.anchorBlockId),
+            difficulty: keccak256(abi.encode("TAIKO_DIFFICULTY", local.b.numBlocks)),
+            blobHash: 0, // to be initialized below
+            // To make sure each L2 block can be exexucated deterministiclly by the client
+            // without referering to its metadata on Ethereum, we need to encode
+            // config.sharingPctg into the extraData.
+            extraData: local.postFork ? _encodeBaseFeeConfig(_config.baseFeeConfig) : local.extraData,
+            coinbase: local.params.coinbase,
+            id: local.b.numBlocks,
+            gasLimit: _config.blockMaxGasLimit,
+            timestamp: local.params.timestamp,
+            anchorBlockId: local.params.anchorBlockId,
+            minTier: 0, // to be initialized below
+            blobUsed: _txList.length == 0,
+            parentMetaHash: local.params.parentMetaHash,
+            proposer: local.params.proposer,
+            livenessBond: _config.livenessBond,
+            proposedAt: uint64(block.timestamp),
+            proposedIn: uint64(block.number),
+            blobTxListOffset: local.params.blobTxListOffset,
+            blobTxListLength: local.params.blobTxListLength,
+            blobIndex: local.params.blobIndex,
+            baseFeeConfig: _config.baseFeeConfig
+        });
 
         // Update certain meta fields
         if (meta_.blobUsed) {

--- a/packages/protocol/contracts/layer1/based/LibProposing.sol
+++ b/packages/protocol/contracts/layer1/based/LibProposing.sol
@@ -178,11 +178,11 @@ library LibProposing {
             local.params.coinbase = local.params.proposer;
         }
 
-        if (!local.postFork || local.params.anchorBlockId == 0) {
+        if (local.params.anchorBlockId == 0) {
             local.params.anchorBlockId = uint64(block.number - 1);
         }
 
-        if (!local.postFork || local.params.timestamp == 0) {
+        if (local.params.timestamp == 0) {
             local.params.timestamp = uint64(block.timestamp);
         }
 
@@ -288,8 +288,8 @@ library LibProposing {
             assignedProver: address(0),
             livenessBond: local.postFork ? 0 : meta_.livenessBond,
             blockId: local.b.numBlocks,
-            proposedAt: local.postFork ? local.params.timestamp : uint64(block.timestamp),
-            proposedIn: local.postFork ? local.params.anchorBlockId : uint64(block.number),
+            proposedAt: local.params.timestamp,
+            proposedIn: local.params.anchorBlockId,
             // For a new block, the next transition ID is always 1, not 0.
             nextTransitionId: 1,
             livenessBondReturned: false,

--- a/packages/protocol/contracts/layer1/based/LibProposing.sol
+++ b/packages/protocol/contracts/layer1/based/LibProposing.sol
@@ -179,7 +179,8 @@ library LibProposing {
         }
 
         if (local.params.anchorBlockId == 0) {
-            local.params.anchorBlockId = uint64(block.number - 1);
+            local.params.anchorBlockId =
+                local.postFork ? uint64(block.number - 1) : uint64(block.number);
         }
 
         if (local.params.timestamp == 0) {
@@ -289,7 +290,7 @@ library LibProposing {
             livenessBond: local.postFork ? 0 : meta_.livenessBond,
             blockId: local.b.numBlocks,
             proposedAt: local.params.timestamp,
-            proposedIn: local.postFork ? local.params.anchorBlockId : uint64(block.number),
+            proposedIn: local.params.anchorBlockId,
             // For a new block, the next transition ID is always 1, not 0.
             nextTransitionId: 1,
             livenessBondReturned: false,

--- a/packages/protocol/contracts/layer1/based/LibProposing.sol
+++ b/packages/protocol/contracts/layer1/based/LibProposing.sol
@@ -289,7 +289,7 @@ library LibProposing {
             livenessBond: local.postFork ? 0 : meta_.livenessBond,
             blockId: local.b.numBlocks,
             proposedAt: local.params.timestamp,
-            proposedIn: local.params.anchorBlockId,
+            proposedIn: local.postFork ? local.params.anchorBlockId : uint64(block.number),
             // For a new block, the next transition ID is always 1, not 0.
             nextTransitionId: 1,
             livenessBondReturned: false,

--- a/packages/protocol/contracts/layer1/based/LibProving.sol
+++ b/packages/protocol/contracts/layer1/based/LibProving.sol
@@ -648,7 +648,7 @@ library LibProving {
 
     /// @dev Returns the reward after applying 12.5% friction.
     function _rewardAfterFriction(uint256 _amount) private pure returns (uint256) {
-        return _amount == 0 ? 0 : (_amount * 7) >> 3;
+        return (_amount * 7) >> 3;
     }
 
     /// @dev Returns if the liveness bond shall be returned.

--- a/packages/protocol/contracts/layer1/based/LibVerifying.sol
+++ b/packages/protocol/contracts/layer1/based/LibVerifying.sol
@@ -98,20 +98,21 @@ library LibVerifying {
 
                 if (ts.contester != address(0)) {
                     break;
-                } else {
-                    if (local.tierRouter == ITierRouter(address(0))) {
-                        local.tierRouter =
-                            ITierRouter(_resolver.resolve(LibStrings.B_TIER_ROUTER, false));
-                    }
+                }
 
-                    uint24 cooldown = ITierProvider(local.tierRouter.getProvider(local.blockId))
-                        .getTier(local.tier).cooldownWindow;
+                if (local.tierRouter == ITierRouter(address(0))) {
+                    local.tierRouter =
+                        ITierRouter(_resolver.resolve(LibStrings.B_TIER_ROUTER, false));
+                }
 
-                    if (!LibUtils.isPostDeadline(ts.timestamp, local.b.lastUnpausedAt, cooldown)) {
-                        // If cooldownWindow is 0, the block can theoretically
-                        // be proved and verified within the same L1 block.
-                        break;
-                    }
+                uint24 cooldown = ITierProvider(local.tierRouter.getProvider(local.blockId)).getTier(
+                    local.tier
+                ).cooldownWindow;
+
+                if (!LibUtils.isPostDeadline(ts.timestamp, local.b.lastUnpausedAt, cooldown)) {
+                    // If cooldownWindow is 0, the block can theoretically
+                    // be proved and verified within the same L1 block.
+                    break;
                 }
 
                 // Update variables


### PR DESCRIPTION
Throughout the codebase, multiple opportunities for code simplification were identified:

- In the _proposeBlock function, the local.params object has [a zero anchorBlockId and timestamp](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/based/LibData.sol#L24-L25) for pre-fork blocks. This means that the first part of the condition, the [postFork flag](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/based/LibProposing.sol#L181-L187), is redundant when setting default values.
- [This unchecked block](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/based/LibProposing.sol#L231) does not wrap any math operations and can be removed.
- Since local.params.timestamp is [set to the L1 block timestamp](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/based/LibProposing.sol#L186) before the fork, it covers [both conditions](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/based/LibProposing.sol#L295) when setting the block's proposedAt field.
- This [conditional statement](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/based/LibProving.sol#L647) is unnecessary because the computation returns zero when _amount is zero.
- [This else block](https://github.com/taikoxyz/taiko-mono-oz-audit/blob/fd1c0391045b51b41eba45f2fcdff24fc4d2346e/packages/protocol/contracts/layer1/based/LibVerifying.sol#L102-L114) is redundant because the if case breaks out of the loop.
To improve code maintainability and clarity, consider implementing the aforementioned simplification suggestions.