### PR TITLE
fix(taiko-client): fix an occasional `engine.SYNCING` error when receiving P2P preconf blocks

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/blob/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/blocks_inserter/common.go
@@ -68,7 +68,7 @@ func createExecutionPayloadsAndSetHead(
 	txListBytes []byte,
 ) (payloadData *engine.ExecutableData, err error) {
 	// Before updating the fork choice, we need to check if the parent block is in the canonical chain,
-	// if the parent is in a frok, we need to set the fork choice to the parent block at first.
+	// if the parent is in a fork, we need to set the fork choice to the parent block at first.
 	parent, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(meta.BlockID.Uint64()-1))
 	if err != nil && !errors.Is(err, ethereum.NotFound) {
 		return nil, fmt.Errorf("failed to get parent block: %w", err)

--- a/packages/taiko-client/driver/chain_syncer/blob/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/blocks_inserter/common.go
@@ -67,26 +67,51 @@ func createExecutionPayloadsAndSetHead(
 	meta *createExecutionPayloadsMetaData,
 	txListBytes []byte,
 ) (payloadData *engine.ExecutableData, err error) {
-	// Before updating the fork choice, we need to check if the parent block is in the canonical chain,
-	// if the parent is in a fork, we need to set the fork choice to the parent block at first.
+	// Before updating the fork choice, we need to check if the parent block's height is equal to or less than the
+	// current canonical head block's height. if not, that means the current incoming block is in another fork,
+	// we need to send the fork choice requests to rebuild the missing gap at first. The caller MUST ensure that the
+	// parent block is either in the canonical chain or in a known fork.
 	parent, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(meta.BlockID.Uint64()-1))
 	if err != nil && !errors.Is(err, ethereum.NotFound) {
 		return nil, fmt.Errorf("failed to get parent block: %w", err)
 	}
 	if parent == nil || parent.Hash() != meta.ParentHash {
+		currentCanonicalHead, err := rpc.L2.HeaderByNumber(ctx, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current canonical head: %w", err)
+		}
 		log.Info(
 			"Parent block not in canonical chain, setting fork choice to parent",
 			"blockID", meta.BlockID,
 			"parentNumber", meta.BlockID.Uint64()-1,
 			"parentHash", meta.ParentHash,
+			"currentCanonicalHead", currentCanonicalHead.Number,
+			"currentCanonicalHeadHash", currentCanonicalHead.Hash(),
 		)
 
-		fcRes, err := rpc.L2Engine.ForkchoiceUpdate(ctx, &engine.ForkchoiceStateV1{HeadBlockHash: meta.ParentHash}, nil)
-		if err != nil {
-			return nil, err
+		// Get all the missing parent hashes for the current canonical chain, to build the fork choice calls.
+		parentHashes := []common.Hash{meta.ParentHash}
+		for i := meta.BlockID.Uint64() - 1; i > currentCanonicalHead.Number.Uint64(); i-- {
+			if parent, err = rpc.L2.HeaderByHash(ctx, parentHashes[0]); err != nil {
+				return nil, fmt.Errorf("failed to get parent block: %w", err)
+			}
+			parentHashes = append([]common.Hash{parent.ParentHash}, parentHashes...)
 		}
-		if fcRes.PayloadStatus.Status != engine.VALID {
-			return nil, fmt.Errorf("unexpected ForkchoiceUpdate response status: %s", fcRes.PayloadStatus.Status)
+
+		// Keep updating the fork choice from the current canonical chain until we reach
+		// the parent block for the incoming block.
+		for _, hash := range parentHashes {
+			parent, err := rpc.L2.HeaderByHash(ctx, hash)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get parent block: %w", err)
+			}
+			fcRes, err := rpc.L2Engine.ForkchoiceUpdate(ctx, &engine.ForkchoiceStateV1{HeadBlockHash: parent.Hash()}, nil)
+			if err != nil {
+				return nil, err
+			}
+			if fcRes.PayloadStatus.Status != engine.VALID {
+				return nil, fmt.Errorf("unexpected ForkchoiceUpdate response status: %s", fcRes.PayloadStatus.Status)
+			}
 		}
 	}
 

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -646,6 +646,132 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithInvalidPayload() {
 	s.Equal(l2Head1.Hash(), l2Head2.Hash())
 }
 
+func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
+	s.ForkIntoPacaya(s.p, s.d.ChainSyncer().BlobSyncer())
+	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().BlobSyncer())
+
+	l1Head, err := s.d.rpc.L1.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	l2Head1, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+
+	headL1Origin, err := s.RPCClient.L2.HeadL1Origin(context.Background())
+	s.Nil(err)
+	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
+
+	snapshotID := s.SetL1Snapshot()
+
+	var (
+		lenForkA = rand.Intn(6) + 3
+		forkA    = make([]*types.Block, 0)
+		lenForkB = lenForkA + rand.Intn(3) + 1
+		forkB    = make([]*types.Block, 0)
+	)
+
+	for i := 0; i < lenForkA; i++ {
+		s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
+	}
+
+	l2Head2, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	s.Greater(l2Head2.Number.Uint64(), l2Head1.Number.Uint64())
+
+	for i := l2Head1.Number.Uint64() + 1; i <= l2Head2.Number.Uint64(); i++ {
+		block, err := s.RPCClient.L2.BlockByNumber(context.Background(), new(big.Int).SetUint64(i))
+		s.Nil(err)
+		forkA = append(forkA, block)
+	}
+	s.Equal(l2Head2.Number.Uint64()-l2Head1.Number.Uint64(), uint64(len(forkA)))
+
+	s.RevertL1Snapshot(snapshotID)
+	s.L1Mine()
+	s.Nil(rpc.SetHead(context.Background(), s.RPCClient.L2, l2Head1.Number))
+	_, err = s.RPCClient.L2Engine.SetHeadL1Origin(context.Background(), headL1Origin.BlockID)
+	s.Nil(err)
+	s.d.state.SetL1Current(l1Head)
+	s.Nil(s.d.ChainSyncer().Sync())
+	s.InitProposer()
+
+	snapshotID = s.SetL1Snapshot()
+
+	for i := 0; i < lenForkB; i++ {
+		s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().BlobSyncer())
+	}
+
+	l2Head3, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	s.Greater(l2Head3.Number.Uint64(), l2Head2.Number.Uint64())
+
+	for i := l2Head1.Number.Uint64() + 1; i <= l2Head3.Number.Uint64(); i++ {
+		block, err := s.RPCClient.L2.BlockByNumber(context.Background(), new(big.Int).SetUint64(i))
+		s.Nil(err)
+		forkB = append(forkB, block)
+	}
+	s.Equal(l2Head3.Number.Uint64()-l2Head1.Number.Uint64(), uint64(len(forkB)))
+
+	s.RevertL1Snapshot(snapshotID)
+	s.L1Mine()
+	s.Nil(rpc.SetHead(context.Background(), s.RPCClient.L2, l2Head1.Number))
+	_, err = s.RPCClient.L2Engine.SetHeadL1Origin(context.Background(), headL1Origin.BlockID)
+	s.Nil(err)
+	s.d.state.SetL1Current(l1Head)
+	s.Nil(s.d.ChainSyncer().Sync())
+	s.InitProposer()
+
+	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
+	s.Nil(err)
+	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
+
+	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	s.Equal(l2Head1.Number.Uint64(), l2Head4.Number.Uint64())
+
+	// Randomly gossip preconfirmation messages based on the blocks
+	// in the forkA and forkB
+	blocks := append(forkA, forkB...)
+	for i := len(blocks) - 1; i > 0; i-- {
+		j := rand.Intn(i + 1)
+		blocks[i], blocks[j] = blocks[j], blocks[i]
+	}
+
+	for _, block := range blocks {
+		baseFee, overflow := uint256.FromBig(block.BaseFee())
+		s.False(overflow)
+
+		b, err := utils.EncodeAndCompressTxList(block.Transactions())
+		s.Nil(err)
+		s.GreaterOrEqual(len(block.Transactions()), 1)
+
+		s.Nil(s.d.preconfBlockServer.OnUnsafeL2Payload(
+			context.Background(),
+			peer.ID(testutils.RandomBytes(32)),
+			&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
+				BlockHash:     block.Hash(),
+				ParentHash:    block.ParentHash(),
+				FeeRecipient:  block.Coinbase(),
+				PrevRandao:    eth.Bytes32(block.MixDigest()),
+				BlockNumber:   eth.Uint64Quantity(block.Number().Uint64()),
+				GasLimit:      eth.Uint64Quantity(block.GasLimit()),
+				Timestamp:     eth.Uint64Quantity(block.Time()),
+				ExtraData:     block.Extra(),
+				BaseFeePerGas: eth.Uint256Quantity(*baseFee),
+				Transactions:  []eth.Data{b},
+				Withdrawals:   &types.Withdrawals{},
+			}},
+		))
+	}
+
+	l2Head5, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
+	s.Nil(err)
+
+	log.Info("Current L2 head", "number", l2Head5.Number().Uint64(), "expected", l2Head3.Number.Uint64())
+	s.Equal(l2Head3.Number.Uint64(), l2Head5.Number().Uint64())
+
+	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
+	s.Nil(err)
+	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
+}
+
 func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 	s.ForkIntoPacaya(s.p, s.d.ChainSyncer().BlobSyncer())
 	// Propose some valid L2 blocks

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -646,6 +646,127 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithInvalidPayload() {
 	s.Equal(l2Head1.Hash(), l2Head2.Hash())
 }
 
+func (s *DriverTestSuite) TestReorgToHeigherFork() {
+	s.ForkIntoPacaya(s.p, s.d.ChainSyncer().BlobSyncer())
+	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().BlobSyncer())
+
+	l1Head, err := s.d.rpc.L1.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	l2Head1, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+
+	headL1Origin, err := s.RPCClient.L2.HeadL1Origin(context.Background())
+	s.Nil(err)
+	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
+
+	snapshotID := s.SetL1Snapshot()
+
+	var (
+		lenForkA = 5
+		forkA    = make([]*types.Block, 0)
+		lenForkB = 10
+		forkB    = make([]*types.Block, 0)
+	)
+
+	for i := 0; i < lenForkA; i++ {
+		s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
+	}
+
+	l2Head2, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	s.Greater(l2Head2.Number.Uint64(), l2Head1.Number.Uint64())
+
+	for i := l2Head1.Number.Uint64() + 1; i <= l2Head2.Number.Uint64(); i++ {
+		block, err := s.RPCClient.L2.BlockByNumber(context.Background(), new(big.Int).SetUint64(i))
+		s.Nil(err)
+		forkA = append(forkA, block)
+	}
+	s.Equal(l2Head2.Number.Uint64()-l2Head1.Number.Uint64(), uint64(len(forkA)))
+
+	s.RevertL1Snapshot(snapshotID)
+	s.L1Mine()
+	s.Nil(rpc.SetHead(context.Background(), s.RPCClient.L2, l2Head1.Number))
+	_, err = s.RPCClient.L2Engine.SetHeadL1Origin(context.Background(), headL1Origin.BlockID)
+	s.Nil(err)
+	s.d.state.SetL1Current(l1Head)
+	s.Nil(s.d.ChainSyncer().Sync())
+	s.InitProposer()
+
+	snapshotID = s.SetL1Snapshot()
+
+	for i := 0; i < lenForkB; i++ {
+		s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().BlobSyncer())
+	}
+
+	l2Head3, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	s.Greater(l2Head3.Number.Uint64(), l2Head2.Number.Uint64())
+
+	for i := l2Head1.Number.Uint64() + 1; i <= l2Head3.Number.Uint64(); i++ {
+		block, err := s.RPCClient.L2.BlockByNumber(context.Background(), new(big.Int).SetUint64(i))
+		s.Nil(err)
+		forkB = append(forkB, block)
+	}
+	s.Equal(l2Head3.Number.Uint64()-l2Head1.Number.Uint64(), uint64(len(forkB)))
+
+	s.RevertL1Snapshot(snapshotID)
+	s.L1Mine()
+	s.Nil(rpc.SetHead(context.Background(), s.RPCClient.L2, l2Head1.Number))
+	_, err = s.RPCClient.L2Engine.SetHeadL1Origin(context.Background(), headL1Origin.BlockID)
+	s.Nil(err)
+	s.d.state.SetL1Current(l1Head)
+	s.Nil(s.d.ChainSyncer().Sync())
+	s.InitProposer()
+
+	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
+	s.Nil(err)
+	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
+
+	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	s.Equal(l2Head1.Number.Uint64(), l2Head4.Number.Uint64())
+
+	insertPreconfBlock := func(block *types.Block) {
+		baseFee, overflow := uint256.FromBig(block.BaseFee())
+		s.False(overflow)
+
+		b, err := utils.EncodeAndCompressTxList(block.Transactions())
+		s.Nil(err)
+		s.GreaterOrEqual(len(block.Transactions()), 1)
+
+		s.Nil(s.d.preconfBlockServer.OnUnsafeL2Payload(
+			context.Background(),
+			peer.ID(testutils.RandomBytes(32)),
+			&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
+				BlockHash:     block.Hash(),
+				ParentHash:    block.ParentHash(),
+				FeeRecipient:  block.Coinbase(),
+				PrevRandao:    eth.Bytes32(block.MixDigest()),
+				BlockNumber:   eth.Uint64Quantity(block.Number().Uint64()),
+				GasLimit:      eth.Uint64Quantity(block.GasLimit()),
+				Timestamp:     eth.Uint64Quantity(block.Time()),
+				ExtraData:     block.Extra(),
+				BaseFeePerGas: eth.Uint256Quantity(*baseFee),
+				Transactions:  []eth.Data{b},
+				Withdrawals:   &types.Withdrawals{},
+			}},
+		))
+	}
+
+	for i := 0; i < len(forkB)-1; i++ {
+		insertPreconfBlock(forkB[i])
+	}
+	for i := 0; i < len(forkA); i++ {
+		insertPreconfBlock(forkA[i])
+	}
+	insertPreconfBlock(forkB[len(forkB)-1])
+
+	l2Head5, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
+	s.Nil(err)
+
+	s.Equal(l2Head3.Number.Uint64(), l2Head5.Number().Uint64())
+}
+
 func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	s.ForkIntoPacaya(s.p, s.d.ChainSyncer().BlobSyncer())
 	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().BlobSyncer())
@@ -764,7 +885,6 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	l2Head5, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
 
-	log.Info("Current L2 head", "number", l2Head5.Number().Uint64(), "expected", l2Head3.Number.Uint64())
 	s.Equal(l2Head3.Number.Uint64(), l2Head5.Number().Uint64())
 
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())

--- a/packages/taiko-client/internal/testutils/suite.go
+++ b/packages/taiko-client/internal/testutils/suite.go
@@ -230,6 +230,10 @@ func (s *ClientTestSuite) IncreaseTime(time uint64) {
 	s.NotNil(result)
 }
 
+func (s *ClientTestSuite) L1Mine() {
+	s.Nil(s.RPCClient.L1.CallContext(context.Background(), nil, "evm_mine"))
+}
+
 func (s *ClientTestSuite) SetNextBlockTimestamp(time uint64) {
 	var result uint64
 	s.Nil(s.RPCClient.L1.CallContext(context.Background(), &result, "evm_setNextBlockTimestamp", time))

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -979,19 +979,19 @@ func (c *Client) calculateBaseFeeOntake(
 		parentGasExcess uint64
 	)
 	parentGasTarget, err := c.OntakeClients.TaikoL2.
-		ParentGasTarget(&bind.CallOpts{BlockNumber: l2Head.Number, Context: ctx})
+		ParentGasTarget(&bind.CallOpts{BlockNumber: l2Head.Number, BlockHash: l2Head.Hash(), Context: ctx})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch parent gas target: %w", err)
 	}
 
 	if newGasTarget != parentGasTarget && parentGasTarget != 0 {
 		oldParentGasExcess, err := c.OntakeClients.TaikoL2.
-			ParentGasExcess(&bind.CallOpts{BlockNumber: l2Head.Number, Context: ctx})
+			ParentGasExcess(&bind.CallOpts{BlockNumber: l2Head.Number, BlockHash: l2Head.Hash(), Context: ctx})
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch old parent gas excess: %w", err)
 		}
 		if parentGasExcess, err = c.OntakeClients.TaikoL2.AdjustExcess(
-			&bind.CallOpts{BlockNumber: l2Head.Number, Context: ctx},
+			&bind.CallOpts{BlockNumber: l2Head.Number, BlockHash: l2Head.Hash(), Context: ctx},
 			oldParentGasExcess,
 			parentGasTarget,
 			newGasTarget,
@@ -1000,7 +1000,7 @@ func (c *Client) calculateBaseFeeOntake(
 			// to calculate the base fee.
 			if strings.Contains(encoding.TryParsingCustomError(err).Error(), "L2_DEPRECATED_METHOD") {
 				baseFeeInfo, err := c.OntakeClients.TaikoL2.GetBasefeeV2(
-					&bind.CallOpts{BlockNumber: l2Head.Number, Context: ctx},
+					&bind.CallOpts{BlockNumber: l2Head.Number, BlockHash: l2Head.Hash(), Context: ctx},
 					uint32(l2Head.GasUsed),
 					currentTimestamp,
 					ontakeBindings.LibSharedDataBaseFeeConfig{
@@ -1021,14 +1021,14 @@ func (c *Client) calculateBaseFeeOntake(
 		}
 	} else {
 		if parentGasExcess, err = c.OntakeClients.TaikoL2.ParentGasExcess(&bind.CallOpts{
-			BlockNumber: l2Head.Number, Context: ctx,
+			BlockNumber: l2Head.Number, BlockHash: l2Head.Hash(), Context: ctx,
 		}); err != nil {
 			return nil, fmt.Errorf("failed to fetch parent gas excess: %w", err)
 		}
 	}
 
 	baseFeeInfo, err := c.OntakeClients.TaikoL2.CalculateBaseFee(
-		&bind.CallOpts{BlockNumber: l2Head.Number, Context: ctx},
+		&bind.CallOpts{BlockNumber: l2Head.Number, BlockHash: l2Head.Hash(), Context: ctx},
 		ontakeBindings.LibSharedDataBaseFeeConfig{
 			AdjustmentQuotient:     baseFeeConfig.AdjustmentQuotient,
 			SharingPctg:            baseFeeConfig.SharingPctg,
@@ -1045,7 +1045,7 @@ func (c *Client) calculateBaseFeeOntake(
 		// to calculate the base fee.
 		if strings.Contains(encoding.TryParsingCustomError(err).Error(), "L2_DEPRECATED_METHOD") {
 			baseFeeInfo, err := c.OntakeClients.TaikoL2.GetBasefeeV2(
-				&bind.CallOpts{BlockNumber: l2Head.Number, Context: ctx},
+				&bind.CallOpts{BlockNumber: l2Head.Number, BlockHash: l2Head.Hash(), Context: ctx},
 				uint32(l2Head.GasUsed),
 				currentTimestamp,
 				ontakeBindings.LibSharedDataBaseFeeConfig{


### PR DESCRIPTION
Also added some improvements for Ontake blocks `basefee` calculation in this PR, which is not necessary but a nice to have.