### PR TITLE
fix(taiko-client): use unique log key for block ID in fallback check

### DIFF
--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -534,7 +534,7 @@ func (p *Proposer) shouldPropose(ctx context.Context) (bool, error) {
 		if time.Since(p.l2HeadUpdate.updatedAt.UTC()) < p.FallbackTimeout {
 			log.Info("Fallback timeout not reached, skip proposing",
 				"l2HeadUpdate", p.l2HeadUpdate.updatedAt.UTC(),
-				"l2HeadUpdate", p.l2HeadUpdate.blockID,
+				"blockID", p.l2HeadUpdate.blockID,
 				"now", time.Now().UTC(),
 				"fallbackTimeout", p.FallbackTimeout,
 			)


### PR DESCRIPTION
Replace duplicated log key in shouldPropose fallback check. Use "blockID" instead of a second "l2HeadUpdate" to avoid ambiguous structured logs and align with nearby log usage. No functional changes.