### PR TITLE
chore(protocol): remove unused TT_INVALID_PARAM error from TaikoToken.sol

### DIFF
--- a/packages/protocol/contracts/layer1/token/TaikoToken.sol
+++ b/packages/protocol/contracts/layer1/token/TaikoToken.sol
@@ -18,7 +18,6 @@ contract TaikoToken is TaikoTokenBase {
     // v20.based.taiko.eth
     address public constant TAIKO_ERC20_VAULT = 0x996282cA11E5DEb6B5D122CC3B9A1FcAAD4415Ab;
 
-    error TT_INVALID_PARAM();
     error TT_NON_VOTING_ACCOUNT();
 
     /// @notice Initializes the contract.


### PR DESCRIPTION
The TT_INVALID_PARAM() custom error in TaikoToken.sol was never referenced anywhere in the contract or the wider codebase for the canonical token. Removing it is safe because it does not affect any functions, storage layout, or behavior. Similar errors remain in other contracts (e.g., HeklaTaikoToken.sol) where they are actually used, so this change preserves intended functionality while reducing dead code.