### PR TITLE
refactor(taiko-client): use the built-in max/min to simplify the code

### DIFF
--- a/packages/taiko-client/proposer/transaction_builder/blob.go
+++ b/packages/taiko-client/proposer/transaction_builder/blob.go
@@ -164,10 +164,7 @@ func (b *BlobTransactionBuilder) BuildPacaya(
 func (b *BlobTransactionBuilder) splitToBlobs(txListBytes []byte) ([]*eth.Blob, error) {
 	var blobs []*eth.Blob
 	for start := 0; start < len(txListBytes); start += eth.MaxBlobDataSize {
-		end := start + eth.MaxBlobDataSize
-		if end > len(txListBytes) {
-			end = len(txListBytes)
-		}
+		end := min(start+eth.MaxBlobDataSize, len(txListBytes))
 
 		var blob = &eth.Blob{}
 		if err := blob.FromData(txListBytes[start:end]); err != nil {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.