### PR TITLE
fix(protocol): add proposeIn into forced inclusion structure

### DIFF
--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -44,6 +44,8 @@ interface ITaikoInbox {
         uint32 byteOffset;
         // The byte size of the blob.
         uint32 byteSize;
+        // The block number who holds the blob.
+        uint64 submittedIn;
     }
 
     struct BatchParams {

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -150,7 +150,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
                 blobHashes: new bytes32[](0), // to be initialised later
                 extraData: bytes32(uint256(config.baseFeeConfig.sharingPctg)),
                 coinbase: params.coinbase,
-                proposedIn: uint64(block.number),
+                proposedIn: params.blobParams.submittedIn, // use blob info even if txList is used
                 blobByteOffset: params.blobParams.byteOffset,
                 blobByteSize: params.blobParams.byteSize,
                 gasLimit: config.blockMaxGasLimit,

--- a/packages/protocol/contracts/layer1/forced-inclusion/ForcedInclusionStore.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/ForcedInclusionStore.sol
@@ -67,6 +67,7 @@ contract ForcedInclusionStore is EssentialContract, IForcedInclusionStore {
 
         ForcedInclusion memory inclusion = ForcedInclusion({
             blobHash: blobHash,
+            proposedIn: uint64(block.number),
             feeInGwei: uint64(msg.value / 1 gwei),
             createdAtBatchId: _nextBatchId(),
             blobByteOffset: blobByteOffset,

--- a/packages/protocol/contracts/layer1/forced-inclusion/IForcedInclusionStore.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/IForcedInclusionStore.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.24;
 interface IForcedInclusionStore {
     struct ForcedInclusion {
         bytes32 blobHash;
+        uint64 proposedIn;
         uint64 feeInGwei;
         uint64 createdAtBatchId;
         uint32 blobByteOffset;


### PR DESCRIPTION
A problem here for https://github.com/taikoxyz/taiko-mono/pull/18909/files is the forced inclusion batch uses a previous blob , but its block id is missed when we get the block proposal event. 
Not sure if reuse blob param is a good idea or not (since there is a txlist calldata path), maybe better to add this field in BatchParam.
