### PR TITLE
chore(protocol): remove unused BTOKEN_INVALID_PARAMS error

### DIFF
--- a/packages/protocol/contracts/shared/tokenvault/BridgedERC721.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BridgedERC721.sol
@@ -26,7 +26,6 @@ contract BridgedERC721 is
 
     uint256[48] private __gap;
 
-    error BTOKEN_INVALID_PARAMS();
     error BTOKEN_INVALID_BURN();
 
     constructor(address _erc721Vault) {


### PR DESCRIPTION
The error is never reverted in BridgedERC721. Parameter validation is delegated to LibBridgedToken.validateInputs, which already reverts with BTOKEN_INVALID_PARAMS. Keeping a duplicate, unused error in the contract confuses ABI consumers and bloats the ABI. Removing it aligns ERC721 with the ERC1155/Lib patterns where only the throwing scope declares the error.