### PR TITLE
chore(protocol): check bridge message.to is not zero address

### DIFF
--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -127,6 +127,7 @@ contract Bridge is EssentialResolverContract, IBridge {
         override
         nonZeroAddr(_message.srcOwner)
         nonZeroAddr(_message.destOwner)
+        nonZeroAddr(_message.to)
         diffChain(_message.destChainId)
         whenNotPaused
         nonReentrant

--- a/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
@@ -28,6 +28,7 @@ contract TestBridge2_recallMessage is TestBridge2Base {
         message.destOwner = Bob;
         message.destChainId = taikoChainId;
         message.value = 1 ether;
+        message.to = Zachary;
 
         vm.expectRevert(Bridge.B_INVALID_CHAINID.selector);
         eBridge.recallMessage(message, FAKE_PROOF);
@@ -70,6 +71,7 @@ contract TestBridge2_recallMessage is TestBridge2Base {
         message.destChainId = taikoChainId;
         message.value = 1 ether;
         message.srcChainId = ethereumChainId;
+        message.to = Zachary;
 
         vm.prank(address(callableSender));
         (bytes32 mhash, IBridge.Message memory m) = eBridge.sendMessage{ value: 1 ether }(message);

--- a/packages/protocol/test/shared/bridge/Bridge2_sendMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_sendMessage.t.sol
@@ -15,6 +15,11 @@ contract TestBridge2_sendMessage is TestBridge2Base {
         vm.expectRevert(EssentialContract.ZERO_ADDRESS.selector);
         eBridge.sendMessage(message);
 
+        message.to = Zachary;
+
+        vm.expectRevert(EssentialContract.ZERO_ADDRESS.selector);
+        eBridge.sendMessage(message);
+
         message.srcOwner = Alice;
         vm.expectRevert(EssentialContract.ZERO_ADDRESS.selector);
         eBridge.sendMessage(message);
@@ -38,6 +43,7 @@ contract TestBridge2_sendMessage is TestBridge2Base {
         message.value = 10_000_000;
         message.gasLimit = 20_000_000;
         message.fee = 30_000_000;
+
         vm.expectRevert(Bridge.B_INVALID_VALUE.selector);
 
         message.data = "hello";
@@ -72,6 +78,7 @@ contract TestBridge2_sendMessage is TestBridge2Base {
         message.destOwner = Bob;
         message.destChainId = taikoChainId;
         message.fee = 1;
+        message.to = Zachary;
         vm.expectRevert(Bridge.B_INVALID_FEE.selector);
         eBridge.sendMessage(message);
 


### PR DESCRIPTION
I realised we have never checked Bridge `message.to` address to be non-zero. This is not a bug, but I think it's a good tiny feature to add.