### PR TITLE
chore(docs-site): proverset docs & fix software releases badges

### DIFF
--- a/packages/docs-site/src/content/docs/guides/node-operators/deploy-a-proverset.mdx
+++ b/packages/docs-site/src/content/docs/guides/node-operators/deploy-a-proverset.mdx
@@ -25,7 +25,7 @@ This guide outlines how to achieve this with separate EOAs running prover and pr
 
 1. **Clone the Taiko Alethia monorepo**
 
-    The [Taiko Alethia monorepo](https://github.com/taikoxyz/taiko-mono) contains the scripts for deploying your `ProverSet`. Checkout the latest stable release. (Use `taiko-alethia-protocol-v1.11.0` for Taiko Hekla!)
+    The [Taiko Alethia monorepo](https://github.com/taikoxyz/taiko-mono) contains the scripts for deploying your `ProverSet`. Checkout the latest stable release. (Use `taiko-alethia-protocol-v2.2.0` for Taiko Hekla, )
 
     <Tabs>
         <TabItem label="Mac/Linux">
@@ -46,24 +46,43 @@ This guide outlines how to achieve this with separate EOAs running prover and pr
 
 2. **Deploy the ProverSet**
 
-    Set `ROLLUP_ADDRESS_MANAGER` to the address of the RollupAddressManager contract on the network you are deploying to. You can find these values in our network reference docs.
+    Set `PROVER_SET_ADMIN` or `ADMIN` to the address of your **prover** EOA. You will be able to withdraw TAIKO/TTKOh from the contract to this address.
 
-    Set `PROVER_SET_ADMIN` to the address of your **prover** EOA. You will be able to withdraw TAIKO/TTKOh from the contract to this address.
+    Run the `DeployProverSet.s.sol` script with your **proposer's private key**.
 
-    Run the `DeployProverSet.s.sol` script with your **proposer's private key**. You can find the script [here](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v1.12.0/packages/protocol/script/layer1/DeployProverSet.s.sol).
+    <Tabs>
+      <TabItem label="Taiko Alethia">
+      ```bash
+      PROVER_SET_ADMIN={ADDRESS} ROLLUP_ADDRESS_MANAGER=0x579f40D0BE111b823962043702cabe6Aaa290780 forge script --chain-id 1 --rpc-url {YOUR_RPC_URL} --private-key {PRIVATE_KEY} --broadcast script/layer1/DeployProverSet.s.sol:DeployProverSet
+      ```
 
-    ```bash
-    ROLLUP_ADDRESS_MANAGER={ADDRESS} PROVER_SET_ADMIN={ADDRESS} forge script --chain-id {CHAIN_ID} --rpc-url {YOUR_RPC_URL} --private-key {PRIVATE_KEY} --broadcast script/layer1/DeployProverSet.s.sol:DeployProverSet
-    ```
+      The script should print your implementation and proxy address with the log:
 
-    The script should print your implementation and proxy address with the log:
+      ```
+      Deployed ProverSet impl at address: 0x....
+      Deployed ProverSet proxy at address: 0x....
+      ```
 
-    ```
-    Deployed ProverSet impl at address: 0x....
-    Deployed ProverSet proxy at address: 0x....
-    ```
+      Use proxy address for the following steps.
+      </TabItem>
+      <TabItem label="Taiko Hekla">
+      ```bash
+      ADMIN={ADDRESS} TAIKO_TOKEN=0x6490E12d480549D333499236fF2Ba6676C296011 ENTRYPOINT=0x8698690dEeDB923fA0A674D3f65896B0031BF7c9 INBOX=0x79C9109b764609df928d16fC4a91e9081F7e87DB forge script --evm-version cancun --chain-id 17000 --rpc-url {YOUR_RPC_URL} --private-key {PRIVATE_KEY} --broadcast script/layer1/mainnet/DeployProverSet.s.sol
+      ```
 
-    Use proxy address for the following steps.
+      The script if run correctly will print the following logs:
+
+      ```
+      == Logs ==
+         proxy   : 0x.....
+         impl    : 0x.....
+         owner   : 0x.....
+         chain id: 17000
+      ```
+
+      Use proxy address for the following steps.
+      </TabItem>
+    </Tabs>
 
 3. **Verify the contract as a proxy on Etherscan**
 
@@ -128,9 +147,18 @@ If you've already deployed a ProverSet but would like to upgrade it through the 
 
     Execute the following command, filling in the values in the curly braces appropriately.
 
+    <Tabs>
+    <TabItem label="Taiko Alethia">
     ```bash
-    forge create --private-key {YOUR_PRIVATE_KEY} --chain-id {CHAIN_ID} --rpc-url {YOUR_RPC_URL} contracts/layer1/provers/ProverSet.sol:ProverSet
+    forge create --private-key {YOUR_PRIVATE_KEY} --chain-id 1 --rpc-url {YOUR_RPC_URL} contracts/layer1/provers/ProverSet.sol:ProverSet
     ```
+    </TabItem>
+    <TabItem label="Taiko Hekla">
+    ```bash
+    forge create --private-key {YOUR_PRIVATE_KEY} --chain-id 17000 --rpc-url {YOUR_RPC_URL} contracts/layer1/provers/ProverSet.sol:ProverSet --broadcast --constructor-args 0x3C82907B5895DB9713A0BB874379eF8A37aA2A68 0x79C9109b764609df928d16fC4a91e9081F7e87DB 0x6490E12d480549D333499236fF2Ba6676C296011 0x8698690dEeDB923fA0A674D3f65896B0031BF7c9
+    ```
+    </TabItem>
+    </Tabs>
 
     <Aside>
     If you are getting EvmErrors, your private key may be formatted incorrectly; try prefixing it with `0x` and rerunning the script.

--- a/packages/docs-site/src/content/docs/network-reference/software-releases-and-deployments.md
+++ b/packages/docs-site/src/content/docs/network-reference/software-releases-and-deployments.md
@@ -7,13 +7,23 @@ description: Reference page showing the latest Taiko Alethia software versions a
 
 It is **highly recommended** you use the latest software. You can find the latest versions here:
 
+### Taiko Hekla
 | Package                                                                                | Release notes                                                                                                                                                                                     |
 | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [protocol](https://github.com/taikoxyz/taiko-mono/tree/main/packages/protocol)         | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/taiko-mono?filter=taiko-alethia-protocol*&label=)](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/CHANGELOG.md)         |
+| [protocol](https://github.com/taikoxyz/taiko-mono/tree/main/packages/protocol)         | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/taiko-mono?include_prereleases&filter=taiko-alethia-protocol*&label=)](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/CHANGELOG.md)         |
+| [taiko-geth](https://github.com/taikoxyz/taiko-geth)                                   | [![GitHub Release](https://img.shields.io/github/v/release/taikoxyz/taiko-geth?include_prereleases&label=)](https://github.com/taikoxyz/taiko-geth/blob/taiko/CHANGELOG.md)                                           |
+| [taiko-client](https://github.com/taikoxyz/taiko-mono/tree/main/packages/taiko-client) | [![GitHub Release](https://img.shields.io/github/v/release/taikoxyz/taiko-mono?include_prereleases&filter=taiko-alethia-client*&label=)](https://github.com/taikoxyz/taiko-mono/blob/main/packages/taiko-client/CHANGELOG.md) |
+| [simple-taiko-node](https://github.com/taikoxyz/simple-taiko-node/tree/main)           | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/simple-taiko-node?include_prereleases&label=)](https://github.com/taikoxyz/simple-taiko-node/blob/main/CHANGELOG.md)                              |
+| [raiko](https://github.com/taikoxyz/raiko/tree/main)                                   | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/raiko?label=)](https://github.com/taikoxyz/raiko/blob/main/CHANGELOG.md)                                                      |
+
+### Taiko Alethia
+| Package                                                                                | Release notes                                                                                                                                                                                     |
+| :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [protocol](https://github.com/taikoxyz/taiko-mono/tree/main/packages/protocol)         | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/taiko-mono?filter=protocol*&label=)](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/CHANGELOG.md)         |
 | [taiko-geth](https://github.com/taikoxyz/taiko-geth)                                   | [![GitHub Release](https://img.shields.io/github/v/release/taikoxyz/taiko-geth?label=)](https://github.com/taikoxyz/taiko-geth/blob/taiko/CHANGELOG.md)                                           |
 | [taiko-client](https://github.com/taikoxyz/taiko-mono/tree/main/packages/taiko-client) | [![GitHub Release](https://img.shields.io/github/v/release/taikoxyz/taiko-mono?filter=taiko-alethia-client*&label=)](https://github.com/taikoxyz/taiko-mono/blob/main/packages/taiko-client/CHANGELOG.md) |
-| [simple-taiko-node](https://github.com/taikoxyz/simple-taiko-node/tree/main)           | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/simple-taiko-node?label=)](https://github.com/taikoxyz/simple-taiko-node/blob/main/CHANGELOG.md)                              |
-| [raiko](https://github.com/taikoxyz/raiko/tree/main)                                   | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/raiko?label=)](https://github.com/taikoxyz/raiko/blob/main/CHANGELOG.md)                                                      |
+| [simple-taiko-node](https://github.com/taikoxyz/simple-taiko-node/tree/main)           | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/simple-taiko-node?filter=v1.10.3&label=)](https://github.com/taikoxyz/simple-taiko-node/blob/main/CHANGELOG.md)                              |
+| [raiko](https://github.com/taikoxyz/raiko/tree/main)                                   | [![Github Release](https://img.shields.io/github/v/release/taikoxyz/raiko?filter=v1.5.0&label=)](https://github.com/taikoxyz/raiko/blob/main/CHANGELOG.md)                                                      |
 
 ## Taiko Alethia deployment logs
 


### PR DESCRIPTION
Going forward we can set Hekla releases to pre-releases and live releases as regular releases. The badges should update automatically.