### PR TITLE
fix(taiko-client): decompress transaction list when inserting the preconf block

### DIFF
--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -785,7 +785,7 @@ func (s *DriverTestSuite) insertPreconfBlock(
 	)
 	s.Nil(err)
 
-	b, err := rlp.EncodeToBytes(types.Transactions{anchorTx, signedTx})
+	b, err := utils.EncodeAndCompressTxList(types.Transactions{anchorTx, signedTx})
 	s.Nil(err)
 
 	extraData := encoding.EncodeBaseFeeConfig(s.d.protocolConfig.BaseFeeConfig())


### PR DESCRIPTION
Preconf API receives the compressed transactions, geth consensus API uses the depressed transactions and p2p sync receives the compressed txs.