### PR TITLE
fix(taiko-client): check for nil headL1Origin to avoid panic

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -428,7 +428,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Request(
 		return err
 	}
 
-	if block.NumberU64() <= headL1Origin.BlockID.Uint64() {
+	if headL1Origin != nil && block.NumberU64() <= headL1Origin.BlockID.Uint64() {
 		log.Warn(
 			"Ignore the message for outdated block",
 			"peer", from,


### PR DESCRIPTION
This PR prevents a potential panic in `OnUnsafeL2Request` by adding a check for `headL1Origin`. If `headL1Origin` is not set attempting to access `headL1Origin.BlockID` would cause a runtime panic.

```
INFO [07-16|16:13:19.678] "🔊 New preconfirmation block request from P2P network" peer=16Uiu2HAm2DxKhZkqXzHh65UGnpHQS7DcZCynT8TNKwvNAVtMCGex hash=0x83d9afdce4be6556c66d1eb790b7f044e78ab92f3324014f0fec7cd46b10269f
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18a72bd]

goroutine 393 [running]:
github.com/taikoxyz/taiko-mono/packages/taiko-client/driver/preconf_blocks.(*PreconfBlockAPIServer).OnUnsafeL2Request(0xc0009fc790, {0x269eb30, 0xc000be0870}, {0xc000c22e10, 0x27}, {0x83, 0xd9, 0xaf, 0xdc, 0xe4, ...})
	/build/packages/taiko-client/driver/preconf_blocks/server.go:431 +0x51d
github.com/ethereum-optimism/optimism/op-node/p2p.newRequestTopic.RequestsHandler.func4({0x269eb30?, 0xc000be0870?}, {0xc000c22e10?, 0x1821a476175c1f6d?}, {0x1f018c0?, 0xc0019e4b00?})
	/go/pkg/mod/github.com/taikoxyz/optimism@v0.0.0-20250715223632-43d24ba09dd8/op-node/p2p/gossip.go:1266 +0x85
github.com/ethereum-optimism/optimism/op-node/p2p.newRequestTopic.MakeSubscriber.func5({0x269eb30, 0xc000be0870}, 0xc000be0c80)
	/go/pkg/mod/github.com/taikoxyz/optimism@v0.0.0-20250715223632-43d24ba09dd8/op-node/p2p/gossip.go:1294 +0x143
created by github.com/ethereum-optimism/optimism/op-node/p2p.newRequestTopic in goroutine 1
	/go/pkg/mod/github.com/taikoxyz/optimism@v0.0.0-20250715223632-43d24ba09dd8/op-node/p2p/gossip.go:1159 +0x497

```