### PR TITLE
chore(repo): only run claude auto review once

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,9 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    # Only run the first time the PR is opened or when it is marked as ready for review
+    # This is to avoid claude from automatically reviewing the PR every time there's a new commit
+    types: [opened, ready_for_review]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/repo--claude.yml
+++ b/.github/workflows/repo--claude.yml
@@ -29,6 +29,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+  
+      - name: Verify Node.js installation
+        run: |
+          echo "Node.js location:"
+          which node || echo "Node not found in PATH"
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
Follow up of #19815 

- only run auto review once when PR is opened to avoid burning too many tokens
- Install Node on the manual claude auction(when `@cluade` is tagged)