### PR TITLE
chore(protocol): lower liveness bond to 25 TAIKO tokens for whitelist launch

### DIFF
--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -31,7 +31,7 @@ contract DevnetInbox is TaikoInbox {
             batchRingBufferSize: 360_000,
             maxBatchesToVerify: 16,
             blockMaxGasLimit: 240_000_000,
-            livenessBond: 125e18, // 125 Taiko token per batch
+            livenessBond: 25e18, // 25 Taiko token per batch.
             stateRootSyncInternal: 16,
             maxAnchorHeightOffset: 96,
             baseFeeConfig: LibSharedData.BaseFeeConfig({

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -34,7 +34,7 @@ contract MainnetInbox is TaikoInbox {
             batchRingBufferSize: batchRingBufferSize_,
             maxBatchesToVerify: 16,
             blockMaxGasLimit: 32_000_000,
-            livenessBond: 125e18, // 125 Taiko token per batch
+            livenessBond: 25e18, // 25 Taiko token per batch
             stateRootSyncInternal: 4,
             maxAnchorHeightOffset: 96,
             baseFeeConfig: LibSharedData.BaseFeeConfig({


### PR DESCRIPTION
Reduce the liveness bond to 25 TAIKO tokens for whitelist launch. Note that this value should be reconsidered for post-whitelist launch.