### PR TITLE
fix(protocol): enforce non-zero ringBufferSize in constructor

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/shasta/impl/Inbox.sol
@@ -144,6 +144,7 @@ contract Inbox is IInbox, IForcedInclusionStore, ICheckpointStore, EssentialCont
     /// @param _config Configuration struct containing all constructor parameters
     constructor(IInbox.Config memory _config) {
         require(_config.maxCheckpointHistory != 0, LibCheckpointStore.InvalidMaxCheckpointHistory());
+        require(_config.ringBufferSize != 0, RingBufferSizeZero());
         _bondToken = IERC20(_config.bondToken);
         _proofVerifier = IProofVerifier(_config.proofVerifier);
         _proposerChecker = IProposerChecker(_config.proposerChecker);


### PR DESCRIPTION
Adds a constructor guard to require ringBufferSize != 0 using the existing RingBufferSizeZero error.

Reason for the change:

- The contract performs modulo operations with ringBufferSize (e.g., computing ring buffer slots). If ringBufferSize is 0 due to misconfiguration, these paths would revert at runtime with division-by-zero.
- Production/devnet configs already set a positive ringBufferSize; this change hardens deployment safety without altering intended behavior.
- Reuses the already-declared RingBufferSizeZero error for clear signaling.