### PR TITLE
chore(protocol): remove selfDelegate from Bridge

### DIFF
--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -130,12 +130,6 @@ contract Bridge is EssentialContract, IBridge {
         __reserved3 = 0;
     }
 
-    /// @notice Delegates a given token's voting power to the bridge itself.
-    /// @param _anyToken Any token that supports delegation.
-    function selfDelegate(address _anyToken) external nonZeroAddr(_anyToken) {
-        ERC20VotesUpgradeable(_anyToken).delegate(address(this));
-    }
-
     /// @inheritdoc IBridge
     function sendMessage(Message calldata _message)
         external


### PR DESCRIPTION
This function is not used and will probably will never be used.

Related to https://github.com/aragon/taiko-contracts/pull/52