### PR TITLE
docs(docs-site): fix ERC-4337 doc link

### DIFF
--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/account-abstraction.mdx
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/account-abstraction.mdx
@@ -16,4 +16,4 @@ It is deployed at
 
 ### More Info
 
-Read more about ERC4337 Account Abstraction [here](https://www.erc4337.io/docs)!
+Read more about ERC4337 Account Abstraction [here](https://docs.erc4337.io)!


### PR DESCRIPTION
updated the old link to point to the new docs: [https://docs.erc4337.io/](https://docs.erc4337.io).