### PR TITLE
feat(taiko-client): check router on taiko wrapper before allowing preconf block to be made

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
@@ -182,7 +182,7 @@ func (i *BlocksInserterPacaya) InsertBlocks(
 				parent,
 			)
 			if err != nil {
-				log.Warn("Failed to check if batch is in canonical chain already", "batchID", meta.GetBatchID(), "err", err)
+				log.Info("Unknown batch for the current canonical chain", "batchID", meta.GetBatchID(), "reason", err)
 			} else if lastBlockHeader != nil {
 				log.Info(
 					"🧬 Known batch in canonical chain",

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -18,8 +18,8 @@ import (
 	"github.com/modern-go/reflect2"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/encoding"
-	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/metrics"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/utils"
 )
 

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -197,6 +197,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 		log.Info(
 			"Gossiping unsafe L2 payload",
 			"blockID", header.Number,
+			"hash", header.Hash(),
 			"coinbase", header.Coinbase,
 			"timestamp", header.Time,
 			"gasLimit", header.GasLimit,

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -67,19 +67,13 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if s.rpc.PacayaClients != nil && s.rpc.PacayaClients.TaikoWrapper != nil {
-		taikoWrapper, err := s.rpc.PacayaClients.TaikoWrapper.PreconfRouter(
-			&bind.CallOpts{
-				Context: c.Request().Context(),
-			},
-		)
-		if err != nil {
-			return s.returnError(c, http.StatusInternalServerError, err)
-		}
-
-		if taikoWrapper == rpc.ZeroAddress {
-			return s.returnError(c, http.StatusInternalServerError, errors.New("preconfs are disabled via taiko wrapper"))
-		}
+	// Check if the preconfirmation is enabled.
+	preconfRouter, err := s.rpc.GetPreconfRouterPacaya(&bind.CallOpts{Context: c.Request().Context()})
+	if err != nil {
+		return s.returnError(c, http.StatusInternalServerError, err)
+	}
+	if preconfRouter == rpc.ZeroAddress {
+		return s.returnError(c, http.StatusInternalServerError, errors.New("preconfirmation is disabled via taikoWrapper"))
 	}
 
 	// Parse the request body.

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -195,7 +195,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	// connects to the P2P network.
 	if s.p2pNode != nil && !reflect2.IsNil(s.p2pSigner) {
 		log.Info(
-			"Gossiping L2 Payload",
+			"Gossiping L2 unsafe payload",
 			"blockID", header.Number,
 			"coinbase", header.Coinbase,
 			"timestamp", header.Time,

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -67,13 +67,16 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	// Check if the preconfirmation is enabled.
-	preconfRouter, err := s.rpc.GetPreconfRouterPacaya(&bind.CallOpts{Context: c.Request().Context()})
-	if err != nil {
-		return s.returnError(c, http.StatusInternalServerError, err)
-	}
-	if preconfRouter == rpc.ZeroAddress {
-		return s.returnError(c, http.StatusInternalServerError, errors.New("preconfirmation is disabled via taikoWrapper"))
+	if s.rpc.PacayaClients.TaikoWrapper != nil {
+		// Check if the preconfirmation is enabled.
+		preconfRouter, err := s.rpc.GetPreconfRouterPacaya(&bind.CallOpts{Context: c.Request().Context()})
+		if err != nil {
+			return s.returnError(c, http.StatusInternalServerError, err)
+		}
+		if preconfRouter == rpc.ZeroAddress {
+			log.Warn("Preconfirmation is disabled via taikoWrapper", "preconfRouter", preconfRouter.Hex())
+			return s.returnError(c, http.StatusInternalServerError, errors.New("preconfirmation is disabled via taikoWrapper"))
+		}
 	}
 
 	// Parse the request body.

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -67,17 +67,19 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	taikoWrapper, err := s.rpc.PacayaClients.TaikoWrapper.PreconfRouter(
-		&bind.CallOpts{
-			Context: c.Request().Context(),
-		},
-	)
-	if err != nil {
-		return s.returnError(c, http.StatusInternalServerError, err)
-	}
+	if s.rpc.PacayaClients != nil && s.rpc.PacayaClients.TaikoWrapper != nil {
+		taikoWrapper, err := s.rpc.PacayaClients.TaikoWrapper.PreconfRouter(
+			&bind.CallOpts{
+				Context: c.Request().Context(),
+			},
+		)
+		if err != nil {
+			return s.returnError(c, http.StatusInternalServerError, err)
+		}
 
-	if taikoWrapper == rpc.ZeroAddress {
-		return s.returnError(c, http.StatusInternalServerError, errors.New("preconfs are disabled via taiko wrapper"))
+		if taikoWrapper == rpc.ZeroAddress {
+			return s.returnError(c, http.StatusInternalServerError, errors.New("preconfs are disabled via taiko wrapper"))
+		}
 	}
 
 	// Parse the request body.

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -195,7 +195,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	// connects to the P2P network.
 	if s.p2pNode != nil && !reflect2.IsNil(s.p2pSigner) {
 		log.Info(
-			"Gossiping L2 unsafe payload",
+			"Gossiping unsafe L2 payload",
 			"blockID", header.Number,
 			"coinbase", header.Coinbase,
 			"timestamp", header.Time,

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -194,7 +194,17 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	// Propagate the preconfirmation block to the P2P network, if the current server
 	// connects to the P2P network.
 	if s.p2pNode != nil && !reflect2.IsNil(s.p2pSigner) {
-		log.Info("Gossiping L2 Payload", "blockID", header.Number.Uint64(), "time", header.Time)
+		log.Info(
+			"Gossiping L2 Payload",
+			"blockID", header.Number,
+			"coinbase", header.Coinbase,
+			"timestamp", header.Time,
+			"gasLimit", header.GasLimit,
+			"baseFeePerGas", utils.WeiToEther(new(big.Int).SetUint64(header.BaseFee.Uint64())),
+			"extraData", common.Bytes2Hex(header.Extra),
+			"parentHash", header.ParentHash,
+			"endOfSequencing", endOfSequencing,
+		)
 
 		var u256 uint256.Int
 		if overflow := u256.SetFromBig(header.BaseFee); overflow {

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -75,7 +75,11 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 		}
 		if preconfRouter == rpc.ZeroAddress {
 			log.Warn("Preconfirmation is disabled via taikoWrapper", "preconfRouter", preconfRouter.Hex())
-			return s.returnError(c, http.StatusInternalServerError, errors.New("preconfirmation is disabled via taikoWrapper"))
+			return s.returnError(
+				c,
+				http.StatusInternalServerError,
+				errors.New("preconfirmation is disabled via taikoWrapper"),
+			)
 		}
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -78,6 +78,7 @@ type PreconfBlockAPIServer struct {
 	// Last seen proposal
 	latestSeenProposalCh chan *encoding.LastSeenProposal
 	latestSeenProposal   *encoding.LastSeenProposal
+
 	// Mutex for P2P message handlers
 	mutex sync.Mutex
 }


### PR DESCRIPTION
Will block preconfs from being submitted if we disable the router, barring a sequencer issue of failing to detect this and tryign to preconf blocks.