### PR TITLE
fix(protocol): burn solver fee correctly in ERC20Vault

### DIFF
--- a/packages/protocol/contracts/shared/tokenvault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/ERC20Vault.sol
@@ -545,8 +545,10 @@ contract ERC20Vault is BaseVault {
         } else if (bridgedToCanonical[_op.token].addr != address(0)) {
             // Handle bridged token
             ctoken_ = bridgedToCanonical[_op.token];
-            IERC20(_op.token).safeTransferFrom(msg.sender, address(this), _op.amount);
-            IBridgedERC20(_op.token).burn(_op.amount);
+            uint256 amount = _op.amount + _op.solverFee;
+            IERC20(_op.token).safeTransferFrom(msg.sender, address(this), amount);
+            IBridgedERC20(_op.token).burn(amount);
+
             balanceChangeAmount_ = _op.amount;
             balanceChangeSolverFee_ = _op.solverFee;
         } else {

--- a/packages/protocol/test/shared/tokenvault/ERC20Vault_solver.t.sol
+++ b/packages/protocol/test/shared/tokenvault/ERC20Vault_solver.t.sol
@@ -65,6 +65,35 @@ contract TestERC20Vault_solver is CommonTest {
         vm.deal(Bob, 1 ether);
     }
 
+    function test_20vault_send_erc20_with_solver_fee() public {
+        vm.chainId(taikoChainId);
+
+        vm.startPrank(deployer);
+
+        vm.warp(block.timestamp + 91 days);
+        tVault.changeBridgedToken(erc20ToCanonicalERC20(ethereumChainId), address(tUSDC));
+        tUSDC.mint(Alice, 3);
+
+        vm.stopPrank();
+
+        vm.startPrank(Alice);
+
+        uint256 amount = 2;
+        uint256 solverFee = 1;
+
+        uint256 aliceBalanceBefore = tUSDC.balanceOf(Alice);
+
+        tUSDC.approve(address(tVault), 3);
+        tVault.sendToken(
+            ERC20Vault.BridgeTransferOp(
+                ethereumChainId, address(0), Bob, 0, address(tUSDC), 1_000_000, amount, solverFee
+            )
+        );
+
+        uint256 aliceBalanceAfter = tUSDC.balanceOf(Alice);
+        assertEq(aliceBalanceBefore - aliceBalanceAfter, amount + solverFee);
+    }
+
     function test_20Vault_receive_erc20_solved() public {
         eERC20Token1.mint(address(eVault));
 


### PR DESCRIPTION
Reported by Lilian from Halborn:

> In ERC20Vault , if (bridgedToCanonical[_op.token].addr != address(0)) , op.solverFee is not fetched from msg.sender, only _op.amount is transferredFrom and burned


@AnshuJalan Do you mind adding a test for this.