### PR TITLE
fix(taiko-client): check if preconfirmation whitelist address is set before fetching it

### DIFF
--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -81,8 +81,8 @@ var (
 		EnvVars:  []string{"PRECONFIRMATION_SERVER_SIGNATURE_CHECK"},
 	}
 	PreconfWhitelistAddress = &cli.StringFlag{
-		Name:     "preconfWhitelist",
-		Usage:    "PreconfWhitelist L1 `address`",
+		Name:     "preconfirmation.whitelist",
+		Usage:    "PreconfWhitelist contract L1 `address`",
 		Required: false,
 		Category: driverCategory,
 		EnvVars:  []string{"PRECONF_WHITELIST"},

--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -85,7 +85,7 @@ var (
 		Usage:    "PreconfWhitelist contract L1 `address`",
 		Required: false,
 		Category: driverCategory,
-		EnvVars:  []string{"PRECONF_WHITELIST"},
+		EnvVars:  []string{"PRECONFIRMATION_WHITELIST"},
 	}
 )
 

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -1109,6 +1109,10 @@ func (c *Client) GetProofVerifierPacaya(opts *bind.CallOpts) (common.Address, er
 
 // GetPreconfWhiteListOperator resolves the current preconf whitelist operator address.
 func (c *Client) GetPreconfWhiteListOperator(opts *bind.CallOpts) (common.Address, error) {
+	if c.PacayaClients.PreconfWhitelist == nil {
+		return common.Address{}, errors.New("preconf whitelist contract is not set")
+	}
+
 	var cancel context.CancelFunc
 	if opts == nil {
 		opts = &bind.CallOpts{Context: context.Background()}


### PR DESCRIPTION
Since `--preconfirmation.whitelist` is not a required flag.