### PR TITLE
chore(taiko-client): remove unused blockMaxGasLimit from TxListDecompressor

### DIFF
--- a/packages/taiko-client/driver/txlist_decompressor/txlist_decompressor.go
+++ b/packages/taiko-client/driver/txlist_decompressor/txlist_decompressor.go
@@ -11,16 +11,14 @@ import (
 // TxListDecompressor is responsible for validating and decompressing
 // the transactions list in a TaikoInbox.proposeBatch transaction.
 type TxListDecompressor struct {
-	blockMaxGasLimit  uint64
 	maxBytesPerTxList uint64
 }
 
 // NewTxListDecompressor creates a new TxListDecompressor instance based on giving configurations.
 func NewTxListDecompressor(
-	blockMaxGasLimit uint64,
 	maxBytesPerTxList uint64,
 ) *TxListDecompressor {
-	return &TxListDecompressor{blockMaxGasLimit: blockMaxGasLimit, maxBytesPerTxList: maxBytesPerTxList}
+	return &TxListDecompressor{maxBytesPerTxList: maxBytesPerTxList}
 }
 
 // TryDecompress validates and decompresses whether the transactions list in the TaikoInbox.proposeBatch transaction's


### PR DESCRIPTION
The TxListDecompressor never used blockMaxGasLimit; it only validates calldata size, decompresses, and RLP-decodes. Gas limit constraints are enforced upstream (engine/proposer) and at the protocol/ZKP level, not at decompression time. Removing this dead field and parameter reduces confusion and improves clarity without changing behavior.