### PR TITLE
ci(protocol): update CI workflow to update and commit gas snapshots

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -62,14 +62,15 @@ jobs:
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies
 
-      - name: Prepare gas-reports and layout directories for CI
+      - name: Prepare generated artifacts directories for CI
         working-directory: ./packages/protocol
         run: |
           # Ensure directories exist and are writable in CI
-          mkdir -p gas-reports layout
+          mkdir -p gas-reports layout snapshots
           # Reset skip-worktree flags that might exist from local dev
           git ls-files gas-reports/ | xargs -r git update-index --no-skip-worktree || true
           git ls-files layout/ | xargs -r git update-index --no-skip-worktree || true
+          git ls-files snapshots/ | xargs -r git update-index --no-skip-worktree || true
           # Configure merge strategy for auto-generated files
           git config merge.ours.driver true
 
@@ -90,6 +91,7 @@ jobs:
         working-directory: ./packages/protocol
         run: pnpm compile:shared && pnpm compile:l1 && pnpm snapshot:l1 && pnpm layout:l1
 
+
       - name: Check for changes
         id: git_status
         run: |
@@ -100,11 +102,11 @@ jobs:
             echo "changes=false" >> $GITHUB_ENV
           fi
 
-      - name: Commit contract layout table
+      - name: Commit generated protocol artifacts
         if: env.changes == 'true' && github.event.pull_request.head.repo.fork == false
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
-          commit_message: "forge fmt & update contract layout tables"
+          commit_message: "Update protocol generated artifacts"
           branch: ${{ github.head_ref }}
           push_options: "--force-with-lease"
 


### PR DESCRIPTION
For shasta our main way of measuring gas snapshots are the json files that are generated with `vm.startSnapshotGas`, but the problem is that they may not get updated by whoever is creating the PR.

This PR makes it such that they are also committed similar to the other files that the CI checks