### PR TITLE
fix(taiko-client): pacaya block timestamp

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/blob/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/blocks_inserter/pacaya.go
@@ -144,7 +144,7 @@ func (i *BlocksInserterPacaya) InsertBlocks(
 			return fmt.Errorf("failed to calculate difficulty: %w", err)
 		}
 		timestamp := meta.GetLastBlockTimestamp()
-		for i := len(meta.GetBlocks()) - 1; i >= 0; i-- {
+		for i := len(meta.GetBlocks()) - 1; i > j; i-- {
 			timestamp = timestamp - uint64(meta.GetBlocks()[i].TimeShift)
 		}
 


### PR DESCRIPTION
The pacaya block A's timestamp should be `the LastBlockTimestamp` - the sum of `TimeShift` of the blocks behind A.