### PR TITLE
fix(protocol): correct LibEIP1559.basefee argument order in TestLibEIP1559

### DIFF
--- a/packages/protocol/test/layer2/based/libs/LibEIP1559.t.sol
+++ b/packages/protocol/test/layer2/based/libs/LibEIP1559.t.sol
@@ -54,7 +54,7 @@ contract TestLibEIP1559 is Layer2Test {
         uint256 basefee = LibEIP1559.basefee(target * 2, excess) / unit;
         console2.log("basefee will decrease if target increases:", basefee);
 
-        basefee = LibEIP1559.basefee(excess, target / 2) / unit;
+        basefee = LibEIP1559.basefee(target / 2, excess) / unit;
         console2.log("basefee will increase if target decreases:", basefee);
 
         console2.log("maintain basefee when target increases");


### PR DESCRIPTION
Problem: In TestLibEIP1559.test_change_of_quotient_and_gasIssuancePerSecond the call to basefee used swapped arguments (excess, target/2), violating the expected (target, excess) signature and contradicting the log intention (“basefee will increase if target decreases”).
Solution: Pass the correct order (target / 2, excess) so the test accurately measures the effect of decreasing the gas target while keeping excess constant. No changes to the library logic or other tests.