### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/bridge-ui--ci.yml
+++ b/.github/workflows/bridge-ui--ci.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       # Check out the repo to access release-please-config.json
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Clean up old releases
         shell: bash

--- a/.github/workflows/docs-site--preview.yml
+++ b/.github/workflows/docs-site--preview.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/docs-site--production.yml
+++ b/.github/workflows/docs-site--production.yml
@@ -17,7 +17,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/eventindexer.yml
+++ b/.github/workflows/eventindexer.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.23.0
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
@@ -49,7 +49,7 @@ jobs:
       - name: Install Git
         run: sudo apt-get update && sudo apt-get install -y git
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: ">=1.23.0"
@@ -77,7 +77,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/fork-diff--preview.yml
+++ b/.github/workflows/fork-diff--preview.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/fork-diff--production.yml
+++ b/.github/workflows/fork-diff--production.yml
@@ -18,7 +18,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/nfts.yml
+++ b/.github/workflows/nfts.yml
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -42,7 +42,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git wget
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
@@ -114,7 +114,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.23.0
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
@@ -49,7 +49,7 @@ jobs:
       - name: Install Git
         run: sudo apt-get update && sudo apt-get install -y git
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: "1.23.0"
@@ -77,7 +77,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/repo--check-links.yml
+++ b/.github/workflows/repo--check-links.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/repo--claude.yml
+++ b/.github/workflows/repo--claude.yml
@@ -26,7 +26,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/repo--typo-check.yml
+++ b/.github/workflows/repo--typo-check.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install wget
         run: sudo apt-get update && sudo apt-get install -y wget

--- a/.github/workflows/repo--vercel-deploy.yml
+++ b/.github/workflows/repo--vercel-deploy.yml
@@ -37,7 +37,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/snaefell-ui--ci.yml
+++ b/.github/workflows/snaefell-ui--ci.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/supplementary-contracts.yml
+++ b/.github/workflows/supplementary-contracts.yml
@@ -26,7 +26,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to GAR
         uses: docker/login-action@v3

--- a/.github/workflows/taiko-client--hive-test.yml
+++ b/.github/workflows/taiko-client--hive-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Git
         run: sudo apt-get update && sudo apt-get install -y git
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/taiko-client--pages.yml
+++ b/.github/workflows/taiko-client--pages.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [ubuntu-latest]
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -57,7 +57,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -71,7 +71,7 @@ jobs:
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: taikoxyz/taiko-mono
           path: ${{ env.PACAYA_FORK_TAIKO_MONO_DIR }}

--- a/.github/workflows/taikoon-ui--ci.yml
+++ b/.github/workflows/taikoon-ui--ci.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/ui-lib--ci.yml
+++ b/.github/workflows/ui-lib--ci.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0