### PR TITLE
docs: fix typos and wording issues in network reference docs

### DIFF
--- a/packages/docs-site/src/content/docs/network-reference/contract-addresses.mdx
+++ b/packages/docs-site/src/content/docs/network-reference/contract-addresses.mdx
@@ -85,7 +85,7 @@ You can find the contract addresses of the latest L2 smart contract deployments 
 
 ## Taiko Hekla contract addresses
 
-You can find the all L1 and L2 contract addresses of the latest smart contract deployments of the Taiko Alethia Protocol [here](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/deployments/hekla-contract-logs.md).
+You can find all L1 and L2 contract addresses of the latest smart contract deployments of the Taiko Alethia Protocol [here](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/deployments/hekla-contract-logs.md).
 
 ## Taiko Alethia bootnode addresses
 

--- a/packages/docs-site/src/content/docs/network-reference/differences-from-ethereum.md
+++ b/packages/docs-site/src/content/docs/network-reference/differences-from-ethereum.md
@@ -7,7 +7,7 @@ description: Network reference page describing the differences between Taiko Ale
 | ---------------- | -------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Block gas limit  | 36,000,000 gas | 240,000,000 gas               | Currently in Raiko, memory use scales linearly with block size both in the host (witness generation) and in the guest (memory use inside the VM/program being proven) so we set the block gas limit to 240m gas. |
 | Block gas target | 18,000,000 gas | 40,000,000 gas (per L1 block) | Assuming an L2 block time of ~3 seconds will have a ~15,000,000 gas target.                                                                                                                                      |
-| Block time       | 12 seconds     | 12-20~ seconds                | This value is variable and will change as of based preconfirmations.                                                                                                                                             |
+| Block time       | 12 seconds     | ~12–20 seconds                | This value is variable and will change as of based preconfirmations.                                                                                                                                             |
 
 ## Geth Diff
 

--- a/packages/docs-site/src/content/docs/network-reference/network-configuration.mdx
+++ b/packages/docs-site/src/content/docs/network-reference/network-configuration.mdx
@@ -9,7 +9,7 @@ import {Aside} from '@astrojs/starlight/components';
 
 This segment lists the cooldown windows and proving windows in Taiko Alethia.
 
-The cooldown window describes how long after the proof has been provided that the block is verified.
+The cooldown window describes how long after the proof has been provided the block is verified.
 
 The proving window describes how long a prover has to provide a proof for a block after they have been assigned the block (i.e. a block has been proposed with them as the assigned prover).
 

--- a/packages/docs-site/src/content/docs/network-reference/rpc-configuration.mdx
+++ b/packages/docs-site/src/content/docs/network-reference/rpc-configuration.mdx
@@ -17,7 +17,7 @@ Below are the RPCs maintained by Taiko Labs. You can find additional RPCs at [ch
 | Name               | Value                                                           |
 | ------------------ | --------------------------------------------------------------- |
 | Chain ID           | 17000                                                           |
-| RPC                | See Holesky chainlist [here](https://chainlist.org/chain/17000) |
+| RPC                | See Holesky Chainlist [here](https://chainlist.org/chain/17000) |
 | Symbol             | ETH                                                             |
 | Block explorer URL | https://holesky.etherscan.io                                    |
 


### PR DESCRIPTION
went through the network reference docs and fixed a few small mistakes:

* **packages/docs-site/src/content/docs/network-reference/contract-addresses.mdx**
  removed the extra *the* in “You can find the all L1 and L2…”

* **packages/docs-site/src/content/docs/network-reference/differences-from-ethereum.md**
  updated block time phrasing to “\~12–20 seconds” for consistency

* **packages/docs-site/src/content/docs/network-reference/network-configuration.mdx**
  removed redundant *that* in the cooldown window description

* **packages/docs-site/src/content/docs/network-reference/rpc-configuration.mdx**
  corrected capitalization of *Chainlist*

these are minor text fixes to improve clarity and consistency in the docs.
