### PR TITLE
fix(docs-site): modify image links for GitHub rendering

### DIFF
--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md
@@ -74,7 +74,7 @@ When a user initiates a transfer:
 
 **Diagram: Sending a message on the source chain**
 
-![Bridging source chain process](~/assets/content/docs/taiko-alethia-protocol/bridging-source-chain.webp)
+![Bridging source chain process](../../../../assets/content/docs/taiko-alethia-protocol/bridging-source-chain.webp)
 
 #### Receiving assets on destination chain
 
@@ -89,7 +89,7 @@ To complete the transfer:
 
 **Diagram: Processing a message on the destination chain**
 
-![Bridging destination chain process](~/assets/content/docs/taiko-alethia-protocol/bridging-dest-chain.webp)
+![Bridging destination chain process](../../../../assets/content/docs/taiko-alethia-protocol/bridging-dest-chain.webp)
 
 ## Ether bridging
 

--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/economics.md
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/economics.md
@@ -7,7 +7,7 @@ Taiko Alethia's **based rollup design** and **multiproving architecture** create
 
 The following diagram illustrates **Taiko Alethia's transaction fee flow**:
 
-![Economics](~/assets/content/docs/taiko-alethia-protocol/based-economics.png)
+![Economics](../../../../assets/content/docs/taiko-alethia-protocol/based-economics.png)
 
 ---
 


### PR DESCRIPTION
This PR addresses broken image links in the documentation by updating their paths to be relative.

Previously, image links using `~/assets/...` or absolute paths like `/assets/...` were not rendering correctly on GitHub. This change ensures that all referenced images display properly across both the documentation site and GitHub.

