### PR TITLE
fix(taiko-client): check the `blockID` of the last verified block before using it as `FinalizedBlockHash`

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/blob/soft_block.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/soft_block.go
@@ -231,7 +231,7 @@ func (s *Syncer) InsertSoftBlockFromTransactionsBatch(
 		return nil, fmt.Errorf("unexpected NewPayload response status: %s", execStatus.Status)
 	}
 
-	lastVerifiedBlockHash, err := s.rpc.GetLastVerifiedBlockHash(ctx)
+	lastVerifiedBlock, err := s.rpc.GetLastVerifiedBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch last verified block hash: %w", err)
 	}
@@ -245,7 +245,7 @@ func (s *Syncer) InsertSoftBlockFromTransactionsBatch(
 	fc = &engine.ForkchoiceStateV1{
 		HeadBlockHash:      payload.BlockHash,
 		SafeBlockHash:      canonicalHead.L2BlockHash,
-		FinalizedBlockHash: lastVerifiedBlockHash,
+		FinalizedBlockHash: lastVerifiedBlock.BlockHash,
 	}
 	fcRes, err = s.rpc.L2Engine.ForkchoiceUpdate(ctx, fc, nil)
 	if err != nil {

--- a/packages/taiko-client/driver/chain_syncer/blob/soft_block.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/soft_block.go
@@ -231,7 +231,7 @@ func (s *Syncer) InsertSoftBlockFromTransactionsBatch(
 		return nil, fmt.Errorf("unexpected NewPayload response status: %s", execStatus.Status)
 	}
 
-	lastVerifiedBlock, err := s.rpc.GetLastVerifiedBlock(ctx)
+	lastVerifiedBlockInfo, err := s.rpc.GetLastVerifiedBlock(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch last verified block hash: %w", err)
 	}
@@ -245,7 +245,7 @@ func (s *Syncer) InsertSoftBlockFromTransactionsBatch(
 	fc = &engine.ForkchoiceStateV1{
 		HeadBlockHash:      payload.BlockHash,
 		SafeBlockHash:      canonicalHead.L2BlockHash,
-		FinalizedBlockHash: lastVerifiedBlock.BlockHash,
+		FinalizedBlockHash: lastVerifiedBlockInfo.BlockHash,
 	}
 	fcRes, err = s.rpc.L2Engine.ForkchoiceUpdate(ctx, fc, nil)
 	if err != nil {

--- a/packages/taiko-client/driver/chain_syncer/blob/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/syncer.go
@@ -409,23 +409,12 @@ func (s *Syncer) insertNewHead(
 	}
 
 	var lastVerifiedBlockHash common.Hash
-	if lastVerifiedBlockHash, err = s.rpc.GetLastVerifiedBlockHash(ctx); err != nil {
-		log.Debug("Failed to fetch last verified block hash", "error", err)
-
-		stateVars, err := s.rpc.GetProtocolStateVariables(&bind.CallOpts{Context: ctx})
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch protocol state variables: %w", err)
-		}
-
-		lastVerifiedBlockHeader, err := s.rpc.L2.HeaderByNumber(
-			ctx,
-			new(big.Int).SetUint64(stateVars.B.LastVerifiedBlockId),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch last verified block: %w", err)
-		}
-
-		lastVerifiedBlockHash = lastVerifiedBlockHeader.Hash()
+	lastVerifiedBlockInfo, err := s.rpc.GetLastVerifiedBlock(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch last verified block: %w", err)
+	}
+	if payload.Number > lastVerifiedBlockInfo.BlockId {
+		lastVerifiedBlockHash = lastVerifiedBlockInfo.BlockHash
 	}
 
 	fc := &engine.ForkchoiceStateV1{

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -502,7 +502,7 @@ func (c *Client) GetProtocolStateVariables(opts *bind.CallOpts) (*struct {
 
 // GetLastVerifiedBlock gets the last verified block from TaikoL1 contract.
 func (c *Client) GetLastVerifiedBlock(ctx context.Context) (struct {
-	BlockId    uint64 //nolint:revive,stylecheck
+	BlockId    uint64 //nolint:stylecheck
 	BlockHash  [32]byte
 	StateRoot  [32]byte
 	VerifiedAt uint64

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -500,17 +500,17 @@ func (c *Client) GetProtocolStateVariables(opts *bind.CallOpts) (*struct {
 	return GetProtocolStateVariables(c.TaikoL1, opts)
 }
 
-// GetLastVerifiedBlockHash gets the last verified block hash from TaikoL1 contract.
-func (c *Client) GetLastVerifiedBlockHash(ctx context.Context) (common.Hash, error) {
+// GetLastVerifiedBlock gets the last verified block from TaikoL1 contract.
+func (c *Client) GetLastVerifiedBlock(ctx context.Context) (struct {
+	BlockId    uint64
+	BlockHash  [32]byte
+	StateRoot  [32]byte
+	VerifiedAt uint64
+}, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
-	b, err := c.TaikoL1.GetLastVerifiedBlock(&bind.CallOpts{Context: ctxWithTimeout})
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	return b.BlockHash, nil
+	return c.TaikoL1.GetLastVerifiedBlock(&bind.CallOpts{Context: ctxWithTimeout})
 }
 
 // GetL2BlockInfo fetches the L2 block information from the protocol.

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -502,7 +502,7 @@ func (c *Client) GetProtocolStateVariables(opts *bind.CallOpts) (*struct {
 
 // GetLastVerifiedBlock gets the last verified block from TaikoL1 contract.
 func (c *Client) GetLastVerifiedBlock(ctx context.Context) (struct {
-	BlockId    uint64
+	BlockId    uint64 //nolint:revive,stylecheck
 	BlockHash  [32]byte
 	StateRoot  [32]byte
 	VerifiedAt uint64


### PR DESCRIPTION
ref:
![telegram-cloud-photo-size-5-6053379241615147620-w](https://github.com/user-attachments/assets/def9c273-5058-4d8e-ba4e-629aaf56e95d)

Error in `taiko-geth`:
```
WARN [01-09|02:00:51.973] Served engine_forkchoiceUpdatedV2        conn=[::1]:51920 reqid=324196 duration=8.170036ms err="Invalid forkchoice state" errdata="{\"err\":\"final block not available in database\"}"
```