### PR TITLE
fix(taiko-client): fix preconf router config

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main, fix_preconf_router_config]
+    branches: [main]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix_preconf_router_config]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 
 replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447
 
-replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20250904150606-a7cc5bd28ed2
+replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20250904153513-c03e7cc023f2
 
 replace github.com/uber/jaeger-client-go => github.com/uber/jaeger-client-go v2.25.0+incompatible
 

--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 
 replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447
 
-replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20250825180038-bb7cd4289b8e
+replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20250903214221-39d04b925741
 
 replace github.com/uber/jaeger-client-go => github.com/uber/jaeger-client-go v2.25.0+incompatible
 

--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 
 replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447
 
-replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20250903214221-39d04b925741
+replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20250904150606-a7cc5bd28ed2
 
 replace github.com/uber/jaeger-client-go => github.com/uber/jaeger-client-go v2.25.0+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082 h1:ymZR+Y88LOnA8i3KeuJXK7hff2n7bpMIhONPJwpcA5w=
 github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082/go.mod h1:RHnIu3EFehrWX3JhFAMQSXD5uz7l0xaNroTzXrap7EQ=
-github.com/taikoxyz/optimism v0.0.0-20250903214221-39d04b925741 h1:P1U93F2t36ftbiYI+ffg+wAyvEuasiiNS5KzIvxRRR0=
-github.com/taikoxyz/optimism v0.0.0-20250903214221-39d04b925741/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
+github.com/taikoxyz/optimism v0.0.0-20250904150606-a7cc5bd28ed2 h1:4Tirr35cTwJ1gDPrsI/kwnJIZG/j14cZmY2b1SI4uH8=
+github.com/taikoxyz/optimism v0.0.0-20250904150606-a7cc5bd28ed2/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
 github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447 h1:RPZRS/bwaxZY8gJLHVoU+UT8sdFOlgpOm5iBd62Gpjw=
 github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082 h1:ymZR+Y88LOnA8i3KeuJXK7hff2n7bpMIhONPJwpcA5w=
 github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082/go.mod h1:RHnIu3EFehrWX3JhFAMQSXD5uz7l0xaNroTzXrap7EQ=
-github.com/taikoxyz/optimism v0.0.0-20250904150606-a7cc5bd28ed2 h1:4Tirr35cTwJ1gDPrsI/kwnJIZG/j14cZmY2b1SI4uH8=
-github.com/taikoxyz/optimism v0.0.0-20250904150606-a7cc5bd28ed2/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
+github.com/taikoxyz/optimism v0.0.0-20250904153513-c03e7cc023f2 h1:rB8kA1Hx3dIJbKn0483GQLiDE//MvjSBlNm2gBSEf3U=
+github.com/taikoxyz/optimism v0.0.0-20250904153513-c03e7cc023f2/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
 github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447 h1:RPZRS/bwaxZY8gJLHVoU+UT8sdFOlgpOm5iBd62Gpjw=
 github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082 h1:ymZR+Y88LOnA8i3KeuJXK7hff2n7bpMIhONPJwpcA5w=
 github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082/go.mod h1:RHnIu3EFehrWX3JhFAMQSXD5uz7l0xaNroTzXrap7EQ=
-github.com/taikoxyz/optimism v0.0.0-20250825180038-bb7cd4289b8e h1:cah5SZJ4anV3O2i+aPwd1dXj8hszkIcqpc10QzyGG3g=
-github.com/taikoxyz/optimism v0.0.0-20250825180038-bb7cd4289b8e/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
+github.com/taikoxyz/optimism v0.0.0-20250903214221-39d04b925741 h1:P1U93F2t36ftbiYI+ffg+wAyvEuasiiNS5KzIvxRRR0=
+github.com/taikoxyz/optimism v0.0.0-20250903214221-39d04b925741/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
 github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447 h1:RPZRS/bwaxZY8gJLHVoU+UT8sdFOlgpOm5iBd62Gpjw=
 github.com/taikoxyz/taiko-geth v1.15.1-0.20250714172126-8dc1f9603447/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -65,6 +65,13 @@ var (
 		Category: driverCategory,
 		EnvVars:  []string{"PRECONFIRMATION_WHITELIST"},
 	}
+	DriverTaikoWrapperAddress = &cli.StringFlag{
+		Name:     "taikoWrapper",
+		Usage:    "TaikoWrapper contract `address`",
+		Required: false,
+		Category: driverCategory,
+		EnvVars:  []string{"TAIKO_WRAPPER"},
+	}
 )
 
 // DriverFlags All driver flags.
@@ -81,4 +88,5 @@ var DriverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	PreconfBlockServerJWTSecret,
 	PreconfBlockServerCORSOrigins,
 	PreconfWhitelistAddress,
+	DriverTaikoWrapperAddress,
 }, p2pFlags.P2PFlags("PRECONFIRMATION"))

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -93,6 +93,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			L2EngineEndpoint:        c.String(flags.L2AuthEndpoint.Name),
 			JwtSecret:               string(jwtSecret),
 			Timeout:                 c.Duration(flags.RPCTimeout.Name),
+			TaikoWrapperAddress:     common.HexToAddress(c.String(flags.DriverTaikoWrapperAddress.Name)),
 		}
 		p2pConfigs    *p2p.Config
 		signerConfigs p2p.SignerSetup

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -399,7 +399,11 @@ func (d *Driver) cacheLookaheadLoop() {
 
 			hash, seen := d.preconfBlockServer.GetSequencingEndedForEpoch(epoch)
 			if !seen {
-				log.Info("Lookahead requesting end of sequencing for epoch", "epoch", epoch, "slot", slot)
+				log.Info("Lookahead requesting end of sequencing for epoch",
+					"epoch", epoch,
+					"slot", slot,
+				)
+
 				if err := d.p2pNode.GossipOut().PublishL2EndOfSequencingRequest(
 					context.Background(),
 					epoch,

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -438,7 +438,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Request(
 	// Fetch the block from L2 EE and gossip it out.
 	block, err := s.rpc.L2.BlockByHash(ctx, hash)
 	if err != nil {
-		log.Warn(
+		log.Debug(
 			"Failed to fetch preconfirmation request block by hash",
 			"peer", from,
 			"hash", hash.Hex(),
@@ -899,7 +899,7 @@ func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context
 func (s *PreconfBlockAPIServer) P2PSequencerAddress() common.Address {
 	operatorAddress, err := s.rpc.GetPreconfWhiteListOperator(nil)
 	if err != nil || operatorAddress == (common.Address{}) {
-		log.Warn("Failed to get current preconfirmation whitelist operator address", "error", err)
+		log.Debug("Failed to get current preconfirmation whitelist operator address", "error", err)
 		return common.Address{}
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -905,7 +905,7 @@ func (s *PreconfBlockAPIServer) P2PSequencerAddress() common.Address {
 		return common.Address{}
 	}
 
-	log.Info("Current operator address for epoch as P2P sequencer", "address", operatorAddress.Hex())
+	log.Debug("Current operator address for epoch as P2P sequencer", "address", operatorAddress.Hex())
 
 	return operatorAddress
 }

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
-	"github.com/ethereum-optimism/optimism/op-node/p2p/gating"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -27,7 +26,6 @@ import (
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -925,30 +923,6 @@ func (s *PreconfBlockAPIServer) P2PSequencerAddresses() []common.Address {
 		s.lookahead.CurrOperator,
 		s.lookahead.NextOperator,
 	}
-}
-
-// AllP2PSequencerAddresses implements the p2p.PreconfGossipRuntimeConfig interface.
-func (s *PreconfBlockAPIServer) AllP2PSequencerAddresses() []common.Address {
-	s.lookaheadMutex.Lock()
-	defer s.lookaheadMutex.Unlock()
-
-	operators, err := s.rpc.GetAllPreconfOperators(nil)
-	if err != nil {
-		log.Warn("Failed to get all preconfirmation operators", "error", err)
-		return []common.Address{}
-	}
-
-	return operators
-}
-
-// P2pHost returns the host of the connected p2pNode for the p2p.PreconfGossipRuntimeConfig interface
-func (s *PreconfBlockAPIServer) P2PHost() host.Host {
-	return s.p2pNode.Host()
-}
-
-// ConnGater returns the connection gater of the connected p2pNode for the p2p.PreconfGossipRuntimeConfig interface
-func (s *PreconfBlockAPIServer) ConnGater() gating.BlockingConnectionGater {
-	return s.p2pNode.ConnectionGater()
 }
 
 // UpdateLookahead updates the lookahead information.

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -1098,7 +1098,15 @@ func (c *Client) GetPreconfRouterPacaya(opts *bind.CallOpts) (common.Address, er
 // GetPreconfRouterConfig returns the PreconfRouter config.
 func (c *Client) GetPreconfRouterConfig(opts *bind.CallOpts) (*pacayaBindings.IPreconfRouterConfig, error) {
 	if c.PacayaClients.PreconfRouter == nil {
-		return nil, errors.New("preconfRouter contract is not set")
+		preconfRouterAddr, err := c.GetPreconfRouterPacaya(opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve preconfirmation router address: %w", err)
+		}
+
+		c.PacayaClients.PreconfRouter, err = pacayaBindings.NewPreconfRouter(preconfRouterAddr, c.L1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create preconfirmation router: %w", err)
+		}
 	}
 
 	var cancel context.CancelFunc


### PR DESCRIPTION
also we should pass `--taikoWrapper` to the driver, otherwise a section of API code doesnt work, and we also cant fetch the preconf router config.

Only sequencer nodes need the wrapper.