### PR TITLE
chore(protocol): do not run unit tests for protocol changes

### DIFF
--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - "packages/protocol/contracts/layer1/based/**"
       - "packages/taiko-client/**"
       - "go.mod"
       - "go.sum"


### PR DESCRIPTION
At least before we finished the client changes for protocol `ontake cleanup`