### PR TITLE
fix(protocol): change modifier to `onlyOwner`

### DIFF
--- a/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
@@ -115,10 +115,7 @@ contract SgxVerifier is EssentialContract, IVerifier {
 
     /// @notice Deletes SGX instances from the registry.
     /// @param _ids The ids array of SGX instances.
-    function deleteInstances(uint256[] calldata _ids)
-        external
-        onlyOwner
-    {
+    function deleteInstances(uint256[] calldata _ids) external onlyOwner {
         uint256 size = _ids.length;
         for (uint256 i; i < size; ++i) {
             uint256 idx = _ids[i];

--- a/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
@@ -117,7 +117,7 @@ contract SgxVerifier is EssentialContract, IVerifier {
     /// @param _ids The ids array of SGX instances.
     function deleteInstances(uint256[] calldata _ids)
         external
-        onlyFromOwnerOrNamed(LibStrings.B_SGX_WATCHDOG)
+        onlyOwner
     {
         uint256 size = _ids.length;
         for (uint256 i; i < size; ++i) {

--- a/packages/protocol/contracts/shared/libs/LibStrings.sol
+++ b/packages/protocol/contracts/shared/libs/LibStrings.sol
@@ -21,7 +21,6 @@ library LibStrings {
     bytes32 internal constant B_PROOF_VERIFIER = bytes32("proof_verifier");
     bytes32 internal constant B_PROVER_SET = bytes32("prover_set");
     bytes32 internal constant B_QUOTA_MANAGER = bytes32("quota_manager");
-    bytes32 internal constant B_SGX_WATCHDOG = bytes32("sgx_watchdog");
     bytes32 internal constant B_SIGNAL_SERVICE = bytes32("signal_service");
     bytes32 internal constant B_TAIKO = bytes32("taiko");
     bytes32 internal constant B_TAIKO_TOKEN = bytes32("taiko_token");


### PR DESCRIPTION
The reasons for changing the modifier for `deleteInstances` to `onlyOwner` are:
1. Since the contract of `SgxVerifier` don't have resolver, when the `deleteInstances` function is called, it will revert.
2. The address  of `B_SGX_WATCHDOG` on Mainnet is guardian prover contract, since after pacaya we don't support gp at all, so remove the logic.
