### PR TITLE
chore(protocol): minor changes to PreconfSlasher

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/iface/IPreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/iface/IPreconfSlasher.sol
@@ -138,7 +138,6 @@ interface IPreconfSlasher is ISlasher {
     error ParentHashMismatch();
     error PossibleReorgOfAnchorBlock();
     error PreconfirmationIsValid();
-    error ReorgedPreconf();
 
     /// @notice Returns the slash amount for each violation type
     /// @return slashAmount The slash amount for each violation type

--- a/packages/protocol/contracts/layer1/preconf/iface/IPreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/iface/IPreconfSlasher.sol
@@ -127,6 +127,7 @@ interface IPreconfSlasher is ISlasher {
     error InvalidBlockHeader();
     error InvalidChainId();
     error InvalidDomainSeparator();
+    error InvalidActualBlockHeader();
     error InvalidNextBatchMetadata();
     error InvalidVerifiedBlockHeader();
     error InvalidViolationType();
@@ -137,6 +138,7 @@ interface IPreconfSlasher is ISlasher {
     error ParentHashMismatch();
     error PossibleReorgOfAnchorBlock();
     error PreconfirmationIsValid();
+    error ReorgedPreconf();
 
     /// @notice Returns the slash amount for each violation type
     /// @return slashAmount The slash amount for each violation type

--- a/packages/protocol/contracts/layer1/preconf/iface/IPreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/iface/IPreconfSlasher.sol
@@ -41,6 +41,9 @@ interface IPreconfSlasher is ISlasher {
         ITaikoInbox.BatchInfo batchInfo;
         // This is the BatchMetadata of the batch that contains the block at height X
         ITaikoInbox.BatchMetadata batchMetadata;
+        // Blockhash value of the block that was proposed at height X,
+        // but does not match with the blockhash of the preconfirmed block at the same height.
+        LibBlockHeader.BlockHeader actualBlockHeader;
         // This is the Blockheader of the last block in the batch that contains the block at height
         // X. This is used as the reference blockheader for verifying anchor state.
         LibBlockHeader.BlockHeader verifiedBlockHeader;
@@ -81,8 +84,6 @@ interface IPreconfSlasher is ISlasher {
     // Merkle trie proof for a blockhash stored in L2 TaikoAnchor contract.
     // The EVM `slot` containing the blockhash is calculated dynamically based on the block number.
     struct BlockhashProofs {
-        // Blockhash value
-        LibBlockHeader.BlockHeader actualBlockHeader;
         // Patricia trie account proof
         bytes[] accountProof;
         // Patricia trie storage proof

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
@@ -125,12 +125,9 @@ contract PreconfSlasher is IPreconfSlasher, EssentialContract {
         if (batchInfo.proposer != _committer) {
             // If the beacon block root is not available, it means that the preconfirmed block
             // was reorged out due to an L1 reorg.
-            require(
-                LibPreconfUtils.getBeaconBlockRootAt(_payload.preconferSlotTimestamp) == 0,
-                ReorgedPreconf()
-            );
-
-            return getSlashAmount().reorgedPreconf;
+            if (LibPreconfUtils.getBeaconBlockRootAt(_payload.preconferSlotTimestamp) == 0) {
+                return getSlashAmount().reorgedPreconf;
+            }
         }
 
         LibBlockHeader.BlockHeader memory actual = evidence.parentBlockhashProofs.actualBlockHeader;

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
@@ -136,7 +136,8 @@ contract PreconfSlasher is IPreconfSlasher, EssentialContract {
         require(actual.number == preconfed.number, InvalidActualBlockHeader());
 
         // The verified block must be at a higher height than the preconfirmed block, otherwise, the
-        // preconfed block hash won't be written by the anchor transaction.
+        // preconfed block hash won't be written by the anchor transaction. Note that the verified
+        // block deosn't have to be the last blcok in th same batch.
         require(verified.number > preconfed.number, InvalidVerifiedBlockHeader());
 
         // The preconfirmed blockhash must not match the hash of the proposed block for a

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
@@ -134,7 +134,10 @@ contract PreconfSlasher is IPreconfSlasher, EssentialContract {
         LibBlockHeader.BlockHeader memory verified = evidence.verifiedBlockHeader;
 
         require(actual.number == preconfed.number, InvalidActualBlockHeader());
-        require(verified.number >= preconfed.number, InvalidVerifiedBlockHeader());
+
+        // The verified block must be at a higher height than the preconfirmed block, otherwise, the
+        // preconfed block hash won't be written by the anchor transaction.
+        require(verified.number > preconfed.number, InvalidVerifiedBlockHeader());
 
         // The preconfirmed blockhash must not match the hash of the proposed block for a
         // preconfirmation violation

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
@@ -146,6 +146,7 @@ contract PreconfSlasher is IPreconfSlasher, EssentialContract {
             taikoInbox.v4GetBatchVerifyingTransition(uint64(_payload.batchId + 1));
 
         // Validate the verified blockheader
+        LibBlockHeader.BlockHeader memory verified = evidence.verifiedBlockHeader;
         require(transition.blockHash == verified.hash(), InvalidVerifiedBlockHeader());
 
         // Validate that the parent on which this block was preconfirmed made it to the inbox, i.e
@@ -160,20 +161,16 @@ contract PreconfSlasher is IPreconfSlasher, EssentialContract {
             evidence.parentBlockhashProofs.storageProof
         );
 
-        if (verified.number == blockId) {
-            require(transition.blockHash == actualBlockHash, InvalidVerifiedBlockHeader());
-        } else {
-            // Verify that `blockhashProofs` correctly proves the blockhash of the block proposed
-            // at the same height as the preconfirmed block.
-            LibTrieProof.verifyMerkleProof(
-                verified.stateRoot,
-                taikoAnchor,
-                _calcBlockHashSlot(blockId),
-                actualBlockHash,
-                evidence.parentBlockhashProofs.accountProof,
-                evidence.parentBlockhashProofs.storageProof
-            );
-        }
+        // Verify that `blockhashProofs` correctly proves the blockhash of the block proposed
+        // at the same height as the preconfirmed block.
+        LibTrieProof.verifyMerkleProof(
+            verified.stateRoot,
+            taikoAnchor,
+            _calcBlockHashSlot(blockId),
+            actualBlockHash,
+            evidence.parentBlockhashProofs.accountProof,
+            evidence.parentBlockhashProofs.storageProof
+        );
 
         return getSlashAmount().invalidPreconf;
     }

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
@@ -136,8 +136,7 @@ contract PreconfSlasher is IPreconfSlasher, EssentialContract {
         require(actual.number == preconfed.number, InvalidActualBlockHeader());
 
         // The verified block must be at a higher height than the preconfirmed block, otherwise, the
-        // preconfed block hash won't be written by the anchor transaction. Note that the verified
-        // block deosn't have to be the last blcok in th same batch.
+        // preconfed block hash won't be written by the anchor transaction. 
         require(verified.number > preconfed.number, InvalidVerifiedBlockHeader());
 
         // The preconfirmed blockhash must not match the hash of the proposed block for a

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
@@ -138,7 +138,6 @@ contract PreconfSlasher is IPreconfSlasher, EssentialContract {
 
         require(actual.number == preconfed.number, InvalidActualBlockHeader());
         require(verified.number >= preconfed.number, InvalidVerifiedBlockHeader());
-        require(verified.number == batchInfo.lastBlockId, InvalidVerifiedBlockHeader());
 
         // The preconfirmed blockhash must not match the hash of the proposed block for a
         // preconfirmation violation

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasher.sol
@@ -168,8 +168,8 @@ contract PreconfSlasher is IPreconfSlasher, EssentialContract {
             taikoAnchor,
             _calcBlockHashSlot(blockId),
             actualBlockHash,
-            evidence.parentBlockhashProofs.accountProof,
-            evidence.parentBlockhashProofs.storageProof
+            evidence.blockhashProofs.accountProof,
+            evidence.blockhashProofs.storageProof
         );
 
         return getSlashAmount().invalidPreconf;


### PR DESCRIPTION
This PR tries to fix a bug where the block in question is the last block in a batch. In such case, we cannot use L2 anchor's storage-based proof verification to verify the block hash as this last block's hash will only be written by the first block in the next batch.