### PR TITLE
docs: fixed typo in `retryMessage` method description

### DIFF
--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/codebase-analysis/bridge-contract.md
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/codebase-analysis/bridge-contract.md
@@ -75,7 +75,7 @@ Retries processing a **failed message**.
 | Parameter        | Type      | Description                                                |
 | ---------------- | --------- | ---------------------------------------------------------- |
 | `_message`       | `Message` | The message to retry.                                      |
-| `_isLastAttempt` | `bool`    | If `true`, marks the message as **failed** if retry fails. |
+| `_isLastAttempt` | `bool`    | If `true`, marked the message as **failed** if retry fails.|
 
 **Mechanism**:
 


### PR DESCRIPTION
Corrected a minor issue in the `retryMessage` method documentation.
The word "marks" was changed to "**marked**" to better reflect the past tense of the action described.