### PR TITLE
fix: spelling and grammar in comments & docs

### DIFF
--- a/packages/eventindexer/indexer/filter_pacaya.go
+++ b/packages/eventindexer/indexer/filter_pacaya.go
@@ -48,7 +48,7 @@ func filterFuncPacaya(
 			return nil
 		})
 
-		// dont run in goroutines, as the batchProposed events need to be processed in order and
+		// don't run in goroutines, as the batchProposed events need to be processed in order and
 		// saved to the DB in order, as we need the previous one's "lastBlockId" to calculate
 		// the blockIds of the next batchProposed event, since they are no longer
 		// emitted in the event themself.

--- a/packages/eventindexer/indexer/index_erc20_transfers.go
+++ b/packages/eventindexer/indexer/index_erc20_transfers.go
@@ -139,7 +139,7 @@ func (i *Indexer) saveERC20Transfer(ctx context.Context, chainID *big.Int, vLog 
 	if pk == 0 {
 		symbol, err := getERC20Symbol(ctx, i.ethClient, vLog.Address.Hex())
 		if err != nil {
-			// some erc20 dont have symbol method properly,
+			// some erc20 don't have symbol method properly,
 			// returns `invalid opcode`.
 			if strings.Contains(err.Error(), "invalid opcode") {
 				symbol = "ERC20"

--- a/packages/protocol/audit/code4rena-2024-03-taiko-final-report.md
+++ b/packages/protocol/audit/code4rena-2024-03-taiko-final-report.md
@@ -1157,7 +1157,7 @@ Add new functionality in the vault that allows users to send a new message to th
 > We are OK with med, no issue. Please proceed accordinlgy - as we dont have:
 >
 > 1. the perfect solution to the problem
-> 2. the intention to fix it ATM - since we wont be using any native tokens anytime soon.
+> 2. the intention to fix it ATM - since we won't be using any native tokens anytime soon.
 >
 > But please proceed the way which is suitable for the wardens better, we appreciate their efforts. (So not questioning the severity)
 


### PR DESCRIPTION


### Description
- Corrected minor typos in comments (`dont` → `don't`, `wont` → `won't`).  
