### PR TITLE
fix(taiko-client): update `highestUnsafeL2PayloadBlockID` if reorging via `POST /preconfBlocks`

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -166,11 +166,9 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 
 	header := headers[0]
 
-	// If the block number is greater than the highest unsafe L2 payload block ID,
-	// update the highest unsafe L2 payload block ID.
-	if header.Number.Uint64() > s.highestUnsafeL2PayloadBlockID {
-		s.updateHighestUnsafeL2Payload(header.Number.Uint64())
-	}
+	// always update the highest unsafe L2 payload block ID.
+	// its either higher than the existing one, or we reorged.
+	s.updateHighestUnsafeL2Payload(header.Number.Uint64())
 
 	// Propagate the preconfirmation block to the P2P network, if the current server
 	// connects to the P2P network.

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -942,6 +942,9 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 	if err != nil && !errors.Is(err, ethereum.NotFound) {
 		return false, fmt.Errorf("failed to fetch header by hash: %w", err)
 	}
+
+	willReorg := false
+
 	if header != nil {
 		if header.Hash() == msg.ExecutionPayload.BlockHash {
 			log.Info(
@@ -962,6 +965,8 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 				"headerHash", header.Hash().Hex(),
 				"headerParentHash", header.ParentHash.Hex(),
 			)
+
+			willReorg = true
 		}
 	}
 
@@ -976,7 +981,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 
 	// If the block number is greater than the highest unsafe L2 payload block ID,
 	// update the highest unsafe L2 payload block ID.
-	if uint64(msg.ExecutionPayload.BlockNumber) > s.highestUnsafeL2PayloadBlockID {
+	if uint64(msg.ExecutionPayload.BlockNumber) > s.highestUnsafeL2PayloadBlockID || willReorg {
 		s.updateHighestUnsafeL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1005,11 +1005,18 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 
 // updateHighestUnsafeL2Payload updates the highest unsafe L2 payload block ID.
 func (s *PreconfBlockAPIServer) updateHighestUnsafeL2Payload(blockID uint64) {
-	log.Info(
-		"Updating highest unsafe L2 payload block ID",
-		"blockID", blockID,
-		"currentHighestUnsafeL2PayloadBlockID", s.highestUnsafeL2PayloadBlockID,
-	)
+	if blockID > s.highestUnsafeL2PayloadBlockID {
+		log.Info(
+			"Updating highest unsafe L2 payload block ID",
+			"blockID", blockID,
+			"currentHighestUnsafeL2PayloadBlockID", s.highestUnsafeL2PayloadBlockID,
+		)
+	} else {
+		log.Info("Reorging highest unsafe L2 payload blockID",
+			"blockID", blockID,
+			"currentHighestUnsafeL2PayloadBlockID", s.highestUnsafeL2PayloadBlockID,
+		)
+	}
 	s.highestUnsafeL2PayloadBlockID = blockID
 }
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -943,8 +943,6 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 		return false, fmt.Errorf("failed to fetch header by hash: %w", err)
 	}
 
-	willReorg := false
-
 	if header != nil {
 		if header.Hash() == msg.ExecutionPayload.BlockHash {
 			log.Info(
@@ -965,8 +963,6 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 				"headerHash", header.Hash().Hex(),
 				"headerParentHash", header.ParentHash.Hex(),
 			)
-
-			willReorg = true
 		}
 	}
 
@@ -981,7 +977,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 
 	// If the block number is greater than the highest unsafe L2 payload block ID,
 	// update the highest unsafe L2 payload block ID.
-	if uint64(msg.ExecutionPayload.BlockNumber) > s.highestUnsafeL2PayloadBlockID || willReorg {
+	if uint64(msg.ExecutionPayload.BlockNumber) > s.highestUnsafeL2PayloadBlockID {
 		s.updateHighestUnsafeL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
 	}
 


### PR DESCRIPTION
Intentional P2P reorg can happen, and we allow it, but we dont update the highestUnsafeL2PayloadBlockID, which we need to.

We already do on the reception of this block on the P2P Network in OnUnsafeL2Payload:
```
	// If the block number is less than or equal to the highest unsafe L2 payload block ID,
	// we also need to update the highest unsafe L2 payload block ID.
	if header != nil && uint64(msg.ExecutionPayload.BlockNumber) <= header.Number.Uint64() {
		log.Info(
			"Preconfirmation block is reorging",
			"blockID", uint64(msg.ExecutionPayload.BlockNumber),
			"hash", msg.ExecutionPayload.BlockHash.Hex(),
			"parentHash", msg.ExecutionPayload.ParentHash.Hex(),
			"headerHash", header.Hash().Hex(),
			"headerParentHash", header.ParentHash.Hex(),
		)
		s.updateHighestUnsafeL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
	}
```

but we dont do it when the block is actually made, so that node gets bricked because headL1Origing gets updated but highestUnsafeL2Payload doesn't.