### PR TITLE
feat(taiko-client): remove signature verification in `PreconfBlockAPIServer.BuildPreconfBlock`

### DIFF
--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -73,13 +73,6 @@ var (
 		Value:    "*",
 		EnvVars:  []string{"PRECONFIRMATION_SERVER_CORS_ORIGINS"},
 	}
-	PreconfBlockServerCheckSig = &cli.BoolFlag{
-		Name:     "preconfirmation.signatureCheck",
-		Usage:    "If the preconfirmation block server will check the signature of the incoming preconf blocks",
-		Category: driverCategory,
-		Value:    false,
-		EnvVars:  []string{"PRECONFIRMATION_SERVER_SIGNATURE_CHECK"},
-	}
 	PreconfWhitelistAddress = &cli.StringFlag{
 		Name:     "preconfirmation.whitelist",
 		Usage:    "PreconfWhitelist contract L1 `address`",
@@ -104,6 +97,5 @@ var DriverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	PreconfBlockServerPort,
 	PreconfBlockServerJWTSecret,
 	PreconfBlockServerCORSOrigins,
-	PreconfBlockServerCheckSig,
 	PreconfWhitelistAddress,
 }, p2pFlags.P2PFlags("PRECONFIRMATION"))

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -137,7 +137,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		PreconfBlockServerPort:        c.Uint64(flags.PreconfBlockServerPort.Name),
 		PreconfBlockServerJWTSecret:   preconfBlockServerJWTSecret,
 		PreconfBlockServerCORSOrigins: c.String(flags.PreconfBlockServerCORSOrigins.Name),
-		PreconfBlockServerCheckSig:    c.Bool(flags.PreconfBlockServerCheckSig.Name),
 		P2PConfigs:                    p2pConfigs,
 		P2PSignerConfigs:              signerConfigs,
 	}, nil

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -808,10 +808,6 @@ func (s *DriverTestSuite) insertPreconfBlock(
 	s.Nil(err)
 	s.NotEmpty(payload)
 
-	sig, err := crypto.Sign(crypto.Keccak256(payload), preconferPrivKey)
-	s.Nil(err)
-	reqBody.Signature = common.Bytes2Hex(sig)
-
 	// Try to propose a preconfirmation block
 	res, err := resty.New().
 		R().


### PR DESCRIPTION
As we discussed in the call, we shall remove the signature verification in `PreconfBlockAPIServer.BuildPreconfBlock`, since JWT token is required already.