### PR TITLE
feat(taiko-client): Add duration metrics to PreconfBlockApiServer

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -76,6 +76,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	defer func() {
 		elapsed := float64(time.Since(start).Milliseconds())
 		metrics.DriverPreconfBuildPreconfBlockDuration.Observe(elapsed)
+		log.Debug("BuildPreconfBlock completed", "elapsed", elapsed)
 	}()
 
 	// make a new context, we don't want to cancel the request if the caller times out.

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -70,6 +71,12 @@ type BuildPreconfBlockResponseBody struct {
 func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	start := time.Now()
+	defer func() {
+		elapsed := float64(time.Since(start).Milliseconds())
+		metrics.DriverPreconfBuildPreconfBlockDuration.Observe(elapsed)
+	}()
 
 	// make a new context, we don't want to cancel the request if the caller times out.
 	ctx := context.Background()

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -218,6 +218,13 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 ) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	start := time.Now()
+	defer func() {
+		elapsed := float64(time.Since(start).Milliseconds())
+		metrics.DriverPreconfOnUnsafeL2PayloadDuration.Observe(elapsed)
+	}()
+
 	// Ignore the message if it is from the current P2P node, when `from` is empty,
 	// it means the message is for importing the pending blocks from the cache after
 	// a new L2 EE chain has just finished a beacon-sync.
@@ -310,6 +317,12 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	start := time.Now()
+	defer func() {
+		elapsed := float64(time.Since(start).Milliseconds())
+		metrics.DriverPreconfOnL2UnsafeResponseDuration.Observe(elapsed)
+	}()
+
 	// add responses seen to cache.
 	s.responseSeenCache.Add(msg.ExecutionPayload.BlockHash, time.Now().UTC())
 
@@ -397,6 +410,12 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Request(
 ) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	start := time.Now()
+	defer func() {
+		elapsed := float64(time.Since(start).Milliseconds())
+		metrics.DriverPreconfOnL2UnsafeRequestDuration.Observe(elapsed)
+	}()
 
 	// Ignore the message if it is from the current P2P node.
 	if from != "" && s.p2pNode.Host().ID() == from {
@@ -530,6 +549,12 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2EndOfSequencingRequest(
 ) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	start := time.Now()
+	defer func() {
+		elapsed := float64(time.Since(start).Milliseconds())
+		metrics.DriverPreconfOnEndOfSequencingRequestDuration.Observe(elapsed)
+	}()
 
 	// Ignore the message if it is from the current P2P node.
 	if from != "" && s.p2pNode.Host().ID() == from {

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -223,6 +223,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 	defer func() {
 		elapsed := float64(time.Since(start).Milliseconds())
 		metrics.DriverPreconfOnUnsafeL2PayloadDuration.Observe(elapsed)
+		log.Debug("OnUnsafeL2Payload completed", "elapsed", elapsed)
 	}()
 
 	// Ignore the message if it is from the current P2P node, when `from` is empty,
@@ -321,6 +322,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 	defer func() {
 		elapsed := float64(time.Since(start).Milliseconds())
 		metrics.DriverPreconfOnL2UnsafeResponseDuration.Observe(elapsed)
+		log.Debug("OnUnsafeL2Response completed", "elapsed", elapsed)
 	}()
 
 	// add responses seen to cache.
@@ -415,6 +417,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Request(
 	defer func() {
 		elapsed := float64(time.Since(start).Milliseconds())
 		metrics.DriverPreconfOnL2UnsafeRequestDuration.Observe(elapsed)
+		log.Debug("OnUnsafeL2Request completed", "elapsed", elapsed)
 	}()
 
 	// Ignore the message if it is from the current P2P node.
@@ -554,6 +557,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2EndOfSequencingRequest(
 	defer func() {
 		elapsed := float64(time.Since(start).Milliseconds())
 		metrics.DriverPreconfOnEndOfSequencingRequestDuration.Observe(elapsed)
+		log.Debug("OnUnsafeL2EndOfSequencingRequest completed", "elapsed", elapsed)
 	}()
 
 	// Ignore the message if it is from the current P2P node.
@@ -824,7 +828,7 @@ func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionP
 	if payload.GasLimit == 0 {
 		return errors.New("non-zero gas limit is required")
 	}
-	var u256BaseFee = uint256.Int(payload.BaseFeePerGas)
+	u256BaseFee := uint256.Int(payload.BaseFeePerGas)
 	if u256BaseFee.ToBig().Cmp(common.Big0) == 0 {
 		return errors.New("non-zero base fee per gas is required")
 	}

--- a/packages/taiko-client/internal/metrics/metrics.go
+++ b/packages/taiko-client/internal/metrics/metrics.go
@@ -47,14 +47,29 @@ var (
 	DriverPreconfOnL2UnsafeRequestCounter = factory.NewCounter(prometheus.CounterOpts{
 		Name: "driver_on_l2_unsafe_request",
 	})
+	DriverPreconfOnL2UnsafeRequestDuration = factory.NewHistogram(prometheus.HistogramOpts{
+		Name: "driver_on_l2_unsafe_request_duration",
+	})
 	DriverPreconfOnL2UnsafeResponseCounter = factory.NewCounter(prometheus.CounterOpts{
 		Name: "driver_on_l2_unsafe_response",
+	})
+	DriverPreconfOnL2UnsafeResponseDuration = factory.NewHistogram(prometheus.HistogramOpts{
+		Name: "driver_on_l2_unsafe_response_duration",
+	})
+	DriverPreconfOnUnsafeL2PayloadDuration = factory.NewHistogram(prometheus.HistogramOpts{
+		Name: "driver_on_unsafe_l2_payload_duration",
 	})
 	DriverPreconfOnEndOfSequencingRequestCounter = factory.NewCounter(prometheus.CounterOpts{
 		Name: "driver_on_end_of_sequencing_request",
 	})
+	DriverPreconfOnEndOfSequencingRequestDuration = factory.NewHistogram(prometheus.HistogramOpts{
+		Name: "driver_on_end_of_sequencing_request_duration",
+	})
 	DriverImportedPreconBlocksFromCacheCounter = factory.NewCounter(prometheus.CounterOpts{
 		Name: "driver_imported_preconf_blocks_from_cache",
+	})
+	DriverPreconfBuildPreconfBlockDuration = factory.NewHistogram(prometheus.HistogramOpts{
+		Name: "driver_preconf_build_preconf_block_duration",
 	})
 
 	// Proposer


### PR DESCRIPTION
Rationale: to help understanding whether the `/preconfBlock` endpoint is sometimes blocked by p2p methods, and identify potential bottlenecks.