### PR TITLE
fix(protocol): validate proposer in TaikoWrapper for forced inclussions

### DIFF
--- a/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
@@ -47,6 +47,7 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
     error InvalidTimeShift();
     error InvalidSignalSlots();
     error OldestForcedInclusionDue();
+    error InvalidProposer();
 
     IProposeBatch public immutable inbox;
     IForcedInclusionStore public immutable forcedInclusionStore;
@@ -84,17 +85,17 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
         returns (ITaikoInbox.BatchInfo memory, ITaikoInbox.BatchMetadata memory)
     {
         (bytes memory bytesX, bytes memory bytesY) = abi.decode(_params, (bytes, bytes));
+        ITaikoInbox.BatchParams memory params = abi.decode(bytesY, (ITaikoInbox.BatchParams));
 
         if (bytesX.length == 0) {
             require(!forcedInclusionStore.isOldestForcedInclusionDue(), OldestForcedInclusionDue());
         } else {
-            _validateForcedInclusionParams(forcedInclusionStore, bytesX);
+            address proposer = params.proposer;
+            _validateForcedInclusionParams(forcedInclusionStore, bytesX, proposer);
             inbox.v4ProposeBatch(bytesX, "", "");
         }
 
         // Propose the normal batch after the potential forced inclusion batch.
-        ITaikoInbox.BatchParams memory params = abi.decode(bytesY, (ITaikoInbox.BatchParams));
-
         require(params.blobParams.blobHashes.length == 0, ITaikoInbox.InvalidBlobParams());
         require(params.blobParams.createdIn == 0, ITaikoInbox.InvalidBlobCreatedIn());
         require(params.isForcedInclusion == false, ITaikoInbox.InvalidForcedInclusion());
@@ -104,7 +105,8 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
 
     function _validateForcedInclusionParams(
         IForcedInclusionStore _forcedInclusionStore,
-        bytes memory _bytesX
+        bytes memory _bytesX,
+        address _proposer
     )
         internal
     {
@@ -112,6 +114,9 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
 
         IForcedInclusionStore.ForcedInclusion memory inclusion =
             _forcedInclusionStore.consumeOldestForcedInclusion(p.proposer);
+
+        // Ensure the proposer is the same that for the regular batch(which is validated upstream)
+        require(p.proposer == _proposer, InvalidProposer());
 
         // Only one block can be built from the request
         require(p.blocks.length == 1, InvalidBlockSize());


### PR DESCRIPTION
## The issue

> I think when forced including blocks, the proposer who adds a forced inclusions can assign anyone to be the params.proposer and making them pay the liveness bond. This is because the check that enforces the value of params.proposer is in the  preconf router, but the forced inclusions go directly through the wrapper.

## The solution

This PR fixes the issue by making sure the proposer in both regular and forced included batches is the same. It relies on the upstream validation of the `PreconfRouter` for who the proposer should be.

TODO's:

- [ ] If we rely on the validation of the router, we should not allow this contract to function alone(change the `onlyFromOptional` modifier to `onlyFrom`)
- [ ] Add tests