### PR TITLE
fix(taiko-client): curr range lookahead fix

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main]
+    branches: [main, lookahead_fix_2]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main, lookahead_fix_2]
+    branches: [main]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -467,7 +467,7 @@ func (d *Driver) cacheLookaheadLoop() {
 					"currOp", currOp.Hex(),
 					"nextOp", nextOp.Hex(),
 				)
-				opWin.Push(currentEpoch, currOp, nextOp)
+				opWin.Push(currentEpoch, currOp, nextOp) // push both ops in, we are current and next
 
 				log.Info(
 					"Pushing into window for next epoch as current operator",

--- a/packages/taiko-client/driver/preconf_blocks/lookahead.go
+++ b/packages/taiko-client/driver/preconf_blocks/lookahead.go
@@ -81,7 +81,7 @@ func (w *opWindow) SequencingWindowSplit(operator common.Address, curr bool) []S
 		startEpoch := epoch * w.slotsPerEpoch
 
 		if curr {
-			if w.currOps[i] == operator || w.nextOps[i] == operator {
+			if w.currOps[i] == operator {
 				ranges = append(ranges, SlotRange{
 					Start: startEpoch,
 					End:   startEpoch + threshold,

--- a/packages/taiko-client/driver/preconf_blocks/lookahead_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/lookahead_test.go
@@ -67,12 +67,23 @@ func (s *PreconfBlockAPIServerTestSuite) TestLookheadSequencingWindowSplitWithDu
 
 	s.True(reflect.DeepEqual(currRanges, []SlotRange{
 		{Start: 0, End: 28},
-		{Start: 32, End: 60},
 		{Start: 64, End: 92},
 	}), "currRanges = %v", currRanges)
 
 	s.True(reflect.DeepEqual(nextRanges, []SlotRange{
 		{Start: 60, End: 64},
+	}), "nextRanges = %v", nextRanges)
+
+	currRanges = w.SequencingWindowSplit(other, true)
+	nextRanges = w.SequencingWindowSplit(other, false)
+
+	s.True(reflect.DeepEqual(currRanges, []SlotRange{
+		{Start: 32, End: 60},
+	}), "currRanges = %v", currRanges)
+
+	s.True(reflect.DeepEqual(nextRanges, []SlotRange{
+		{Start: 28, End: 32},
+		{Start: 92, End: 96},
 	}), "nextRanges = %v", nextRanges)
 }
 

--- a/packages/taiko-client/driver/preconf_blocks/lookahead_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/lookahead_test.go
@@ -68,23 +68,23 @@ func (s *PreconfBlockAPIServerTestSuite) TestLookheadSequencingWindowSplitWithDu
 	s.True(reflect.DeepEqual(currRanges, []SlotRange{
 		{Start: 0, End: 28},
 		{Start: 64, End: 92},
-	}), "currRanges = %v", currRanges)
+	}), "currRanges addr = %v", currRanges)
 
 	s.True(reflect.DeepEqual(nextRanges, []SlotRange{
 		{Start: 60, End: 64},
-	}), "nextRanges = %v", nextRanges)
+	}), "nextRanges addr = %v", nextRanges)
 
 	currRanges = w.SequencingWindowSplit(other, true)
 	nextRanges = w.SequencingWindowSplit(other, false)
 
 	s.True(reflect.DeepEqual(currRanges, []SlotRange{
 		{Start: 32, End: 60},
-	}), "currRanges = %v", currRanges)
+	}), "currRanges other = %v", currRanges)
 
 	s.True(reflect.DeepEqual(nextRanges, []SlotRange{
 		{Start: 28, End: 32},
 		{Start: 92, End: 96},
-	}), "nextRanges = %v", nextRanges)
+	}), "nextRanges other = %v", nextRanges)
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestLookheadSequencingWindowSplitCurrRange() {

--- a/packages/taiko-client/driver/preconf_blocks/lookahead_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/lookahead_test.go
@@ -46,7 +46,6 @@ func (s *PreconfBlockAPIServerTestSuite) TestLookheadSequencingWindowSplit() {
 	s.True(reflect.DeepEqual(currRanges,
 		[]SlotRange{
 			{Start: 0, End: 28},
-			{Start: 32, End: 60},
 		}), "currRanges = %v", currRanges)
 	s.True(reflect.DeepEqual(nextRanges, []SlotRange{{Start: 60, End: 64}}), "nextRanges = %v", nextRanges)
 }


### PR DESCRIPTION
current lookahead incorrectly returns current range of the current epoch for regardless of operator, this fixes it.  Not a big issue because preconf sidecars also keep track of this, but should be fixed.