### PR TITLE
fix(protocol): fix issue with prove function when aggregating claims

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
@@ -95,10 +95,9 @@ interface IInbox {
     /// @param proposal The proposal that was proposed.
     event Proposed(Proposal proposal, CoreState coreState);
 
-    /// @notice Emitted when a proof is submitted for a proposal.
-    /// @param proposal The proposal that was proven.
+    /// @notice Emitted when a proof is submitted
     /// @param claimRecord The claim record containing the proof details.
-    event Proved(Proposal proposal, ClaimRecord claimRecord);
+    event Proved(ClaimRecord claimRecord);
 
     /// @notice Emitted when bond instructions are issued
     /// @param instructions The bond instructions that need to be performed.

--- a/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/iface/IInbox.sol
@@ -42,6 +42,8 @@ interface IInbox {
 
     /// @notice Represents a claim about the state transition of a proposal.
     struct Claim {
+        /// @notice The proposal's ID.
+        uint48 proposalId;
         /// @notice The proposal's hash.
         bytes32 proposalHash;
         /// @notice The parent claim's hash, this is used to link the claim to its parent claim to

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -163,10 +163,10 @@ abstract contract Inbox is EssentialContract, IInbox {
 
         ClaimRecord[] memory claimRecords = _buildClaimRecords(config, proposals, claims);
 
-        for (uint256 i; i < proposals.length; ++i) {
+        for (uint256 i; i < claimRecords.length; ++i) {
             _setClaimRecordHash(
                 config,
-                proposals[i].id,
+                claimRecords[i].claim.proposalId,
                 claimRecords[i].claim.parentClaimHash,
                 keccak256(abi.encode(claimRecords[i]))
             );

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -274,14 +274,13 @@ abstract contract Inbox is EssentialContract, IInbox {
         internal
         view
     {
-        if (_proposal.id != _claim.proposalId) revert ProposalIdMismatch();
+        require(_proposal.id == _claim.proposalId, ProposalIdMismatch());
 
         bytes32 proposalHash = keccak256(abi.encode(_proposal));
-        if (proposalHash != _claim.proposalHash) revert ProposalHashMismatch();
+        require(proposalHash == _claim.proposalHash, ProposalHashMismatch());
 
-        // Validate the proposal hash matches what's stored on-chain.
         uint256 bufferSlot = _proposal.id % _config.ringBufferSize;
-        if (proposalHash != proposalRingBuffer[bufferSlot].proposalHash) revert ProposalHashMismatch();
+        require(proposalHash == proposalRingBuffer[bufferSlot].proposalHash, ProposalHashMismatch());
     }
 
     /// @dev Sets the hash of the core state.

--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -170,7 +170,7 @@ abstract contract Inbox is EssentialContract, IInbox {
                 claimRecords[i].claim.parentClaimHash,
                 keccak256(abi.encode(claimRecords[i]))
             );
-            emit Proved(proposals[i], claimRecords[i]);
+            emit Proved(claimRecords[i]);
         }
 
         bytes32 claimsHash = keccak256(abi.encode(claims));

--- a/packages/protocol/contracts/layer1/shasta/impl/InboxWithClaimAggregation.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/InboxWithClaimAggregation.sol
@@ -45,7 +45,7 @@ abstract contract InboxWithClaimAggregation is InboxWithSlotReuse {
         if (_proposals.length == 0) return claimRecords_;
 
         // Validate first proposal and create initial claim record
-        _validateProposal(_config, _proposals[0], _claims[0]);
+        _validateClaim(_config, _proposals[0], _claims[0]);
         LibBonds.BondInstruction[] memory currentInstructions =
             _calculateBondInstructions(_config, _proposals[0], _claims[0]);
 
@@ -58,7 +58,7 @@ abstract contract InboxWithClaimAggregation is InboxWithSlotReuse {
 
         // Process remaining proposals
         for (uint256 i = 1; i < _proposals.length; ++i) {
-            _validateProposal(_config, _proposals[i], _claims[i]);
+            _validateClaim(_config, _proposals[i], _claims[i]);
 
             // Check if current proposal can be aggregated with the previous group
             // The next expected proposal ID is: start of current group + current span


### PR DESCRIPTION
## Issue
The prove() function iterates over proposals.length but accesses claimRecords[i], causing an array out-of-bounds error when claim aggregation isenabled. With aggregation, multiple continuous proposals are combined into fewer claim records (e.g., 5 proposals → 2 aggregated records), breaking the 1:1 assumption.

## Solution
- Changed loop to iterate over claimRecords.length instead of proposals.length