### PR TITLE
chore(taiko-client): improve error messages when initiating pacaya clients

### DIFF
--- a/packages/taiko-client/pkg/rpc/client.go
+++ b/packages/taiko-client/pkg/rpc/client.go
@@ -285,7 +285,7 @@ func (c *Client) initPacayaClients(cfg *ClientConfig) error {
 	defer cancel()
 	composeVerifierAddress, err := taikoInbox.Verifier(opts)
 	if err != nil {
-		return fmt.Errorf("failed to get compose verifier address: %w", err)
+		return fmt.Errorf("failed to retrieve compose verifier address: %w", err)
 	}
 	composeVerifier, err := pacayaBindings.NewComposeVerifier(composeVerifierAddress, c.L1)
 	if err != nil {

--- a/packages/taiko-client/pkg/rpc/client.go
+++ b/packages/taiko-client/pkg/rpc/client.go
@@ -249,17 +249,17 @@ func (c *Client) initOntakeClients(cfg *ClientConfig) error {
 func (c *Client) initPacayaClients(cfg *ClientConfig) error {
 	taikoInbox, err := pacayaBindings.NewTaikoInboxClient(cfg.TaikoL1Address, c.L1)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create new instance of TaikoInboxClient: %w", err)
 	}
 
 	forkRouter, err := pacayaBindings.NewForkRouter(cfg.TaikoL1Address, c.L1)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create new instance of ForkRouter: %w", err)
 	}
 
 	taikoAnchor, err := pacayaBindings.NewTaikoAnchorClient(cfg.TaikoL2Address, c.L2)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create new instance of TaikoAnchorClient: %w", err)
 	}
 
 	var (
@@ -271,12 +271,12 @@ func (c *Client) initPacayaClients(cfg *ClientConfig) error {
 	)
 	if cfg.TaikoTokenAddress.Hex() != ZeroAddress.Hex() {
 		if taikoToken, err = pacayaBindings.NewTaikoToken(cfg.TaikoTokenAddress, c.L1); err != nil {
-			return err
+			return fmt.Errorf("failed to create new instance of TaikoToken: %w", err)
 		}
 	}
 	if cfg.ProverSetAddress.Hex() != ZeroAddress.Hex() {
 		if proverSet, err = pacayaBindings.NewProverSet(cfg.ProverSetAddress, c.L1); err != nil {
-			return err
+			return fmt.Errorf("failed to create new instance of ProverSet: %w", err)
 		}
 	}
 	var cancel context.CancelFunc
@@ -285,16 +285,16 @@ func (c *Client) initPacayaClients(cfg *ClientConfig) error {
 	defer cancel()
 	composeVerifierAddress, err := taikoInbox.Verifier(opts)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get compose verifier address: %w", err)
 	}
 	composeVerifier, err := pacayaBindings.NewComposeVerifier(composeVerifierAddress, c.L1)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create new instance of ComposeVerifier: %w", err)
 	}
 
 	if cfg.TaikoWrapperAddress.Hex() != ZeroAddress.Hex() {
 		if taikoWrapper, err = pacayaBindings.NewTaikoWrapperClient(cfg.TaikoWrapperAddress, c.L1); err != nil {
-			return err
+			return fmt.Errorf("failed to create new instance of TaikoWrapperClient: %w", err)
 		}
 	}
 
@@ -303,14 +303,14 @@ func (c *Client) initPacayaClients(cfg *ClientConfig) error {
 			cfg.ForcedInclusionStoreAddress,
 			c.L1,
 		); err != nil {
-			return err
+			return fmt.Errorf("failed to create new instance of ForcedInclusionStore: %w", err)
 		}
 	}
 
 	if cfg.PreconfWhitelistAddress.Hex() != ZeroAddress.Hex() {
 		preconfWhitelist, err = pacayaBindings.NewPreconfWhitelist(cfg.PreconfWhitelistAddress, c.L1)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create new instance of PreconfWhitelist: %w", err)
 		}
 	}
 


### PR DESCRIPTION
If there is a misconfiguration or some other error when initiating pacaya clients it can happen to receive the following, opaque error: `failed to initialize Pacaya clients: execution reverted`.

This PR adds more detailed error messages so that we can identify which contract call fails.