### PR TITLE
fix(protocol): correct MainnetInbox title and notice references

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -5,10 +5,10 @@ import "src/layer1/based/TaikoInbox.sol";
 import "src/shared/libs/LibNetwork.sol";
 import "./libs/LibFasterReentryLock.sol";
 
-/// @title MainnetTaikoL1
+/// @title MainnetInbox
 /// @dev This contract shall be deployed to replace its parent contract on Ethereum for Taiko
 /// mainnet to reduce gas cost.
-/// @notice See the documentation in {TaikoL1}.
+/// @notice See the documentation in {TaikoInbox}.
 /// @custom:security-contact security@taiko.xyz
 contract MainnetInbox is TaikoInbox {
     constructor(


### PR DESCRIPTION
- Update @title to match contract name MainnetInbox for consistency with other mainnet contracts.
- Update @notice reference from {TaikoL1} to {TaikoInbox}, which is the actual parent contract.
- These changes improve documentation accuracy, reduce confusion for readers and tooling that indexes NatSpec, and align with established naming conventions in adjacent mainnet contracts.