### PR TITLE
feat(protocol):  add getNamedSettings to Inbox

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
@@ -145,10 +145,16 @@ interface IInbox {
     // External View Functions
     // ---------------------------------------------------------------
 
-    /// @notice Retrieves the values of multiple settings to aid in synchronizing off-chain
+    /// @notice Fetches the values of specified settings to assist in aligning off-chain
     /// software configurations.
-    /// @param _names The identifiers of the settings to retrieve.
-    /// @return values_ The corresponding values of the specified settings.
+    /// @dev To minimize frequent queries for new values, these settings should only update at
+    /// specific time unit boundaries, such as daily at midnight GMT:
+    /// ```
+    /// require(itemChangeTimestamp % 86400 == 0);
+    /// return (block.timestamp >= itemChangeTimestamp) ? itemNewValue : itemOldValue;
+    /// ```
+    /// @param _names An array of identifiers for the settings to be fetched.
+    /// @return values_ An array containing the values corresponding to the specified settings.
     function getNamedSettings(bytes32[] memory _names)
         external
         view

--- a/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
@@ -140,4 +140,25 @@ interface IInbox {
     /// @param _data The data containing the proposals and claims to be proven.
     /// @param _proof Validity proof for the claims.
     function prove(bytes calldata _data, bytes calldata _proof) external;
+
+    // ---------------------------------------------------------------
+    // External View Functions
+    // ---------------------------------------------------------------
+
+    /// @notice Retrieves the values of multiple settings to aid in synchronizing off-chain
+    /// software configurations.
+    /// @param _names The identifiers of the settings to retrieve.
+    /// @return values_ The corresponding values of the specified settings.
+    function getNamedSettings(bytes32[] memory _names)
+        external
+        view
+        returns (bytes32[] memory values_);
+
+    /// @notice Returns the capacity for unfinalized proposals.
+    /// @return _ The maximum number of unfinalized proposals that can exist.
+    function getCapacity() external view returns (uint256);
+
+    /// @notice Returns the configuration parameters for the Inbox contract.
+    /// @return config_ The configuration parameters.
+    function getConfig() external view returns (Config memory config_);
 }

--- a/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
@@ -154,7 +154,8 @@ interface IInbox {
     /// return (block.timestamp >= itemChangeTimestamp) ? itemNewValue : itemOldValue;
     /// ```
     /// @param _names An array of identifiers for the settings to be fetched.
-    /// @return values_ An array containing the values corresponding to the specified settings.
+    /// @return values_ An array containing the values corresponding to the specified settings. If a
+    /// name is invalid, bytes32(0) will be returned without reverting.
     function getNamedSettings(bytes32[] memory _names)
         external
         view

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -260,8 +260,19 @@ abstract contract Inbox is EssentialContract, IInbox {
         return proposalRingBuffer[bufferSlot].claimHashLookup[_parentClaimHash].claimRecordHash;
     }
 
-    /// @notice Gets the capacity for unfinalized proposals.
-    /// @return _ The maximum number of unfinalized proposals that can exist.
+    /// @inheritdoc IInbox
+    function getNamedSettings(bytes32[] memory _names)
+        external
+        pure
+        returns (bytes32[] memory values_)
+    {
+        values_ = new bytes32[](_names.length);
+        for (uint256 i; i < _names.length; i++) {
+            values_[i] = _getNamedSetting(_names[i]);
+        }
+    }
+
+    /// @inheritdoc IInbox
     function getCapacity() public view returns (uint256) {
         Config memory config = getConfig();
         return _getCapacity(config);
@@ -417,6 +428,11 @@ abstract contract Inbox is EssentialContract, IInbox {
     {
         return (_proposalIds, _claimRecords);
     }
+
+    /// @dev Gets the value of a named setting.
+    /// @param _name The name of the setting.
+    /// @return value_ The value of the setting.
+    function _getNamedSetting(bytes32 _name) internal view virtual returns (bytes32 value_);
 
     // ---------------------------------------------------------------
     // Private Functions

--- a/packages/protocol/contracts/layer1/shasta/impl/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/MainnetInbox.sol
@@ -65,9 +65,15 @@ contract MainnetInbox is Inbox {
         return LibFasterReentryLock.loadReentryLock();
     }
 
+    function _getNamedSetting(bytes32 _name) internal pure override returns (bytes32 value_) {
+        if (_name == bytes32("handover_slots")) {
+            value_ = bytes32(uint256(6));
+        }
+    }
     // ---------------------------------------------------------------
     // Errors
     // ---------------------------------------------------------------
 
     error InvalidCoreState();
+    error InvalidNamedSetting(bytes32 _name);
 }


### PR DESCRIPTION
This function can be used by off-chain software to synchronise configurations (such as handover slots)