### PR TITLE
fix(taiko-client): don't return err when single sp1 proof is null

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main]
+    branches: [main,fix/sp1-single-proof-null]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main,fix/sp1-single-proof-null]
+    branches: [main]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -171,5 +171,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		SGXProofBufferSize:        c.Uint64(flags.SGXBatchSize.Name),
 		ZKVMProofBufferSize:       c.Uint64(flags.ZKVMBatchSize.Name),
 		ForceBatchProvingInterval: c.Duration(flags.ForceBatchProvingInterval.Name),
+		ProofPollingInterval:      c.Duration(flags.ProofPollingInterval.Name),
 	}, nil
 }

--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -45,6 +45,7 @@ func (res *RaikoRequestProofBodyResponseV2) Validate() error {
 	if res.Data.Status == ErrZkAnyNotDrawn.Error() {
 		return ErrZkAnyNotDrawn
 	}
+	// Note: Since the single sp1 proof from raiko is null, we need to ignore the case.
 	if ProofTypeZKSP1 != res.ProofType &&
 		(res.Data.Proof == nil || len(res.Data.Proof.Proof) == 0) {
 		return errEmptyProof

--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -45,7 +45,8 @@ func (res *RaikoRequestProofBodyResponseV2) Validate() error {
 	if res.Data.Status == ErrZkAnyNotDrawn.Error() {
 		return ErrZkAnyNotDrawn
 	}
-	if res.Data.Proof == nil || len(res.Data.Proof.Proof) == 0 {
+	if ProofTypeZKSP1 != res.ProofType &&
+		(res.Data.Proof == nil || len(res.Data.Proof.Proof) == 0) {
 		return errEmptyProof
 	}
 

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
@@ -236,6 +236,13 @@ func (s *ComposeProofProducer) requestBatchProof(
 	}
 
 	if err := output.Validate(); err != nil {
+		log.Debug(
+			"Validation result",
+			"start", batches[0].BatchID,
+			"end", batches[len(batches)-1].BatchID,
+			"proofType", output.ProofType,
+			"err", err,
+		)
 		return nil, fmt.Errorf("invalid Raiko response(start: %d, end: %d): %w",
 			batches[0].BatchID,
 			batches[len(batches)-1].BatchID,

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
@@ -93,8 +93,10 @@ func (s *ComposeProofProducer) RequestProof(
 			); err != nil {
 				return err
 			} else {
-				proof = common.Hex2Bytes(resp.Data.Proof.Proof[2:])
 				proofType = resp.ProofType
+				if ProofTypeZKSP1 != proofType {
+					proof = common.Hex2Bytes(resp.Data.Proof.Proof[2:])
+				}
 			}
 		}
 		return nil

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
@@ -94,6 +94,7 @@ func (s *ComposeProofProducer) RequestProof(
 				return err
 			} else {
 				proofType = resp.ProofType
+				// Note: Since the single sp1 proof from raiko is null, we need to ignore the case.
 				if ProofTypeZKSP1 != proofType {
 					proof = common.Hex2Bytes(resp.Data.Proof.Proof[2:])
 				}

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
@@ -239,7 +239,7 @@ func (s *ComposeProofProducer) requestBatchProof(
 
 	if err := output.Validate(); err != nil {
 		log.Debug(
-			"Validation result",
+			"Proof output validation result",
 			"start", batches[0].BatchID,
 			"end", batches[len(batches)-1].BatchID,
 			"proofType", output.ProofType,

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_pacaya.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_pacaya.go
@@ -157,6 +157,11 @@ func (s *ProofSubmitterPacaya) RequestProof(ctx context.Context, meta metadata.T
 				return err
 			}
 			if proofStatus.IsSubmitted && !proofStatus.Invalid {
+				log.Info(
+					"A valid proof has been submitted, skip requesting proof",
+					"batchID", meta.Pacaya().GetBatchID(),
+					"parent", proofStatus.ParentHeader.Hash(),
+				)
 				return nil
 			}
 			// If zk proof is enabled, request zk proof first, and check if ZK proof is drawn.

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_pacaya.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_pacaya.go
@@ -193,6 +193,7 @@ func (s *ProofSubmitterPacaya) RequestProof(ctx context.Context, meta metadata.T
 					return fmt.Errorf("failed to request base proof, error: %w", err)
 				}
 			}
+			
 			// Try to add the proof to the buffer.
 			proofBuffer, exist := s.proofBuffers[proofResponse.ProofType]
 			if !exist {

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_pacaya.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_pacaya.go
@@ -193,7 +193,6 @@ func (s *ProofSubmitterPacaya) RequestProof(ctx context.Context, meta metadata.T
 					return fmt.Errorf("failed to request base proof, error: %w", err)
 				}
 			}
-			
 			// Try to add the proof to the buffer.
 			proofBuffer, exist := s.proofBuffers[proofResponse.ProofType]
 			if !exist {

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_pacaya.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_pacaya.go
@@ -188,6 +188,7 @@ func (s *ProofSubmitterPacaya) RequestProof(ctx context.Context, meta metadata.T
 					return fmt.Errorf("failed to request base proof, error: %w", err)
 				}
 			}
+			
 			// Try to add the proof to the buffer.
 			proofBuffer, exist := s.proofBuffers[proofResponse.ProofType]
 			if !exist {


### PR DESCRIPTION
Since the single sp1 proof from raiko is null, we need to ignore the case.