### PR TITLE
fix(protocol): use seconds in slot, not seconds in epoch

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
@@ -217,7 +217,7 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist {
         // (zero), return address(0) directly.
         uint256 rand = uint256(
             LibPreconfUtils.getBeaconBlockRoot(
-                _epochTimestamp - LibPreconfConstants.SECONDS_IN_EPOCH
+                _epochTimestamp - LibPreconfConstants.SECONDS_IN_SLOT
             )
         );
 


### PR DESCRIPTION
if we use seconds in epoch, we are using `epoch start minus one epoch`. we need to be using `epoch start minus one slot`. otherwise, we are querying the last epoch, until it flips mid-epoch and changes.