### PR TITLE
chore(taiko-client): correct Raiko RESTful API description

### DIFF
--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -30,13 +30,13 @@ var (
 var (
 	RaikoHostEndpoint = &cli.StringFlag{
 		Name:     "raiko.host",
-		Usage:    "RPC endpoint of a Raiko host service",
+		Usage:    "RESTful API endpoint of a Raiko host service",
 		Category: proverCategory,
 		EnvVars:  []string{"RAIKO_HOST"},
 	}
 	RaikoZKVMHostEndpoint = &cli.StringFlag{
 		Name:     "raiko.host.zkvm",
-		Usage:    "RPC endpoint of a Raiko ZKVM host service",
+		Usage:    "RESTful API endpoint of a Raiko ZKVM host service",
 		Category: proverCategory,
 		EnvVars:  []string{"RAIKO_HOST_ZKVM"},
 	}

--- a/packages/taiko-client/prover/proof_producer/sgx_producer.go
+++ b/packages/taiko-client/prover/proof_producer/sgx_producer.go
@@ -28,7 +28,7 @@ const (
 
 // SGXProofProducer generates a SGX proof for the given block.
 type SGXProofProducer struct {
-	RaikoHostEndpoint   string // a proverd RPC endpoint
+	RaikoHostEndpoint   string // Raiko RESTful API endpoint
 	ProofType           string // Proof type
 	JWT                 string // JWT provided by Raiko
 	Dummy               bool


### PR DESCRIPTION
Currently, Raiko endpoint is RESTful instead of JSONRPC.