### PR TITLE
feat(protocol): measure and store `lastAnchorGasUsed` in TaikoAnchor

### DIFF
--- a/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
@@ -51,6 +51,7 @@ abstract contract PacayaAnchor is OntakeAnchor {
     /// @notice The L1's chain ID.
     /// @dev Slot 4.
     uint64 public l1ChainId;
+    uint32 public lastAnchorGasUsed;
 
     uint256[46] private __gap;
 

--- a/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
@@ -68,7 +68,9 @@ abstract contract ShastaAnchor is PacayaAnchor {
 
         signalService.receiveSignals(_signalSlots);
 
-        lastAnchorGasUsed = uint32(ANCHOR_GAS_LIMIT - gasleft());
+        // We need to add one SSTORE from non-zero to non-zero (5000), one addition (3), and one
+        // subtraction (3).
+        lastAnchorGasUsed = uint32(ANCHOR_GAS_LIMIT - gasleft() + 5006);
     }
 
     function v4GetBaseFee(

--- a/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
@@ -26,6 +26,12 @@ abstract contract ShastaAnchor is PacayaAnchor {
         shastaForkHeight = _shastaForkHeight;
     }
 
+    modifier recordTxGasUsed() {
+        uint256 _gasleft = gasleft();
+        _;
+        lastAnchorGasUsed = uint32(_gasleft - gasleft());
+    }
+
     /// @notice Anchors the latest L1 block details to L2 for cross-layer
     /// message verification.
     /// @dev The gas limit for this transaction must be set to 1,000,000 gas.
@@ -46,6 +52,7 @@ abstract contract ShastaAnchor is PacayaAnchor {
         bytes32[] calldata _signalSlots
     )
         external
+        recordTxGasUsed
         nonZeroBytes32(_anchorStateRoot)
         nonZeroValue(_anchorBlockId)
         nonZeroValue(_baseFeeConfig.gasIssuancePerSecond)

--- a/packages/protocol/layout/layer2-contracts.txt
+++ b/packages/protocol/layout/layer2-contracts.txt
@@ -710,6 +710,8 @@
 |
 | l1ChainId                   | uint64                      | 254  | 0      | 8     |
 |
+| lastAnchorGasUsed           | uint32                      | 254  | 8      | 4     |
+|
 | __gap                       | uint256[46]                 | 255  | 0      | 1472  |
 |
 | __gap                       | uint256[50]                 | 301  | 0      | 1600  |

--- a/packages/protocol/test/layer2/based/anchor/TaikoAnchor.t.sol
+++ b/packages/protocol/test/layer2/based/anchor/TaikoAnchor.t.sol
@@ -88,8 +88,7 @@ contract TestTaikoAnchor is Layer2Test {
         uint32 _gasIssuancePerSecond,
         uint64 _minGasExcess,
         uint32 _maxGasIssuancePerBlock,
-        uint8 _adjustmentQuotient,
-        uint8 _sharingPctg
+        uint8 _adjustmentQuotient
     )
         external
         onTaiko
@@ -113,8 +112,7 @@ contract TestTaikoAnchor is Layer2Test {
         uint32 _gasIssuancePerSecond,
         uint64 _minGasExcess,
         uint32 _maxGasIssuancePerBlock,
-        uint8 _adjustmentQuotient,
-        uint8 _sharingPctg
+        uint8 _adjustmentQuotient
     )
         external
         onTaiko


### PR DESCRIPTION
This opens the door for supporting ideas similar to https://x.com/Brechtpd/status/1854192593804177410 but using the second transaction, not the first one.