### PR TITLE
Pack batch context in Proposed event and add codec helpers

### DIFF
--- a/packages/protocol/contracts/layer1/based2/IInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/IInbox.sol
@@ -263,12 +263,12 @@ interface IInbox {
 
     /// @notice Emitted when a batch is proposed.
     /// @param batchId The ID of the proposed batch.
-    /// @param context The batch context data
-    event Proposed(uint48 batchId, BatchContext context);
+    /// @param packedContext The batch context data packed into bytes.
+    event Proposed(uint48 batchId, bytes packedContext);
 
     /// @notice Emitted when a batch is proved.
     /// @param batchId The ID of the proved batch.
-    /// @param packedTranMeta The encoded transition metadata.
+    /// @param packedTranMeta The transition metadata packed into bytes.
     event Proved(uint256 indexed batchId, bytes packedTranMeta);
 
     /// @notice Emitted when a batch is verified.

--- a/packages/protocol/contracts/layer1/based2/IInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/IInbox.sol
@@ -42,7 +42,6 @@ interface IInbox {
     struct Batch {
         address proposer;
         address coinbase;
-        address prover;
         uint48 lastBlockTimestamp;
         bool isForcedInclusion;
         // Specifies the number of blocks to be generated from this batch.
@@ -56,6 +55,7 @@ interface IInbox {
     /// @notice Output structure containing validated batch information
     /// @dev This struct aggregates all validation results for efficient batch processing
     struct BatchContext {
+        address prover;
         /// @notice Hash of all transactions in the batch
         bytes32 txsHash; // TODO: remove this?
         /// @notice Array of blob hashes associated with the batch

--- a/packages/protocol/contracts/layer1/based2/IInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/IInbox.sol
@@ -177,13 +177,13 @@ interface IInbox {
 
     struct Summary {
         uint48 numBatches;
-        uint48 lastUnpausedAt;
         uint48 lastSyncedBlockId;
         uint48 lastSyncedAt;
         uint48 lastVerifiedBatchId;
         bytes32 lastVerifiedBlockHash;
         bytes32 lastBatchMetaHash;
         uint32 gasIssuancePerSecond;
+        uint48 gasIssuanceUpdatedAt;
     }
 
     /// @notice Struct holding the fork heights.

--- a/packages/protocol/contracts/layer1/based2/IInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/IInbox.sol
@@ -238,6 +238,7 @@ interface IInbox {
         address inboxWrapper;
         address verifier;
         address signalService;
+        uint16 gasIssuanceUpdateDelay;
     }
 
     /// @notice Struct holding the state variables for the {Taiko} contract.

--- a/packages/protocol/contracts/layer1/based2/IInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/IInbox.sol
@@ -49,6 +49,7 @@ interface IInbox {
         bytes32[] signalSlots;
         uint48[] anchorBlockIds;
         uint256[] encodedBlocks; // encoded Block
+        uint32 gasIssuancePerSecond;
         bytes proverAuth;
     }
 
@@ -182,6 +183,7 @@ interface IInbox {
         uint48 lastVerifiedBatchId;
         bytes32 lastVerifiedBlockHash;
         bytes32 lastBatchMetaHash;
+        uint32 gasIssuancePerSecond;
     }
 
     /// @notice Struct holding the fork heights.

--- a/packages/protocol/contracts/layer1/based2/libs/LibCodec.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibCodec.sol
@@ -158,6 +158,7 @@ library LibCodec {
         }
     }
 
+    // TODO: 
     function packBatchContext(I.BatchContext memory _context)
         internal
         pure
@@ -166,6 +167,7 @@ library LibCodec {
         return abi.encode(_context);
     }
 
+    // TODO: 
     function unpackBatchContext(bytes memory _packed)
         internal
         pure

--- a/packages/protocol/contracts/layer1/based2/libs/LibCodec.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibCodec.sol
@@ -158,6 +158,22 @@ library LibCodec {
         }
     }
 
+    function packBatchContext(I.BatchContext memory _context)
+        internal
+        pure
+        returns (bytes memory packed_)
+    {
+        return abi.encode(_context);
+    }
+
+    function unpackBatchContext(bytes memory _packed)
+        internal
+        pure
+        returns (I.BatchContext memory context_)
+    {
+        return abi.decode(_packed, (I.BatchContext));
+    }
+
     // -------------------------------------------------------------------------
     // Custom Errors
     // -------------------------------------------------------------------------

--- a/packages/protocol/contracts/layer1/based2/libs/LibData.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibData.sol
@@ -65,7 +65,7 @@ library LibData {
         }
         meta_.proveMeta = I.BatchProveMetadata({
             proposer: _batch.proposer,
-            prover: _batch.prover,
+            prover: _context.prover,
             proposedAt: _blockTimestamp,
             firstBlockId: firstBlockId,
             lastBlockId: meta_.buildMeta.lastBlockId,

--- a/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
@@ -32,7 +32,7 @@ library LibPropose {
         I.Config memory _conf,
         LibState.ReadWrite memory _rw,
         I.Summary memory _summary,
-        I.Batch[] calldata _batches,
+        I.Batch[] memory _batches,
         I.BatchProposeMetadataEvidence memory _evidence
     )
         internal
@@ -55,7 +55,9 @@ library LibPropose {
                 (meta, _summary.lastBatchMetaHash) =
                     _proposeBatch(_conf, _rw, _summary, _batches[i], parent);
 
+                _summary.gasIssuancePerSecond = _batches[i].gasIssuancePerSecond;
                 _summary.numBatches += 1;
+
                 parent = meta.proposeMeta;
             }
 
@@ -79,14 +81,14 @@ library LibPropose {
         I.Config memory _conf,
         LibState.ReadWrite memory _rw,
         I.Summary memory _summary,
-        I.Batch calldata _batch,
+        I.Batch memory _batch,
         I.BatchProposeMetadata memory _parent
     )
         private
         returns (I.BatchMetadata memory meta_, bytes32 batchMetaHash_)
     {
         // Validate the batch parameters and return batch and batch context data
-        I.BatchContext memory context = LibValidate.validate(_conf, _rw, _batch, _parent);
+        I.BatchContext memory context = LibValidate.validate(_conf, _rw, _summary, _batch, _parent);
 
         context.prover = LibProver.validateProver(_conf, _rw, _summary, _batch.proverAuth, _batch);
 

--- a/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
@@ -55,7 +55,11 @@ library LibPropose {
                 (meta, _summary.lastBatchMetaHash) =
                     _proposeBatch(_conf, _rw, _summary, _batches[i], parent);
 
-                _summary.gasIssuancePerSecond = _batches[i].gasIssuancePerSecond;
+                if (_summary.gasIssuancePerSecond != _batches[i].gasIssuancePerSecond) {
+                    _summary.gasIssuancePerSecond = _batches[i].gasIssuancePerSecond;
+                    _summary.gasIssuanceUpdatedAt = uint48(block.timestamp);
+                }
+
                 _summary.numBatches += 1;
 
                 parent = meta.proposeMeta;

--- a/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
@@ -5,6 +5,7 @@ import { IInbox as I } from "../IInbox.sol";
 import "./LibValidate.sol";
 import "./LibData.sol";
 import "./LibProver.sol";
+import "./LibCodec.sol";
 
 /// @title LibPropose
 /// @notice Library for processing batch proposals and metadata generation in Taiko protocol
@@ -96,7 +97,7 @@ library LibPropose {
         batchMetaHash_ = LibData.hashBatch(_summary.numBatches, meta_);
         _rw.saveBatchMetaHash(_conf, _summary.numBatches, batchMetaHash_);
 
-        emit I.Proposed(_summary.numBatches, context);
+        emit I.Proposed(_summary.numBatches, LibCodec.packBatchContext(context));
     }
 
     // -------------------------------------------------------------------------

--- a/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
@@ -88,7 +88,7 @@ library LibPropose {
         // Validate the batch parameters and return batch and batch context data
         I.BatchContext memory context = LibValidate.validate(_conf, _rw, _batch, _parent);
 
-        LibProver.validateProver(_conf, _rw, _summary, _batch.proverAuth, _batch);
+        context.prover = LibProver.validateProver(_conf, _rw, _summary, _batch.proverAuth, _batch);
 
         meta_ = LibData.buildBatchMetadata(
             uint48(block.number), uint48(block.timestamp), _batch, context

--- a/packages/protocol/contracts/layer1/based2/libs/LibProve.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibProve.sol
@@ -97,11 +97,8 @@ library LibProve {
             ? _input.tran.stateRoot
             : bytes32(0);
 
-        (I.ProofTiming proofTiming, address prover) = _determineProofTiming(
-            _conf,
-            _input.proveMeta.prover,
-            uint256(_input.proveMeta.proposedAt).max(_summary.lastUnpausedAt)
-        );
+        (I.ProofTiming proofTiming, address prover) =
+            _determineProofTiming(_conf, _input.proveMeta.prover, _input.proveMeta.proposedAt);
 
         // Create the transition metadata
         I.TransitionMeta memory tranMeta = I.TransitionMeta({

--- a/packages/protocol/snapshots/PackParamsGas.json
+++ b/packages/protocol/snapshots/PackParamsGas.json
@@ -1,4 +1,4 @@
 {
-  "no packing": "19789",
-  "packing": "17227"
+  "no packing": "19645",
+  "packing": "17125"
 }


### PR DESCRIPTION
The Proposed event in IInbox now emits the batch context as packed bytes instead of the struct. LibCodec adds pack/unpack helpers for BatchContext, and LibPropose uses the new packing function when emitting the event. Updated gas snapshot values to reflect these changes.