### PR TITLE
chore(repo): use the right settings file for claude code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,12 +15,13 @@
       "Bash(mv:*)",
       "Bash(rm:*)",
       "Bash(mkdir:*)",
-      "Bash(pnpm compile:l1:*)",
+      "Bash(grep:*)",
       "Bash(pnpm compile:*)",
-      "Bash(forge test *)",
-      "Bash(forge test:*)",
-      "Bash(grep:*)"
+      "Bash(pnpm test:*)",
+      "Bash(pnpm snapshot:*)",
+      "Bash(pnpm layout:*)",
+      "Bash(forge test:*)"
     ],
-    "deny": []
+    "deny": ["Bash(git push --force:*)"]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ packages/protocol/snapshots/InboxTest_ProposeAndProve.json
 packages/taiko-client/opnode_discovery_db
 packages/taiko-client/opnode_peerstore_db
 packages/taiko-client/opnode_p2p_priv.txt
+
+#Claude
+.claude/settings.local.json


### PR DESCRIPTION
We should use `settings.json` for shared permissions in the team for claude instead of `settings.local.json`, which is for user specific settings and should be gitignored.
https://docs.anthropic.com/en/docs/claude-code/settings#settings-files