### PR TITLE
docs(protocol): improve terminology in documentation

### DIFF
--- a/packages/protocol/docs/analysis/kaveyjoe-Analysis.md
+++ b/packages/protocol/docs/analysis/kaveyjoe-Analysis.md
@@ -20,7 +20,7 @@ Taiko aims to be a fully Ethereum-equivalent ZK-Rollup. aim to scale Ethereum in
 Taiko operates by utilizing a Zero Knowledge Rollup (ZK-Rollup) mechanism, specifically designed to scale the Ethereum blockchain without compromising its foundational features of security, censorship resistance, and permissionless access. Here's a breakdown of how Taiko functions:
 
 - Zero Knowledge Proofs (ZKPs): Taiko leverages ZKPs to validate transactions confidentially, reducing data processing on Ethereum's mainnet. This efficiency cuts costs and increases transaction speed.
-- Integration with Ethereum L1: Unlike rollups that use a centralized sequencer, Taiko's transactions are sequenced by Ethereum's Layer 1 validators. This method, called based sequencing, ensures that Taiko inherits Ethereum's security and decentralization properties.
+- Integration with Ethereum L1: Unlike rollups that use a centralized sequencer, Taiko's transactions are sequenced by Ethereum's Layer 1 validators. This method, called base sequencing, ensures that Taiko inherits Ethereum's security and decentralization properties.
 - Smart Contracts and Governance: Taiko operates through smart contracts on Ethereum, detailing its protocol. Governance, including protocol updates, is managed by the Taiko DAO, ensuring community-driven decisions.
 - Open Source and Compatibility: As an open-source platform, Taiko allows developers to deploy dApps seamlessly, maintaining Ethereum's ease of use and accessibility.
 - Decentralized Validation: Taiko supports a decentralized model for proposers and validators, enhancing network security and integrity. Ethereum L1 validators also play a pivotal role, emphasizing decentralization.

--- a/packages/protocol/docs/eip1559_on_l2.md
+++ b/packages/protocol/docs/eip1559_on_l2.md
@@ -32,7 +32,7 @@ It turns out the initial value of gasExcess doesn't really matter for the above 
 
 ## Adjust the slope
 
-To adjust the slope of the curve to satisfy $R == basefee(2T)/basefee(T)$, we simply need to choose $M$ and $b_0$. $b_0$ is simply to decide -- if we believe the cost of a L2 transaction is $1/n$ of the same L1 transaction, we simply use the current L1 base fee divided by $n$. Then we can simply tune $M$ to make sure $R == basefee(2T)/basefee(T)$ holds. This is very simply manually a try-and-adjust approach as shown in `Lib1559Math.t.sol`. The TaikoL1 contract will check if $R == basefee(2T)/basefee(T)$ holds but will not calculate $M$ for us.
+To adjust the slope of the curve to satisfy $R == basefee(2T)/basefee(T)$, we simply need to choose $M$ and $b_0$. $b_0$ is simply to decide -- if we believe the cost of a L2 transaction is $1/n$ of the same L1 transaction, we simply use the current L1 base fee divided by $n$. Then we can simply tune $M$ to make sure $R == basefee(2T)/basefee(T)$ holds. This is very simple manually a try-and-adjust approach as shown in `Lib1559Math.t.sol`. The TaikoL1 contract will check if $R == basefee(2T)/basefee(T)$ holds but will not calculate $M$ for us.
 
 ## Implementation Difference
 

--- a/packages/protocol/simulation/README.md
+++ b/packages/protocol/simulation/README.md
@@ -26,7 +26,7 @@ Assuming you are in this directory.
 
 ### Exporting Configuration
 
-4. **Export Simulation Configuration**
+3. **Export Simulation Configuration**
 
    Run the following command to export the configuration used in the `test_eip1559_math` test to a file in the `out/` directory. A unique file name based on the current timestamp will be generated automatically (e.g., `simconf_<timestamp>.txt`):
 
@@ -38,7 +38,7 @@ Assuming you are in this directory.
 
 ### Running Simulation
 
-5. **Run Simulation**
+4. **Run Simulation**
 
    After exporting the configuration, locate the newly created file in the `out/` directory. Run the simulation using the command below, replacing `simconf_<timestamp>.txt` with the name of your specific file:
 


### PR DESCRIPTION
Changes Made

1. packages/protocol/docs/analysis/kaweyjoe-Analysis.md
Changed "based" to "base" in the sequencing description

2. packages/protocol/docs/eip1559_on_l2.md
Changed "simply" to "simple" in the slope adjustment explanation

3. packages/protocol/simulation/README.md
Updated section numbering for better consistency