### PR TITLE
fix: set timer duration in seconds instead of nanoseconds

### DIFF
--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -379,7 +379,7 @@ func (d *Driver) cacheLookaheadLoop() {
 		return
 	}
 
-	ticker := time.NewTicker(time.Duration(d.rpc.L1Beacon.SecondsPerSlot) / 3)
+	ticker := time.NewTicker(time.Second * time.Duration(d.rpc.L1Beacon.SecondsPerSlot) / 3)
 	d.wg.Add(1)
 
 	defer func() {

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -319,7 +319,7 @@ func (s *PreconfBlockAPIServer) GetStatus(c echo.Context) error {
 
 	endOfSequencingBlockHash := common.Hash{}
 
-	if s.rpc.L1Beacon == nil {
+	if s.rpc.L1Beacon != nil {
 		hash, ok := s.sequencingEndedForEpoch.Get(s.rpc.L1Beacon.CurrentEpoch())
 		if ok {
 			endOfSequencingBlockHash = hash


### PR DESCRIPTION
`time.Duration` is in nanoseconds; this was causing an infinite loop 