### PR TITLE
feat(repo): don't run vercel workflow on fork

### DIFF
--- a/.github/workflows/repo--vercel-deploy.yml
+++ b/.github/workflows/repo--vercel-deploy.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   build-deploy:
-    if: github.actor != 'dependabot'
+    if: ${{ github.actor != 'dependabot' && github.event.pull_request.head.repo.fork == false }}
     runs-on: [arc-runner-set]
     steps:
       - name: Print Vercel Project ID


### PR DESCRIPTION
will always fail on forks due to lack of secrets access so just disable