### PR TITLE
fix CORS middleware: avoid premature 200 and handle OPTIONS

### DIFF
--- a/packages/geth-rpc-gateway/main.go
+++ b/packages/geth-rpc-gateway/main.go
@@ -94,10 +94,16 @@ func enableCORS(next http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin") // Ensure caching based on origin
 		}
 
-		w.Header().Set("Access-Control-Allow-Methods", r.Method)
+		// Allow common methods; do not mirror request method.
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		w.WriteHeader(http.StatusOK)
+		// Handle CORS preflight early to avoid committing headers for non-OPTIONS.
+		if r.Method == http.MethodOptions {
+			// No body for preflight responses
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION


- Description:
  - This PR fixes a CORS middleware issue that prematurely sent 200 OK before passing control to the next handler, potentially masking upstream errors.
  - Adds explicit handling for CORS preflight (OPTIONS) with 204 No Content.
  - Sets Access-Control-Allow-Methods to a safe, fixed list ("GET, POST, OPTIONS") instead of mirroring the request method.

- Why:
  - Prevents incorrect 200 responses when upstream returns errors.
  - Ensures standards-compliant CORS behavior for preflight requests.

- Impact:
  - More accurate HTTP status codes and headers in proxied responses.
  - No breaking changes expected for consumers.
