### PR TITLE
feat(taiko-client): lookahead cache + account for missed slots

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main]
+    branches: [main, lookahead_cache]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main, lookahead_cache]
+    branches: [main]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -30,6 +30,7 @@ import (
 const (
 	protocolStatusReportInterval     = 30 * time.Second
 	exchangeTransitionConfigInterval = 1 * time.Minute
+	lookaheadInterval                = 5 * time.Second
 )
 
 // Driver keeps the L2 execution engine's local block chain in sync with the TaikoL1
@@ -180,6 +181,8 @@ func (d *Driver) Start() error {
 			&rollup.Config{L1ChainID: d.rpc.L1.ChainID, L2ChainID: d.rpc.L2.ChainID, Taiko: true},
 			d.p2pSetup.TargetPeers(),
 		)
+
+		go d.cacheLookaheadLoop()
 	}
 
 	return nil
@@ -353,6 +356,85 @@ func (d *Driver) exchangeTransitionConfigLoop() {
 			} else {
 				log.Debug("Exchanged transition config", "transitionConfig", tc)
 			}
+		}
+	}
+}
+
+// cacheLookaheadLoop
+func (d *Driver) cacheLookaheadLoop() {
+	ticker := time.NewTicker(time.Duration(d.rpc.L1Beacon.SecondsPerSlot) / 3)
+	d.wg.Add(1)
+
+	defer func() {
+		ticker.Stop()
+		d.wg.Done()
+	}()
+
+	var seenBlockNumber uint64 = 0
+
+	var lastSlot uint64 = 0
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-ticker.C:
+			currentSlot := d.rpc.L1Beacon.CurrentSlot()
+
+			latestSeenBlockNumber, err := d.rpc.L1.BlockNumber(d.ctx)
+			if err != nil {
+				log.Warn("error getting latestSeenBlockNumber")
+				continue
+			}
+
+			// avoid fetching on missed slots, otherwise the previous "current" can get tagged as
+			// the new "current" for this epoch
+			if latestSeenBlockNumber == seenBlockNumber {
+				// leave some grace period for the block to arrive
+				if lastSlot != currentSlot && uint64(time.Now().UTC().Unix())-d.rpc.L1Beacon.TimestampOfSlot(currentSlot) > 6 {
+					log.Warn("possible missed slot detected", "currentSlot", currentSlot, "latestNumber", latestSeenBlockNumber)
+					lastSlot = currentSlot
+				}
+
+				continue
+			}
+
+			seenBlockNumber = latestSeenBlockNumber
+
+			lastSlot = currentSlot
+
+			currentEpoch := d.rpc.L1Beacon.CurrentEpoch()
+
+			remainingSlots := d.rpc.L1Beacon.SlotsPerEpoch - d.rpc.L1Beacon.SlotInEpoch()
+
+			currentOperatorAddress, err := d.rpc.GetPreconfWhiteListOperator(nil)
+			if err != nil {
+				log.Warn("Failed to get current preconf whitelist operator address", "error", err)
+				return
+			}
+
+			nextOperatorAddress, err := d.rpc.GetNextPreconfWhiteListOperator(nil)
+			if err != nil {
+				log.Warn("Failed to get next preconf whitelist operator address", "error", err)
+
+				nextOperatorAddress = common.BigToAddress(common.Big0)
+			}
+
+			l := &preconfBlocks.Lookahead{
+				CurrOperator: currentOperatorAddress,
+				NextOperator: nextOperatorAddress,
+				UpdatedAt:    time.Now().UTC(),
+			}
+
+			d.preconfBlockServer.UpdateLookahead(l)
+
+			log.Info("Lookahead info",
+				"remainingSlots", remainingSlots,
+				"currentEpoch", currentEpoch,
+				"currentOperator", currentOperatorAddress.Hex(),
+				"nextOperator", nextOperatorAddress.Hex(),
+			)
+
 		}
 	}
 }

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -30,7 +30,6 @@ import (
 const (
 	protocolStatusReportInterval     = 30 * time.Second
 	exchangeTransitionConfigInterval = 1 * time.Minute
-	lookaheadInterval                = 5 * time.Second
 )
 
 // Driver keeps the L2 execution engine's local block chain in sync with the TaikoL1

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -383,6 +383,7 @@ func (d *Driver) cacheLookaheadLoop() {
 			latestSeenBlockNumber, err := d.rpc.L1.BlockNumber(d.ctx)
 			if err != nil {
 				log.Error("lookahead error getting latestSeenBlockNumber", "error", err)
+
 				continue
 			}
 
@@ -391,7 +392,11 @@ func (d *Driver) cacheLookaheadLoop() {
 			if latestSeenBlockNumber == seenBlockNumber {
 				// leave some grace period for the block to arrive
 				if lastSlot != currentSlot && uint64(time.Now().UTC().Unix())-d.rpc.L1Beacon.TimestampOfSlot(currentSlot) > 6 {
-					log.Warn("lookahead possible missed slot detected", "currentSlot", currentSlot, "latestNumber", latestSeenBlockNumber)
+					log.Warn("lookahead possible missed slot detected",
+						"currentSlot", currentSlot,
+						"latestNumber", latestSeenBlockNumber,
+					)
+
 					lastSlot = currentSlot
 				}
 

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -433,7 +433,6 @@ func (d *Driver) cacheLookaheadLoop() {
 				"currentOperator", currentOperatorAddress.Hex(),
 				"nextOperator", nextOperatorAddress.Hex(),
 			)
-
 		}
 	}
 }

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -382,7 +382,7 @@ func (d *Driver) cacheLookaheadLoop() {
 
 			latestSeenBlockNumber, err := d.rpc.L1.BlockNumber(d.ctx)
 			if err != nil {
-				log.Warn("error getting latestSeenBlockNumber")
+				log.Error("lookahead error getting latestSeenBlockNumber", "error", err)
 				continue
 			}
 
@@ -391,7 +391,7 @@ func (d *Driver) cacheLookaheadLoop() {
 			if latestSeenBlockNumber == seenBlockNumber {
 				// leave some grace period for the block to arrive
 				if lastSlot != currentSlot && uint64(time.Now().UTC().Unix())-d.rpc.L1Beacon.TimestampOfSlot(currentSlot) > 6 {
-					log.Warn("possible missed slot detected", "currentSlot", currentSlot, "latestNumber", latestSeenBlockNumber)
+					log.Warn("lookahead possible missed slot detected", "currentSlot", currentSlot, "latestNumber", latestSeenBlockNumber)
 					lastSlot = currentSlot
 				}
 

--- a/packages/taiko-client/driver/preconf_blocks/lookahead.go
+++ b/packages/taiko-client/driver/preconf_blocks/lookahead.go
@@ -1,0 +1,13 @@
+package preconfblocks
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type Lookahead struct {
+	CurrOperator common.Address
+	NextOperator common.Address
+	UpdatedAt    time.Time
+}

--- a/packages/taiko-client/pkg/rpc/beaconclient.go
+++ b/packages/taiko-client/pkg/rpc/beaconclient.go
@@ -84,7 +84,11 @@ func NewBeaconClient(endpoint string, timeout time.Duration) (*BeaconClient, err
 		return nil, err
 	}
 
-	log.Info("L1 beacon info", "secondsPerSlot", secondsPerSlot, "slotsPerEpoch", slotsPerEpoch, "genesisTime", genesisTime)
+	log.Info("L1 beacon info",
+		"secondsPerSlot", secondsPerSlot,
+		"slotsPerEpoch", slotsPerEpoch,
+		"genesisTime", genesisTime,
+	)
 
 	return &BeaconClient{cli, timeout, uint64(genesisTime), uint64(secondsPerSlot), uint64(slotsPerEpoch)}, nil
 }

--- a/packages/taiko-client/pkg/rpc/beaconclient.go
+++ b/packages/taiko-client/pkg/rpc/beaconclient.go
@@ -135,10 +135,6 @@ func (c *BeaconClient) SlotInEpoch() uint64 {
 	return c.CurrentSlot() % c.SlotsPerEpoch
 }
 
-func (c *BeaconClient) SlotEpochStart(epoch uint64) uint64 {
-	return epoch * c.SlotsPerEpoch
-}
-
 func (c *BeaconClient) TimestampOfSlot(slot uint64) uint64 {
 	return c.genesisTime + slot*c.SecondsPerSlot
 }


### PR DESCRIPTION
doing these rpcs calls every preconf'd block is inefficient and adds latency to preconfs, we should be polling for these on a per slot basis. we also need to account for missed slots, where the preconfer could be incorrect.

This optimization brings a 3s preconf to about 1.67second, and fixes the missed slot issue.