### PR TITLE
feat(taiko-client): introduce `ImportPendingBlocksFromCache` in `PreconfBlockAPIServer`

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/blob/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/blob/blocks_inserter/pacaya.go
@@ -234,6 +234,7 @@ func (i *BlocksInserterPacaya) InsertBlocks(
 func (i *BlocksInserterPacaya) InsertPreconfBlocksFromExecutionPayloads(
 	ctx context.Context,
 	executionPayloads []*eth.ExecutionPayload,
+	fromCache bool,
 ) ([]*types.Header, error) {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
@@ -244,6 +245,19 @@ func (i *BlocksInserterPacaya) InsertPreconfBlocksFromExecutionPayloads(
 		if err != nil {
 			return nil, fmt.Errorf("failed to insert preconf block: %w", err)
 		}
+		log.Info(
+			"⏰ New preconfirmation L2 block inserted",
+			"blockID", header.Number,
+			"hash", header.Hash(),
+			"coinbase", header.Coinbase.Hex(),
+			"timestamp", header.Time,
+			"baseFee", utils.WeiToGWei(header.BaseFee),
+			"withdrawalsHash", header.WithdrawalsHash,
+			"gasLimit", header.GasLimit,
+			"gasUsed", header.GasUsed,
+			"parentHash", header.ParentHash,
+			"fromCache", fromCache,
+		)
 		headers[j] = header
 	}
 

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -85,62 +85,74 @@ func (s *L2ChainSyncer) Sync() error {
 		return nil
 	}
 
-	// Mark the beacon sync progress as finished, To make sure that
-	// we will only check and trigger P2P sync progress once right after the driver starts
+	// Mark the beacon sync progress as finished, to make sure that
+	// we will only check and trigger P2P sync progress once right after the driver starts.
 	s.progressTracker.MarkFinished()
 
 	// We have triggered at least a beacon sync in L2 execution engine, we should reset the L1Current
-	// cursor at first, before start inserting pending L2 blocks one by one.
+	// cursor at first, then try to import the pending preconfirmation blocks from the cache, before
+	// start inserting pending L2 batches one by one.
 	if s.progressTracker.Triggered() {
 		log.Info(
-			"Switch to insert pending blocks one by one",
+			"Switch to insert pending batches one by one",
 			"p2pEnabled", s.p2pSync,
 			"p2pOutOfSync", s.progressTracker.OutOfSync(),
 		)
 
-		// Get the execution engine's chain head.
-		l2Head, err := s.rpc.L2.HeaderByNumber(s.ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to get L2 chain head: %w", err)
-		}
-
-		log.Info(
-			"L2 head information",
-			"number", l2Head.Number,
-			"hash", l2Head.Hash(),
-			"lastSyncedBlockID", s.progressTracker.LastSyncedBlockID(),
-			"lastSyncedBlockHash", s.progressTracker.LastSyncedBlockHash(),
-		)
-
-		// Reset the L1Current cursor.
-		if err := s.state.ResetL1Current(s.ctx, l2Head.Number); err != nil {
-			return fmt.Errorf("failed to reset L1 current cursor: %w", err)
-		}
-
-		// Reset to the latest L2 execution engine's chain status.
-		s.progressTracker.UpdateMeta(l2Head.Number, l2Head.Hash())
-
-		// If the preconfirmation block server is enabled, we should try to insert the pending
-		// preconfirmation blocks from the cache.
-		if s.preconfBlockServer != nil {
-			log.Info(
-				"Try importing pending preconfirmation blocks",
-				"currentL2HeadNumber", l2Head.Number,
-				"currentL2HeadHash", l2Head.Hash(),
-			)
-			if err := s.preconfBlockServer.ImportPendingBlocksFromCache(s.ctx); err != nil {
-				log.Warn(
-					"Failed to import the pending preconfirmation blocks from cache, skip the import",
-					"currentL2HeadNumber", l2Head.Number,
-					"currentL2HeadHash", l2Head.Hash(),
-					"error", err,
-				)
-			}
+		if err := s.SetUpBlobSync(); err != nil {
+			return fmt.Errorf("failed to set up blob synchronization: %w", err)
 		}
 	}
 
-	// Insert the proposed block one by one.
+	// Insert the proposed batches one by one.
 	return s.blobSyncer.ProcessL1Blocks(s.ctx)
+}
+
+// SetUpBlobSync resets the L1Current cursor to the latest L2 execution engine's chain head,
+// and tries to import the pending preconfirmation blocks from the cache,  this method should only be
+// called after the L2 execution engine's chain has just finished a beacon sync.
+func (s *L2ChainSyncer) SetUpBlobSync() error {
+	// Get the execution engine's chain head.
+	l2Head, err := s.rpc.L2.HeaderByNumber(s.ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get L2 chain head: %w", err)
+	}
+
+	log.Info(
+		"L2 head information",
+		"number", l2Head.Number,
+		"hash", l2Head.Hash(),
+		"lastSyncedBlockID", s.progressTracker.LastSyncedBlockID(),
+		"lastSyncedBlockHash", s.progressTracker.LastSyncedBlockHash(),
+	)
+
+	// Reset the L1Current cursor.
+	if err := s.state.ResetL1Current(s.ctx, l2Head.Number); err != nil {
+		return fmt.Errorf("failed to reset L1 current cursor: %w", err)
+	}
+
+	// Reset to the latest L2 execution engine's chain status.
+	s.progressTracker.UpdateMeta(l2Head.Number, l2Head.Hash())
+
+	// If the preconfirmation block server is enabled, we should try to insert the pending
+	// preconfirmation blocks from the cache.
+	if s.preconfBlockServer != nil {
+		log.Info(
+			"Try importing pending preconfirmation blocks",
+			"currentL2HeadNumber", l2Head.Number,
+			"currentL2HeadHash", l2Head.Hash(),
+		)
+		if err := s.preconfBlockServer.ImportPendingBlocksFromCache(s.ctx); err != nil {
+			log.Warn(
+				"Failed to import the pending preconfirmation blocks from cache, skip the import",
+				"currentL2HeadNumber", l2Head.Number,
+				"currentL2HeadHash", l2Head.Hash(),
+				"error", err,
+			)
+		}
+	}
+
+	return nil
 }
 
 // AheadOfHeadToSync checks whether the L2 chain is ahead of the head to sync in protocol.

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -124,12 +124,17 @@ func (s *L2ChainSyncer) Sync() error {
 		// preconfirmation blocks from the cache.
 		if s.preconfBlockServer != nil {
 			log.Info(
-				"Try inserting pending preconf blocks",
+				"Try importing pending preconfirmation blocks",
 				"currentL2HeadNumber", l2Head.Number,
 				"currentL2HeadHash", l2Head.Hash(),
 			)
 			if err := s.preconfBlockServer.ImportPendingBlocksFromCache(s.ctx); err != nil {
-				log.Warn("Failed to recover the preconfirmation blocks from cache", "error", err)
+				log.Warn(
+					"Failed to import the pending preconfirmation blocks from cache, skip the import",
+					"currentL2HeadNumber", l2Head.Number,
+					"currentL2HeadHash", l2Head.Hash(),
+					"error", err,
+				)
 			}
 		}
 	}

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -46,7 +46,6 @@ func New(
 	p2pSync bool,
 	p2pSyncTimeout time.Duration,
 	blobServerEndpoint *url.URL,
-	preconfBlockServer *preconfBlocks.PreconfBlockAPIServer,
 ) (*L2ChainSyncer, error) {
 	tracker := beaconsync.NewSyncProgressTracker(rpc.L2, p2pSyncTimeout)
 	go tracker.Track(ctx)
@@ -214,4 +213,9 @@ func (s *L2ChainSyncer) BeaconSyncer() *beaconsync.Syncer {
 // BlobSyncer returns the inner blob syncer.
 func (s *L2ChainSyncer) BlobSyncer() *blob.Syncer {
 	return s.blobSyncer
+}
+
+// SetPreconfBlockServer sets the preconfirmation block server.
+func (s *L2ChainSyncer) SetPreconfBlockServer(server *preconfBlocks.PreconfBlockAPIServer) {
+	s.preconfBlockServer = server
 }

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -39,6 +39,7 @@ func (s *ChainSyncerTestSuite) SetupTest() {
 		false,
 		1*time.Hour,
 		s.BlobServer.URL(),
+		nil,
 	)
 	s.Nil(err)
 	s.s = syncer

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -39,7 +39,6 @@ func (s *ChainSyncerTestSuite) SetupTest() {
 		false,
 		1*time.Hour,
 		s.BlobServer.URL(),
-		nil,
 	)
 	s.Nil(err)
 	s.s = syncer

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -95,7 +95,6 @@ func (d *Driver) InitFromConfig(ctx context.Context, cfg *Config) (err error) {
 		cfg.P2PSync,
 		cfg.P2PSyncTimeout,
 		cfg.BlobServerEndpoint,
-		d.preconfBlockServer,
 	); err != nil {
 		return err
 	}
@@ -156,6 +155,9 @@ func (d *Driver) InitFromConfig(ctx context.Context, cfg *Config) (err error) {
 			d.preconfBlockServer.SetP2PNode(d.p2pNode)
 			d.preconfBlockServer.SetP2PSigner(d.p2pSigner)
 		}
+
+		// Set the preconf block server to the chain syncer.
+		d.l2ChainSyncer.SetPreconfBlockServer(d.preconfBlockServer)
 	}
 
 	return nil

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -95,6 +95,7 @@ func (d *Driver) InitFromConfig(ctx context.Context, cfg *Config) (err error) {
 		cfg.P2PSync,
 		cfg.P2PSyncTimeout,
 		cfg.BlobServerEndpoint,
+		d.preconfBlockServer,
 	); err != nil {
 		return err
 	}

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -1128,7 +1128,7 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 	s.Nil(err)
 	s.Equal(l2Head1.Number().Uint64(), headL1Origin.BlockID.Uint64())
 
-	s.Nil(s.d.preconfBlockServer.ImportPendingBlocksFromCache(context.Background()))
+	s.Nil(s.d.ChainSyncer().SetUpBlobSync())
 
 	l2Head3, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -125,6 +125,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	headers, err := s.chainSyncer.InsertPreconfBlocksFromExecutionPayloads(
 		c.Request().Context(),
 		[]*eth.ExecutionPayload{executablePayload},
+		false,
 	)
 	if err != nil {
 		return s.returnError(c, http.StatusInternalServerError, err)
@@ -134,20 +135,6 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	}
 
 	header := headers[0]
-
-	log.Info(
-		"⏰ New preconfirmation L2 block inserted",
-		"blockID", header.Number,
-		"hash", header.Hash(),
-		"coinbase", header.Coinbase.Hex(),
-		"timestamp", header.Time,
-		"gasLimit", header.GasLimit,
-		"gasUsed", header.GasUsed,
-		"mixDigest", common.Bytes2Hex(header.MixDigest[:]),
-		"extraData", common.Bytes2Hex(header.Extra),
-		"baseFee", utils.WeiToGWei(header.BaseFee),
-		"parentHash", header.ParentHash.Hex(),
-	)
 
 	// Propagate the preconfirmation block to the P2P network, if the current server
 	// connects to the P2P network.

--- a/packages/taiko-client/driver/preconf_blocks/queue.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue.go
@@ -22,8 +22,7 @@ type payloadQueueItem struct {
 // payloadQueue tracks the latest payloads from the P2P gossip messages.
 type payloadQueue struct {
 	payloads     []*payloadQueueItem
-	latestPaylod *eth.ExecutionPayload
-	lock         sync.RWMutex
+	latestPayload *eth.ExecutionPayload
 }
 
 // newPayloadQueue creates a pre-initialized queue with a fixed number of slots

--- a/packages/taiko-client/driver/preconf_blocks/queue.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue.go
@@ -121,7 +121,7 @@ func (q *payloadQueue) getLatestPayload() *eth.ExecutionPayload {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
-	if len(q.payloads) == 0 {
+	if q.payloads[0] == nil {
 		return nil
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/queue.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue.go
@@ -21,8 +21,9 @@ type payloadQueueItem struct {
 
 // payloadQueue tracks the latest payloads from the P2P gossip messages.
 type payloadQueue struct {
-	payloads []*payloadQueueItem
-	lock     sync.RWMutex
+	payloads     []*payloadQueueItem
+	latestPaylod *eth.ExecutionPayload
+	lock         sync.RWMutex
 }
 
 // newPayloadQueue creates a pre-initialized queue with a fixed number of slots
@@ -43,6 +44,7 @@ func (q *payloadQueue) put(id uint64, payload *eth.ExecutionPayload) {
 		id:      id,
 		payload: payload,
 	}
+	q.latestPaylod = payload
 }
 
 // get retrieves a previously stored payload item or nil if it does not exist.

--- a/packages/taiko-client/driver/preconf_blocks/queue.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue.go
@@ -21,8 +21,8 @@ type payloadQueueItem struct {
 
 // payloadQueue tracks the latest payloads from the P2P gossip messages.
 type payloadQueue struct {
-	payloads     []*payloadQueueItem
-	latestPayload *eth.ExecutionPayload
+	payloads []*payloadQueueItem
+	lock     sync.RWMutex
 }
 
 // newPayloadQueue creates a pre-initialized queue with a fixed number of slots
@@ -43,7 +43,6 @@ func (q *payloadQueue) put(id uint64, payload *eth.ExecutionPayload) {
 		id:      id,
 		payload: payload,
 	}
-	q.latestPaylod = payload
 }
 
 // get retrieves a previously stored payload item or nil if it does not exist.
@@ -115,4 +114,16 @@ func (q *payloadQueue) has(id uint64, hash common.Hash) bool {
 		}
 	}
 	return false
+}
+
+// getLatestPayload retrieves the latest payload stored in the queue.
+func (q *payloadQueue) getLatestPayload() *eth.ExecutionPayload {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	if len(q.payloads) == 0 {
+		return nil
+	}
+
+	return q.payloads[0].payload
 }

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -441,7 +441,7 @@ func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context
 
 	log.Info(
 		"Found pending payloads in the cache, try importing",
-		"lastestPayloadNumber", uint64(lastestPayload.BlockNumber),
+		"latestPayloadNumber", uint64(lastestPayload.BlockNumber),
 		"latestPayloadBlockHash", lastestPayload.BlockHash.Hex(),
 		"latestPayloadParentHash", lastestPayload.ParentHash.Hex(),
 	)

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -438,6 +438,13 @@ func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context
 		log.Info("No payloads in cache, skip recovering from cache")
 		return nil
 	}
+
+	log.Info(
+		"Found pending payloads in the cache, try importing",
+		"lastestPayloadNumber", uint64(lastestPayload.BlockNumber),
+		"latestPayloadBlockHash", lastestPayload.BlockHash.Hex(),
+		"latestPayloadParentHash", lastestPayload.ParentHash.Hex(),
+	)
 	return s.ImportChildBlocksFromCache(ctx, lastestPayload)
 }
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -433,11 +433,12 @@ func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionP
 // ImportPendingBlocksFromCache tries to insert pending blocks from the cache,
 // if there is no payload in the cache, it will skip the operation.
 func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context) error {
-	if s.payloadsCache.latestPaylod == nil {
+	lastestPayload := s.payloadsCache.getLatestPayload()
+	if lastestPayload == nil {
 		log.Info("No payloads in cache, skip recovering from cache")
 		return nil
 	}
-	return s.ImportChildBlocksFromCache(ctx, s.payloadsCache.latestPaylod)
+	return s.ImportChildBlocksFromCache(ctx, lastestPayload)
 }
 
 // P2PSequencerAddress implements the p2p.GossipRuntimeConfig interface.

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -433,19 +433,19 @@ func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionP
 // ImportPendingBlocksFromCache tries to insert pending blocks from the cache,
 // if there is no payload in the cache, it will skip the operation.
 func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context) error {
-	lastestPayload := s.payloadsCache.getLatestPayload()
-	if lastestPayload == nil {
+	latestPayload := s.payloadsCache.getLatestPayload()
+	if latestPayload == nil {
 		log.Info("No payloads in cache, skip recovering from cache")
 		return nil
 	}
 
 	log.Info(
 		"Found pending payloads in the cache, try importing",
-		"latestPayloadNumber", uint64(lastestPayload.BlockNumber),
-		"latestPayloadBlockHash", lastestPayload.BlockHash.Hex(),
-		"latestPayloadParentHash", lastestPayload.ParentHash.Hex(),
+		"latestPayloadNumber", uint64(latestPayload.BlockNumber),
+		"latestPayloadBlockHash", latestPayload.BlockHash.Hex(),
+		"latestPayloadParentHash", latestPayload.ParentHash.Hex(),
 	)
-	return s.ImportChildBlocksFromCache(ctx, lastestPayload)
+	return s.ImportChildBlocksFromCache(ctx, latestPayload)
 }
 
 // P2PSequencerAddress implements the p2p.GossipRuntimeConfig interface.

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -395,7 +395,7 @@ func (s *PreconfBlockAPIServer) ImportChildBlocksFromCache(
 func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionPayload) error {
 	if payload.BlockNumber < eth.Uint64Quantity(s.rpc.PacayaClients.ForkHeight) {
 		return fmt.Errorf(
-			"block number %d is less than the fork height %d",
+			"block number %d is less than the Pacaya fork height %d",
 			payload.BlockNumber,
 			s.rpc.PacayaClients.ForkHeight,
 		)

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -435,6 +435,7 @@ func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionP
 func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context) error {
 	if s.payloadsCache.latestPaylod == nil {
 		log.Info("No payloads in cache, skip recovering from cache")
+		return nil
 	}
 	return s.ImportChildBlocksFromCache(ctx, s.payloadsCache.latestPaylod)
 }

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -435,7 +435,7 @@ func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionP
 func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context) error {
 	latestPayload := s.payloadsCache.getLatestPayload()
 	if latestPayload == nil {
-		log.Info("No payloads in cache, skip recovering from cache")
+		log.Info("No payloads in cache, skip importing from cache")
 		return nil
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -430,6 +430,15 @@ func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionP
 	return nil
 }
 
+// ImportPendingBlocksFromCache tries to insert pending blocks from the cache,
+// if there is no payload in the cache, it will skip the operation.
+func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context) error {
+	if s.payloadsCache.latestPaylod == nil {
+		log.Info("No payloads in cache, skip recovering from cache")
+	}
+	return s.ImportChildBlocksFromCache(ctx, s.payloadsCache.latestPaylod)
+}
+
 // P2PSequencerAddress implements the p2p.GossipRuntimeConfig interface.
 func (s *PreconfBlockAPIServer) P2PSequencerAddress() common.Address {
 	operatorAddress, err := s.rpc.GetPreconfWhiteListOperator(nil)


### PR DESCRIPTION
After this PR, when a newly started L2 EE chain has finished a beacon sync, `driver` will try to import pending P2P preconf blocks in the cache.