### PR TITLE
 feat(protocol): record lastAnchorGasUsed during basefee verification

### DIFF
--- a/packages/protocol/contracts/layer2/based/PacayaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/PacayaAnchor.sol
@@ -285,6 +285,9 @@ abstract contract PacayaAnchor is OntakeAnchor {
 
         emit EIP1559Update(parentGasTarget, newGasTarget, parentGasExcess, newGasExcess, basefee);
 
+        // Record telemetry for the last observed parent gas used value.
+        lastAnchorGasUsed = _parentGasUsed;
+
         parentGasTarget = newGasTarget;
         parentGasExcess = newGasExcess;
     }


### PR DESCRIPTION
Set lastAnchorGasUsed = parentGasUsed in _verifyBaseFeeAndUpdateGasExcess after successful basefee verification and event emission. This field was previously exposed in storage/ABI and client bindings but never updated, making it effectively dead state. Recording the value provides useful telemetry, removes ambiguity for integrators, and preserves full ABI/storage compatibility without changing protocol logic or invariants.