### PR TITLE
docs(protocol): update verifier names in `UpgradeDevnetPacayaL1` contract

### DIFF
--- a/packages/protocol/script/layer1/devnet/UpgradeDevnetPacayaL1.s.sol
+++ b/packages/protocol/script/layer1/devnet/UpgradeDevnetPacayaL1.s.sol
@@ -210,7 +210,7 @@ contract UpgradeDevnetPacayaL1 is DeployCapability {
             new RiscZeroGroth16Verifier(ControlID.CONTROL_ROOT, ControlID.BN254_CONTROL_ID);
         register(rollupResolver, "risc0_groth16_verifier", address(risc0Groth16Verifier));
         risc0Verifier = deployProxy({
-            name: "risc0_verifier",
+            name: "risc0_reth_verifier",
             impl: address(new Risc0Verifier(l2ChainId, address(risc0Groth16Verifier))),
             data: abi.encodeCall(Risc0Verifier.init, (address(0))),
             registerTo: rollupResolver
@@ -220,7 +220,7 @@ contract UpgradeDevnetPacayaL1 is DeployCapability {
         SuccinctVerifier sp1RemoteVerifier = new SuccinctVerifier();
         register(rollupResolver, "sp1_remote_verifier", address(sp1RemoteVerifier));
         sp1Verifier = deployProxy({
-            name: "sp1_verifier",
+            name: "sp1_reth_verifier",
             impl: address(new SP1Verifier(l2ChainId, address(sp1RemoteVerifier))),
             data: abi.encodeCall(SP1Verifier.init, (address(0))),
             registerTo: rollupResolver
@@ -252,7 +252,7 @@ contract UpgradeDevnetPacayaL1 is DeployCapability {
         });
 
         sgxVerifier = deployProxy({
-            name: "sgx_verifier",
+            name: "sgx_reth_verifier",
             impl: address(new SgxVerifier(l2ChainId, taikoInbox, proofVerifier, automataProxy)),
             data: abi.encodeCall(SgxVerifier.init, (address(0))),
             registerTo: rollupResolver


### PR DESCRIPTION


**Description:** 
This pull request updates the names of verifiers in the `UpgradeDevnetPacayaL1` contract to include the `_reth_` suffix. The changes affect the following verifiers:
- `risc0_verifier` to `risc0_reth_verifier`
- `sp1_verifier` to `sp1_reth_verifier`
- `sgx_verifier` to `sgx_reth_verifier`

These updates ensure consistency in naming conventions across the contract.

