### PR TITLE
chore(protocol): temporarily lower liveness bond for whitelisted preconfers

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -32,7 +32,7 @@ contract MainnetInbox is TaikoInbox {
             batchRingBufferSize: 360_000, // DO NOT CHANGE!!!
             maxBatchesToVerify: 16,
             blockMaxGasLimit: 240_000_000,
-            livenessBondBase: 125e18, // 125 Taiko token per batch
+            livenessBondBase: 50e18, // 50 Taiko token per batch
             livenessBondPerBlock: 5e18, // 5 Taiko token per block
             stateRootSyncInternal: 4,
             maxAnchorHeightOffset: 64,


### PR DESCRIPTION
This PR may not be strictly necessary based on the[ initial analysis](https://github.com/taikoxyz/taiko-mono/issues/19206), but it also doesn’t hurt. It further reduces the penalty for failed proofs by whitelisted preconfers (our partners).