### PR TITLE
docs(repo): improve grammar and readability

### DIFF
--- a/packages/fork-diff/README.md
+++ b/packages/fork-diff/README.md
@@ -29,4 +29,4 @@ There is a workflow dispatch you can use to manually trigger a preview or produc
 
 > It is possible that state expiry might be unnecessary in a world where Verkle Tries succeed at their goals.
 
-can anyone explain this like im 5. i dont even know what a verkle trie is outside of ppl saying merkle tries r annoying and these r better.
+Can anyone explain this like I'm 5? I don't even know what a Verkle Trie is outside of people saying Merkle Tries are annoying and these are better.

--- a/packages/protocol/contracts/layer1/automata-attestation/README.md
+++ b/packages/protocol/contracts/layer1/automata-attestation/README.md
@@ -1,4 +1,4 @@
 # Readme
 
-Original code (main branch) forked from https://github.com/automata-network/automata-dcap-v3-attestation and applied some gas optimizations here: https://github.com/smtmfft/automata-dcap-v3-attestation/tree/parse-quote-offline, which then got merged into taiko-mono.
+Original code (main branch) forked from https://github.com/automata-network/automata-dcap-v3-attestation and applying some gas optimizations here: https://github.com/smtmfft/automata-dcap-v3-attestation/tree/parse-quote-offline, which then was merged into taiko-mono.
 The corresponding upstream PR is: https://github.com/automata-network/automata-dcap-v3-attestation/pull/6, waiting to be merged.


### PR DESCRIPTION
1. In packages/protocol/contracts/layer1/automata-attestation/README.md:
- Changed: "got merged" → "was merged"
Reason: Using proper formal English instead of colloquial language in technical documentation
- Changed: "applied" → "applying"
Reason: Fixed verb tense consistency in the sentence

Update README.md
Original informal text was updated to use proper grammar, capitalization and technical terminology:

- can anyone explain this like im 5. i dont even know what a verkle trie is outside of ppl saying merkle tries r annoying and these r better.
+ Can anyone explain this like I'm 5? I don't even know what a Verkle Trie is outside of people saying Merkle Tries are annoying and these are better.

The changes improve readability and professionalism by:
Adding proper capitalization at sentence starts
Using proper contractions (I'm)
Spelling out abbreviations (people instead of ppl, are instead of r)
Adding proper punctuation including question mark
Capitalizing technical terms (Verkle Trie, Merkle Tries)
These updates align with standard technical writing practices while maintaining the original meaning and making the documentation more accessible to all readers.