### PR TITLE
[DO NOT MERGE] gas analysis results

### DIFF
--- a/packages/protocol/gas-reports/inbox_without_provermarket.txt
+++ b/packages/protocol/gas-reports/inbox_without_provermarket.txt
@@ -1,5 +1,5 @@
 See `test_inbox_measure_gas_used` in InboxTest_ProposeAndProve.t.sol
 
-Gas per proposing: 195386
-Gas per proving + verification: 160360
-Total: 355746
+Gas per proposing: 170701
+Gas per proving + verification: 161123
+Total: 331824

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -582,7 +582,6 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
         (, ITaikoInbox.BatchMetadata memory meta) =
             inbox.v4ProposeBatch(abi.encode(batchParams), abi.encodePacked("txList"), "");
         uint256 gas1 = vm.stopSnapshotGas("proposeBatch");
-        console2.log("Now i stoppped measuring the v4ProposeBatch()");
 
         ITaikoInbox.BatchMetadata[] memory metas = new ITaikoInbox.BatchMetadata[](1);
         metas[0] = meta;

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -578,7 +578,6 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
         batchParams.blocks[0].anchorBlockId = uint64(block.number);
         vm.roll(block.number + 1);
 
-        console2.log("Now i measure the v4ProposeBatch()");
         vm.startSnapshotGas("proposeBatch");
         (, ITaikoInbox.BatchMetadata memory meta) =
             inbox.v4ProposeBatch(abi.encode(batchParams), abi.encodePacked("txList"), "");

--- a/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ProposeAndProve.t.sol
@@ -578,10 +578,12 @@ contract InboxTest_ProposeAndProve is InboxTestBase {
         batchParams.blocks[0].anchorBlockId = uint64(block.number);
         vm.roll(block.number + 1);
 
+        console2.log("Now i measure the v4ProposeBatch()");
         vm.startSnapshotGas("proposeBatch");
         (, ITaikoInbox.BatchMetadata memory meta) =
             inbox.v4ProposeBatch(abi.encode(batchParams), abi.encodePacked("txList"), "");
         uint256 gas1 = vm.stopSnapshotGas("proposeBatch");
+        console2.log("Now i stoppped measuring the v4ProposeBatch()");
 
         ITaikoInbox.BatchMetadata[] memory metas = new ITaikoInbox.BatchMetadata[](1);
         metas[0] = meta;


### PR DESCRIPTION
Command to run (and banchmark with base):

`FOUNDRY_TRACE=1 forge test --match-test test_inbox_measure_gas_used -vv`

Notes:
- Please read the whole analysis carefully! 
- I had to coment out emit events both in `one_nonzero_anchor_id_per_batch` and `main` branches due to stack too deep error
- I put the logging in the `main` branch on the same locations as the `one_nonzero_anchor_id_per_batch` (if you want i can attach that file too, but it is locally in my second, benchmark repo)


**v4ProposeBatch analysis:**  

**one_nonzero_anchor_id_per_batch** branch

**1st 10** batches are proposed with this modifier: `WhenMultipleBatchesAreProposedWithDefaultParameters` 
**11th** batch is proposed with 10 blocks with `anchorBlockId` set in 1 block

**1st batch** 
=== v4ProposeBatch Gas Analysis Start ===
  Initial gas: 77364543
  Gas after validation block: 77355947 consumed: 8596
  Creating BatchInfo for 1 blocks
  Gas after BatchInfo creation: 77351283 consumed: 13260
  Starting anchor block processing loop
  Block 0 processed anchor block 2
  Gas after anchor loop: 77348164 consumed: 16379
  Gas after validation+txsHash: 77346779 consumed: 17764
  Gas after metadata+fork check: 77342919 consumed: 21624
  Gas after bond operations: 77303963 consumed: 60580
  Gas after storage updates: 77233407 consumed: 131136
  Gas after verification: 77215145 consumed: 149398
  === **Total gas consumed: 150402** ===

**2nd batch**
  === v4ProposeBatch Gas Analysis Start ===
  Initial gas: 76456586
  Gas after validation block: 76450490 consumed: 6096
  Creating BatchInfo for 1 blocks
  Gas after BatchInfo creation: 76445826 consumed: 10760
  Starting anchor block processing loop
  Block 0 processed anchor block 3
  Gas after anchor loop: 76442707 consumed: 13879
  Gas after validation+txsHash: 76441322 consumed: 15264
  Gas after metadata+fork check: 76437462 consumed: 19124
  Gas after bond operations: 76424406 consumed: 32180
  Gas after storage updates: 76353850 consumed: 102736
  Gas after verification: 76342888 consumed: 113698
  === **Total gas consumed: 114702** === 
  ..
**10th batch is the same**

 **This is where we measure the gas!!**
**11th batch:** 
=== v4ProposeBatch Gas Analysis Start ===
  Initial gas: 67925968
  Gas after validation block: 67910633 consumed: 15335
  Creating BatchInfo for 10 blocks
  Gas after BatchInfo creation: 67904040 consumed: 21928
  Starting anchor block processing loop
  Block 0 processed anchor block 11
  Gas after anchor loop: 67899454 consumed: 26514
  Gas after validation+txsHash: 67898065 consumed: 27903
  Gas after metadata+fork check: 67888492 consumed: 37476
  Gas after bond operations: 67885522 consumed: 40446
  Gas after storage updates: 67814958 consumed: 111010
  Gas after verification: 67803972 consumed: 121996
  === **Total gas consumed: 123000** ===

**Emit event measurements** (separate cause it fucks me over with stack too deep even with hacks and workarounds): Without the emit event the function consumes cca.: **160K gas**. 
With the emit event it consumes cca.: **195K gas** . 

So emitting the new struct consumes **35K gas**.  

**main** branch:
**1st to 10th** batches are proposed with this modifier: `WhenMultipleBatchesAreProposedWithDefaultParameters` 
**11th** batch is proposed with same empty 10 blocks (aka default) since no `anchorIds` per block

  **1st** batch:
=== v4ProposeBatch Gas Analysis Start ===
  Initial gas: 77383347
  Gas after validation block: 77374726 consumed: 8686
  Creating BatchInfo for 1 blocks
  Gas after BatchInfo creation: 77363750 consumed: 19662
  Gas after validation+txsHash: 77362811 consumed: 20602
  Gas after metadata+fork check: 77359458 consumed: 23955
  Gas after bond operations: 77320497 consumed: 62916
  Gas after storage updates: 77252314 consumed: 131099
  Gas after verification: 77234053 consumed: 149352
  === **Total gas consumed: 150257** ===

**2nd** batch:
  === v4ProposeBatch Gas Analysis Start ===
  Initial gas: 76599151
  Gas after validation block: 76593030 consumed: 6186
  Creating BatchInfo for 1 blocks
  Gas after BatchInfo creation: 76588054 consumed: 11162
  Gas after validation+txsHash: 76587115 consumed: 12102
  Gas after metadata+fork check: 76583762 consumed: 15455
  Gas after bond operations: 76570701 consumed: 28516
  Gas after storage updates: 76502518 consumed: 96699
  Gas after verification: 76491557 consumed: 107652
  === Total gas consumed: 108557 ===
.. 
**10th batch is the same**  

**This is where we measure the gas!!** 

**11th batch:** 
=== v4ProposeBatch Gas Analysis Start ===
  Initial gas: 69114755
  Gas after validation block: 69100382 consumed: 14439
  Creating BatchInfo for 10 blocks
  Gas after BatchInfo creation: 69093606 consumed: 21215
  Gas after validation+txsHash: 69092664 consumed: 22157
  Gas after metadata+fork check: 69085991 consumed: 28831
  Gas after bond operations: 69083019 consumed: 31803
  Gas after storage updates: 69014834 consumed: 99988
  Gas after verification: 69003855 consumed: 110958
  === **Total gas consumed: 111863** ===  
  
  **Emit event measurements:**
Without the emit event the function consumes cca.: **141K gas**. 
With the emit event it consumes cca.: **168K** gas  
So emitting the new struct consumes **27K gas** here.  

Conclusions: 
- The gas measurement is always (both branches) is for the 11th batch
- The anchor loop overhead is **4,357 extra gas**
- The emit event overhead is cca **8K** extra gas

This is a clean **overhead** of **12.5K gas** and the last (11th batch) has more data to emit and less on the main, so can add some + extra. But where comes the rest ? I have no idea. (I think also gas measurements not averaging out just using the last measurement, which might distort!!)