### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/protocol/audit/code4rena-2024-03-taiko-final-report.md
+++ b/packages/protocol/audit/code4rena-2024-03-taiko-final-report.md
@@ -1157,7 +1157,7 @@ Add new functionality in the vault that allows users to send a new message to th
 > We are OK with med, no issue. Please proceed accordinlgy - as we dont have:
 >
 > 1. the perfect solution to the problem
-> 2. the intention to fix it ATM - since we wont be using any native tokens anytime soon.
+> 2. the intention to fix it ATM - since we won't be using any native tokens anytime soon.
 >
 > But please proceed the way which is suitable for the wardens better, we appreciate their efforts. (So not questioning the severity)
 

--- a/packages/protocol/contracts/layer1/based2/codec/CodecPrompt.md
+++ b/packages/protocol/contracts/layer1/based2/codec/CodecPrompt.md
@@ -282,4 +282,4 @@ function decode(bytes memory data) public pure returns (ProverAuth memory result
 - [ ] No memory corruption or overwrites
 - [ ] Handles maximum values for all numeric types
 - [ ] Proper validation of all array lengths before encoding
-- [ ] For every encode or decode function annotated with `/// @custom:encode optimize-gas`, make sure there is a corresponding gas measurement/comparision test at the end of its test file. The test should evaluate gas savings appropriately based on whether the function is for encoding or decoding.
+- [ ] For every encode or decode function annotated with `/// @custom:encode optimize-gas`, make sure there is a corresponding gas measurement/comparison test at the end of its test file. The test should evaluate gas savings appropriately based on whether the function is for encoding or decoding.


### PR DESCRIPTION


This PR fixes minor typos found in the documentation:

- **`code4rena-2024-03-taiko-final-report.md`**: Fixed "wont" → "won't" (line 1160)
- **`CodecPrompt.md`**: Fixed "comparision" → "comparison" (line 285)

