### PR TITLE
chore(protocol): test TransitionNotFound in getTransition(_batchId, _parentHash)

### DIFF
--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -220,6 +220,17 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
         assertEq(tran.blockHash, correctBlockhash(9));
         assertEq(tran.stateRoot, bytes32(uint256(0)));
 
+        vm.expectRevert(ITaikoInbox.TransitionNotFound.selector);
+        tran = inbox.getTransition(9, uint24(0));
+
+        tran = inbox.getTransition(9, uint24(1));
+        assertEq(tran.parentHash, correctBlockhash(8));
+        assertEq(tran.blockHash, correctBlockhash(9));
+        assertEq(tran.stateRoot, bytes32(uint256(0)));
+
+        vm.expectRevert(ITaikoInbox.TransitionNotFound.selector);
+        tran = inbox.getTransition(9, tran.parentHash);
+
         (batchId, blockId, tran) = inbox.getLastSyncedTransition();
         assertEq(batchId, 5);
         assertEq(blockId, 5);


### PR DESCRIPTION
Before
<img width="1059" alt="Screen Shot 2025-01-19 at 8 59 08 AM" src="https://github.com/user-attachments/assets/6d1575fd-5fdc-4a16-aaeb-cf97092670c6" />


After

<img width="981" alt="Screen Shot 2025-01-19 at 8 59 45 AM" src="https://github.com/user-attachments/assets/9bf013a7-79bd-4a56-86a9-51ce467f5c7b" />

