### PR TITLE
fix(protocol): allow preconfer from next epoch to propose in advanced in current epoch

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/iface/ILookaheadStore.sol
+++ b/packages/protocol/contracts/layer1/preconf/iface/ILookaheadStore.sol
@@ -6,18 +6,9 @@ import "@eth-fabric/urc/ISlasher.sol";
 /// @title ILookaheadStore
 /// @custom:security-contact security@taiko.xyz
 interface ILookaheadStore {
-    // An array of `LookaheadPayload` will be byte-encoded to be the payload of the
-    // lookahead commitment.
-    struct LookaheadPayload {
-        // Timestamp of the L1 slot
-        uint48 slotTimestamp;
-        // Registration root of the operator in the URC
-        bytes32 registrationRoot;
-        // Index of the Operator's registration merkle tree leaf that contains the validator
-        // for the slot
-        uint256 validatorLeafIndex;
-    }
-
+    // An array of LookaheadSlot structs is used in two ways:
+    // 1. It is byte-encoded to form the payload of the lookahead commitment
+    // 2. The same array is hashed (using keccak256) and stored in the lookahead store
     struct LookaheadSlot {
         // The preconfer operator's committer address that is fetched from the slashing commitment.
         address committer;
@@ -47,6 +38,7 @@ interface ILookaheadStore {
     }
 
     error CommitmentSignerMismatch();
+    error CommitterMismatch();
     error InvalidLookaheadEpoch();
     error InvalidSlotTimestamp();
     error InvalidValidatorLeafIndex();
@@ -74,7 +66,13 @@ interface ILookaheadStore {
     /// @param _registrationRoot The registration root of the posting-operator in the URC.
     /// @param _data The signed commitment containing the lookahead data, or the lookahead data if
     /// posted by the protector.
-    function updateLookahead(bytes32 _registrationRoot, bytes calldata _data) external;
+    /// @return lookaheadHash_ The lookahead hash.
+    function updateLookahead(
+        bytes32 _registrationRoot,
+        bytes calldata _data
+    )
+        external
+        returns (bytes26 lookaheadHash_);
 
     /// @notice Calculates the lookahead hash for a given epoch and lookahead slots.
     /// @param _epochTimestamp The timestamp of the epoch.

--- a/packages/protocol/contracts/layer1/preconf/impl/LookaheadStore.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/LookaheadStore.sol
@@ -38,23 +38,24 @@ contract LookaheadStore is ILookaheadStore, EssentialContract {
     )
         external
         nonReentrant
+        returns (bytes26 lookaheadHash_)
     {
         bool isPostedByProtector = msg.sender == protector;
-        LookaheadPayload[] memory lookaheadPayloads;
+        LookaheadSlot[] memory lookaheadSlots;
 
         if (isPostedByProtector) {
-            lookaheadPayloads = abi.decode(_data, (LookaheadPayload[]));
+            lookaheadSlots = abi.decode(_data, (LookaheadSlot[]));
         } else if (isLookaheadRequired()) {
             // Validate the lookahead poster's operator status within the URC
-            lookaheadPayloads = _validateLookaheadPoster(
+            lookaheadSlots = _validateLookaheadPoster(
                 _registrationRoot, abi.decode(_data, (ISlasher.SignedCommitment))
             );
         } else {
             revert LookaheadNotRequired();
         }
 
-        _updateLookahead(
-            LibPreconfUtils.getEpochTimestamp(1), lookaheadPayloads, isPostedByProtector
+        return _updateLookahead(
+            LibPreconfUtils.getEpochTimestamp(1), lookaheadSlots, isPostedByProtector
         );
     }
 
@@ -103,12 +104,13 @@ contract LookaheadStore is ILookaheadStore, EssentialContract {
 
     function _updateLookahead(
         uint256 _nextEpochTimestamp,
-        LookaheadPayload[] memory _lookaheadPayloads,
+        LookaheadSlot[] memory _lookaheadSlots,
         bool _isPostedByProtector
     )
         internal
+        returns (bytes26 lookaheadHash_)
     {
-        LookaheadSlot[] memory lookaheadSlots = new LookaheadSlot[](_lookaheadPayloads.length);
+        LookaheadSlot[] memory lookaheadSlots = new LookaheadSlot[](_lookaheadSlots.length);
 
         unchecked {
             // Set this value to the last slot timestamp of the previous epoch
@@ -118,20 +120,20 @@ contract LookaheadStore is ILookaheadStore, EssentialContract {
 
             uint256 minCollateralForPreconfing = getConfig().minCollateralForPreconfing;
 
-            for (uint256 i; i < _lookaheadPayloads.length; ++i) {
-                LookaheadPayload memory lookaheadPayload = _lookaheadPayloads[i];
+            for (uint256 i; i < _lookaheadSlots.length; ++i) {
+                LookaheadSlot memory lookaheadSlot = _lookaheadSlots[i];
 
                 require(
-                    lookaheadPayload.slotTimestamp > prevSlotTimestamp,
+                    lookaheadSlot.slotTimestamp > prevSlotTimestamp,
                     SlotTimestampIsNotIncrementing()
                 );
                 require(
-                    (lookaheadPayload.slotTimestamp - _nextEpochTimestamp)
+                    (lookaheadSlot.slotTimestamp - _nextEpochTimestamp)
                         % LibPreconfConstants.SECONDS_IN_EPOCH == 0,
                     InvalidSlotTimestamp()
                 );
 
-                prevSlotTimestamp = lookaheadPayload.slotTimestamp;
+                prevSlotTimestamp = lookaheadSlot.slotTimestamp;
 
                 // Validate the operator in the lookahead payload with the current epoch as
                 // reference
@@ -139,22 +141,23 @@ contract LookaheadStore is ILookaheadStore, EssentialContract {
                     IRegistry.OperatorData memory operatorData,
                     IRegistry.SlasherCommitment memory slasherCommitment
                 ) = _validateOperator(
-                    lookaheadPayload.registrationRoot,
+                    lookaheadSlot.registrationRoot,
                     currentEpochTimestamp,
                     minCollateralForPreconfing,
                     preconfSlasher
                 );
 
                 require(
-                    lookaheadPayload.validatorLeafIndex < operatorData.numKeys,
+                    lookaheadSlot.validatorLeafIndex < operatorData.numKeys,
                     InvalidValidatorLeafIndex()
                 );
+                require(lookaheadSlot.committer == slasherCommitment.committer, CommitterMismatch());
 
                 lookaheadSlots[i] = LookaheadSlot({
                     committer: slasherCommitment.committer,
-                    slotTimestamp: lookaheadPayload.slotTimestamp,
-                    registrationRoot: lookaheadPayload.registrationRoot,
-                    validatorLeafIndex: lookaheadPayload.validatorLeafIndex
+                    slotTimestamp: lookaheadSlot.slotTimestamp,
+                    registrationRoot: lookaheadSlot.registrationRoot,
+                    validatorLeafIndex: lookaheadSlot.validatorLeafIndex
                 });
             }
 
@@ -166,12 +169,11 @@ contract LookaheadStore is ILookaheadStore, EssentialContract {
         }
 
         // Hash the lookahead slots and update the lookahead hash for next epoch
-        bytes26 lookaheadHash =
-            LibPreconfUtils.calculateLookaheadHash(_nextEpochTimestamp, lookaheadSlots);
-        _setLookaheadHash(_nextEpochTimestamp, lookaheadHash);
+        lookaheadHash_ = LibPreconfUtils.calculateLookaheadHash(_nextEpochTimestamp, lookaheadSlots);
+        _setLookaheadHash(_nextEpochTimestamp, lookaheadHash_);
 
         emit LookaheadPosted(
-            _isPostedByProtector, _nextEpochTimestamp, lookaheadHash, lookaheadSlots
+            _isPostedByProtector, _nextEpochTimestamp, lookaheadHash_, lookaheadSlots
         );
     }
 
@@ -187,7 +189,7 @@ contract LookaheadStore is ILookaheadStore, EssentialContract {
     )
         internal
         view
-        returns (LookaheadPayload[] memory)
+        returns (LookaheadSlot[] memory)
     {
         require(_signedCommitment.commitment.slasher == protector, SlasherIsNotProtector());
 
@@ -201,7 +203,7 @@ contract LookaheadStore is ILookaheadStore, EssentialContract {
         );
         require(committer == slasherCommitment.committer, CommitmentSignerMismatch());
 
-        return abi.decode(_signedCommitment.commitment.payload, (LookaheadPayload[]));
+        return abi.decode(_signedCommitment.commitment.payload, (LookaheadSlot[]));
     }
 
     /// @dev Validates if the operator is registered and has not been slashed at the given epoch

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter2.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter2.sol
@@ -27,6 +27,7 @@ contract PreconfRouter2 is EssentialContract, IProposeBatch {
     error InvalidLookaheadTimestamp();
     error InvalidNextLookahead();
     error InvalidPreviousLookahead();
+    error InvalidSlotIndex();
     error NotPreconfer();
     error NotPreconferOrFallback();
     error OperatorIsNotOptedIn();
@@ -77,39 +78,96 @@ contract PreconfRouter2 is EssentialContract, IProposeBatch {
             (uint256, ILookaheadStore.LookaheadSlot[], ILookaheadStore.LookaheadSlot[], bytes)
         );
 
-        uint256 epochTimestamp = LibPreconfUtils.getEpochTimestamp();
+        require(
+            slotIndex == type(uint256).max || slotIndex < currLookahead.length, InvalidSlotIndex()
+        );
 
         {
-            bytes26 currLookaheadHash = lookaheadStore.getLookaheadHash(epochTimestamp);
-            if (currLookaheadHash != 0) {
-                _validateLookahead(epochTimestamp, currLookahead, currLookaheadHash);
+            uint256 epochTimestamp = LibPreconfUtils.getEpochTimestamp();
+
+            {
+                bytes26 currLookaheadHash = lookaheadStore.getLookaheadHash(epochTimestamp);
+                if (currLookaheadHash != 0) {
+                    _validateLookahead(epochTimestamp, currLookahead, currLookaheadHash);
+                } else {
+                    require(currLookahead.length == 0, InvalidCurrentLookahead());
+                }
             }
-        }
 
-        {
-            // Try fetching the lookahead for the next epoch.
             uint256 nextEpochTimestamp = epochTimestamp + LibPreconfConstants.SECONDS_IN_EPOCH;
             bytes26 nextLookaheadHash = lookaheadStore.getLookaheadHash(nextEpochTimestamp);
-            if (nextLookaheadHash == 0) {
-                // If the lookahead for the next epoch is not posted, we post it here.
-                (bytes32 registrationRoot, bytes memory data) =
-                    abi.decode(nextLookaheadUpdateData, (bytes32, bytes));
-                lookaheadStore.updateLookahead(registrationRoot, data);
+            bool nextLookaheadNeedsValidation;
 
-                // Refetch the lookahead hash for the next epoch.
-                nextLookaheadHash = lookaheadStore.getLookaheadHash(nextEpochTimestamp);
+            // Wrapped inside a scope to avoid stack too deep error
+            {
+                if (nextLookaheadHash == 0) {
+                    // If the lookahead for the next epoch is not posted, we post it here.
+                    (bytes32 registrationRoot, bytes memory data) =
+                        abi.decode(nextLookaheadUpdateData, (bytes32, bytes));
+                    nextLookaheadHash = lookaheadStore.updateLookahead(registrationRoot, data);
+                } else {
+                    require(nextLookaheadUpdateData.length == 0, InvalidNextLookahead());
+                    nextLookaheadNeedsValidation = true;
+                }
             }
-        }
 
-        if (currLookahead.length == 0) {
-            // The current lookahead is empty, so we use a whitelisted preconfer
-            _validateWhitelistPreconfer();
-        } else {
-            _validatePreconfingPeriod(epochTimestamp, slotIndex, currLookahead, nextLookahead);
+            if (currLookahead.length == 0 || nextLookahead.length == 0) {
+                // The current lookahead is empty, so we use a whitelisted preconfer
+                _validateWhitelistPreconfer();
+            } else {
+                uint256 preconfSlotTimestamp;
+                uint256 prevSlotTimestamp;
+                ILookaheadStore.LookaheadSlot memory _lookaheadSlot;
 
-            ILookaheadStore.LookaheadSlot memory _lookaheadSlot =
-                slotIndex == type(uint256).max ? nextLookahead[0] : currLookahead[slotIndex];
-            _validateProposer(_lookaheadSlot);
+                if (slotIndex == type(uint256).max) {
+                    // This is the case when the first preconfer from the next epoch is proposing in
+                    // advanced in the current epoch.
+                    //
+                    // Eg: [x x x Pa y y y] [z z z Pb v v v]
+                    //     [  curr epoch  ] [  next epoch  ]
+                    // - Pb is our preconfer.
+                    // - x, y, z and v represent empty slots with no opted in preconfer.
+                    // - Pb intends to propose at any slot y
+                    //
+                    if (nextLookaheadNeedsValidation) {
+                        _validateLookahead(nextEpochTimestamp, nextLookahead, nextLookaheadHash);
+                    }
+
+                    preconfSlotTimestamp = nextLookahead[0].slotTimestamp;
+                    prevSlotTimestamp = currLookahead[currLookahead.length - 1].slotTimestamp;
+                    _lookaheadSlot = nextLookahead[0];
+                } else {
+                    // This is the case when the preconfer is proposing in the same epoch in which
+                    // it has its lookahead slot.
+                    //
+                    // Eg: [x x x Pa y y y]
+                    //     [  curr epoch  ]
+                    // - Pa is our preconfer.
+                    // - x and y represent empty slots with no opted in preconfer.
+                    // - Pa intends to propose at any slot x
+                    //
+                    // OR
+                    //
+                    // Eg: [x x x Pa y y y Pb z z z]
+                    //     [      curr epoch       ]
+                    // - Pb is our preconfer.
+                    // - x, y and z represent empty slots with no opted in preconfer.
+                    // - Pb intends to propose at any slot y
+                    //
+                    preconfSlotTimestamp = currLookahead[slotIndex].slotTimestamp;
+                    prevSlotTimestamp = slotIndex == 0
+                        ? epochTimestamp - LibPreconfConstants.SECONDS_IN_SLOT
+                        : currLookahead[slotIndex - 1].slotTimestamp;
+                    _lookaheadSlot = currLookahead[slotIndex];
+                }
+
+                require(
+                    block.timestamp > prevSlotTimestamp && block.timestamp <= preconfSlotTimestamp,
+                    InvalidLookaheadTimestamp()
+                );
+
+                _validateProposer(_lookaheadSlot);
+            }
         }
 
         // Both TaikoInbox and TaikoWrapper implement the same ABI for IProposeBatch.
@@ -144,66 +202,6 @@ contract PreconfRouter2 is EssentialContract, IProposeBatch {
         require(
             urc.isOptedIntoSlasher(_lookaheadSlot.registrationRoot, preconfSlasher),
             OperatorIsNotOptedIn()
-        );
-    }
-
-    /// @dev Validates if the provided lookahead data points to the current preconfing period.
-    function _validatePreconfingPeriod(
-        uint256 _epochTimestamp,
-        uint256 _slotIndex,
-        ILookaheadStore.LookaheadSlot[] memory _currLookahead,
-        ILookaheadStore.LookaheadSlot[] memory _nextLookahead
-    )
-        internal
-        view
-    {
-        uint256 preconfSlotTimestamp;
-        uint256 prevSlotTimestamp;
-
-        if (_slotIndex == type(uint256).max) {
-            // This is the case when the first preconfer from the next epoch is proposing in
-            // advanced in the current epoch.
-            //
-            // Eg: [x x x Pa y y y] [z z z Pb v v v]
-            //     [  curr epoch  ] [  next epoch  ]
-            // - Pb is our preconfer.
-            // - x, y, z and v represent empty slots with no opted in preconfer.
-            // - Pb intends to propose at any slot y
-            //
-            uint256 nextEpochTimestamp = _epochTimestamp + LibPreconfConstants.SECONDS_IN_EPOCH;
-            bytes26 nextLookaheadHash = lookaheadStore.getLookaheadHash(nextEpochTimestamp);
-            _validateLookahead(nextEpochTimestamp, _nextLookahead, nextLookaheadHash);
-
-            preconfSlotTimestamp = _nextLookahead[0].slotTimestamp;
-            prevSlotTimestamp = _currLookahead[_currLookahead.length - 1].slotTimestamp;
-        } else {
-            // This is the case when the preconfer is proposing in the same epoch in which
-            // it has its lookahead slot.
-            //
-            // Eg: [x x x Pa y y y]
-            //     [  curr epoch  ]
-            // - Pa is our preconfer.
-            // - x and y represent empty slots with no opted in preconfer.
-            // - Pa intends to propose at any slot x
-            //
-            // OR
-            //
-            // Eg: [x x x Pa y y y Pb z z z]
-            //     [      curr epoch       ]
-            // - Pb is our preconfer.
-            // - x, y and z represent empty slots with no opted in preconfer.
-            // - Pb intends to propose at any slot y
-            //
-            preconfSlotTimestamp = _currLookahead[_slotIndex].slotTimestamp;
-            prevSlotTimestamp = _slotIndex == 0
-                ? _epochTimestamp - LibPreconfConstants.SECONDS_IN_SLOT
-                : _currLookahead[_slotIndex - 1].slotTimestamp;
-        }
-
-        require(
-            block.timestamp > prevSlotTimestamp
-                && block.timestamp <= _currLookahead[_slotIndex].slotTimestamp,
-            InvalidLookaheadTimestamp()
         );
     }
 


### PR DESCRIPTION
This PR does two things:
- It fixes an issue where the first preconfer from the next epoch was not able to propose in advanced in the current epoch.
  - Eg: [x x x x Pa y y y y] [z z z Pb v v v v] 
  - Pb was able to propose at slots **z**, but not in **y**
- While implementing this fix, I noticed we do not need the previous lookahead to be passed.
  - In the above example, we were covering proposals in slots **z** using the previous lookahead's last entry as the reference, but that is not needed. We can just use the epoch's starting timestamp as the reference boundary.
  - And slots **y** are already getting covered by the newly implemented scenario.