### PR TITLE
fix(repo): improve link checking

### DIFF
--- a/.github/workflows/repo--check-links.yml
+++ b/.github/workflows/repo--check-links.yml
@@ -2,9 +2,9 @@ name: Check links
 
 on:
   push:
-    paths:
-      - "**/README.md"
-      - docs/**
+    # paths:
+    #   - "**/README.md"
+    #   - docs/**
 
 jobs:
   check-links:

--- a/.github/workflows/repo--check-links.yml
+++ b/.github/workflows/repo--check-links.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --verbose --max-retries 3 --retry-delay 2 --exclude "etherscan.io" --user-agent 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3' '**/README.md'
+          args: --no-progress --verbose "**/README.md"

--- a/.github/workflows/repo--check-links.yml
+++ b/.github/workflows/repo--check-links.yml
@@ -2,9 +2,9 @@ name: Check links
 
 on:
   push:
-    # paths:
-    #   - "**/README.md"
-    #   - docs/**
+    paths:
+      - "**/README.md"
+      - docs/**
 
 jobs:
   check-links:

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,2 +1,2 @@
 exclude_path = ["node_modules"]
-# exclude = ["etherscan.io"]
+exclude = ["etherscan.io"]

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,1 +1,2 @@
 exclude_path = ["node_modules"]
+exclude = ["etherscan.io"]

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,2 +1,2 @@
 exclude_path = ["node_modules"]
-exclude = ["etherscan.io"]
+# exclude = ["etherscan.io"]


### PR DESCRIPTION
If this gives us problems again (eg. `[403] Forbidden`), I recommend we narrow the regex to only check for our documentation links `docs.taiko.xyz/*` links from `**/README.md` files.