### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/relayer/bridge/bridge.go
+++ b/packages/relayer/bridge/bridge.go
@@ -120,7 +120,7 @@ func InitFromConfig(ctx context.Context, b *Bridge, cfg *Config) error {
 	b.destChainId = destChainID
 
 	b.backOffRetryInterval = time.Duration(cfg.BackoffRetryInterval) * time.Second
-	b.backOffMaxRetries = cfg.BackOffMaxRetrys
+	b.backOffMaxRetries = cfg.BackOffMaxRetries
 	b.ethClientTimeout = time.Duration(cfg.ETHClientTimeout) * time.Second
 
 	b.bridgeMessageValue = cfg.BridgeMessageValue


### PR DESCRIPTION
Corrected `BackOffMaxRetrys` to `BackOffMaxRetries`