### PR TITLE
chore(docs-site): update block-states.mdx

### DIFF
--- a/packages/docs-site/src/content/docs/core-concepts/block-states.mdx
+++ b/packages/docs-site/src/content/docs/core-concepts/block-states.mdx
@@ -34,4 +34,4 @@ A Taiko block is `Finalized`/`Verified` when every state transition from genesis
 
 The above Taiko block with blockID `0x19a3c` would thus be considered `Safe` if the L1 block with the blockHash `0x419f..` reaches a `Safe` state.
 
-The Taiko block with blockID `019a3c` would be `Finalized`/`Verified` if every state transition from genesis to the current block has a valid proof.
+The Taiko block with blockID `0x19a3c` would be `Finalized`/`Verified` if every state transition from genesis to the current block has a valid proof.


### PR DESCRIPTION
**"The Taiko block with blockID `019a3c`..."**

Here, the block ID is incorrectly written as `019a3c`, while it should be `0x19a3c`, matching the earlier reference where the block ID is `0x19a3c`.

The correct version should be:
**"The Taiko block with blockID `0x19a3c`..."**

Corrected.