### PR TITLE
fix(protocol): fix recall context check to validate source vault address

### DIFF
--- a/packages/protocol/contracts/shared/tokenvault/BaseVault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BaseVault.sol
@@ -72,7 +72,7 @@ abstract contract BaseVault is
         returns (IBridge.Context memory ctx_)
     {
         ctx_ = IBridge(msg.sender).context();
-        address selfOnSourceChain = resolve(ctx_.srcChainId, name(), false);
+        address selfOnSourceChain = resolve(ctx_.srcChainId, name(), LibNames.B_BRIDGE);
         if (ctx_.from != selfOnSourceChain) revert VAULT_PERMISSION_DENIED();
     }
 

--- a/packages/protocol/contracts/shared/tokenvault/BaseVault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BaseVault.sol
@@ -50,6 +50,8 @@ abstract contract BaseVault is
     /// @return The name of the vault.
     function name() public pure virtual returns (bytes32);
 
+    /// @dev Ensures the message was sent by this vault on the source chain via Bridge.
+    /// Resolves this vault's address on the source chain and compares with ctx.from.
     function checkProcessMessageContext()
         internal
         view
@@ -61,6 +63,8 @@ abstract contract BaseVault is
         if (ctx_.from != selfOnSourceChain) revert VAULT_PERMISSION_DENIED();
     }
 
+    /// @dev Ensures the recall message was initiated by this vault on the source chain via Bridge.
+    /// Resolves this vault's address on the source chain and compares with ctx.from.
     function checkRecallMessageContext()
         internal
         view
@@ -68,7 +72,8 @@ abstract contract BaseVault is
         returns (IBridge.Context memory ctx_)
     {
         ctx_ = IBridge(msg.sender).context();
-        if (ctx_.from != msg.sender) revert VAULT_PERMISSION_DENIED();
+        address selfOnSourceChain = resolve(ctx_.srcChainId, name(), false);
+        if (ctx_.from != selfOnSourceChain) revert VAULT_PERMISSION_DENIED();
     }
 
     function checkToAddressOnDestChain(address _to) internal view {


### PR DESCRIPTION

- Summary: Corrects checkRecallMessageContext to validate that ctx.from equals this vault’s resolved address on the source chain. Aligns with checkProcessMessageContext. Adds brief @dev docs.
- Motivation: Previously compared ctx.from with msg.sender (bridge on dest chain), causing unintended reverts and blocking recalls.
- Changes:
  - Replace comparison with resolve(ctx.srcChainId, name(), false) in BaseVault.sol
  - Add @dev comments to both context-check helpers
- Impact: Affects recall flows in ERC20/721/1155 vaults; restores intended behavior.
