### PR TITLE
(chore): fix dead links across repo; switch Hekla explorer domain

### DIFF
--- a/packages/docs-site/src/content/docs/guides/app-developers/deploy-a-contract.mdx
+++ b/packages/docs-site/src/content/docs/guides/app-developers/deploy-a-contract.mdx
@@ -430,7 +430,7 @@ Hardhat is an Ethereum development environment for deploying smart contracts, ru
     Transaction hash: 0x75f219defa....
     ```
 
-    You can now check your deployed contract on [the explorer](https://hekla.taikoscan.network/) using the `deployed contract address`.
+    You can now check your deployed contract on [the explorer](https://explorer.hekla.taiko.xyz/) using the `deployed contract address`.
 
 </Steps>
 

--- a/packages/protocol/docs/analysis/kaveyjoe-Analysis.md
+++ b/packages/protocol/docs/analysis/kaveyjoe-Analysis.md
@@ -769,7 +769,7 @@ Overall, I'm excited to see where the Taiko project will go, and I'm confident t
 - https://github.com/code-423n4/2024-03-taiko
 - https://docs.taiko.xyz/start-here/getting-started
 - https://taiko.mirror.xyz/oRy3ZZ_4-6IEQcuLCMMlxvdH6E-T3_H7UwYVzGDsgf4
-- https://www.datawallet.com/crypto/what-is-taiko
+- https://blog.thirdweb.com/what-is-taiko
 - https://medium.com/@mustafa.hourani/interview-with-taiko-a-leading-type-1-zkevm-ddf71eb4eabe
 - https://taiko.mirror.xyz/y_47kIOL5kavvBmG0zVujD2TRztMZt-xgM5d4oqp4_Y?ref=bankless.ghost.io
 


### PR DESCRIPTION

 Updated Hekla explorer URLs to the new domain `https://explorer.hekla.taiko.xyz/`.

