### PR TITLE
feat(protocol): add blobCreatedIn to BlobParams

### DIFF
--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -44,7 +44,7 @@ interface ITaikoInbox {
         uint32 byteOffset;
         // The byte size of the blob.
         uint32 byteSize;
-        //
+        // The block number when the blob was created.
         uint64 createdIn;
     }
 

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -44,6 +44,8 @@ interface ITaikoInbox {
         uint32 byteOffset;
         // The byte size of the blob.
         uint32 byteSize;
+        //
+        uint64 createdIn;
     }
 
     struct BatchParams {
@@ -68,6 +70,7 @@ interface ITaikoInbox {
         bytes32 extraData;
         address coinbase;
         uint64 proposedIn; // Used by node/client
+        uint64 blobCreatedIn;
         uint32 blobByteOffset;
         uint32 blobByteSize;
         uint32 gasLimit;
@@ -271,6 +274,7 @@ interface ITaikoInbox {
     error EtherNotPaidAsBond();
     error ForkNotActivated();
     error InsufficientBond();
+    error InvalidBlobCreatedIn();
     error InvalidBlobParams();
     error InvalidGenesisBlockHash();
     error InvalidParams();

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -95,9 +95,13 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
 
                     // blob hashes are only accepted if the caller is trusted.
                     require(params.blobParams.blobHashes.length == 0, InvalidBlobParams());
+
+                    require(params.blobParams.createdIn == 0, InvalidBlobCreatedIn());
+                    params.blobParams.createdIn = uint64(block.number);
                 } else {
                     require(msg.sender == inboxWrapper, NotInboxWrapper());
                     require(params.proposer != address(0), CustomProposerMissing());
+                    require(params.blobParams.createdIn != 0, InvalidBlobCreatedIn());
                 }
 
                 if (params.coinbase == address(0)) {
@@ -118,6 +122,8 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
                     require(params.blobParams.numBlobs == 0, InvalidBlobParams());
                     require(params.blobParams.firstBlobIndex == 0, InvalidBlobParams());
                 }
+            } else {
+                params.blobParams.createdIn = 0;
             }
 
             // Keep track of last batch's information.
@@ -151,6 +157,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
                 extraData: bytes32(uint256(config.baseFeeConfig.sharingPctg)),
                 coinbase: params.coinbase,
                 proposedIn: uint64(block.number),
+                blobCreatedIn: params.blobParams.createdIn,
                 blobByteOffset: params.blobParams.byteOffset,
                 blobByteSize: params.blobParams.byteSize,
                 gasLimit: config.blockMaxGasLimit,

--- a/packages/protocol/contracts/layer1/forced-inclusion/ForcedInclusionStore.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/ForcedInclusionStore.sol
@@ -70,7 +70,8 @@ contract ForcedInclusionStore is EssentialContract, IForcedInclusionStore {
             feeInGwei: uint64(msg.value / 1 gwei),
             createdAtBatchId: _nextBatchId(),
             blobByteOffset: blobByteOffset,
-            blobByteSize: blobByteSize
+            blobByteSize: blobByteSize,
+            blobCreatedIn: uint64(block.number)
         });
 
         queue[tail++] = inclusion;

--- a/packages/protocol/contracts/layer1/forced-inclusion/IForcedInclusionStore.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/IForcedInclusionStore.sol
@@ -10,6 +10,7 @@ interface IForcedInclusionStore {
         uint64 createdAtBatchId;
         uint32 blobByteOffset;
         uint32 blobByteSize;
+        uint64 blobCreatedIn;
     }
 
     /// @dev Event emitted when a forced inclusion is stored.

--- a/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
@@ -43,6 +43,7 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
     error InvalidBlobHash();
     error InvalidBlobByteOffset();
     error InvalidBlobByteSize();
+    error InvalidBlobCreatedIn();
     error OldestForcedInclusionDue();
 
     uint16 public constant MIN_TXS_PER_FORCED_INCLUSION = 512;
@@ -116,6 +117,7 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
         require(p.blobParams.blobHashes[0] == inclusion.blobHash, InvalidBlobHash());
         require(p.blobParams.byteOffset == inclusion.blobByteOffset, InvalidBlobByteOffset());
         require(p.blobParams.byteSize == inclusion.blobByteSize, InvalidBlobByteSize());
+        require(p.blobParams.createdIn == inclusion.blobCreatedIn, InvalidBlobCreatedIn());
 
         emit ForcedInclusionProcessed(inclusion);
     }

--- a/packages/protocol/test/layer1/forced-inclusion/ForcedInclusionStore.t.sol
+++ b/packages/protocol/test/layer1/forced-inclusion/ForcedInclusionStore.t.sol
@@ -77,7 +77,8 @@ contract ForcedInclusionStoreTest is ForcedInclusionStoreTestBase {
                 uint64 feeInGwei,
                 uint64 createdAt,
                 uint32 blobByteOffset,
-                uint32 blobByteSize
+                uint32 blobByteSize,
+                uint64 blobCreatedIn
             ) = store.queue(store.tail() - 1);
 
             assertEq(blobHash, bytes32(uint256(i + 1))); //  = blobIndex + 1
@@ -85,6 +86,7 @@ contract ForcedInclusionStoreTest is ForcedInclusionStoreTestBase {
             assertEq(feeInGwei, _feeInGwei);
             assertEq(blobByteOffset, 0);
             assertEq(blobByteSize, 1024);
+            assertEq(blobCreatedIn, uint64(block.number));
         }
     }
 

--- a/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
+++ b/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
@@ -34,6 +34,7 @@ contract MockTaikoInbox is EssentialContract {
             lastBlockId: 0,
             lastBlockTimestamp: 0,
             proposedIn: uint64(block.number),
+            blobCreatedIn: 0,
             anchorBlockId: params.anchorBlockId,
             anchorBlockHash: bytes32(0), // Mock value
             blocks: params.blocks,


### PR DESCRIPTION
A problem here for https://github.com/taikoxyz/taiko-mono/pull/18909/files is the forced inclusion batch uses a previous blob , but its block id is missed when we get the block proposal event. 
Not sure if reuse blob param is a good idea or not (since there is a txlist calldata path), maybe better to add this field in BatchParam.
