### PR TITLE
chore: get rid of empty class

### DIFF
--- a/packages/bridge-ui/src/components/Dialogs/Shared/ReviewStep.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/Shared/ReviewStep.svelte
@@ -56,7 +56,7 @@
 
         <div class="flex justify-between">
           <div class="text-secondary-content">{$t('common.recipient')}</div>
-          <div class="">
+          <div>
             <ExplorerLink category="address" chainId={Number(tx.destChainId)} urlParam={tx.message.to}
               >{shortenAddress(tx.message?.to, 5, 5)}</ExplorerLink>
           </div>


### PR DESCRIPTION
just removed an empty `class` from a `<div>`.
no changes to behavior.
