### PR TITLE
chore(protocol): remove unused Unauthorized error declarations

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -956,5 +956,4 @@ error ProposerBondInsufficient();
 error RingBufferSizeZero();
 error SpanOutOfBounds();
 error TransitionWithSameParentHashAlreadyProved();
-error Unauthorized();
 error UnprocessedForcedInclusionIsDue();

--- a/packages/protocol/contracts/layer2/based/BondManager.sol
+++ b/packages/protocol/contracts/layer2/based/BondManager.sol
@@ -216,6 +216,5 @@ contract BondManager is EssentialContract, IBondManager {
     error MustMaintainMinBond();
     error NoBondToWithdraw();
     error NoWithdrawalRequested();
-    error Unauthorized();
     error WithdrawalAlreadyRequested();
 }

--- a/packages/protocol/contracts/shared/based/impl/CheckpointManager.sol
+++ b/packages/protocol/contracts/shared/based/impl/CheckpointManager.sol
@@ -131,5 +131,4 @@ contract CheckpointManager is EssentialContract, ICheckpointManager {
     error InvalidMaxStackSize();
     error InvalidCheckpoint();
     error NoCheckpoints();
-    error Unauthorized();
 }


### PR DESCRIPTION
Removed stray error Unauthorized() declarations that were not referenced anywhere. Access control in this codebase uniformly reverts with ACCESS_DENIED() via EssentialContract’s checks, so keeping per-file Unauthorized errors is misleading and dead code. This cleanup reduces noise, avoids confusion for auditors/reviewers, and aligns files with the actual access-control mechanism.