### PR TITLE
fix(repo): fix protocol checkout in CI

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -43,11 +43,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.TAIKO_KITTY_TOKEN }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1.4.0


### PR DESCRIPTION
forks have no access to the token, so will always fail. other tests don't use it or use github.token, should keep consistent where possible