### PR TITLE
fix(protocol): fix the same or the conflicted transaction

### DIFF
--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -287,13 +287,14 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
 
                 bool isSameTransition = _ts.blockHash == tran.blockHash
                     && (_ts.stateRoot == 0 || _ts.stateRoot == tran.stateRoot);
-                require(!isSameTransition, SameTransition());
 
-                hasConflictingProof = true;
-                emit ConflictingProof(meta.batchId, _ts, tran);
+                if (!isSameTransition) {
+                    hasConflictingProof = true;
+                    emit ConflictingProof(meta.batchId, _ts, tran);
 
-                // Invalidate the existing transition
-                state.transitions[slot][tid].blockHash = 0;
+                    // Invalidate the conflict transition
+                    state.transitions[slot][tid].blockHash = 0;
+                }
 
                 // Do not save this transition
                 continue;

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -463,7 +463,7 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
         }
     }
 
-    function test_inbox_reprove_the_same_batch_with_same_transition_will_revert()
+    function test_inbox_reprove_the_same_batch_with_same_transition_will_do_nothing()
         external
         transactBy(Alice)
         WhenMultipleBatchesAreProposedWithDefaultParameters(1)
@@ -481,8 +481,9 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
         inbox.proveBatches(abi.encode(metas, transitions), "proof");
         _logAllBatchesAndTransitions();
 
-        vm.expectRevert(ITaikoInbox.SameTransition.selector);
         inbox.proveBatches(abi.encode(metas, transitions), "proof");
+
+        assertTrue(!EssentialContract(address(inbox)).paused());
     }
 
     function test_inbox_reprove_by_transition_with_same_parent_hash_but_different_block_hash_or_state_root_will_pause_inbox(


### PR DESCRIPTION
The fix is based on the following rules:
1. It appears to be the same transaction, do nothing;
2. A conflict has been detected, the inbox should be paused;
3. Store a new one;