### PR TITLE
feat(protocol): support forced transactions as escape hatch  

### DIFF
--- a/packages/protocol/contracts/layer1/based/IForcedTransactionProvider.sol
+++ b/packages/protocol/contracts/layer1/based/IForcedTransactionProvider.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IForcedTransactionProvider
+/// @custom:security-contact security@taiko.xyz
+interface IForcedTransactionProvider {
+    function consumeForcedTransactions()
+        external
+        returns (bytes memory forcedTxs_, uint96 priorityFee_);
+}

--- a/packages/protocol/contracts/layer1/based/IForcedTransactionProvider.sol
+++ b/packages/protocol/contracts/layer1/based/IForcedTransactionProvider.sol
@@ -6,5 +6,5 @@ pragma solidity ^0.8.24;
 interface IForcedTransactionProvider {
     function consumeForcedTransactions()
         external
-        returns (bytes memory forcedTxs_, uint96 priorityFee_);
+        returns (bytes memory forcedTxs_);
 }

--- a/packages/protocol/contracts/layer1/based/IForcedTransactionStore.sol
+++ b/packages/protocol/contracts/layer1/based/IForcedTransactionStore.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-/// @title IForcedTransactionProvider
+/// @title IForcedTransactionStore
 /// @custom:security-contact security@taiko.xyz
-interface IForcedTransactionProvider {
+interface IForcedTransactionStore {
     function consumeForcedTransactions()
         external
         returns (bytes memory forcedTxs_);

--- a/packages/protocol/contracts/layer1/based/IForcedTransactionStore.sol
+++ b/packages/protocol/contracts/layer1/based/IForcedTransactionStore.sol
@@ -4,7 +4,5 @@ pragma solidity ^0.8.24;
 /// @title IForcedTransactionStore
 /// @custom:security-contact security@taiko.xyz
 interface IForcedTransactionStore {
-    function consumeForcedTransactions()
-        external
-        returns (bytes memory forcedTxs_);
+    function consumeForcedTransactions() external returns (bytes memory forcedTxs_);
 }

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -157,6 +157,8 @@ interface ITaikoInbox {
         uint8 maxSignalsToReceive;
         /// @notice The maximum number of blocks per batch.
         uint16 maxBlocksPerBatch;
+        /// @notice The minimum number of transactions to include in a "forced txs" block.
+        uint16 minForcedTxsPerBlock;
         /// @notice Historical heights of the forks.
         ForkHeights forkHeights;
     }
@@ -243,8 +245,9 @@ interface ITaikoInbox {
     error BatchNotFound();
     error BatchVerified();
     error BlobNotFound();
-    error BlockNotFound();
     error BlobNotSpecified();
+    error BlockNotFound();
+    error BlockTooSmallForForcedTxs();
     error ContractPaused();
     error CustomProposerMissing();
     error CustomProposerNotAllowed();

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -159,6 +159,8 @@ interface ITaikoInbox {
         uint16 maxBlocksPerBatch;
         /// @notice The minimum number of transactions to include in a "forced txs" block.
         uint16 minForcedTxsPerBlock;
+        /// @notice The number of batches between two "forced txs" blocks.
+        uint64 forcedTxsBlockInternal;
         /// @notice Historical heights of the forks.
         ForkHeights forkHeights;
     }

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -209,9 +209,9 @@ interface ITaikoInbox {
 
     /// @notice Emitted when a batch is proposed.
     /// @param meta The metadata of the proposed batch.
-    /// @param calldataUsed Whether calldata is used for txList DA.
+    /// @param forcedTxs Transactions forced to be included in the batch.
     /// @param txListInCalldata The tx list in calldata.
-    event BatchProposed(BatchMetadata meta, bool calldataUsed, bytes txListInCalldata);
+    event BatchProposed(BatchMetadata meta, bytes forcedTxs, bytes txListInCalldata);
 
     /// @notice Emitted when multiple transitions are proved.
     /// @param verifier The address of the verifier.

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -158,7 +158,7 @@ interface ITaikoInbox {
         /// @notice The maximum number of blocks per batch.
         uint16 maxBlocksPerBatch;
         /// @notice The minimum number of transactions to include in a "forced txs" block.
-        uint16 minForcedTxsPerBlock;
+        uint16 minForcedTxsBlockTxCount;
         /// @notice The number of batches between two "forced txs" blocks.
         uint64 forcedTxsBlockInternal;
         /// @notice Historical heights of the forks.

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -29,6 +29,16 @@ interface ITaikoInbox {
         uint8 timeShift;
     }
 
+    struct BlobParams {
+        // The index of the first blob in this batch.
+        uint8 firstBlobIndex;
+        // The number of blobs in this batch. Blobs are initially concatenated and subsequently
+        // decompressed via Zlib.
+        uint8 numBlobs;
+        uint32 byteOffset;
+        uint32 byteSize;
+    }
+
     struct BatchParams {
         address proposer;
         address coinbase;
@@ -36,16 +46,10 @@ interface ITaikoInbox {
         uint64 anchorBlockId;
         bytes32 anchorInput;
         uint64 lastBlockTimestamp;
-        uint32 txListOffset;
-        uint32 txListSize;
-        // The index of the first blob in this batch.
-        uint8 firstBlobIndex;
-        // The number of blobs in this batch. Blobs are initially concatenated and subsequently
-        // decompressed via Zlib.
-        uint8 numBlobs;
         bool revertIfNotFirstProposal;
         bytes32[] signalSlots;
         // Specifies the number of blocks to be generated from this batch.
+        BlobParams blobParams;
         BlockParams[] blocks;
     }
 
@@ -61,15 +65,12 @@ interface ITaikoInbox {
         uint96 livenessBond;
         uint64 proposedAt; // Used by node/client
         uint64 proposedIn; // Used by node/client
-        uint32 txListOffset;
-        uint32 txListSize;
-        uint8 firstBlobIndex;
-        uint8 numBlobs;
         uint64 anchorBlockId;
         bytes32 anchorBlockHash;
         bytes32[] signalSlots;
-        BlockParams[] blocks;
         bytes32 anchorInput;
+        BlockParams[] blocks;
+        BlobParams blobParams;
         LibSharedData.BaseFeeConfig baseFeeConfig;
     }
 

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -159,7 +159,6 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
             });
 
             require(meta_.anchorBlockHash != 0, ZeroAnchorBlockHash());
-            require(meta_.txListHash != 0, BlobNotFound());
             bytes32 metaHash = keccak256(abi.encode(meta_));
 
             Batch storage batch = state.batches[stats2.numBatches % config.batchRingBufferSize];

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -116,7 +116,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
             // forced transactions.
             if (forcedTxs.length != 0) {
                 require(
-                    params.blocks[1].numTransactions >= config.minForcedTxsBlockTxCount,
+                    params.blocks[0].numTransactions >= config.minForcedTxsBlockTxCount,
                     BlockTooSmallForForcedTxs()
                 );
             }

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -12,7 +12,7 @@ import "src/shared/signal/ISignalService.sol";
 import "src/layer1/verifiers/IVerifier.sol";
 import "./IFork.sol";
 import "./ITaikoInbox.sol";
-import "./IForcedTransactionProvider.sol";
+import "./IForcedTransactionStore.sol";
 
 // import "forge-std/src/console2.sol";
 
@@ -108,7 +108,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
             {
                 address provider = resolve(LibStrings.B_FORCED_TX_PROVIDER, true);
                 if (provider != address(0)) {
-                    forcedTxs = IForcedTransactionProvider(provider).consumeForcedTransactions();
+                    forcedTxs = IForcedTransactionStore(provider).consumeForcedTransactions();
                 }
             }
 

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -106,9 +106,9 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
 
             bytes memory forcedTxs = "";
             {
-                address provider = resolve(LibStrings.B_FORCED_TX_PROVIDER, true);
-                if (provider != address(0)) {
-                    forcedTxs = IForcedTransactionStore(provider).consumeForcedTransactions();
+                address store = resolve(LibStrings.B_FORCED_TX_STORE, true);
+                if (store != address(0)) {
+                    forcedTxs = IForcedTransactionStore(store).consumeForcedTransactions();
                 }
             }
 

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -116,7 +116,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
             // forced transactions.
             if (forcedTxs.length != 0) {
                 require(
-                    params.blocks[1].numTransactions >= config.minForcedTxsPerBlock,
+                    params.blocks[1].numTransactions >= config.minForcedTxsBlockTxCount,
                     BlockTooSmallForForcedTxs()
                 );
             }

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -106,12 +106,19 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
 
             bytes memory forcedTxs = "";
             {
-                uint96 priorityFee;
                 address provider = resolve(LibStrings.B_FORCED_TX_PROVIDER, true);
                 if (provider != address(0)) {
-                    (forcedTxs, priorityFee) =
-                        IForcedTransactionProvider(provider).consumeForcedTransactions();
+                    forcedTxs = IForcedTransactionProvider(provider).consumeForcedTransactions();
                 }
+            }
+
+            // If forced txs is not empty, the first block must be big enough to include all these
+            // forced transactions.
+            if (forcedTxs.length != 0) {
+                require(
+                    params.blocks[1].numTransactions >= config.minForcedTxsPerBlock,
+                    BlockTooSmallForForcedTxs()
+                );
             }
 
             // This section constructs the metadata for the proposed batch, which is crucial for
@@ -126,7 +133,11 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
             //  `keccak256(abi.encode("TAIKO_DIFFICULTY", block.number))`
 
             meta_ = BatchMetadata({
-                txListHash: _calcTxListHash(keccak256(forcedTxs), keccak256(_txList), params.blobParams),
+                txListHash: _calcTxListHash(
+                    forcedTxs.length == 0 ? bytes32(0) : keccak256(forcedTxs),
+                    _txList.length == 0 ? bytes32(0) : keccak256(_txList),
+                    params.blobParams
+                ),
                 extraData: bytes32(uint256(config.baseFeeConfig.sharingPctg)),
                 coinbase: params.coinbase,
                 batchId: stats2.numBatches,
@@ -541,7 +552,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
             blobHashes[0] = _forcedTxsHash;
             blobHashes[1] = _txListHash;
             for (uint256 i; i < _blobParams.numBlobs; ++i) {
-                uint j = i + 2;
+                uint256 j = i + 2;
                 blobHashes[j] = blobhash(_blobParams.firstBlobIndex + i);
                 require(blobHashes[j] != 0, BlobNotFound());
             }

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -105,7 +105,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko, IFork {
             );
 
             bytes memory forcedTxs = "";
-            {
+            if (stats2.numBatches % config.forcedTxsBlockInternal == 0) {
                 address store = resolve(LibStrings.B_FORCED_TX_STORE, true);
                 if (store != address(0)) {
                     forcedTxs = IForcedTransactionStore(store).consumeForcedTransactions();

--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -32,7 +32,7 @@ contract DevnetInbox is TaikoInbox {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -32,6 +32,7 @@ contract DevnetInbox is TaikoInbox {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -31,6 +31,7 @@ contract DevnetInbox is TaikoInbox {
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -31,7 +31,7 @@ contract DevnetInbox is TaikoInbox {
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -32,7 +32,7 @@ contract HeklaInbox is TaikoInbox {
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 840_512,

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -33,6 +33,7 @@ contract HeklaInbox is TaikoInbox {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 840_512,
                 pacaya: 840_512 * 10 // TODO

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -32,6 +32,7 @@ contract HeklaInbox is TaikoInbox {
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 840_512,
                 pacaya: 840_512 * 10 // TODO

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -33,7 +33,7 @@ contract HeklaInbox is TaikoInbox {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 840_512,
                 pacaya: 840_512 * 10 // TODO

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -41,6 +41,7 @@ contract MainnetInbox is TaikoInbox {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 538_304,
                 pacaya: 538_304 * 10 // TODO

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -41,7 +41,7 @@ contract MainnetInbox is TaikoInbox {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 538_304,
                 pacaya: 538_304 * 10 // TODO

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -39,7 +39,8 @@ contract MainnetInbox is TaikoInbox {
              }),
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 768,
+             maxBlocksPerBatch: 768,
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 538_304,
                 pacaya: 538_304 * 10 // TODO

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -40,7 +40,7 @@ contract MainnetInbox is TaikoInbox {
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 538_304,

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -39,7 +39,7 @@ contract MainnetInbox is TaikoInbox {
              }),
             provingWindow: 2 hours,
             maxSignalsToReceive: 16,
-             maxBlocksPerBatch: 768,
+            maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({
                 ontake: 538_304,

--- a/packages/protocol/contracts/shared/libs/LibStrings.sol
+++ b/packages/protocol/contracts/shared/libs/LibStrings.sol
@@ -15,6 +15,7 @@ library LibStrings {
     bytes32 internal constant B_ERC1155_VAULT = bytes32("erc1155_vault");
     bytes32 internal constant B_ERC20_VAULT = bytes32("erc20_vault");
     bytes32 internal constant B_ERC721_VAULT = bytes32("erc721_vault");
+    bytes32 internal constant B_FORCED_TX_PROVIDER = bytes32("forced_tx_provider");
     bytes32 internal constant B_PRECONF_ROUTER = bytes32("preconf_router");
     bytes32 internal constant B_PRECONF_WHITELIST = bytes32("preconf_whitelist");
     bytes32 internal constant B_PRECONF_WHITELIST_OWNER = bytes32("preconf_whitelist_owner");

--- a/packages/protocol/contracts/shared/libs/LibStrings.sol
+++ b/packages/protocol/contracts/shared/libs/LibStrings.sol
@@ -15,7 +15,7 @@ library LibStrings {
     bytes32 internal constant B_ERC1155_VAULT = bytes32("erc1155_vault");
     bytes32 internal constant B_ERC20_VAULT = bytes32("erc20_vault");
     bytes32 internal constant B_ERC721_VAULT = bytes32("erc721_vault");
-    bytes32 internal constant B_FORCED_TX_PROVIDER = bytes32("forced_tx_provider");
+    bytes32 internal constant B_FORCED_TX_STORE = bytes32("forced_tx_store");
     bytes32 internal constant B_PRECONF_ROUTER = bytes32("preconf_router");
     bytes32 internal constant B_PRECONF_WHITELIST = bytes32("preconf_whitelist");
     bytes32 internal constant B_PRECONF_WHITELIST_OWNER = bytes32("preconf_whitelist_owner");

--- a/packages/protocol/test/layer1/Layer1Test.sol
+++ b/packages/protocol/test/layer1/Layer1Test.sol
@@ -32,8 +32,8 @@ contract ConfigurableInbox is TaikoInbox {
         return __config;
     }
 
-    function _calcTxListHash(bytes32 , bytes32 , BlobParams memory ) internal pure override returns (bytes32) {
-        return keccak256("BLOB");
+    function _calcTxListHash(bytes32 , bytes32 _txListHash , BlobParams memory ) internal pure override returns (bytes32) {
+        return _txListHash;
     }
 }
 

--- a/packages/protocol/test/layer1/Layer1Test.sol
+++ b/packages/protocol/test/layer1/Layer1Test.sol
@@ -32,7 +32,7 @@ contract ConfigurableInbox is TaikoInbox {
         return __config;
     }
 
-    function _calcTxListHash(uint8, uint8) internal pure override returns (bytes32) {
+    function _calcTxListHash(BlobParams memory) internal pure override returns (bytes32) {
         return keccak256("BLOB");
     }
 }

--- a/packages/protocol/test/layer1/Layer1Test.sol
+++ b/packages/protocol/test/layer1/Layer1Test.sol
@@ -32,7 +32,7 @@ contract ConfigurableInbox is TaikoInbox {
         return __config;
     }
 
-    function _calcTxListHash(BlobParams memory) internal pure override returns (bytes32) {
+    function _calcTxListHash(bytes32 , bytes32 , BlobParams memory ) internal pure override returns (bytes32) {
         return keccak256("BLOB");
     }
 }

--- a/packages/protocol/test/layer1/Layer1Test.sol
+++ b/packages/protocol/test/layer1/Layer1Test.sol
@@ -32,7 +32,16 @@ contract ConfigurableInbox is TaikoInbox {
         return __config;
     }
 
-    function _calcTxListHash(bytes32 , bytes32 _txListHash , BlobParams memory ) internal pure override returns (bytes32) {
+    function _calcTxListHash(
+        bytes32,
+        bytes32 _txListHash,
+        BlobParams memory
+    )
+        internal
+        pure
+        override
+        returns (bytes32)
+    {
         return _txListHash;
     }
 }

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -27,6 +27,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -27,7 +27,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -26,7 +26,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -26,6 +26,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
@@ -27,7 +27,7 @@ contract InboxTest_BondToken is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
@@ -26,6 +26,7 @@ contract InboxTest_BondToken is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
@@ -27,6 +27,7 @@ contract InboxTest_BondToken is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
@@ -26,7 +26,7 @@ contract InboxTest_BondToken is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -25,7 +25,9 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 768,
+             maxBlocksPerBatch: 768,
+            
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -27,6 +27,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -25,8 +25,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-             maxBlocksPerBatch: 768,
-            
+            maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -95,7 +95,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
 
         // With empty txList
         ITaikoInbox.BatchMetadata memory meta = inbox.proposeBatch(abi.encode(params), "");
-        assertTrue(meta.txListHash != 0, "txListHash should not be zero for valid blobIndex");
+        assertEq(meta.txListHash, 0);
 
         _saveMetadata(meta);
 

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -87,7 +87,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
 
         ITaikoInbox.BatchParams memory params;
         params.blocks = new ITaikoInbox.BlockParams[](1);
-        params.numBlobs = 1;
+        params.blobParams.numBlobs = 1;
 
         vm.prank(Alice);
 

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -26,7 +26,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -27,7 +27,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -27,7 +27,7 @@ contract InboxTest_EtherAsBond is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -25,8 +25,7 @@ contract InboxTest_EtherAsBond is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-             maxBlocksPerBatch: 768,
-            
+            maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -26,7 +26,7 @@ contract InboxTest_EtherAsBond is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -25,7 +25,9 @@ contract InboxTest_EtherAsBond is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 768,
+             maxBlocksPerBatch: 768,
+            
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -27,6 +27,7 @@ contract InboxTest_EtherAsBond is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -26,7 +26,7 @@ contract InboxTest_Params is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -24,7 +24,9 @@ contract InboxTest_Params is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 768,
+             maxBlocksPerBatch: 768,
+            
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -24,8 +24,7 @@ contract InboxTest_Params is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-             maxBlocksPerBatch: 768,
-            
+            maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -26,6 +26,7 @@ contract InboxTest_Params is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -25,7 +25,7 @@ contract InboxTest_Params is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -26,6 +26,7 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -25,7 +25,7 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -26,7 +26,7 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -24,7 +24,9 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-            maxBlocksPerBatch: 768,
+             maxBlocksPerBatch: 768,
+            
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -24,8 +24,7 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
              }),
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
-             maxBlocksPerBatch: 768,
-            
+            maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
@@ -26,7 +26,7 @@ contract InboxTest_StopBatch is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
-            forcedTxsBlockInternal: 1024,
+            forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
@@ -25,6 +25,7 @@ contract InboxTest_StopBatch is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
+            minForcedTxsPerBlock: 256,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
@@ -25,7 +25,7 @@ contract InboxTest_StopBatch is InboxTestBase {
             provingWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
-            minForcedTxsPerBlock: 256,
+            minForcedTxsBlockTxCount: 256,
             forcedTxsBlockInternal: 128,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });

--- a/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
@@ -26,6 +26,7 @@ contract InboxTest_StopBatch is InboxTestBase {
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             minForcedTxsPerBlock: 256,
+            forcedTxsBlockInternal: 1024,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
         });
     }

--- a/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
+++ b/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
@@ -36,15 +36,12 @@ contract MockTaikoInbox is EssentialContract {
             livenessBond: 0, // Mock value
             proposedAt: uint64(block.timestamp),
             proposedIn: uint64(block.number),
-            txListOffset: params.txListOffset,
-            txListSize: params.txListSize,
-            firstBlobIndex: 0,
-            numBlobs: params.numBlobs,
             anchorBlockId: params.anchorBlockId,
             anchorBlockHash: bytes32(0), // Mock value
             signalSlots: params.signalSlots,
             blocks: params.blocks,
             anchorInput: params.anchorInput,
+            blobParams: params.blobParams,
             baseFeeConfig: LibSharedData.BaseFeeConfig({
                 adjustmentQuotient: 0,
                 sharingPctg: 0,

--- a/packages/protocol/test/layer1/preconf/router/RouterTest.t.sol
+++ b/packages/protocol/test/layer1/preconf/router/RouterTest.t.sol
@@ -32,6 +32,8 @@ contract RouterTest is RouterTestBase {
         ITaikoInbox.BlockParams[] memory blockParams = new ITaikoInbox.BlockParams[](1);
         blockParams[0] = ITaikoInbox.BlockParams({ numTransactions: 1, timeShift: 1 });
 
+        ITaikoInbox.BlobParams memory blobParams;
+
         // Create batch params with correct structure
         ITaikoInbox.BatchParams memory params = ITaikoInbox.BatchParams({
             proposer: Carol,
@@ -40,12 +42,9 @@ contract RouterTest is RouterTestBase {
             anchorBlockId: 0,
             anchorInput: bytes32(0),
             lastBlockTimestamp: uint64(block.timestamp),
-            txListOffset: 0,
-            txListSize: 0,
-            firstBlobIndex: 0,
-            numBlobs: 0,
             revertIfNotFirstProposal: false,
             signalSlots: new bytes32[](0),
+            blobParams: blobParams,
             blocks: blockParams
         });
 
@@ -118,6 +117,8 @@ contract RouterTest is RouterTestBase {
         ITaikoInbox.BlockParams[] memory blockParams = new ITaikoInbox.BlockParams[](1);
         blockParams[0] = ITaikoInbox.BlockParams({ numTransactions: 1, timeShift: 1 });
 
+        ITaikoInbox.BlobParams memory blobParams;
+
         // Create batch params with DIFFERENT proposer than sender
         ITaikoInbox.BatchParams memory params = ITaikoInbox.BatchParams({
             proposer: Bob, // Set different proposer than sender (Carol)
@@ -126,12 +127,9 @@ contract RouterTest is RouterTestBase {
             anchorBlockId: 0,
             anchorInput: bytes32(0),
             lastBlockTimestamp: uint64(block.timestamp),
-            txListOffset: 0,
-            txListSize: 0,
-            firstBlobIndex: 0,
-            numBlobs: 0,
             revertIfNotFirstProposal: false,
             signalSlots: new bytes32[](0),
+            blobParams: blobParams,
             blocks: blockParams
         });
 


### PR DESCRIPTION
This PR adds forced transaction supportas escape hatchwhen rollup proposers become overly centralized.  

## Key Implementation:

A block will now support 3 L2 transaction data sources at the same time:  

  - `forcedTxs`: Read from ForcedTransactionStore (empty if invalid decoding/non-existent).  
  - `txList`: Calldata from `proposeBatch` function.  
  - `blobs`: Data from 0+ blobs, concatenated before processing. 
 

## Data-to-Block Conversion Flow

1. Each source is zlib-decoded into transaction lists **A** (`forcedTxs`), **B** (`txList`), **C** (blob data). Invalid results become empty lists.  
2. Transactions are concatenated into final list **T** = **A** + **B** + **C** (notice the order)
3. L2 blocks are built from **T** by:  
   - Taking up to `blockParams.numTransactions` transactions per L2 block.
   - Removing invalid transactions (e.g., bad nonce, insufficient Ether balance)
   - Truncating transactions exceeding the block’s gas limit (discarded permanently, not reused by next block).  

This ensures forced transactions bypass centralized proposers while maintaining validity and gas constraints.

@davidcardenasus @smtmfft we need to talk about this PR ASAP.

## TODO
- [ ] copy the conversion flow as net-spec comments to TaikoInbox.sol.