### PR TITLE
feat(protocol): allow `local.params.parentMetaHash` to remain as 0

### DIFF
--- a/packages/protocol/contracts/layer1/based/LibProposing.sol
+++ b/packages/protocol/contracts/layer1/based/LibProposing.sol
@@ -202,11 +202,10 @@ library LibProposing {
 
         // Check if parent block has the right meta hash. This is to allow the proposer to make sure
         // the block builds on the expected latest chain state.
-        if (local.params.parentMetaHash == 0) {
-            local.params.parentMetaHash = parentBlk.metaHash;
-        } else {
-            require(local.params.parentMetaHash == parentBlk.metaHash, L1_UNEXPECTED_PARENT());
-        }
+        require(
+            local.params.parentMetaHash == 0 || local.params.parentMetaHash == parentBlk.metaHash,
+            L1_UNEXPECTED_PARENT()
+        );
 
         // Initialize metadata to compute a metaHash, which forms a part of the block data to be
         // stored on-chain for future integrity checks. If we choose to persist all data fields in


### PR DESCRIPTION
Previously if this parameter is zero, we set it to parent's hash, now we simply use 0. This will avoid a SLOAD for many blocks.

@davidtaikocha  @smtmfft  will this be a breaking change for client or prover? Note now the metadata may have `parentMetaHash` as 0.


<img width="807" alt="Screenshot 2024-11-06 at 12 21 02" src="https://github.com/user-attachments/assets/c65f894e-434a-4a3e-b6f6-40294d33b057">
