### PR TITLE
revert(protocol): revert "trigger client tests when there are chang…

### DIFF
--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - "packages/protocol/contracts/layer1/based/**"
       - "packages/taiko-client/**"
       - "go.mod"
       - "go.sum"


### PR DESCRIPTION
New protocol PRs introduce breaking changes, causing client tests to consistently fail. Since protocol changes are implemented first, followed by client updates, we shouldn’t block protocol PRs from being merged due to the client lagging behind.