### PR TITLE
chore(protocol): change maxBlocksPerBatch to 768 to support 0.5s average block time

### DIFF
--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -27,7 +27,7 @@ contract DevnetInbox is TaikoInbox {
             }),
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -28,7 +28,7 @@ contract HeklaInbox is TaikoInbox {
              }),
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 840_512,
                 pacaya: 840_512 * 10 // TODO

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -36,7 +36,7 @@ contract MainnetInbox is TaikoInbox {
              }),
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 538_304,
                 pacaya: 538_304 * 10 // TODO

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -26,7 +26,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_BondToken.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondToken.sol
@@ -24,7 +24,7 @@ contract InboxTest_BondToken is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -24,7 +24,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -24,7 +24,7 @@ contract InboxTest_EtherAsBond is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -23,7 +23,7 @@ contract InboxTest_Params is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -23,7 +23,7 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 256,
+            maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }


### PR DESCRIPTION
If the average L2 block time is 0.5 second, then one epoch is 32*12 = 384 seconds, which means 768 blocks.