### PR TITLE
feat(protocol): prepare Pacaya hardfork

### DIFF
--- a/packages/protocol/contract_layout_layer1.md
+++ b/packages/protocol/contract_layout_layer1.md
@@ -511,6 +511,24 @@
 | state            | struct TaikoData.State | 251  | 0      | 1600  | TaikoL1 |
 | __gap            | uint256[50]            | 301  | 0      | 1600  | TaikoL1 |
 
+## TaikoInbox
+| Name             | Type                   | Slot | Offset | Bytes | Contract                                         |
+|------------------|------------------------|------|--------|-------|--------------------------------------------------|
+| _initialized     | uint8                  | 0    | 0      | 1     | TaikoInbox |
+| _initializing    | bool                   | 0    | 1      | 1     | TaikoInbox |
+| __gap            | uint256[50]            | 1    | 0      | 1600  | TaikoInbox |
+| _owner           | address                | 51   | 0      | 20    | TaikoInbox |
+| __gap            | uint256[49]            | 52   | 0      | 1568  | TaikoInbox |
+| _pendingOwner    | address                | 101  | 0      | 20    | TaikoInbox |
+| __gap            | uint256[49]            | 102  | 0      | 1568  | TaikoInbox |
+| addressManager   | address                | 151  | 0      | 20    | TaikoInbox |
+| __gap            | uint256[49]            | 152  | 0      | 1568  | TaikoInbox |
+| __reentry        | uint8                  | 201  | 0      | 1     | TaikoInbox |
+| __paused         | uint8                  | 201  | 1      | 1     | TaikoInbox |
+| __lastUnpausedAt | uint64                 | 201  | 2      | 8     | TaikoInbox |
+| __gap            | uint256[49]            | 202  | 0      | 1568  | TaikoInbox |
+| state            | struct TaikoData.State | 251  | 0      | 1600  | TaikoInbox |
+
 ## HeklaTaikoL1
 | Name             | Type                   | Slot | Offset | Bytes | Contract                                             |
 |------------------|------------------------|------|--------|-------|------------------------------------------------------|

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
+import "src/shared/common/EssentialContract.sol";
+import "./LibData.sol";
+import "./LibProposing.sol";
+import "./LibProving.sol";
+import "./LibVerifying.sol";
+import "./TaikoEvents.sol";
+import "./ITaikoL1.sol";
+
+/// @title TaikoL1
+/// @notice This contract serves as the "base layer contract" of the Taiko protocol, providing
+/// functionalities for proposing, proving, and verifying blocks. The term "base layer contract"
+/// means that although this is usually deployed on L1, it can also be deployed on L2s to create
+/// L3s. The contract also handles the deposit and withdrawal of Taiko tokens and Ether.
+/// Additionally, this contract doesn't hold any Ether. Ether deposited to L2 are held by the Bridge
+/// contract.
+/// @dev Labeled in AddressResolver as "taiko"
+/// @custom:security-contact security@taiko.xyz
+contract TaikoL1 is EssentialContract {
+	/// @notice The TaikoL1 state.
+    TaikoData.State public state;
+}

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -10,16 +10,9 @@ import "./LibVerifying.sol";
 import "./TaikoEvents.sol";
 import "./ITaikoL1.sol";
 
-/// @title TaikoL1
-/// @notice This contract serves as the "base layer contract" of the Taiko protocol, providing
-/// functionalities for proposing, proving, and verifying blocks. The term "base layer contract"
-/// means that although this is usually deployed on L1, it can also be deployed on L2s to create
-/// L3s. The contract also handles the deposit and withdrawal of Taiko tokens and Ether.
-/// Additionally, this contract doesn't hold any Ether. Ether deposited to L2 are held by the Bridge
-/// contract.
-/// @dev Labeled in AddressResolver as "taiko"
+/// @title TaikoInbox
 /// @custom:security-contact security@taiko.xyz
-contract TaikoL1 is EssentialContract {
+contract TaikoInbox is EssentialContract {
 	/// @notice The TaikoL1 state.
     TaikoData.State public state;
 }

--- a/packages/protocol/script/gen-layouts.sh
+++ b/packages/protocol/script/gen-layouts.sh
@@ -31,6 +31,7 @@ contracts_layer1=(
 "contracts/layer1/verifiers/SgxVerifier.sol:SgxVerifier"
 "contracts/layer1/automata-attestation/AutomataDcapV3Attestation.sol:AutomataDcapV3Attestation"
 "contracts/layer1/based/TaikoL1.sol:TaikoL1"
+"contracts/layer1/based/TaikoInbox.sol:TaikoInbox"
 "contracts/layer1/hekla/HeklaTaikoL1.sol:HeklaTaikoL1"
 "contracts/layer1/hekla/HeklaTierRouter.sol:HeklaTierRouter"
 "contracts/layer1/mainnet/multirollup/MainnetBridge.sol:MainnetBridge"


### PR DESCRIPTION
## Major Changes in Pacaya:

- [ ] Removal of Tier-Based Proofs and Proof Contestation
    - Tier-based proofs and the associated proof contestation mechanism are being removed.
    - Guardian provers will also be deprecated as a result.
    - This change significantly simplifies the protocol, reducing complexity and potential attack vectors.
- [ ] Support for Batch Block Proposal and Proving Only
    - The protocol will now exclusively support batch block proposals and batch/aggregated proving.
