### PR TITLE
chore(protocol): remove dead error InvalidParams from IForcedInclusionStore

### DIFF
--- a/packages/protocol/contracts/layer1/forced-inclusion/IForcedInclusionStore.sol
+++ b/packages/protocol/contracts/layer1/forced-inclusion/IForcedInclusionStore.sol
@@ -20,8 +20,6 @@ interface IForcedInclusionStore {
 
     /// @dev Error thrown when a blob is not found.
     error BlobNotFound();
-    /// @dev Error thrown when the parameters are invalid.
-    error InvalidParams();
     /// @dev Error thrown when the fee is incorrect.
     error IncorrectFee();
     /// @dev Error thrown when the index is invalid.


### PR DESCRIPTION
Remove unused InvalidParams error from IForcedInclusionStore; validation covered by specific errors. No functional changes.