### PR TITLE
ci(protocol): account for fork ref

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -41,12 +41,18 @@ jobs:
         continue-on-error: true
         run: sudo apt-get update && sudo apt-get install -y git wget
 
+      - name: Fetch owner/repo of pull request
+        uses: alessbell/pull-request-comment-branch@v2.1.0
+        id: comment-branch
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          # account for forked repos case
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
+          # Fetch more history for better git operations
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
           token: ${{ github.event.pull_request.head.repo.fork == false && secrets.TAIKO_KITTY_TOKEN || github.token }}
 
       - name: Install Foundry


### PR DESCRIPTION
[ref](https://github.com/RogerLamTd/taiko-mono/actions/runs/17685126771/job/50268157742?pr=11). previous fix just accounted for token, this should account for the repo; imported from claude code review action