### PR TITLE
fix: don't reset l1Origin fields after BatchProposed event

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -530,9 +530,11 @@ func updateL1OriginForBatch(
 				return fmt.Errorf("failed to get L1Origin by ID %d: %w", blockID, err)
 			}
 			// If L1Origin is not found, it means this block is synced from beacon sync,
-			// and we also won't set the `BuildPayloadArgsID` value.
+			// and we also won't set the `BuildPayloadArgsID` value and related fields.
 			if originalL1Origin != nil {
 				l1Origin.BuildPayloadArgsID = originalL1Origin.BuildPayloadArgsID
+				l1Origin.Signature = originalL1Origin.Signature
+				l1Origin.IsForcedInclusion = originalL1Origin.IsForcedInclusion
 			}
 
 			if _, err := rpc.L2Engine.UpdateL1Origin(ctx, l1Origin); err != nil {


### PR DESCRIPTION
Fixes an issue where `l1Origin.Signature` and `IsForcedInclusion` fields were being reset after the `BatchProposed` event on L1. These fields are now preserved if the original L1Origin is available.