### PR TITLE
feat(repo): use codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+go.mod                      @YoGhurt111 @RogerLamTd
+go.sum                      @YoGhurt111 @RogerLamTd
+.github/workflows/*         @YoGhurt111 @RogerLamTd
+/packages/*/package.json    @KorbinianK @bearni95
+/packages/docs-site/**      @RogerLamTd
+/packages/taiko-client/**   @cyberhorsey @YoGhurt111
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,6 @@ updates:
       day: "saturday"
       time: "04:20"
       timezone: "America/New_York"
-    reviewers:
-      - "YoGhurt111"
-      - "RogerLamTd"
     open-pull-requests-limit: 1
     groups:
       go-updates:
@@ -35,9 +32,6 @@ updates:
       day: "saturday"
       time: "04:20"
       timezone: "America/New_York"
-    reviewers:
-      - "YoGhurt111"
-      - "RogerLamTd"
     open-pull-requests-limit: 1
     groups:
       github-actions-updates:
@@ -51,9 +45,6 @@ updates:
       day: "saturday"
       time: "04:20"
       timezone: "America/New_York"
-    reviewers:
-      - "KorbinianK"
-      - "bearni95"
     open-pull-requests-limit: 1
     groups:
       npm-updates:


### PR DESCRIPTION
[`reviewers` is deprecated](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/), should use codeowners instead 