### PR TITLE
fix(taiko-client): make the check of preconf blocks synchronously

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -211,56 +211,51 @@ func isKnownCanonicalBatch(
 ) (*types.Header, error) {
 	var (
 		headers = make([]*types.Header, len(metadata.Pacaya().GetBlocks()))
-		g       = new(errgroup.Group)
 	)
 
 	// Check each block in the batch, and if the all blocks are preconfirmed, return the header of the last block.
 	for i := 0; i < len(metadata.Pacaya().GetBlocks()); i++ {
-		g.Go(func() error {
-			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
-			if err != nil {
-				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
-			}
+		parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
+		}
 
-			createExecutionPayloadsMetaData, anchorTx, err := assembleCreateExecutionPayloadMetaPacaya(
-				ctx,
-				rpc,
-				anchorConstructor,
-				metadata,
-				allTxs,
-				parentHeader,
-				i,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to assemble execution payload creation metadata: %w", err)
-			}
+		createExecutionPayloadsMetaData, anchorTx, err := assembleCreateExecutionPayloadMetaPacaya(
+			ctx,
+			rpc,
+			anchorConstructor,
+			metadata,
+			allTxs,
+			parentHeader,
+			i,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to assemble execution payload creation metadata: %w", err)
+		}
 
-			b, err := rlp.EncodeToBytes(append([]*types.Transaction{anchorTx}, createExecutionPayloadsMetaData.Txs...))
-			if err != nil {
-				return fmt.Errorf("failed to RLP encode tx list: %w", err)
-			}
+		b, err := rlp.EncodeToBytes(append([]*types.Transaction{anchorTx}, createExecutionPayloadsMetaData.Txs...))
+		if err != nil {
+			return nil, fmt.Errorf("failed to RLP encode tx list: %w", err)
+		}
 
-			if headers[i], err = isKnownCanonicalBlock(
-				ctx,
-				rpc,
-				&createPayloadAndSetHeadMetaData{
-					createExecutionPayloadsMetaData: createExecutionPayloadsMetaData,
-					AnchorBlockID:                   new(big.Int).SetUint64(metadata.Pacaya().GetAnchorBlockID()),
-					AnchorBlockHash:                 metadata.Pacaya().GetAnchorBlockHash(),
-					BaseFeeConfig:                   metadata.Pacaya().GetBaseFeeConfig(),
-					Parent:                          parentHeader,
-				},
-				b,
-				anchorTx,
-			); err != nil {
-				return fmt.Errorf("block %d is an unknown block, reason: %w", createExecutionPayloadsMetaData.BlockID, err)
-			}
-
-			return nil
-		})
+		if headers[i], err = isKnownCanonicalBlock(
+			ctx,
+			rpc,
+			&createPayloadAndSetHeadMetaData{
+				createExecutionPayloadsMetaData: createExecutionPayloadsMetaData,
+				AnchorBlockID:                   new(big.Int).SetUint64(metadata.Pacaya().GetAnchorBlockID()),
+				AnchorBlockHash:                 metadata.Pacaya().GetAnchorBlockHash(),
+				BaseFeeConfig:                   metadata.Pacaya().GetBaseFeeConfig(),
+				Parent:                          parentHeader,
+			},
+			b,
+			anchorTx,
+		); err != nil {
+			return nil, fmt.Errorf("block %d is an unknown block, reason: %w", createExecutionPayloadsMetaData.BlockID, err)
+		}
 	}
 
-	return headers[len(headers)-1], g.Wait()
+	return headers[len(headers)-1], nil
 }
 
 // isKnownCanonicalBlock checks if the block is in canonical chain already.


### PR DESCRIPTION
@cyberhorsey Can we just make the check of preconf blocks synchronously and simply first? The block would be processed one by one, although it will take a long time, in this case the interval between batches is long enough that we have enough time to process the batch slowly. WDYT?