### PR TITLE
feat(protocol): improve `DeployMainnetPacayaL1` script

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/resolvers/RollupResolver.sol
+++ b/packages/protocol/contracts/layer1/mainnet/resolvers/RollupResolver.sol
@@ -32,9 +32,6 @@ contract RollupResolver is ResolverBase {
         if (_name == LibStrings.B_AUTOMATA_DCAP_ATTESTATION) {
             return 0x8d7C954960a36a7596d7eA4945dDf891967ca8A3;
         }
-        if (_name == LibStrings.B_CHAIN_WATCHDOG) {
-            return 0xE3D777143Ea25A6E031d1e921F396750885f43aC;
-        }
         if (_name == LibStrings.B_PROOF_VERIFIER) {
             return 0xB16931e78d0cE3c9298bbEEf3b5e2276D34b8da1;
         }

--- a/packages/protocol/contracts/layer1/mainnet/resolvers/RollupResolver.sol
+++ b/packages/protocol/contracts/layer1/mainnet/resolvers/RollupResolver.sol
@@ -36,7 +36,7 @@ contract RollupResolver is ResolverBase {
             return 0xE3D777143Ea25A6E031d1e921F396750885f43aC;
         }
         if (_name == LibStrings.B_PROOF_VERIFIER) {
-            return address(0); // TODO(david)
+            return 0xB16931e78d0cE3c9298bbEEf3b5e2276D34b8da1;
         }
         return address(0);
     }

--- a/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
+++ b/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
@@ -28,6 +28,7 @@ import "src/layer1/mainnet/verifiers/MainnetVerifier.sol";
 import "src/layer1/mainnet/MainnetInbox.sol";
 import "src/layer1/mainnet/resolvers/RollupResolver.sol";
 import "src/layer1/mainnet/resolvers/SharedResolver.sol";
+import "src/layer1/mainnet/multirollup/MainnetSignalService.sol";
 import "src/layer1/automata-attestation/AutomataDcapV3Attestation.sol";
 import "src/layer1/automata-attestation/lib/PEMCertChainLib.sol";
 import "src/layer1/automata-attestation/utils/SigVerifyLib.sol";

--- a/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
+++ b/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
@@ -74,13 +74,13 @@ contract DeployMainnetPacayaL1 is DeployCapability {
         // Shared resolver
         address sharedResolver = deployProxy({
             name: "shared_resolver",
-            impl: address(new SharedResolver()),
+            impl: address(new DefaultResolver()),
             data: abi.encodeCall(DefaultResolver.init, (address(0)))
         });
         // Rollup resolver
         address rollupResolver = deployProxy({
             name: "rollup_address_resolver",
-            impl: address(new RollupResolver()),
+            impl: address(new DefaultResolver()),
             data: abi.encodeCall(DefaultResolver.init, (address(0)))
         });
         // register unchanged contract

--- a/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
+++ b/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
@@ -75,13 +75,13 @@ contract DeployMainnetPacayaL1 is DeployCapability {
         address sharedResolver = deployProxy({
             name: "shared_resolver",
             impl: address(new SharedResolver()),
-            data: abi.encodeCall(SharedResolver.init, (address(0)))
+            data: abi.encodeCall(DefaultResolver.init, (address(0)))
         });
         // Rollup resolver
         address rollupResolver = deployProxy({
             name: "rollup_address_resolver",
             impl: address(new RollupResolver()),
-            data: abi.encodeCall(RollupResolver.init, (address(0)))
+            data: abi.encodeCall(DefaultResolver.init, (address(0)))
         });
         // register unchanged contract
         register(sharedResolver, "taiko_token", taikoToken);

--- a/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
+++ b/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
@@ -26,6 +26,8 @@ import "src/layer1/fork-router/PacayaForkRouter.sol";
 import "src/layer1/verifiers/compose/ComposeVerifier.sol";
 import "src/layer1/mainnet/verifiers/MainnetVerifier.sol";
 import "src/layer1/mainnet/MainnetInbox.sol";
+import "src/layer1/mainnet/resolvers/RollupResolver.sol";
+import "src/layer1/mainnet/resolvers/SharedResolver.sol";
 import "src/layer1/automata-attestation/AutomataDcapV3Attestation.sol";
 import "src/layer1/automata-attestation/lib/PEMCertChainLib.sol";
 import "src/layer1/automata-attestation/utils/SigVerifyLib.sol";
@@ -71,14 +73,14 @@ contract DeployMainnetPacayaL1 is DeployCapability {
         // Shared resolver
         address sharedResolver = deployProxy({
             name: "shared_resolver",
-            impl: address(new DefaultResolver()),
-            data: abi.encodeCall(DefaultResolver.init, (address(0)))
+            impl: address(new SharedResolver()),
+            data: abi.encodeCall(SharedResolver.init, (address(0)))
         });
         // Rollup resolver
         address rollupResolver = deployProxy({
             name: "rollup_address_resolver",
-            impl: address(new DefaultResolver()),
-            data: abi.encodeCall(DefaultResolver.init, (address(0)))
+            impl: address(new RollupResolver()),
+            data: abi.encodeCall(RollupResolver.init, (address(0)))
         });
         // register unchanged contract
         register(sharedResolver, "taiko_token", taikoToken);
@@ -154,7 +156,7 @@ contract DeployMainnetPacayaL1 is DeployCapability {
         address newProverSetImpl =
             address(new ProverSet(rollupResolver, taikoInbox, taikoToken, taikoWrapper));
         console2.log("newProverSetImpl:", newProverSetImpl);
-        address newSignalServiceImpl = address(new SignalService(sharedResolver));
+        address newSignalServiceImpl = address(new MainnetSignalService(sharedResolver));
         console2.log("newSignalServiceImpl:", newSignalServiceImpl);
         register(rollupResolver, "taiko", taikoInbox);
         // Other verifiers

--- a/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
+++ b/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
@@ -19,7 +19,7 @@ contract DeployMainnetPacayaL2 is DeployCapability {
     uint256 public privateKey = vm.envUint("PRIVATE_KEY");
     uint64 public pacayaForkHeight = 1_166_000;
     address public signalService = 0x1670000000000000000000000000000000000005;
-    address public contractOwner = vm.envAddress("CONTRACT_OWNER");
+    address public contractOwner = 0xCa5b76Cc7A38b86Db11E5aE5B1fc9740c3bA3DE8;
 
     modifier broadcast() {
         require(privateKey != 0, "invalid private key");

--- a/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
+++ b/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "test/shared/DeployCapability.sol";
 import "src/shared/bridge/Bridge.sol";
+import "src/shared/common/DefaultResolver.sol";
 import "src/layer1/mainnet/resolvers/RollupResolver.sol";
 import "src/layer1/mainnet/resolvers/SharedResolver.sol";
 import "src/layer1/mainnet/multirollup/MainnetSignalService.sol";

--- a/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
+++ b/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
@@ -7,7 +7,7 @@ import "src/shared/bridge/Bridge.sol";
 import "src/shared/common/DefaultResolver.sol";
 import "src/layer1/mainnet/resolvers/RollupResolver.sol";
 import "src/layer1/mainnet/resolvers/SharedResolver.sol";
-import "src/layer1/mainnet/multirollup/MainnetSignalService.sol";
+import "src/shared/signal/SignalService.sol";
 import "src/layer2/based/TaikoAnchor.sol";
 import "src/layer2/DelegateOwner.sol";
 
@@ -78,7 +78,7 @@ contract DeployMainnetPacayaL2 is DeployCapability {
         register(rollupResolver, "bridged_erc721", 0xC3310905E2BC9Cfb198695B75EF3e5B69C6A1Bf7, 1);
         register(rollupResolver, "bridged_erc1155", 0x3c90963cFBa436400B0F9C46Aa9224cB379c2c40, 1);
         // SignalService
-        address signalServiceImpl = address(new MainnetSignalService(sharedResolver));
+        address signalServiceImpl = address(new SignalService(sharedResolver));
         console2.log("signalServiceImpl", signalServiceImpl);
         // Taiko Anchor
         address taikoAnchorImpl =

--- a/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
+++ b/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
@@ -4,14 +4,9 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "test/shared/DeployCapability.sol";
 import "src/shared/bridge/Bridge.sol";
-import "src/shared/common/DefaultResolver.sol";
-import "src/shared/signal/SignalService.sol";
-import "src/shared/tokenvault/BridgedERC1155.sol";
-import "src/shared/tokenvault/BridgedERC20.sol";
-import "src/shared/tokenvault/BridgedERC721.sol";
-import "src/shared/tokenvault/ERC1155Vault.sol";
-import "src/shared/tokenvault/ERC20Vault.sol";
-import "src/shared/tokenvault/ERC721Vault.sol";
+import "src/layer1/mainnet/resolvers/RollupResolver.sol";
+import "src/layer1/mainnet/resolvers/SharedResolver.sol";
+import "src/layer1/mainnet/multirollup/MainnetSignalService.sol";
 import "src/layer2/based/TaikoAnchor.sol";
 import "src/layer2/DelegateOwner.sol";
 
@@ -33,13 +28,13 @@ contract DeployMainnetPacayaL2 is DeployCapability {
         // Shared resolver
         address sharedResolver = deployProxy({
             name: "shared_resolver",
-            impl: address(new DefaultResolver()),
+            impl: address(new SharedResolver()),
             data: abi.encodeCall(DefaultResolver.init, (address(0)))
         });
         // Rollup resolver
         address rollupResolver = deployProxy({
             name: "rollup_resolver",
-            impl: address(new DefaultResolver()),
+            impl: address(new RollupResolver()),
             data: abi.encodeCall(DefaultResolver.init, (address(0)))
         });
         // Copy register
@@ -82,7 +77,7 @@ contract DeployMainnetPacayaL2 is DeployCapability {
         register(rollupResolver, "bridged_erc721", 0xC3310905E2BC9Cfb198695B75EF3e5B69C6A1Bf7, 1);
         register(rollupResolver, "bridged_erc1155", 0x3c90963cFBa436400B0F9C46Aa9224cB379c2c40, 1);
         // SignalService
-        address signalServiceImpl = address(new SignalService(sharedResolver));
+        address signalServiceImpl = address(new MainnetSignalService(sharedResolver));
         console2.log("signalServiceImpl", signalServiceImpl);
         // Taiko Anchor
         address taikoAnchorImpl =

--- a/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
+++ b/packages/protocol/script/layer2/mainnet/DeployMainnetPacayaL2.s.sol
@@ -29,13 +29,13 @@ contract DeployMainnetPacayaL2 is DeployCapability {
         // Shared resolver
         address sharedResolver = deployProxy({
             name: "shared_resolver",
-            impl: address(new SharedResolver()),
+            impl: address(new DefaultResolver()),
             data: abi.encodeCall(DefaultResolver.init, (address(0)))
         });
         // Rollup resolver
         address rollupResolver = deployProxy({
             name: "rollup_resolver",
-            impl: address(new RollupResolver()),
+            impl: address(new DefaultResolver()),
             data: abi.encodeCall(DefaultResolver.init, (address(0)))
         });
         // Copy register


### PR DESCRIPTION
During the review, we all missed that we better to use `mainnet/resolvers/RollupResolver.sol`, `mainnet/resolvers/SharedResolver.sol` and `MainnetSignalService`. Will create another multi-sig to proxy upgrade these 3 addresses, once its merged. 

EDIT: let's double-check if we still need the `fallback` functionality for `RollupResolver` and `SharedResolver`. @dantaik 