### PR TITLE
fix(bridge-ui): correct ENS address resolution error message

### DIFF
--- a/packages/snaefell-ui/src/lib/ens/getAddress.ts
+++ b/packages/snaefell-ui/src/lib/ens/getAddress.ts
@@ -12,6 +12,6 @@ export default async function getAddress(ensName: string): Promise<IAddress> {
     chainId,
   })) as GetEnsAddressReturnType;
 
-  if (!address) throw new Error('No ENS name');
+  if (!address) throw new Error('No ENS address');
   return address;
 }

--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -35,7 +35,7 @@ var (
 	}
 	RaikoApiKeyPath = &cli.StringFlag{
 		Name:     "raiko.apiKeyPath",
-		Usage:    "Path to a api key for the Raiko service",
+		Usage:    "Path to an api key for the Raiko service",
 		Category: proverCategory,
 		EnvVars:  []string{"RAIKO_API_KEY_PATH"},
 	}

--- a/packages/taikoon-ui/src/lib/ens/getAddress.ts
+++ b/packages/taikoon-ui/src/lib/ens/getAddress.ts
@@ -14,6 +14,6 @@ export default async function getAddress(ensName: string): Promise<IAddress> {
     chainId,
   })) as GetEnsAddressReturnType;
 
-  if (!address) throw new Error('No ENS name');
+  if (!address) throw new Error('No ENS address');
   return address;
 }


### PR DESCRIPTION
Replaced the misleading error message `'No ENS name'` with `'No ENS address'` when ENS address resolution fails. 
Corrected the indefinite article from `'a'` to `'an'` in the usage description for the Raiko API key path.