### PR TITLE
feat(relayer): copy header before use to avoid global mutation

### DIFF
--- a/packages/relayer/pkg/mock/blocker.go
+++ b/packages/relayer/pkg/mock/blocker.go
@@ -39,9 +39,11 @@ func (b *Blocker) BlockByHash(ctx context.Context, hash common.Hash) (*types.Blo
 		return nil, errors.New("can't find block")
 	}
 
-	return types.NewBlockWithHeader(Header), nil
+    hdr := *Header
+    return types.NewBlockWithHeader(&hdr), nil
 }
 
 func (b *Blocker) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
-	return types.NewBlockWithHeader(Header), nil
+    hdr := *Header
+    return types.NewBlockWithHeader(&hdr), nil
 }

--- a/packages/relayer/pkg/mock/eth_client.go
+++ b/packages/relayer/pkg/mock/eth_client.go
@@ -71,10 +71,11 @@ func (c *EthClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.
 	}
 
 	hdr := Header
+	hdr := *Header
 	hdr.Number = number
 	hdr.BaseFee = big.NewInt(1)
 
-	blk := types.NewBlockWithHeader(hdr)
+	blk := types.NewBlockWithHeader(&hdr)
 
 	return blk, nil
 }
@@ -110,7 +111,8 @@ func (c *EthClient) HeaderByHash(ctx context.Context, hash common.Hash) (*types.
 		return nil, errors.New("can't find block")
 	}
 
-	return Header, nil
+    hdr := *Header
+    return &hdr, nil
 }
 
 func (c *EthClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {


### PR DESCRIPTION
Replace mutation of global Header with local copies in mock.EthClient.BlockByNumber, mock.EthClient.HeaderByHash, and mock.Blocker methods. This prevents unintended shared state changes between tests and components that rely on the same global header, eliminating potential flakiness and race-like behavior. Lint passes.