### PR TITLE
fix(protocol): add back `deployments/deploy_l1.json` output for L1 deployment scripts

### DIFF
--- a/packages/protocol/test/shared/DeployCapability.sol
+++ b/packages/protocol/test/shared/DeployCapability.sol
@@ -37,6 +37,11 @@ abstract contract DeployCapability is Script {
         console2.log("  owner      :", OwnableUpgradeable(proxy).owner());
         console2.log("  msg.sender :", msg.sender);
         console2.log("  this       :", address(this));
+
+        vm.writeJson(
+            vm.serializeAddress("deployment", name, proxy),
+            string.concat(vm.projectRoot(), "/deployments/deploy_l1.json")
+        );
     }
 
     function deployProxy(


### PR DESCRIPTION
Its part of the `taiko-client`'s unit tests.