### PR TITLE
feat(protocol): add back cooldown settings

### DIFF
--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -170,6 +170,8 @@ interface ITaikoInbox {
         LibSharedData.BaseFeeConfig baseFeeConfig;
         /// @notice The proving window in seconds.
         uint16 provingWindow;
+        /// @notice The time required for a transition to be used for verifying a batch.
+        uint16 cooldownWindow;
         /// @notice The maximum number of signals to be received by TaikoL2.
         uint8 maxSignalsToReceive;
         /// @notice The maximum number of blocks per batch.

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -106,6 +106,7 @@ interface ITaikoInbox {
         bytes32 stateRoot;
         address prover;
         bool inProvingWindow;
+        uint48 createdAt;
     }
 
     /// @notice 3 slots used.

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -172,7 +172,7 @@ interface ITaikoInbox {
         /// @notice The proving window in seconds.
         uint16 provingWindow;
         /// @notice The time required for a transition to be used for verifying a batch.
-        uint16 cooldownWindow;
+        uint24 cooldownWindow;
         /// @notice The maximum number of signals to be received by TaikoL2.
         uint8 maxSignalsToReceive;
         /// @notice The maximum number of blocks per batch.

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -12,8 +12,6 @@ import "src/shared/signal/ISignalService.sol";
 import "src/layer1/verifiers/IVerifier.sol";
 import "./ITaikoInbox.sol";
 
-// import "forge-std/src/console2.sol";
-
 /// @title TaikoInbox
 /// @notice Acts as the inbox for the Taiko Alethia protocol, a simplified version of the
 /// original Taiko-Based Contestable Rollup (BCR). The tier-based proof system and

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -285,7 +285,8 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
 
             ts.inProvingWindow = inProvingWindow;
             ts.prover = inProvingWindow ? meta.proposer : msg.sender;
-
+            ts.createdAt = uint48(block.timestamp);
+            
             if (tid == 1) {
                 ts.parentHash = tran.parentHash;
             } else {
@@ -628,7 +629,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
                 }
 
                 unchecked {
-                    if (uint256(ts.createdAt) + _config.cooldownWindow < block.timestamp) {
+                    if (ts.createdAt + _config.cooldownWindow < block.timestamp) {
                         break;
                     }
                 }

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -355,6 +355,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
         ts.prover = _prover;
         ts.inProvingWindow = _inProvingWindow;
         ts.createdAt = uint48(block.timestamp);
+        
         if (tid == 1) {
             ts.parentHash = _parentHash;
         } else {

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -354,7 +354,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
         ts.blockHash = _blockHash;
         ts.prover = _prover;
         ts.inProvingWindow = _inProvingWindow;
-
+        ts.createdAt = uint48(block.timestamp);
         if (tid == 1) {
             ts.parentHash = _parentHash;
         } else {
@@ -364,7 +364,14 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
         emit TransitionWritten(
             _batchId,
             tid,
-            TransitionState(_parentHash, _blockHash, _stateRoot, _prover, _inProvingWindow)
+            TransitionState(
+                _parentHash,
+                _blockHash,
+                _stateRoot,
+                _prover,
+                _inProvingWindow,
+                uint48(block.timestamp)
+            )
         );
     }
 
@@ -617,6 +624,12 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
                     ts = state.transitions[slot][tid];
                 } else {
                     break;
+                }
+
+                unchecked {
+                    if (uint256(ts.createdAt) + _config.cooldownWindow < block.timestamp) {
+                        break;
+                    }
                 }
 
                 blockHash = ts.blockHash;

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -12,6 +12,8 @@ import "src/shared/signal/ISignalService.sol";
 import "src/layer1/verifiers/IVerifier.sol";
 import "./ITaikoInbox.sol";
 
+// import "forge-std/src/console2.sol";
+
 /// @title TaikoInbox
 /// @notice Acts as the inbox for the Taiko Alethia protocol, a simplified version of the
 /// original Taiko-Based Contestable Rollup (BCR). The tier-based proof system and
@@ -286,7 +288,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
             ts.inProvingWindow = inProvingWindow;
             ts.prover = inProvingWindow ? meta.proposer : msg.sender;
             ts.createdAt = uint48(block.timestamp);
-            
+
             if (tid == 1) {
                 ts.parentHash = tran.parentHash;
             } else {
@@ -356,7 +358,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
         ts.prover = _prover;
         ts.inProvingWindow = _inProvingWindow;
         ts.createdAt = uint48(block.timestamp);
-        
+
         if (tid == 1) {
             ts.parentHash = _parentHash;
         } else {
@@ -629,7 +631,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, ITaiko {
                 }
 
                 unchecked {
-                    if (ts.createdAt + _config.cooldownWindow < block.timestamp) {
+                    if (ts.createdAt + _config.cooldownWindow > block.timestamp) {
                         break;
                     }
                 }

--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -29,6 +29,7 @@ contract DevnetInbox is TaikoInbox {
                 maxGasIssuancePerBlock: 600_000_000
             }),
             provingWindow: 2 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -29,7 +29,7 @@ contract DevnetInbox is TaikoInbox {
                 maxGasIssuancePerBlock: 600_000_000
             }),
             provingWindow: 2 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -30,6 +30,7 @@ contract HeklaInbox is TaikoInbox {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
             provingWindow: 2 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -30,7 +30,7 @@ contract HeklaInbox is TaikoInbox {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
             provingWindow: 2 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -38,7 +38,7 @@ contract MainnetInbox is TaikoInbox {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 2 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -38,6 +38,7 @@ contract MainnetInbox is TaikoInbox {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 2 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({

--- a/packages/protocol/test/layer1/based/InboxTestBase.sol
+++ b/packages/protocol/test/layer1/based/InboxTestBase.sol
@@ -220,6 +220,7 @@ abstract contract InboxTestBase is Layer1Test {
                     unicode"│    │    └── inProvingWindow:",
                     ts.inProvingWindow ? "Y" : "N"
                 );
+                console2.log(unicode"│    │    └── createdAt:", ts.createdAt);
             }
         }
         console2.log("");

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -24,6 +24,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -24,7 +24,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
@@ -24,6 +24,7 @@ contract InboxTest_BondToken is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondToken.t.sol
@@ -24,7 +24,7 @@ contract InboxTest_BondToken is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -24,6 +24,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -24,7 +24,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_Cooldown.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Cooldown.t.sol
@@ -35,7 +35,7 @@ contract InboxTest_Cooldownis is InboxTestBase {
         bondToken = deployBondToken();
     }
 
-    function test_inbox_cooldown_blocks_will_not_verify()
+    function test_inbox_batches_cannot_verify_inside_cooldown_window()
         external
         WhenEachBatchHasMultipleBlocks(7)
         transactBy(Alice)

--- a/packages/protocol/test/layer1/based/InboxTest_Cooldown.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Cooldown.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "./InboxTestBase.sol";
+
+contract InboxTest_Cooldownis is InboxTestBase {
+    function pacayaConfig() internal pure override returns (ITaikoInbox.Config memory) {
+        return ITaikoInbox.Config({
+            chainId: LibNetwork.TAIKO_MAINNET,
+            maxUnverifiedBatches: 10,
+            batchRingBufferSize: 15,
+            maxBatchesToVerify: 20,
+            blockMaxGasLimit: 240_000_000,
+            livenessBondBase: 125e18, // 125 Taiko token per batch
+            livenessBondPerBlock: 5e18, // 5 Taiko token per block
+            stateRootSyncInternal: 5,
+            maxAnchorHeightOffset: 64,
+            baseFeeConfig: LibSharedData.BaseFeeConfig({
+                adjustmentQuotient: 8,
+                sharingPctg: 75,
+                gasIssuancePerSecond: 5_000_000,
+                minGasExcess: 1_340_000_000, // correspond to 0.008847185 gwei basefee
+                maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
+             }),
+            provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
+            maxSignalsToReceive: 16,
+            maxBlocksPerBatch: 768,
+            forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
+        });
+    }
+
+    function setUpOnEthereum() internal override {
+        super.setUpOnEthereum();
+        bondToken = deployBondToken();
+    }
+
+    function test_inbox_cooldown_blocks_will_not_verify()
+        external
+        WhenEachBatchHasMultipleBlocks(7)
+        transactBy(Alice)
+        WhenMultipleBatchesAreProposedWithDefaultParameters(9)
+        WhenMultipleBatchesAreProvedWithCorrectTransitions(1, 10)
+        WhenLogAllBatchesAndTransitions
+    {
+        // - All stats are correct and expected
+        ITaikoInbox.Stats1 memory stats1 = inbox.getStats1();
+        assertEq(stats1.lastSyncedBatchId, 0);
+        assertEq(stats1.lastSyncedAt, 0);
+
+        ITaikoInbox.Stats2 memory stats2 = inbox.getStats2();
+        assertEq(stats2.numBatches, 10);
+        assertEq(stats2.lastVerifiedBatchId, 0);
+        assertEq(stats2.paused, false);
+        assertEq(stats2.lastProposedIn, block.number);
+        assertEq(stats2.lastUnpausedAt, 0);
+
+        vm.warp(block.timestamp + pacayaConfig().cooldownWindow);
+        _proveBatchesWithWrongTransitions(range(1, 10));
+
+        stats2 = inbox.getStats2();
+        assertEq(stats2.numBatches, 10);
+        assertEq(stats2.lastVerifiedBatchId, 9);
+    }
+}

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -24,6 +24,7 @@ contract InboxTest_EtherAsBond is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_EtherAsBond.t.sol
@@ -24,7 +24,7 @@ contract InboxTest_EtherAsBond is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -23,7 +23,7 @@ contract InboxTest_Params is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -23,6 +23,7 @@ contract InboxTest_Params is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -23,6 +23,7 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -23,7 +23,7 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
@@ -23,7 +23,7 @@ contract InboxTest_StopBatch is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
-            cooldownWindow: 1 hours,
+            cooldownWindow: 0 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_StopBatch.t.sol
@@ -23,6 +23,7 @@ contract InboxTest_StopBatch is InboxTestBase {
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
             maxSignalsToReceive: 16,
             maxBlocksPerBatch: 768,
             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })

--- a/packages/protocol/test/layer1/team/tokenunlock/TokenUnlock_ProverSet.t.sol
+++ b/packages/protocol/test/layer1/team/tokenunlock/TokenUnlock_ProverSet.t.sol
@@ -31,8 +31,8 @@ pragma solidity ^0.8.24;
 //                 minGasExcess: 1_340_000_000, // correspond to 0.008847185 gwei basefee
 //                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
 //              }),
-//             provingWindow: 1 hours,
-//             maxSignalsToReceive: 16,
+//             provingWindow: 1 hours,             cooldownWindow: 1 hours,//             maxSignalsToReceive:
+// 16,
 //             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
 //         });
 //     }

--- a/packages/protocol/test/layer1/team/tokenunlock/TokenUnlock_ProverSet.t.sol
+++ b/packages/protocol/test/layer1/team/tokenunlock/TokenUnlock_ProverSet.t.sol
@@ -32,7 +32,7 @@ pragma solidity ^0.8.24;
 //                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
 //              }),
 //             provingWindow: 1 hours,
-//             cooldownWindow: 1 hours,
+//             cooldownWindow: 0 hours,
 //             maxSignalsToReceive: 16,
 //             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
 //         });

--- a/packages/protocol/test/layer1/team/tokenunlock/TokenUnlock_ProverSet.t.sol
+++ b/packages/protocol/test/layer1/team/tokenunlock/TokenUnlock_ProverSet.t.sol
@@ -31,8 +31,9 @@ pragma solidity ^0.8.24;
 //                 minGasExcess: 1_340_000_000, // correspond to 0.008847185 gwei basefee
 //                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
 //              }),
-//             provingWindow: 1 hours,             cooldownWindow: 1 hours,//             maxSignalsToReceive:
-// 16,
+//             provingWindow: 1 hours,
+//             cooldownWindow: 1 hours,
+//             maxSignalsToReceive: 16,
 //             forkHeights: ITaikoInbox.ForkHeights({ ontake: 0, pacaya: 0 })
 //         });
 //     }


### PR DESCRIPTION
This cooldown window enables pausing proof verifier and block verification if conflicting proofs are verified on-chain. It can be set to 0 to disable the feature, with minimal additional gas cost.