### PR TITLE
fix(protocol): fix a bug with reusing pacaya slots for proposal

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/impl/MainnetShastaInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/MainnetShastaInbox.sol
@@ -14,8 +14,8 @@ contract MainnetShastaInbox is InboxOptimized2 {
     // ---------------------------------------------------------------
 
     /// @dev Ring buffer size for storing proposal hashes.
-    /// This value is inherited from the Pacaya fork as we are reusing the same slots.
-    uint64 private constant _RING_BUFFER_SIZE = 360_000;
+    /// Sized for ~38 hours of proposals (1 per epoch, 225 epochs/day + buffer).
+    uint64 private constant _RING_BUFFER_SIZE = 360;
 
     // ---------------------------------------------------------------
     // Constructor


### PR DESCRIPTION
This is one possible solution to the issue described [here](https://github.com/taikoxyz/taiko-mono/pull/19882#discussion_r2288498864). The other option is just not to reuse the storage slots from pacaya for proposals.
It also removes a couple unnecessary checks for proposal length(if the proposer sends a larger array they just waste calldata, but it is not an issue).

This solution initializes the ring buffer with empty markers in the `init` function. Since those storage slots are already non-zero(reused from pacaya) each `SSTORE` will "only" cost 5k gas. This means the deployment will be more expensive, but it is a one time operation, and all proposals from the first one will be cheaper.
**Ring buffer is decreased to a more reasonable number of 360 - more than one and a half day of unfinalized proposals**
