### PR TITLE
docs(protocol): fix broken link

### DIFF
--- a/packages/protocol/docs/tokenomics-whitepaper.tex
+++ b/packages/protocol/docs/tokenomics-whitepaper.tex
@@ -49,7 +49,7 @@ The total supply of Taiko Tokens, "TKO", is fixed at 1 billion, with 18 decimals
     \item \href{https://github.com/taikoxyz/taiko-mono/blob/based_contestable_zkrollup/packages/protocol/docs/contestable_validity_rollup.md}{Taiko BCR Design Doc}
     \item \href{https://ethresear.ch/t/booster-rollups-scaling-l1-directly/17125}{Ethereum Research on Booster Rollups}
     \item \href{https://taiko.mirror.xyz/anPjF35Mrc_xzYgOTbUmfjr_MlhE3L8ZBZIxqmz9GZ8}{Taiko BBR Design Overview}
-    \item \href{https://ethereum.org/en/developers/docs/layer-2-scaling/}{Ethereum Layer 1 and Layer 2 Integration}
+    \item \href{https://ethereum.org/developers/docs/scaling/#layer-2-scaling}{Ethereum Layer 1 and Layer 2 Integration}
     \item \href{https://ethereum.org/en/governance/}{Ethereum Governance Documentation}
     \item \href{https://ethereum.org/en/whitepaper/}{Ethereum Whitepaper}
     \item \href{https://docs.soliditylang.org/en/latest/}{Solidity Documentation}


### PR DESCRIPTION
https://ethereum.org/en/developers/docs/layer-2-scaling/ - this link is broken
https://ethereum.org/developers/docs/scaling/#layer-2-scaling - this link is correct and equal to the previous one