### PR TITLE
feat(protocol): add back proposeBatchWithExpectedLastBlockId function but optimized

### DIFF
--- a/packages/protocol/contracts/layer1/based/IProposeBatch.sol
+++ b/packages/protocol/contracts/layer1/based/IProposeBatch.sol
@@ -18,5 +18,5 @@ interface IProposeBatch {
         bytes calldata _txList
     )
         external
-        returns (ITaikoInbox.BatchMetadata memory meta_);
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_);
 }

--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -305,7 +305,7 @@ interface ITaikoInbox {
         bytes calldata _txList
     )
         external
-        returns (ITaikoInbox.BatchMetadata memory meta_);
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_);
 
     /// @notice Proves state transitions for multiple batches with a single aggregated proof.
     /// @param _params ABI-encoded parameter containing:

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -72,7 +72,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
         public
         override(ITaikoInbox, IProposeBatch)
         nonReentrant
-        returns (BatchMetadata memory meta_)
+        returns (BatchMetadata memory meta_, uint64 lastBlockId_)
     {
         Stats2 memory stats2 = state.stats2;
         Config memory config = pacayaConfig();
@@ -182,6 +182,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
             info_.lastBlockId = stats2.numBatches == config.forkHeights.pacaya
                 ? stats2.numBatches + uint64(params.blocks.length) - 1
                 : lastBatch.lastBlockId + uint64(params.blocks.length);
+            lastBlockId_ = info_.lastBlockId;
 
             (info_.txsHash, info_.blobHashes) =
                 _calculateTxsHash(keccak256(_txList), params.blobParams);

--- a/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
@@ -82,7 +82,7 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
         external
         onlyFrom(preconfRouter)
         nonReentrant
-        returns (ITaikoInbox.BatchMetadata memory meta_)
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_)
     {
         (bytes memory forcedInclusionBytes, bytes memory regularBatchBytes) =
             abi.decode(_params, (bytes, bytes));
@@ -94,7 +94,7 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
         }
 
         // Propose the normal batch after the potential forced inclusion batch.
-        meta_ = inbox.proposeBatch(regularBatchBytes, _txList);
+        (meta_, lastBlockId_) = inbox.proposeBatch(regularBatchBytes, _txList);
 
         if (forcedInclusionBytes.length > 0) {
             // we validate the forced inclusion params here since we now have access to the proposer

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfRouter.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import "src/shared/common/EssentialContract.sol";
 import "../iface/IPreconfRouter.sol";
 import "../iface/IPreconfWhitelist.sol";
+import "src/layer1/based/ITaikoInbox.sol";
 
 /// @title PreconfRouter
 /// @custom:security-contact security@taiko.xyz
@@ -48,9 +49,26 @@ contract PreconfRouter is EssentialContract, IPreconfRouter {
         bytes calldata _txList
     )
         external
-        returns (ITaikoInbox.BatchMetadata memory meta_)
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_)
     {
         return _proposeBatch(_params, _txList);
+    }
+
+    function proposeBatchWithExpectedLastBlockId(
+        bytes calldata _params,
+        bytes calldata _txList,
+        uint96 _expectedLastBlockId
+    )
+        external
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_)
+    {
+        (meta_, lastBlockId_) = _proposeBatch(_params, _txList);
+
+        // Verify that the last block id is as expected
+        require(
+            lastBlockId_ == _expectedLastBlockId,
+            InvalidLastBlockId(uint96(lastBlockId_), _expectedLastBlockId)
+        );
     }
 
     function _proposeBatch(
@@ -59,10 +77,10 @@ contract PreconfRouter is EssentialContract, IPreconfRouter {
     )
         internal
         onlyFromPreconferOrFallback
-        returns (ITaikoInbox.BatchMetadata memory meta_)
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_)
     {
         // Both TaikoInbox and TaikoWrapper implement the same ABI for proposeBatch.
-        meta_ = IProposeBatch(proposeBatchEntrypoint).proposeBatch(_params, _txList);
+        (meta_, lastBlockId_) = IProposeBatch(proposeBatchEntrypoint).proposeBatch(_params, _txList);
 
         // Verify that the sender had set itself as the proposer
         require(meta_.proposer == msg.sender, ProposerIsNotPreconfer());

--- a/packages/protocol/contracts/layer1/provers/ProverSet.sol
+++ b/packages/protocol/contracts/layer1/provers/ProverSet.sol
@@ -32,7 +32,7 @@ contract ProverSet is ProverSetBase, IProposeBatch {
     )
         external
         onlyProver
-        returns (ITaikoInbox.BatchMetadata memory)
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_)
     {
         return IProposeBatch(entrypoint).proposeBatch(_params, _txList);
     }

--- a/packages/protocol/deployments/test_inbox_measure_gas_used.txt
+++ b/packages/protocol/deployments/test_inbox_measure_gas_used.txt
@@ -1,5 +1,5 @@
 See `test_inbox_measure_gas_used` in InboxTest_ProposeAndProve.t.sol
 
-Gas per proposeBatches: 162778
-Gas per proveBatches: 37160
-Total: 199939
+Gas per proposeBatches: 163065
+Gas per proveBatches: 37250
+Total: 200316

--- a/packages/protocol/snapshots/ProposeAndProve.json
+++ b/packages/protocol/snapshots/ProposeAndProve.json
@@ -1,3 +1,3 @@
 {
-  "proposeBatchWithRouter": "243990"
+  "proposeBatchWithRouter": "244489"
 }

--- a/packages/protocol/test/layer1/based/InboxTestBase.sol
+++ b/packages/protocol/test/layer1/based/InboxTestBase.sol
@@ -124,7 +124,7 @@ abstract contract InboxTestBase is Layer1Test {
         batchIds = new uint64[](numBatchesToPropose);
 
         for (uint256 i; i < numBatchesToPropose; ++i) {
-            ITaikoInbox.BatchMetadata memory meta =
+            (ITaikoInbox.BatchMetadata memory meta,) =
                 inbox.proposeBatch(abi.encode(batchParams), txList);
             _saveMetadata(meta);
             batchIds[i] = meta.batchId;

--- a/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_BondMechanics.t.sol
@@ -128,7 +128,7 @@ contract InboxTest_BondMechanics is InboxTestBase {
         ITaikoInbox.BatchParams memory params;
         params.blocks = new ITaikoInbox.BlockParams[](2);
 
-        ITaikoInbox.BatchMetadata memory meta = inbox.proposeBatch(abi.encode(params), "txList");
+        (ITaikoInbox.BatchMetadata memory meta,) = inbox.proposeBatch(abi.encode(params), "txList");
 
         ITaikoInbox.Batch memory batch = inbox.getBatch(meta.batchId);
 

--- a/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_CalldataForTxList.t.sol
@@ -88,7 +88,7 @@ contract InboxTest_CalldataForTxList is InboxTestBase {
         vm.prank(Alice);
 
         // With empty txList
-        ITaikoInbox.BatchMetadata memory meta = inbox.proposeBatch(abi.encode(params), "");
+        (ITaikoInbox.BatchMetadata memory meta,) = inbox.proposeBatch(abi.encode(params), "");
         _saveMetadata(meta);
 
         vm.prank(Alice);

--- a/packages/protocol/test/layer1/based/helpers/StubInbox.sol
+++ b/packages/protocol/test/layer1/based/helpers/StubInbox.sol
@@ -11,7 +11,7 @@ contract StubInbox is ITaikoInbox {
         bytes calldata _txList
     )
         external
-        returns (ITaikoInbox.BatchMetadata memory meta_)
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_)
     { }
 
     function proveBatches(bytes calldata _params, bytes calldata _proof) external { }

--- a/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
+++ b/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
@@ -18,12 +18,12 @@ contract MockTaikoInbox is EssentialContract {
         bytes calldata _txList
     )
         external
-        returns (ITaikoInbox.BatchInfo memory info_, ITaikoInbox.BatchMetadata memory meta_)
+        returns (ITaikoInbox.BatchMetadata memory meta_, uint64 lastBlockId_)
     {
         // Decode the batch params
         ITaikoInbox.BatchParams memory params = abi.decode(_params, (ITaikoInbox.BatchParams));
 
-        info_ = ITaikoInbox.BatchInfo({
+        ITaikoInbox.BatchInfo memory info_ = ITaikoInbox.BatchInfo({
             txsHash: keccak256(_txList),
             blobHashes: new bytes32[](0),
             blobByteOffset: 0,
@@ -31,7 +31,7 @@ contract MockTaikoInbox is EssentialContract {
             extraData: bytes32(0),
             coinbase: params.coinbase == address(0) ? params.proposer : params.coinbase,
             gasLimit: 0, // Mock value
-            lastBlockId: 0,
+            lastBlockId: 100, // Mock value for lastBlockId
             lastBlockTimestamp: 0,
             proposedIn: uint64(block.number),
             blobCreatedIn: 0,
@@ -55,5 +55,6 @@ contract MockTaikoInbox is EssentialContract {
         });
 
         metaHash = keccak256(abi.encode(meta_));
+        lastBlockId_ = info_.lastBlockId;
     }
 }

--- a/packages/protocol/test/layer1/preconf/router/PreconfRouter.t.sol
+++ b/packages/protocol/test/layer1/preconf/router/PreconfRouter.t.sol
@@ -137,7 +137,7 @@ contract PreconfRouterTest is PreconfRouterTestBase {
 
         vm.startSnapshotGas("ProposeAndProve", "proposeBatchWithRouter");
         vm.prank(Carol);
-        ITaikoInbox.BatchMetadata memory meta = router.proposeBatch(wrappedParams, "");
+        (ITaikoInbox.BatchMetadata memory meta,) = router.proposeBatch(wrappedParams, "");
         vm.stopSnapshotGas();
 
         assertEq(meta.proposer, Carol);


### PR DESCRIPTION
Some of the sidecar implementations were actually using `proposeBatchWithExpectedLastBlockId` function. This PR adds that function back to the `PreconfRouter`, but does it in an optimized way without requiring the full struct to be returned.

`proposeBatch` now also returns last block id for consistency(inherits from `IProposeBatch`), but this should not have any impact unless the caller relied on the exact returned data struct.