### PR TITLE
feat(protocol): support multiple blobs for new shasta design

### DIFF
--- a/packages/protocol/contracts/layer1/based3/IShastaInbox.sol
+++ b/packages/protocol/contracts/layer1/based3/IShastaInbox.sol
@@ -19,7 +19,7 @@ interface IShastaInbox {
         // Slot 2
         bytes32 referenceL1BlockHash;
         // Slot 3
-        bytes32 blobDataHash;
+        bytes32[] blobDataHashes;
     }
 
     struct Claim {
@@ -64,8 +64,8 @@ interface IShastaInbox {
     // -------------------------------------------------------------------------
 
     /// @notice Proposes a new proposal of L2 blocks
-    /// @param _blobIndex Index of the blob in the current transaction
-    function propose(uint48 _blobIndex) external;
+    /// @param _blobIndices Array of blob indices in the current transaction
+    function propose(uint256[] calldata _blobIndices) external;
 
     /// @notice Submits a proof for a proposal's state transition
     /// @param _proposalId ID of the proposal being proven


### PR DESCRIPTION
This is a small PR to support multiple blobs when proposing in the new shasta design.

@dantaik I saw you mentioned in your `Design.md` dock that if no blobs are provided or `blockhash(blobIndex)` is invalid the node will replace this with an empty block? Does this mean this will be enforced in the derivation pipeline and we can get rid of the validations I added?
Even if that's the case not sure if it's worth given how cheap those two ifs will be.