### PR TITLE
feat(protocol): allow anyone to prove a block before the deadline

### DIFF
--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -237,7 +237,6 @@ interface ITaikoInbox {
     error NotFirstProposal();
     error NotPreconfRouter();
     error ParentMetaHashMismatch();
-    error ProverNotPermitted();
     error SignalNotSent();
     error TimestampSmallerThanParent();
     error TimestampTooLarge();

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -375,6 +375,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
         return true;
     }
 
+    // @inheritdoc IFork
     function isForkActive() external view override returns (bool) {
         return state.stats2.numBatches >= getConfig().forkHeights.pacaya;
     }

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -260,7 +260,6 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
                     uint256 deadline =
                         uint256(meta.proposedAt).max(stats2.lastUnpausedAt) + config.provingWindow;
                     if (block.timestamp <= deadline) {
-                        require(msg.sender == meta.proposer, ProverNotPermitted());
                         _creditBond(meta.proposer, meta.livenessBond);
                     }
 

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -70,7 +70,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
         _proveBatchesWithCorrectTransitions(batchIds);
 
         assertEq(inbox.bondBalanceOf(Alice), bondAmount);
-    } 
+    }
 
     function test_inbox_bonds_debited_on_proposal_not_credited_back_if_proved_after_deadline()
         external

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -54,25 +54,23 @@ contract InboxTest_BondMechanics is InboxTestBase {
         assertEq(inbox.bondBalanceOf(Alice), bondAmount);
     }
 
-    function test_only_proposer_can_prove_block_before_deadline() external {
+    function test_inbox_bonds_debit_and_credit_on_proposal_and_proof_2() external {
         vm.warp(1_000_000);
 
         uint256 initialBondBalance = 100_000 ether;
         uint256 bondAmount = 1000 ether;
 
         setupBondTokenState(Alice, initialBondBalance, bondAmount);
-        setupBondTokenState(Bob, initialBondBalance, bondAmount);
 
         vm.prank(Alice);
         uint64[] memory batchIds = _proposeBatchesWithDefaultParameters(1);
         assertEq(inbox.bondBalanceOf(Alice) < bondAmount, true);
 
         vm.prank(Bob);
-        vm.expectRevert(ITaikoInbox.ProverNotPermitted.selector);
         _proveBatchesWithCorrectTransitions(batchIds);
 
-        assertEq(inbox.bondBalanceOf(Bob), bondAmount);
-    }
+        assertEq(inbox.bondBalanceOf(Alice), bondAmount);
+    } 
 
     function test_inbox_bonds_debited_on_proposal_not_credited_back_if_proved_after_deadline()
         external

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -36,7 +36,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
         bondToken = deployBondToken();
     }
 
-    function test_inbox_bonds_debit_and_credit_on_proposal_and_proof() external {
+    function test_inbox_bonds_debit_and_credit_proved_by_proposer() external {
         vm.warp(1_000_000);
 
         uint256 initialBondBalance = 100_000 ether;
@@ -54,7 +54,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
         assertEq(inbox.bondBalanceOf(Alice), bondAmount);
     }
 
-    function test_inbox_bonds_debit_and_credit_on_proposal_and_proof_2() external {
+    function test_inbox_bonds_debit_and_credit_proved_by_non_proposer() external {
         vm.warp(1_000_000);
 
         uint256 initialBondBalance = 100_000 ether;


### PR DESCRIPTION
Previous: Only the block proposer was allowed to submit proof for a block before the deadline.
Now: Anyone can submit proof for a block before the deadline. However, the liveness bond with the block is returned to the block proposer.