### PR TITLE
feat(taiko-client): add HTTP 429 rate limit detection for Raiko

### DIFF
--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -135,8 +135,6 @@ func requestHTTPProofResponse[T any](
 	return res, nil
 }
 
-
-
 // updateProvingMetrics updates the metrics for the given proof type, including
 // the generation time and the number of proofs generated.
 func updateProvingMetrics(proofType ProofType, requestAt time.Time, isAggregation bool) {

--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -120,6 +120,11 @@ func requestHTTPProofResponse[T any](
 	}
 
 	if res.StatusCode != http.StatusOK {
+		// Check for rate limiting (429 Too Many Requests)
+		if res.StatusCode == http.StatusTooManyRequests {
+			log.Error("Rate limit on L2 RPC has been reached. Using your own Taiko L2 node as RPC for Raiko is recommended")
+		}
+
 		return nil, fmt.Errorf(
 			"failed to request proof, url: %s, statusCode: %d",
 			url,
@@ -129,6 +134,8 @@ func requestHTTPProofResponse[T any](
 
 	return res, nil
 }
+
+
 
 // updateProvingMetrics updates the metrics for the given proof type, including
 // the generation time and the number of proofs generated.


### PR DESCRIPTION
**Summary**
Adds detection for HTTP 429 (Too Many Requests) errors when the Raiko proof service hits RPC rate limits.

**Changes**

- Enhanced error handling: Detects HTTP 429 status codes from Raiko responses
- Clear user guidance: Logs informative message when L2 RPC rate limit is reached
- Actionable recommendation: Suggests using own Taiko L2 node as RPC for Raiko


**Problem Solved**

When Raiko services hit rate limits on their RPC providers, users previously saw generic HTTP error messages without understanding the root cause. This change provides immediate clarity about the issue and actionable steps to resolve it.
