### PR TITLE
CI: migrate workflows to golangci-lint-action v8

### DIFF
--- a/.github/workflows/eventindexer.yml
+++ b/.github/workflows/eventindexer.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.23.0
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.23.0
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest


### PR DESCRIPTION
Bumps golangci-lint-action to v8 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0