### PR TITLE
ci(protocol): improve claude workflow

### DIFF
--- a/.github/workflows/repo--claude.yml
+++ b/.github/workflows/repo--claude.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # account for forked repos case
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          # SECURITY: Pin to exact commit at comment time to prevent TOCTOU attacks
+          ref: ${{ steps.comment-branch.outputs.head_sha }}
           repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
           # Fetch more history for better git operations
           fetch-depth: 0
@@ -53,7 +53,7 @@ jobs:
           # Allow Claude to run specific commands
           allowed_tools: |
             mcp__github__create_pull_request
-            Bash(pnpm install)
+            Bash(pnpm install --ignore-scripts)
             Bash(pnpm test:*)
             Bash(pnpm fmt:sol)
             Bash(pnpm snapshot:*)
@@ -69,7 +69,7 @@ jobs:
           # Add custom instructions for Claude to customize its behavior for your project
           custom_instructions: |
             For protocol(smart contract) changes always start in the `packages/protocol` directory.
-            You MUST run `pnpm install` first.
+            You MUST run `pnpm install --ignore-scripts` first for security (prevents malicious lifecycle scripts).
             You MUST follow the development workflow described in CLAUDE.md.
             You MUST make sure the tests are passing before creating a pull request.
             You MUST open a draft pull request after creating a branch.


### PR DESCRIPTION
Address this feedback:

> Dear Taiko,
https://github.com/taikoxyz/taiko-mono/blob/main/.github%2Fworkflows%2Frepo--claude.yml is vulnerable to Remote Code ExecutionW
While Claude Code will only run when a collaborator comments, it has been provided the instruction You MUST run `pnpm install` first.. While this wouldn’t seem like an issue, since an authorized user told it to do so, there is no verification that the PR is safe.
Between the time-of-comment, and time-of-execution, the PR could have changed. In the above step, https://github.com/taikoxyz/taiko-mono/blob/main/.github%2Fworkflows%2Frepo--claude.yml#L25, when the PR is checked-out, it may have had malicious content pushed after the comment. So, pnpm install could run malicious lifecycle scripts, leading to RCE.