### PR TITLE
chore(main): fix misspelled

### DIFF
--- a/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
+++ b/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
@@ -13,7 +13,7 @@ Day 2-7
 
 - Reviewing base contracts (least inherited)
 - Adding inline bookmarks for notes
-- Understanding RLP encoding, EIP-4844,
+- Understanding RLP encoding, EIP-4844
 
 Day 8-12
 
@@ -110,7 +110,7 @@ Eventually, after the best tier i.e. highest tier proof (ZK proof) is solid and 
 4. Benefits of Based Contestable Rollup
 
 - Abstraction of special if-else code into a tier-based proof system makes the developers aware that the team cannot just shut down the chain uasing guardian prover and does not have control over it.
-- Taiko has 3 types of bonds - validity bonds, contestation bonds and liveness bonds. We've spoken about the first two. Liveness bonds are basically, le's say, I have a prover off-chain and this prover is supposed to submit the proof within 15 minutes, then if the prover does not submit the proof in that time, then the prover's liveness bond is burnt.
+- Taiko has 3 types of bonds - validity bonds, contestation bonds and liveness bonds. We've spoken about the first two. Liveness bonds are basically, let's say, I have a prover off-chain and this prover is supposed to submit the proof within 15 minutes, then if the prover does not submit the proof in that time, then the prover's liveness bond is burnt.
 - As an app dev, you can always change your config a long way. You can just use one layer-1 transaction to go from 100% optimistic to 100% ZK rollup.
 - As ZK becomes more trustworthy, the team will slowly increase the % to ZK until they become fully ZK and remove the guardian prover.
 
@@ -147,7 +147,7 @@ End game: multiple zkVMs (Guardians removed)
 
 There are a few risks associated with the protocol:
 
-- The protocol does not have a robust on-chain fee estimation mechanism. On calling the on-chain functions, the relayers should provide the contracts with upto date prices for users or atleast maintain a default amount of gas to send across.
+- The protocol does not have a robust on-chain fee estimation mechanism. On calling the on-chain functions, the relayers should provide the contracts with up to date prices for users or atleast maintain a default amount of gas to send across.
 - The protocol would not work perfectly with swapping protocols. This is because the bridge includes invocation delays which can cause swaps to go outdated.
 - There is an issue related to custom coinbase transfers which can create a risk among block proposers.
 


### PR DESCRIPTION
small typo and fix misspelled

''upto date prices" → should be "up to date prices."


"le's say" → should be "let's say."