### PR TITLE
feat(taiko-client): preconf handover skip slots

### DIFF
--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -65,6 +65,13 @@ var (
 		Category: driverCategory,
 		EnvVars:  []string{"PRECONFIRMATION_WHITELIST"},
 	}
+	PreconfHandoverSkipSlots = &cli.Uint64Flag{
+		Name:     "preconfirmation.handoverSkipSlots",
+		Usage:    "Handover slots to provide a boundary at the end of an epoch",
+		Category: driverCategory,
+		EnvVars:  []string{"PRECONF_HANDOVER_SKIP_SLOTS"},
+		Value:    4,
+	}
 )
 
 // DriverFlags All driver flags.
@@ -81,4 +88,5 @@ var DriverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	PreconfBlockServerJWTSecret,
 	PreconfBlockServerCORSOrigins,
 	PreconfWhitelistAddress,
+	PreconfHandoverSkipSlots,
 }, p2pFlags.P2PFlags("PRECONFIRMATION"))

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -115,6 +115,15 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		return nil, err
 	}
 
+	preconfHandoverSkipSlots := c.Uint64(flags.PreconfHandoverSkipSlots.Name)
+	if rpc.L1Beacon != nil && preconfHandoverSkipSlots > rpc.L1Beacon.SlotsPerEpoch {
+		return nil, fmt.Errorf(
+			"preconf handover skip slots %d is greater than slots per epoch %d",
+			preconfHandoverSkipSlots,
+			rpc.L1Beacon.SlotsPerEpoch,
+		)
+	}
+
 	return &Config{
 		ClientConfig:                  clientConfig,
 		RetryInterval:                 c.Duration(flags.BackOffRetryInterval.Name),
@@ -126,6 +135,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		PreconfBlockServerCORSOrigins: c.String(flags.PreconfBlockServerCORSOrigins.Name),
 		P2PConfigs:                    p2pConfigs,
 		P2PSignerConfigs:              signerConfigs,
-		PreconfHandoverSkipSlots:      c.Uint64(flags.PreconfHandoverSkipSlots.Name),
+		PreconfHandoverSkipSlots:      preconfHandoverSkipSlots,
 	}, nil
 }

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	PreconfBlockServerCORSOrigins string
 	P2PConfigs                    *p2p.Config
 	P2PSignerConfigs              p2p.SignerSetup
+	PreconfHandoverSkipSlots      uint64
 }
 
 // NewConfigFromCliContext creates a new config instance from
@@ -125,5 +126,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		PreconfBlockServerCORSOrigins: c.String(flags.PreconfBlockServerCORSOrigins.Name),
 		P2PConfigs:                    p2pConfigs,
 		P2PSignerConfigs:              signerConfigs,
+		PreconfHandoverSkipSlots:      c.Uint64(flags.PreconfHandoverSkipSlots.Name),
 	}, nil
 }

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -117,6 +117,7 @@ func (d *Driver) InitFromConfig(ctx context.Context, cfg *Config) (err error) {
 		if d.preconfBlockServer, err = preconfBlocks.New(
 			d.PreconfBlockServerCORSOrigins,
 			d.PreconfBlockServerJWTSecret,
+			d.PreconfHandoverSkipSlots,
 			d.TaikoL2Address,
 			d.l2ChainSyncer.BlobSyncer().BlocksInserterPacaya(),
 			d.rpc,

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -79,6 +79,16 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 		"parentHash", reqBody.ExecutableData.ParentHash.Hex(),
 	)
 
+	if err := checkLookaheadHandover(
+		s.rpc.L1Beacon.SlotsPerEpoch,
+		s.handoverSlots,
+		s.lookahead,
+		s.rpc.L1Beacon.CurrentSlot(),
+		reqBody.ExecutableData.FeeRecipient,
+	); err != nil {
+		return s.returnError(c, http.StatusBadRequest, err)
+	}
+
 	difficulty, err := encoding.CalculatePacayaDifficulty(new(big.Int).SetUint64(reqBody.ExecutableData.Number))
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -79,13 +79,8 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 		"parentHash", reqBody.ExecutableData.ParentHash.Hex(),
 	)
 
-	if err := checkLookaheadHandover(
-		s.rpc.L1Beacon.SlotsPerEpoch,
-		s.handoverSlots,
-		s.lookahead,
-		s.rpc.L1Beacon.CurrentSlot(),
-		reqBody.ExecutableData.FeeRecipient,
-	); err != nil {
+	// Check if the fee recipient the current operator or the next operator if its in handover window.
+	if err := s.checkLookaheadHandover(reqBody.ExecutableData.FeeRecipient); err != nil {
 		return s.returnError(c, http.StatusBadRequest, err)
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -28,6 +28,11 @@ import (
 	validator "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/anchor_tx_validator"
 )
 
+var (
+	errInvalidCurrOperator = errors.New("invalid operator: expected current operator in handover window")
+	errInvalidNextOperator = errors.New("invalid operator: expected next operator in handover window")
+)
+
 // preconfBlockChainSyncer is an interface for preconf block chain syncer.
 type preconfBlockChainSyncer interface {
 	InsertPreconfBlocksFromExecutionPayloads(context.Context, []*eth.ExecutionPayload) ([]*types.Header, error)
@@ -56,12 +61,14 @@ type PreconfBlockAPIServer struct {
 	payloadsCache  *payloadQueue
 	lookahead      *Lookahead
 	lookaheadMutex sync.Mutex
+	handoverSlots  uint64
 }
 
 // New creates a new preconf blcok server instance, and starts the server.
 func New(
 	cors string,
 	jwtSecret []byte,
+	handoverSlots uint64,
 	taikoAnchorAddress common.Address,
 	chainSyncer preconfBlockChainSyncer,
 	cli *rpc.Client,
@@ -75,6 +82,7 @@ func New(
 		echo:            echo.New(),
 		anchorValidator: anchorValidator,
 		chainSyncer:     chainSyncer,
+		handoverSlots:   handoverSlots,
 		rpc:             cli,
 		payloadsCache:   newPayloadQueue(),
 		lookahead:       &Lookahead{},
@@ -447,4 +455,34 @@ func (s *PreconfBlockAPIServer) UpdateLookahead(l *Lookahead) {
 	s.lookaheadMutex.Lock()
 	defer s.lookaheadMutex.Unlock()
 	s.lookahead = l
+}
+
+func checkLookaheadHandover(
+	slotsPerEpoch uint64,
+	handoverSlots uint64,
+	lookahead *Lookahead,
+	currentSlot uint64,
+	feeRecipient common.Address,
+) error {
+	if lookahead.CurrOperator.Hex() == lookahead.NextOperator.Hex() {
+		return nil
+	}
+
+	threshold := slotsPerEpoch - handoverSlots
+
+	if currentSlot < threshold {
+		// For slots [0, threshold-1], only the current operator is allowed.
+		if lookahead.CurrOperator.Hex() != feeRecipient.Hex() {
+			return errInvalidCurrOperator
+		}
+
+		return nil
+	} else {
+		// For slots [threshold, slotsPerEpoch-1], only the next operator is allowed.
+		if lookahead.NextOperator.Hex() != feeRecipient.Hex() {
+			return errInvalidNextOperator
+		}
+
+		return nil
+	}
 }

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -34,11 +34,7 @@ func (s *PreconfBlockAPIServerTestSuite) TestShutdown() {
 	s.Nil(s.s.Shutdown(context.Background()))
 }
 
-func TestPreconfBlockAPIServerTestSuite(t *testing.T) {
-	suite.Run(t, new(PreconfBlockAPIServerTestSuite))
-}
-
-func Test_checkLookaheadHandover(t *testing.T) {
+func (s *PreconfBlockAPIServerTestSuite) TestCheckLookaheadHandover() {
 	l := &Lookahead{
 		CurrOperator: common.HexToAddress("0x1234567890123456789012345678901234567890"),
 		NextOperator: common.HexToAddress("0x0987654321098765432109876543210987654321"),
@@ -81,7 +77,7 @@ func Test_checkLookaheadHandover(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		s.T().Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, checkLookaheadHandover(
 				tt.slotsPerEpoch,
 				tt.handoverSlots,
@@ -91,4 +87,8 @@ func Test_checkLookaheadHandover(t *testing.T) {
 			), tt.wantErr)
 		})
 	}
+}
+
+func TestPreconfBlockAPIServerTestSuite(t *testing.T) {
+	suite.Run(t, new(PreconfBlockAPIServerTestSuite))
 }

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -69,7 +69,15 @@ func Test_checkLookaheadHandover(t *testing.T) {
 		{"currOperator too late small handover slots", 32, 1, l, 31, l.CurrOperator, errInvalidNextOperator},
 		{"nextOperator on edge small handover slots", 32, 1, l, 31, l.NextOperator, nil},
 		{"nextOperator too early small handover slots", 32, 1, l, 30, l.NextOperator, errInvalidCurrOperator},
-		{"currOperator and nextOperator the same small handover slots", 32, 4, sameOperatorLookahead, 27, l.NextOperator, nil},
+		{
+			"currOperator and nextOperator the same small handover slots",
+			32,
+			4,
+			sameOperatorLookahead,
+			27,
+			l.NextOperator,
+			nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/packages/taiko-client/pkg/rpc/beaconclient.go
+++ b/packages/taiko-client/pkg/rpc/beaconclient.go
@@ -22,20 +22,22 @@ var (
 	getConfigSpecPath  = "/eth/v1/config/spec"
 )
 
+// ConfigSpec is the config spec of the beacon node.
 type ConfigSpec struct {
 	SecondsPerSlot string `json:"SECONDS_PER_SLOT"`
 	SlotsPerEpoch  string `json:"SLOTS_PER_EPOCH"`
 }
 
+// GenesisResponse is the response from the beacon node for fetching the genesis time.
 type GenesisResponse struct {
 	Data struct {
 		GenesisTime string `json:"genesis_time"`
 	} `json:"data"`
 }
 
+// BeaconClient is a client for the beacon node.
 type BeaconClient struct {
 	*beacon.Client
-
 	timeout        time.Duration
 	genesisTime    uint64
 	SecondsPerSlot uint64


### PR DESCRIPTION
the driver should be aware of the boundary. thus, for a `preconf_handover_skip_slots = 4`:

the current sequencer for epoch N sequences slots 28-31 of epoch N-1, and slots 0-27 of epoch N.
the next sequencer can start in slot 28.