### PR TITLE
fix(protocol): check proposer param must be msg.sender in PreconfRouter

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/iface/IPreconfRouter.sol
+++ b/packages/protocol/contracts/layer1/preconf/iface/IPreconfRouter.sol
@@ -6,6 +6,7 @@ import "src/layer1/based/ITaikoInbox.sol";
 /// @title IPreconfRouter
 /// @custom:security-contact security@taiko.xyz
 interface IPreconfRouter {
+    error InvalidParams();
     error NotTheOperator();
     error ProposerIsNotTheSender();
 

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
@@ -27,6 +27,11 @@ contract PreconfRouter is EssentialContract, IPreconfRouter {
         external
         returns (ITaikoInbox.BatchMetadata memory meta_)
     {
+        // Make sure the proposer must be the msg.sender itself.
+        ITaikoInbox.BatchParams memory batchParams =
+            abi.decode(_batchParams, (ITaikoInbox.BatchParams));
+        require(msg.sender == batchParams.proposer, InvalidParams());
+
         // Sender must be the selected operator for the epoch
         address selectedOperator =
             IPreconfWhitelist(resolve(LibStrings.B_PRECONF_WHITELIST, false)).getOperatorForEpoch();

--- a/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
@@ -97,7 +97,7 @@ contract InboxTest_BondToken is InboxTestBase {
         inbox.depositBond(depositAmount);
     }
 
-    function test_inbox_exceeding_balance() external {
+    function test_inbox_exceeding_token_balance() external {
         vm.warp(1_000_000);
         vm.deal(Alice, 1000 ether);
 

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -68,7 +68,7 @@ contract InboxTest_EtherAsBond is InboxTestBase {
         inbox.withdrawBond(withdrawAmount);
     }
 
-    function test_inbox_exceeding_balance() external {
+    function test_inbox_exceeding_ether_balance() external {
         vm.warp(1_000_000);
         vm.deal(Alice, 0.5 ether);
 

--- a/packages/protocol/test/layer1/preconf/router/RouterTest.t.sol
+++ b/packages/protocol/test/layer1/preconf/router/RouterTest.t.sol
@@ -85,13 +85,16 @@ contract RouterTest is RouterTestBase {
         // Warp to arbitrary slot in epoch 2
         vm.warp(epochTwoStart + 2 * LibPreconfConstants.SECONDS_IN_SLOT);
 
+        ITaikoInbox.BatchParams memory batchParams;
+        batchParams.proposer = David;
+
         // Prank as David (not the selected operator) and propose blocks
         vm.prank(David);
         vm.expectRevert(IPreconfRouter.NotTheOperator.selector);
-        router.proposePreconfedBlocks("", "", "");
+        router.proposePreconfedBlocks("", abi.encode(batchParams), "");
     }
 
-    function test_proposePreconfedBlocks_proposerNotSender() external {
+    function test_proposePreconfedBlocks_InvalidProposerParam() external {
         address[] memory operators = new address[](3);
         operators[0] = Bob;
         operators[1] = Carol;
@@ -138,7 +141,56 @@ contract RouterTest is RouterTestBase {
 
         // Prank as Carol (selected operator) and propose blocks
         vm.prank(Carol);
-        vm.expectRevert(IPreconfRouter.ProposerIsNotTheSender.selector);
+        vm.expectRevert(IPreconfRouter.InvalidParams.selector);
+        router.proposePreconfedBlocks("", abi.encode(params), "");
+    }
+
+    function test_proposePreconfedBlocks_proposerNotSender() external {
+        address[] memory operators = new address[](1);
+        operators[0] = Bob;
+        addOperators(operators);
+
+        // Setup mock beacon for operator selection
+        vm.chainId(1);
+        uint256 epochOneStart = LibPreconfConstants.getGenesisTimestamp(block.chainid);
+        // Current epoch
+        uint256 epochTwoStart = epochOneStart + LibPreconfConstants.SECONDS_IN_EPOCH;
+
+        MockBeaconBlockRoot mockBeacon = new MockBeaconBlockRoot();
+        bytes32 mockRoot = bytes32(uint256(1)); // This will select Carol
+
+        address beaconBlockRootContract = LibPreconfConstants.getBeaconBlockRootContract();
+        vm.etch(beaconBlockRootContract, address(mockBeacon).code);
+        MockBeaconBlockRoot(payable(beaconBlockRootContract)).set(
+            epochOneStart + LibPreconfConstants.SECONDS_IN_SLOT, mockRoot
+        );
+
+        // Setup block params
+        ITaikoInbox.BlockParams[] memory blockParams = new ITaikoInbox.BlockParams[](1);
+        blockParams[0] = ITaikoInbox.BlockParams({ numTransactions: 1, timeShift: 1 });
+
+        ITaikoInbox.BlobParams memory blobParams;
+
+        // Create batch params with DIFFERENT proposer than sender
+        ITaikoInbox.BatchParams memory params = ITaikoInbox.BatchParams({
+            proposer: Carol, // Set different proposer than sender (Carol)
+            coinbase: address(0),
+            parentMetaHash: bytes32(0),
+            anchorBlockId: 0,
+            anchorInput: bytes32(0),
+            lastBlockTimestamp: uint64(block.timestamp),
+            revertIfNotFirstProposal: false,
+            signalSlots: new bytes32[](0),
+            blobParams: blobParams,
+            blocks: blockParams
+        });
+
+        // Warp to arbitrary slot in epoch 2
+        vm.warp(epochTwoStart + 2 * LibPreconfConstants.SECONDS_IN_SLOT);
+
+        // Prank as Carol (selected operator) and propose blocks
+        vm.prank(Carol);
+        vm.expectRevert(IPreconfRouter.NotTheOperator.selector);
         router.proposePreconfedBlocks("", abi.encode(params), "");
     }
 }


### PR DESCRIPTION
This was reported by OZ. Note that same issue also exist in our main branch, but the code will not be used in production for Hekla/Mainnet.


> Possible to Debit Bond Balances from Any Account
> Taiko developed the PreconfTaskManager and related smart contracts to address preconfirmation challenges in based rollups. In this approach, users that want to execute transaction pass them to a proposer, who provides a preconfirmation that can be used to penalize the proposer if the transaction is not included. At the start of each epoch, a proposer is designated for the next epoch. Once the PreconfTaskManager is deployed and the appropriate name is assigned in the resolver, the designated proposer calls the newBlockProposals[ function](https://github.com/PufferFinance/unifi-mono/blob/afd0c91dda95f56050fc36bb7188742a1402d267/packages/protocol/contracts/layer1/preconf/impl/PreconfTaskManager.sol#L89), triggering a block proposal in TaikoL1 after stake locking and other parameter validations. Notably, there is no validation of the blockParamsArr[argument](https://github.com/PufferFinance/unifi-mono/blob/afd0c91dda95f56050fc36bb7188742a1402d267/packages/protocol/contracts/layer1/preconf/impl/PreconfTaskManager.sol#L129) in this workflow.
In the TaikoL1[ contract](https://github.com/PufferFinance/unifi-mono/blob/afd0c91dda95f56050fc36bb7188742a1402d267/packages/protocol/contracts/layer1/based/TaikoL1.sol#L71-L83), LibProposing’s proposeBlocks function manages block proposals by calling _proposeBlock for each proposed block. After verifying the block number, it retrieves the preconfTaskManager[ address](https://github.com/PufferFinance/unifi-mono/blob/afd0c91dda95f56050fc36bb7188742a1402d267/packages/protocol/contracts/layer1/based/LibProposing.sol#L142-L146). If that address is set, only PreconfTaskManager is allowed to propose blocks, and the actual proposer is assumed to be encoded in the _params argument. This argument is decoded and checked in _validateParams. If _local.params.proposer[ is set to a non-zero address](https://github.com/PufferFinance/unifi-mono/blob/afd0c91dda95f56050fc36bb7188742a1402d267/packages/protocol/contracts/layer1/based/LibProposing.sol#L246-L251), the caller must be the designated proposer or _local.allowCustomProposer must be true (which it is when called through PreconfTaskManager). In case of default values, the contract will compute and assign the correct values on its own. The decoded proposer address [is written to the block metadata](https://github.com/PufferFinance/unifi-mono/blob/afd0c91dda95f56050fc36bb7188742a1402d267/packages/protocol/contracts/layer1/based/LibProposing.sol#L174) stored in the contract’s blocks, and the [proposer’s bond balance is debited](https://github.com/PufferFinance/unifi-mono/blob/afd0c91dda95f56050fc36bb7188742a1402d267/packages/protocol/contracts/layer1/based/LibProposing.sol#L226) by the livenessBond amount of 125 Taiko tokens. Because any address can be passed as the proposer, an external actor can effectively debit tokens from an arbitrary account. The actor can also provide invalid data in the proposed block to dispute it and potentially claim part of specified proposer’s bond balance.
Consider implementing verification of both the caller and the proposer address in the PreconfTaskManager contract and the LibProposing library to ensure only the genuine proposer’s bond is debited.