### PR TITLE
chore(taiko-client): lower request sync margin

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main]
+    branches: [main, sync_request]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main, sync_request]
+    branches: [main]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -44,7 +44,7 @@ var (
 	wsUpgrader             = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 )
 
-const requestSyncMargin = uint64(512)
+const requestSyncMargin = uint64(64) // Margin for requesting sync, to avoid requesting very old blocks.
 
 // preconfBlockChainSyncer is an interface for preconfirmation block chain syncer.
 type preconfBlockChainSyncer interface {
@@ -426,7 +426,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Request(
 	}
 
 	if headL1Origin != nil && block.NumberU64() <= headL1Origin.BlockID.Uint64() {
-		log.Warn(
+		log.Debug(
 			"Ignore the message for outdated block",
 			"peer", from,
 			"blockID", block.NumberU64(),
@@ -684,9 +684,6 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 					} else {
 						publishRequest()
 					}
-				} else {
-					// No known tip yet → safest is to skip to avoid spam during startup/backfill.
-					publishRequest()
 				}
 			}
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -674,16 +675,24 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 						s.blockRequestsCache.Add(currentPayload.Payload.ParentHash, struct{}{})
 					}
 				}
-				if s.latestSeenProposal != nil {
-					tip := s.latestSeenProposal.Pacaya().GetLastBlockID()
-					if tip >= requestSyncMargin && parentNum <= tip-requestSyncMargin {
-						log.Debug("Skipping request for very old block",
-							"tip", tip,
-							"margin", requestSyncMargin,
-						)
-					} else {
-						publishRequest()
-					}
+				// Try get the highest block ID from the Pacaya protocol state variables.
+				stateVars, err := s.rpc.GetProtocolStateVariablesPacaya(&bind.CallOpts{Context: ctx})
+				if err != nil {
+					return err
+				}
+
+				batch, err := s.rpc.PacayaClients.TaikoInbox.GetBatch(&bind.CallOpts{Context: ctx}, stateVars.Stats2.NumBatches-1)
+				if err != nil {
+					return err
+				}
+
+				tip := batch.LastBlockId // last block ID proposed on chain
+
+				if tip >= requestSyncMargin && parentNum <= tip-requestSyncMargin {
+					log.Debug("Skipping request for very old block",
+						"tip", tip,
+						"margin", requestSyncMargin,
+					)
 				} else {
 					publishRequest()
 				}

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -675,18 +674,8 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 						s.blockRequestsCache.Add(currentPayload.Payload.ParentHash, struct{}{})
 					}
 				}
-				// Try get the highest block ID from the Pacaya protocol state variables.
-				stateVars, err := s.rpc.GetProtocolStateVariablesPacaya(&bind.CallOpts{Context: ctx})
-				if err != nil {
-					return err
-				}
 
-				batch, err := s.rpc.PacayaClients.TaikoInbox.GetBatch(&bind.CallOpts{Context: ctx}, stateVars.Stats2.NumBatches-1)
-				if err != nil {
-					return err
-				}
-
-				tip := batch.LastBlockId // last block ID proposed on chain
+				tip := progress.HighestOriginBlockID.Uint64()
 
 				if tip >= requestSyncMargin && parentNum <= tip-requestSyncMargin {
 					log.Debug("Skipping request for very old block",

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -684,6 +684,8 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 					} else {
 						publishRequest()
 					}
+				} else {
+					publishRequest()
 				}
 			}
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -44,7 +44,7 @@ var (
 	wsUpgrader             = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 )
 
-const requestSyncMargin = uint64(64) // Margin for requesting sync, to avoid requesting very old blocks.
+const requestSyncMargin = uint64(128) // Margin for requesting sync, to avoid requesting very old blocks.
 
 // preconfBlockChainSyncer is an interface for preconfirmation block chain syncer.
 type preconfBlockChainSyncer interface {


### PR DESCRIPTION
nobody should be requesting such old blocks, and they are often far behind the tip. I screwed up the tip - we should check *the onchain tip*, not the latest seen proposal tip. The network is being spammed with these requests.