### PR TITLE
fix(protocol): fee recipient in taiko wrapper

### DIFF
--- a/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
@@ -88,10 +88,10 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
     )
         internal
     {
-        IForcedInclusionStore.ForcedInclusion memory inclusion =
-            _store.consumeOldestForcedInclusion(msg.sender);
-
         ITaikoInbox.BatchParams memory p = abi.decode(_bytesX, (ITaikoInbox.BatchParams));
+
+        IForcedInclusionStore.ForcedInclusion memory inclusion =
+            _store.consumeOldestForcedInclusion(p.proposer);
 
         uint256 numBlocks = p.blocks.length;
         require(numBlocks != 0, NoBlocks());


### PR DESCRIPTION
Issue pointed out by Lin - the feeRecipient was set to the msg.sender i.e the preconf router, which is problematic. Changed it to the custom proposer.