### PR TITLE
chore(protocol): change Hekla sharingPctg to 80% & gasIssuancePerSecond to 1000000

### DIFF
--- a/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
@@ -23,7 +23,7 @@ contract HeklaTaikoL1 is TaikoL1 {
             baseFeeConfig: LibSharedData.BaseFeeConfig({
                 adjustmentQuotient: 8,
                 sharingPctg: 80,
-                gasIssuancePerSecond: 5_000_000,
+                gasIssuancePerSecond: 1_000_000,
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),

--- a/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
@@ -22,7 +22,7 @@ contract HeklaTaikoL1 is TaikoL1 {
             maxAnchorHeightOffset: 64,
             baseFeeConfig: LibSharedData.BaseFeeConfig({
                 adjustmentQuotient: 8,
-                sharingPctg: 75,
+                sharingPctg: 80,
                 gasIssuancePerSecond: 5_000_000,
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000 // two minutes

--- a/packages/protocol/test/layer2/Lib1559Math.t.sol
+++ b/packages/protocol/test/layer2/Lib1559Math.t.sol
@@ -36,7 +36,7 @@ contract TestLib1559Math is TaikoL2Test {
         console2.log("Mainnet minimal basefee: ", Lib1559Math.basefee(1_340_000_000, 5_000_000 * 8));
     }
 
-    function test_change_of_quotient_and_gips() public {
+    function test_change_of_quotient_and_gasIssuancePerSecond() public {
         uint64 excess = 150 * 2_000_000;
         uint64 target = 4 * 2_000_000;
         uint256 unit = 10_000_000; // 0.01 gwei
@@ -74,7 +74,7 @@ contract TestLib1559Math is TaikoL2Test {
         }
     }
 
-    function test_change_of_quotient_and_gips2() public {
+    function test_change_of_quotient_and_gasIssuancePerSecond2() public {
         uint64 excess = 1;
         uint64 target = 60_000_000 * 8;
         uint256 unit = 10_000_000; // 0.01 gwei


### PR DESCRIPTION
@davidtaikocha when we release 1.10.0, we can test that the fee sharing pctg will be 80%. Do you think taiko-geth already support this?

Maybe we should also change _gasIssuancePerSecond_ to a much smaller value for Hekla? 