### PR TITLE
feat(taiko-client): only read handover config at epoch transitions

### DIFF
--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -431,11 +431,13 @@ func (d *Driver) cacheLookaheadLoop() {
 		if currentEpoch > d.lastConfigReloadEpoch {
 			routerConfig, err := d.rpc.GetPreconfRouterConfig(&bind.CallOpts{Context: d.ctx})
 			if err != nil {
-				log.Warn("Failed to fetch preconf router config, keeping current handoverSkipSlots", "error", err, "currentHandoverSkipSlots", d.handoverSkipSlots)
+				log.Warn("Failed to fetch preconf router config, keeping current handoverSkipSlots",
+					"error", err, "currentHandoverSkipSlots", d.handoverSkipSlots)
 			} else {
 				newHandoverSkipSlots := routerConfig.HandOverSlots.Uint64()
 				if newHandoverSkipSlots != d.handoverSkipSlots {
-					log.Info("Updated handover config for new epoch", "epoch", currentEpoch, "oldHandoverSkipSlots", d.handoverSkipSlots, "newHandoverSkipSlots", newHandoverSkipSlots)
+					log.Info("Updated handover config for new epoch", "epoch", currentEpoch,
+						"oldHandoverSkipSlots", d.handoverSkipSlots, "newHandoverSkipSlots", newHandoverSkipSlots)
 					d.handoverSkipSlots = newHandoverSkipSlots
 				}
 			}

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -426,7 +426,7 @@ func (d *Driver) cacheLookaheadLoop() {
 			slotsLeftInEpoch = d.rpc.L1Beacon.SlotsPerEpoch - d.rpc.L1Beacon.SlotInEpoch()
 		)
 
-		// Only read and update handover config at epoch transitions to avoide race conditions
+		// Only read and update handover config at epoch transitions to avoid race conditions
 		// where different nodes might read different configs during mid-epoch upgrades
 		if currentEpoch > d.lastConfigReloadEpoch {
 			routerConfig, err := d.rpc.GetPreconfRouterConfig(&bind.CallOpts{Context: d.ctx})


### PR DESCRIPTION
Builds on top of https://github.com/taikoxyz/taiko-mono/pull/19987

We need to be careful about the timing of reading and applying the new handover config or there can be a race condition. Say the handover upgrade happens within the new handover but before the old handover - Depending on when driver/sidecar reads the config and when different nodes receive the L1 block, people can have different view of the "current preconfer", which would lead to an L2 chain split and reorg.

One way to avoid this would be to only read and reflect the on-chain handover confing at the start of the epoch. So if handover is upgraded within epoch N, it does not take effect at the epoch N -> N+1 handover, and only takes effect from epoch N+1 -> epoch N+2 handover. 