### PR TITLE
feat(taiko-client): add checks to ensure preconfirmation blocks are based on canonical chain

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
@@ -2,6 +2,7 @@ package blocksinserter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -376,11 +377,11 @@ func (i *BlocksInserterPacaya) IsInCanonicalChain(
 	headL1Origin *rawdb.L1Origin,
 ) (bool, error) {
 	canonicalParent, err := i.rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(uint64(executableData.BlockNumber-1)))
-	if err != nil {
+	if err != nil && !errors.Is(err, ethereum.NotFound) {
 		return false, fmt.Errorf("failed to fetch canonical parent block: %w", err)
 	}
 	// If the parent hash of the executable data matches the canonical parent block hash, it is in the canonical chain.
-	if canonicalParent.Hash() == executableData.ParentHash {
+	if canonicalParent != nil && canonicalParent.Hash() == executableData.ParentHash {
 		return true, nil
 	}
 

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
@@ -285,7 +285,7 @@ func (i *BlocksInserterPacaya) insertPreconfBlockFromExecutionPayload(
 			)
 		}
 	}
-	// Ensure the preconfirmation block number is in the canonical chain.
+	// Ensure the preconfirmation block is in the canonical chain.
 	canonicalParent, err := i.rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(uint64(executableData.BlockNumber-1)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch canonical parent block: %w", err)

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
@@ -287,7 +287,7 @@ func (i *BlocksInserterPacaya) insertPreconfBlockFromExecutionPayload(
 			)
 		}
 
-		ok, err := i.IsInCanonicalChain(ctx, executableData, headL1Origin)
+		ok, err := i.IsBasedOnCanonicalChain(ctx, executableData, headL1Origin)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to check if preconfirmation block (%d, %s) is in canonical chain: %w",
@@ -370,8 +370,8 @@ func (i *BlocksInserterPacaya) RemovePreconfBlocks(ctx context.Context, newLastB
 	return nil
 }
 
-// IsInCanonicalChain checks if the given executable data is in the canonical chain.
-func (i *BlocksInserterPacaya) IsInCanonicalChain(
+// IsBasedOnCanonicalChain checks if the given executable data is based on the canonical chain.
+func (i *BlocksInserterPacaya) IsBasedOnCanonicalChain(
 	ctx context.Context,
 	executableData *eth.ExecutionPayload,
 	headL1Origin *rawdb.L1Origin,

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
@@ -285,6 +285,18 @@ func (i *BlocksInserterPacaya) insertPreconfBlockFromExecutionPayload(
 			)
 		}
 	}
+	// Ensure the preconfirmation block number is in the canonical chain.
+	canonicalParent, err := i.rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(uint64(executableData.BlockNumber-1)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch canonical parent block: %w", err)
+	}
+	if canonicalParent.Hash() != executableData.ParentHash {
+		return nil, fmt.Errorf(
+			"canonical parent block hash (%s) does not match the executable data parent hash (%s)",
+			canonicalParent.Hash().Hex(),
+			executableData.ParentHash.Hex(),
+		)
+	}
 
 	if len(executableData.Transactions) == 0 {
 		return nil, fmt.Errorf("no transactions data in the payload")

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -889,6 +889,18 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	s.Nil(err)
 	s.True(ok)
 
+	ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
+		context.Background(),
+		&eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(forkA[len(forkA)-1].Number().Uint64()),
+			BlockHash:   forkA[len(forkA)-1].Hash(),
+			ParentHash:  forkA[len(forkA)-1].ParentHash(),
+		},
+		headL1Origin,
+	)
+	s.Nil(err)
+	s.True(ok)
+
 	if isInForkA {
 		ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
 			context.Background(),

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -877,7 +877,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	s.Nil(err)
 	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
 
-	ok, err := s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
+	ok, err := s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsBasedOnCanonicalChain(
 		context.Background(),
 		&eth.ExecutionPayload{
 			BlockNumber: eth.Uint64Quantity(forkB[len(forkB)-1].Number().Uint64()),
@@ -889,7 +889,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	s.Nil(err)
 	s.True(ok)
 
-	ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
+	ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsBasedOnCanonicalChain(
 		context.Background(),
 		&eth.ExecutionPayload{
 			BlockNumber: eth.Uint64Quantity(forkA[len(forkA)-1].Number().Uint64()),
@@ -902,7 +902,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	s.True(ok)
 
 	if isInForkA {
-		ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
+		ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsBasedOnCanonicalChain(
 			context.Background(),
 			&eth.ExecutionPayload{
 				BlockNumber: eth.Uint64Quantity(forkB[len(forkB)-1].Number().Uint64()),
@@ -914,7 +914,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 		s.Nil(err)
 		s.False(ok)
 	} else {
-		ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
+		ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsBasedOnCanonicalChain(
 			context.Background(),
 			&eth.ExecutionPayload{
 				BlockNumber: eth.Uint64Quantity(forkA[len(forkA)-1].Number().Uint64()),

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	consensus "github.com/ethereum/go-ethereum/consensus/taiko"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -833,22 +834,24 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 		s.Nil(err)
 		s.GreaterOrEqual(len(block.Transactions()), 1)
 
+		payload := &eth.ExecutionPayload{
+			BlockHash:     block.Hash(),
+			ParentHash:    block.ParentHash(),
+			FeeRecipient:  block.Coinbase(),
+			PrevRandao:    eth.Bytes32(block.MixDigest()),
+			BlockNumber:   eth.Uint64Quantity(block.Number().Uint64()),
+			GasLimit:      eth.Uint64Quantity(block.GasLimit()),
+			Timestamp:     eth.Uint64Quantity(block.Time()),
+			ExtraData:     block.Extra(),
+			BaseFeePerGas: eth.Uint256Quantity(*baseFee),
+			Transactions:  []eth.Data{b},
+			Withdrawals:   &types.Withdrawals{},
+		}
+
 		s.Nil(s.d.preconfBlockServer.OnUnsafeL2Payload(
 			context.Background(),
 			peer.ID(testutils.RandomBytes(32)),
-			&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
-				BlockHash:     block.Hash(),
-				ParentHash:    block.ParentHash(),
-				FeeRecipient:  block.Coinbase(),
-				PrevRandao:    eth.Bytes32(block.MixDigest()),
-				BlockNumber:   eth.Uint64Quantity(block.Number().Uint64()),
-				GasLimit:      eth.Uint64Quantity(block.GasLimit()),
-				Timestamp:     eth.Uint64Quantity(block.Time()),
-				ExtraData:     block.Extra(),
-				BaseFeePerGas: eth.Uint256Quantity(*baseFee),
-				Transactions:  []eth.Data{b},
-				Withdrawals:   &types.Withdrawals{},
-			}},
+			&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload},
 		))
 	}
 
@@ -873,6 +876,44 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
 	s.Nil(err)
 	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
+
+	ok, err := s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
+		context.Background(),
+		&eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(forkB[len(forkB)-1].Number().Uint64()),
+			BlockHash:   forkB[len(forkB)-1].Hash(),
+			ParentHash:  forkB[len(forkB)-1].ParentHash(),
+		},
+		headL1Origin,
+	)
+	s.Nil(err)
+	s.True(ok)
+
+	if isInForkA {
+		ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
+			context.Background(),
+			&eth.ExecutionPayload{
+				BlockNumber: eth.Uint64Quantity(forkB[len(forkB)-1].Number().Uint64()),
+				BlockHash:   forkB[len(forkB)-1].Hash(),
+				ParentHash:  forkB[len(forkB)-1].ParentHash(),
+			},
+			&rawdb.L1Origin{BlockID: headL1Origin.BlockID, L2BlockHash: testutils.RandomHash()},
+		)
+		s.Nil(err)
+		s.False(ok)
+	} else {
+		ok, err = s.d.ChainSyncer().EventSyncer().BlocksInserterPacaya().IsInCanonicalChain(
+			context.Background(),
+			&eth.ExecutionPayload{
+				BlockNumber: eth.Uint64Quantity(forkA[len(forkA)-1].Number().Uint64()),
+				BlockHash:   forkA[len(forkA)-1].Hash(),
+				ParentHash:  forkA[len(forkA)-1].ParentHash(),
+			},
+			&rawdb.L1Origin{BlockID: headL1Origin.BlockID, L2BlockHash: testutils.RandomHash()},
+		)
+		s.Nil(err)
+		s.False(ok)
+	}
 }
 
 func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingChildren() {


### PR DESCRIPTION
This will introduce an O(n) search through RPC calls when the preconf block is in another (valid / invalid) fork, we can optimize it by moving the search to a new `taiko-geth` RPC method later.