### PR TITLE
fix(prover-set): add forced inclusion parameter validation for security

### DIFF
--- a/packages/protocol/contracts/layer1/provers/ProverSet.sol
+++ b/packages/protocol/contracts/layer1/provers/ProverSet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import "./ProverSetBase.sol";
 import "../based/IProposeBatch.sol";
+import "../based/ITaikoInbox.sol";
 
 contract ProverSet is ProverSetBase, IProposeBatch {
     using Address for address;
@@ -34,6 +35,14 @@ contract ProverSet is ProverSetBase, IProposeBatch {
         onlyProver
         returns (ITaikoInbox.BatchInfo memory, ITaikoInbox.BatchMetadata memory)
     {
+        // Validate parameters to prevent forced inclusion attacks
+        ITaikoInbox.BatchParams memory params = abi.decode(_params, (ITaikoInbox.BatchParams));
+        
+        // ProverSet should not allow forced inclusion parameters for security reasons
+        require(params.isForcedInclusion == false, ForcedInclusionParamsNotAllowed());
+        require(params.blobParams.blobHashes.length == 0, ITaikoInbox.InvalidBlobParams());
+        require(params.blobParams.createdIn == 0, ITaikoInbox.InvalidBlobCreatedIn());
+        
         return iProposeBatch.v4ProposeBatch(_params, _txList, _additionalData);
     }
 


### PR DESCRIPTION
ProverSet was the only contract in the system that didn't validate batch parameters before 
processing. TaikoWrapper and TaikoInbox both have these same validations, so ProverSet 
should be consistent. The unused ForcedInclusionParamsNotAllowed() error was declared 
but never used - now it serves its intended purpose.

This ensures ProverSet follows the same security patterns as other parts of the system 
and prevents potential misuse of forced inclusion parameters through the prover set.