### PR TITLE
fix(docs-site): update ethstaker org name

### DIFF
--- a/packages/docs-site/src/content/docs/guides/node-operators/run-an-ethereum-testnet-node.mdx
+++ b/packages/docs-site/src/content/docs/guides/node-operators/run-an-ethereum-testnet-node.mdx
@@ -20,7 +20,7 @@ This guide will help you get a Holesky archive node up and running.
 1. Clone eth-docker
 
     ```bash
-    git clone https://github.com/eth-educators/eth-docker
+    git clone https://github.com/ethstaker/eth-docker
     cd eth-docker
     ```
 


### PR DESCRIPTION
the ethstaker github org recently changed from eth-educators to ethstaker (squatted handle was released) - updating here