### PR TITLE
docs(taiko-client): fix incorrect function documentation for EncodeAndCompressShast…

### DIFF
--- a/packages/taiko-client/pkg/utils/utils.go
+++ b/packages/taiko-client/pkg/utils/utils.go
@@ -89,7 +89,7 @@ func EncodeAndCompressTxList(txs types.Transactions) ([]byte, error) {
 	return compressed, nil
 }
 
-// EncodeAndCompressTxList encodes and compresses the given transactions list using RLP encoding
+// EncodeAndCompressShastaProposal encodes and compresses the given Shasta proposal using RLP encoding
 // followed by zlib compression.
 func EncodeAndCompressShastaProposal(proposal manifest.ProtocolProposalManifest) ([]byte, error) {
 	b, err := rlp.EncodeToBytes(proposal)


### PR DESCRIPTION
Fix copy-paste error in function comment where EncodeAndCompressShastaProposal 
was incorrectly documented as encoding transactions instead of Shasta proposals.

The function works with manifest.ProtocolProposalManifest, not types.Transactions.