### PR TITLE
Replace Broken Link with Working Alternative

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3265,7 +3265,7 @@ packages:
 
   '@motionone/vue@10.16.4':
     resolution: {integrity: sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==}
-    deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion
+    deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/overview/about
 
   '@multiformats/dns@1.0.6':
     resolution: {integrity: sha512-nt/5UqjMPtyvkG9BQYdJ4GfLK3nMqGpFZOzf4hAmIa0sJh2LlS9YKXZ4FgwBDsaHvzZqR/rUFIywIc7pkHNNuw==}


### PR DESCRIPTION
Found a 404 error with the link https://oku-ui.com/motion.
Replaced it with a working link: https://oku-ui.com/overview/about.
If you have a better alternative, please suggest it, and I will update the link accordingly.