### PR TITLE
chore(relayer, taiko-client): fix typo/grammar in comments

### DIFF
--- a/packages/relayer/indexer/handle_message_processed_event.go
+++ b/packages/relayer/indexer/handle_message_processed_event.go
@@ -25,7 +25,7 @@ func (i *Indexer) handleMessageProcessedEvent(
 
 	message := event.Message
 
-	// if the destination doesnt match our source chain, we dont want to handle this event.
+	// if the destination doesn't match our source chain, we dont want to handle this event.
 	if new(big.Int).SetUint64(message.DestChainId).Cmp(i.srcChainId) != 0 {
 		slog.Info("skipping event, wrong chainID",
 			"messageDestChainID",

--- a/packages/relayer/pkg/mock/blocker.go
+++ b/packages/relayer/pkg/mock/blocker.go
@@ -36,7 +36,7 @@ type Blocker struct {
 
 func (b *Blocker) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
 	if hash == relayer.ZeroHash {
-		return nil, errors.New("cant find block")
+		return nil, errors.New("can't find block")
 	}
 
 	return types.NewBlockWithHeader(Header), nil

--- a/packages/relayer/pkg/mock/eth_client.go
+++ b/packages/relayer/pkg/mock/eth_client.go
@@ -107,7 +107,7 @@ func (c *EthClient) BlockNumber(ctx context.Context) (uint64, error) {
 
 func (c *EthClient) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	if hash == relayer.ZeroHash {
-		return nil, errors.New("cant find block")
+		return nil, errors.New("can't find block")
 	}
 
 	return Header, nil

--- a/packages/relayer/pkg/queue/rabbitmq/queue.go
+++ b/packages/relayer/pkg/queue/rabbitmq/queue.go
@@ -408,7 +408,7 @@ func (r *RabbitMQ) Subscribe(ctx context.Context, msgChan chan<- queue.Message, 
 
 	if err != nil {
 		if err == amqp.ErrClosed {
-			slog.Info("cant subscribe to rabbitmq, channel closed. attempting reconnection")
+			slog.Info("can't subscribe to rabbitmq, channel closed. attempting reconnection")
 
 			if err := r.connect(); err != nil {
 				slog.Error("error reconnecting to channel during subscribe", "err", err.Error())

--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -503,7 +503,7 @@ func (p *Proposer) shouldPropose(ctx context.Context) (bool, error) {
 		p.preconfRouterAddress = rpc.ZeroAddress
 	} else {
 		p.preconfRouterAddress = preconfRouterAddr
-		// if we havent set the preconfRouter, do so now.
+		// if we haven't set the preconfRouter, do so now.
 		if p.rpc.PacayaClients.PreconfRouter == nil {
 			p.rpc.PacayaClients.PreconfRouter, err = pacayaBindings.NewPreconfRouter(preconfRouterAddr, p.rpc.L1)
 			if err != nil {


### PR DESCRIPTION


### Description
- Standardize contractions in messages and comments: "can't", "haven't", "doesn't".

