### PR TITLE
test(protocol): rename taikoInbox variable to taikoInboxImpl

### DIFF
--- a/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
@@ -78,7 +78,7 @@ contract DeployProtocolOnL1 is DeployCapability {
 
         address taikoInboxAddr =
             IResolver(rollupResolver).resolve(uint64(block.chainid), LibStrings.B_TAIKO, false);
-        TaikoInbox taikoInbox = TaikoInbox(payable(taikoInboxAddr));
+        TaikoInbox taikoInboxImpl = TaikoInbox(payable(taikoInboxAddr));
 
         if (vm.envAddress("SHARED_RESOLVER") == address(0)) {
             SignalService(signalServiceAddr).authorize(taikoInboxAddr, true);
@@ -342,7 +342,7 @@ contract DeployProtocolOnL1 is DeployCapability {
             registerTo: rollupResolver
         });
 
-        TaikoInbox taikoInbox = TaikoInbox(payable(taikoInboxAddr));
+        TaikoInbox taikoInboxImpl = TaikoInbox(payable(taikoInboxAddr));
         taikoInbox.init(msg.sender, vm.envBytes32("L2_GENESIS_HASH"));
         uint64 l2ChainId = taikoInbox.pacayaConfig().chainId;
         require(l2ChainId != block.chainid, "same chainid");


### PR DESCRIPTION
This PR renames the `taikoInbox` variable to `taikoInboxImpl` in DeployProtocolOnL1.s.sol to better reflect its purpose as an implementation instance. The change improves code readability and makes the variable naming more consistent with the implementation pattern used throughout the codebase.

Changes:
- Renamed `taikoInbox` to `taikoInboxImpl` in two locations (lines 81 and 345)
- No functional changes, only variable renaming for clarity