### PR TITLE
fix(protocol): use bigger size for blob references to be extra careful

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/libs/LibBlobs.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibBlobs.sol
@@ -20,9 +20,9 @@ library LibBlobs {
     /// in this transaction.
     struct BlobReference {
         /// @notice The starting index of the blob.
-        uint8 blobStartIndex;
+        uint16 blobStartIndex;
         /// @notice The number of blobs.
-        uint8 numBlobs;
+        uint16 numBlobs;
         /// @notice The field-element offset within the blob data.
         uint24 offset;
     }


### PR DESCRIPTION
context: https://github.com/taikoxyz/taiko-mono/pull/19934/files#r2275202279