### PR TITLE
refactor(main): use the built-in max/min to simplify the code

### DIFF
--- a/packages/blobstorage/indexer/indexer.go
+++ b/packages/blobstorage/indexer/indexer.go
@@ -191,7 +191,7 @@ func (i *Indexer) filter(ctx context.Context) error {
 	for j := i.latestIndexedBlockNumber + 1; j <= endBlockID; j += defaultBlockBatchSize + 1 {
 		// if the end of the batch is greater than the latest block number, set end
 		// to the latest block number
-		end := utils.Min(j+defaultBlockBatchSize, endBlockID)
+		end := min(j+defaultBlockBatchSize, endBlockID)
 
 		slog.Info("block batch", "start", j, "end", end)
 

--- a/packages/blobstorage/pkg/utils/utils.go
+++ b/packages/blobstorage/pkg/utils/utils.go
@@ -2,26 +2,8 @@ package utils
 
 import (
 	"time"
-
-	"golang.org/x/exp/constraints"
 )
 
 const (
 	DefaultTimeout = 1 * time.Minute
 )
-
-// Min return the minimum value of two integers.
-func Min[T constraints.Integer](a, b T) T {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// Max return the maximum value of two integers.
-func Max[T constraints.Integer](a, b T) T {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.