### PR TITLE
fix: remove unnecessary wrapper around `%sveltekit.body%`

### DIFF
--- a/packages/ui-lib/src/app.html
+++ b/packages/ui-lib/src/app.html
@@ -7,6 +7,6 @@
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">
-		<div>%sveltekit.body%</div>
+		%sveltekit.body%
 	</body>
 </html>


### PR DESCRIPTION
removed the extra `<div>` surrounding `%sveltekit.body%`.
was interfering with proper hydration, and this change fixes the issue without affecting layout or functionality.
