### PR TITLE
chore: fix wrong usage of `fsPromises.readdir`

### DIFF
--- a/packages/nfts/script/taikoon/js/4everland.js
+++ b/packages/nfts/script/taikoon/js/4everland.js
@@ -53,11 +53,14 @@ async function main() {
     path.resolve(__dirname, "../../../data/taikoon"),
     "images",
   );
-  const filesName = await fsPromises.readdir(imgDirPath, (err) => {
-    if (err) {
-      console.log("Import from directory failed: ", err);
-    }
-  });
+
+  let filesName = [];
+  try {
+    filesName = await fsPromises.readdir(imgDirPath);
+  } catch (err) {
+    console.error("Import from directory failed: ", err);
+    return;
+  }
 
   // Uploading images to IPFS
   console.log(`Uploading image data to IPFS...`);


### PR DESCRIPTION
turns out `fsPromises.readdir` doesn’t take a callback..
now it’s just awaited in a `try/catch`, so `filesName` properly comes back as an array like `["1.png", "2.png", "3.jpg"]`.
this was breaking file loading before, so it’s kind of a big deal.
