### PR TITLE
ci(repo): refactor eventindexer and relayer workflows, remove redundant workflow steps

### DIFF
--- a/.github/workflows/docs-site--preview.yml
+++ b/.github/workflows/docs-site--preview.yml
@@ -21,9 +21,6 @@ jobs:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && github.event.pull_request.head.repo.fork == false && !startsWith(github.head_ref, 'dependabot') }}
     runs-on: [arc-runner-set]
     steps:
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
 

--- a/.github/workflows/docs-site--production.yml
+++ b/.github/workflows/docs-site--production.yml
@@ -13,9 +13,6 @@ jobs:
   deploy-docs-site-production:
     runs-on: [arc-runner-set]
     steps:
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
 

--- a/.github/workflows/ejector--docker.yml
+++ b/.github/workflows/ejector--docker.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-          sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout
         uses: actions/checkout@v5
@@ -106,9 +105,6 @@ jobs:
     needs: [build]
 
     steps:
-      - name: Prepare Environment
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Download digests
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/eventindexer--docker.yml
+++ b/.github/workflows/eventindexer--docker.yml
@@ -1,0 +1,62 @@
+name: "Build and Push Multi-Arch Docker Image (eventindexer)"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "eventindexer-v*"
+    paths:
+      - "packages/eventindexer/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  push-eventindexer-docker-image:
+    name: Build and push docker image
+    runs-on: [arc-runner-set]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            us-docker.pkg.dev/evmchain/images/eventindexer
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PACKAGE=eventindexer

--- a/.github/workflows/eventindexer--test.yml
+++ b/.github/workflows/eventindexer--test.yml
@@ -1,4 +1,7 @@
-name: Eventindexer
+name: "Eventindexer CI"
+
+permissions:
+  contents: read
 
 on:
   push:
@@ -9,6 +12,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "packages/eventindexer/**"
+      - "go.mod"
+      - "go.sum"
+      - "!**/*.md"
     branches-ignore:
       - release-please--branches--**
 
@@ -63,50 +69,3 @@ jobs:
           flags: eventindexer
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  push-eventindexer-docker-image:
-    # Skip dependabot PRs
-    if: ${{ github.event_name == 'pull_request' && ! startsWith(github.head_ref, 'dependabot') && !startsWith(github.head_ref, 'release-please') && github.event.pull_request.head.repo.fork == false }}
-    name: Build and push docker image
-    runs-on: [arc-runner-set]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Login to GAR
-        uses: docker/login-action@v3
-        with:
-          registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            us-docker.pkg.dev/evmchain/images/eventindexer
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=ref,event=tag
-            type=sha
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            PACKAGE=eventindexer

--- a/.github/workflows/fork-diff--preview.yml
+++ b/.github/workflows/fork-diff--preview.yml
@@ -21,9 +21,6 @@ jobs:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
     runs-on: [arc-runner-set]
     steps:
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
 

--- a/.github/workflows/fork-diff--production.yml
+++ b/.github/workflows/fork-diff--production.yml
@@ -14,9 +14,6 @@ jobs:
   deploy-fork-diff-production:
     runs-on: [arc-runner-set]
     steps:
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
 

--- a/.github/workflows/relayer--docker.yml
+++ b/.github/workflows/relayer--docker.yml
@@ -1,0 +1,62 @@
+name: "Build and Push Multi-Arch Docker Image (relayer)"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "relayer-v*"
+    paths:
+      - "packages/relayer/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  push-relayer-docker-image:
+    name: Build and push docker image
+    runs-on: [arc-runner-set]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            us-docker.pkg.dev/evmchain/images/relayer
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PACKAGE=relayer

--- a/.github/workflows/relayer--test.yml
+++ b/.github/workflows/relayer--test.yml
@@ -1,4 +1,7 @@
-name: Relayer
+name: "Relayer CI"
+
+permissions:
+  contents: read
 
 on:
   push:
@@ -9,6 +12,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "packages/relayer/**"
+      - "go.mod"
+      - "go.sum"
+      - "!**/*.md"
     branches-ignore:
       - release-please--branches--**
 
@@ -63,50 +69,3 @@ jobs:
           flags: relayer
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  push-relayer-docker-image:
-    # Skip dependabot PRs
-    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') && github.event.pull_request.head.repo.fork == false }}
-    name: Build and push docker image
-    runs-on: [arc-runner-set]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Login to GAR
-        uses: docker/login-action@v3
-        with:
-          registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            us-docker.pkg.dev/evmchain/images/relayer
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=ref,event=tag
-            type=sha
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            PACKAGE=relayer

--- a/.github/workflows/repo--vercel-deploy.yml
+++ b/.github/workflows/repo--vercel-deploy.yml
@@ -33,9 +33,6 @@ jobs:
         run: |
           echo "Vercel Project ID: ${{ env.VERCEL_PROJECT_ID }}"
 
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
 

--- a/.github/workflows/snaefell-ui--ci.yml
+++ b/.github/workflows/snaefell-ui--ci.yml
@@ -11,9 +11,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/supplementary-contracts.yml
+++ b/.github/workflows/supplementary-contracts.yml
@@ -22,9 +22,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-          sudo apt-get update && sudo apt-get install -y git
 
       - name: Checkout
         uses: actions/checkout@v5
@@ -95,9 +94,6 @@ jobs:
     needs:
       - build
     steps:
-      - name: Prepare Environment
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Download digests
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/taiko-client--hive-test.yml
+++ b/.github/workflows/taiko-client--hive-test.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - uses: actions/checkout@v5
 
       - name: Set up Go

--- a/.github/workflows/taikoon-ui--ci.yml
+++ b/.github/workflows/taikoon-ui--ci.yml
@@ -11,9 +11,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/ui-lib--ci.yml
+++ b/.github/workflows/ui-lib--ci.yml
@@ -11,9 +11,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Install Git
-        run: sudo apt-get update && sudo apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
With latest runners, `git` and `jq` come auto-installed so these steps can be skipped.

<img width="566" height="132" alt="Screenshot 2025-10-02 at 4 44 11 PM" src="https://github.com/user-attachments/assets/d89b26e5-3d31-4dc2-9d47-35c54188a59e" />

Refactor eventindexer and relayer workflows to match other packages.