### PR TITLE
refactor(protocol): wrap blob related parameter into `BlobParams` for clarity

### DIFF
--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -29,6 +29,16 @@ interface ITaikoInbox {
         uint8 timeShift;
     }
 
+    struct BlobParams {
+        // The index of the first blob in this batch.
+        uint8 firstBlobIndex;
+        // The number of blobs in this batch. Blobs are initially concatenated and subsequently
+        // decompressed via Zlib.
+        uint8 numBlobs;
+        uint32 byteOffset;
+        uint32 byteSize;
+    }
+
     struct BatchParams {
         address proposer;
         address coinbase;
@@ -36,16 +46,10 @@ interface ITaikoInbox {
         uint64 anchorBlockId;
         bytes32 anchorInput;
         uint64 lastBlockTimestamp;
-        uint32 txListOffset;
-        uint32 txListSize;
-        // The index of the first blob in this batch.
-        uint8 firstBlobIndex;
-        // The number of blobs in this batch. Blobs are initially concatenated and subsequently
-        // decompressed via Zlib.
-        uint8 numBlobs;
         bool revertIfNotFirstProposal;
         bytes32[] signalSlots;
         // Specifies the number of blocks to be generated from this batch.
+        BlobParams blobParams;
         BlockParams[] blocks;
     }
 
@@ -61,15 +65,12 @@ interface ITaikoInbox {
         uint96 livenessBond;
         uint64 proposedAt; // Used by node/client
         uint64 proposedIn; // Used by node/client
-        uint32 txListOffset;
-        uint32 txListSize;
-        uint8 firstBlobIndex;
-        uint8 numBlobs;
         uint64 anchorBlockId;
         bytes32 anchorBlockHash;
         bytes32[] signalSlots;
-        BlockParams[] blocks;
         bytes32 anchorInput;
+        BlockParams[] blocks;
+        BlobParams blobParams;
         LibSharedData.BaseFeeConfig baseFeeConfig;
     }
 

--- a/packages/protocol/test/layer1/Layer1Test.sol
+++ b/packages/protocol/test/layer1/Layer1Test.sol
@@ -32,7 +32,7 @@ contract ConfigurableInbox is TaikoInbox {
         return __config;
     }
 
-    function _calcTxListHash(uint8, uint8) internal pure override returns (bytes32) {
+    function _calcTxListHash(BlobParams memory) internal pure override returns (bytes32) {
         return keccak256("BLOB");
     }
 }

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -87,7 +87,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
 
         ITaikoInbox.BatchParams memory params;
         params.blocks = new ITaikoInbox.BlockParams[](1);
-        params.numBlobs = 1;
+        params.blobParams.numBlobs = 1;
 
         vm.prank(Alice);
 

--- a/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
+++ b/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
@@ -36,15 +36,12 @@ contract MockTaikoInbox is EssentialContract {
             livenessBond: 0, // Mock value
             proposedAt: uint64(block.timestamp),
             proposedIn: uint64(block.number),
-            txListOffset: params.txListOffset,
-            txListSize: params.txListSize,
-            firstBlobIndex: 0,
-            numBlobs: params.numBlobs,
             anchorBlockId: params.anchorBlockId,
             anchorBlockHash: bytes32(0), // Mock value
             signalSlots: params.signalSlots,
             blocks: params.blocks,
             anchorInput: params.anchorInput,
+            blobParams: params.blobParams,
             baseFeeConfig: LibSharedData.BaseFeeConfig({
                 adjustmentQuotient: 0,
                 sharingPctg: 0,

--- a/packages/protocol/test/layer1/preconf/router/RouterTest.t.sol
+++ b/packages/protocol/test/layer1/preconf/router/RouterTest.t.sol
@@ -32,6 +32,8 @@ contract RouterTest is RouterTestBase {
         ITaikoInbox.BlockParams[] memory blockParams = new ITaikoInbox.BlockParams[](1);
         blockParams[0] = ITaikoInbox.BlockParams({ numTransactions: 1, timeShift: 1 });
 
+        ITaikoInbox.BlobParams memory blobParams;
+
         // Create batch params with correct structure
         ITaikoInbox.BatchParams memory params = ITaikoInbox.BatchParams({
             proposer: Carol,
@@ -40,12 +42,9 @@ contract RouterTest is RouterTestBase {
             anchorBlockId: 0,
             anchorInput: bytes32(0),
             lastBlockTimestamp: uint64(block.timestamp),
-            txListOffset: 0,
-            txListSize: 0,
-            firstBlobIndex: 0,
-            numBlobs: 0,
             revertIfNotFirstProposal: false,
             signalSlots: new bytes32[](0),
+            blobParams: blobParams,
             blocks: blockParams
         });
 
@@ -118,6 +117,8 @@ contract RouterTest is RouterTestBase {
         ITaikoInbox.BlockParams[] memory blockParams = new ITaikoInbox.BlockParams[](1);
         blockParams[0] = ITaikoInbox.BlockParams({ numTransactions: 1, timeShift: 1 });
 
+        ITaikoInbox.BlobParams memory blobParams;
+
         // Create batch params with DIFFERENT proposer than sender
         ITaikoInbox.BatchParams memory params = ITaikoInbox.BatchParams({
             proposer: Bob, // Set different proposer than sender (Carol)
@@ -126,12 +127,9 @@ contract RouterTest is RouterTestBase {
             anchorBlockId: 0,
             anchorInput: bytes32(0),
             lastBlockTimestamp: uint64(block.timestamp),
-            txListOffset: 0,
-            txListSize: 0,
-            firstBlobIndex: 0,
-            numBlobs: 0,
             revertIfNotFirstProposal: false,
             signalSlots: new bytes32[](0),
+            blobParams: blobParams,
             blocks: blockParams
         });
 


### PR DESCRIPTION
This make it clearer that the offset and size only apply to data in the blobs, not the calldata txList.