### PR TITLE
docs(protocol): more important updates to the derivation doc

### DIFF
--- a/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
@@ -84,7 +84,7 @@ library LibManifest {
     /// @notice Represents a derivation source manifest containing blocks for one source
     /// @dev Each proposal can have multiple DerivationSourceManifests (one per DerivationSource).
     /// If a DerivationSourceManifest is invalid, it is replaced with a default manifest
-    /// (single empty block), but the entire proposal is NOT invalidated. This design prevents
+    /// (single block with only an anchor transaction), but the entire proposal is NOT invalidated. This design prevents
     /// censorship of forced inclusions: a malicious proposer cannot invalidate their entire
     /// proposal (including valid forced inclusions) by including bad data in one source.
     ///

--- a/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
@@ -84,7 +84,8 @@ library LibManifest {
     /// @notice Represents a derivation source manifest containing blocks for one source
     /// @dev Each proposal can have multiple DerivationSourceManifests (one per DerivationSource).
     /// If a DerivationSourceManifest is invalid, it is replaced with a default manifest
-    /// (single block with only an anchor transaction), but the entire proposal is NOT invalidated. This design prevents
+    /// (single block with only an anchor transaction), but the entire proposal is NOT invalidated.
+    /// This design prevents
     /// censorship of forced inclusions: a malicious proposer cannot invalidate their entire
     /// proposal (including valid forced inclusions) by including bad data in one source.
     ///

--- a/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
@@ -70,14 +70,29 @@ library LibManifest {
         SignedTransaction[] transactions;
     }
 
-    /// @notice Represents a derivation source manifest
+    /// @notice Represents a proposal manifest containing proposal-level metadata and all sources
+    /// @dev The ProposalManifest aggregates all DerivationSources' blob data for a proposal.
+    /// The proverAuthBytes is proposal-level (one designated prover per proposal), while the
+    /// sources array contains per-source block data.
+    struct ProposalManifest {
+        /// @notice Prover authentication data (proposal-level, shared across all sources).
+        bytes proverAuthBytes;
+        /// @notice Array of derivation source manifests (one per DerivationSource).
+        DerivationSourceManifest[] sources;
+    }
+
+    /// @notice Represents a derivation source manifest containing blocks for one source
     /// @dev Each proposal can have multiple DerivationSourceManifests (one per DerivationSource).
     /// If a DerivationSourceManifest is invalid, it is replaced with a default manifest
     /// (single empty block), but the entire proposal is NOT invalidated. This design prevents
     /// censorship of forced inclusions: a malicious proposer cannot invalidate their entire
     /// proposal (including valid forced inclusions) by including bad data in one source.
+    ///
+    /// IMPORTANT: The _blockIndex parameter in updateState() must be globally monotonic across
+    /// all DerivationSourceManifests within a proposal (not reset per source). This ensures
+    /// proposal-level operations (prover designation, bond processing) execute exactly once.
     struct DerivationSourceManifest {
-        bytes proverAuthBytes;
+        /// @notice The blocks for this derivation source.
         BlockManifest[] blocks;
     }
 }

--- a/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/shasta/libs/LibManifest.sol
@@ -70,8 +70,13 @@ library LibManifest {
         SignedTransaction[] transactions;
     }
 
-    /// @notice Represents a proposal manifest
-    struct ProposalManifest {
+    /// @notice Represents a derivation source manifest
+    /// @dev Each proposal can have multiple DerivationSourceManifests (one per DerivationSource).
+    /// If a DerivationSourceManifest is invalid, it is replaced with a default manifest
+    /// (single empty block), but the entire proposal is NOT invalidated. This design prevents
+    /// censorship of forced inclusions: a malicious proposer cannot invalidate their entire
+    /// proposal (including valid forced inclusions) by including bad data in one source.
+    struct DerivationSourceManifest {
         bytes proverAuthBytes;
         BlockManifest[] blocks;
     }

--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -173,7 +173,7 @@ To maintain the integrity of the proposal process, the `proposer` address must p
 - Confirming that the proposer holds a sufficient balance in the L2 BondManager contract.
 - Ensuring the proposer is not waiting for exiting.
 
-Should any of these validation checks fail (as determined by the `updateState` function returning `isLowBondProposal = true`), the proposal is replaced with the default manifest, which contains a single block with only an anchor transaction.
+Should any of these validation checks fail (as determined by the `updateState` function returning `isLowBondProposal = true`), the proposer's derivation source is replaced with the default manifest, which contains a single block with only an anchor transaction.
 
 ### Manifest Extraction
 
@@ -223,7 +223,7 @@ After processing all sources, the `ProposalManifest` is constructed:
 
 ```solidity
 ProposalManifest memory manifest;
-manifest.proverAuthBytes = proverAuthBytesFromSource0;  // Empty if source 0 failed
+manifest.proverAuthBytes = proverAuthBytesFromProposerSource;
 manifest.sources = [sourceManifest0, sourceManifest1, ...];  // With defaults for failed sources
 ```
 
@@ -395,7 +395,7 @@ Low-bond proposals present a critical challenge: maintaining chain liveness when
 
 ##### Immediate Mitigations
 
-- **Default Manifest Replacement**: When `isLowBondProposal = true`, the entire manifest is replaced with the default manifest (containing a single empty block with no transactions), minimizing proving costs and disincentivizing spam
+- **Default Manifest Replacement**: When `isLowBondProposal = true`, the **only the proposer's manifest** is replaced with the default manifest, minimizing proving costs and disincentivizing spam. Forced inclusion manifests are still processed.
 - **Prover Persistence**: The designated prover is never `address(0)`, ensuring someone is always responsible
 - **Inheritance Mechanism**: Low-bond proposals inherit their parent's designated prover, maintaining continuity
 

--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -228,6 +228,20 @@ manifest.sources = [sourceManifest0, sourceManifest1, ...];  // With defaults fo
 
 **Censorship Resistance**: This per-source validation design prevents a malicious proposer from invalidating valid forced inclusions by including invalid data in other sources. Each source is isolated: failures only affect that specific source, not the entire proposal.
 
+#### Forced Inclusion Submission Requirements
+
+Users submit forced inclusion transactions directly to L1 by posting blob data containing a `DerivationSourceManifest` struct. To ensure valid forced inclusions that pass validation, the following `BlockManifest` fields must be set to zero, allowing the protocol to assign appropriate values:
+
+| Field               | Required Value | Reason                                                  |
+| ------------------- | -------------- | ------------------------------------------------------- |
+| `timestamp`         | `0`            | Protocol assigns based on proposal timing               |
+| `coinbase`          | `address(0)`   | Protocol uses `proposal.proposer` for forced inclusions |
+| `anchorBlockNumber` | `0`            | Protocol inherits from parent block                     |
+| `gasLimit`          | `0`            | Protocol inherits from parent block                     |
+| `transactions`      | User-provided  | The actual transactions to be forcibly included         |
+
+This design ensures forced inclusions integrate properly with the chain's metadata while allowing users to specify only their transactions without requiring knowledge of chain state parameters.
+
 ### Metadata Validation and Computation
 
 With the extracted `ProposalManifest`, metadata computation proceeds using both the proposal manifest data and the parent block's metadata (`parent.metadata`). Each `DerivationSourceManifest` within the `ProposalManifest.sources[]` array is processed sequentially, with validation applied to each source's blocks. The following sections detail the validation rules for each metadata component:


### PR DESCRIPTION
full context: https://www.notion.so/taikoxyz/Update-Shasta-Derivation-Doc-2759673143d68095a586cc678b249431?source=copy_link

**I pushed this on a rush before leaving, so there are some missing details I'm gonna leave in the comments**

## Changes

- **Restructured manifest hierarchy**: Introduced `ProposalManifest` containing proposal-level `proverAuthBytes` and an array of `DerivationSourceManifest[]`. Previously, `proverAuthBytes` was duplicated in each source manifest but only the first was used, wasting blob space and creating semantic confusion.

- **Renamed struct for clarity**: `ProposalManifest` → `DerivationSourceManifest` to accurately reflect that each represents one derivation source's blocks, not the entire proposal.

- **Documented invalid source handling**: Clarified that invalid `DerivationSourceManifest` objects are replaced with default manifests (single empty block) without invalidating the entire proposal. This prevents forced inclusion censorship—a malicious proposer cannot invalidate valid forced inclusions by including bad data in another source.

- **Documented block index monotonicity**: Added explicit requirement that `_blockIndex` must be globally monotonic across all sources in a proposal (not reset per source). This ensures proposal-level operations (prover designation, bond processing) execute exactly once, preventing financial incorrectness and hash chain violations.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors manifest to proposal-level `proverAuthBytes` plus per-source manifests, and rewrites derivation docs to add source-level metadata, per-source validation/defaulting, forced inclusion handling, and globally monotonic block index.
> 
> - **Contracts (LibManifest.sol)**:
>   - **Manifest Hierarchy**: `ProposalManifest` now contains proposal-level `proverAuthBytes` and `DerivationSourceManifest[] sources`.
>   - **New Struct**: `DerivationSourceManifest` with `blocks` array; added notes on globally monotonic `_blockIndex` across all sources.
> - **Docs (Derivation.md)**:
>   - **Metadata Model**: Expanded to three tiers: proposal-level, derivation source-level, and block-level; updated assignment tables.
>   - **Manifests & Extraction**:
>     - Introduces `ProposalManifest` aggregating per-source `DerivationSourceManifest`s.
>     - Defines per-source blob validation/decoding pipeline and limits; failures default only that source (single anchor-only block).
>     - Details forced inclusion publishing and required zeroed fields for FI blocks.
>   - **Validation Rules**:
>     - Timestamp/anchor validations applied per source; non-forced sources without valid anchors defaulted (FI exempt).
>     - Coinbase selection clarified; gas limit rules unchanged in method but re-referenced per source.
>   - **Prover System**:
>     - `proverAuthBytes` is proposal-level (processed once at `_blockIndex == 0`).
>     - Low-bond handling replaces only the proposer’s source manifest; FI sources still processed.
>   - **Block Indexing**: `_blockIndex` must be globally monotonic across all sources within a proposal to ensure single execution of proposal-level ops.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f54723687eb70f9dbc99e9f7b19dff809fbc37ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->