### PR TITLE
chore(protocol): add tests for _validateBlockParams

### DIFF
--- a/packages/protocol/test/layer1/based/InBoxTest_BlockParams.t.sol
+++ b/packages/protocol/test/layer1/based/InBoxTest_BlockParams.t.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "./InboxTestBase.sol";
+
+contract InBoxTest_BlockParams is InboxTestBase {
+    function getConfig() internal pure override returns (ITaikoInbox.ConfigV3 memory) {
+        return ITaikoInbox.ConfigV3({
+            chainId: LibNetwork.TAIKO_MAINNET,
+            blockMaxProposals: 10,
+            blockRingBufferSize: 15,
+            maxBlocksToVerify: 5,
+            blockMaxGasLimit: 240_000_000,
+            livenessBond: 125e18, // 125 Taiko token
+            stateRootSyncInternal: 5,
+            maxAnchorHeightOffset: 64,
+            baseFeeConfig: LibSharedData.BaseFeeConfig({
+                adjustmentQuotient: 8,
+                sharingPctg: 75,
+                gasIssuancePerSecond: 5_000_000,
+                minGasExcess: 1_340_000_000, // correspond to 0.008847185 gwei basefee
+                maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
+             }),
+            provingWindow: 1 hours,
+            maxSignalsToReceive: 16,
+            forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
+        });
+    }
+
+    function setUpOnEthereum() internal override {
+        super.setUpOnEthereum();
+        bondToken = deployBondToken();
+    }
+
+    function test_validateBlockParams_defaults_when_anchorBlockId_is_zero()
+        external
+        transactBy(Alice)
+    {
+        ITaikoInbox.BlockParamsV3[] memory paramsArray = new ITaikoInbox.BlockParamsV3[](1);
+        paramsArray[0] = ITaikoInbox.BlockParamsV3({
+            anchorBlockId: 0, // Simulate missing anchor block ID
+            timestamp: 0,
+            parentMetaHash: 0,
+            signalSlots: new bytes32[](0),
+            blobIndex: 0,
+            txListOffset: 0,
+            txListSize: 0,
+            anchorInput: bytes32(0)
+        });
+
+        ITaikoInbox.BlockMetadataV3[] memory metas = inbox.proposeBlocksV3(
+            address(0),
+            address(0),
+            paramsArray,
+            "txList"
+        );
+
+        // Extract the updated parameters
+        uint64 updatedAnchorBlockId = metas[0].anchorBlockId;
+
+        // Assert that the default anchorBlockId was set correctly
+        uint64 expectedAnchorBlockId = uint64(block.number - 1);
+        assertEq(updatedAnchorBlockId, expectedAnchorBlockId, "AnchorBlockId mismatch");
+    }
+
+    function test_validateBlockParams_reverts_when_anchorBlockId_too_small()
+        external
+        transactBy(Alice)
+    {
+        ITaikoInbox.ConfigV3 memory config = inbox.getConfigV3();
+
+        // Advance the block number to create the appropriate test scenario
+        vm.roll(config.maxAnchorHeightOffset + 2);
+
+        // Calculate an invalid anchorBlockId (too small)
+        uint64 anchorBlockId = uint64(block.number - config.maxAnchorHeightOffset - 1);
+
+        ITaikoInbox.BlockParamsV3[] memory paramsArray = new ITaikoInbox.BlockParamsV3[](1);
+        paramsArray[0] = ITaikoInbox.BlockParamsV3({
+            anchorBlockId: anchorBlockId,
+            timestamp: 0,
+            parentMetaHash: 0,
+            signalSlots: new bytes32[](0),
+            blobIndex: 0,
+            txListOffset: 0,
+            txListSize: 0,
+            anchorInput: bytes32(0)
+        });
+
+        vm.expectRevert(ITaikoInbox.AnchorBlockIdTooSmall.selector);
+        inbox.proposeBlocksV3(
+            address(0),
+            address(0),
+            paramsArray,
+            "txList"
+        );
+    }
+
+    function test_validateBlockParams_reverts_when_anchorBlockId_too_large()
+        external
+        transactBy(Alice)
+    {
+        // Calculate an invalid anchorBlockId (too large)
+        uint64 anchorBlockId = uint64(block.number);
+
+        ITaikoInbox.BlockParamsV3[] memory paramsArray = new ITaikoInbox.BlockParamsV3[](1);
+        paramsArray[0] = ITaikoInbox.BlockParamsV3({
+            anchorBlockId: anchorBlockId,
+            timestamp: 0,
+            parentMetaHash: 0,
+            signalSlots: new bytes32[](0),
+            blobIndex: 0,
+            txListOffset: 0,
+            txListSize: 0,
+            anchorInput: bytes32(0)
+        });
+
+        vm.expectRevert(ITaikoInbox.AnchorBlockIdTooLarge.selector);
+        inbox.proposeBlocksV3(
+            address(0),
+            address(0),
+            paramsArray,
+            "txList"
+        );
+    }
+
+    function test_validateBlockParams_reverts_when_anchorBlockId_smaller_than_parent()
+        external
+        transactBy(Alice)
+    {
+        vm.roll(10);
+        _proposeBlocksWithDefaultParameters(1);
+        ITaikoInbox.BlockV3 memory parent = inbox.getBlockV3(1);
+
+        ITaikoInbox.BlockParamsV3[] memory paramsArray = new ITaikoInbox.BlockParamsV3[](1);
+        paramsArray[0] = ITaikoInbox.BlockParamsV3({
+            anchorBlockId: parent.anchorBlockId - 1,
+            timestamp: 0,
+            parentMetaHash: 0,
+            signalSlots: new bytes32[](0),
+            blobIndex: 0,
+            txListOffset: 0,
+            txListSize: 0,
+            anchorInput: bytes32(0)
+        });
+
+        vm.expectRevert(ITaikoInbox.AnchorBlockIdSmallerThanParent.selector);
+        inbox.proposeBlocksV3(
+            address(0),
+            address(0),
+            paramsArray,
+            "txList"
+        );
+    }
+
+    function test_validateBlockParams_when_anchorBlockId_is_not_zero()
+        external
+        transactBy(Alice)
+    {
+        ITaikoInbox.BlockParamsV3[] memory paramsArray = new ITaikoInbox.BlockParamsV3[](1);
+        paramsArray[0] = ITaikoInbox.BlockParamsV3({
+            anchorBlockId: uint64(block.number - 1),
+            timestamp: 0,
+            parentMetaHash: 0,
+            signalSlots: new bytes32[](0),
+            blobIndex: 0,
+            txListOffset: 0,
+            txListSize: 0,
+            anchorInput: bytes32(0)
+        });
+
+        inbox.proposeBlocksV3(
+            address(0),
+            address(0),
+            paramsArray,
+            "txList"
+        );
+    }
+
+    function test_validateBlockParams_reverts_when_timestamp_too_large()
+        external
+        transactBy(Alice)
+    {
+        ITaikoInbox.BlockParamsV3[] memory paramsArray = new ITaikoInbox.BlockParamsV3[](1);
+        paramsArray[0] = ITaikoInbox.BlockParamsV3({
+            anchorBlockId: 0,
+            timestamp: uint64(block.timestamp + 1),
+            parentMetaHash: 0,
+            signalSlots: new bytes32[](0),
+            blobIndex: 0,
+            txListOffset: 0,
+            txListSize: 0,
+            anchorInput: bytes32(0)
+        });
+
+        vm.expectRevert(ITaikoInbox.TimestampTooLarge.selector);
+        inbox.proposeBlocksV3(
+            address(0),
+            address(0),
+            paramsArray,
+            "txList"
+        );
+    }
+}

--- a/packages/protocol/test/layer1/based/InBoxTest_BlockParams.t.sol
+++ b/packages/protocol/test/layer1/based/InBoxTest_BlockParams.t.sol
@@ -48,12 +48,8 @@ contract InBoxTest_BlockParams is InboxTestBase {
             anchorInput: bytes32(0)
         });
 
-        ITaikoInbox.BlockMetadataV3[] memory metas = inbox.proposeBlocksV3(
-            address(0),
-            address(0),
-            paramsArray,
-            "txList"
-        );
+        ITaikoInbox.BlockMetadataV3[] memory metas =
+            inbox.proposeBlocksV3(address(0), address(0), paramsArray, "txList");
 
         // Assert that the default anchorBlockId was set correctly
         uint64 expectedAnchorBlockId = uint64(block.number - 1);
@@ -85,12 +81,7 @@ contract InBoxTest_BlockParams is InboxTestBase {
         });
 
         vm.expectRevert(ITaikoInbox.AnchorBlockIdTooSmall.selector);
-        inbox.proposeBlocksV3(
-            address(0),
-            address(0),
-            paramsArray,
-            "txList"
-        );
+        inbox.proposeBlocksV3(address(0), address(0), paramsArray, "txList");
     }
 
     function test_validateBlockParams_reverts_when_anchorBlockId_too_large()
@@ -113,12 +104,7 @@ contract InBoxTest_BlockParams is InboxTestBase {
         });
 
         vm.expectRevert(ITaikoInbox.AnchorBlockIdTooLarge.selector);
-        inbox.proposeBlocksV3(
-            address(0),
-            address(0),
-            paramsArray,
-            "txList"
-        );
+        inbox.proposeBlocksV3(address(0), address(0), paramsArray, "txList");
     }
 
     function test_validateBlockParams_reverts_when_anchorBlockId_smaller_than_parent()
@@ -142,18 +128,10 @@ contract InBoxTest_BlockParams is InboxTestBase {
         });
 
         vm.expectRevert(ITaikoInbox.AnchorBlockIdSmallerThanParent.selector);
-        inbox.proposeBlocksV3(
-            address(0),
-            address(0),
-            paramsArray,
-            "txList"
-        );
+        inbox.proposeBlocksV3(address(0), address(0), paramsArray, "txList");
     }
 
-    function test_validateBlockParams_when_anchorBlockId_is_not_zero()
-        external
-        transactBy(Alice)
-    {
+    function test_validateBlockParams_when_anchorBlockId_is_not_zero() external transactBy(Alice) {
         ITaikoInbox.BlockParamsV3[] memory paramsArray = new ITaikoInbox.BlockParamsV3[](1);
         paramsArray[0] = ITaikoInbox.BlockParamsV3({
             anchorBlockId: uint64(block.number - 1),
@@ -166,12 +144,8 @@ contract InBoxTest_BlockParams is InboxTestBase {
             anchorInput: bytes32(0)
         });
 
-        ITaikoInbox.BlockMetadataV3[] memory metas = inbox.proposeBlocksV3(
-            address(0),
-            address(0),
-            paramsArray,
-            "txList"
-        );
+        ITaikoInbox.BlockMetadataV3[] memory metas =
+            inbox.proposeBlocksV3(address(0), address(0), paramsArray, "txList");
 
         uint64 expectedAnchorBlockId = uint64(block.number - 1);
         assertEq(metas[0].anchorBlockId, expectedAnchorBlockId, "AnchorBlockId mismatch");
@@ -194,11 +168,6 @@ contract InBoxTest_BlockParams is InboxTestBase {
         });
 
         vm.expectRevert(ITaikoInbox.TimestampTooLarge.selector);
-        inbox.proposeBlocksV3(
-            address(0),
-            address(0),
-            paramsArray,
-            "txList"
-        );
+        inbox.proposeBlocksV3(address(0), address(0), paramsArray, "txList");
     }
 }

--- a/packages/protocol/test/layer1/based/InBoxTest_BlockParams.t.sol
+++ b/packages/protocol/test/layer1/based/InBoxTest_BlockParams.t.sol
@@ -55,12 +55,9 @@ contract InBoxTest_BlockParams is InboxTestBase {
             "txList"
         );
 
-        // Extract the updated parameters
-        uint64 updatedAnchorBlockId = metas[0].anchorBlockId;
-
         // Assert that the default anchorBlockId was set correctly
         uint64 expectedAnchorBlockId = uint64(block.number - 1);
-        assertEq(updatedAnchorBlockId, expectedAnchorBlockId, "AnchorBlockId mismatch");
+        assertEq(metas[0].anchorBlockId, expectedAnchorBlockId, "AnchorBlockId mismatch");
     }
 
     function test_validateBlockParams_reverts_when_anchorBlockId_too_small()
@@ -169,12 +166,15 @@ contract InBoxTest_BlockParams is InboxTestBase {
             anchorInput: bytes32(0)
         });
 
-        inbox.proposeBlocksV3(
+        ITaikoInbox.BlockMetadataV3[] memory metas = inbox.proposeBlocksV3(
             address(0),
             address(0),
             paramsArray,
             "txList"
         );
+
+        uint64 expectedAnchorBlockId = uint64(block.number - 1);
+        assertEq(metas[0].anchorBlockId, expectedAnchorBlockId, "AnchorBlockId mismatch");
     }
 
     function test_validateBlockParams_reverts_when_timestamp_too_large()


### PR DESCRIPTION
Add tests for several checks:
- AnchorBlockIdTooSmall
- AnchorBlockIdTooLarge
- AnchorBlockIdSmallerThanParent
- TimestampTooLarge


Before
<img width="1168" alt="Screen Shot 2024-12-31 at 4 21 09 AM" src="https://github.com/user-attachments/assets/f868cf9d-937e-422c-b220-5011f323e32d" />


After
<img width="1148" alt="Screen Shot 2024-12-31 at 4 19 45 AM" src="https://github.com/user-attachments/assets/69b213b6-05fa-44e3-b069-607a5eae8063" />


