### PR TITLE
fix(taiko-client): handle reorg case when getting blobs

### DIFF
--- a/packages/taiko-client/driver/txlist_fetcher/blob.go
+++ b/packages/taiko-client/driver/txlist_fetcher/blob.go
@@ -3,6 +3,7 @@ package txlistfetcher
 import (
 	"context"
 	"crypto/sha256"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg"
+	chainiterator "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/chain_iterator"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
@@ -48,7 +50,7 @@ func (d *BlobFetcher) FetchPacaya(ctx context.Context, meta metadata.TaikoBatchM
 	// Fetch the L1 block sidecars.
 	sidecars, err := d.dataSource.GetBlobs(ctx, l1Header.Time, meta.GetBlobHashes())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get blobs, errs: %w and %w", err, chainiterator.ErrEOF)
 	}
 
 	log.Info("Fetch sidecars", "blockNumber", blockNum, "sidecars", len(sidecars))

--- a/packages/taiko-client/pkg/chain_iterator/block_batch_iterator.go
+++ b/packages/taiko-client/pkg/chain_iterator/block_batch_iterator.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	errEOF      = errors.New("end of blockBatchIterator batch")
+	ErrEOF      = errors.New("end of blockBatchIterator batch")
 	errContinue = errors.New("continue")
 )
 
@@ -144,7 +144,7 @@ func (i *BlockBatchIterator) Iter() error {
 				break
 			}
 			if err := i.iter(); err != nil {
-				if errors.Is(err, errEOF) {
+				if errors.Is(err, ErrEOF) {
 					log.Debug(
 						"Block batch iterator finished",
 						"start", i.startHeight,
@@ -209,7 +209,7 @@ func (i *BlockBatchIterator) iter() (err error) {
 	}
 
 	if i.current.Number.Uint64() >= destHeight {
-		return errEOF
+		return ErrEOF
 	}
 
 	endHeight = i.current.Number.Uint64() + i.blocksReadPerEpoch
@@ -230,7 +230,7 @@ func (i *BlockBatchIterator) iter() (err error) {
 	}
 
 	if i.isEnd {
-		return errEOF
+		return ErrEOF
 	}
 
 	i.current = endHeader
@@ -239,7 +239,7 @@ func (i *BlockBatchIterator) iter() (err error) {
 		return errContinue
 	}
 
-	return errEOF
+	return ErrEOF
 }
 
 // updateCurrent updates the iterator's current cursor.

--- a/packages/taiko-client/pkg/chain_iterator/block_batch_iterator_test.go
+++ b/packages/taiko-client/pkg/chain_iterator/block_batch_iterator_test.go
@@ -109,7 +109,7 @@ func (s *BlockBatchIteratorTestSuite) TestIterWithLessThanConfirmations() {
 	})
 
 	s.Nil(err)
-	s.Equal(errEOF, iter.iter())
+	s.Equal(ErrEOF, iter.iter())
 	s.Equal(headHeight, lastEnd)
 }
 


### PR DESCRIPTION
If reorg occurs when getting a blob, it will keep retrying before this PR, causing the block to get stuck. We need to break the loop.