### PR TITLE
chore(repo): add batch-level indexers for proposing/proving stats

### DIFF
--- a/packages/tools/taiko-batch-stats-indexer/README.md
+++ b/packages/tools/taiko-batch-stats-indexer/README.md
@@ -93,7 +93,7 @@ THe example log of `batches-proposed-index.js`
 ```
 BondDebited - user: 0x68d30f47F19c07bCCEf4Ac7FAE2Dc12FCa3e0dC9, amount: 125000000000000000000
 anchorBlockId: 22710658, batchId: 1207978, lastBlockId: 1207978, number of blocks: 1
-Fetching L2 block 1207978, number of transations 457 for batch 1207978...
+Fetching L2 block 1207978, number of transactions 457 for batch 1207978...
 Tx Block 1207978 cumulative tips so far: 0.0003921037806939977 ETH, base fees: 0.0002230709500000006 ETH, l2TxCount: 457
 ```
 

--- a/packages/tools/taiko-batch-stats-indexer/README.md
+++ b/packages/tools/taiko-batch-stats-indexer/README.md
@@ -1,0 +1,104 @@
+# Taiko Batch Stats Indexer
+
+This project indexes batch-level statistics for Taiko's Ethereum-based ZK rollup by scanning events from both L1 and L2, and stores the results into a Supabase database.
+
+## Features
+
+This indexer extracts data from `BatchProposed`, `BatchesProved`, `BondDebited`, and `BondCredited` events across both L1 and L2, and writes structured statistics to Supabase.
+
+Table `batches_proposed`
+Populated from the `BatchProposed` and `BatchesProved` events and correlated L2 data, this table contains:
+
+- `batch_id`: unique batch identifier
+- `timestamp`: proposal timestamp
+- `last_block_id`, `anchor_block_id`: block range metadata
+- `block_count`, `l2_tx_count`: number of L2 blocks and transactions in the batch
+- `block_number`, `tx_hash`: L1 inclusion details
+- `proposer`: address who proposed the batch
+- `assigned_proposer`: intended prover specified at proposal time
+- `debited_user`: actual user debited
+- `bond_debited_amount`: actual debited bond amount
+- `tx_l1_fee_eth`: L1 gas fee paid by proposer
+- `l2_total_tips_eth`, `l2_total_base_fees_eth`: total L2 tips and base fee income
+- Base fee configuration:
+  - `l2_base_fee_gas_target`
+  - `l2_base_fee_base_fee_max_change_denominator`
+  - `l2_base_fee_min_base_fee`
+  - `l2_base_fee_target_resource_limit`
+  - `l2_base_fee_resource_limit_multiplier`
+
+Table `batches_proved`
+Populated from the `BatchesProved` and `BondCredited` events on L1, this table contains:
+
+- `batch_id`: proved batch ID
+- `tx_hash`: L1 transaction that proved the batch
+- `tx_from`: address that submitted the proof
+- `block_number`: block number of the proving transaction
+- `tx_l1_fee_eth`: L1 gas fee paid by the prover
+- `prover`: actual address that received the bond credit
+- `bond_credited_amount`: bond reward (split across batches if applicable)
+
+## Structure
+
+- `batches-proposed-index.js` — handles `BatchProposed` and `BondDebited` events, and computes L2 tips/base fee info.
+- `batches-proved-index.js` — handles `BatchesProved` and `BondCredited` events, and verifies the actual prover.
+- `networks.js` — defines supported networks and block ranges.
+- `utils.js` — includes helpers like fetching L1 tx fees.
+
+## Output
+
+All data is stored in the following Supabase tables:
+
+- `batches_proposed`
+- `batches_proved`
+
+Each batch's stats are periodically upserted with `batch_id` + `tx_hash` as unique keys.
+
+## Setup
+
+### Prerequisites
+
+- Node.js v18+
+- Supabase project and key
+- RPC access to both L1 and L2 Taiko endpoints
+
+### Install dependencies
+
+- Node.js v22+
+- Install dependencies:
+
+```bash
+nvm use 22
+npm install ethers
+```
+
+### Set environment variables
+
+```bash
+export SUPABASE_KEY=<your-supabase-service-role-key>
+export SUPABASE_URL=<your-supabase-url>
+```
+
+### Run indexers
+
+```bash
+node batches-proposed-index.js
+node batches-proved-index.js
+```
+
+### Example
+
+THe example log of `batches-proposed-index.js`
+
+```
+BondDebited - user: 0x68d30f47F19c07bCCEf4Ac7FAE2Dc12FCa3e0dC9, amount: 125000000000000000000
+anchorBlockId: 22710658, batchId: 1207978, lastBlockId: 1207978, number of blocks: 1
+Fetching L2 block 1207978, number of transations 457 for batch 1207978...
+Tx Block 1207978 cumulative tips so far: 0.0003921037806939977 ETH, base fees: 0.0002230709500000006 ETH, l2TxCount: 457
+```
+
+THe example log of `batches-proved-index.js`
+
+```
+Inserting batchId 1272838, prover 0xa5cb34B75bD72f15290ef37A01F06183E8036875, tx 0x4dca69bc826a814b5ecc9eb3c0144554bef77266e67ad8330937740f70b518c8
+```

--- a/packages/tools/taiko-batch-stats-indexer/batches-proposed-index.js
+++ b/packages/tools/taiko-batch-stats-indexer/batches-proposed-index.js
@@ -1,0 +1,182 @@
+// index.js
+import { JsonRpcProvider, Contract, Interface } from "ethers";
+import fs from "fs/promises";
+import path from "path";
+import { networks } from "./networks.js";
+import { getLastScannedBlock, getL1TxFee } from "./utils.js";
+import { createClient } from '@supabase/supabase-js';
+
+const TAIKO_L1_ABI = [
+  "event BatchProposed((bytes32,(uint16,uint8,bytes32[])[],bytes32[],bytes32,address,uint64,uint64,uint32,uint32,uint32,uint64,uint64,uint64,bytes32,(uint8,uint8,uint32,uint64,uint32)),(bytes32,address,uint64,uint64),bytes)",
+];
+
+const BOND_DEBITED_ABI = [
+  "event BondDebited(address indexed user, uint256 amount)"
+];
+const bondDebitedInterface = new Interface(BOND_DEBITED_ABI);
+
+// Create a single supabase client for interacting with your database
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+
+(async () => {
+  for (const net of networks) {
+    const { name, chainId, rpcUrlL1, rpcUrlL2, taikoL1Address, fromBlock, toBlock } = net;
+    const providerL1 = new JsonRpcProvider(rpcUrlL1, chainId);
+    const providerL2 = new JsonRpcProvider(rpcUrlL2);
+
+    const latestBlock2 = await providerL2.getBlockNumber();
+    const block = await providerL2.getBlock(latestBlock2 - 10); // warm up
+    console.log(`Connected to L2 at block ${latestBlock2}, sample block ${block.number} timestamp ${block.timestamp}`);
+
+    const latestBlock = await providerL1.getBlockNumber();
+    const finalBlock = toBlock === "latest" ? latestBlock : Number(toBlock);
+
+    const chunkSize = 1000;
+
+    const outputDir = path.join("data", name.replace(/\s+/g, "_"), "BatchProposed");
+    await fs.mkdir(outputDir, { recursive: true });
+
+    let startBlock = fromBlock || 0;
+
+    const { data, error } = await supabase
+      .from('batches_proposed')
+      .select('block_number')
+      .order('block_number', { ascending: false })
+      .limit(1);
+    const maxBlock = data?.[0]?.block_number;
+    startBlock = Math.max(startBlock, (maxBlock || 0) - 10);
+
+    console.log(`\n=== ${name} ===`);
+    console.log(`Fetching blocks from ${startBlock} to ${finalBlock}...`);
+
+    const contract = new Contract(taikoL1Address, TAIKO_L1_ABI, providerL1);
+
+    while (startBlock <= finalBlock) {
+      const chunkEnd = Math.min(startBlock + chunkSize - 1, finalBlock);
+      console.log(`Processing chunk: [${startBlock}, ${chunkEnd}]`);
+
+      const proposedEvents = await contract.queryFilter(contract.filters.BatchProposed(), startBlock, chunkEnd);
+      console.log(`Found ${proposedEvents.length} proposed events.`);
+
+      for (const evt of proposedEvents) {
+        const info = evt.args[0];
+        const meta = evt.args[1];
+
+        const assignedProverInProposedTx = meta[1];
+        const batchId = Number(meta[2]);
+        const timestamp = Number(meta[3]);
+
+        // Proposer info from L1 tx
+        const tx = await providerL1.getTransaction(evt.transactionHash);
+        const from = tx.from;
+        const proposer = from;
+        const { l1Rceipt: proposerL1Rceipt, l1FeeEth: proposerL1FeeEth } = await getL1TxFee(providerL1, evt.transactionHash);
+
+        const proposedL1TransactionReceipt = await providerL1.getTransactionReceipt(evt.transactionHash);
+        let debitedUser = null;
+        let bondDebitedAmount = 0;
+        for (const log of proposedL1TransactionReceipt.logs) {
+          try {
+            const parsed = bondDebitedInterface.parseLog(log);
+            if (parsed.name === "BondDebited") {
+              const { user, amount } = parsed.args;
+              console.log(`BondDebited - user: ${user}, amount: ${amount.toString()}`);
+              bondDebitedAmount += Number(amount) / 1e18;
+
+              if (debitedUser === null) {
+                debitedUser = user;
+              } else if (debitedUser.toLowerCase() !== user.toLowerCase()) {
+                throw new Error(`❌ Multiple BondDebited users found: ${debitedUser} and ${user}`);
+              }
+            }
+          } catch {}
+        }
+
+        // base fee configuration
+        const l2BaseFeeConfig = info[14];
+        const l2BaseFee = {
+          gasTarget: Number(l2BaseFeeConfig[0]),
+          baseFeeMaxChangeDenominator: Number(l2BaseFeeConfig[1]),
+          minBaseFee: Number(l2BaseFeeConfig[2]),
+          targetResourceLimit: Number(l2BaseFeeConfig[3]),
+          resourceLimitMultiplier: Number(l2BaseFeeConfig[4])
+        };
+
+        const blockParams = info[1].map((b, i) => ({
+          index: i,
+          numTransactions: Number(b[0]),
+          timeShift: Number(b[1]),
+          signalSlots: b[2]
+        }));
+
+        const lastBlockId = Number(info[10]);
+        const anchorBlockId = Number(info[12]);
+        console.log(`anchorBlockId: ${anchorBlockId}, batchId: ${batchId}, lastBlockId: ${lastBlockId}, number of blocks: ${blockParams.length}`);
+
+        let l2TotalTips = 0;
+        let l2TotalBaseFees = 0;
+        let l2TxCount = 0;
+
+        const blockCount = blockParams.length;
+        const firstBlockId = lastBlockId - blockCount + 1;
+        for (let i = 0; i < blockCount; i++) {
+          const blockId = firstBlockId + i;
+
+          const l2Block = await providerL2.getBlock(Number(blockId));
+          l2TxCount = l2Block.transactions.length;
+          console.log(`Fetching L2 block ${blockId}, number of transations ${l2Block.transactions.length} for batch ${batchId}...`);
+
+          const receipts = await providerL2.send("eth_getBlockReceipts", [l2Block.hash]);
+          const baseFeePerGas = BigInt(l2Block.baseFeePerGas.toString());
+          const blockBasedFee = BigInt(l2Block.gasUsed.toString()) * baseFeePerGas;
+
+          for (const receipt of receipts) {
+            const gasUsed = BigInt(receipt.gasUsed);
+            const gasPrice = receipt.effectiveGasPrice ? BigInt(receipt.effectiveGasPrice) : BigInt(0); // fallback if field is missing
+            const tip = gasPrice > baseFeePerGas ? (gasPrice - baseFeePerGas) * gasUsed : BigInt(0);
+            const base = baseFeePerGas * gasUsed;
+        
+            l2TotalTips += Number(tip) / 1e18;
+            l2TotalBaseFees += Number(base) / 1e18;
+          }          
+          console.log(`Tx Block ${blockId} cumulative tips so far: ${l2TotalTips} ETH, base fees: ${l2TotalBaseFees} ETH, l2TxCount: ${l2TxCount}`);
+        }
+
+        const { error } = await supabase
+          .from('batches_proposed')
+          .upsert({
+            batch_id: batchId,
+            timestamp: timestamp,
+            last_block_id: lastBlockId,
+            anchor_block_id: anchorBlockId,
+            block_count: blockParams.length,
+            l2_tx_count: l2TxCount,
+            block_number: evt.blockNumber,
+            tx_hash: evt.transactionHash,
+            proposer: proposer,
+            tx_l1_fee_eth: proposerL1FeeEth,
+            assigned_proposer: assignedProverInProposedTx,
+            debited_user: debitedUser,
+            bond_debited_amount: bondDebitedAmount,
+            l2_total_tips_eth: l2TotalTips,
+            l2_total_base_fees_eth: l2TotalBaseFees,
+            l2_base_fee_gas_target: l2BaseFee.gasTarget,
+            l2_base_fee_base_fee_max_change_denominator: l2BaseFee.baseFeeMaxChangeDenominator,
+            l2_base_fee_min_base_fee: l2BaseFee.minBaseFee,
+            l2_base_fee_target_resource_limit: l2BaseFee.targetResourceLimit,
+            l2_base_fee_resource_limit_multiplier: l2BaseFee.resourceLimitMultiplier,
+          }, {
+            onConflict: 'batch_id,tx_hash'
+          });
+
+          if (error) {
+            throw new Error(`Supabase upsert error for batch ${batchId}: ${error.message}`);
+          }
+      }
+      startBlock = chunkEnd + 1;
+    }
+  }
+})();

--- a/packages/tools/taiko-batch-stats-indexer/batches-proposed-index.js
+++ b/packages/tools/taiko-batch-stats-indexer/batches-proposed-index.js
@@ -127,7 +127,7 @@ const supabase = createClient(supabaseUrl, supabaseKey);
 
           const l2Block = await providerL2.getBlock(Number(blockId));
           l2TxCount = l2Block.transactions.length;
-          console.log(`Fetching L2 block ${blockId}, number of transations ${l2Block.transactions.length} for batch ${batchId}...`);
+          console.log(`Fetching L2 block ${blockId}, number of transactions ${l2Block.transactions.length} for batch ${batchId}...`);
 
           const receipts = await providerL2.send("eth_getBlockReceipts", [l2Block.hash]);
           const baseFeePerGas = BigInt(l2Block.baseFeePerGas.toString());

--- a/packages/tools/taiko-batch-stats-indexer/batches-proved-index.js
+++ b/packages/tools/taiko-batch-stats-indexer/batches-proved-index.js
@@ -1,0 +1,116 @@
+// batches-proved-index.js
+import { JsonRpcProvider, Contract, Interface } from "ethers";
+import fs from "fs/promises";
+import path from "path";
+import { networks } from "./networks.js";
+import { getLastScannedBlock, getL1TxFee } from "./utils.js";
+import { createClient } from '@supabase/supabase-js';
+
+
+const TAIKO_L1_ABI = [
+  "event BatchesProved(address verifier, uint64[] batchIds, tuple(bytes32 parentHash, bytes32 postStateRoot, bytes32 withdrawRoot)[] transitions)"
+];
+
+const BOND_CREDITED_ABI = [
+  "event BondCredited(address indexed user, uint256 amount)"
+];
+const bondCreditedInterface = new Interface(BOND_CREDITED_ABI);
+
+// Create a single supabase client for interacting with your database
+const supabaseUrl = 'https://qmjtymqzhjdkqolqwzbn.supabase.co';
+const supabaseKey = process.env.SUPABASE_KEY;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+
+(async () => {
+  for (const net of networks) {
+    const { name, chainId, rpcUrlL1, rpcUrlL2, taikoL1Address, fromBlock, toBlock } = net;
+    const providerL1 = new JsonRpcProvider(rpcUrlL1, chainId);
+    const providerL2 = new JsonRpcProvider(rpcUrlL2);
+
+    const latestBlock2 = await providerL2.getBlockNumber();
+    const block = await providerL2.getBlock(latestBlock2 - 10); // warm up
+    console.log(`Connected to L2 at block ${latestBlock2}, sample block ${block.number} timestamp ${block.timestamp}`);
+
+    const latestBlock = await providerL1.getBlockNumber();
+    const finalBlock = toBlock === "latest" ? latestBlock : Number(toBlock);
+
+    const outputDir = path.join("data", name.replace(/\s+/g, "_"), "BatchProposed");
+    await fs.mkdir(outputDir, { recursive: true });
+
+    let startBlock = fromBlock || 0;
+
+    const { data, error } = await supabase
+      .from('batches_proved')
+      .select('block_number')
+      .order('block_number', { ascending: false })
+      .limit(1);
+    const maxBlock = data?.[0]?.block_number;
+    startBlock = Math.max(startBlock, (maxBlock || 0) - 10);
+
+    console.log(`\n=== ${name} ===`);
+    console.log(`Fetching blocks from ${startBlock} to ${finalBlock}...`);
+
+    const contract = new Contract(taikoL1Address, TAIKO_L1_ABI, providerL1);
+
+    const allChunkSize = 1000;
+
+    while (startBlock <= finalBlock) {
+      const currentEnd = Math.min(startBlock + allChunkSize - 1, finalBlock);
+      console.log(`Scanning BatchesProved [${startBlock}, ${currentEnd}]`);
+      const provenEvents = await contract.queryFilter(contract.filters.BatchesProved(), startBlock, currentEnd);
+      for (const evt of provenEvents) {
+        // console.log(evt);
+        const tx = await providerL1.getTransaction(evt.transactionHash);
+        const from = tx.from;
+        // console.log(tx);
+
+        const { l1Rceipt: proverL1Rceipt, l1FeeEth: proverTxL1FeeEth } = await getL1TxFee(providerL1, evt.transactionHash);
+
+        // Prover bond credited logs
+        const proverL1TransactionReceipt = await providerL1.getTransactionReceipt(evt.transactionHash);
+        let actualProver = null;
+        let bondCreditedAmount = 0;
+        for (const log of proverL1TransactionReceipt.logs) {    
+          try {
+            const parsed = bondCreditedInterface.parseLog(log);
+            if (parsed.name === "BondCredited") {
+              const { user, amount } = parsed.args;
+              console.log(`BondCredited - user: ${user}, amount: ${amount.toString()}`);
+              bondCreditedAmount += Number(amount) / 1e18;
+  
+              if (actualProver === null) {
+                actualProver = user;
+              } else if (actualProver.toLowerCase() !== user.toLowerCase()) {
+                throw new Error(`❌ Multiple users found in BondCredited logs: ${actualProver} and ${user}`);
+              }
+            }
+          } catch {}
+        }
+
+        const batchIds = evt.args.batchIds.map((id) => Number(id));
+
+        for (const batchId of batchIds) {
+          console.log(`Inserting batchId ${batchId}, prover ${from}, tx ${evt.transactionHash}`);
+
+          const { error } = await supabase
+            .from('batches_proved')
+            .upsert({
+              batch_id: batchId,
+              tx_hash: evt.transactionHash,
+              tx_from: from,
+              block_number: evt.blockNumber,
+              tx_l1_fee_eth: proverTxL1FeeEth,
+              prover: actualProver,
+              bond_credited_amount: bondCreditedAmount / batchIds.length,
+            }, { onConflict: 'batch_id,tx_hash' });
+
+          if (error) {
+            throw new Error(`Supabase upsert error for batch ${batchId}: ${error.message}`);
+          }
+        }
+      }
+      startBlock = currentEnd + 1;
+    }
+  }
+})();

--- a/packages/tools/taiko-batch-stats-indexer/batches-proved-index.js
+++ b/packages/tools/taiko-batch-stats-indexer/batches-proved-index.js
@@ -100,7 +100,7 @@ const supabase = createClient(supabaseUrl, supabaseKey);
               tx_hash: evt.transactionHash,
               tx_from: from,
               block_number: evt.blockNumber,
-              tx_l1_fee_eth: proverTxL1FeeEth,
+              tx_l1_fee_eth: proverTxL1FeeEth / batchIds.length,
               prover: actualProver,
               bond_credited_amount: bondCreditedAmount / batchIds.length,
             }, { onConflict: 'batch_id,tx_hash' });

--- a/packages/tools/taiko-batch-stats-indexer/networks.js
+++ b/packages/tools/taiko-batch-stats-indexer/networks.js
@@ -1,0 +1,23 @@
+// networks.js
+export const networks = [
+  /*
+  {
+    name: "Holesky",
+    chainId: 17000,
+    rpcUrlL1: "https://l1rpc.hekla.taiko.xyz",
+    rpcUrlL2: "https://rpc.hekla.taiko.xyz",
+    taikoL1Address: "0x79C9109b764609df928d16fC4a91e9081F7e87DB",
+    fromBlock: 4150000,
+    toBlock: "latest"
+  },
+  */
+  {
+    name: "Ethereum",
+    chainId: 1,
+    rpcUrlL1: "https://l1rpc.mainnet.taiko.xyz/",
+    rpcUrlL2: "https://rpc.mainnet.taiko.xyz/",
+    taikoL1Address: "0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a",
+    fromBlock: 22432338, // Taiko L1 Mainnet deployment block
+    toBlock: "latest"
+  }
+];

--- a/packages/tools/taiko-batch-stats-indexer/networks.js
+++ b/packages/tools/taiko-batch-stats-indexer/networks.js
@@ -1,16 +1,15 @@
 // networks.js
 export const networks = [
-  /*
   {
     name: "Holesky",
     chainId: 17000,
     rpcUrlL1: "https://l1rpc.hekla.taiko.xyz",
     rpcUrlL2: "https://rpc.hekla.taiko.xyz",
     taikoL1Address: "0x79C9109b764609df928d16fC4a91e9081F7e87DB",
-    fromBlock: 4150000,
+    fromBlock: 4280000,
     toBlock: "latest"
   },
-  */
+  /*
   {
     name: "Ethereum",
     chainId: 1,
@@ -20,4 +19,5 @@ export const networks = [
     fromBlock: 22432338, // Taiko L1 Mainnet deployment block
     toBlock: "latest"
   }
+  */
 ];

--- a/packages/tools/taiko-batch-stats-indexer/package-lock.json
+++ b/packages/tools/taiko-batch-stats-indexer/package-lock.json
@@ -1,0 +1,287 @@
+{
+  "name": "batch",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@supabase/supabase-js": "^2.52.0",
+        "csv-writer": "^1.6.0",
+        "dotenv": "^16.5.0",
+        "ethers": "^6.14.3"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/realtime-js/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.52.0.tgz",
+      "integrity": "sha512-jbs3CV1f2+ge7sgBeEduboT9v/uGjF22v0yWi/5/XFn5tbM8MfWRccsMtsDwAwu24XK8H6wt2LJDiNnZLtx/bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==",
+      "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
+      "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/packages/tools/taiko-batch-stats-indexer/package.json
+++ b/packages/tools/taiko-batch-stats-indexer/package.json
@@ -1,0 +1,9 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@supabase/supabase-js": "^2.52.0",
+    "csv-writer": "^1.6.0",
+    "dotenv": "^16.5.0",
+    "ethers": "^6.14.3"
+  }
+}


### PR DESCRIPTION
This PR introduces two event indexers to gather batch-level metrics across L1 and L2 chains for Taiko.

Included:
- `batches-proposed-index.js`: Handles BatchProposed and BondDebited events. Calculates L2 tips and base fees per block.
- `batches-proved-index.js`: Handles BatchesProved and BondCredited events. Extracts actual prover and credited bond info.
- Writes to Supabase https://supabase.com using upserts keyed on (batch_id, tx_hash).

Stats gathered:
- proposing/proving L1 fees
- bond amount (credited/debited)
- assigned vs actual prover
- proposer address
- total tips and base fees on L2