### PR TITLE
docs(docs-site): fix incorrect Hardhat initialization command

### DIFF
--- a/packages/docs-site/src/content/docs/guides/app-developers/deploy-a-contract.mdx
+++ b/packages/docs-site/src/content/docs/guides/app-developers/deploy-a-contract.mdx
@@ -81,7 +81,7 @@ Hardhat is an Ethereum development environment for deploying smart contracts, ru
     ```
     - Initialize Hardhat
     ```bash
-    npx hardhat init
+    npx hardhat
     ```
     Choose `Create a JavaScript project` and follow the prompts, agreeing to create a `.gitignore` and install suggested dependencies.
 
@@ -321,7 +321,7 @@ Hardhat is an Ethereum development environment for deploying smart contracts, ru
     ```
     - Initialize Hardhat
     ```bash
-    npx hardhat init
+    npx hardhat
     ```
     Choose `Create a JavaScript project` and follow the prompts, agreeing to create a `.gitignore` and install suggested dependencies.
 


### PR DESCRIPTION
noticed the docs referenced `npx hardhat init`, but Hardhat doesn’t actually support that command.
updated it to the correct usage: `npx hardhat`.

**this aligns with both the official documentation and the CLI behavior.**
