### PR TITLE
feat(taiko-client): cache lookahead every l1 block

### DIFF
--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -457,7 +457,7 @@ func (d *Driver) cacheLookaheadLoop() {
 		// once per epoch, since we push the next operator as the current range when we check.
 		// so, this means we should use a reliable slot past 0 where the operator has no possible
 		// way to change. mid-epooch works, so we use slot 16.
-		if lookahead == nil || lookahead.LastEpochUpdated < currentEpoch && slotInEpoch >= 2 {
+		if lookahead == nil || slotInEpoch >= 2 {
 			if currOp == d.PreconfOperatorAddress && nextOp == d.PreconfOperatorAddress {
 				log.Info(
 					"Pushing into window for current epoch as current and next operator",


### PR DESCRIPTION
this means we dont have to subscribe to `operatorRemoved` events in the contract, in the situation an operator must be removed with `effectiveImmediately.`

This should make it in the mainnet release version.