### PR TITLE
feat(repo): claude missing tool usage

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,6 +50,7 @@ jobs:
           # Allow Claude to run specific commands
           allowed_tools: |
             mcp__github__create_pull_request
+            Bash(pnpm install)
             Bash(pnpm test:*)
             Bash(pnpm fmt:sol)
             Bash(pnpm snapshot:*)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta
+        env:
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: "30000"   # any safe value < 32000 to avoid reaching token limit
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           
@@ -57,7 +59,6 @@ jobs:
             Bash(find:*)
             Bash(grep:*)
             Bash(ls:*)
-            Bash()
             WebFetch(domain:docs.anthropic.com)
           
           # Add custom instructions for Claude to customize its behavior for your project

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,10 +56,10 @@ jobs:
             Bash(pnpm snapshot:*)
             Bash(pnpm compile:*)
             Bash(pnpm layout:*)
-            Bash(cat:*)
-            Bash(find:*)
-            Bash(grep:*)
-            Bash(ls:*)
+            Bash(cat *)
+            Bash(find *)
+            Bash(grep *)
+            Bash(ls *)
             WebFetch(domain:docs.anthropic.com)
           
           # Add custom instructions for Claude to customize its behavior for your project

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,23 +38,35 @@ jobs:
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
           
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
           
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          # Allow Claude to run specific commands
+          allowed_tools: |
+            mcp__github__create_pull_request
+            Bash(pnpm test:*)
+            Bash(pnpm fmt:sol)
+            Bash(pnpm snapshot:*)
+            Bash(pnpm compile:*)
+            Bash(pnpm layout:*)
+            Bash(cat:*)
+            Bash(find:*)
+            Bash(grep:*)
+            Bash(ls:*)
+            Bash()
+            WebFetch(domain:docs.anthropic.com)
           
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+          # Add custom instructions for Claude to customize its behavior for your project
+          custom_instructions: |
+            For protocol(smart contract) changes always start in the `packages/protocol` directory.
+            You MUST run `pnpm install` first.
+            You MUST follow the development workflow described in CLAUDE.md.
+            You MUST make sure the tests are passing before creating a pull request.
+            You MUST open a draft pull request after creating a branch.
+            You MUST create a pull request after completing your task.
+            You can create pull requests using the `mcp__github__create_pull_request` tool.
 


### PR DESCRIPTION
I hope this is the last one to get claude to be able to open PRs and commit to branches! Docs are incomplete, and even after giving the correct permissions to the workflow you have to list the tools manually.

I tested this same config on a personal repo and it worked fine.