### PR TITLE
test(taiko-client): remove the dependency of `debug_setHead` for better node implementations diversity support

### DIFF
--- a/packages/taiko-client/driver/anchor_tx_constructor/anchor_tx_constructor_test.go
+++ b/packages/taiko-client/driver/anchor_tx_constructor/anchor_tx_constructor_test.go
@@ -58,7 +58,6 @@ func TestNewAnchorTransactor(t *testing.T) {
 	opts, err := c.transactOpts(context.Background(), common.Big1, common.Big256, head.Hash())
 	require.Nil(t, err)
 	require.True(t, opts.NoSend)
-	require.Equal(t, common.Big0, opts.Nonce)
 	require.Equal(t, goldenTouchAddress, opts.From)
 	require.Equal(t, common.Big256, opts.GasFeeCap)
 	require.Equal(t, common.Big0, opts.GasTipCap)

--- a/packages/taiko-client/driver/anchor_tx_constructor/anchor_tx_constructor_test.go
+++ b/packages/taiko-client/driver/anchor_tx_constructor/anchor_tx_constructor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -52,7 +53,7 @@ func TestNewAnchorTransactor(t *testing.T) {
 	require.Nil(t, err)
 
 	head, err := client.L2.HeaderByNumber(context.Background(), nil)
-	require.NotNil(t, err)
+	require.Nil(t, err)
 
 	opts, err := c.transactOpts(context.Background(), common.Big1, common.Big256, head.Hash())
 	require.Nil(t, err)
@@ -113,7 +114,7 @@ func TestSign(t *testing.T) {
 }
 
 func TestSignShortHash(t *testing.T) {
-	rand := common.Hex2Bytes(os.Getenv("TAIKO_INBOX"))
+	rand := crypto.Keccak256Hash([]byte(time.Now().UTC().String()))
 	hash := rand[:len(rand)-2]
 	c, err := New(newTestClient(t))
 	require.Nil(t, err)

--- a/packages/taiko-client/driver/anchor_tx_constructor/anchor_tx_constructor_test.go
+++ b/packages/taiko-client/driver/anchor_tx_constructor/anchor_tx_constructor_test.go
@@ -2,128 +2,146 @@ package anchortxconstructor
 
 import (
 	"context"
-	"math/big"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	consensus "github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 
 	pacayaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/pacaya"
-	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
-type AnchorTxConstructorTestSuite struct {
-	testutils.ClientTestSuite
-	l1Height *big.Int
-	l1Hash   common.Hash
-	c        *AnchorTxConstructor
+func TestGasLimit(t *testing.T) {
+	require.Greater(t, consensus.AnchorGasLimit, uint64(0))
 }
 
-func (s *AnchorTxConstructorTestSuite) SetupTest() {
-	s.ClientTestSuite.SetupTest()
-	c, err := New(s.RPCClient)
-	s.Nil(err)
-	head, err := s.RPCClient.L1.BlockByNumber(context.Background(), nil)
-	s.Nil(err)
-	s.l1Height = head.Number()
-	s.l1Hash = head.Hash()
-	s.c = c
-}
+func TestAssembleAnchorV3Tx(t *testing.T) {
+	client := newTestClient(t)
+	l1Head, err := client.L1.HeaderByNumber(context.Background(), nil)
+	require.Nil(t, err)
 
-func (s *AnchorTxConstructorTestSuite) TestGasLimit() {
-	s.Greater(consensus.AnchorGasLimit, uint64(0))
-}
-
-func (s *AnchorTxConstructorTestSuite) TestAssembleAnchorV3Tx() {
-	head, err := s.RPCClient.L2.HeaderByNumber(context.Background(), nil)
-	s.Nil(err)
-	tx, err := s.c.AssembleAnchorV3Tx(
+	c, err := New(client)
+	require.Nil(t, err)
+	head, err := client.L2.HeaderByNumber(context.Background(), nil)
+	require.Nil(t, err)
+	tx, err := c.AssembleAnchorV3Tx(
 		context.Background(),
-		s.l1Height,
-		s.l1Hash,
+		l1Head.Number,
+		l1Head.Hash(),
 		head,
 		&pacayaBindings.LibSharedDataBaseFeeConfig{},
 		[][32]byte{},
 		common.Big1,
 		common.Big256,
 	)
-	s.Nil(err)
-	s.NotNil(tx)
+	require.Nil(t, err)
+	require.NotNil(t, tx)
 }
 
-func (s *AnchorTxConstructorTestSuite) TestNewAnchorTransactor() {
-	goldenTouchAddress, err := s.RPCClient.PacayaClients.TaikoAnchor.GOLDENTOUCHADDRESS(nil)
-	s.Nil(err)
+func TestNewAnchorTransactor(t *testing.T) {
+	client := newTestClient(t)
 
-	c, err := New(s.RPCClient)
-	s.Nil(err)
+	goldenTouchAddress, err := client.PacayaClients.TaikoAnchor.GOLDENTOUCHADDRESS(nil)
+	require.Nil(t, err)
 
-	head, err := s.RPCClient.L2.HeaderByNumber(context.Background(), nil)
-	s.Nil(err)
+	c, err := New(client)
+	require.Nil(t, err)
+
+	head, err := client.L2.HeaderByNumber(context.Background(), nil)
+	require.NotNil(t, err)
 
 	opts, err := c.transactOpts(context.Background(), common.Big1, common.Big256, head.Hash())
-	s.Nil(err)
-	s.Equal(true, opts.NoSend)
-	s.Equal(common.Big0, opts.Nonce)
-	s.Equal(goldenTouchAddress, opts.From)
-	s.Equal(common.Big256, opts.GasFeeCap)
-	s.Equal(common.Big0, opts.GasTipCap)
+	require.Nil(t, err)
+	require.True(t, opts.NoSend)
+	require.Equal(t, common.Big0, opts.Nonce)
+	require.Equal(t, goldenTouchAddress, opts.From)
+	require.Equal(t, common.Big256, opts.GasFeeCap)
+	require.Equal(t, common.Big0, opts.GasTipCap)
 }
 
-func (s *AnchorTxConstructorTestSuite) TestCancelCtxTransactOpts() {
+func TestCancelCtxTransactOpts(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	head, err := s.RPCClient.L2.HeaderByNumber(context.Background(), nil)
-	s.Nil(err)
+	client := newTestClient(t)
 
-	opts, err := s.c.transactOpts(ctx, common.Big1, common.Big256, head.Hash())
-	s.Nil(opts)
-	s.ErrorContains(err, "context canceled")
+	head, err := client.L2.HeaderByNumber(context.Background(), nil)
+	require.Nil(t, err)
+	c, err := New(client)
+	require.Nil(t, err)
+	opts, err := c.transactOpts(ctx, common.Big1, common.Big256, head.Hash())
+	require.Nil(t, opts)
+	require.ErrorContains(t, err, "context canceled")
 }
 
-func (s *AnchorTxConstructorTestSuite) TestSign() {
+func TestSign(t *testing.T) {
 	// Payload 1
 	hash := hexutil.MustDecode("0x44943399d1507f3ce7525e9be2f987c3db9136dc759cb7f92f742154196868b9")
-	signatureBytes := testutils.SignatureFromRSV(
+	signatureBytes := signatureFromRSV(
 		"0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
 		"0x782a1e70872ecc1a9f740dd445664543f8b7598c94582720bca9a8c48d6a4766",
 		1,
 	)
+	c, err := New(newTestClient(t))
+	require.Nil(t, err)
 	pubKey, err := crypto.Ecrecover(hash, signatureBytes)
-	s.Nil(err)
+	require.Nil(t, err)
 	isValid := crypto.VerifySignature(pubKey, hash, signatureBytes[:64])
-	s.True(isValid)
-	signed, err := s.c.signTxPayload(hash)
-	s.Nil(err)
-	s.Equal(signatureBytes, signed)
+	require.True(t, isValid)
+	signed, err := c.signTxPayload(hash)
+	require.Nil(t, err)
+	require.Equal(t, signatureBytes, signed)
 
 	// Payload 2
 	hash = hexutil.MustDecode("0x663d210fa6dba171546498489de1ba024b89db49e21662f91bf83cdffe788820")
-	signatureBytes = testutils.SignatureFromRSV(
+	signatureBytes = signatureFromRSV(
 		"0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
 		"0x568130fab1a3a9e63261d4278a7e130588beb51f27de7c20d0258d38a85a27ff",
 		1,
 	)
 	pubKey, err = crypto.Ecrecover(hash, signatureBytes)
-	s.Nil(err)
+	require.Nil(t, err)
 	isValid = crypto.VerifySignature(pubKey, hash, signatureBytes[:64])
-	s.True(isValid)
-	signed, err = s.c.signTxPayload(hash)
-	s.Nil(err)
-	s.Equal(signatureBytes, signed)
+	require.True(t, isValid)
+	signed, err = c.signTxPayload(hash)
+	require.Nil(t, err)
+	require.Equal(t, signatureBytes, signed)
 }
 
-func (s *AnchorTxConstructorTestSuite) TestSignShortHash() {
-	rand := testutils.RandomHash().Bytes()
+func TestSignShortHash(t *testing.T) {
+	rand := common.Hex2Bytes(os.Getenv("TAIKO_INBOX"))
 	hash := rand[:len(rand)-2]
-	_, err := s.c.signTxPayload(hash)
-	s.ErrorContains(err, "hash is required to be exactly 32 bytes")
+	c, err := New(newTestClient(t))
+	require.Nil(t, err)
+	_, err = c.signTxPayload(hash)
+	require.ErrorContains(t, err, "hash is required to be exactly 32 bytes")
 }
 
-func TestAnchorTxConstructorTestSuite(t *testing.T) {
-	suite.Run(t, new(AnchorTxConstructorTestSuite))
+func newTestClient(t *testing.T) *rpc.Client {
+	client, err := rpc.NewClient(context.Background(), &rpc.ClientConfig{
+		L1Endpoint:                  os.Getenv("L1_WS"),
+		L2Endpoint:                  os.Getenv("L2_WS"),
+		TaikoInboxAddress:           common.HexToAddress(os.Getenv("TAIKO_INBOX")),
+		TaikoWrapperAddress:         common.HexToAddress(os.Getenv("TAIKO_WRAPPER")),
+		ForcedInclusionStoreAddress: common.HexToAddress(os.Getenv("FORCED_INCLUSION_STORE")),
+		ProverSetAddress:            common.HexToAddress(os.Getenv("PROVER_SET")),
+		TaikoAnchorAddress:          common.HexToAddress(os.Getenv("TAIKO_ANCHOR")),
+		TaikoTokenAddress:           common.HexToAddress(os.Getenv("TAIKO_TOKEN")),
+		L2EngineEndpoint:            os.Getenv("L2_AUTH"),
+		JwtSecret:                   os.Getenv("JWT_SECRET"),
+	})
+
+	require.Nil(t, err)
+	require.NotNil(t, client)
+
+	return client
+}
+
+// signatureFromRSV creates the signature bytes from r,s,v.
+func signatureFromRSV(r, s string, v byte) []byte {
+	return append(append(hexutil.MustDecode(r), hexutil.MustDecode(s)...), v)
 }

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -117,17 +117,6 @@ func TestChainSyncerTestSuite(t *testing.T) {
 	suite.Run(t, new(ChainSyncerTestSuite))
 }
 
-func (s *ChainSyncerTestSuite) TakeSnapshot() {
-	// record snapshot state to revert to before changes
-	s.snapshotID = s.SetL1Snapshot()
-}
-
-func (s *ChainSyncerTestSuite) RevertSnapshot() {
-	// revert to the snapshot state so protocol configs are unaffected
-	s.RevertL1Snapshot(s.snapshotID)
-	s.Nil(rpc.SetHead(context.Background(), s.RPCClient.L2, common.Big0))
-}
-
 func (s *ChainSyncerTestSuite) TestAheadOfProtocolVerifiedHead() {
 	s.True(s.s.AheadOfHeadToSync(0))
 }

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -21,9 +21,8 @@ import (
 
 type ChainSyncerTestSuite struct {
 	testutils.ClientTestSuite
-	s          *L2ChainSyncer
-	snapshotID string
-	p          testutils.Proposer
+	s *L2ChainSyncer
+	p testutils.Proposer
 }
 
 func (s *ChainSyncerTestSuite) SetupTest() {

--- a/packages/taiko-client/driver/chain_syncer/event/syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer_test.go
@@ -75,7 +75,7 @@ func (s *EventSyncerTestSuite) TestEventSyncRobustness() {
 	s.Nil(err)
 
 	// Reset the L2 chain.
-	s.Nil(rpc.SetHead(ctx, s.RPCClient.L2, common.Big0))
+	s.SetHead(common.Big1)
 
 	difficulty, err := encoding.CalculatePacayaDifficulty(new(big.Int).SetUint64(meta.Pacaya().GetLastBlockID()))
 	s.Nil(err)

--- a/packages/taiko-client/driver/preconf_blocks/util.go
+++ b/packages/taiko-client/driver/preconf_blocks/util.go
@@ -2,7 +2,6 @@ package preconfblocks
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -53,7 +52,7 @@ func checkMessageBlockNumber(
 	msg *eth.ExecutionPayloadEnvelope,
 ) (*rawdb.L1Origin, error) {
 	headL1Origin, err := rpc.L2.HeadL1Origin(ctx)
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
+	if err != nil && err.Error() != ethereum.NotFound.Error() {
 		return nil, fmt.Errorf("failed to fetch head L1 origin: %w", err)
 	}
 

--- a/packages/taiko-client/driver/signer/fixed_k_signer_test.go
+++ b/packages/taiko-client/driver/signer/fixed_k_signer_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
-
-	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
 )
 
 func TestSignWithK(t *testing.T) {
@@ -22,7 +20,7 @@ func TestSignWithK(t *testing.T) {
 
 	// K = 2, test case 1
 	payload := hexutil.MustDecode("0x44943399d1507f3ce7525e9be2f987c3db9136dc759cb7f92f742154196868b9")
-	expected := testutils.SignatureFromRSV(
+	expected := signatureFromRSV(
 		"0xc6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
 		"0x38940d69b21d5b088beb706e9ebabe6422307e12863997a44239774467e240d5",
 		1,
@@ -34,7 +32,7 @@ func TestSignWithK(t *testing.T) {
 
 	// K = 2, test case 2
 	payload = hexutil.MustDecode("0x663d210fa6dba171546498489de1ba024b89db49e21662f91bf83cdffe788820")
-	expected = testutils.SignatureFromRSV(
+	expected = signatureFromRSV(
 		"0xc6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
 		"0x5840695138a83611aa9dac67beb95aba7323429787a78df993f1c5c7f2c0ef7f",
 		0,
@@ -43,4 +41,9 @@ func TestSignWithK(t *testing.T) {
 	signed, ok = signer.SignWithK(new(secp256k1.ModNScalar).SetInt(2))(payload)
 	require.True(t, ok)
 	require.Equal(t, expected, signed)
+}
+
+// signatureFromRSV creates the signature bytes from r,s,v.
+func signatureFromRSV(r, s string, v byte) []byte {
+	return append(append(hexutil.MustDecode(r), hexutil.MustDecode(s)...), v)
 }

--- a/packages/taiko-client/driver/state/l1_current_test.go
+++ b/packages/taiko-client/driver/state/l1_current_test.go
@@ -27,7 +27,7 @@ func (s *DriverStateTestSuite) TestResetL1CurrentEmptyHeight() {
 }
 
 func (s *DriverStateTestSuite) TestResetL1CurrentEmptyID() {
-	s.ErrorContains(s.s.ResetL1Current(context.Background(), common.Big1), "execution reverted")
+	s.ErrorContains(s.s.ResetL1Current(context.Background(), nil), "empty block ID")
 }
 
 func (s *DriverStateTestSuite) TestResetL1CurrentCtxErr() {

--- a/packages/taiko-client/internal/docker/start.sh
+++ b/packages/taiko-client/internal/docker/start.sh
@@ -5,8 +5,7 @@ source scripts/common.sh
 if [ "$L2_NODE" == "l2_geth" ];then
     DOCKER_SERVICE_LIST=("l1_node" "l2_geth")
   else
-    echo "unsupported L2_NODE: $L2_NODE"
-    exit 1
+    DOCKER_SERVICE_LIST=("l1_node")
 fi
 
 # start docker compose services

--- a/packages/taiko-client/internal/docker/stop.sh
+++ b/packages/taiko-client/internal/docker/stop.sh
@@ -5,8 +5,7 @@ source scripts/common.sh
 if [ "$L2_NODE" == "l2_geth" ];then
     DOCKER_SERVICE_LIST=("l1_node" "l2_geth")
   else
-    echo "unsupported L2_NODE: $L2_NODE"
-    exit 1
+    DOCKER_SERVICE_LIST=("l1_node")
 fi
 
 echo "stop docker compose service: ${DOCKER_SERVICE_LIST[*]}"

--- a/packages/taiko-client/internal/testutils/helper.go
+++ b/packages/taiko-client/internal/testutils/helper.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -233,11 +232,6 @@ func RandomPort() int {
 		log.Crit("Failed to get local free random port", "error", err)
 	}
 	return port
-}
-
-// SignatureFromRSV creates the signature bytes from r,s,v.
-func SignatureFromRSV(r, s string, v byte) []byte {
-	return append(append(hexutil.MustDecode(r), hexutil.MustDecode(s)...), v)
 }
 
 // AssembleAndSendTestTx assembles a test transaction, and sends it to the given node.

--- a/packages/taiko-client/internal/testutils/helper.go
+++ b/packages/taiko-client/internal/testutils/helper.go
@@ -5,19 +5,29 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"math/big"
+	"os"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
+	consensus "github.com/ethereum/go-ethereum/consensus/taiko"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/phayes/freeport"
 
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/encoding"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 	pacayaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/pacaya"
+	anchortxconstructor "github.com/taikoxyz/taiko-mono/packages/taiko-client/driver/anchor_tx_constructor"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/utils"
 )
 
 func (s *ClientTestSuite) proposeEmptyBlockOp(ctx context.Context, proposer Proposer) {
@@ -311,4 +321,106 @@ func SendDynamicFeeTx(
 		return nil, err
 	}
 	return tx, nil
+}
+
+func (s *ClientTestSuite) resetToBaseBlock(key *ecdsa.PrivateKey) {
+	// Propose an empty block at genesis.
+	t := s.TxMgr("proposer", key)
+	inbox := common.HexToAddress(os.Getenv("PROVER_SET"))
+	params := &encoding.BatchParams{
+		Proposer:   crypto.PubkeyToAddress(key.PublicKey),
+		Coinbase:   common.HexToAddress(RandomHash().Hex()),
+		BlobParams: encoding.BlobParams{ByteOffset: 0, ByteSize: 0},
+		Blocks: []pacayaBindings.ITaikoInboxBlockParams{{
+			NumTransactions: 0,
+			TimeShift:       0,
+			SignalSlots:     make([][32]byte, 0),
+		}},
+	}
+	encoded, err := encoding.EncodeBatchParamsWithForcedInclusion(nil, params)
+	s.Nil(err)
+
+	emptyTxlistBytes, err := utils.EncodeAndCompressTxList(types.Transactions{})
+	s.Nil(err)
+
+	data, err := encoding.TaikoInboxABI.Pack("proposeBatch", encoded, emptyTxlistBytes)
+	s.Nil(err)
+
+	sink := make(chan *pacayaBindings.TaikoInboxClientBatchProposed, 1)
+	sub, err := s.RPCClient.PacayaClients.TaikoInbox.WatchBatchProposed(nil, sink)
+	s.Nil(err)
+	defer func() {
+		sub.Unsubscribe()
+		close(sink)
+	}()
+	_, err = t.Send(
+		context.Background(),
+		txmgr.TxCandidate{TxData: data, To: &inbox, Blobs: nil, GasLimit: 1_000_000},
+	)
+	s.Nil(encoding.TryParsingCustomError(err))
+	e := <-sink
+	s.NotNil(e)
+
+	// After received the event, we start building the payload.
+	difficulty, err := encoding.CalculatePacayaDifficulty(new(big.Int).SetUint64(e.Info.LastBlockId))
+	s.Nil(err)
+
+	parent, err := s.RPCClient.L2.HeaderByNumber(
+		context.Background(),
+		new(big.Int).Sub(new(big.Int).SetUint64(e.Info.LastBlockId), common.Big1),
+	)
+	s.Nil(err)
+
+	baseFee, err := s.RPCClient.CalculateBaseFee(
+		context.Background(), parent, &e.Info.BaseFeeConfig, e.Info.LastBlockTimestamp,
+	)
+	s.Nil(err)
+
+	anchorBlock, err := s.RPCClient.L1.HeaderByNumber(context.Background(), new(big.Int).SetUint64(e.Info.AnchorBlockId))
+	s.Nil(err)
+
+	anchorTxConstructor, err := anchortxconstructor.New(s.RPCClient)
+	s.Nil(err)
+	anchor, err := anchorTxConstructor.AssembleAnchorV3Tx(
+		context.Background(),
+		anchorBlock.Number,
+		anchorBlock.Root,
+		parent,
+		&e.Info.BaseFeeConfig,
+		[][32]byte{},
+		new(big.Int).SetUint64(e.Info.LastBlockId),
+		baseFee,
+	)
+	s.Nil(err)
+
+	txListBytes, err := rlp.EncodeToBytes(types.Transactions{anchor})
+	s.Nil(err)
+
+	// Call engine APIs to insert the base block.
+	s.forkTo(&engine.PayloadAttributes{
+		Timestamp:             e.Info.LastBlockTimestamp,
+		Random:                common.BytesToHash(difficulty),
+		SuggestedFeeRecipient: e.Info.Coinbase,
+		Withdrawals:           []*types.Withdrawal{},
+		BlockMetadata: &engine.BlockMetadata{
+			Beneficiary: e.Info.Coinbase,
+			GasLimit:    uint64(e.Info.GasLimit) + consensus.AnchorV3GasLimit,
+			Timestamp:   e.Info.LastBlockTimestamp,
+			TxList:      txListBytes,
+			MixHash:     common.Hash(difficulty),
+			ExtraData:   e.Info.ExtraData[:],
+		},
+		BaseFeePerGas: baseFee,
+		L1Origin: &rawdb.L1Origin{
+			BlockID:            new(big.Int).SetUint64(e.Info.LastBlockId),
+			L1BlockHeight:      new(big.Int).SetUint64(e.Raw.BlockNumber),
+			L2BlockHash:        common.Hash{},
+			L1BlockHash:        e.Raw.BlockHash,
+			BuildPayloadArgsID: [8]byte{},
+		},
+	}, parent.Hash())
+
+	head, err := s.RPCClient.L2.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	s.Equal(common.Big1, head.Number)
 }

--- a/packages/taiko-client/internal/testutils/suite.go
+++ b/packages/taiko-client/internal/testutils/suite.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
-	consensus "github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -23,8 +22,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/encoding"
-	pacayaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/pacaya"
-	anchortxconstructor "github.com/taikoxyz/taiko-mono/packages/taiko-client/driver/anchor_tx_constructor"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/jwt"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/utils"
@@ -97,9 +94,10 @@ func (s *ClientTestSuite) SetupTest() {
 		s.depositProverSetTokens(ownerPrivKey)
 	}
 
+	// At the beginning of each test, we ensure the L2 chain has been reset to the base block (height: 1).
 	s.once.Do(func() {
 		s.testnetL1SnapshotID = s.SetL1Snapshot()
-		s.initBaseBlock(l1ProposerPrivKey)
+		s.resetToBaseBlock(l1ProposerPrivKey)
 	})
 
 	s.BlobServer = NewMemoryBlobServer()
@@ -224,7 +222,7 @@ func (s *ClientTestSuite) KeyFromEnv(envName string) *ecdsa.PrivateKey {
 func (s *ClientTestSuite) TearDownTest() {
 	s.RevertL1Snapshot(s.testnetL1SnapshotID)
 	s.testnetL1SnapshotID = s.SetL1Snapshot()
-	s.initBaseBlock(s.KeyFromEnv("L1_PROPOSER_PRIVATE_KEY"))
+	s.resetToBaseBlock(s.KeyFromEnv("L1_PROPOSER_PRIVATE_KEY"))
 	_, err := s.RPCClient.L2Engine.SetHeadL1Origin(context.Background(), common.Big1)
 	s.Nil(err)
 	s.BlobServer.Close()
@@ -241,6 +239,10 @@ func (s *ClientTestSuite) SetHead(headNum *big.Int) {
 		return
 	}
 
+	// For other nodes, we need to use the engine API to set the head instead,
+	// to reset the chain head to a block which is already in the canonical chain,
+	// we need to fork the chain to a block with different attributes at the same height
+	// at first, then set the canonical head to the block we want.
 	block, err := s.RPCClient.L2.BlockByNumber(context.Background(), headNum)
 	s.Nil(err)
 
@@ -273,11 +275,12 @@ func (s *ClientTestSuite) SetHead(headNum *big.Int) {
 			BuildPayloadArgsID: [8]byte{},
 		},
 	}
+	// Set the chain head to a block with different attributes at first.
 	attributes.SuggestedFeeRecipient = common.HexToAddress(RandomHash().Hex())
 	attributes.BlockMetadata.Beneficiary = attributes.SuggestedFeeRecipient
-
 	s.forkTo(attributes, block.ParentHash())
 
+	// Set the chain head back to the block we want.
 	attributes.SuggestedFeeRecipient = originalCoinbase
 	attributes.BlockMetadata.Beneficiary = originalCoinbase
 	s.forkTo(attributes, block.ParentHash())
@@ -351,103 +354,4 @@ func (s *ClientTestSuite) forkTo(attributes *engine.PayloadAttributes, parentHas
 	s.Nil(err)
 
 	s.Equal(attributes.L1Origin.BlockID.Uint64(), head.Number.Uint64())
-}
-
-func (s *ClientTestSuite) initBaseBlock(key *ecdsa.PrivateKey) {
-	t := s.TxMgr("proposer", key)
-	inbox := common.HexToAddress(os.Getenv("PROVER_SET"))
-	params := &encoding.BatchParams{
-		Proposer:   crypto.PubkeyToAddress(key.PublicKey),
-		Coinbase:   common.HexToAddress(RandomHash().Hex()),
-		BlobParams: encoding.BlobParams{ByteOffset: 0, ByteSize: 0},
-		Blocks: []pacayaBindings.ITaikoInboxBlockParams{{
-			NumTransactions: 0,
-			TimeShift:       0,
-			SignalSlots:     make([][32]byte, 0),
-		}},
-	}
-	encoded, err := encoding.EncodeBatchParamsWithForcedInclusion(nil, params)
-	s.Nil(err)
-
-	emptyTxlistBytes, err := utils.EncodeAndCompressTxList(types.Transactions{})
-	s.Nil(err)
-
-	data, err := encoding.TaikoInboxABI.Pack("proposeBatch", encoded, emptyTxlistBytes)
-	s.Nil(err)
-
-	sink := make(chan *pacayaBindings.TaikoInboxClientBatchProposed, 1)
-	sub, err := s.RPCClient.PacayaClients.TaikoInbox.WatchBatchProposed(nil, sink)
-	s.Nil(err)
-	defer func() {
-		sub.Unsubscribe()
-		close(sink)
-	}()
-	_, err = t.Send(
-		context.Background(),
-		txmgr.TxCandidate{TxData: data, To: &inbox, Blobs: nil, GasLimit: 1_000_000},
-	)
-	s.Nil(encoding.TryParsingCustomError(err))
-	e := <-sink
-	s.NotNil(e)
-
-	difficulty, err := encoding.CalculatePacayaDifficulty(new(big.Int).SetUint64(e.Info.LastBlockId))
-	s.Nil(err)
-
-	parent, err := s.RPCClient.L2.HeaderByNumber(
-		context.Background(),
-		new(big.Int).Sub(new(big.Int).SetUint64(e.Info.LastBlockId), common.Big1),
-	)
-	s.Nil(err)
-
-	baseFee, err := s.RPCClient.CalculateBaseFee(
-		context.Background(), parent, &e.Info.BaseFeeConfig, e.Info.LastBlockTimestamp,
-	)
-	s.Nil(err)
-
-	anchorBlock, err := s.RPCClient.L1.HeaderByNumber(context.Background(), new(big.Int).SetUint64(e.Info.AnchorBlockId))
-	s.Nil(err)
-
-	anchorTxConstructor, err := anchortxconstructor.New(s.RPCClient)
-	s.Nil(err)
-	anchor, err := anchorTxConstructor.AssembleAnchorV3Tx(
-		context.Background(),
-		anchorBlock.Number,
-		anchorBlock.Root,
-		parent,
-		&e.Info.BaseFeeConfig,
-		[][32]byte{},
-		new(big.Int).SetUint64(e.Info.LastBlockId),
-		baseFee,
-	)
-	s.Nil(err)
-
-	txListBytes, err := rlp.EncodeToBytes(types.Transactions{anchor})
-	s.Nil(err)
-
-	s.forkTo(&engine.PayloadAttributes{
-		Timestamp:             e.Info.LastBlockTimestamp,
-		Random:                common.BytesToHash(difficulty),
-		SuggestedFeeRecipient: e.Info.Coinbase,
-		Withdrawals:           []*types.Withdrawal{},
-		BlockMetadata: &engine.BlockMetadata{
-			Beneficiary: e.Info.Coinbase,
-			GasLimit:    uint64(e.Info.GasLimit) + consensus.AnchorV3GasLimit,
-			Timestamp:   e.Info.LastBlockTimestamp,
-			TxList:      txListBytes,
-			MixHash:     common.Hash(difficulty),
-			ExtraData:   e.Info.ExtraData[:],
-		},
-		BaseFeePerGas: baseFee,
-		L1Origin: &rawdb.L1Origin{
-			BlockID:            new(big.Int).SetUint64(e.Info.LastBlockId),
-			L1BlockHeight:      new(big.Int).SetUint64(e.Raw.BlockNumber),
-			L2BlockHash:        common.Hash{},
-			L1BlockHash:        e.Raw.BlockHash,
-			BuildPayloadArgsID: [8]byte{},
-		},
-	}, parent.Hash())
-
-	head, err := s.RPCClient.L2.HeaderByNumber(context.Background(), nil)
-	s.Nil(err)
-	s.Equal(common.Big1, head.Number)
 }

--- a/packages/taiko-client/internal/testutils/suite.go
+++ b/packages/taiko-client/internal/testutils/suite.go
@@ -335,11 +335,7 @@ func (s *ClientTestSuite) forkTo(attributes *engine.PayloadAttributes, parentHas
 	s.Nil(err)
 	s.Equal(engine.VALID, execStatus.Status)
 
-	fc := &engine.ForkchoiceStateV1{
-		HeadBlockHash:      payload.BlockHash,
-		SafeBlockHash:      payload.BlockHash,
-		FinalizedBlockHash: payload.BlockHash,
-	}
+	fc := &engine.ForkchoiceStateV1{HeadBlockHash: payload.BlockHash}
 
 	fcRes, err = s.RPCClient.L2Engine.ForkchoiceUpdate(context.Background(), fc, nil)
 	s.Nil(err)

--- a/packages/taiko-client/internal/testutils/suite.go
+++ b/packages/taiko-client/internal/testutils/suite.go
@@ -235,6 +235,12 @@ func (s *ClientTestSuite) TearDownSuite() {
 }
 
 func (s *ClientTestSuite) SetHead(headNum *big.Int) {
+	// For geth node, we can set the head directly.
+	if os.Getenv("L2_NODE") == "l2_geth" {
+		rpc.SetHead(context.Background(), s.RPCClient.L2, headNum)
+		return
+	}
+
 	block, err := s.RPCClient.L2.BlockByNumber(context.Background(), headNum)
 	s.Nil(err)
 

--- a/packages/taiko-client/internal/testutils/suite.go
+++ b/packages/taiko-client/internal/testutils/suite.go
@@ -235,7 +235,7 @@ func (s *ClientTestSuite) TearDownSuite() {
 func (s *ClientTestSuite) SetHead(headNum *big.Int) {
 	// For geth node, we can set the head directly.
 	if os.Getenv("L2_NODE") == "l2_geth" {
-		rpc.SetHead(context.Background(), s.RPCClient.L2, headNum)
+		s.Nil(rpc.SetHead(context.Background(), s.RPCClient.L2, headNum))
 		return
 	}
 
@@ -263,7 +263,7 @@ func (s *ClientTestSuite) SetHead(headNum *big.Int) {
 			GasLimit:    block.GasLimit(),
 			Timestamp:   block.Time(),
 			TxList:      b,
-			MixHash:     common.Hash(block.MixDigest()),
+			MixHash:     block.MixDigest(),
 			ExtraData:   block.Extra(),
 		},
 		BaseFeePerGas: block.BaseFee(),

--- a/packages/taiko-client/pkg/rpc/dial_test.go
+++ b/packages/taiko-client/pkg/rpc/dial_test.go
@@ -25,13 +25,10 @@ func TestDialEngineClientWithBackoff(t *testing.T) {
 		12*time.Second,
 		10,
 	)
-
 	require.Nil(t, err)
 
 	var result engine.ExecutableData
-	err = client.CallContext(context.Background(), &result, "engine_getPayloadV1", engine.PayloadID{})
-
-	require.Equal(t, engine.UnsupportedFork.Error(), err.Error())
+	require.NotNil(t, client.CallContext(context.Background(), &result, "engine_getPayloadV2", engine.PayloadID{}))
 }
 
 func TestDialClientWithBackoff(t *testing.T) {

--- a/packages/taiko-client/pkg/rpc/methods_test.go
+++ b/packages/taiko-client/pkg/rpc/methods_test.go
@@ -55,7 +55,7 @@ func TestL2ParentByBlockId(t *testing.T) {
 	require.Zero(t, header.Number.Uint64())
 
 	_, err = client.L2ParentByCurrentBlockID(context.Background(), common.Big2)
-	require.NotNil(t, err)
+	require.Nil(t, err)
 }
 
 func TestL2ExecutionEngineSyncProgress(t *testing.T) {

--- a/packages/taiko-client/pkg/rpc/utils_test.go
+++ b/packages/taiko-client/pkg/rpc/utils_test.go
@@ -1,16 +1,10 @@
 package rpc
 
 import (
-	"context"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
-
-func TestSetHead(t *testing.T) {
-	require.Nil(t, SetHead(context.Background(), newTestClient(t).L2, common.Big0))
-}
 
 func TestStringToBytes32(t *testing.T) {
 	require.Equal(t, [32]byte{}, StringToBytes32(""))

--- a/packages/taiko-client/proposer/proposer_test.go
+++ b/packages/taiko-client/proposer/proposer_test.go
@@ -162,6 +162,9 @@ func (s *ProposerTestSuite) TestProposeWithRevertProtection() {
 }
 
 func (s *ProposerTestSuite) TestTxPoolContentWithMinTip() {
+	if os.Getenv("L2_NODE") != "l2_geth" {
+		s.T().Skip("This test is only applicable for L2 Geth node")
+	}
 	var (
 		txsCountForEachSender = 300
 		sendersCount          = 5

--- a/packages/taiko-client/proposer/proposer_test.go
+++ b/packages/taiko-client/proposer/proposer_test.go
@@ -440,7 +440,9 @@ func (s *ProposerTestSuite) TestProposeMultiBlobsInOneBatch() {
 				common.Big1,
 				[]byte{1},
 			)
-			s.Nil(err)
+			if err != nil {
+				s.Equal("replacement transaction underpriced", err.Error())
+			}
 			txsBatch[i] = append(txsBatch[i], tx)
 		}
 	}


### PR DESCRIPTION
After this PR, the L2 chain head will be reset to height `1` after each test case (not reset to genesis anymore), to make the tests compatible with other L2 Taiko node implementations which don't support `debug_setHead` (e.g. `reth`, `nethermind`). Then they can use `engine_forkchoiceUpdate` to reset the chain head to a non-genesis height. 

Also including:
- Removed `testify.Suite` dependency in `anchor_tx_constructor_test.go` and `fixed_k_signer_test.go` to solve an import-cycle issue.
- Some changes to pass the tests when initial L2 chain head is `1`.
- Changed some `errors.Is(err, ethereum.NotFound)` to `err.Error() == ethereum.NotFound.Error()` to make the code compatible with other non-golang L2 node implementations.