### PR TITLE
feat(protocol): make verifiers non upgradable

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/verifiers/ShastaRisc0Verifier.sol
+++ b/packages/protocol/contracts/layer1/shasta/verifiers/ShastaRisc0Verifier.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.24;
 
 import "@risc0/contracts/IRiscZeroVerifier.sol";
-import "src/shared/common/EssentialContract.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "src/shared/libs/LibNames.sol";
 import "./LibPublicInput.sol";
 import "../iface/IProofVerifier.sol";
 
 /// @title ShastaRisc0Verifier
 /// @custom:security-contact security@taiko.xyz
-contract ShastaRisc0Verifier is EssentialContract, IProofVerifier {
+contract ShastaRisc0Verifier is IProofVerifier, Ownable {
     bytes32 internal constant RISCZERO_GROTH16_VERIFIER = bytes32("risc0_groth16_verifier");
 
     // [32, 0, 0, 0] -- big-endian uint32(32) for hash bytes len
@@ -31,17 +31,13 @@ contract ShastaRisc0Verifier is EssentialContract, IProofVerifier {
     error RISC_ZERO_INVALID_AGGREGATION_IMAGE_ID();
     error RISC_ZERO_INVALID_PROOF();
 
-    constructor(uint64 _taikoChainId, address _riscoGroth16Verifier) {
+    constructor(uint64 _taikoChainId, address _riscoGroth16Verifier, address _owner) {
         require(_taikoChainId != 0, "Invalid chain id");
         require(_riscoGroth16Verifier != address(0), "Invalid risc0 groth16 verifier");
         taikoChainId = _taikoChainId;
         riscoGroth16Verifier = _riscoGroth16Verifier;
-    }
-
-    /// @notice Initializes the contract with the provided address manager.
-    /// @param _owner The address of the owner.
-    function init(address _owner) external initializer {
-        __Essential_init(_owner);
+        
+        _transferOwnership(_owner);
     }
 
     /// @notice Sets/unsets an the imageId as trusted entity

--- a/packages/protocol/contracts/layer1/shasta/verifiers/ShastaRisc0Verifier.sol
+++ b/packages/protocol/contracts/layer1/shasta/verifiers/ShastaRisc0Verifier.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.24;
 
 import "@risc0/contracts/IRiscZeroVerifier.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import "src/shared/libs/LibNames.sol";
 import "./LibPublicInput.sol";
 import "../iface/IProofVerifier.sol";
 
 /// @title ShastaRisc0Verifier
 /// @custom:security-contact security@taiko.xyz
-contract ShastaRisc0Verifier is IProofVerifier, Ownable {
+contract ShastaRisc0Verifier is IProofVerifier, Ownable2Step {
     bytes32 internal constant RISCZERO_GROTH16_VERIFIER = bytes32("risc0_groth16_verifier");
 
     // [32, 0, 0, 0] -- big-endian uint32(32) for hash bytes len

--- a/packages/protocol/contracts/layer1/shasta/verifiers/ShastaRisc0Verifier.sol
+++ b/packages/protocol/contracts/layer1/shasta/verifiers/ShastaRisc0Verifier.sol
@@ -36,7 +36,7 @@ contract ShastaRisc0Verifier is IProofVerifier, Ownable {
         require(_riscoGroth16Verifier != address(0), "Invalid risc0 groth16 verifier");
         taikoChainId = _taikoChainId;
         riscoGroth16Verifier = _riscoGroth16Verifier;
-        
+
         _transferOwnership(_owner);
     }
 

--- a/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSP1Verifier.sol
+++ b/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSP1Verifier.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.24;
 
 import "@sp1-contracts/src/ISP1Verifier.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import "src/shared/libs/LibNames.sol";
 import "./LibPublicInput.sol";
 import "../iface/IProofVerifier.sol";
 
 /// @title ShastaSP1Verifier
 /// @custom:security-contact security@taiko.xyz
-contract ShastaSP1Verifier is IProofVerifier, Ownable {
+contract ShastaSP1Verifier is IProofVerifier, Ownable2Step {
     bytes32 internal constant SP1_REMOTE_VERIFIER = bytes32("sp1_remote_verifier");
 
     uint64 public immutable taikoChainId;

--- a/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSP1Verifier.sol
+++ b/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSP1Verifier.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.24;
 
 import "@sp1-contracts/src/ISP1Verifier.sol";
-import "src/shared/common/EssentialContract.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "src/shared/libs/LibNames.sol";
 import "./LibPublicInput.sol";
 import "../iface/IProofVerifier.sol";
 
 /// @title ShastaSP1Verifier
 /// @custom:security-contact security@taiko.xyz
-contract ShastaSP1Verifier is EssentialContract, IProofVerifier {
+contract ShastaSP1Verifier is IProofVerifier, Ownable {
     bytes32 internal constant SP1_REMOTE_VERIFIER = bytes32("sp1_remote_verifier");
 
     uint64 public immutable taikoChainId;
@@ -30,15 +30,11 @@ contract ShastaSP1Verifier is EssentialContract, IProofVerifier {
     error SP1_INVALID_PARAMS();
     error SP1_INVALID_PROOF();
 
-    constructor(uint64 _taikoChainId, address _sp1RemoteVerifier) {
+    constructor(uint64 _taikoChainId, address _sp1RemoteVerifier, address _owner) {
         taikoChainId = _taikoChainId;
         sp1RemoteVerifier = _sp1RemoteVerifier;
-    }
 
-    /// @notice Initializes the contract with the provided address manager.
-    /// @param _owner The address of the owner.
-    function init(address _owner) external initializer {
-        __Essential_init(_owner);
+        _transferOwnership(_owner);
     }
 
     /// @notice Sets/unsets an the program's verification key as trusted entity

--- a/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSgxVerifier.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "src/shared/common/EssentialContract.sol";
 import "src/shared/libs/LibNames.sol";
 import "src/layer1/automata-attestation/interfaces/IAttestation.sol";
 import "src/layer1/automata-attestation/lib/QuoteV3Auth/V3Struct.sol";
@@ -16,7 +16,7 @@ import "../iface/IProofVerifier.sol";
 /// - Reference #1: https://ethresear.ch/t/2fa-zk-rollups-using-sgx/14462
 /// - Reference #2: https://github.com/gramineproject/gramine/discussions/1579
 /// @custom:security-contact security@taiko.xyz
-contract ShastaSgxVerifier is EssentialContract, IProofVerifier {
+contract ShastaSgxVerifier is IProofVerifier, Ownable {
     /// @dev Each public-private key pair (Ethereum address) is generated within
     /// the SGX program when it boots up. The off-chain remote attestation
     /// ensures the validity of the program hash and has the capability of
@@ -80,15 +80,11 @@ contract ShastaSgxVerifier is EssentialContract, IProofVerifier {
     error SGX_INVALID_INSTANCE();
     error SGX_INVALID_PROOF();
 
-    constructor(uint64 _taikoChainId) {
+    constructor(uint64 _taikoChainId, address _owner) {
         require(_taikoChainId != 0, "Invalid chain id");
         taikoChainId = _taikoChainId;
-    }
-
-    /// @notice Initializes the contract.
-    /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
-    function init(address _owner) external initializer {
-        __Essential_init(_owner);
+        
+        _transferOwnership(_owner);
     }
 
     /// @notice Adds trusted SGX instances to the registry.

--- a/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSgxVerifier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "src/shared/libs/LibNames.sol";
 import "src/layer1/automata-attestation/interfaces/IAttestation.sol";
@@ -16,7 +16,7 @@ import "../iface/IProofVerifier.sol";
 /// - Reference #1: https://ethresear.ch/t/2fa-zk-rollups-using-sgx/14462
 /// - Reference #2: https://github.com/gramineproject/gramine/discussions/1579
 /// @custom:security-contact security@taiko.xyz
-contract ShastaSgxVerifier is IProofVerifier, Ownable {
+contract ShastaSgxVerifier is IProofVerifier, Ownable2Step {
     /// @dev Each public-private key pair (Ethereum address) is generated within
     /// the SGX program when it boots up. The off-chain remote attestation
     /// ensures the validity of the program hash and has the capability of

--- a/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/shasta/verifiers/ShastaSgxVerifier.sol
@@ -83,7 +83,7 @@ contract ShastaSgxVerifier is IProofVerifier, Ownable {
     constructor(uint64 _taikoChainId, address _owner) {
         require(_taikoChainId != 0, "Invalid chain id");
         taikoChainId = _taikoChainId;
-        
+
         _transferOwnership(_owner);
     }
 


### PR DESCRIPTION
A possible solution to [this comment](https://github.com/taikoxyz/taiko-mono/pull/20200#discussion_r2365002316).

Verifiers still hold state, but are non upgradable. This allows:
- Less proxy overhead
- Proving system can be upgraded with backwards compatibility(two programs can be set as trusted until all provers migrate)
- If the verifier needs to be changed, a new one can be deployed and the inbox can point to that one