### PR TITLE
chore(protocol): remove return-values from propose4()

### DIFF
--- a/packages/protocol/contracts/layer1/based2/AbstractInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/AbstractInbox.sol
@@ -51,12 +51,7 @@ abstract contract AbstractInbox is EssentialContract, IInbox, IPropose, IProve {
     }
 
     /// @inheritdoc IPropose
-    function propose4(bytes calldata _inputs)
-        external
-        override(IInbox, IPropose)
-        nonReentrant
-        returns (Summary memory)
-    {
+    function propose4(bytes calldata _inputs) external override(IInbox, IPropose) nonReentrant {
         LibBinding.Bindings memory bindings = _getBindings();
 
         (
@@ -87,8 +82,6 @@ abstract contract AbstractInbox is EssentialContract, IInbox, IPropose, IProve {
             bindings.encodeBatchContexts(contexts),
             bindings.encodeSummary(summary)
         );
-
-        return summary;
     }
 
     /// @inheritdoc IProve

--- a/packages/protocol/contracts/layer1/based2/IInbox.sol
+++ b/packages/protocol/contracts/layer1/based2/IInbox.sol
@@ -422,8 +422,7 @@ interface IInbox {
     /// memory, IInbox.Batch[] memory, IInbox.ProposeBatchEvidence memory, IInbox.TransitionMeta[]
     /// memory)
     /// @custom:encode max-size:7 for decoded IInbox.Batch[]
-    /// @return The updated summary
-    function propose4(bytes calldata _inputs) external returns (Summary memory);
+    function propose4(bytes calldata _inputs) external;
 
     /// @notice Proves batch transitions using cryptographic proofs
     /// @dev Validates and processes cryptographic proofs for batch state transitions

--- a/packages/protocol/contracts/layer1/based2/IPropose.sol
+++ b/packages/protocol/contracts/layer1/based2/IPropose.sol
@@ -14,6 +14,5 @@ interface IPropose {
     /// IInbox.TransitionMeta[] memory)
     /// @dev The length of IInbox.Batch[] must be smaller than 8.
     /// @custom:encode max-size:7 for decoded IInbox.Batch[]
-    /// @return The updated summary
-    function propose4(bytes calldata _inputs) external returns (IInbox.Summary memory);
+    function propose4(bytes calldata _inputs) external;
 }


### PR DESCRIPTION
## Summary
  - Removed Summary return value from propose4() function in TaikoInbox
  - Affects AbstractInbox.sol, IInbox.sol, and IPropose.sol

## Rationale
  The propose4() function was returning a Summary struct that duplicates data already emitted in the Proposed event. Since:
  - No external contracts or off-chain code currently use this return value
  - Events are the standard pattern for protocol state changes
  - Discourage another contracts from calling propose4() and promote EOA to call it.
