### PR TITLE
feat(protocol): whitelist addition + deploy script update

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/iface/IPreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/iface/IPreconfWhitelist.sol
@@ -15,6 +15,7 @@ interface IPreconfWhitelist {
     error InvalidOperatorIndex();
     error InvalidOperatorCount();
     error InvalidOperatorAddress();
+    error OperatorAlreadyExists();
 
     /// @notice Adds a new operator to the whitelist.
     /// @param _operatorAddress The address of the operator to be added.

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
@@ -19,7 +19,7 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist {
     // Maps operator index to their corresponding operator addresses
     mapping(uint256 operatorIndex => address operator) public operatorIndexToOperator;
 
-    uint256[50] private __gap;
+    uint256[47] private __gap;
 
     constructor(address _resolver) EssentialContract(_resolver) { }
 

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
@@ -13,6 +13,9 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist {
     // Tracks the total number of operators in the whitelist
     uint256 public operatorCount;
 
+    // Tracks whether an address is an operator
+    mapping(address operator => bool isOperator) public isOperator;
+
     // Maps operator index to their corresponding operator addresses
     mapping(uint256 operatorIndex => address operator) public operatorIndexToOperator;
 
@@ -30,10 +33,11 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist {
         onlyFromOwnerOrNamed(LibStrings.B_PRECONF_WHITELIST_OWNER)
     {
         require(_operatorAddress != address(0), InvalidOperatorAddress());
+        require(!isOperator[_operatorAddress], OperatorAlreadyExists());
 
-        // For simplicity, we assume that the whitelist owner does not add the same operator more
-        // than once.
         operatorIndexToOperator[operatorCount++] = _operatorAddress;
+
+        isOperator[_operatorAddress] = true;
 
         emit OperatorAdded(_operatorAddress);
     }
@@ -55,6 +59,8 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist {
 
             --operatorCount;
         }
+
+        isOperator[removedOperator] = false;
 
         emit OperatorRemoved(removedOperator);
     }

--- a/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
@@ -389,7 +389,10 @@ contract DeployProtocolOnL1 is DeployCapability {
     function deployPreconfContracts(
         address owner,
         address resolver
-    ) private returns (address whitelist, address router) {
+    )
+        private
+        returns (address whitelist, address router)
+    {
         whitelist = deployProxy({
             name: "preconf_whitelist",
             impl: address(new PreconfWhitelist(resolver)),

--- a/packages/protocol/script/layer1/based/deploy_protocol_on_l1.sh
+++ b/packages/protocol/script/layer1/based/deploy_protocol_on_l1.sh
@@ -17,6 +17,7 @@ SHARED_RESOLVER=0x0000000000000000000000000000000000000000 \
 L2_GENESIS_HASH=0xee1950562d42f0da28bd4550d88886bc90894c77c9c9eaefef775d4c8223f259 \
 PAUSE_BRIDGE=true \
 FOUNDRY_PROFILE="layer1" \
+DEPLOY_PRECONF_CONTRACTS=true \
 forge script ./script/layer1/based/DeployProtocolOnL1.s.sol:DeployProtocolOnL1 \
     --fork-url http://localhost:8545 \
     --broadcast \

--- a/packages/protocol/test/layer1/preconf/whitelist/WhitelistTest.t.sol
+++ b/packages/protocol/test/layer1/preconf/whitelist/WhitelistTest.t.sol
@@ -13,6 +13,7 @@ contract WhitelistTest is WhitelistTestBase {
 
         assertEq(whitelist.operatorCount(), 1);
         assertEq(whitelist.operatorIndexToOperator(0), operator);
+        assertEq(whitelist.isOperator(operator), true);
     }
 
     function test_addOperator_onlyOwner() external {
@@ -27,6 +28,20 @@ contract WhitelistTest is WhitelistTestBase {
         vm.prank(whitelistOwner);
         vm.expectRevert(IPreconfWhitelist.InvalidOperatorAddress.selector);
         whitelist.addOperator(address(0));
+    }
+
+    function test_addOperator_alreadyAdded() external {
+        address operator = Bob;
+
+        vm.prank(whitelistOwner);
+        whitelist.addOperator(operator);
+
+        assertEq(whitelist.operatorCount(), 1);
+        assertEq(whitelist.operatorIndexToOperator(0), operator);
+        assertEq(whitelist.isOperator(operator), true);
+
+        vm.expectRevert(IPreconfWhitelist.OperatorAlreadyExists.selector);
+        whitelist.addOperator(operator);
     }
 
     function test_removeOperator() external {
@@ -44,6 +59,7 @@ contract WhitelistTest is WhitelistTestBase {
         assertEq(whitelist.operatorCount(), 2);
         assertEq(whitelist.operatorIndexToOperator(0), Bob);
         assertEq(whitelist.operatorIndexToOperator(1), David);
+        assertEq(whitelist.isOperator(Carol), false);
 
         vm.stopPrank();
     }

--- a/packages/protocol/test/layer1/preconf/whitelist/WhitelistTest.t.sol
+++ b/packages/protocol/test/layer1/preconf/whitelist/WhitelistTest.t.sol
@@ -33,7 +33,7 @@ contract WhitelistTest is WhitelistTestBase {
     function test_addOperator_alreadyAdded() external {
         address operator = Bob;
 
-        vm.prank(whitelistOwner);
+        vm.startPrank(whitelistOwner);
         whitelist.addOperator(operator);
 
         assertEq(whitelist.operatorCount(), 1);
@@ -42,6 +42,8 @@ contract WhitelistTest is WhitelistTestBase {
 
         vm.expectRevert(IPreconfWhitelist.OperatorAlreadyExists.selector);
         whitelist.addOperator(operator);
+
+        vm.stopPrank();
     }
 
     function test_removeOperator() external {


### PR DESCRIPTION
deplying the preconf contracts is now tested with `pnpm run test:deploy:l1`, and as well deployable via our kubernetes scripts for a one-script deploy setup.

We also add a mapping to keep track of operators so we can't double-add by accident., and read offchain if someone is an operator already.