### PR TITLE
fix(taiko-client): reduce slot required for updating lookahead

### DIFF
--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -456,27 +456,57 @@ func (d *Driver) cacheLookaheadLoop() {
 		// We dont need to update the lookahead on every slot, we just need to make sure we do it
 		// once per epoch, since we push the next operator as the current range when we check.
 		// so, this means we should use a reliable slot past 0 where the operator has no possible
-		// way to change. mid-epooch works, so we use slot 2.
+		// way to change. mid-epooch works, so we use slot 16.
 		if lookahead == nil || lookahead.LastEpochUpdated < currentEpoch && slotInEpoch >= 2 {
-			log.Info(
-				"Pushing into window for current epoch",
-				"epoch", currentEpoch,
-				"currentSlot", currentSlot,
-				"slotInEpoch", slotInEpoch,
-				"currOp", currOp.Hex(),
-				"nextOp", nextOp.Hex(),
-			)
-			opWin.Push(currentEpoch, currOp, nextOp)
+			if currOp == d.PreconfOperatorAddress && nextOp == d.PreconfOperatorAddress {
+				log.Info(
+					"Pushing into window for current epoch as current and next operator",
+					"epoch", currentEpoch,
+					"currentSlot", currentSlot,
+					"slotInEpoch", slotInEpoch,
+					"currOp", currOp.Hex(),
+					"nextOp", nextOp.Hex(),
+				)
+				opWin.Push(currentEpoch, currOp, nextOp)
 
-			// Push next epoch into window.
-			log.Info(
-				"Pushing into window for next epoch",
-				"epoch", currentEpoch+1,
-				"currentSlot", currentSlot,
-				"slotInEpoch", slotInEpoch,
-				"currOp", nextOp.Hex(), // currOp becomes nextOp at next epoch
-			)
-			opWin.Push(currentEpoch+1, nextOp, common.Address{}) // We don't know next-next-op, safe to leave zero
+				log.Info(
+					"Pushing into window for next epoch as current operator",
+					"epoch", currentEpoch+1,
+					"currentSlot", currentSlot,
+					"slotInEpoch", slotInEpoch,
+					"currOp", nextOp.Hex(),
+				)
+				opWin.Push(currentEpoch+1, nextOp, common.Address{}) // next next op is safe to leave 0
+			} else if currOp == d.PreconfOperatorAddress {
+				log.Info(
+					"Pushing into window for current epoch as current operator",
+					"epoch", currentEpoch,
+					"currentSlot", currentSlot,
+					"slotInEpoch", slotInEpoch,
+					"currOp", currOp.Hex(),
+					"nextOp", nextOp.Hex(),
+				)
+				opWin.Push(currentEpoch, currOp, common.Address{})
+			} else if nextOp == d.PreconfOperatorAddress {
+				log.Info(
+					"Pushing into window for current epoch as next operator",
+					"epoch", currentEpoch,
+					"currentSlot", currentSlot,
+					"slotInEpoch", slotInEpoch,
+					"currOp", currOp.Hex(),
+					"nextOp", nextOp.Hex(),
+				)
+				opWin.Push(currentEpoch, common.Address{}, nextOp)
+
+				log.Info(
+					"Pushing into window for next epoch as current operator",
+					"epoch", currentEpoch+1,
+					"currentSlot", currentSlot,
+					"slotInEpoch", slotInEpoch,
+					"currOp", nextOp.Hex(),
+				)
+				opWin.Push(currentEpoch+1, nextOp, common.Address{}) // next next op is safe to leave 0
+			}
 
 			var (
 				currRanges = opWin.SequencingWindowSplit(d.PreconfOperatorAddress, true)

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -456,8 +456,8 @@ func (d *Driver) cacheLookaheadLoop() {
 		// We dont need to update the lookahead on every slot, we just need to make sure we do it
 		// once per epoch, since we push the next operator as the current range when we check.
 		// so, this means we should use a reliable slot past 0 where the operator has no possible
-		// way to change. mid-epooch works, so we use slot 16.
-		if lookahead == nil || lookahead.LastEpochUpdated < currentEpoch && slotInEpoch >= 15 {
+		// way to change. mid-epooch works, so we use slot 2.
+		if lookahead == nil || lookahead.LastEpochUpdated < currentEpoch && slotInEpoch >= 2 {
 			log.Info(
 				"Pushing into window for current epoch",
 				"epoch", currentEpoch,


### PR DESCRIPTION
we missed `34` slots on Holesky today due to our beacon node having an issue, this means that after current epoch + 2, we need to wait 13 slots to update lookahead. This reduces it to 2 to immediately resolve this issue.

```
May 23 20:13:05.455 WARN Error when importing rpc blobs          slot: 4344033, block_hash: 0xd4b0be87d0fd60df5dbab17c4ee7e91e2550984ab5a1370b1861896893d55e3c, error: ParentUnknown { parent_root: 0xfc83f9f2c08433772f8ac9f727ca469e6412522003b204ed0bc610b29da12686 }
May 23 20:13:06.000 INFO Syncing                                 est_time: 0 mins, speed: 0.69 slots/sec, distance: 34 slots (6 mins), peers: 102, service: slot_notifier
May 23 20:13:14.362 INFO New RPC block received                  hash: 0xd913747454a718c8cd3e114824bbaa38abe3eab499a91a1208469c26e1383d
```

beacon missed 34 slots.

Now we make two changes:
1) update lookahead at slot 2 or greater, to minimize the risk of this edge case
2) we only push into the split window slot range ring is we are actually the operator there.