### PR TITLE
ci(repo): upgrade to Node.js 24

### DIFF
--- a/.github/actions/install-pnpm-dependencies/action.yml
+++ b/.github/actions/install-pnpm-dependencies/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
         cache: pnpm
 
     - name: Install dependencies

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Verify Node.js installation
         run: |

--- a/.github/workflows/repo--claude.yml
+++ b/.github/workflows/repo--claude.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
   
       - name: Verify Node.js installation
         run: |


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 20.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)