### PR TITLE
feat(bridge-ui): add solverfee to type

### DIFF
--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -21,7 +21,7 @@ import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
 import { calculateMessageDataSize } from './calculateMessageDataSize';
-import type { ApproveArgs, BridgeTransferOp, ERC20BridgeArgs, RequireAllowanceArgs } from './types';
+import type { ApproveArgs, ERC20BridgeArgs, ERC20BridgeTransferOp, RequireAllowanceArgs } from './types';
 
 const log = getLogger('ERC20Bridge');
 
@@ -81,7 +81,8 @@ export class ERC20Bridge extends Bridge {
       amount,
       gasLimit: Number(gasLimit),
       fee,
-    } satisfies BridgeTransferOp;
+      solverFee: BigInt(0), // not supported in the UI yet, default to 0
+    } satisfies ERC20BridgeTransferOp;
 
     log('Preparing transaction with args', sendERC20Args);
 

--- a/packages/bridge-ui/src/libs/bridge/types.ts
+++ b/packages/bridge-ui/src/libs/bridge/types.ts
@@ -124,8 +124,9 @@ interface BaseBridgeTransferOp {
   fee: bigint;
 }
 
-export interface BridgeTransferOp extends BaseBridgeTransferOp {
+export interface ERC20BridgeTransferOp extends BaseBridgeTransferOp {
   amount: bigint;
+  solverFee: bigint;
 }
 
 export interface NFTBridgeTransferOp {


### PR DESCRIPTION
Closes #19655 

This pull request refactors the `ERC20Bridge` class and related types to introduce a new `ERC20BridgeTransferOp` interface, replacing the previous generic `BridgeTransferOp`. This change adds a new `solverFee` property, defaulting to `BigInt(0)`, to better support future features.

### Refactoring of types:

* [`packages/bridge-ui/src/libs/bridge/types.ts`](diffhunk://#diff-52debfbf4e20798a7bb0172c1c674de9a851ae1150b5c10fe21331abacab0fb6L127-R129): Renamed `BridgeTransferOp` to `ERC20BridgeTransferOp` and added a new `solverFee` property to the interface.

### Updates to `ERC20Bridge` class:

* [`packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts`](diffhunk://#diff-61faebadd7d623ea04949887bba73783274daee890c27021bf223944bfaa2f1bL84-R85): Updated the type of the transaction arguments to use the new `ERC20BridgeTransferOp` interface, and added a default value of `BigInt(0)` for the `solverFee` property, as it is not yet supported in the UI.
* [`packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts`](diffhunk://#diff-61faebadd7d623ea04949887bba73783274daee890c27021bf223944bfaa2f1bL24-R24): Adjusted the imports to reflect the renaming of `BridgeTransferOp` to `ERC20BridgeTransferOp`.