### PR TITLE
feat(protocol): add function in preconf whitelist to retrieve operator for next epoch

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/iface/IPreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/iface/IPreconfWhitelist.sol
@@ -16,6 +16,7 @@ interface IPreconfWhitelist {
     error InvalidOperatorCount();
     error InvalidOperatorAddress();
     error OperatorAlreadyExists();
+    error OperatorNotAvailableYet();
 
     /// @notice Adds a new operator to the whitelist.
     /// @param _operatorAddress The address of the operator to be added.
@@ -32,5 +33,11 @@ interface IPreconfWhitelist {
     /// @dev Uses the beacon block root of the first block in the last epoch as the source
     ///      of randomness.
     /// @return The address of the operator.
-    function getOperatorForEpoch() external view returns (address);
+    function getOperatorForCurrentEpoch() external view returns (address);
+
+    /// @notice Retrieves the address of the operator for the next epoch.
+    /// @dev Uses the beacon block root of the first block in the current epoch as the source
+    ///      of randomness.
+    /// @return The address of the operator.
+    function getOperatorForNextEpoch() external view returns (address);
 }

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
@@ -38,7 +38,7 @@ contract PreconfRouter is EssentialContract, IPreconfRouter {
         returns (ITaikoInbox.BatchInfo memory info_, ITaikoInbox.BatchMetadata memory meta_)
     {
         // Sender must be the selected operator for the epoch
-        address selectedOperator = IPreconfWhitelist(preconfWhitelist).getOperatorForEpoch();
+        address selectedOperator = IPreconfWhitelist(preconfWhitelist).getOperatorForCurrentEpoch();
         require(msg.sender == selectedOperator, NotTheOperator());
 
         // Both TaikoInbox and TaikoWrapper implement the same ABI for proposeBatch.

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
@@ -66,7 +66,7 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist {
     }
 
     /// @inheritdoc IPreconfWhitelist
-    function getOperatorForEpoch() external view returns (address) {
+    function getOperatorForCurrentEpoch() external view returns (address) {
         uint256 _operatorCount = operatorCount;
         require(_operatorCount != 0, InvalidOperatorCount());
 
@@ -76,6 +76,25 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist {
         // Use the beacon block root at the first block of the last epoch as the
         // source of randomness
         bytes32 randomness = LibPreconfUtils.getBeaconBlockRoot(timestampOfLastEpoch);
+        uint256 index = uint256(randomness) % _operatorCount;
+        return operatorIndexToOperator[index];
+    }
+
+    /// @inheritdoc IPreconfWhitelist
+    function getOperatorForNextEpoch() external view returns (address) {
+        uint256 _operatorCount = operatorCount;
+        require(_operatorCount != 0, InvalidOperatorCount());
+
+        // Timestamp at which the current epoch started
+        uint256 timestampOfCurrentEpoch = LibPreconfUtils.getEpochTimestamp();
+
+        // We can only get the beacon block root of the first block in the current
+        // epoch from the second block onward.
+        require(block.timestamp > timestampOfCurrentEpoch, OperatorNotAvailableYet());
+
+        // Use the beacon block root at the first block of the current epoch as the
+        // source of randomness
+        bytes32 randomness = LibPreconfUtils.getBeaconBlockRoot(timestampOfCurrentEpoch);
         uint256 index = uint256(randomness) % _operatorCount;
         return operatorIndexToOperator[index];
     }

--- a/packages/protocol/test/layer1/preconf/whitelist/WhitelistTest.t.sol
+++ b/packages/protocol/test/layer1/preconf/whitelist/WhitelistTest.t.sol
@@ -95,7 +95,7 @@ contract WhitelistTest is WhitelistTestBase {
         vm.stopPrank();
     }
 
-    function test_getOperatorForEpoch_immediateRoot() external {
+    function test_getOperatorForCurrentEpoch_immediateRoot() external {
         address[] memory operators = new address[](3);
         operators[0] = Bob;
         operators[1] = Carol;
@@ -124,11 +124,11 @@ contract WhitelistTest is WhitelistTestBase {
             epochOneStart + LibPreconfConstants.SECONDS_IN_SLOT, mockRoot
         );
 
-        address selectedOperator = whitelist.getOperatorForEpoch();
+        address selectedOperator = whitelist.getOperatorForCurrentEpoch();
         assertEq(selectedOperator, Carol);
     }
 
-    function test_getOperatorForEpoch_iteratedRoot() external {
+    function test_getOperatorForCurrentEpoch_iteratedRoot() external {
         address[] memory operators = new address[](3);
         operators[0] = Bob;
         operators[1] = Carol;
@@ -157,12 +157,12 @@ contract WhitelistTest is WhitelistTestBase {
             epochOneStart + LibPreconfConstants.SECONDS_IN_SLOT * 3, mockRoot
         );
 
-        address selectedOperator = whitelist.getOperatorForEpoch();
+        address selectedOperator = whitelist.getOperatorForCurrentEpoch();
         assertEq(selectedOperator, Carol);
     }
 
-    function test_getOperatorForEpoch_emptyList() external {
+    function test_getOperatorForCurrentEpoch_emptyList() external {
         vm.expectRevert(IPreconfWhitelist.InvalidOperatorCount.selector);
-        whitelist.getOperatorForEpoch();
+        whitelist.getOperatorForCurrentEpoch();
     }
 }


### PR DESCRIPTION
This function will help the client abstract away the logic of fallback operator selection.