### PR TITLE
chore(protocol): fix tests due to recent foundry change

### DIFF
--- a/packages/protocol/test/shared/libs/LibBytes.t.sol
+++ b/packages/protocol/test/shared/libs/LibBytes.t.sol
@@ -35,6 +35,7 @@ contract TestLibBytes is CommonTest {
         assertEq(result, "");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_LibBytes_revertWithExtractedError_validRevertData() public {
         string memory expectedMessage = "Custom error message";
         bytes memory revertData = abi.encodeWithSignature("Error(string)", expectedMessage);
@@ -42,6 +43,7 @@ contract TestLibBytes is CommonTest {
         LibBytes.revertWithExtractedError(revertData);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_LibBytes_revertWithExtractedError_malformedData() public {
         // Length < 68
         bytes memory malformedData = hex"1234";
@@ -49,6 +51,7 @@ contract TestLibBytes is CommonTest {
         LibBytes.revertWithExtractedError(malformedData);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_LibBytes_revertWithExtractedError_noRevertMessage() public {
         bytes memory emptyRevertData = new bytes(68);
         vm.expectRevert(bytes(""));

--- a/packages/protocol/test/shared/libs/LibBytes.t.sol
+++ b/packages/protocol/test/shared/libs/LibBytes.t.sol
@@ -6,6 +6,7 @@ import "forge-std/src/console2.sol";
 import "src/shared/libs/LibBytes.sol";
 import "../CommonTest.sol";
 
+/// forge-config: default.allow_internal_expect_revert = true
 contract TestLibBytes is CommonTest {
     function test_LibBytes_toString_largeThan64ByteString() public pure {
         bytes memory abiEncodedString = abi.encode("Test String");
@@ -35,7 +36,6 @@ contract TestLibBytes is CommonTest {
         assertEq(result, "");
     }
 
-    /// forge-config: default.allow_internal_expect_revert = true
     function test_LibBytes_revertWithExtractedError_validRevertData() public {
         string memory expectedMessage = "Custom error message";
         bytes memory revertData = abi.encodeWithSignature("Error(string)", expectedMessage);
@@ -43,7 +43,6 @@ contract TestLibBytes is CommonTest {
         LibBytes.revertWithExtractedError(revertData);
     }
 
-    /// forge-config: default.allow_internal_expect_revert = true
     function test_LibBytes_revertWithExtractedError_malformedData() public {
         // Length < 68
         bytes memory malformedData = hex"1234";
@@ -51,7 +50,6 @@ contract TestLibBytes is CommonTest {
         LibBytes.revertWithExtractedError(malformedData);
     }
 
-    /// forge-config: default.allow_internal_expect_revert = true
     function test_LibBytes_revertWithExtractedError_noRevertMessage() public {
         bytes memory emptyRevertData = new bytes(68);
         vm.expectRevert(bytes(""));

--- a/packages/protocol/test/shared/libs/LibTrieProof.t.sol
+++ b/packages/protocol/test/shared/libs/LibTrieProof.t.sol
@@ -5,6 +5,7 @@ import "src/shared/libs/LibTrieProof.sol";
 import "../CommonTest.sol";
 
 contract TestLibTrieProof is CommonTest {
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_verifyMerkleProof() public {
         // Not needed for now, but leave it as is.
         //uint64 chainId = 11_155_111; // Created the proofs on a deployed Sepolia
@@ -71,6 +72,7 @@ contract TestLibTrieProof is CommonTest {
         assertEq(storageRoot2, storageRoot);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_verifyMerkleProof_w_multi_array_StorageProof() public {
         // This one is the "sender app" aka the source bridge but i mocked it for now to be an EOA
         // (for slot calculation)

--- a/packages/protocol/test/shared/libs/LibTrieProof.t.sol
+++ b/packages/protocol/test/shared/libs/LibTrieProof.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.24;
 import "src/shared/libs/LibTrieProof.sol";
 import "../CommonTest.sol";
 
+/// forge-config: default.allow_internal_expect_revert = true
 contract TestLibTrieProof is CommonTest {
-    /// forge-config: default.allow_internal_expect_revert = true
     function test_verifyMerkleProof() public {
         // Not needed for now, but leave it as is.
         //uint64 chainId = 11_155_111; // Created the proofs on a deployed Sepolia
@@ -72,7 +72,6 @@ contract TestLibTrieProof is CommonTest {
         assertEq(storageRoot2, storageRoot);
     }
 
-    /// forge-config: default.allow_internal_expect_revert = true
     function test_verifyMerkleProof_w_multi_array_StorageProof() public {
         // This one is the "sender app" aka the source bridge but i mocked it for now to be an EOA
         // (for slot calculation)


### PR DESCRIPTION
The test failures you’re encountering—[FAIL: call didn't revert at a lower depth than cheatcode call depth]—are due to changes in Foundry’s vm.expectRevert behavior introduced in version 1.0. Previously, vm.expectRevert could be used to anticipate reverts from internal function calls. However, in Foundry 1.0, this behavior is disabled by default to prevent unintended test passes when internal calls revert unexpectedly