### PR TITLE
feat(protocol): allow ejectors to add operators to whitelist

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
@@ -70,7 +70,7 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist {
     }
 
     /// @inheritdoc IPreconfWhitelist
-    function addOperator(address _proposer, address _sequencer) external onlyOwner {
+    function addOperator(address _proposer, address _sequencer) external onlyOwnerOrEjecter {
         _addOperator(_proposer, _sequencer, operatorChangeDelay);
     }
 


### PR DESCRIPTION
Allow ejecter role to add operators to the pre-confirmation whitelist.
