### PR TITLE
fix(taiko-client): only update the lookahead once per epoch

### DIFF
--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -489,18 +489,19 @@ func (d *Driver) cacheLookaheadLoop() {
 		// so, this means we should use a reliable slot past 0 where the operator has no possible
 		// way to change. mid-epooch works, so we use slot 16.
 		if l == nil || l.LastEpochUpdated < currentEpoch && slotInEpoch >= 15 {
-			// push into our 3‑epoch ring
 			log.Info("Pushing into window for current epoch",
 				"epoch", currentEpoch,
+				"slotInEpoch", slotInEpoch,
 				"currOp", currOp.Hex(),
 				"nextOp", nextOp.Hex(),
 			)
 			opWin.Push(currentEpoch, currOp, nextOp)
 
-			// Push next epoch (nextOp becomes currOp at next epoch)
+			// Push next epoch
 			log.Info("Pushing into window for next epoch",
 				"epoch", currentEpoch+1,
-				"currOp", nextOp.Hex(),
+				"slotInEpoch", slotInEpoch,
+				"currOp", nextOp.Hex(), // currOp becomes nextOp at next epoch
 			)
 			opWin.Push(currentEpoch+1, nextOp, common.Address{}) // we don't know next-next-op, safe to leave zero
 

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -490,11 +490,18 @@ func (d *Driver) cacheLookaheadLoop() {
 		// way to change. mid-epooch works, so we use slot 16.
 		if l == nil || l.LastEpochUpdated < currentEpoch && slotInEpoch >= 15 {
 			// push into our 3‑epoch ring
-			log.Debug("Pushing into window", "epoch", currentEpoch, "currOp", currOp.Hex(), "nextOp", nextOp.Hex())
+			log.Info("Pushing into window for current epoch",
+				"epoch", currentEpoch,
+				"currOp", currOp.Hex(),
+				"nextOp", nextOp.Hex(),
+			)
 			opWin.Push(currentEpoch, currOp, nextOp)
 
 			// Push next epoch (nextOp becomes currOp at next epoch)
-			log.Debug("Pushing into window", "epoch", currentEpoch+1, "currOp", nextOp.Hex(), "nextOp", common.Address{})
+			log.Info("Pushing into window for next epoch",
+				"epoch", currentEpoch+1,
+				"currOp", nextOp.Hex(),
+			)
 			opWin.Push(currentEpoch+1, nextOp, common.Address{}) // we don't know next-next-op, safe to leave zero
 
 			var (

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -491,6 +491,7 @@ func (d *Driver) cacheLookaheadLoop() {
 		if l == nil || l.LastEpochUpdated < currentEpoch && slotInEpoch >= 15 {
 			log.Info("Pushing into window for current epoch",
 				"epoch", currentEpoch,
+				"currentSlot", currentSlot,
 				"slotInEpoch", slotInEpoch,
 				"currOp", currOp.Hex(),
 				"nextOp", nextOp.Hex(),
@@ -500,6 +501,7 @@ func (d *Driver) cacheLookaheadLoop() {
 			// Push next epoch
 			log.Info("Pushing into window for next epoch",
 				"epoch", currentEpoch+1,
+				"currentSlot", currentSlot,
 				"slotInEpoch", slotInEpoch,
 				"currOp", nextOp.Hex(), // currOp becomes nextOp at next epoch
 			)

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -483,13 +483,14 @@ func (d *Driver) cacheLookaheadLoop() {
 			return err
 		}
 
-		l := d.preconfBlockServer.GetLookahead()
+		lookahead := d.preconfBlockServer.GetLookahead()
 		// we dont need to update the lookahead on every slot, we just need to make sure we do it
 		// once per epoch, since we push the next operator as the current range when we check.
 		// so, this means we should use a reliable slot past 0 where the operator has no possible
 		// way to change. mid-epooch works, so we use slot 16.
-		if l == nil || l.LastEpochUpdated < currentEpoch && slotInEpoch >= 15 {
-			log.Info("Pushing into window for current epoch",
+		if lookahead == nil || lookahead.LastEpochUpdated < currentEpoch && slotInEpoch >= 15 {
+			log.Info(
+				"Pushing into window for current epoch",
 				"epoch", currentEpoch,
 				"currentSlot", currentSlot,
 				"slotInEpoch", slotInEpoch,
@@ -498,8 +499,9 @@ func (d *Driver) cacheLookaheadLoop() {
 			)
 			opWin.Push(currentEpoch, currOp, nextOp)
 
-			// Push next epoch
-			log.Info("Pushing into window for next epoch",
+			// Push next epoch into window.
+			log.Info(
+				"Pushing into window for next epoch",
 				"epoch", currentEpoch+1,
 				"currentSlot", currentSlot,
 				"slotInEpoch", slotInEpoch,
@@ -511,7 +513,6 @@ func (d *Driver) cacheLookaheadLoop() {
 				currRanges = opWin.SequencingWindowSplit(d.PreconfOperatorAddress, true)
 				nextRanges = opWin.SequencingWindowSplit(d.PreconfOperatorAddress, false)
 			)
-
 			d.preconfBlockServer.UpdateLookahead(&preconfBlocks.Lookahead{
 				CurrOperator:     currOp,
 				NextOperator:     nextOp,
@@ -536,13 +537,14 @@ func (d *Driver) cacheLookaheadLoop() {
 			return nil
 		}
 
-		// otherwise, just log out information
+		// Otherwise, just log out lookahead information.
 		var (
 			currRanges = opWin.SequencingWindowSplit(d.PreconfOperatorAddress, true)
 			nextRanges = opWin.SequencingWindowSplit(d.PreconfOperatorAddress, false)
 		)
 
-		log.Info("Lookahead tick",
+		log.Info(
+			"Lookahead tick",
 			"currentSlot", currentSlot,
 			"currentEpoch", currentEpoch,
 			"slotsLeftInEpoch", slotsLeftInEpoch,

--- a/packages/taiko-client/driver/preconf_blocks/lookahead.go
+++ b/packages/taiko-client/driver/preconf_blocks/lookahead.go
@@ -102,9 +102,10 @@ func (w *opWindow) SequencingWindowSplit(operator common.Address, curr bool) []S
 
 // Lookahead holds the up‑to‑date sequencing window and operator addrs.
 type Lookahead struct {
-	CurrOperator common.Address `json:"currOperator"`
-	NextOperator common.Address `json:"nextOperator"`
-	CurrRanges   []SlotRange    `json:"currRanges"` // slots allowed for CurrOperator (0..threshold-1)
-	NextRanges   []SlotRange    `json:"nextRanges"` // slots allowed for NextOperator (threshold..slotsPerEpoch-1)
-	UpdatedAt    time.Time      `json:"updatedAt"`
+	CurrOperator     common.Address `json:"currOperator"`
+	NextOperator     common.Address `json:"nextOperator"`
+	CurrRanges       []SlotRange    `json:"currRanges"` // slots allowed for CurrOperator (0..threshold-1)
+	NextRanges       []SlotRange    `json:"nextRanges"` // slots allowed for NextOperator (threshold..slotsPerEpoch-1)
+	UpdatedAt        time.Time      `json:"updatedAt"`
+	LastEpochUpdated uint64         `json:"lastUpdatedEpoch"`
 }

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -779,6 +779,14 @@ func (s *PreconfBlockAPIServer) UpdateLookahead(lookahead *Lookahead) {
 	s.lookahead = lookahead
 }
 
+// GetLookahead updates the lookahead information.
+func (s *PreconfBlockAPIServer) GetLookahead() *Lookahead {
+	s.lookaheadMutex.Lock()
+	defer s.lookaheadMutex.Unlock()
+
+	return s.lookahead
+}
+
 // CheckLookaheadHandover returns nil if feeRecipient is allowed to build at slot globalSlot (absolute L1 slot).
 // and checks the  handover window to see if we need to request the end of sequencing
 // block.


### PR DESCRIPTION
if a slot is late and we update the lookahead at slotInEpoch 0, it can be the same as a missed slot - the beacon chain will not update properly and the current/next operators from the contract will not roll over correctly. This will lead to incorrectly adding slot ranges for a sequencer whos *not the active sequencer*.

Instead, we grab a safe slot - any slot past 16 is fine, mid-epoch it will not change, since we have a delayed whitelist implementation as well. Then on every slot tick, we just emit logs instead, and only update once-per-epoch.

This is fine because we also update the current ranges for the *next operator* when we update the lookahead already.

IE: if CurrentOperator owns epoch 0 (slots 0-31), and the NextOperator will own epoch 1 (slots 32-63), when we pull down the NextOperator during epoch 0, we update the CurrentRanges for that address already. This is the advantage of "global slot based lookahead sequencing" instead of just using the current/nextoperator - we don't care about missed slots, and now with this fix, we also don't care about late slots at the epoch boundaries.