### PR TITLE
fix(protocol): fix a bug in forced inclusion proposer

### DIFF
--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -253,7 +253,6 @@ interface ITaikoInbox is IBondManager, IProveBatches {
     error BlobNotSpecified();
     error BlockNotFound();
     error ContractPaused();
-    error CustomProposerMissing();
     error CustomProposerNotAllowed();
     error EtherNotPaidAsBond();
     error FirstBlockTimeShiftNotZero();

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -93,14 +93,17 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
 
             {
                 if (inboxWrapper == address(0)) {
-                    require(params.proposer == msg.sender, CustomProposerNotAllowed());
+                   if (params.proposer == address(0)) {
+                        params.proposer = msg.sender;
+                    } else {
+                        require(params.proposer == msg.sender, CustomProposerNotAllowed());
+                    }
 
                     // blob hashes are only accepted if the caller is trusted.
                     require(params.blobParams.blobHashes.length == 0, InvalidBlobParams());
                     require(params.blobParams.createdIn == 0, InvalidBlobCreatedIn());
                     require(params.isForcedInclusion == false, InvalidForcedInclusion());
                 } else {
-                    require(params.proposer != address(0), CustomProposerMissing());
                     require(msg.sender == inboxWrapper, NotInboxWrapper());
                 }
 

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -93,7 +93,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
 
             {
                 if (inboxWrapper == address(0)) {
-                   if (params.proposer == address(0)) {
+                    if (params.proposer == address(0)) {
                         params.proposer = msg.sender;
                     } else {
                         require(params.proposer == msg.sender, CustomProposerNotAllowed());

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -93,11 +93,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
 
             {
                 if (inboxWrapper == address(0)) {
-                    if (params.proposer == address(0)) {
-                        params.proposer = msg.sender;
-                    } else {
-                        require(params.proposer == msg.sender, CustomProposerNotAllowed());
-                    }
+                    require(params.proposer == msg.sender, CustomProposerNotAllowed());
 
                     // blob hashes are only accepted if the caller is trusted.
                     require(params.blobParams.blobHashes.length == 0, InvalidBlobParams());

--- a/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
@@ -44,6 +44,7 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
     error InvalidBlobByteSize();
     error InvalidBlobCreatedIn();
     error InvalidBlockSize();
+    error InvalidProposer();
     error InvalidTimeShift();
     error InvalidSignalSlots();
     error OldestForcedInclusionDue();
@@ -131,6 +132,8 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
         require(p.blobParams.byteOffset == inclusion.blobByteOffset, InvalidBlobByteOffset());
         require(p.blobParams.byteSize == inclusion.blobByteSize, InvalidBlobByteSize());
         require(p.blobParams.createdIn == inclusion.blobCreatedIn, InvalidBlobCreatedIn());
+
+        require(p.proposer == msg.sender, InvalidProposer());
 
         emit ForcedInclusionProcessed(inclusion);
     }


### PR DESCRIPTION
In forced inclusion, `params.proposer` must always be set to `msg.sender`.

@claude https://github.com/cursor please review.
@gavin please cherrypick this PR to the preconf release.