### PR TITLE
Introducing Taiko Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/taikoxyz?style=social)](https://twitter.com/taikoxyz)
 [![Discord](https://img.shields.io/discord/984015101017346058?color=%235865F2&label=Discord&logo=discord&logoColor=%23fff)](https://discord.gg/taikoxyz)
 [![YouTube](https://img.shields.io/youtube/channel/subscribers/UCxd_ARE9LtAEdnRQA6g1TaQ)](https://www.youtube.com/@taikoxyz)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Taiko%20Guru-006BFF)](https://gurubase.io/g/taiko)
 
 [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/taikoxyz/taiko-mono/badge)](https://www.gitpoap.io/gh/taikoxyz/taiko-mono)
 [![License](https://img.shields.io/github/license/taikoxyz/taiko-mono)](https://github.com/taikoxyz/taiko-mono/blob/main/LICENSE.md)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Taiko%20Guru-006BFF)](https://gurubase.io/g/taiko)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/taikoxyz/taiko-mono/badge)](https://www.gitpoap.io/gh/taikoxyz/taiko-mono)
 [![License](https://img.shields.io/github/license/taikoxyz/taiko-mono)](https://github.com/taikoxyz/taiko-mono/blob/main/LICENSE.md)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Taiko%20Guru-006BFF)](https://gurubase.io/g/taiko)
 
 </div>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Taiko Guru](https://gurubase.io/g/taiko) to Gurubase. Taiko Guru uses the data from this repo and data from the [docs](https://docs.taiko.xyz) to answer questions by leveraging the LLM.

In this PR, I showcased the "Taiko Guru", which highlights that Taiko now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Taiko Guru in Gurubase, just let me know that's totally fine.
