### PR TITLE
feat(protocol): removes proposal and block limit constants

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
@@ -9,9 +9,6 @@ library LibManifest {
     // Constants
     // ---------------------------------------------------------------
 
-    /// @notice Maximum number of transactions allowed in proposal's manifest data. This cap ensures
-    /// the cost of a worst-case prover attack is bounded.
-    uint256 internal constant BLOCK_MAX_RAW_TRANSACTIONS = 4096 * 2;
 
     /// @notice The maximum anchor block number offset from the proposal origin block number.
     uint256 internal constant ANCHOR_MAX_OFFSET = 128;
@@ -24,7 +21,7 @@ library LibManifest {
 
     /// @notice The maximum block gas limit change per block, in millionths (1/1,000,000).
     /// @dev For example, 10 = 10 / 1,000,000 = 0.001%.
-    uint256 internal constant MAX_BLOCK_GAS_LIMIT_CHANGE_PERMYRIAD = 10;
+    uint256 internal constant BLOCK_GAS_LIMIT_MAX_CHANGE = 10;
 
     /// @notice The minimum block gas limit.
     /// @dev This ensures block gas limit never drops below a critical threshold.

--- a/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
@@ -7,6 +7,9 @@ library LibManifest {
     // ---------------------------------------------------------------
     // Constants
     // ---------------------------------------------------------------
+    /// @notice The maximum number of blocks allowed in a proposal. If we assume block time is as
+    /// small as one second, 384 blocks will cover an Ethereum epoch.
+    uint256 internal constant PROPOSAL_MAX_BLOCKS = 384;
 
     /// @notice The maximum anchor block number offset from the proposal origin block number.
     uint256 internal constant ANCHOR_MAX_OFFSET = 128;

--- a/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { LibBlobs } from "./LibBlobs.sol";
 
 /// @title LibManifest
 /// @custom:security-contact security@taiko.xyz
@@ -9,14 +8,6 @@ library LibManifest {
     // ---------------------------------------------------------------
     // Constants
     // ---------------------------------------------------------------
-    /// @notice The maximum number of blobs allowed in a proposal.
-    uint256 internal constant PROPOSAL_MAX_BLOBS = 4;
-    /// @notice The maximum number of bytes allowed in a proposal.
-    uint256 internal constant PROPOSAL_MAX_BYTES = LibBlobs.BLOB_BYTES * PROPOSAL_MAX_BLOBS;
-
-    /// @notice The maximum number of blocks allowed in a proposal. If we assume block time is as
-    /// small as one second, 384 blocks will cover an Ethereum epoch.
-    uint256 internal constant PROPOSAL_MAX_BLOCKS = 384;
 
     /// @notice Maximum number of transactions allowed in proposal's manifest data. This cap ensures
     /// the cost of a worst-case prover attack is bounded.

--- a/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-
 /// @title LibManifest
 /// @custom:security-contact security@taiko.xyz
 library LibManifest {
     // ---------------------------------------------------------------
     // Constants
     // ---------------------------------------------------------------
-
 
     /// @notice The maximum anchor block number offset from the proposal origin block number.
     uint256 internal constant ANCHOR_MAX_OFFSET = 128;

--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -171,7 +171,6 @@ A default manifest is returned when any of the following validation criteria fai
 - **Version validation**: Version number is not `0x1`
 - **Decompression failure**: ZLIB decompression fails
 - **Decoding failure**: RLP decoding fails
-- **Transaction limit**: Any block contains more than `BLOCK_MAX_RAW_TRANSACTIONS` transactions
 
 The default manifest is one initialized as:
 
@@ -223,14 +222,14 @@ The L2 coinbase address determination follows a hierarchical priority system:
 
 #### `gasLimit` Validation
 
-Gas limit adjustments are constrained by `MAX_BLOCK_GAS_LIMIT_CHANGE_PERMYRIAD` permyriad (units of 1/10,000) per block to ensure economic stability. With the default value of 10 permyriad, this allows ±10 basis points (±0.1%) change per block. Additionally, block gas limit must never fall below `MIN_BLOCK_GAS_LIMIT`:
+Gas limit adjustments are constrained by `BLOCK_GAS_LIMIT_MAX_CHANGE` permyriad (units of 1/10,000) per block to ensure economic stability. With the default value of 10 permyriad, this allows ±10 basis points (±0.1%) change per block. Additionally, block gas limit must never fall below `MIN_BLOCK_GAS_LIMIT`:
 
 **Calculation process**:
 
 1. **Define bounds**:
 
-   - `lowerBound = max(parent.metadata.gasLimit * (10000 - MAX_BLOCK_GAS_LIMIT_CHANGE_PERMYRIAD) / 10000, MIN_BLOCK_GAS_LIMIT)`
-   - `upperBound = parent.metadata.gasLimit * (10000 + MAX_BLOCK_GAS_LIMIT_CHANGE_PERMYRIAD) / 10000`
+   - `lowerBound = max(parent.metadata.gasLimit * (10000 - BLOCK_GAS_LIMIT_MAX_CHANGE) / 10000, MIN_BLOCK_GAS_LIMIT)`
+   - `upperBound = parent.metadata.gasLimit * (10000 + BLOCK_GAS_LIMIT_MAX_CHANGE) / 10000`
 
 2. **Apply constraints**:
    - If `manifest.blocks[i].gasLimit == 0`: Inherit parent value

--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -166,13 +166,11 @@ The `BlobSlice` struct represents binary data distributed across multiple blobs.
 
 A default manifest is returned when any of the following validation criteria fail:
 
-- **Blob validation**: `blobHashes.length` is zero or exceeds `PROPOSAL_MAX_BLOBS`
+- **Blob validation**: `blobHashes.length` is zero
 - **Offset validation**: `offset > BLOB_BYTES * blobHashes.length - 64`
 - **Version validation**: Version number is not `0x1`
-- **Size validation**: `size` exceeds `PROPOSAL_MAX_BYTES`
 - **Decompression failure**: ZLIB decompression fails
 - **Decoding failure**: RLP decoding fails
-- **Block count validation**: `manifest.blocks.length` exceeds `PROPOSAL_MAX_BLOCKS`
 - **Transaction limit**: Any block contains more than `BLOCK_MAX_RAW_TRANSACTIONS` transactions
 
 The default manifest is one initialized as:

--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -171,6 +171,7 @@ A default manifest is returned when any of the following validation criteria fai
 - **Version validation**: Version number is not `0x1`
 - **Decompression failure**: ZLIB decompression fails
 - **Decoding failure**: RLP decoding fails
+- **Block count validation**: `manifest.blocks.length` exceeds `PROPOSAL_MAX_BLOCKS`
 
 The default manifest is one initialized as:
 


### PR DESCRIPTION
## Key Changes:

### 1. LibManifest.sol - Removed unused constants:

  - ❌ PROPOSAL_MAX_BLOBS = 4
  - ❌ PROPOSAL_MAX_BYTES = LibBlobs.BLOB_BYTES * PROPOSAL_MAX_BLOBS
  - ❌ BLOCK_MAX_RAW_TRANSACTIONS = 4096 * 2

### 2. Constant renaming for consistency:

  - ✏️ MAX_BLOCK_GAS_LIMIT_CHANGE_PERMYRIAD → BLOCK_GAS_LIMIT_MAX_CHANGE
