### PR TITLE
chore(taiko-client): add emoji to quickly identify logs

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -140,7 +140,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	}
 
 	log.Info(
-		"New preconfirmation block building request",
+		"🏗️New preconfirmation block building request",
 		"blockID", reqBody.ExecutableData.Number,
 		"coinbase", reqBody.ExecutableData.FeeRecipient.Hex(),
 		"timestamp", reqBody.ExecutableData.Timestamp,

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -148,7 +148,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	}
 
 	log.Info(
-		"🏗️New preconfirmation block building request",
+		"🏗️ New preconfirmation block building request",
 		"blockID", reqBody.ExecutableData.Number,
 		"coinbase", reqBody.ExecutableData.FeeRecipient.Hex(),
 		"timestamp", reqBody.ExecutableData.Timestamp,


### PR DESCRIPTION
The addtional emoji can help to identify who is the operator of current epoch.