### PR TITLE
chore(protocol): update base `ontakeForkHeight` to 0

### DIFF
--- a/packages/protocol/contracts/layer1/based/TaikoL1.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoL1.sol
@@ -305,7 +305,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
             ontakeForkHeight: 0
-         });
+        });
     }
 
     /// @dev chain watchdog is supposed to be a cold wallet.

--- a/packages/protocol/contracts/layer1/based/TaikoL1.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoL1.sol
@@ -304,7 +304,7 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
-            ontakeForkHeight: 374_400 // = 7200 * 52
+            ontakeForkHeight: 0
          });
     }
 


### PR DESCRIPTION
Let's fix `ontakeForkHeight` to 0? Since there are no functions before ontake at all after cleanup.