### PR TITLE
refactor(protocol): rename DevnetShastaInbox to ShastaDevnetInbox

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/impl/ShastaDevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/ShastaDevnetInbox.sol
@@ -5,11 +5,11 @@ import { InboxOptimized2 } from "./InboxOptimized2.sol";
 import { IInbox } from "../iface/IInbox.sol";
 import { LibFasterReentryLock } from "../../mainnet/libs/LibFasterReentryLock.sol";
 
-/// @title DevnetShastaInbox
+/// @title ShastaDevnetInbox
 /// @dev This contract extends the base Inbox contract for devnet deployment
 /// with optimized reentrancy lock implementation.
 /// @custom:security-contact security@taiko.xyz
-contract DevnetShastaInbox is InboxOptimized2 {
+contract ShastaDevnetInbox is InboxOptimized2 {
     // ---------------------------------------------------------------
     // Constants
     // ---------------------------------------------------------------

--- a/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
@@ -35,7 +35,7 @@ import "src/layer1/verifiers/TaikoSgxVerifier.sol";
 import "src/layer1/verifiers/compose/ComposeVerifier.sol";
 import "src/layer1/devnet/verifiers/DevnetVerifier.sol";
 import { Inbox } from "src/layer1/shasta/impl/Inbox.sol";
-import { DevnetShastaInbox } from "src/layer1/shasta/impl/DevnetShastaInbox.sol";
+import { ShastaDevnetInbox } from "src/layer1/shasta/impl/ShastaDevnetInbox.sol";
 import { InboxHelper } from "src/layer1/shasta/impl/InboxHelper.sol";
 import "test/shared/helpers/FreeMintERC20Token.sol";
 import "test/shared/helpers/FreeMintERC20Token_With50PctgMintAndTransferFailure.sol";
@@ -316,7 +316,7 @@ contract DeployProtocolOnL1 is DeployCapability {
         }
         address helper = address(new InboxHelper());
         address tempFork =
-            address(new DevnetShastaInbox(proofVerifier, whitelist, bondToken, helper));
+            address(new ShastaDevnetInbox(proofVerifier, whitelist, bondToken, helper));
         taikoInboxAddr = deployProxy({
             name: "taiko",
             impl: address(new ShastaForkRouter(oldFork, tempFork)),
@@ -324,7 +324,7 @@ contract DeployProtocolOnL1 is DeployCapability {
         });
 
         address newFork =
-            address(new DevnetShastaInbox(proofVerifier, whitelist, bondToken, helper));
+            address(new ShastaDevnetInbox(proofVerifier, whitelist, bondToken, helper));
 
         console2.log("  oldFork       :", oldFork);
         console2.log("  newFork       :", newFork);


### PR DESCRIPTION
## Summary
- Renamed `DevnetShastaInbox` to `ShastaDevnetInbox` for better naming consistency
- Updated contract name and documentation comments
- Updated all import statements and constructor calls in deployment script

## Test plan
- [ ] Verify contract compilation succeeds
- [ ] Ensure deployment script works with renamed contract
- [ ] Run protocol tests to verify no breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)