### PR TITLE
docs(protocol): rename verifier identifiers 

### DIFF
--- a/packages/protocol/script/layer1/devnet/DeployPacayaL1.s.sol
+++ b/packages/protocol/script/layer1/devnet/DeployPacayaL1.s.sol
@@ -206,7 +206,7 @@ contract DeployPacayaL1 is DeployCapability {
         returns (address risc0Verifier, address sp1Verifier)
     {
         risc0Verifier = deployProxy({
-            name: "risc0_verifier",
+            name: "risc0_reth_verifier",
             impl: address(new Risc0Verifier(l2ChainId, risc0Groth16Verifier)),
             data: abi.encodeCall(Risc0Verifier.init, (address(0))),
             registerTo: rollupResolver
@@ -214,7 +214,7 @@ contract DeployPacayaL1 is DeployCapability {
 
         // Deploy sp1 verifier
         sp1Verifier = deployProxy({
-            name: "sp1_verifier",
+            name: "sp1_reth_verifier",
             impl: address(new SP1Verifier(l2ChainId, sp1RemoteVerifier)),
             data: abi.encodeCall(SP1Verifier.init, (address(0))),
             registerTo: rollupResolver
@@ -229,7 +229,7 @@ contract DeployPacayaL1 is DeployCapability {
         returns (address sgxVerifier)
     {
         sgxVerifier = deployProxy({
-            name: "sgx_verifier",
+            name: "sgx_reth_verifier",
             impl: address(new SgxVerifier(l2ChainId, taikoInbox, proofVerifier, automata)),
             data: abi.encodeCall(SgxVerifier.init, (address(0))),
             registerTo: rollupResolver


### PR DESCRIPTION


This PR updates the naming convention for verifiers in DeployPacayaL1.s.sol by changing:
- "risc0_verifier" to "risc0_reth_verifier"
- "sp1_verifier" to "sp1_reth_verifier"
- "sgx_verifier" to "sgx_reth_verifier"

