### PR TITLE
feat(protocol): make TaikoAnchor EIP-7702 delegatable

### DIFF
--- a/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
@@ -82,7 +82,7 @@ abstract contract PacayaAnchor is OntakeAnchor {
     error L2_PUBLIC_INPUT_HASH_MISMATCH();
     error L2_TOO_LATE();
 
-    modifier onlyGoldenTouchOr77702Delegated() {
+    modifier onlyGoldenTouchOr7702Delegated() {
         require(
             msg.sender == address(this) // The sender EOA delegated to this contract
                 || msg.sender == GOLDEN_TOUCH_ADDRESS,
@@ -125,7 +125,7 @@ abstract contract PacayaAnchor is OntakeAnchor {
         nonZeroValue(_anchorBlockId)
         nonZeroValue(_baseFeeConfig.gasIssuancePerSecond)
         nonZeroValue(_baseFeeConfig.adjustmentQuotient)
-        onlyGoldenTouchOr77702Delegated
+        onlyGoldenTouchOr7702Delegated
         nonReentrant
     {
         require(block.number >= pacayaForkHeight, L2_FORK_ERROR());

--- a/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
@@ -82,9 +82,11 @@ abstract contract PacayaAnchor is OntakeAnchor {
     error L2_PUBLIC_INPUT_HASH_MISMATCH();
     error L2_TOO_LATE();
 
-   modifier onlyGoldenTouchOr77702Delegated() {
+    modifier onlyGoldenTouchOr77702Delegated() {
         require(
-            msg.sender == address(this) || msg.sender == GOLDEN_TOUCH_ADDRESS, L2_INVALID_SENDER()
+            msg.sender == address(this) // The sender EOA delegated to this contract
+                || msg.sender == GOLDEN_TOUCH_ADDRESS,
+            L2_INVALID_SENDER()
         );
         _;
     }

--- a/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
@@ -82,8 +82,10 @@ abstract contract PacayaAnchor is OntakeAnchor {
     error L2_PUBLIC_INPUT_HASH_MISMATCH();
     error L2_TOO_LATE();
 
-    modifier onlyGoldenTouch() {
-        require(msg.sender == GOLDEN_TOUCH_ADDRESS, L2_INVALID_SENDER());
+   modifier onlyGoldenTouchOr77702Delegated() {
+        require(
+            msg.sender == address(this) || msg.sender == GOLDEN_TOUCH_ADDRESS, L2_INVALID_SENDER()
+        );
         _;
     }
 
@@ -121,7 +123,7 @@ abstract contract PacayaAnchor is OntakeAnchor {
         nonZeroValue(_anchorBlockId)
         nonZeroValue(_baseFeeConfig.gasIssuancePerSecond)
         nonZeroValue(_baseFeeConfig.adjustmentQuotient)
-        onlyGoldenTouch
+        onlyGoldenTouchOr77702Delegated
         nonReentrant
     {
         require(block.number >= pacayaForkHeight, L2_FORK_ERROR());

--- a/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
@@ -55,7 +55,7 @@ abstract contract ShastaAnchor is PacayaAnchor {
         nonZeroValue(_anchorBlockId)
         nonZeroValue(_baseFeeConfig.gasIssuancePerSecond)
         nonZeroValue(_baseFeeConfig.adjustmentQuotient)
-        onlyGoldenTouchOr77702Delegated
+        onlyGoldenTouchOr7702Delegated
         nonReentrant
     {
         require(block.number >= shastaForkHeight, L2_FORK_ERROR());

--- a/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
@@ -55,7 +55,7 @@ abstract contract ShastaAnchor is PacayaAnchor {
         nonZeroValue(_anchorBlockId)
         nonZeroValue(_baseFeeConfig.gasIssuancePerSecond)
         nonZeroValue(_baseFeeConfig.adjustmentQuotient)
-        onlyGoldenTouch
+        onlyGoldenTouchOr77702Delegated
         nonReentrant
     {
         require(block.number >= shastaForkHeight, L2_FORK_ERROR());


### PR DESCRIPTION
Once EIP-7702 is supported on Taiko EVM, we can remove GOLDEN_TOUCH_ADDRESS 