### PR TITLE
fix(taiko-client): cache only if using a signer

### DIFF
--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -196,7 +196,10 @@ func (d *Driver) Start() error {
 		log.Warn("Skip P2P discovery process")
 	}
 
-	go d.cacheLookaheadLoop()
+	// only cache lookahead loop if we actually are running a signer
+	if !reflect2.IsNil(d.Config.P2PSignerConfigs) {
+		go d.cacheLookaheadLoop()
+	}
 
 	return nil
 }


### PR DESCRIPTION
that way nodes that run without beign part of the WL doesnt expend unnecessary resources