### PR TITLE
chore(balance-monitor): use slog for error logging in metrics server shutdown

### DIFF
--- a/packages/balance-monitor/balance-monitor/metrics.go
+++ b/packages/balance-monitor/balance-monitor/metrics.go
@@ -6,7 +6,6 @@ import (
 
 	echoprom "github.com/labstack/echo-contrib/prometheus"
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/gommon/log"
 	"github.com/taikoxyz/taiko-mono/packages/balance-monitor/cmd/flags"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/exp/slog"
@@ -24,7 +23,7 @@ func Serve(ctx context.Context, c *cli.Context) (*echo.Echo, func() error) {
 		<-ctx.Done()
 
 		if err := e.Shutdown(ctx); err != nil {
-			log.Error("Failed to close metrics server", "error", err)
+			slog.Error("Failed to close metrics server", "error", err)
 		}
 	}()
 


### PR DESCRIPTION
Replaced the use of log.Error from github.com/labstack/gommon/log with slog.Error for logging errors during the metrics server shutdown. This change ensures consistent logging practices across the project, as slog is used throughout the codebase for error and info messages.