### PR TITLE
docs(balance-monitor): fix typo Update main.go

### DIFF
--- a/packages/balance-monitor/cmd/main.go
+++ b/packages/balance-monitor/cmd/main.go
@@ -31,7 +31,7 @@ func main() {
 		{
 			Name:        "balance-monitor",
 			Flags:       flags.CommonFlags,
-			Usage:       "Starts the balance monitor oftware",
+			Usage:       "Starts the balance monitor software",
 			Description: "Taiko balance monitor",
 			Action:      utils.SubcommandAction(new(balanceMonitor.BalanceMonitor)),
 		},


### PR DESCRIPTION
### Description:
This pull request fixes a minor typo in the description of the `balance-monitor` command. The phrase:

`"Starts the balance monitor oftware"`

has been corrected to:

`"Starts the balance monitor software"`

<img width="507" alt="Снимок экрана 2024-11-21 в 21 23 20" src="https://github.com/user-attachments/assets/5865a385-07cd-408d-aabe-bf21df3c8497">

### Importance:
Correcting this typo improves the clarity and professionalism of the documentation. While the error does not affect the functionality, ensuring proper spelling enhances user experience and avoids any confusion. 
