### PR TITLE
chore(protocol): Add tests for proposeBlocksV3 reverts for invalid preconfRouter

### DIFF
--- a/packages/protocol/test/layer1/based/InboxTest_Suite1.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Suite1.t.sol
@@ -388,6 +388,37 @@ contract InboxTest_Suite1 is InboxTestBase {
         _logAllBlocksAndTransitions();
     }
 
+    function test_proposeBlocksV3_reverts_for_invalid_proposer_and_preconfRouter()
+        external
+        transactBy(Alice)
+    {
+        uint64 count = 1;
+
+        vm.expectRevert(ITaikoInbox.CustomProposerNotAllowed.selector);
+        inbox.proposeBlocksV3(
+            Alice, address(0), new ITaikoInbox.BlockParamsV3[](count), "txList"
+        );
+
+        vm.startPrank(deployer);
+        address preconfRouter = Bob;
+        resolver.registerAddress(block.chainid, "preconf_router", preconfRouter);
+        vm.stopPrank();
+
+        vm.startPrank(Alice);
+        vm.expectRevert(ITaikoInbox.NotPreconfRouter.selector);
+        inbox.proposeBlocksV3(
+            preconfRouter, address(0), new ITaikoInbox.BlockParamsV3[](count), "txList"
+        );
+        vm.stopPrank();
+
+        vm.startPrank(preconfRouter);
+        vm.expectRevert(ITaikoInbox.CustomProposerMissing.selector);
+        inbox.proposeBlocksV3(
+            address(0), address(0), new ITaikoInbox.BlockParamsV3[](count), "txList"
+        );
+        vm.stopPrank();
+    }
+
     function test_inbox_measure_gas_used()
         external
         transactBy(Alice)

--- a/packages/protocol/test/layer1/based/InboxTest_Suite1.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Suite1.t.sol
@@ -395,9 +395,7 @@ contract InboxTest_Suite1 is InboxTestBase {
         uint64 count = 1;
 
         vm.expectRevert(ITaikoInbox.CustomProposerNotAllowed.selector);
-        inbox.proposeBlocksV3(
-            Alice, address(0), new ITaikoInbox.BlockParamsV3[](count), "txList"
-        );
+        inbox.proposeBlocksV3(Alice, address(0), new ITaikoInbox.BlockParamsV3[](count), "txList");
 
         vm.startPrank(deployer);
         address preconfRouter = Bob;


### PR DESCRIPTION
Before
<img width="1092" alt="Screen Shot 2024-12-19 at 1 10 30 AM" src="https://github.com/user-attachments/assets/55e47864-e486-4395-87e8-9d5a58bd7bbb" />

After
<img width="967" alt="Screen Shot 2024-12-19 at 1 14 36 AM" src="https://github.com/user-attachments/assets/7d035d35-6d4b-4a93-9caf-c1a8f2a549b6" />

