### PR TITLE
fix(protocol): add timestamp as a new parameter to getBasefeeV2

### DIFF
--- a/packages/protocol/contracts/layer2/based/TaikoL2.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoL2.sol
@@ -201,7 +201,7 @@ contract TaikoL2 is EssentialContract, IBlockHash, TaikoL2Deprecated {
         (newGasTarget_, newGasExcess_) =
             LibEIP1559.adjustExcess(parentGasTarget, newGasTarget, parentGasExcess);
 
-        uint64 gasIssuance = (_curTimestamp - parentTimestamp) * _baseFeeConfig.gasIssuancePerSecond;
+        uint64 gasIssuance = (_blockTimestamp - parentTimestamp) * _baseFeeConfig.gasIssuancePerSecond;
 
         if (
             _baseFeeConfig.maxGasIssuancePerBlock != 0

--- a/packages/protocol/contracts/layer2/based/TaikoL2.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoL2.sol
@@ -201,7 +201,8 @@ contract TaikoL2 is EssentialContract, IBlockHash, TaikoL2Deprecated {
         (newGasTarget_, newGasExcess_) =
             LibEIP1559.adjustExcess(parentGasTarget, newGasTarget, parentGasExcess);
 
-        uint64 gasIssuance = (_blockTimestamp - parentTimestamp) * _baseFeeConfig.gasIssuancePerSecond;
+        uint64 gasIssuance =
+            (_blockTimestamp - parentTimestamp) * _baseFeeConfig.gasIssuancePerSecond;
 
         if (
             _baseFeeConfig.maxGasIssuancePerBlock != 0

--- a/packages/protocol/contracts/layer2/based/TaikoL2.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoL2.sol
@@ -187,7 +187,7 @@ contract TaikoL2 is EssentialContract, IBlockHash, TaikoL2Deprecated {
     /// @return newGasExcess_ The new gas excess value.
     function getBasefeeV2(
         uint32 _parentGasUsed,
-        uint64 _curTimestamp,
+        uint64 _blockTimestamp,
         LibSharedData.BaseFeeConfig calldata _baseFeeConfig
     )
         public

--- a/packages/protocol/contracts/layer2/based/TaikoL2.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoL2.sol
@@ -187,6 +187,7 @@ contract TaikoL2 is EssentialContract, IBlockHash, TaikoL2Deprecated {
     /// @return newGasExcess_ The new gas excess value.
     function getBasefeeV2(
         uint32 _parentGasUsed,
+        uint64 _curTimestamp,
         LibSharedData.BaseFeeConfig calldata _baseFeeConfig
     )
         public
@@ -200,8 +201,7 @@ contract TaikoL2 is EssentialContract, IBlockHash, TaikoL2Deprecated {
         (newGasTarget_, newGasExcess_) =
             LibEIP1559.adjustExcess(parentGasTarget, newGasTarget, parentGasExcess);
 
-        uint64 gasIssuance =
-            uint64(block.timestamp - parentTimestamp) * _baseFeeConfig.gasIssuancePerSecond;
+        uint64 gasIssuance = (_curTimestamp - parentTimestamp) * _baseFeeConfig.gasIssuancePerSecond;
 
         if (
             _baseFeeConfig.maxGasIssuancePerBlock != 0
@@ -292,7 +292,7 @@ contract TaikoL2 is EssentialContract, IBlockHash, TaikoL2Deprecated {
         private
     {
         (uint256 basefee, uint64 newGasTarget, uint64 newGasExcess) =
-            getBasefeeV2(_parentGasUsed, _baseFeeConfig);
+            getBasefeeV2(_parentGasUsed, uint64(block.timestamp), _baseFeeConfig);
 
         require(block.basefee == basefee || skipFeeCheck(), L2_BASEFEE_MISMATCH());
 

--- a/packages/protocol/test/layer2/TaikoL2.t.sol
+++ b/packages/protocol/test/layer2/TaikoL2.t.sol
@@ -123,7 +123,8 @@ contract TaikoL2Tests is TaikoL2Test {
             maxGasIssuancePerBlock: _maxGasIssuancePerBlock
         });
 
-        (uint256 basefee_,,) = L2.getBasefeeV2(_parentGasUsed, baseFeeConfig);
+        (uint256 basefee_,,) =
+            L2.getBasefeeV2(_parentGasUsed, uint64(block.timestamp), baseFeeConfig);
         assertTrue(basefee_ != 0, "basefee is 0");
     }
 
@@ -156,7 +157,8 @@ contract TaikoL2Tests is TaikoL2Test {
         vm.prank(L2.GOLDEN_TOUCH_ADDRESS());
         L2.anchorV2(++anchorBlockId, anchorStateRoot, _parentGasUsed, baseFeeConfig);
 
-        (uint256 basefee, uint64 newGasTarget,) = L2.getBasefeeV2(_parentGasUsed, baseFeeConfig);
+        (uint256 basefee, uint64 newGasTarget,) =
+            L2.getBasefeeV2(_parentGasUsed, uint64(block.timestamp), baseFeeConfig);
 
         assertTrue(basefee != 0, "basefee is 0");
         assertEq(newGasTarget, L2.parentGasTarget());
@@ -164,7 +166,8 @@ contract TaikoL2Tests is TaikoL2Test {
         // change the gas issuance to change the gas target
         baseFeeConfig.gasIssuancePerSecond += 1;
 
-        (basefee, newGasTarget,) = L2.getBasefeeV2(_parentGasUsed, baseFeeConfig);
+        (basefee, newGasTarget,) =
+            L2.getBasefeeV2(_parentGasUsed, uint64(block.timestamp), baseFeeConfig);
 
         assertTrue(basefee != 0, "basefee is 0");
         assertTrue(newGasTarget != L2.parentGasTarget());


### PR DESCRIPTION
Not sure if the 1s diff with `block.timestamp` will have an effect on base fee.