### PR TITLE
chore(protocol): clarify forced-inclusion numTransactions policy in TaikoWrapper

### DIFF
--- a/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/TaikoWrapper.sol
@@ -125,10 +125,9 @@ contract TaikoWrapper is EssentialContract, IProposeBatch {
         require(p.blocks.length == 1, InvalidBlockSize());
         require(p.isForcedInclusion, ITaikoInbox.InvalidForcedInclusion());
 
-        // Ensure that msg.sender does not throttle transactions in the inclusion by setting a small
-        // `numTransactions` parameter value. The `numTransactions` is set to its maximum possible
-        // value, allowing the actual number of transactions in the block to be determined by the
-        // gas used and the transactions contained within the blobs.
+        // Ensure the proposer uses a bounded `numTransactions` value to prevent unbounded blocks
+        // and throttling games. Setting it to `uint16.max` is disallowed; the proposer must supply
+        // an appropriate cap per policy.
         require(p.blocks[0].numTransactions != type(uint16).max, InvalidBlockTxs());
 
         require(p.blocks[0].timeShift == 0, InvalidTimeShift());


### PR DESCRIPTION
Update comment to state that numTransactions must not be uint16.max and should be a bounded value provided by the proposer per policy. This reflects actual behavior in the proposer (uses a finite cap derived from policy) and prevents confusion from the previous, outdated wording.