### PR TITLE
Refactor config usage in TaikoInbox2 and libraries

### DIFF
--- a/packages/protocol/contracts/layer1/based2/ITaikoInbox2.sol
+++ b/packages/protocol/contracts/layer1/based2/ITaikoInbox2.sol
@@ -222,6 +222,9 @@ interface ITaikoInbox2 {
         ForkHeights forkHeights;
         /// @notice The token used for bonding.
         address bondToken;
+        address inboxWrapper;
+        address verifier;
+        address signalService;
     }
 
     /// @notice Struct holding the state variables for the {Taiko} contract.

--- a/packages/protocol/contracts/layer1/based2/TaikoInbox2.sol
+++ b/packages/protocol/contracts/layer1/based2/TaikoInbox2.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "src/shared/common/EssentialContract.sol";
 import "src/shared/based/ITaiko.sol";
+import "src/shared/signal/ISignalService.sol";
+import "src/shared/signal/LibSignals.sol";
 import "src/layer1/verifiers/IVerifier.sol";
 import "./libs/LibBonds2.sol";
 // import "./libs/LibInit2.sol";

--- a/packages/protocol/contracts/layer1/based2/TaikoInbox2.sol
+++ b/packages/protocol/contracts/layer1/based2/TaikoInbox2.sol
@@ -74,7 +74,6 @@ abstract contract TaikoInbox2 is
         I.Config memory conf = _getConfig();
         LibPropose2.Environment memory env = LibPropose2.Environment({
             // reads
-            sender: msg.sender,
             blockTimestamp: uint48(block.timestamp),
             blockNumber: uint48(block.number),
             encodeBatchMetadata: LibData2.encodeBatchMetadata,
@@ -114,12 +113,11 @@ abstract contract TaikoInbox2 is
         I.Config memory conf = _getConfig();
         LibProve2.Environment memory env = LibProve2.Environment({
             // reads
-            sender: msg.sender,
             blockTimestamp: uint48(block.timestamp),
             blockNumber: uint48(block.number),
             // writes
-            debitBond: _debitBond,
             creditBond: _creditBond,
+            debitBond: _debitBond,
             saveTransition: _saveTransition
         });
 

--- a/packages/protocol/contracts/layer1/based2/TaikoInbox2.sol
+++ b/packages/protocol/contracts/layer1/based2/TaikoInbox2.sol
@@ -195,19 +195,19 @@ abstract contract TaikoInbox2 is
     )
         private
         view
-        returns (bytes32)
+        returns (bytes32 metaHash_, bool isFirstTransition_)
     {
         uint256 slot = _batchId % _conf.batchRingBufferSize;
 
         (uint48 embededBatchId, bytes32 partialParentHash) =
             LibData2.loadBatchIdAndPartialParentHash(state, slot); // 1 SLOAD
 
-        if (embededBatchId != _batchId) return 0;
+        if (embededBatchId != _batchId) return (0, false);
 
         if (partialParentHash == _lastVerifiedBlockHash >> 48) {
-            return state.transitions[slot][1].metaHash;
+            return (state.transitions[slot][1].metaHash, true);
         } else {
-            return state.transitionMetaHashes[_batchId][_lastVerifiedBlockHash];
+            return (state.transitionMetaHashes[_batchId][_lastVerifiedBlockHash], false);
         }
     }
 

--- a/packages/protocol/contracts/layer1/based2/TaikoInbox2.sol
+++ b/packages/protocol/contracts/layer1/based2/TaikoInbox2.sol
@@ -60,7 +60,7 @@ abstract contract TaikoInbox2 is
     function v4ProposeBatches(
         I.Summary memory _summary,
         I.Batch[] memory _batch,
-        I.BatchProposeMetadataEvidence calldata _parentProposeMetaEvidence,
+        I.BatchProposeMetadataEvidence calldata _evidence,
         I.TransitionMeta[] calldata _trans
     )
         public
@@ -90,8 +90,7 @@ abstract contract TaikoInbox2 is
             validateProverAuth: LibAuth2.validateProverAuth
         });
 
-        _summary =
-            LibPropose2.proposeBatches(conf, env, _summary, _batch, _parentProposeMetaEvidence);
+        _summary = LibPropose2.proposeBatches(conf, env, _summary, _batch, _evidence);
         _summary = LibVerify2.verifyBatches(conf, env, _summary, _trans);
 
         state.updateSummary(_summary, _paused);

--- a/packages/protocol/contracts/layer1/based2/libs/LibPropose2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibPropose2.sol
@@ -40,7 +40,6 @@ library LibPropose2 {
 
     struct Environment {
         // reads
-        address sender;
         uint48 blockTimestamp;
         uint48 blockNumber;
         bytes32 parentBatchMetaHash;
@@ -52,9 +51,9 @@ library LibPropose2 {
             validateProverAuth;
         function(uint256) view returns (bytes32) getBlobHash;
         // writes
-        function(I.Config memory, address, uint256) debitBond;
-        function(address, uint256) creditBond;
         function(address, address, address, uint256) transferFee;
+        function(address, uint256) creditBond;
+        function(I.Config memory, address, uint256) debitBond;
         function(I.Config memory, uint256, bytes32) saveBatchMetaHash;
         function(I.Config memory, uint64, bytes32) syncChainData;
     }
@@ -76,7 +75,7 @@ library LibPropose2 {
         I.Config memory _conf,
         Environment memory _env,
         I.Summary memory _summary,
-        I.Batch[] memory _batch, // make call data, and keep changed field in output.
+        I.Batch[] memory _batch,
         I.BatchProposeMetadataEvidence calldata _evidence
     )
         internal
@@ -212,9 +211,9 @@ library LibPropose2 {
 
         if (_conf.inboxWrapper == address(0)) {
             if (_batch.proposer == address(0)) {
-                _batch.proposer = _env.sender;
+                _batch.proposer = msg.sender;
             } else {
-                require(_batch.proposer == _env.sender, CustomProposerNotAllowed());
+                require(_batch.proposer == msg.sender, CustomProposerNotAllowed());
             }
 
             // blob hashes are only accepted if the caller is trusted.
@@ -223,7 +222,7 @@ library LibPropose2 {
             require(_batch.isForcedInclusion == false, InvalidForcedInclusion());
         } else {
             require(_batch.proposer != address(0), CustomProposerMissing());
-            require(_env.sender == _conf.inboxWrapper, NotInboxWrapper());
+            require(msg.sender == _conf.inboxWrapper, NotInboxWrapper());
         }
 
         // In the upcoming Shasta fork, we might need to enforce the coinbase address as the
@@ -333,7 +332,7 @@ library LibPropose2 {
         // have a non-zero anchor block id. Otherwise, delegate this validation to the
         // inboxWrapper contract.
         require(
-            _env.sender == _conf.inboxWrapper || foundNoneZeroAnchorBlockId,
+            msg.sender == _conf.inboxWrapper || foundNoneZeroAnchorBlockId,
             NoAnchorBlockIdWithinThisBatch()
         );
 

--- a/packages/protocol/contracts/layer1/based2/libs/LibPropose2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibPropose2.sol
@@ -40,23 +40,21 @@ library LibPropose2 {
 
     struct Environment {
         // reads
-        I.Config conf;
-        address inboxWrapper;
         address sender;
         uint48 blockTimestamp;
         uint48 blockNumber;
         bytes32 parentBatchMetaHash;
         function(I.BatchMetadata memory) pure returns (bytes memory) encodeBatchMetadata;
-        function(bytes32) view returns (bool) isSignalSent;
+        function(I.Config memory, bytes32) view returns (bool) isSignalSent;
         function(I.Config memory, bytes32, uint256) view returns (bytes32) loadTransitionMetaHash;
         function(uint64, uint64, bytes32,  bytes memory) view returns (address, address, uint96)
             validateProverAuth;
         function(uint256) view returns (bytes32) getBlobHash;
         // writes
-        function(address, address, uint256) debitBond;
+        function(I.Config memory, address, uint256) debitBond;
         function(address, uint256) creditBond;
-        function(I.Config memory, uint256, bytes32) saveBatchMetaHash;
         function(address, address, address, uint256) transferFee;
+        function(I.Config memory, uint256, bytes32) saveBatchMetaHash;
         function(I.Config memory, uint64, bytes32) syncChainData;
     }
 
@@ -74,6 +72,7 @@ library LibPropose2 {
     }
 
     function proposeBatches(
+        I.Config memory _conf,
         Environment memory _env,
         I.Summary memory _summary,
         I.Batch[] memory _batch, // make call data, and keep changed field in output.
@@ -89,7 +88,8 @@ library LibPropose2 {
             I.BatchProposeMetadata memory parentProposeMeta = _evidence.proposeMeta;
 
             for (uint256 i; i < _batch.length; ++i) {
-                parentProposeMeta = _proposeBatch(_env, _summary, _batch[i], parentProposeMeta);
+                parentProposeMeta =
+                    _proposeBatch(_conf, _env, _summary, _batch[i], parentProposeMeta);
                 _summary.numBatches += 1;
                 _summary.lastProposedIn = _env.blockNumber;
             }
@@ -99,6 +99,7 @@ library LibPropose2 {
     }
 
     function _proposeBatch(
+        I.Config memory _conf,
         Environment memory _env,
         I.Summary memory _summary,
         I.Batch memory _batch,
@@ -108,20 +109,20 @@ library LibPropose2 {
         returns (I.BatchProposeMetadata memory)
     {
         require(
-            _summary.numBatches <= _summary.lastVerifiedBatchId + _env.conf.maxUnverifiedBatches,
+            _summary.numBatches <= _summary.lastVerifiedBatchId + _conf.maxUnverifiedBatches,
             TooManyBatches()
         );
 
         // Validate the params and returns an updated copy
         (I.Batch memory params, ParamsValidationOutput memory output) =
-            _validateBatch(_env, _batch, _parentProposeMeta);
+            _validateBatch(_conf, _env, _batch, _parentProposeMeta);
 
-        output.prover = _validateProver(_env, _summary, params.proverAuth, params);
+        output.prover = _validateProver(_conf, _env, _summary, params.proverAuth, params);
 
-        I.BatchMetadata memory meta = _populateBatchMetadata(_env, params, output);
+        I.BatchMetadata memory meta = _populateBatchMetadata(_conf, _env, params, output);
 
         bytes32 batchMetaHash = hashBatch(_summary.numBatches, meta);
-        _env.saveBatchMetaHash(_env.conf, _summary.numBatches, batchMetaHash);
+        _env.saveBatchMetaHash(_conf, _summary.numBatches, batchMetaHash);
 
         emit I.BatchProposed(_summary.numBatches, _env.encodeBatchMetadata(meta));
 
@@ -145,6 +146,7 @@ library LibPropose2 {
     }
 
     function _validateProver(
+        I.Config memory _conf,
         Environment memory _env,
         I.Summary memory _summary,
         bytes memory _proverAuth,
@@ -155,11 +157,7 @@ library LibPropose2 {
     {
         unchecked {
             if (_batch.proverAuth.length == 0) {
-                _env.debitBond(
-                    _env.conf.bondToken,
-                    _batch.proposer,
-                    _env.conf.livenessBond + _env.conf.provabilityBond
-                );
+                _env.debitBond(_conf, _batch.proposer, _conf.livenessBond + _conf.provabilityBond);
                 return _batch.proposer;
             }
 
@@ -172,31 +170,25 @@ library LibPropose2 {
             address feeToken;
             uint96 fee;
             (prover_, feeToken, fee) = _env.validateProverAuth(
-                _env.conf.chainId, _summary.numBatches, keccak256(abi.encode(_batch)), _proverAuth
+                _conf.chainId, _summary.numBatches, keccak256(abi.encode(_batch)), _proverAuth
             );
 
-            if (feeToken == _env.conf.bondToken) {
+            if (feeToken == _conf.bondToken) {
                 // proposer pay the prover fee with bond tokens
-                _env.debitBond(
-                    _env.conf.bondToken, _batch.proposer, fee + _env.conf.provabilityBond
-                );
+                _env.debitBond(_conf, _batch.proposer, fee + _conf.provabilityBond);
 
                 // if bondDelta is negative (proverFee < livenessBond), deduct the diff
                 // if not then add the diff to the bond balance
-                int256 bondDelta = int96(fee) - int96(_env.conf.livenessBond);
+                int256 bondDelta = int96(fee) - int96(_conf.livenessBond);
 
                 bondDelta < 0
-                    ? _env.debitBond(_env.conf.bondToken, prover_, uint256(-bondDelta))
+                    ? _env.debitBond(_conf, prover_, uint256(-bondDelta))
                     : _env.creditBond(prover_, uint256(bondDelta));
             } else if (_batch.proposer == prover_) {
-                _env.debitBond(
-                    _env.conf.bondToken,
-                    _batch.proposer,
-                    _env.conf.livenessBond + _env.conf.provabilityBond
-                );
+                _env.debitBond(_conf, _batch.proposer, _conf.livenessBond + _conf.provabilityBond);
             } else {
-                _env.debitBond(_env.conf.bondToken, _batch.proposer, _env.conf.provabilityBond);
-                _env.debitBond(_env.conf.bondToken, prover_, _env.conf.livenessBond);
+                _env.debitBond(_conf, _batch.proposer, _conf.provabilityBond);
+                _env.debitBond(_conf, prover_, _conf.livenessBond);
 
                 if (fee != 0) {
                     _env.transferFee(feeToken, _batch.proposer, prover_, fee);
@@ -206,6 +198,7 @@ library LibPropose2 {
     }
 
     function _validateBatch(
+        I.Config memory _conf,
         Environment memory _env,
         I.Batch memory _batch,
         I.BatchProposeMetadata memory _parentProposeMeta
@@ -216,7 +209,7 @@ library LibPropose2 {
     {
         ParamsValidationOutput memory output;
 
-        if (_env.inboxWrapper == address(0)) {
+        if (_conf.inboxWrapper == address(0)) {
             if (_batch.proposer == address(0)) {
                 _batch.proposer = _env.sender;
             } else {
@@ -229,7 +222,7 @@ library LibPropose2 {
             require(_batch.isForcedInclusion == false, InvalidForcedInclusion());
         } else {
             require(_batch.proposer != address(0), CustomProposerMissing());
-            require(_env.sender == _env.inboxWrapper, NotInboxWrapper());
+            require(_env.sender == _conf.inboxWrapper, NotInboxWrapper());
         }
 
         // In the upcoming Shasta fork, we might need to enforce the coinbase address as the
@@ -255,7 +248,7 @@ library LibPropose2 {
         uint256 nBlocks = _batch.encodedBlocks.length;
 
         require(nBlocks != 0, BlockNotFound());
-        require(nBlocks <= _env.conf.maxBlocksPerBatch, TooManyBlocks());
+        require(nBlocks <= _conf.maxBlocksPerBatch, TooManyBlocks());
 
         output.blocks = new I.Block[](nBlocks);
 
@@ -282,10 +275,12 @@ library LibPropose2 {
 
             if (output.blocks[i].numSignals == 0) continue;
 
-            require(output.blocks[i].numSignals <= _env.conf.maxSignalsToReceive, TooManySignals());
+            require(output.blocks[i].numSignals <= _conf.maxSignalsToReceive, TooManySignals());
 
             for (uint256 j; j < output.blocks[i].numSignals; ++j) {
-                require(_env.isSignalSent(_batch.signalSlots[signalSlotsIdx]), SignalNotSent());
+                require(
+                    _env.isSignalSent(_conf, _batch.signalSlots[signalSlotsIdx]), SignalNotSent()
+                );
                 signalSlotsIdx++;
             }
         }
@@ -295,7 +290,7 @@ library LibPropose2 {
         uint256 firstBlockTimestamp = _batch.lastBlockTimestamp - totalShift;
 
         require(
-            firstBlockTimestamp + _env.conf.maxAnchorHeightOffset * LibNetwork.ETHEREUM_BLOCK_TIME
+            firstBlockTimestamp + _conf.maxAnchorHeightOffset * LibNetwork.ETHEREUM_BLOCK_TIME
                 >= _env.blockTimestamp,
             TimestampTooSmall()
         );
@@ -319,7 +314,7 @@ library LibPropose2 {
 
                 require(
                     foundNoneZeroAnchorBlockId
-                        || anchorBlockId + _env.conf.maxAnchorHeightOffset >= _env.blockNumber,
+                        || anchorBlockId + _conf.maxAnchorHeightOffset >= _env.blockNumber,
                     AnchorIdTooSmall()
                 );
 
@@ -337,7 +332,7 @@ library LibPropose2 {
         // have a non-zero anchor block id. Otherwise, delegate this validation to the
         // inboxWrapper contract.
         require(
-            _env.sender == _env.inboxWrapper || foundNoneZeroAnchorBlockId,
+            _env.sender == _conf.inboxWrapper || foundNoneZeroAnchorBlockId,
             NoAnchorBlockIdWithinThisBatch()
         );
 
@@ -347,7 +342,7 @@ library LibPropose2 {
         output.lastBlockId = uint48(output.firstBlockId + nBlocks);
 
         require(
-            LibFork2.isBlocksInCurrentFork(_env.conf, output.firstBlockId, output.lastBlockId),
+            LibFork2.isBlocksInCurrentFork(_conf, output.firstBlockId, output.lastBlockId),
             BlocksNotInCurrentFork()
         );
         return (_batch, output);
@@ -392,6 +387,7 @@ library LibPropose2 {
     }
 
     function _populateBatchMetadata(
+        I.Config memory _conf,
         Environment memory _env,
         I.Batch memory _batch,
         ParamsValidationOutput memory _output
@@ -403,19 +399,19 @@ library LibPropose2 {
         meta_.buildMeta = I.BatchBuildMetadata({
             txsHash: _output.txsHash,
             blobHashes: _output.blobHashes,
-            extraData: _encodeExtraDataLower128Bits(_env.conf, _batch),
+            extraData: _encodeExtraDataLower128Bits(_conf, _batch),
             coinbase: _batch.coinbase,
             proposedIn: _env.blockNumber,
             blobCreatedIn: _batch.blobs.createdIn,
             blobByteOffset: _batch.blobs.byteOffset,
             blobByteSize: _batch.blobs.byteSize,
-            gasLimit: _env.conf.blockMaxGasLimit,
+            gasLimit: _conf.blockMaxGasLimit,
             lastBlockId: _output.lastBlockId,
             lastBlockTimestamp: _batch.lastBlockTimestamp,
             anchorBlockIds: _batch.anchorBlockIds,
             anchorBlockHashes: _output.anchorBlockHashes,
             encodedBlocks: _batch.encodedBlocks,
-            baseFeeConfig: _env.conf.baseFeeConfig
+            baseFeeConfig: _conf.baseFeeConfig
         });
 
         meta_.proposeMeta = I.BatchProposeMetadata({
@@ -430,8 +426,8 @@ library LibPropose2 {
             proposedAt: _env.blockTimestamp,
             firstBlockId: _output.firstBlockId,
             lastBlockId: meta_.buildMeta.lastBlockId,
-            livenessBond: _env.conf.livenessBond,
-            provabilityBond: _env.conf.provabilityBond
+            livenessBond: _conf.livenessBond,
+            provabilityBond: _conf.provabilityBond
         });
     }
 
@@ -439,14 +435,14 @@ library LibPropose2 {
     /// - bits 0-7: used to store _config.baseFeeConfig.sharingPctg.
     /// - bit 8: used to store _batch.isForcedInclusion.
     function _encodeExtraDataLower128Bits(
-        I.Config memory _config,
+        I.Config memory _conf,
         I.Batch memory _batch
     )
         private
         pure
         returns (bytes32)
     {
-        uint128 v = _config.baseFeeConfig.sharingPctg; // bits 0-7
+        uint128 v = _conf.baseFeeConfig.sharingPctg; // bits 0-7
         v |= _batch.isForcedInclusion ? 1 << 8 : 0; // bit 8
         return bytes32(uint256(v));
     }

--- a/packages/protocol/contracts/layer1/based2/libs/LibPropose2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibPropose2.sol
@@ -46,7 +46,8 @@ library LibPropose2 {
         bytes32 parentBatchMetaHash;
         function(I.BatchMetadata memory) pure returns (bytes memory) encodeBatchMetadata;
         function(I.Config memory, bytes32) view returns (bool) isSignalSent;
-        function(I.Config memory, bytes32, uint256) view returns (bytes32) loadTransitionMetaHash;
+        function(I.Config memory, bytes32, uint256) view returns (bytes32, bool)
+            loadTransitionMetaHash;
         function(uint64, uint64, bytes32,  bytes memory) view returns (address, address, uint96)
             validateProverAuth;
         function(uint256) view returns (bytes32) getBlobHash;

--- a/packages/protocol/contracts/layer1/based2/libs/LibProve2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibProve2.sol
@@ -138,7 +138,7 @@ library LibProve2 {
         uint256 _proposedAt
     )
         private
-        view
+        pure
         returns (I.ProofTiming timing_, address prover_)
     {
         unchecked {

--- a/packages/protocol/contracts/layer1/based2/libs/LibProve2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibProve2.sol
@@ -23,12 +23,11 @@ library LibProve2 {
 
     struct Environment {
         // reads
-        address sender;
         uint48 blockTimestamp;
         uint48 blockNumber;
         // writes
-        function(I.Config memory, address, uint256) debitBond;
         function(address, uint256) creditBond;
+        function(I.Config memory, address, uint256) debitBond;
         function(I.Config memory, uint256, bytes32, bytes32) returns (bool) saveTransition;
     }
 
@@ -56,7 +55,7 @@ library LibProve2 {
             (metas[i], ctxHashes[i]) = _proveBatch($, _conf, _env, _summary, _evidences[i]);
         }
         bytes32 aggregatedBatchHash =
-            keccak256(abi.encode(_conf.chainId, _env.sender, _conf.verifier, ctxHashes));
+            keccak256(abi.encode(_conf.chainId, msg.sender, _conf.verifier, ctxHashes));
 
         emit I.BatchesProved(_conf.verifier, metas);
         return (_summary, aggregatedBatchHash);
@@ -103,7 +102,7 @@ library LibProve2 {
             proofTiming: I.ProofTiming.OutOfExtendedProvingWindow, // to be updated below
             prover: address(0), // to be updated below
             createdAt: _env.blockTimestamp,
-            byAssignedProver: _env.sender == _input.proveMeta.prover,
+            byAssignedProver: msg.sender == _input.proveMeta.prover,
             lastBlockId: _input.proveMeta.lastBlockId,
             provabilityBond: _input.proveMeta.provabilityBond,
             livenessBond: _input.proveMeta.livenessBond
@@ -123,9 +122,9 @@ library LibProve2 {
         );
         if (
             isFirstTransition && tranMeta_.proofTiming != I.ProofTiming.OutOfExtendedProvingWindow
-                && _env.sender != _input.proveMeta.proposer
+                && msg.sender != _input.proveMeta.proposer
         ) {
-            _env.debitBond(_conf, _env.sender, _input.proveMeta.provabilityBond);
+            _env.debitBond(_conf, msg.sender, _input.proveMeta.provabilityBond);
             _env.creditBond(_input.proveMeta.proposer, _input.proveMeta.provabilityBond);
         }
     }
@@ -145,9 +144,9 @@ library LibProve2 {
             if (_env.blockTimestamp <= _proposedAt + _conf.provingWindow) {
                 return (I.ProofTiming.InProvingWindow, _assignedProver);
             } else if (_env.blockTimestamp <= _proposedAt + _conf.extendedProvingWindow) {
-                return (I.ProofTiming.InExtendedProvingWindow, _env.sender);
+                return (I.ProofTiming.InExtendedProvingWindow, msg.sender);
             } else {
-                return (I.ProofTiming.OutOfExtendedProvingWindow, _env.sender);
+                return (I.ProofTiming.OutOfExtendedProvingWindow, msg.sender);
             }
         }
     }

--- a/packages/protocol/contracts/layer1/based2/libs/LibProve2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibProve2.sol
@@ -137,7 +137,7 @@ library LibProve2 {
         uint256 _proposedAt
     )
         private
-        pure
+        view
         returns (I.ProofTiming timing_, address prover_)
     {
         unchecked {

--- a/packages/protocol/contracts/layer1/based2/libs/LibProve2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibProve2.sol
@@ -23,19 +23,18 @@ library LibProve2 {
 
     struct Environment {
         // reads
-        I.Config conf;
         address sender;
         uint48 blockTimestamp;
         uint48 blockNumber;
-        address verifier;
         // writes
-        function(address, address, uint256) debitBond;
+        function(I.Config memory, address, uint256) debitBond;
         function(address, uint256) creditBond;
         function(I.Config memory, uint256, bytes32, bytes32) returns (bool) saveTransition;
     }
 
     function proveBatches(
         I.State storage $,
+        I.Config memory _conf,
         Environment memory _env,
         I.Summary memory _summary,
         I.BatchProveInput[] calldata _evidences
@@ -54,17 +53,18 @@ library LibProve2 {
         bytes32[] memory ctxHashes = new bytes32[](nBatches);
 
         for (uint256 i; i < nBatches; ++i) {
-            (metas[i], ctxHashes[i]) = _proveBatch($, _env, _summary, _evidences[i]);
+            (metas[i], ctxHashes[i]) = _proveBatch($, _conf, _env, _summary, _evidences[i]);
         }
         bytes32 aggregatedBatchHash =
-            keccak256(abi.encode(_env.conf.chainId, msg.sender, _env.verifier, ctxHashes));
+            keccak256(abi.encode(_conf.chainId, msg.sender, _conf.verifier, ctxHashes));
 
-        emit I.BatchesProved(_env.verifier, metas);
+        emit I.BatchesProved(_conf.verifier, metas);
         return (_summary, aggregatedBatchHash);
     }
 
     function _proveBatch(
         I.State storage $,
+        I.Config memory _conf,
         Environment memory _env,
         I.Summary memory _summary,
         I.BatchProveInput calldata _input
@@ -81,13 +81,13 @@ library LibProve2 {
         // check.
         require(
             LibFork2.isBlocksInCurrentFork(
-                _env.conf, _input.proveMeta.firstBlockId, _input.proveMeta.firstBlockId
+                _conf, _input.proveMeta.firstBlockId, _input.proveMeta.firstBlockId
             ),
             BlocksNotInCurrentFork()
         );
 
         // Verify the batch's metadata.
-        uint256 slot = _input.transition.batchId % _env.conf.batchRingBufferSize;
+        uint256 slot = _input.transition.batchId % _conf.batchRingBufferSize;
         bytes32 batchMetaHash = $.batches[slot]; // 1 SLOAD
 
         _validateBatchProveMeta(batchMetaHash, _input);
@@ -97,7 +97,7 @@ library LibProve2 {
         tranMeta_ = I.TransitionMeta({
             parentHash: _input.transition.parentHash,
             blockHash: _input.transition.blockHash,
-            stateRoot: _input.transition.batchId % _env.conf.stateRootSyncInternal == 0
+            stateRoot: _input.transition.batchId % _conf.stateRootSyncInternal == 0
                 ? _input.transition.stateRoot
                 : bytes32(0),
             proofTiming: I.ProofTiming.OutOfExtendedProvingWindow, // to be updated below
@@ -110,7 +110,7 @@ library LibProve2 {
         });
 
         (tranMeta_.proofTiming, tranMeta_.prover) = _determineProofTiming(
-            _env.conf,
+            _conf,
             _input.proveMeta.prover,
             uint256(_input.proveMeta.proposedAt).max(_summary.lastProposedIn)
         );
@@ -118,20 +118,20 @@ library LibProve2 {
         bytes32 tranMetaHash = keccak256(abi.encode(tranMeta_));
 
         bool isFirstTransition = _env.saveTransition(
-            _env.conf, _input.transition.batchId, _input.transition.parentHash, tranMetaHash
+            _conf, _input.transition.batchId, _input.transition.parentHash, tranMetaHash
         );
         if (
             isFirstTransition && tranMeta_.proofTiming != I.ProofTiming.OutOfExtendedProvingWindow
                 && msg.sender != _input.proveMeta.proposer
         ) {
-            _env.debitBond(_env.conf.bondToken, msg.sender, _input.proveMeta.provabilityBond);
+            _env.debitBond(_conf, msg.sender, _input.proveMeta.provabilityBond);
             _env.creditBond(_input.proveMeta.proposer, _input.proveMeta.provabilityBond);
         }
     }
 
     /// @dev Decides which time window we are in and who should be recorded as the prover.
     function _determineProofTiming(
-        I.Config memory _config,
+        I.Config memory _conf,
         address _assignedProver,
         uint256 _proposedAt
     )
@@ -140,9 +140,9 @@ library LibProve2 {
         returns (I.ProofTiming timing_, address prover_)
     {
         unchecked {
-            if (block.timestamp <= _proposedAt + _config.provingWindow) {
+            if (block.timestamp <= _proposedAt + _conf.provingWindow) {
                 return (I.ProofTiming.InProvingWindow, _assignedProver);
-            } else if (block.timestamp <= _proposedAt + _config.extendedProvingWindow) {
+            } else if (block.timestamp <= _proposedAt + _conf.extendedProvingWindow) {
                 return (I.ProofTiming.InExtendedProvingWindow, msg.sender);
             } else {
                 return (I.ProofTiming.OutOfExtendedProvingWindow, msg.sender);

--- a/packages/protocol/contracts/layer1/based2/libs/LibVerify2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibVerify2.sol
@@ -33,14 +33,15 @@ library LibVerify2 {
             if (!LibFork2.isBlocksInCurrentFork(_conf, batchId, batchId)) {
                 return _summary;
             }
+
             uint256 stopBatchId = uint256(_summary.numBatches).min(
                 _conf.maxBatchesToVerify + _summary.lastVerifiedBatchId + 1
             );
 
-            uint256 nTransitions = _trans.length;
             uint256 i;
             uint48 lastSyncedBlockId;
             bytes32 lastSyncedStateRoot;
+            uint256 nTransitions = _trans.length;
 
             for (; batchId < stopBatchId; ++batchId) {
                 (bytes32 tranMetaHash, bool isFirstTransition) =
@@ -72,9 +73,8 @@ library LibVerify2 {
                 _summary.lastSyncedAt = uint48(block.timestamp);
                 _env.syncChainData(_conf, lastSyncedBlockId, lastSyncedStateRoot);
             }
-
-            return _summary;
         }
+        return _summary;
     }
 
     function _calcBondToProver(

--- a/packages/protocol/contracts/layer1/based2/libs/LibVerify2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibVerify2.sol
@@ -70,7 +70,7 @@ library LibVerify2 {
 
             if (lastSyncedBlockId != 0) {
                 _summary.lastSyncedBlockId = lastSyncedBlockId;
-                _summary.lastSyncedAt = uint48(block.timestamp);
+                _summary.lastSyncedAt = _env.blockTimestamp;
                 _env.syncChainData(_conf, lastSyncedBlockId, lastSyncedStateRoot);
             }
         }

--- a/packages/protocol/contracts/layer1/based2/libs/LibVerify2.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibVerify2.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "src/shared/signal/ISignalService.sol";
-import "src/shared/signal/LibSignals.sol";
 import "src/shared/libs/LibMath.sol";
 import { ITaikoInbox2 as I } from "../ITaikoInbox2.sol";
 import "./LibBonds2.sol";


### PR DESCRIPTION
Moved key contract addresses (inboxWrapper, verifier, signalService, bondToken) into the I.Config struct and updated TaikoInbox2 and related libraries (LibPropose2, LibProve2, LibVerify2) to consistently pass and use config as a parameter. This change centralizes configuration, simplifies constructor logic, and improves maintainability.