### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
+++ b/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
@@ -6,7 +6,7 @@
 
 Day 1
 
-- Consuming resources provide in the README
+- Consuming resources provided in the README
 - Understanding and noting down the logical scope
 
 Day 2-7


### PR DESCRIPTION
Corrected `provide` to `provided`