### PR TITLE
chore(protocol): fix typos in documentation files

### DIFF
--- a/packages/protocol/deployments/mainnet-transfer-logs-L1.md
+++ b/packages/protocol/deployments/mainnet-transfer-logs-L1.md
@@ -12,11 +12,11 @@
 
 #### tx`0x9ede1da0bb372fbaa210bb1847172888b30e8a3cc68c9d868ec066ca3301f480`
 
-- labs.taiko.eth depositted 10 ETH to proposer: `0x000000633b68f5d8d3a86593ebb815b4663bcbe0`
-- labs.taiko.eth depositted 10 ETH to prover: `0x000000629FBCf27A347d1AEbA658435230D74a5f`
-- labs.taiko.eth depositted 5 ETH to contester: `0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`
-- labs.taiko.eth depositted 0.01 ETH to bridge watchdog: `0x00000291ab79c55dc4fcd97dfba4880df4b93624`
-- labs.taiko.eth depositted 5 ETH to bridge L1 relayer: `0x0000001539d3a970c979ac67a8836a359ce4a1fc`
+- labs.taiko.eth deposited 10 ETH to proposer: `0x000000633b68f5d8d3a86593ebb815b4663bcbe0`
+- labs.taiko.eth deposited 10 ETH to prover: `0x000000629FBCf27A347d1AEbA658435230D74a5f`
+- labs.taiko.eth deposited 5 ETH to contester: `0x00000027F51a57E7FcBC4b481d15fcE5BE68b30B`
+- labs.taiko.eth deposited 0.01 ETH to bridge watchdog: `0x00000291ab79c55dc4fcd97dfba4880df4b93624`
+- labs.taiko.eth deposited 5 ETH to bridge L1 relayer: `0x0000001539d3a970c979ac67a8836a359ce4a1fc`
 - labs.taiko.eth transferred 5 ETH to Daniel Wang: `0x69AA0361Dbb0527d4F1e5312403Bd41788fe61Fe`
 
 #### tx`0xdb04aa0f162cd84cadae96135e471575108954d552a873d42027b579140ca182`

--- a/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
+++ b/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
@@ -51,7 +51,7 @@ Day 19-21
 
 1. The biggest trust assumption in the contract is the owner role handling all the Address manager contracts. This role can pause the contracts at anytime.
 2. The second trust assumption is the guardians multisig. Currently, the guardians are trusted and will be removed over time. But since they are the highest tier, the centralization risk in the proving system exists.
-3. ANother role is the bridge watchdog. This role can ban and suspend any messages at will. It is the most important risk of the bridge contracts.
+3. Another role is the bridge watchdog. This role can ban and suspend any messages at will. It is the most important risk of the bridge contracts.
 4. The snapshooter role has some risks associated since it takes snapshots on the TaikoToken.
 
 There are more roles in the codebase but these are the foremost and most central to the protocol.

--- a/packages/protocol/docs/analysis/kaveyjoe-Analysis.md
+++ b/packages/protocol/docs/analysis/kaveyjoe-Analysis.md
@@ -63,7 +63,7 @@ The block will then mark complete on the chain. The block status changes from gr
 
 - The block consists of a transaction list (txList) and metadata. The txList of an L2 block will eventually (when EIP-4844 is live) be part of a blob in the L1 Consensus Layer (CL).
 - txList is not directly accessible to L1 contracts. Therefore, a ZKP shall prove that the chosen txList is a slice of the given blob data.
-- Block validity criteria that all blocks need to respect: K_maxBobSize, K_BlockMaxTxs, K_BlockMaxGasLimit and config.anchorTxGasLimit
+- Block validity criteria that all blocks need to respect: K_maxBlockSize, K_BlockMaxTxs, K_BlockMaxGasLimit and config.anchorTxGasLimit
 - Once the block is proposed, the Taiko client checks if the block is decoded into a list of transactions
 - Taiko client validates each enclosed transaction and generates a tracelog for each transaction for the prover to use as witness data. If a tx is invalid, it will be dropped.
 - The first transaction in the Taiko L2 block is always an anchoring transaction, which verifies the 256 hashes of the latest blocks, the L2 chain ID and the EIP-1559 base fee
@@ -96,7 +96,7 @@ L2 tx fee = L2 EIP-1559* base fee + L1 tx fee + prover fee + proposer fee*
 
 L2 EIP-1559 fee = L2 EIP-1559 tip (goes to the proposer) + L2 EIP-1559 base fee (goes to the Taiko DAO).
 
-Once a proposer has collected enough transactions, most probably including and ordering them with the intent to generate a (maxim) profit, they create a block.
+Once a proposer has collected enough transactions, most probably including and ordering them with the intent to generate a (maximum) profit, they create a block.
 
 - Profit means that for the proposer, the sum of transaction fees (L2 tx fees) from the block is larger than L1 tx fee + prover fee + EIP-1559 base fee.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "depositted" to "deposited".
Corrected "ANother" to "Another".
Corrected "K_maxBobSize" to "K_maxBlockSize".
Corrected "maxim" to "maximum".

Please review the changes and let me know if any additional changes are needed.

