### PR TITLE
Add HTTP client timeout in proof producer to prevent hanging requests

### DIFF
--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -98,7 +98,10 @@ func requestHTTPProofResponse[T any](
 	apiKey string,
 	reqBody T,
 ) (*http.Response, error) {
-	client := &http.Client{}
+	// Set a client timeout to avoid hanging requests in case of network stalls
+    client := &http.Client{
+        Timeout: 30 * time.Second,
+    }
 
 	jsonValue, err := json.Marshal(reqBody)
 	if err != nil {


### PR DESCRIPTION


### PR Description
- Introduces a 30s `http.Client` timeout in `requestHTTPProofResponse` to avoid indefinitely hanging requests during network stalls.
- Keeps context cancellation semantics intact; the shorter of context deadline vs client timeout will apply.

#### Why
- Without a timeout, network issues can cause goroutines to hang, degrading service reliability and throughput.

#### What changed
- `packages/taiko-client/prover/proof_producer/common.go`:
  - Initialize `http.Client{ Timeout: 30 * time.Second }`
 

