### PR TITLE
fix(taiko-client): update splitToBlobs to use MaxBlobDataSize constant for proper data segmentation

### DIFF
--- a/packages/taiko-client/proposer/transaction_builder/blob.go
+++ b/packages/taiko-client/proposer/transaction_builder/blob.go
@@ -240,8 +240,8 @@ func (b *BlobTransactionBuilder) BuildPacaya(
 // splitToBlobs splits the txListBytes into multiple blobs.
 func (b *BlobTransactionBuilder) splitToBlobs(txListBytes []byte) ([]*eth.Blob, error) {
 	var blobs []*eth.Blob
-	for start := 0; start < len(txListBytes); start += rpc.BlobBytes {
-		end := start + rpc.BlobBytes
+	for start := 0; start < len(txListBytes); start += eth.MaxBlobDataSize {
+		end := start + eth.MaxBlobDataSize
 		if end > len(txListBytes) {
 			end = len(txListBytes)
 		}


### PR DESCRIPTION
In the `splitToBlobs` function, we replaced the use of `rpc.BlobBytes` with the `MaxBlobDataSize` constant to correctly segment the transaction data into blobs.

This change is necessary because in the `blob.FromData` method, the data is checked to ensure it does not exceed the `MaxBlobDataSize`, which is defined as `(4 * 31 + 3) * 1024 - 4`. Previously, `rpc.BlobBytes` was set to `32 * 4096` which did not align with the actual maximum data size that can be handled.

By using `MaxBlobDataSize` we ensure that the transaction data is appropriately segmented into smaller chunks without exceeding the size limit. This adjustment prevents issues during the encoding and ensures proper handling of transaction data.