### PR TITLE
Fix typo in Multi-proofs documentation

### DIFF
--- a/packages/docs-site/src/content/docs/core-concepts/multi-proofs.md
+++ b/packages/docs-site/src/content/docs/core-concepts/multi-proofs.md
@@ -3,7 +3,7 @@ title: Multi-proofs
 description: Core concept page for "Multi-proofs".
 ---
 
-Taiko supports multi-proofs through a mixture of zkVMs, TEE, and guardian proofs. Check out our blog post on zkVMs [here](https://taiko.mirror.xyz/e_5GeGGFJIrOxqvXOfzY6HmWcRjCjRyG0NQF1zbNpNQ) and a Twitter thread on our Raiko architecture [here](https://x.com/taikoxyz/status/1791201812768600209).
+Taiko supports multi-proofs through a mixture of zkVMs, TEE, and guardian proofs. Check out our blog post on zkVMs [here](https://taiko.mirror.xyz/e_5GeGGFJIrOxqvXOfzY6HmWcRjCjRyG0NQF1zbNpNQ) and a Twitter thread on our Taiko architecture [here](https://x.com/taikoxyz/status/1791201812768600209).
 
 ## Proving Taiko blocks
 


### PR DESCRIPTION
### Description for Pull Request:

**Title:** Fix typo in Multi-proofs documentation

**Description:**  
This PR fixes a typo in the `multi-proofs.md` file under the core concepts documentation. The project name "Taiko" was mistakenly written as "Raiko." Correcting this typo ensures the accuracy and professionalism of the documentation, which is important for users and contributors.

**Importance:**  
The documentation is a crucial part of representing the Taiko project to the community and potential users. Typos can cause confusion and reduce trust in the project's quality. This fix eliminates such issues and enhances the reliability of the documentation.
