### PR TITLE
feat(protocol): add optional lastBlockId check in PreconfRouter

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
@@ -11,6 +11,8 @@ contract PreconfRouter is EssentialContract, IPreconfRouter {
     address public immutable proposeBlockEntrypoint;
     address public immutable preconfWhitelist;
 
+    error InvalidLastBlockId(uint96 _actual, uint96 _expected);
+
     uint256[50] private __gap;
 
     constructor(
@@ -46,5 +48,22 @@ contract PreconfRouter is EssentialContract, IPreconfRouter {
 
         // Verify that the sender had set itself as the proposer
         require(meta_.proposer == msg.sender, ProposerIsNotTheSender());
+    }
+
+    function proposeBatchWithExpectedLastBlockId(
+        bytes calldata _params,
+        bytes calldata _txList,
+        uint96 _expectedLastBlockId
+    )
+        external
+        returns (ITaikoInbox.BatchInfo memory info_, ITaikoInbox.BatchMetadata memory meta_)
+    {
+        (info_, meta_) = this.proposeBatch(_params, _txList);
+
+        // Verify that the last block id is as expected
+        require(
+            info_.lastBlockId == _expectedLastBlockId,
+            InvalidLastBlockId(info_.lastBlockId, _expectedLastBlockId)
+        );
     }
 }


### PR DESCRIPTION
Supersedes #19471, pointing to the right base branch used in current preconf team devnets.

The difference with the earlier approach is to use `PreconfRouter` which is the real entrypoint 
that requires to be called by the operator EOA.

The approach using parentMetaHash ended up not working because it requires knowing the `block.timestamp` of
when the transaction will land in a block, which makes it unreliable.