### PR TITLE
chore(protocol): rename verifier identifiers

### DIFF
--- a/packages/protocol/script/layer1/hekla/DeployHeklaPacayaL1.s.sol
+++ b/packages/protocol/script/layer1/hekla/DeployHeklaPacayaL1.s.sol
@@ -198,7 +198,7 @@ contract DeployHeklaPacayaL1 is DeployCapability {
         returns (address risc0Verifier, address sp1Verifier)
     {
         risc0Verifier = deployProxy({
-            name: "risc0_verifier",
+            name: "risc0_reth_verifier",
             impl: address(new Risc0Verifier(l2ChainId, risc0Groth16Verifier)),
             data: abi.encodeCall(Risc0Verifier.init, (address(0))),
             registerTo: rollupResolver
@@ -206,7 +206,7 @@ contract DeployHeklaPacayaL1 is DeployCapability {
 
         // Deploy sp1 verifier
         sp1Verifier = deployProxy({
-            name: "sp1_verifier",
+            name: "sp1_reth_verifier",
             impl: address(new SP1Verifier(l2ChainId, sp1RemoteVerifier)),
             data: abi.encodeCall(SP1Verifier.init, (address(0))),
             registerTo: rollupResolver
@@ -221,7 +221,7 @@ contract DeployHeklaPacayaL1 is DeployCapability {
         returns (address sgxVerifier)
     {
         sgxVerifier = deployProxy({
-            name: "sgx_verifier",
+            name: "sgx_reth_verifier",
             impl: address(new SgxVerifier(l2ChainId, taikoInbox, proofVerifier, automata)),
             data: abi.encodeCall(SgxVerifier.init, (address(0))),
             registerTo: rollupResolver


### PR DESCRIPTION

**Description:** 
This pull request updates the names of the verifiers in the `DeployHeklaPacayaL1` contract to include the "reth" suffix. The changes affect the `risc0Verifier`, `sp1Verifier`, and `sgxVerifier` names, ensuring consistency and clarity in the naming convention. This update involves modifying the names in the `deployProxy` function calls for each verifier.
