### PR TITLE
chore(protocol): change pr permission and remove github_token

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [arc-runner-set]
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -46,7 +46,6 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"


### PR DESCRIPTION
The automatic review workflow is still sometimes [failing](https://github.com/taikoxyz/taiko-mono/actions/runs/16612342962/job/46997772354?pr=19841)

This PR tries to address that by:
- giving it write access to PR(this only allows it to comment, not to write according to what I read in the docs)
- removes the GH token from the workflow, which might be giving conflicting permissions actually. See more details in the Anthropic [docs](https://github.com/anthropics/claude-code-action?tab=readme-ov-file#inputs). It should only be used with custom gh apps, which our installation is not