### PR TITLE
feat(taiko-client): add proof type to batch proof acceptance log messages

### DIFF
--- a/packages/taiko-client/prover/proof_submitter/transaction/sender.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/sender.go
@@ -187,7 +187,7 @@ func (s *Sender) SendBatchProof(
 	}
 
 	log.Info(
-		fmt.Sprintf("🚚 Your %s batch proof were accepted", getProofTypeString(batchProof.Tier)),
+		fmt.Sprintf("🚚 Your %s batch proofs were accepted", getProofTypeString(batchProof.Tier)),
 		"txHash", receipt.TxHash,
 		"tier", batchProof.Tier,
 		"blockIDs", batchProof.BlockIDs,

--- a/packages/taiko-client/prover/proof_submitter/transaction/sender.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/sender.go
@@ -43,6 +43,27 @@ func NewSender(
 	}
 }
 
+func getProofTypeString(tier uint16) string {
+	switch tier {
+	case encoding.TierOptimisticID:
+		return "Optimistic"
+	case encoding.TierSgxID:
+		return "SGX"
+	case encoding.TierZkVMRisc0ID:
+		return "ZK-RISC0"
+	case encoding.TierZkVMSp1ID:
+		return "ZK-SP1"
+	case encoding.TierSgxAndZkVMID:
+		return "SGX+ZK"
+	case encoding.TierGuardianMinorityID:
+		return "Guardian-Minority"
+	case encoding.TierGuardianMajorityID:
+		return "Guardian-Majority"
+	default:
+		return "Unknown"
+	}
+}
+
 // Send sends the given proof to the TaikoL1 smart contract with a backoff policy.
 func (s *Sender) Send(
 	ctx context.Context,
@@ -166,7 +187,7 @@ func (s *Sender) SendBatchProof(
 	}
 
 	log.Info(
-		"🚚 Your batch proofs were accepted",
+		fmt.Sprintf("🚚 Your %s batch proof was accepted", getProofTypeString(batchProof.Tier)),
 		"txHash", receipt.TxHash,
 		"tier", batchProof.Tier,
 		"blockIDs", batchProof.BlockIDs,

--- a/packages/taiko-client/prover/proof_submitter/transaction/sender.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/sender.go
@@ -187,7 +187,7 @@ func (s *Sender) SendBatchProof(
 	}
 
 	log.Info(
-		fmt.Sprintf("🚚 Your %s batch proof was accepted", getProofTypeString(batchProof.Tier)),
+		fmt.Sprintf("🚚 Your %s batch proof were accepted", getProofTypeString(batchProof.Tier)),
 		"txHash", receipt.TxHash,
 		"tier", batchProof.Tier,
 		"blockIDs", batchProof.BlockIDs,


### PR DESCRIPTION

Enhances proof acceptance logs by displaying the proof type (Optimistic/SGX/ZK) in batch proof submission confirmations.


**Changes:**

- Added "getProofTypeString" function to map tier IDs to human-readable names
- Updated batch proof acceptance log to include proof type

Example output:

```
"🚚 Your SGX batch proofs were accepted"
"🚚 Your Optimistic batch proofs were accepted"
```

Tested with multiple proof types (Optimistic, SGX)
Verified log formatting and message clarity
