### PR TITLE
feat(taiko-client): fix bug in RemoveSoftBlocks API

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/blob/soft_block.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/soft_block.go
@@ -269,15 +269,8 @@ func (s *Syncer) RemoveSoftBlocks(ctx context.Context, newLastBlockID uint64) er
 		return err
 	}
 
-	lastVerifiedBlockHash, err := s.rpc.GetLastVerifiedBlockHash(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to fetch last verified block hash: %w", err)
-	}
-
 	fc := &engine.ForkchoiceStateV1{
-		HeadBlockHash:      newHead.Hash(),
-		SafeBlockHash:      newHead.Hash(),
-		FinalizedBlockHash: lastVerifiedBlockHash,
+		HeadBlockHash: newHead.Hash(),
 	}
 	fcRes, err := s.rpc.L2Engine.ForkchoiceUpdate(ctx, fc, nil)
 	if err != nil {

--- a/packages/taiko-client/driver/soft_blocks/api.go
+++ b/packages/taiko-client/driver/soft_blocks/api.go
@@ -262,11 +262,11 @@ func (s *SoftBlockAPIServer) RemoveSoftBlocks(c echo.Context) error {
 		"currentHead", currentHead.Number.Uint64(),
 	)
 
-	if reqBody.NewLastBlockID < canonicalHeadL1Origin.BlockID.Uint64() {
+	if reqBody.NewLastBlockID <= canonicalHeadL1Origin.BlockID.Uint64()+1 {
 		return s.returnError(
 			c,
 			http.StatusBadRequest,
-			errors.New("newLastBlockId must not be smaller than the canonical chain's highest block ID"),
+			errors.New("newLastBlockId must not be bigger than the canonical chain's highest block ID"),
 		)
 	}
 

--- a/packages/taiko-client/driver/soft_blocks/api.go
+++ b/packages/taiko-client/driver/soft_blocks/api.go
@@ -266,7 +266,7 @@ func (s *SoftBlockAPIServer) RemoveSoftBlocks(c echo.Context) error {
 		return s.returnError(
 			c,
 			http.StatusBadRequest,
-			errors.New("newLastBlockId must not be bigger than the canonical chain's highest block ID"),
+			errors.New("newLastBlockId must bigger than the canonical chain's highest block ID"),
 		)
 	}
 


### PR DESCRIPTION
- `canonicalHeadL1Origin.BlockID` equals to `SafeBlockNumber` - 1, so let the API can only remove soft blocks.
- When removing soft blocks in this API, `SafeBlockHash` and `FinalizedBlockHash` don't need to updated.