### PR TITLE
feat(protocol): invalidate existing conflicting transition

### DIFF
--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -253,12 +253,6 @@ interface ITaikoInbox {
     /// @param blockHash The hash of the verified batch.
     event BatchesVerified(uint64 batchId, bytes32 blockHash);
 
-    /// @notice Emitted when a transition is written to the state by the owner.
-    /// @param batchId The ID of the batch containing the transition.
-    /// @param tid The ID of the transition within the batch.
-    /// @param ts The transition state written.
-    event TransitionWritten(uint64 batchId, uint24 tid, TransitionState ts);
-
     error AnchorBlockIdSmallerThanParent();
     error AnchorBlockIdTooLarge();
     error AnchorBlockIdTooSmall();

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -292,8 +292,9 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
                 hasConflictingProof = true;
                 emit ConflictingProof(meta.batchId, _ts, tran);
 
-                // Invalidate the previous transition
+                // Invalidate the existing transition
                 state.transitions[slot][tid].blockHash = 0;
+
                 // Do not save this transition
                 continue;
             }

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -7,6 +7,12 @@ import "../based/TaikoInbox.sol";
 /// @dev Labeled in address resolver as "taiko"
 /// @custom:security-contact security@taiko.xyz
 contract HeklaInbox is TaikoInbox {
+    /// @notice Emitted when a transition is written to the state by the owner.
+    /// @param batchId The ID of the batch containing the transition.
+    /// @param tid The ID of the transition within the batch.
+    /// @param ts The transition state written.
+    event TransitionWritten(uint64 batchId, uint24 tid, TransitionState ts);
+
     constructor(
         address _wrapper,
         address _verifier,
@@ -15,6 +21,62 @@ contract HeklaInbox is TaikoInbox {
     )
         TaikoInbox(_wrapper, _verifier, _bondToken, _signalService)
     { }
+
+    /// @notice Manually write a transition for a batch.
+    /// @dev This function is supposed to be used by the owner to force prove a transition for a
+    /// block that has not been verified.
+    function writeTransition(
+        uint64 _batchId,
+        bytes32 _parentHash,
+        bytes32 _blockHash,
+        bytes32 _stateRoot,
+        address _prover,
+        bool _inProvingWindow
+    )
+        external
+        onlyOwner
+    {
+        require(_blockHash != 0, InvalidParams());
+        require(_parentHash != 0, InvalidParams());
+        require(_stateRoot != 0, InvalidParams());
+        require(_batchId > state.stats2.lastVerifiedBatchId, BatchVerified());
+
+        Config memory config = pacayaConfig();
+        uint256 slot = _batchId % config.batchRingBufferSize;
+        Batch storage batch = state.batches[slot];
+        require(batch.batchId == _batchId, BatchNotFound());
+
+        uint24 tid = state.transitionIds[_batchId][_parentHash];
+        if (tid == 0) {
+            tid = batch.nextTransitionId++;
+        }
+
+        TransitionState storage ts = state.transitions[slot][tid];
+        ts.stateRoot = _batchId % config.stateRootSyncInternal == 0 ? _stateRoot : bytes32(0);
+        ts.blockHash = _blockHash;
+        ts.prover = _prover;
+        ts.inProvingWindow = _inProvingWindow;
+        ts.createdAt = uint48(block.timestamp);
+
+        if (tid == 1) {
+            ts.parentHash = _parentHash;
+        } else {
+            state.transitionIds[_batchId][_parentHash] = tid;
+        }
+
+        emit TransitionWritten(
+            _batchId,
+            tid,
+            TransitionState(
+                _parentHash,
+                _blockHash,
+                _stateRoot,
+                _prover,
+                _inProvingWindow,
+                uint48(block.timestamp)
+            )
+        );
+    }
 
     function pacayaConfig() public pure override returns (ITaikoInbox.Config memory) {
         return ITaikoInbox.Config({


### PR DESCRIPTION
Previously, when a new transition conflicted with an existing one, we still saved it. Now, instead of saving the conflicting transition, we mark the existing one as invalid by setting its blockHash to 0. This way, once the prover/verifier is fixed, there’s no need for manual cleanup of invalid transitions.

To retain the `writeTransition` function, I moved it to `HeklaInbox`.