### PR TITLE
ci(repo): replace Hekla testnet deployment with Hoodi testnet

### DIFF
--- a/.github/workflows/bridge-ui.yml
+++ b/.github/workflows/bridge-ui.yml
@@ -39,8 +39,8 @@ jobs:
   #     vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
   #     vercel_token: ${{ secrets.VERCEL_TOKEN }}
 
-  # Hekla testnet
-  deploy_bridge-ui_hekla_preview:
+  # Hoodi testnet
+  deploy_bridge-ui_hoodi_preview:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
@@ -48,11 +48,11 @@ jobs:
       environment: "preview"
       flags: ""
     secrets:
-      vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_BRIDGE_UI_HEKLA }}
+      vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_BRIDGE_UI_HOODI }}
       vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
       vercel_token: ${{ secrets.VERCEL_TOKEN }}
 
-  deploy_bridge-ui_hekla_production:
+  deploy_bridge-ui_hoodi_production:
     if: ${{ startsWith(github.ref, 'refs/tags/bridge-ui-v') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
@@ -60,7 +60,7 @@ jobs:
       environment: "production"
       flags: "--prod"
     secrets:
-      vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_BRIDGE_UI_HEKLA }}
+      vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_BRIDGE_UI_HOODI }}
       vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
       vercel_token: ${{ secrets.VERCEL_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Replace Hekla testnet deployment configuration with Hoodi testnet
- Update job names from `deploy_bridge-ui_hekla_*` to `deploy_bridge-ui_hoodi_*`
- Replace `VERCEL_PROJECT_ID_BRIDGE_UI_HEKLA` with `VERCEL_PROJECT_ID_BRIDGE_UI_HOODI`

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm that `VERCEL_PROJECT_ID_BRIDGE_UI_HOODI` secret is configured in GitHub repository settings
- [ ] Test preview deployment on PR creation
- [ ] Test production deployment on bridge-ui version tag

🤖 Generated with [Claude Code](https://claude.ai/code)