### PR TITLE
fix: script not executing due to incorrect shebang

### DIFF
--- a/packages/blobstorage/scripts/abigen.sh
+++ b/packages/blobstorage/scripts/abigen.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 if [ ! -d "../protocol/out" ]; then
     echo "ABI not generated in protocol package yet. Please run npm install && npx hardhat compile in ../protocol"

--- a/packages/blobstorage/scripts/swagger.sh
+++ b/packages/blobstorage/scripts/swagger.sh
@@ -1,3 +1,3 @@
-#/bin/sh
+#!/bin/sh
 
 swag init -g server.go -d pkg/http --parseDependency


### PR DESCRIPTION
The script wasn’t running directly on some systems. The shebang was missing the required `!` character (`#/bin/sh` instead of `#!/bin/sh`).