### PR TITLE
(chore): broken image links in the bridging documentation by correcting relative paths

### DIFF
--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md
@@ -74,7 +74,7 @@ When a user initiates a transfer:
 
 **Diagram: Sending a message on the source chain**
 
-![Bridging source chain process](~/assets/content/docs/taiko-alethia-protocol/bridging-source-chain.webp)
+![Bridging source chain process](/assets/content/docs/taiko-alethia-protocol/bridging-source-chain.webp)
 
 #### Receiving assets on destination chain
 
@@ -89,7 +89,7 @@ To complete the transfer:
 
 **Diagram: Processing a message on the destination chain**
 
-![Bridging destination chain process](~/assets/content/docs/taiko-alethia-protocol/bridging-dest-chain.webp)
+![Bridging destination chain process](/assets/content/docs/taiko-alethia-protocol/bridging-dest-chain.webp)
 
 ## Ether bridging
 


### PR DESCRIPTION


##  Changes
- **File:** `packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md`
- **Fixes:** 2 image path corrections
  - `bridging-source-chain.webp` - removed `~` prefix
  - `bridging-dest-chain.webp` - removed `~` prefix

##  Why
The `~` prefix was causing images to not display properly in the documentation. This change ensures images render correctly by using absolute paths from the root.

##  Testing
- Images now load correctly in documentation
- No breaking changes to existing functionality