### PR TITLE
docs(protocol): updated broken links

### DIFF
--- a/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
+++ b/packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md
@@ -72,7 +72,7 @@ There are more roles in the codebase but these are the foremost and most central
 
 3. Protocol Documentation
 
-- [Website Docs](https://docs.taiko.xyz/core-concepts/what-is-taiko/)
+- [Website Docs](https://docs.taiko.xyz/taiko-alethia-protocol/what-is-taiko-alethia/)
 - [Markdown concept-specific docs](https://github.com/code-423n4/2024-03-taiko/blob/main/packages/protocol/docs)
 
 ## Mechanism Review

--- a/packages/protocol/docs/how_taiko_proves_blocks.md
+++ b/packages/protocol/docs/how_taiko_proves_blocks.md
@@ -68,7 +68,7 @@ Note that the anchor transaction emits an `Anchored` event that may help ZKP to 
 ZKP shall also check the signature of the anchor transaction:
 
 - The signer must be _`TaikoL2.GOLDEN_TOUCH_ADDRESS`_.
-- The signature must use `1` as the `k` value if the calculated `r` is not `0`, otherwise, `k` must be `2`. See [LibL2Signer.sol](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/test/layer2/LibL2Signer.sol).
+- The signature must use `1` as the `k` value if the calculated `r` is not `0`, otherwise, `k` must be `2`. See [LibAnchorSigner.sol](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/test/layer2/LibAnchorSigner.sol).
 
 ### Block Metadata
 


### PR DESCRIPTION
1. `packages/protocol/docs/analysis/MrPotatoMagic-Analysis.md`
   - Updated from `/core-concepts/` to `/taiko-alethia-protocol/` path
2. `packages/protocol/docs/how_taiko_proves_blocks.md`
   - Swapped to the correct `LibAnchorSigner.sol` file - ref: #18535