### PR TITLE
docs(protocol): correct recallMessage comment to reflect dest-chain failure and source-chain recall

### DIFF
--- a/packages/protocol/contracts/shared/bridge/IBridge.sol
+++ b/packages/protocol/contracts/shared/bridge/IBridge.sol
@@ -81,10 +81,11 @@ interface IBridge {
         payable
         returns (bytes32 msgHash_, Message memory message_);
 
-    /// @notice Recalls a failed message on its source chain, releasing
-    /// associated assets.
-    /// @dev This function checks if the message failed on the source chain and
-    /// releases associated Ether or tokens.
+    /// @notice Recalls a message on its source chain after it has failed on the
+    /// destination chain, releasing associated assets on the source chain.
+    /// @dev Verifies via proof that the message was marked FAILED on the
+    /// destination chain's Bridge, then releases the associated Ether or tokens
+    /// on the source chain.
     /// @param _message The message whose associated Ether should be released.
     /// @param _proof The merkle inclusion proof.
     function recallMessage(Message calldata _message, bytes calldata _proof) external;


### PR DESCRIPTION
- The previous comment incorrectly stated that failure is checked on the source chain. In reality, the message fails on the destination chain, and recallMessage is executed on the source chain using a proof that the destination marked the message as FAILED.
- This change aligns the interface docs with the implementation in Bridge.sol, existing tests, and the bridge README, preventing confusion for integrators and auditors.