### PR TITLE
chore(protocol): remove unused BlockParams temp array in anchorBlockId parent test

### DIFF
--- a/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_Params.t.sol
@@ -60,13 +60,6 @@ contract InboxTest_Params is InboxTestBase {
         _proposeBatchesWithDefaultParameters(1);
         ITaikoInbox.Batch memory parent = inbox.v4GetBatch(1);
 
-        ITaikoInbox.BlockParams[] memory blocks = new ITaikoInbox.BlockParams[](1);
-        blocks[0] = ITaikoInbox.BlockParams({
-            numTransactions: 0,
-            timeShift: 0,
-            signalSlots: new bytes32[](0)
-        });
-
         ITaikoInbox.BatchParams memory params;
         params.blocks = new ITaikoInbox.BlockParams[](1);
         params.anchorBlockId = parent.anchorBlockId - 1;


### PR DESCRIPTION
Remove dead code in InboxTest_Params.t.sol: a temporary ITaikoInbox.BlockParams[] blocks was created and populated but never assigned to params.blocks.
The test only validates AnchorBlockIdSmallerThanParent; it doesn’t rely on the contents of blocks.
