### PR TITLE
fix(taiko-client): remove `finalizedBlock` info when P2P syncing

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker.go
@@ -157,7 +157,6 @@ func (t *SyncProgressTracker) ClearMeta() {
 
 	log.Debug("Clear sync progress tracker meta")
 
-	t.triggered = false
 	t.lastSyncedBlockID = nil
 	t.lastSyncedBlockHash = common.Hash{}
 	t.outOfSync = false

--- a/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker_test.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker_test.go
@@ -52,7 +52,7 @@ func (s *BeaconSyncProgressTrackerTestSuite) TestSyncProgressed() {
 func (s *BeaconSyncProgressTrackerTestSuite) TestClearMeta() {
 	s.t.triggered = true
 	s.t.ClearMeta()
-	s.False(s.t.triggered)
+	s.True(s.t.triggered)
 }
 
 func (s *BeaconSyncProgressTrackerTestSuite) TestHeadChanged() {

--- a/packages/taiko-client/driver/chain_syncer/beaconsync/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/syncer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/eth/downloader"
@@ -72,30 +71,8 @@ func (s *Syncer) TriggerBeaconSync(blockID uint64) error {
 		return fmt.Errorf("unexpected NewPayload response status: %s", status.Status)
 	}
 
-	var lastVerifiedBlockHash common.Hash
-	if lastVerifiedBlockHash, err = s.rpc.GetLastVerifiedBlockHash(s.ctx); err != nil {
-		log.Debug("Failed to fetch the last verified block hash", "err", err)
-
-		stateVars, err := s.rpc.GetProtocolStateVariables(&bind.CallOpts{Context: s.ctx})
-		if err != nil {
-			return fmt.Errorf("failed to fetch protocol state variables: %w", err)
-		}
-
-		lastVerifiedBlockHeader, err := s.rpc.L2CheckPoint.HeaderByNumber(
-			s.ctx,
-			new(big.Int).SetUint64(stateVars.B.LastVerifiedBlockId),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to fetch the last verified block hash: %w", err)
-		}
-
-		lastVerifiedBlockHash = lastVerifiedBlockHeader.Hash()
-	}
-
 	fcRes, err := s.rpc.L2Engine.ForkchoiceUpdate(s.ctx, &engine.ForkchoiceStateV1{
-		HeadBlockHash:      headPayload.BlockHash,
-		SafeBlockHash:      lastVerifiedBlockHash,
-		FinalizedBlockHash: lastVerifiedBlockHash,
+		HeadBlockHash: headPayload.BlockHash,
 	}, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
1. The beacon sync model can be just triggered once.
2. Finalize block and Soft block don't need to be set in the beacon sync model.