### PR TITLE
fix(protocol): set ETHEREUM_ROPSTEN chain ID to 3 in LibNetwork

### DIFF
--- a/packages/protocol/contracts/shared/libs/LibNetwork.sol
+++ b/packages/protocol/contracts/shared/libs/LibNetwork.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 /// @title LibNetwork
 library LibNetwork {
     uint256 internal constant ETHEREUM_MAINNET = 1;
-    uint256 internal constant ETHEREUM_ROPSTEN = 2;
+    uint256 internal constant ETHEREUM_ROPSTEN = 3;
     uint256 internal constant ETHEREUM_RINKEBY = 4;
     uint256 internal constant ETHEREUM_GOERLI = 5;
     uint256 internal constant ETHEREUM_KOVAN = 42;


### PR DESCRIPTION
Correct the ETHEREUM_ROPSTEN constant from 2 to 3 to match the official Ethereum chain ID specification.
This prevents incorrect environment classification in helper methods like isEthereumTestnet and maintains consistency with external standards (e.g., chainid.network).
Although Ropsten is deprecated, its chain ID must remain accurate for legacy/compatibility checks.