### PR TITLE
fix(bridge-ui): prevent SSR crash by guarding theme store localStorage access

### DIFF
--- a/packages/bridge-ui/src/stores/theme.ts
+++ b/packages/bridge-ui/src/stores/theme.ts
@@ -5,4 +5,13 @@ export const enum Theme {
   LIGHT = 'light',
 }
 
-export const theme = writable<Theme>((localStorage.getItem('theme') as Theme) || Theme.DARK);
+export const theme = writable<Theme>(Theme.DARK);
+
+// Avoid accessing localStorage during SSR. Guard with a runtime window check.
+const isBrowser = typeof window !== 'undefined';
+if (isBrowser) {
+  const saved = localStorage.getItem('theme') as Theme | null;
+  if (saved === Theme.DARK || saved === Theme.LIGHT) {
+    theme.set(saved);
+  }
+}


### PR DESCRIPTION

### Summary
- Make theme store initialization SSR-safe by avoiding module-level localStorage access.

### Changes
- Initialize `theme` store with a safe default on the server.
- Read and apply saved theme only in the browser (guarded by runtime check).

### Why
- Prevents SSR/ prerender crashes (ReferenceError on `localStorage`).
- Reduces FOUC risk and stabilizes tests/CI.

