### PR TITLE
feat(repo): fix workflows, restore merge-gatekeeper

### DIFF
--- a/.github/workflows/bridge-ui.yml
+++ b/.github/workflows/bridge-ui.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build-and-test:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     uses: ./.github/workflows/bridge-ui--ci.yml
 
   # Deployment name follow the pattern: deploy_<appname(bridge-ui)>_<network(devnet|hekla|mainnet)>_<environment(preview|production)>
@@ -37,7 +37,7 @@ jobs:
 
   # Hekla testnet
   deploy_bridge-ui_hekla_preview:
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:
@@ -62,7 +62,7 @@ jobs:
 
   # Mainnet
   deploy_bridge-ui_mainnet_preview:
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:

--- a/.github/workflows/docs-site--preview.yml
+++ b/.github/workflows/docs-site--preview.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy-docs-site-preview:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     runs-on: [arc-runner-set]
     steps:
       - name: Install Git

--- a/.github/workflows/eventindexer.yml
+++ b/.github/workflows/eventindexer.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   lint-eventindexer:
     name: lint-eventindexer
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please' && !startsWith(github.head_ref, 'refs/heads/dependabot/')) }}
     runs-on: [arc-runner-set]
     steps:
       - uses: actions/setup-go@v5
@@ -38,7 +38,7 @@ jobs:
 
   test-eventindexer:
     runs-on: [arc-runner-set]
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please' && !startsWith(github.head_ref, 'refs/heads/dependabot/')) }}
     needs: lint-eventindexer
     steps:
       - name: Cancel Previous Runs
@@ -66,7 +66,7 @@ jobs:
 
   push-eventindexer-docker-image:
     # Skip dependabot PRs
-    if: ${{ github.event_name == 'pull_request' && ! startsWith(github.ref, 'refs/heads/dependabot/') }}
+    if: ${{ github.event_name == 'pull_request' && ! startsWith(github.head_ref, 'refs/heads/dependabot/') && !startsWith(github.head_ref, 'release-please') }}
     name: Build and push docker image
     runs-on: [arc-runner-set]
 

--- a/.github/workflows/fork-diff--preview.yml
+++ b/.github/workflows/fork-diff--preview.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy-fork-diff-preview:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     runs-on: [arc-runner-set]
     steps:
       - name: Install Git

--- a/.github/workflows/guardian-prover-health-check-ui--ci.yml
+++ b/.github/workflows/guardian-prover-health-check-ui--ci.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   check-guardian-prover-health-check-ui:
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'refs/heads/dependabot/') }}
     runs-on: [taiko-runner]
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/guardian-prover-health-check-ui.yml
+++ b/.github/workflows/guardian-prover-health-check-ui.yml
@@ -17,7 +17,7 @@ jobs:
   # Deployment name follow the pattern: deploy_<appname(guardian-prover-health-check-ui)>_<network(devnet|hekla|mainnet)>_<environment(preview|production)>
 
   # deploy_guardians-ui_devnet_preview:
-  #   if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+  #   if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
   #   needs: build-and-test
   #   uses: ./.github/workflows/repo--vercel-deploy.yml
   #   with:
@@ -31,7 +31,7 @@ jobs:
 
 
   deploy_guardians-ui_hekla_preview:
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:
@@ -43,7 +43,7 @@ jobs:
       vercel_token: ${{ secrets.VERCEL_TOKEN }}
 
   deploy_guardians-ui_mainnet_preview:
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:

--- a/.github/workflows/guardian-prover-health-check.yml
+++ b/.github/workflows/guardian-prover-health-check.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   lint-guardian-prover-health-check:
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     name: lint-guardian-prover-health-check
     runs-on: [taiko-runner]
     steps:
@@ -36,7 +36,7 @@ jobs:
           args: --config=.golangci.yml --timeout=4m
 
   test-guardian-prover-health-check:
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     runs-on: [taiko-runner]
     needs: lint-guardian-prover-health-check
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   push-guardian-prover-health-check-docker-image:
     # Skip dependabot PRs
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please' && !startsWith(github.head_ref, 'refs/heads/dependabot/')) }}
     name: Build and push docker image
     runs-on: [taiko-runner]
 

--- a/.github/workflows/nfts.yml
+++ b/.github/workflows/nfts.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-nfts-contracts:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     runs-on: [arc-runner-set]
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/protocol-monitors.yml
+++ b/.github/workflows/protocol-monitors.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy-protocol-monitors:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     runs-on: [taiko-runner]
     permissions:
       # Give the necessary permissions for stefanzweifel/git-auto-commit-action.

--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-protocol:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     runs-on: [arc-runner-set]
     permissions:
       # Give the necessary permissions for stefanzweifel/git-auto-commit-action.
@@ -69,7 +69,7 @@ jobs:
           pnpm test:deploy:l1
 
   genesis-docker:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     runs-on: [taiko-runner]
     permissions:
       # Give the necessary permissions for stefanzweifel/git-auto-commit-action.

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   lint-relayer:
     name: lint-relayer
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'refs/heads/dependabot/')}}
     runs-on: [arc-runner-set]
     steps:
       - uses: actions/setup-go@v5
@@ -37,7 +37,7 @@ jobs:
           args: --config=.golangci.yml --timeout=4m
 
   test-relayer:
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'refs/heads/dependabot/') }}
     runs-on: [arc-runner-set]
     needs: lint-relayer
     steps:
@@ -66,7 +66,7 @@ jobs:
 
   push-relayer-docker-image:
     # Skip dependabot PRs
-    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*') }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'refs/heads/dependabot/') }}
     name: Build and push docker image
     runs-on: [arc-runner-set]
 

--- a/.github/workflows/repo--merge-gatekeeper.yml
+++ b/.github/workflows/repo--merge-gatekeeper.yml
@@ -1,0 +1,21 @@
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group: # Trigger in merge queue to pass the required status check
+
+jobs:
+  merge-gatekeeper:
+    if: github.event_name == 'pull_request'
+    runs-on: [arc-runner-set]
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          timeout: 1200
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/supplementary-contracts.yml
+++ b/.github/workflows/supplementary-contracts.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-supplementary-contracts:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     runs-on: [arc-runner-set]
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/taiko-client--hive_test.yml
+++ b/.github/workflows/taiko-client--hive_test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   hive_tests:
-    if: contains(github.event.pull_request.labels.*.name, 'option.workflow_on') && github.event.pull_request.draft == false && github.head_ref != 'release-please-*'
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     name: hive tests
     runs-on: [arc-runner-set]
     timeout-minutes: 40

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   lint:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     name: Lint
     runs-on: [ubuntu-latest]
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: golangci-lint run --path-prefix=./ --config=.golangci.yml
 
   integration_tests:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     name: Integration tests
     runs-on: [ubuntu-latest]
     timeout-minutes: 15


### PR DESCRIPTION
branches-ignore filter [not working as expected ](https://github.com/orgs/community/discussions/26795#discussioncomment-3253430) found and tested workaround on fork. 

Restoring merge-gatekeeper to prevent PRs from being merged without required status checks at @davidtaikocha 's request, should be okay with less workflow runs on release-please