### PR TITLE
fix(protocol): fix basefee calculation issue

### DIFF
--- a/packages/protocol/contract_layout_layer2.md
+++ b/packages/protocol/contract_layout_layer2.md
@@ -710,6 +710,8 @@
 |
 | l1ChainId                   | uint64                      | 254  | 0      | 8     |
 |
+| accumulatedGasUsed          | uint64                      | 254  | 8      | 8     |
+|
 | __gap                       | uint256[46]                 | 255  | 0      | 1472  |
 |
 | __gap                       | uint256[50]                 | 301  | 0      | 1600  |

--- a/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
@@ -53,9 +53,15 @@ abstract contract PacayaAnchor is EssentialContract, IBlockHashProvider, OntakeA
     /// @dev Slot 4.
     uint64 public l1ChainId;
 
-    /// @notice The accoumulated gas from ancester blocks that have not been used to adjust the base
-    /// fee due the 0 block time.
-    uint64 internal accumulatedGasUsed;
+    /// @notice The accumulated gas from ancestor blocks that have not been used to adjust the base
+    /// fee due to 0 block time. For example, in the block sequence [A] ──10s──▶ [B]
+    /// ──0s──▶ [C] ──2s──▶ [D],
+    /// when calculating the base fee for block D, the combined gas used by both blocks B and C is
+    /// considered
+    /// as the "parent gas used" instead of just using block C’s gas usage. This ensures that the
+    /// gas used by
+    /// block B is correctly included in the base fee calculation.
+    uint64 internal accumulatedAncestorGasUsed;
 
     uint256[46] private __gap;
 

--- a/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
@@ -53,6 +53,10 @@ abstract contract PacayaAnchor is EssentialContract, IBlockHashProvider, OntakeA
     /// @dev Slot 4.
     uint64 public l1ChainId;
 
+    /// @notice The accoumulated gas from ancester blocks that have not been used to adjust the base
+    /// fee due the 0 block time.
+    uint64 internal accumulatedGasUsed;
+
     uint256[46] private __gap;
 
     /// @notice Emitted when the latest L1 block details are anchored to L2.

--- a/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
@@ -42,7 +42,7 @@ abstract contract ShastaAnchor is PacayaAnchor {
         uint64 _anchorBlockId,
         bytes32 _anchorStateRoot,
         uint256 _parentBaseFee,
-        uint32 _parentGasUsed,
+        uint64 _parentGasUsed,
         LibSharedData.BaseFeeConfig calldata _baseFeeConfig,
         bytes32[] calldata _signalSlots
     )
@@ -72,9 +72,9 @@ abstract contract ShastaAnchor is PacayaAnchor {
         );
 
         if (blockTime == 0) {
-            accumulatedGasUsed += _parentGasUsed;
+            accumulatedAncestorGasUsed += _parentGasUsed;
         } else {
-            accumulatedGasUsed = 0;
+            accumulatedAncestorGasUsed = 0;
         }
 
         _syncChainData(_anchorBlockId, _anchorStateRoot);
@@ -98,7 +98,7 @@ abstract contract ShastaAnchor is PacayaAnchor {
             ? _parentBaseFee
             : LibEIP1559Classic.calculateClassicBaseFee(
                 _parentBaseFee,
-                _parentGasUsed + accumulatedGasUsed,
+                _parentGasUsed + accumulatedAncestorGasUsed,
                 _adjustmentQuotient,
                 _gasIssuancePerSecond,
                 _blockTime

--- a/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
@@ -59,7 +59,7 @@ abstract contract ShastaAnchor is PacayaAnchor {
         uint256 parentId = block.number - 1;
         _verifyAndUpdatePublicInputHash(parentId);
 
-        uint64 blockTime = uint64(block.timestamp - parentTimestamp);
+        uint256 blockTime = block.timestamp - parentTimestamp;
         require(
             shastaGetBaseFee(
                 _parentBaseFee,

--- a/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
@@ -59,16 +59,23 @@ abstract contract ShastaAnchor is PacayaAnchor {
         uint256 parentId = block.number - 1;
         _verifyAndUpdatePublicInputHash(parentId);
 
+        uint64 blockTime = uint64(block.timestamp - parentTimestamp);
         require(
             shastaGetBaseFee(
                 _parentBaseFee,
                 _parentGasUsed,
-                block.timestamp,
+                blockTime,
                 _baseFeeConfig.adjustmentQuotient,
                 _baseFeeConfig.gasIssuancePerSecond
             ) == block.basefee || skipFeeCheck(),
             L2_BASEFEE_MISMATCH()
         );
+
+        if (blockTime == 0) {
+            accumulatedGasUsed += _parentGasUsed;
+        } else {
+            accumulatedGasUsed = 0;
+        }
 
         _syncChainData(_anchorBlockId, _anchorStateRoot);
         _updateParentHashAndTimestamp(parentId);
@@ -78,21 +85,23 @@ abstract contract ShastaAnchor is PacayaAnchor {
 
     function shastaGetBaseFee(
         uint256 _parentBaseFee,
-        uint256 _parentGasUsed,
-        uint256 _blockTimestamp,
+        uint64 _parentGasUsed,
+        uint256 _blockTime,
         uint256 _adjustmentQuotient,
         uint256 _gasIssuancePerSecond
     )
         public
         view
-        returns (uint256 basefee_)
+        returns (uint256)
     {
-        return LibEIP1559Classic.calculateClassicBaseFee(
-            _parentBaseFee,
-            _parentGasUsed,
-            _adjustmentQuotient,
-            _gasIssuancePerSecond,
-            _blockTimestamp - parentTimestamp
-        );
+        return _blockTime == 0
+            ? _parentBaseFee
+            : LibEIP1559Classic.calculateClassicBaseFee(
+                _parentBaseFee,
+                _parentGasUsed + accumulatedGasUsed,
+                _adjustmentQuotient,
+                _gasIssuancePerSecond,
+                _blockTime
+            );
     }
 }

--- a/packages/protocol/contracts/layer2/based/eip1559/LibEIP1559Classic.sol
+++ b/packages/protocol/contracts/layer2/based/eip1559/LibEIP1559Classic.sol
@@ -9,6 +9,9 @@ import "src/shared/libs/LibMath.sol";
 library LibEIP1559Classic {
     using LibMath for uint256;
 
+    error ZeroBlockTime();
+    error ZeroGasPerSecond();
+
     /// @dev This value is the minimum base fee for Ontake.
     uint256 public constant MIN_BASE_FEE = 0.008847185 gwei;
 
@@ -33,12 +36,14 @@ library LibEIP1559Classic {
         pure
         returns (uint256)
     {
-        uint256 gasIssuance = _gasPerSeconds * _blockTime.min(GAS_ISSUANCE_TIME_CAP);
-        if (gasIssuance == 0) {
-            return _parentBasefee;
-        }
+        require(_blockTime != 0, ZeroBlockTime());
+        require(_gasPerSeconds != 0, ZeroGasPerSecond());
+
         return _calculateClassicBaseFee(
-            _parentBasefee, _parentGasUsed, _adjustmentQuotient, gasIssuance
+            _parentBasefee,
+            _parentGasUsed,
+            _adjustmentQuotient,
+            _gasPerSeconds * _blockTime.min(GAS_ISSUANCE_TIME_CAP)
         ).max(MIN_BASE_FEE);
     }
 


### PR DESCRIPTION
Given the following block sequence:


```
[A] ──10s──▶ [B] ──0s──▶ [C] ──2s──▶ [D]
              ╰─────┬──────╯
                  'parent' gas used for block D
```

When calculating the base fee for block D, we should consider the combined gas used by both blocks B and C as the “parent gas used” (which this PR implements), instead of just using block C’s gas usage. Otherwise, the gas used by block B would be incorrectly excluded from the base fee calculation.
