### PR TITLE
Fix broken link to bridging images in protocol architecture docs

### DIFF
--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md
@@ -74,7 +74,7 @@ When a user initiates a transfer:
 
 **Diagram: Sending a message on the source chain**
 
-![Bridging source chain process](~/assets/content/docs/taiko-alethia-protocol/bridging-source-chain.webp)
+![Bridging source chain process](../../../assets/content/docs/taiko-alethia-protocol/bridging-source-chain.webp)
 
 #### Receiving assets on destination chain
 
@@ -89,7 +89,7 @@ To complete the transfer:
 
 **Diagram: Processing a message on the destination chain**
 
-![Bridging destination chain process](~/assets/content/docs/taiko-alethia-protocol/bridging-dest-chain.webp)
+![Bridging destination chain process](../../../assets/content/docs/taiko-alethia-protocol/bridging-dest-chain.webp)
 
 ## Ether bridging
 


### PR DESCRIPTION
Updated the image links for "Bridging source chain process" and "Bridging destination chain process" in the bridging protocol architecture documentation. The links now point to the correct location under the assets directory, ensuring the images render properly in the documentation site.