### PR TITLE
feat(protocol): unify Proposed and SummaryUpdated

### DIFF
--- a/packages/protocol/contracts/layer1/based2/AbstractInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/AbstractInbox.sol
@@ -78,6 +78,8 @@ abstract contract AbstractInbox is EssentialContract, IInbox, IPropose, IProve {
         _saveSummaryHash(keccak256(abi.encode(summary)));
 
         // Skip calldata emission for gas optimization when directly called by EOA
+        // TODO: can we call PreconfRouter from within this contract, instead of using the
+        // PreconfRouter as the msg.sender?
         emit Proposed(
             lastProposedBatchId,
             _isOuterMostTransaction() ? bytes("") : _inputs,

--- a/packages/protocol/contracts/layer1/based2/AbstractInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/AbstractInbox.sol
@@ -78,7 +78,7 @@ abstract contract AbstractInbox is EssentialContract, IInbox, IPropose, IProve {
         _saveSummaryHash(keccak256(abi.encode(summary)));
 
         // Skip calldata emission for gas optimization when directly called by EOA
-        // TODO: can we call PreconfRouter from within this contract, instead of using the
+        // TODO: can we call IPreconfWhitelist or LookAhead from within this contract, instead of using the
         // PreconfRouter as the msg.sender?
         emit Proposed(
             lastProposedBatchId,

--- a/packages/protocol/contracts/layer1/based2/IInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/IInbox.sol
@@ -336,6 +336,7 @@ interface IInbox {
         /// @notice Size of the ring buffer for batch storage
         uint24 batchRingBufferSize;
         /// @notice Maximum number of batches to verify in one operation
+        /// @custom:encode max-size:63
         uint8 maxBatchesToVerify;
         /// @notice Bond amount for liveness guarantee (in Gwei)
         uint48 livenessBond;
@@ -394,16 +395,15 @@ interface IInbox {
         uint256[43] __gap;
     }
 
-    /// @notice Emitted when the protocol summary is updated
-    /// @param summary The updated protocol summary encoded as bytes
-    /// @param proposeInputs The calldata inputs for propose4 function
-    event SummaryUpdated(bytes summary, bytes proposeInputs);
-
     /// @notice Emitted when a new batch is proposed
-    /// @param batchId The unique identifier of the proposed batch
-    /// @param context The batch context data encoded as bytes
-    /// TODO(daniel): propose4's `inputs` calldata not emitted in this event.
-    event Proposed(uint256 indexed batchId, bytes context);
+    /// @param lastProposedBatchId The id of the last proposed batch
+    /// @param proposeInputs The calldata inputs for propose4 function. Note that when the propose4
+    /// function is called by an EOA, the proposeInputs will be empty.
+    /// @param batchContexts The array of batch context encoded as bytes encoded as bytes
+    /// @param summary The updated protocol summary encoded as bytes
+    event Proposed(
+        uint256 indexed lastProposedBatchId, bytes proposeInputs, bytes batchContexts, bytes summary
+    );
 
     /// @notice Emitted when a batch transition is proven
     /// @param batchId The unique identifier of the proven batch
@@ -421,6 +421,7 @@ interface IInbox {
     /// (IInbox.Summary
     /// memory, IInbox.Batch[] memory, IInbox.ProposeBatchEvidence memory, IInbox.TransitionMeta[]
     /// memory)
+    /// @custom:encode max-size:7 for decoded IInbox.Batch[]
     /// @return The updated summary
     function propose4(bytes calldata _inputs) external returns (Summary memory);
 

--- a/packages/protocol/contracts/layer1/based2/IInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/IInbox.sol
@@ -396,7 +396,8 @@ interface IInbox {
 
     /// @notice Emitted when the protocol summary is updated
     /// @param summary The updated protocol summary encoded as bytes
-    event SummaryUpdated(bytes summary);
+    /// @param proposeInputs The calldata inputs for propose4 function
+    event SummaryUpdated(bytes summary, bytes proposeInputs);
 
     /// @notice Emitted when a new batch is proposed
     /// @param batchId The unique identifier of the proposed batch

--- a/packages/protocol/contracts/layer1/based2/IPropose.sol
+++ b/packages/protocol/contracts/layer1/based2/IPropose.sol
@@ -12,6 +12,8 @@ interface IPropose {
     /// @param _inputs The inputs to propose and verify batches that can be decoded into
     /// (IInbox.Summary memory, IInbox.Batch[] memory, IInbox.ProposeBatchEvidence memory,
     /// IInbox.TransitionMeta[] memory)
+    /// @dev The length of IInbox.Batch[] must be smaller than 8.
+    /// @custom:encode max-size:7 for decoded IInbox.Batch[]
     /// @return The updated summary
     function propose4(bytes calldata _inputs) external returns (IInbox.Summary memory);
 }

--- a/packages/protocol/contracts/layer1/based2/InboxHelper.sol
+++ b/packages/protocol/contracts/layer1/based2/InboxHelper.sol
@@ -48,24 +48,24 @@ contract InboxHelper {
         return LibCodecSummary.decode(_data);
     }
 
-    /// @notice Encodes a BatchContext struct
-    /// @param _context The BatchContext struct to encode
+    /// @notice Encodes a BatchContext array
+    /// @param _batchContexts The BatchContext struct to encode
     /// @return The encoded bytes
-    function encodeBatchContext(IInbox.BatchContext memory _context)
+    function encodeBatchContexts(IInbox.BatchContext[] memory _batchContexts)
         external
         pure
         returns (bytes memory)
     {
-        return LibCodecBatchContext.encode(_context);
+        return LibCodecBatchContext.encode(_batchContexts);
     }
 
     /// @notice Decodes bytes into a BatchContext struct
     /// @param _data The bytes to decode
-    /// @return The decoded BatchContext struct
+    /// @return The decoded BatchContext array
     function decodeBatchContext(bytes memory _data)
         external
         pure
-        returns (IInbox.BatchContext memory)
+        returns (IInbox.BatchContext[] memory)
     {
         return LibCodecBatchContext.decode(_data);
     }

--- a/packages/protocol/contracts/layer1/based2/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/TaikoInbox.sol
@@ -27,13 +27,13 @@ abstract contract TaikoInbox is Inbox {
     // -------------------------------------------------------------------------
 
     /// @inheritdoc AbstractInbox
-    function _encodeBatchContext(IInbox.BatchContext memory _context)
+    function _encodeBatchContexts(IInbox.BatchContext[] memory _batchContexts)
         internal
         pure
         override
         returns (bytes memory)
     {
-        return LibCodecBatchContext.encode(_context);
+        return LibCodecBatchContext.encode(_batchContexts);
     }
 
     /// @inheritdoc AbstractInbox

--- a/packages/protocol/contracts/layer1/based2/codec/LibCodecBatchContext.sol
+++ b/packages/protocol/contracts/layer1/based2/codec/LibCodecBatchContext.sol
@@ -9,21 +9,21 @@ import "../IInbox.sol";
 // TODO(dnaiel): implement this library
 library LibCodecBatchContext {
     /// @notice Encodes a BatchContext struct into bytes
-    /// @param _batchContext The BatchContext to encode
+    /// @param _batchContexts The array of BatchContext to encode
     /// @return _ The encoded data
     /// @custom:encode optimize-gas
-    function encode(IInbox.BatchContext memory _batchContext)
+    function encode(IInbox.BatchContext[] memory _batchContexts)
         internal
         pure
         returns (bytes memory)
     {
-        return abi.encode(_batchContext);
+        return abi.encode(_batchContexts);
     }
 
     /// @notice Decodes bytes into a BatchContext struct
     /// @param _data The encoded data
-    /// @return _ The decoded BatchContext
-    function decode(bytes memory _data) internal pure returns (IInbox.BatchContext memory) {
-        return abi.decode(_data, (IInbox.BatchContext));
+    /// @return _ The decoded BatchContext array
+    function decode(bytes memory _data) internal pure returns (IInbox.BatchContext[] memory) {
+        return abi.decode(_data, (IInbox.BatchContext[]));
     }
 }

--- a/packages/protocol/contracts/layer1/based2/codec/LibCodecProposeBatchInputs.sol
+++ b/packages/protocol/contracts/layer1/based2/codec/LibCodecProposeBatchInputs.sol
@@ -16,8 +16,10 @@ library LibCodecProposeBatchInputs {
     /// @return _ The encoded data
     function encode(
         IInbox.Summary memory _summary,
+        /// @custom:encode max-size:7
         IInbox.Batch[] memory _batches,
         IInbox.ProposeBatchEvidence memory _proposeBatchEvidence,
+        /// @custom:encode max-size:63
         IInbox.TransitionMeta[] memory _transitionMetas
     )
         internal

--- a/packages/protocol/contracts/layer1/based2/libs/LibBinding.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibBinding.sol
@@ -52,7 +52,7 @@ library LibBinding {
         //
         // Encoding functions -----------------------------------------------------
         //
-        function(IInbox.BatchContext memory) pure returns (bytes memory) encodeBatchContext;
+        function(IInbox.BatchContext[] memory) pure returns (bytes memory) encodeBatchContexts;
         function(IInbox.TransitionMeta[] memory) pure returns (bytes memory) encodeTransitionMetas;
         function(IInbox.Summary memory) pure returns (bytes memory) encodeSummary;
         // Decoding functions -----------------------------------------------------

--- a/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
+++ b/packages/protocol/contracts/layer1/based2/libs/LibPropose.sol
@@ -35,10 +35,11 @@ library LibPropose {
         IInbox.ProposeBatchEvidence memory _evidence
     )
         internal
-        returns (IInbox.Summary memory)
+        returns (IInbox.Summary memory, IInbox.BatchContext[] memory)
     {
         unchecked {
             if (_batches.length == 0) revert EmptyBatchArray();
+            if (_batches.length > 7) revert BatchLimitExceeded();
 
             // Make sure the last verified batch is not overwritten by a new batch.
             // Assuming batchRingBufferSize = 100, right after genesis, we can propose up to 99
@@ -57,9 +58,10 @@ library LibPropose {
             }
 
             IInbox.BatchProposeMetadata memory parentBatch = _evidence.proposeMeta;
+            IInbox.BatchContext[] memory contexts = new IInbox.BatchContext[](_batches.length);
 
             for (uint256 i; i < _batches.length; ++i) {
-                (parentBatch, _summary.lastBatchMetaHash) =
+                (parentBatch, contexts[i], _summary.lastBatchMetaHash) =
                     _proposeBatch(_bindings, _config, _summary, _batches[i], parentBatch);
 
                 ++_summary.nextBatchId;
@@ -70,7 +72,7 @@ library LibPropose {
                 }
             }
 
-            return _summary;
+            return (_summary, contexts);
         }
     }
 
@@ -94,7 +96,7 @@ library LibPropose {
         IInbox.BatchProposeMetadata memory _parentBatch
     )
         private
-        returns (IInbox.BatchProposeMetadata memory, bytes32)
+        returns (IInbox.BatchProposeMetadata memory, IInbox.BatchContext memory, bytes32)
     {
         // Validate the batch parameters and return batch and batch context data
         IInbox.BatchContext memory context =
@@ -106,12 +108,10 @@ library LibPropose {
             uint48(block.number), uint48(block.timestamp), _batch, context
         );
 
-        emit IInbox.Proposed(_summary.nextBatchId, _bindings.encodeBatchContext(context));
-
         bytes32 batchMetaHash = LibData.hashBatch(_summary.nextBatchId, metadata);
         _bindings.saveBatchMetaHash(_config, _summary.nextBatchId, batchMetaHash);
 
-        return (metadata.proposeMeta, batchMetaHash);
+        return (metadata.proposeMeta, context, batchMetaHash);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Also: if `propose4` is called as the outermost transaction, we can safely skip emitting its `inputs` calldata in the `SummaryUpdated` event to save gas.