### PR TITLE
fix(repo): fix codecov ci trigger

### DIFF
--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -1,6 +1,10 @@
 name: "CI"
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/taiko-client/**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:


### PR DESCRIPTION
currently taiko-client CI does not run on merge to main so coverage is never updated on main branch, this should fix it