### PR TITLE
refactor(protocol): remove resolver dependency from TaikoAnchor

### DIFF
--- a/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/PacayaAnchor.sol
@@ -87,13 +87,7 @@ abstract contract PacayaAnchor is OntakeAnchor {
         _;
     }
 
-    constructor(
-        address _resolver,
-        address _signalService,
-        uint64 _pacayaForkHeight
-    )
-        EssentialContract(_resolver)
-    {
+    constructor(address _signalService, uint64 _pacayaForkHeight) EssentialContract(address(0)) {
         signalService = ISignalService(_signalService);
         pacayaForkHeight = _pacayaForkHeight;
     }
@@ -148,7 +142,7 @@ abstract contract PacayaAnchor is OntakeAnchor {
         external
         nonZeroAddr(_to)
         whenNotPaused
-        onlyFromOwnerOrNamed(LibStrings.B_WITHDRAWER)
+        onlyOwner
         nonReentrant
     {
         if (_token == address(0)) {

--- a/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol
@@ -18,12 +18,11 @@ abstract contract ShastaAnchor is PacayaAnchor {
     uint256[50] private __gap;
 
     constructor(
-        address _resolver,
         address _signalService,
         uint64 _pacayaForkHeight,
         uint64 _shastaForkHeight
     )
-        PacayaAnchor(_resolver, _signalService, _pacayaForkHeight)
+        PacayaAnchor(_signalService, _pacayaForkHeight)
     {
         require(
             _shastaForkHeight == 0 || _shastaForkHeight > _pacayaForkHeight, InvalidForkHeight()

--- a/packages/protocol/contracts/layer2/based/anchor/TaikoAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/anchor/TaikoAnchor.sol
@@ -12,12 +12,11 @@ import "./ShastaAnchor.sol";
 /// @custom:security-contact security@taiko.xyz
 contract TaikoAnchor is ShastaAnchor {
     constructor(
-        address _resolver,
         address _signalService,
         uint64 _pacayaForkHeight,
         uint64 _shastaForkHeight
     )
-        ShastaAnchor(_resolver, _signalService, _pacayaForkHeight, _shastaForkHeight)
+        ShastaAnchor(_signalService, _pacayaForkHeight, _shastaForkHeight)
     { }
 
     /// @notice Initializes the contract.

--- a/packages/protocol/contracts/shared/libs/LibStrings.sol
+++ b/packages/protocol/contracts/shared/libs/LibStrings.sol
@@ -31,7 +31,6 @@ library LibStrings {
     bytes32 internal constant B_SIGNAL_SERVICE = bytes32("signal_service");
     bytes32 internal constant B_TAIKO = bytes32("taiko");
     bytes32 internal constant B_TAIKO_TOKEN = bytes32("taiko_token");
-    bytes32 internal constant B_WITHDRAWER = bytes32("withdrawer");
     bytes32 internal constant H_SIGNAL_ROOT = keccak256("SIGNAL_ROOT");
     bytes32 internal constant H_STATE_ROOT = keccak256("STATE_ROOT");
 }

--- a/packages/protocol/script/layer2/devnet/UpgradeDevnetPacayaL2.s.sol
+++ b/packages/protocol/script/layer2/devnet/UpgradeDevnetPacayaL2.s.sol
@@ -65,9 +65,7 @@ contract UpgradeDevnetPacayaL2 is DeployCapability {
 
         // Taiko Anchor
         UUPSUpgradeable(taikoAnchor).upgradeTo(
-            address(
-                new TaikoAnchor(sharedResolver, signalService, pacayaForkHeight, shastaForkHeight)
-            )
+            address(new TaikoAnchor(signalService, pacayaForkHeight, shastaForkHeight))
         );
     }
 }

--- a/packages/protocol/script/layer2/hekla/DeployPacayaL2.s.sol
+++ b/packages/protocol/script/layer2/hekla/DeployPacayaL2.s.sol
@@ -100,9 +100,8 @@ contract DeployPacayaL2 is DeployCapability {
         address signalServiceImpl = address(new SignalService(sharedResolver));
         console2.log("signalService", signalServiceImpl);
         // Taiko Anchor
-        address taikoAnchorImpl = address(
-            new TaikoAnchor(sharedResolver, signalService, pacayaForkHeight, shastaForkHeight)
-        );
+        address taikoAnchorImpl =
+            address(new TaikoAnchor(signalService, pacayaForkHeight, shastaForkHeight));
         console2.log("taikoAnchor", taikoAnchorImpl);
     }
 }

--- a/packages/protocol/test/genesis/GenerateGenesis.g.sol
+++ b/packages/protocol/test/genesis/GenerateGenesis.g.sol
@@ -126,7 +126,6 @@ contract TestGenerateGenesis is Test {
         taikoAnchorProxy.upgradeTo(
             address(
                 new TaikoAnchor(
-                    getPredeployedContractAddress("RollupResolver"),
                     getPredeployedContractAddress("SignalService"),
                     uint64(pacayaForkHeight),
                     uint64(shastaForkHeight)

--- a/packages/protocol/test/layer2/based/anchor/TaikoAnchor.t.sol
+++ b/packages/protocol/test/layer2/based/anchor/TaikoAnchor.t.sol
@@ -21,8 +21,7 @@ contract TestTaikoAnchor is Layer2Test {
         );
 
         anchor = deployAnchor(
-            address(new TaikoAnchor_NoBaseFeeCheck(address(resolver), address(signalService))),
-            ethereumChainId
+            address(new TaikoAnchor_NoBaseFeeCheck(address(signalService))), ethereumChainId
         );
 
         signalService.authorize(address(anchor), true);
@@ -72,7 +71,7 @@ contract TestTaikoAnchor is Layer2Test {
         assertEq(Alice.balance, 100 ether);
 
         // Random EOA cannot call withdraw
-        vm.expectRevert(EssentialContract.ACCESS_DENIED.selector);
+        vm.expectRevert("Ownable: caller is not the owner");
         vm.prank(Alice, Alice);
         anchor.withdraw(address(0), Alice);
     }

--- a/packages/protocol/test/layer2/helpers/TaikoAnchor_NoBaseFeeCheck.sol
+++ b/packages/protocol/test/layer2/helpers/TaikoAnchor_NoBaseFeeCheck.sol
@@ -4,12 +4,7 @@ pragma solidity ^0.8.24;
 import "src/layer2/based/anchor/TaikoAnchor.sol";
 
 contract TaikoAnchor_NoBaseFeeCheck is TaikoAnchor {
-    constructor(
-        address _resolver,
-        address _signalService
-    )
-        TaikoAnchor(_resolver, _signalService, 0, 0)
-    { }
+    constructor(address _signalService) TaikoAnchor(_signalService, 0, 0) { }
 
     function skipFeeCheck() public pure override returns (bool) {
         return true;


### PR DESCRIPTION
From Anshu:

> Hey  [@Daniel Wang](https://taikoorg.slack.com/team/U0613U7RD8E)
 Is this required in Pacaya? https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/contracts/layer1/mainnet/resolvers/RollupResolver.sol
Afaik, everything was shifted to immutable variables, so inbox and anchor contract do not resolve any address.
This is also redundant: https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/contracts/layer2/based/anchor/TaikoAnchor.sol#L15


This PR addresses only the second part of the question.