### PR TITLE
fix(taiko-client): rename SubscribePorposedShasta to SubscribeProposedShasta

### DIFF
--- a/packages/taiko-client/driver/state/state.go
+++ b/packages/taiko-client/driver/state/state.go
@@ -120,7 +120,7 @@ func (s *State) eventLoop(ctx context.Context) {
 			batchesVerifiedPacayaCh,
 		)
 		l2BatchesProvedPacayaSub = rpc.SubscribeBatchesProvedPacaya(s.rpc.PacayaClients.TaikoInbox, batchesProvedPacayaCh)
-		l2ProposedShastaSub      = rpc.SubscribePorposedShasta(s.rpc.ShastaClients.Inbox, proposedShastaCh)
+		l2ProposedShastaSub      = rpc.SubscribeProposedShasta(s.rpc.ShastaClients.Inbox, proposedShastaCh)
 		l2ProvedShastaSub        = rpc.SubscribeProvedShasta(s.rpc.ShastaClients.Inbox, provedShastaCh)
 
 		// Last finalized Shasta proposal ID

--- a/packages/taiko-client/pkg/rpc/subscription.go
+++ b/packages/taiko-client/pkg/rpc/subscription.go
@@ -83,8 +83,8 @@ func SubscribeBatchesProvedPacaya(
 	})
 }
 
-// SubscribePorposedShasta subscribes the Shasta protocol's Proposed events.
-func SubscribePorposedShasta(
+// SubscribeProposedShasta subscribes the Shasta protocol's Proposed events.
+func SubscribeProposedShasta(
 	taikoInbox *shastaBindings.ShastaInboxClient,
 	ch chan *shastaBindings.ShastaInboxClientProposed,
 ) event.Subscription {

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -254,7 +254,7 @@ func (p *Prover) eventLoop() {
 	batchProposedSub := rpc.SubscribeBatchProposedPacaya(p.rpc.PacayaClients.TaikoInbox, batchProposedCh)
 	batchesVerifiedSub := rpc.SubscribeBatchesVerifiedPacaya(p.rpc.PacayaClients.TaikoInbox, batchesVerifiedCh)
 	batchesProvedSub := rpc.SubscribeBatchesProvedPacaya(p.rpc.PacayaClients.TaikoInbox, batchesProvedCh)
-	shastaProposedSub := rpc.SubscribePorposedShasta(p.rpc.ShastaClients.Inbox, shastaProposedCh)
+	shastaProposedSub := rpc.SubscribeProposedShasta(p.rpc.ShastaClients.Inbox, shastaProposedCh)
 	shastaProvedSub := rpc.SubscribeProvedShasta(p.rpc.ShastaClients.Inbox, shastaProvedCh)
 	defer func() {
 		batchProposedSub.Unsubscribe()


### PR DESCRIPTION
Correct function name from `SubscribePorposedShasta` to `SubscribeProposedShasta` across 3 files in taiko-client package. The function name was inconsistent with the underlying Solidity event "Proposed" and related code references.

Files changed:
- pkg/rpc/subscription.go: Function definition and comment
- prover/prover.go: Function call in event subscriptions  
- driver/state/state.go: Function call in state subscriptions