### PR TITLE
feat(protocol): router based forced tx inclusion

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/iface/IPreconfRouter.sol
+++ b/packages/protocol/contracts/layer1/preconf/iface/IPreconfRouter.sol
@@ -6,8 +6,23 @@ import "src/layer1/based/ITaikoInbox.sol";
 /// @title IPreconfRouter
 /// @custom:security-contact security@taiko.xyz
 interface IPreconfRouter {
+
+    struct ForcedTx {
+        bytes txList;
+        uint256 timestamp;
+        bool included;
+        uint256 stakeAmount;
+    }
+
+    error ForcedTxListAlreadyIncluded();
+    error ForcedTxListAlreadyStored();
+    error ForcedTxListHashNotFound();
+    error InsufficientStakeAmount();
     error NotTheOperator();
     error ProposerIsNotTheSender();
+
+
+    event ForcedTxStored(bytes indexed txHash, uint256 timestamp);
 
     /// @notice Proposes a batch of blocks that have been preconfed.
     /// @dev This function only accepts batches from an operator selected to preconf in a particular
@@ -19,8 +34,13 @@ interface IPreconfRouter {
     function proposePreconfedBlocks(
         bytes calldata _params,
         bytes calldata _batchParams,
-        bytes calldata _batchTxList
+        bytes calldata _batchTxList,
+        bool force
     )
         external
         returns (ITaikoInbox.BatchMetadata memory meta_);
+
+    function updateBaseStakeAmount(uint256 _newBaseStakeAmount) external;
+
+    function storeForcedTx(bytes calldata _txList) payable external;
 }

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
@@ -4,33 +4,95 @@ pragma solidity ^0.8.24;
 import "../iface/IPreconfRouter.sol";
 import "../iface/IPreconfWhitelist.sol";
 import "src/layer1/based/ITaikoInbox.sol";
+import "src/shared/libs/LibAddress.sol";
 import "src/shared/libs/LibStrings.sol";
 import "src/shared/common/EssentialContract.sol";
 
 /// @title PreconfRouter
 /// @custom:security-contact security@taiko.xyz
 contract PreconfRouter is EssentialContract, IPreconfRouter {
-    uint256[50] private __gap;
+    mapping(bytes32 => ForcedTx) public forcedTxLists;
 
-    constructor(address _resolver) EssentialContract(_resolver) { }
+    uint256 public pendingForcedTxHashes;
+    
+    uint256 public inclusionWindow;
+
+    uint256 public baseStakeAmount;
+
+    uint256[46] private __gap;
+
+    constructor(address _resolver, uint256 _inclusionWindow, uint256 _baseStakeAmount) EssentialContract(_resolver) {
+        inclusionWindow = _inclusionWindow;
+        baseStakeAmount = _baseStakeAmount;
+    }
 
     function init(address _owner) external initializer {
         __Essential_init(_owner);
+    }
+
+    function updateBaseStakeAmount(uint256 _newBaseStakeAmount) external onlyOwner {
+        baseStakeAmount = _newBaseStakeAmount;
+    }
+
+    function getRequiredStakeAmount() public view returns (uint256) {
+        uint256 multiplier = pendingForcedTxHashes == 0 ? 1 : pendingForcedTxHashes;
+        return baseStakeAmount * multiplier;
+    }
+
+    function storeForcedTx(bytes calldata _txList) payable external {
+        uint256 requiredStake = getRequiredStakeAmount();
+        require(msg.value >= requiredStake, InsufficientStakeAmount());
+
+        bytes32 txListHash = keccak256(_txList);
+        require(forcedTxLists[txListHash].timestamp == 0, ForcedTxListAlreadyStored());
+
+        forcedTxLists[txListHash] = ForcedTx({
+            txList: _txList,
+            timestamp: block.timestamp,
+            included: false,
+            stakeAmount: msg.value
+        });
+
+        pendingForcedTxHashes++;
+
+        emit ForcedTxStored(_txList, block.timestamp);
     }
 
     /// @inheritdoc IPreconfRouter
     function proposePreconfedBlocks(
         bytes calldata,
         bytes calldata _batchParams,
-        bytes calldata _batchTxList
+        bytes calldata _batchTxList,
+        bool force
     )
         external
         returns (ITaikoInbox.BatchMetadata memory meta_)
     {
-        // Sender must be the selected operator for the epoch
+        bytes32 forcedTxListHash = keccak256(_batchTxList);
+        
+        // Sender must be the selected operator for the epoch, or able to propose a forced txList
+        // after the inclusion window has expired
         address selectedOperator =
             IPreconfWhitelist(resolve(LibStrings.B_PRECONF_WHITELIST, false)).getOperatorForEpoch();
-        require(msg.sender == selectedOperator, NotTheOperator());
+        
+        if(force) {
+            require(msg.sender == selectedOperator || canProposeFallback(forcedTxListHash), NotTheOperator());
+        } else {
+            require(msg.sender == selectedOperator, NotTheOperator());
+        }
+
+         if (force) {
+            require(forcedTxLists[forcedTxListHash].timestamp != 0, ForcedTxListHashNotFound());
+            require(!forcedTxLists[forcedTxListHash].included, ForcedTxListAlreadyIncluded());
+
+            // Pay out the stake to the proposer
+            LibAddress.sendEtherAndVerify(msg.sender, forcedTxLists[forcedTxListHash].stakeAmount);
+
+            pendingForcedTxHashes--;
+
+            forcedTxLists[forcedTxListHash].included = true;
+        }
+
 
         // Call the proposeBatch function on the TaikoInbox
         address taikoInbox = resolve(LibStrings.B_TAIKO, false);
@@ -38,5 +100,10 @@ contract PreconfRouter is EssentialContract, IPreconfRouter {
 
         // Verify that the sender had set itself as the proposer
         require(meta_.proposer == msg.sender, ProposerIsNotTheSender());
+    }
+
+     function canProposeFallback(bytes32 _forcedTxHash) public view returns (bool) {
+        return block.timestamp > forcedTxLists[_forcedTxHash].timestamp + inclusionWindow &&
+            !forcedTxLists[_forcedTxHash].included;
     }
 }

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
@@ -35,7 +35,7 @@ contract PreconfRouter is EssentialContract, IPreconfRouter {
     }
 
     function getRequiredStakeAmount() public view returns (uint256) {
-        uint256 multiplier = pendingForcedTxHashes == 0 ? 1 : pendingForcedTxHashes;
+        return (2 ** pendingForcedTxHashes).max(4096) * baseStakeAmount;
         return baseStakeAmount * multiplier;
     }
 

--- a/packages/protocol/script/layer1/preconf/DeployPreconfContracts.s.sol
+++ b/packages/protocol/script/layer1/preconf/DeployPreconfContracts.s.sol
@@ -23,11 +23,10 @@ contract DeployPreconfContracts is BaseScript {
             address(new PreconfWhitelist(sharedResolver)),
             abi.encodeCall(PreconfWhitelist.init, (contractOwner))
         );
-
         // Deploy PreconfRouter
         deploy(
             LibStrings.B_PRECONF_ROUTER,
-            address(new PreconfRouter(sharedResolver)),
+            address(new PreconfRouter(sharedResolver, vm.envUint("INCLUSION_WINDOW"), vm.envUint("BASE_STAKE_AMOUNT"))),
             abi.encodeCall(PreconfRouter.init, (contractOwner))
         );
     }

--- a/packages/protocol/test/layer1/preconf/router/RouterTestBase.sol
+++ b/packages/protocol/test/layer1/preconf/router/RouterTestBase.sol
@@ -11,10 +11,15 @@ abstract contract RouterTestBase is Layer1Test {
     PreconfWhitelist internal whitelist;
     address internal routerOwner;
     address internal whitelistOwner;
+    bytes internal testTxList = "test transaction list";
+    bytes32 internal testTxListHash;
+    uint256 internal initialTimestamp;
 
     function setUpOnEthereum() internal virtual override {
         routerOwner = Alice;
         whitelistOwner = Alice;
+        testTxListHash = keccak256(testTxList);
+        initialTimestamp = block.timestamp;
 
         vm.chainId(1);
 
@@ -37,7 +42,7 @@ abstract contract RouterTestBase is Layer1Test {
         router = PreconfRouter(
             deploy({
                 name: "preconf_router",
-                impl: address(new PreconfRouter(address(resolver))),
+                impl: address(new PreconfRouter(address(resolver), 60, 0.01 ether)),
                 data: abi.encodeCall(PreconfRouter.init, (routerOwner))
             })
         );


### PR DESCRIPTION
offchain, in the gateway itself, we can:
in the gateway itself, we can:
1) add listeners for the events
2) call forcedTxList = preconfRouter.forcedTxLists[keccak256(event.txList)]
3) check forcedTxList.included
4) if !forcedTxList.included, propose a batch with that txList immediately to get it out of the way

if that isnt done, anyone can propose the block after `inclusionWindow` passes. TaikoInbox remains untouched.

Needs some more tests, and some are failing, but please look over @dantaik @AnshuJalan @davidtaikocha 