### PR TITLE
feat(protocol): encode proposer address in L2 block header

### DIFF
--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -128,7 +128,9 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
             txListHash: calldataUsed
                 ? keccak256(_txList)
                 : _calcTxListHash(params.firstBlobIndex, params.numBlobs),
-            extraData: bytes32(uint256(config.baseFeeConfig.sharingPctg)),
+            // Ensure L2 block header has the proposer adddress so that blocks in p2p network can be
+            // verified based on the proposer address.
+            extraData: _encodeExtraData(config.baseFeeConfig.sharingPctg, params.proposer),
             coinbase: params.coinbase,
             batchId: stats2.numBatches,
             gasLimit: config.blockMaxGasLimit,
@@ -668,6 +670,17 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
 
         require(_params.blocks.length != 0, BlockNotFound());
         require(_params.blocks.length <= _maxBlocksPerBatch, TooManyBlocks());
+    }
+
+    function _encodeExtraData(
+        uint8 _baseFeeSharingPctg,
+        address _proposer
+    )
+        private
+        pure
+        returns (bytes32)
+    {
+        return bytes32(uint256(_baseFeeSharingPctg) << 160 | uint160(_proposer));
     }
 
     // Memory-only structs ----------------------------------------------------------------------


### PR DESCRIPTION
Blocks, before being proposed on L1, are now shared by the current proposer in Taiko's P2P network. Prior to this PR, there was no way to verify whether an L2 block originated from the current proposer simply by examining the block itself.

**However, I realized that this PR does not fully address the issue: a malicious node could still broadcast a block using the current proposer's address in the header.**

As a result, this PR will not be merged.


@davidtaikocha It seems in geth, the block must be signed by the preconfer before being broadcasted to p2p.