### PR TITLE
feat(protocol): implement BondManager with finalization checks

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/iface/IBondManagerL1.sol
+++ b/packages/protocol/contracts/layer1/shasta/iface/IBondManagerL1.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { IBondManager } from "contracts/shared/shasta/iface/IBondManager.sol";
+
+/// @title IBondManagerL1
+/// @notice Interface for L1-specific bond management functionality
+/// @custom:security-contact security@taiko.xyz
+interface IBondManagerL1 is IBondManager {
+    /// @notice Notifies the bond manager that a proposal was created by a proposer and checks that
+    /// the proposer has enough balance.
+    /// @dev Called only by the authorized inbox contract on L1.
+    /// @param proposer The proposer address.
+    /// @param proposalId The proposal id.
+    function notifyProposed(address proposer, uint48 proposalId) external;
+}

--- a/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
@@ -117,4 +117,8 @@ interface IInbox {
     /// @param _data The data containing the proposals and claims to be proven.
     /// @param _proof Validity proof for the claims.
     function prove(bytes calldata _data, bytes calldata _proof) external;
+
+    /// @notice Gets the hash of the core state.
+    /// @return coreStateHash_ The hash of the current core state.
+    function getCoreStateHash() external view returns (bytes32 coreStateHash_);
 }

--- a/packages/protocol/contracts/layer1/shasta/impl/BondManagerL1.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/BondManagerL1.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BondManager } from "contracts/shared/shasta/impl/BondManager.sol";
+import { IBondManager } from "contracts/shared/shasta/iface/IBondManager.sol";
+import { IBondManagerL1 } from "../iface/IBondManagerL1.sol";
+import { IInbox } from "../iface/IInbox.sol";
+
+/// @title BondManagerL1
+/// @notice L1 implementation of BondManager with finalization guards
+/// @custom:security-contact security@taiko.xyz
+contract BondManagerL1 is BondManager, IBondManagerL1 {
+    // -------------------------------------------------------------------
+    // State Variables
+    // -------------------------------------------------------------------
+
+    /// @notice Minimum bond required on L1 to propose. uint96-bounded.
+    uint96 public immutable minBond;
+
+    // -------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------
+
+    /// @notice Initializes the L1 BondManager
+    /// @param _authorized The address of the authorized contract (Inbox)
+    /// @param _bondToken The ERC20 bond token address
+    /// @param _minBond The minimum bond required for proposers
+    constructor(
+        address _authorized,
+        address _bondToken,
+        uint96 _minBond
+    )
+        BondManager(_authorized, _bondToken)
+    {
+        minBond = _minBond;
+    }
+
+    // -------------------------------------------------------------------
+    // External Functions
+    // -------------------------------------------------------------------
+
+    /// @inheritdoc IBondManagerL1
+    function notifyProposed(address proposer, uint48 proposalId) external onlyAuthorized {
+        Bond storage bond_ = bond[proposer];
+        if (bond_.balance < minBond) revert InsufficientBond();
+        bond_.maxProposedId = proposalId;
+    }
+
+    /// @notice Withdraw bond to a recipient with finalization guard
+    /// @dev On L1, we only allow withdrawals that do not have unfinalized proposals or that are
+    /// down to the minimum bond.
+    function withdraw(
+        address to,
+        uint96 amount,
+        IInbox.CoreState calldata coreState
+    )
+        external
+        override(BondManager, IBondManager)
+    {
+        // Verify core state hash
+        bytes32 expected = IInbox(authorized).getCoreStateHash();
+        if (keccak256(abi.encode(coreState)) != expected) revert InvalidState();
+
+        // Check for unfinalized proposals
+        Bond storage bond_ = bond[msg.sender];
+        bool hasUnfinalized = bond_.maxProposedId > coreState.lastFinalizedProposalId;
+        if (hasUnfinalized) {
+            // Allow withdrawal only down to minBond
+            require(bond_.balance - amount >= minBond, UnfinalizedProposals());
+        }
+
+        // Use common withdrawal logic
+        _withdraw(msg.sender, to, amount);
+    }
+}

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -146,7 +146,6 @@ contract Inbox is EssentialContract, IInbox {
     /// @inheritdoc IInbox
     function propose(bytes calldata, /*_lookahead*/ bytes calldata _data) external nonReentrant {
         proposerChecker.checkProposer(msg.sender);
-        require(bondManager.getBondBalance(msg.sender) >= minBondBalance, InsufficientBond());
 
         (
             CoreState memory coreState,
@@ -177,7 +176,7 @@ contract Inbox is EssentialContract, IInbox {
         LibBlobs.BlobFrame memory frame = LibBlobs.validateBlobLocator(blobLocator);
         (coreState, proposal) = _propose(coreState, frame, false);
         // Notify bond manager about this proposal for L1 withdraw guard. We only need to notify about the latest proposal.
-        bondManager.notifyProposed(msg.sender, proposal.id);
+        bondManager.notifyProposed(msg.sender, proposal.id, minBondBalance);
         // Finalize proved proposals
         coreState = _finalize(coreState, claimRecords);
         emit Proposed(proposal, coreState);

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -47,7 +47,6 @@ contract Inbox is EssentialContract, IInbox {
     uint48 public immutable livenessBondGwei;
     uint48 public immutable provingWindow;
     uint48 public immutable extendedProvingWindow;
-    uint256 public immutable minBondBalance;
     uint256 public immutable maxFinalizationCount;
     uint256 public immutable ringBufferSize;
 
@@ -86,7 +85,6 @@ contract Inbox is EssentialContract, IInbox {
     /// @param _livenessBondGwei The bond required for prover liveness
     /// @param _provingWindow The initial proving window duration
     /// @param _extendedProvingWindow The extended proving window duration
-    /// @param _minBondBalance The minimum bond balance required for proposers
     /// @param _maxFinalizationCount The maximum number of finalizations allowed
     /// @param _ringBufferSize The size of the ring buffer (must be > 0)
     /// @param _bondManager The address of the bond manager contract
@@ -99,7 +97,6 @@ contract Inbox is EssentialContract, IInbox {
         uint48 _livenessBondGwei,
         uint48 _provingWindow,
         uint48 _extendedProvingWindow,
-        uint256 _minBondBalance,
         uint256 _maxFinalizationCount,
         uint256 _ringBufferSize,
         address _bondManager,
@@ -114,7 +111,6 @@ contract Inbox is EssentialContract, IInbox {
         livenessBondGwei = _livenessBondGwei;
         provingWindow = _provingWindow;
         extendedProvingWindow = _extendedProvingWindow;
-        minBondBalance = _minBondBalance;
         maxFinalizationCount = _maxFinalizationCount;
         ringBufferSize = _ringBufferSize;
         bondManager = IBondManager(_bondManager);
@@ -175,8 +171,9 @@ contract Inbox is EssentialContract, IInbox {
         // Create regular proposal
         LibBlobs.BlobFrame memory frame = LibBlobs.validateBlobLocator(blobLocator);
         (coreState, proposal) = _propose(coreState, frame, false);
-        // Notify bond manager about this proposal for L1 withdraw guard. We only need to notify about the latest proposal.
-        bondManager.notifyProposed(msg.sender, proposal.id, minBondBalance);
+        // Notify bond manager about this proposal for L1 withdraw guard. We only need to notify
+        // about the latest proposal.
+        bondManager.notifyProposed(msg.sender, proposal.id);
         // Finalize proved proposals
         coreState = _finalize(coreState, claimRecords);
         emit Proposed(proposal, coreState);

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import { EssentialContract } from "contracts/shared/common/EssentialContract.sol";
-import { IBondManager } from "contracts/shared/shasta/iface/IBondManager.sol";
+import { IBondManagerL1 } from "../iface/IBondManagerL1.sol";
 import { ISyncedBlockManager } from "contracts/shared/shasta/iface/ISyncedBlockManager.sol";
 import { IForcedInclusionStore } from "../iface/IForcedInclusionStore.sol";
 import { IInbox } from "../iface/IInbox.sol";
@@ -51,7 +51,7 @@ contract Inbox is EssentialContract, IInbox {
     uint256 public immutable ringBufferSize;
 
     /// @notice The bond manager contract
-    IBondManager public immutable bondManager;
+    IBondManagerL1 public immutable bondManager;
 
     /// @notice The synced block manager contract
     ISyncedBlockManager public immutable syncedBlockManager;
@@ -113,7 +113,7 @@ contract Inbox is EssentialContract, IInbox {
         extendedProvingWindow = _extendedProvingWindow;
         maxFinalizationCount = _maxFinalizationCount;
         ringBufferSize = _ringBufferSize;
-        bondManager = IBondManager(_bondManager);
+        bondManager = IBondManagerL1(_bondManager);
         syncedBlockManager = ISyncedBlockManager(_syncedBlockManager);
         proofVerifier = IProofVerifier(_proofVerifier);
         proposerChecker = IProposerChecker(_proposerChecker);

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -170,12 +170,16 @@ contract Inbox is EssentialContract, IInbox {
                 forcedInclusionStore.consumeOldestForcedInclusion(msg.sender);
 
             (coreState, proposal) = _propose(coreState, forcedInclusion.frame, true);
+            // Notify bond manager about this proposal for L1 withdraw guard
+            bondManager.notifyProposed(msg.sender, proposal.id);
             emit Proposed(proposal, coreState);
         }
 
         // Create regular proposal
         LibBlobs.BlobFrame memory frame = LibBlobs.validateBlobLocator(blobLocator);
         (coreState, proposal) = _propose(coreState, frame, false);
+        // Notify bond manager about this proposal for L1 withdraw guard
+        bondManager.notifyProposed(msg.sender, proposal.id);
         // Finalize proved proposals
         coreState = _finalize(coreState, claimRecords);
         emit Proposed(proposal, coreState);

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -41,7 +41,7 @@ contract Inbox is EssentialContract, IInbox {
     // State Variables
     // ---------------------------------------------------------------
 
-    uint256 public constant REWARD_FRACTION = 2;
+    uint96 public constant REWARD_FRACTION = 2;
 
     uint48 public immutable provabilityBondGwei;
     uint48 public immutable livenessBondGwei;
@@ -669,8 +669,8 @@ contract Inbox is EssentialContract, IInbox {
         bondOperation.proposalId = _proposalId;
 
         Claim memory claim = _claimRecord.claim;
-        uint256 livenessBondWei = uint256(_claimRecord.livenessBondGwei) * 1 gwei;
-        uint256 provabilityBondWei = uint256(_claimRecord.provabilityBondGwei) * 1 gwei;
+        uint96 livenessBondWei = _claimRecord.livenessBondGwei * 1 gwei;
+        uint96 provabilityBondWei = _claimRecord.provabilityBondGwei * 1 gwei;
 
         if (_claimRecord.bondDecision == BondDecision.NoOp) {
             // No bond operations needed

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -170,15 +170,13 @@ contract Inbox is EssentialContract, IInbox {
                 forcedInclusionStore.consumeOldestForcedInclusion(msg.sender);
 
             (coreState, proposal) = _propose(coreState, forcedInclusion.frame, true);
-            // Notify bond manager about this proposal for L1 withdraw guard
-            bondManager.notifyProposed(msg.sender, proposal.id);
             emit Proposed(proposal, coreState);
         }
 
         // Create regular proposal
         LibBlobs.BlobFrame memory frame = LibBlobs.validateBlobLocator(blobLocator);
         (coreState, proposal) = _propose(coreState, frame, false);
-        // Notify bond manager about this proposal for L1 withdraw guard
+        // Notify bond manager about this proposal for L1 withdraw guard. We only need to notify about the latest proposal.
         bondManager.notifyProposed(msg.sender, proposal.id);
         // Finalize proved proposals
         coreState = _finalize(coreState, claimRecords);

--- a/packages/protocol/contracts/layer2/shasta/impl/BondManagerL2.sol
+++ b/packages/protocol/contracts/layer2/shasta/impl/BondManagerL2.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BondManager } from "contracts/shared/shasta/impl/BondManager.sol";
+import { IInbox } from "contracts/layer1/shasta/iface/IInbox.sol";
+
+/// @title BondManagerL2
+/// @notice L2 implementation of BondManager without finalization guards
+/// @custom:security-contact security@taiko.xyz
+contract BondManagerL2 is BondManager {
+    // -------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------
+
+    /// @notice Initializes the L2 BondManager
+    /// @param _authorized The address of the authorized contract
+    /// @param _bondToken The ERC20 bond token address
+    constructor(address _authorized, address _bondToken) BondManager(_authorized, _bondToken) { }
+
+    // -------------------------------------------------------------------
+    // External Functions
+    // -------------------------------------------------------------------
+
+    /// @notice Withdraw bond to a recipient without restrictions
+    /// @dev On L2, withdrawals are unrestricted - no finalization guard needed
+    function withdraw(
+        address to,
+        uint96 amount,
+        IInbox.CoreState calldata /* coreState */
+    )
+        external
+        override
+    {
+        _withdraw(msg.sender, to, amount);
+    }
+}

--- a/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
+++ b/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
@@ -58,13 +58,6 @@ interface IBondManager {
     /// @return The bond balance of the address
     function getBondBalance(address _address) external view returns (uint96);
 
-    /// @notice Notifies the bond manager that a proposal was created by a proposer and checks that
-    /// the proposer has enough balance.
-    /// @dev Called only by the authorized inbox contract.
-    /// @param proposer The proposer address.
-    /// @param proposalId The proposal id.
-    function notifyProposed(address proposer, uint48 proposalId) external;
-
     /// @notice Deposit ERC20 bond tokens into the manager.
     /// @param amount The amount to deposit.
     function deposit(uint96 amount) external;

--- a/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
+++ b/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
@@ -28,6 +28,16 @@ interface IBondManager {
     /// @param amount The amount credited
     event BondCredited(address indexed account, uint256 amount);
 
+    /// @notice Emitted when a bond is deposited into the manager
+    /// @param account The account that deposited the bond
+    /// @param amount The amount deposited
+    event BondDeposited(address indexed account, uint256 amount);
+
+    /// @notice Emitted when a bond is withdrawn from the manager
+    /// @param account The account that withdrew the bond
+    /// @param amount The amount withdrawn
+    event BondWithdrawn(address indexed account, uint256 amount);
+
     // -------------------------------------------------------------------
     // External Functions
     // -------------------------------------------------------------------
@@ -48,16 +58,16 @@ interface IBondManager {
     /// @return The bond balance of the address
     function getBondBalance(address _address) external view returns (uint256);
 
-    // -------------------------------------------------------------------------
-    // New Functions (Shasta withdraw flow)
-    // -------------------------------------------------------------------------
-
-    /// @notice Notifies the bond manager that a proposal was created by a proposer and checks that the proposer has enough balance.
+    /// @notice Notifies the bond manager that a proposal was created by a proposer and checks that
+    /// the proposer has enough balance.
     /// @dev Called only by the authorized inbox contract.
     /// @param proposer The proposer address.
     /// @param proposalId The proposal id.
-    /// @param minBondBalance The minimum bond balance required for the proposer.
-    function notifyProposed(address proposer, uint48 proposalId, uint256 minBondBalance) external;
+    function notifyProposed(address proposer, uint48 proposalId) external;
+
+    /// @notice Deposit ERC20 bond tokens into the manager.
+    /// @param amount The amount to deposit.
+    function deposit(uint256 amount) external;
 
     /// @notice Withdraw bond to a recipient.
     /// @dev On L1, this enforces that the caller has no unfinalized proposals by verifying

--- a/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
+++ b/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
@@ -7,6 +7,13 @@ import { IInbox } from "contracts/layer1/shasta/iface/IInbox.sol";
 /// @notice Interface for managing bonds in the Based3 protocol
 /// @custom:security-contact security@taiko.xyz
 interface IBondManager {
+    /// @notice Represents a bond for a given address.
+    /// @dev On L2, the `maxProposedId` is not used.
+    struct Bond {
+        uint48 maxProposedId;
+        uint96 balance;
+    }
+
     // -------------------------------------------------------------------
     // Events
     // -------------------------------------------------------------------
@@ -45,11 +52,12 @@ interface IBondManager {
     // New Functions (Shasta withdraw flow)
     // -------------------------------------------------------------------------
 
-    /// @notice Notifies the bond manager that a proposal was created by a proposer.
+    /// @notice Notifies the bond manager that a proposal was created by a proposer and checks that the proposer has enough balance.
     /// @dev Called only by the authorized inbox contract.
     /// @param proposer The proposer address.
     /// @param proposalId The proposal id.
-    function notifyProposed(address proposer, uint48 proposalId) external;
+    /// @param minBondBalance The minimum bond balance required for the proposer.
+    function notifyProposed(address proposer, uint48 proposalId, uint256 minBondBalance) external;
 
     /// @notice Withdraw bond to a recipient.
     /// @dev On L1, this enforces that the caller has no unfinalized proposals by verifying

--- a/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
+++ b/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import { IInbox } from "contracts/layer1/shasta/iface/IInbox.sol";
+
 /// @title IBondManager
 /// @notice Interface for managing bonds in the Based3 protocol
 /// @custom:security-contact security@taiko.xyz
@@ -38,4 +40,23 @@ interface IBondManager {
     /// @param _address The address to get the bond balance for
     /// @return The bond balance of the address
     function getBondBalance(address _address) external view returns (uint256);
+
+    // -------------------------------------------------------------------------
+    // New Functions (Shasta withdraw flow)
+    // -------------------------------------------------------------------------
+
+    /// @notice Notifies the bond manager that a proposal was created by a proposer.
+    /// @dev Called only by the authorized inbox contract.
+    /// @param proposer The proposer address.
+    /// @param proposalId The proposal id.
+    function notifyProposed(address proposer, uint48 proposalId) external;
+
+    /// @notice Withdraw bond to a recipient.
+    /// @dev On L1, this enforces that the caller has no unfinalized proposals by verifying
+    ///      the provided core state against the inbox's current core state hash. On L2, the
+    ///      guard is skipped and only balance checks apply in the implementation.
+    /// @param to The recipient of withdrawn funds.
+    /// @param amount The amount to withdraw.
+    /// @param coreState The core state to validate (ignored on L2 implementations).
+    function withdraw(address to, uint256 amount, IInbox.CoreState calldata coreState) external;
 }

--- a/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
+++ b/packages/protocol/contracts/shared/shasta/iface/IBondManager.sol
@@ -21,22 +21,22 @@ interface IBondManager {
     /// @notice Emitted when a bond is debited from an address
     /// @param account The account from which the bond was debited
     /// @param amount The amount debited
-    event BondDebited(address indexed account, uint256 amount);
+    event BondDebited(address indexed account, uint96 amount);
 
     /// @notice Emitted when a bond is credited to an address
     /// @param account The account to which the bond was credited
     /// @param amount The amount credited
-    event BondCredited(address indexed account, uint256 amount);
+    event BondCredited(address indexed account, uint96 amount);
 
     /// @notice Emitted when a bond is deposited into the manager
     /// @param account The account that deposited the bond
     /// @param amount The amount deposited
-    event BondDeposited(address indexed account, uint256 amount);
+    event BondDeposited(address indexed account, uint96 amount);
 
     /// @notice Emitted when a bond is withdrawn from the manager
     /// @param account The account that withdrew the bond
     /// @param amount The amount withdrawn
-    event BondWithdrawn(address indexed account, uint256 amount);
+    event BondWithdrawn(address indexed account, uint96 amount);
 
     // -------------------------------------------------------------------
     // External Functions
@@ -46,17 +46,17 @@ interface IBondManager {
     /// @param _address The address to debit the bond from
     /// @param _bond The amount of bond to debit
     /// @return amountDebited_ The actual amount debited
-    function debitBond(address _address, uint256 _bond) external returns (uint256 amountDebited_);
+    function debitBond(address _address, uint96 _bond) external returns (uint96 amountDebited_);
 
     /// @notice Credits a bond to an address
     /// @param _address The address to credit the bond to
     /// @param _bond The amount of bond to credit
-    function creditBond(address _address, uint256 _bond) external;
+    function creditBond(address _address, uint96 _bond) external;
 
     /// @notice Gets the bond balance of an address
     /// @param _address The address to get the bond balance for
     /// @return The bond balance of the address
-    function getBondBalance(address _address) external view returns (uint256);
+    function getBondBalance(address _address) external view returns (uint96);
 
     /// @notice Notifies the bond manager that a proposal was created by a proposer and checks that
     /// the proposer has enough balance.
@@ -67,7 +67,7 @@ interface IBondManager {
 
     /// @notice Deposit ERC20 bond tokens into the manager.
     /// @param amount The amount to deposit.
-    function deposit(uint256 amount) external;
+    function deposit(uint96 amount) external;
 
     /// @notice Withdraw bond to a recipient.
     /// @dev On L1, this enforces that the caller has no unfinalized proposals by verifying
@@ -76,5 +76,5 @@ interface IBondManager {
     /// @param to The recipient of withdrawn funds.
     /// @param amount The amount to withdraw.
     /// @param coreState The core state to validate (ignored on L2 implementations).
-    function withdraw(address to, uint256 amount, IInbox.CoreState calldata coreState) external;
+    function withdraw(address to, uint96 amount, IInbox.CoreState calldata coreState) external;
 }

--- a/packages/protocol/contracts/shared/shasta/impl/BondManager.sol
+++ b/packages/protocol/contracts/shared/shasta/impl/BondManager.sol
@@ -120,12 +120,14 @@ abstract contract BondManager is IBondManager {
         }
 
         _withdraw(msg.sender, to, amount);
+        emit BondWithdrawn(msg.sender, amount);
     }
 
     /// @inheritdoc IBondManager
     function deposit(uint256 amount) external {
-        bondToken.safeTransferFrom(msg.sender, address(this), amount);
         _creditBond(msg.sender, amount);
+
+        bondToken.safeTransferFrom(msg.sender, address(this), amount);
         
         emit BondCredited(msg.sender, amount);
     }
@@ -170,14 +172,10 @@ abstract contract BondManager is IBondManager {
     /// @param to The recipient address
     /// @param amount The amount to withdraw
     function _withdraw(address from, address to, uint256 amount) internal virtual {
-        Bond storage bond_ = bond[from];
-        require(bond_.balance >= amount, InsufficientBond());
-        bond_.balance = uint96(uint256(bond_.balance) - amount);
+        _debitBond(from, amount);
 
         // Transfer ERC20 bond tokens out to recipient
         bondToken.safeTransfer(to, amount);
-
-        emit BondWithdrawn(from, amount);
     }
 
     /// @dev Internal implementation for getting the bond balance

--- a/packages/protocol/contracts/shared/shasta/impl/BondManager.sol
+++ b/packages/protocol/contracts/shared/shasta/impl/BondManager.sol
@@ -7,9 +7,9 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title BondManager
-/// @notice Abstract contract for managing bonds in the Based3 protocol
+/// @notice Contract for managing bonds in the Based3 protocol
 /// @custom:security-contact security@taiko.xyz
-abstract contract BondManager is IBondManager {
+contract BondManager is IBondManager {
     using SafeERC20 for IERC20;
     // -------------------------------------------------------------------
     // State Variables
@@ -132,10 +132,8 @@ abstract contract BondManager is IBondManager {
         emit BondCredited(msg.sender, amount);
     }
 
-    // No setter for minBond since it's immutable
-
     // -------------------------------------------------------------------------
-    // Internal Functions - Abstract
+    // Internal Functions
     // -------------------------------------------------------------------
 
     /// @dev Internal implementation for debiting a bond
@@ -166,7 +164,7 @@ abstract contract BondManager is IBondManager {
     /// @param from The address whose balance will be reduced
     /// @param to The recipient address
     /// @param amount The amount to withdraw
-    function _withdraw(address from, address to, uint96 amount) internal virtual {
+    function _withdraw(address from, address to, uint96 amount) internal {
         _debitBond(from, amount);
 
         // Transfer ERC20 bond tokens out to recipient
@@ -176,7 +174,7 @@ abstract contract BondManager is IBondManager {
     /// @dev Internal implementation for getting the bond balance
     /// @param _address The address to get the bond balance for
     /// @return The bond balance of the address
-    function _getBondBalance(address _address) internal view virtual returns (uint96) {
+    function _getBondBalance(address _address) internal view returns (uint96) {
         return bond[_address].balance;
     }
 

--- a/packages/protocol/contracts/shared/shasta/impl/BondManager.sol
+++ b/packages/protocol/contracts/shared/shasta/impl/BondManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import { IBondManager } from "contracts/shared/shasta/iface/IBondManager.sol";
+import { IInbox } from "contracts/layer1/shasta/iface/IInbox.sol";
 
 /// @title BondManager
 /// @notice Abstract contract for managing bonds in the Based3 protocol
@@ -14,7 +15,13 @@ abstract contract BondManager is IBondManager {
     /// @notice The address of the inbox contract that is allowed to call debitBond and creditBond
     address public immutable authorized;
 
-    // -------------------------------------------------------------------
+    /// @notice Whether to enforce L1 finalization guard in withdraw.
+    bool public immutable enforceFinalizationGuard;
+
+    /// @notice Max proposal id per proposer. Used for L1 withdraw guard.
+    mapping(address => uint48) internal maxProposedId;
+
+    // -------------------------------------------------------------------------
     // Modifiers
     // -------------------------------------------------------------------
 
@@ -30,8 +37,10 @@ abstract contract BondManager is IBondManager {
 
     /// @notice Initializes the BondManager with the inbox address
     /// @param _authorized The address of the authorized contract
-    constructor(address _authorized) {
+    /// @param _enforceFinalizationGuard Whether to enforce L1 guard on withdraw
+    constructor(address _authorized, bool _enforceFinalizationGuard) {
         authorized = _authorized;
+        enforceFinalizationGuard = _enforceFinalizationGuard;
     }
 
     // -------------------------------------------------------------------
@@ -64,7 +73,29 @@ abstract contract BondManager is IBondManager {
         return _getBondBalance(_address);
     }
 
-    // -------------------------------------------------------------------
+    /// @inheritdoc IBondManager
+    /// @dev Since the inbox contract is trusted, we can always assume that the proposalId is bigger than the current maxProposedId.
+    function notifyProposed(address proposer, uint48 proposalId) external onlyAuthorized {
+        maxProposedId[proposer] = proposalId;
+    }
+
+    /// @inheritdoc IBondManager
+    function withdraw(address to, uint256 amount, IInbox.CoreState calldata coreState) external {
+        if (enforceFinalizationGuard) {
+            // Validate coreState against Inbox coreStateHash without adding new storage to Inbox
+            bytes32 expected = IInbox(authorized).getCoreStateHash();
+            if (keccak256(abi.encode(coreState)) != expected) revert InvalidState();
+
+            // Guard: caller must have no unfinalized proposals on L1
+            if (maxProposedId[msg.sender] > coreState.lastFinalizedProposalId) {
+                revert UnfinalizedProposals();
+            }
+        }
+
+        _withdraw(msg.sender, to, amount);
+    }
+
+    // -------------------------------------------------------------------------
     // Internal Functions - Abstract
     // -------------------------------------------------------------------
 
@@ -85,6 +116,12 @@ abstract contract BondManager is IBondManager {
     /// @param _bond The amount of bond to credit
     function _creditBond(address _address, uint256 _bond) internal virtual;
 
+    /// @dev Internal implementation for withdrawing funds from a user's bond balance
+    /// @param from The address whose balance will be reduced
+    /// @param to The recipient address
+    /// @param amount The amount to withdraw
+    function _withdraw(address from, address to, uint256 amount) internal virtual;
+
     /// @dev Internal implementation for getting the bond balance
     /// @param _address The address to get the bond balance for
     /// @return The bond balance of the address
@@ -95,4 +132,6 @@ abstract contract BondManager is IBondManager {
     // -------------------------------------------------------------------
 
     error Unauthorized();
+    error UnfinalizedProposals();
+    error InvalidState();
 }

--- a/packages/protocol/contracts/shared/shasta/libs/LibBondOperation.sol
+++ b/packages/protocol/contracts/shared/shasta/libs/LibBondOperation.sol
@@ -12,7 +12,7 @@ library LibBondOperation {
     struct BondOperation {
         uint48 proposalId;
         address receiver;
-        uint256 credit;
+        uint96 credit;
     }
 
     function aggregateBondOperation(


### PR DESCRIPTION
This is the first option of two proposal I'm working on. Besides implementing the necessary deposit, withdraw, debit, credit, etc. it implements the necessary safety check in the withdraw function on L1 to avoid proposers from withdrawing when they have unfinalized proposal.

The other option uses a time window to allow withdrawals #19905

**Pros**
1. Simple to reason about. If there are unfinalized proposals you cannot withdraw an amount that puts your balance below `minBalance`
2. No arbitrary delay. If you don't have unfinalized proposals you can withdraw any amount you want

**Cons** 
While I tried to optimize it(e.g. having a single struct with balance and lastProposalId) this operation still adds one `SLOAD` and one `SSTORE` to the propose flow. The `SSTORE` will always be from non zero -> non zero(cheaper) except the first time a new proposer submits a batch


----
Also instead of having conditional logic on a single `BondManager`, we now have a common abstract `BondManager` and two specific implementations for L1 and L2. This makes the code simpler and easier to reason about