### PR TITLE
chore: Fix Swagger UI preset import for latest versions

### DIFF
--- a/packages/taiko-client/docs/index.html
+++ b/packages/taiko-client/docs/index.html
@@ -1,18 +1,30 @@
-<script>
-    window.onload = function () {
-        // Begin Swagger UI call region
-        const ui = SwaggerUIBundle({
-            url: "swagger.json", //Location of Open API spec in the repo
-            dom_id: '#swagger-ui',
-            deepLinking: true,
-            presets: [
-                SwaggerUIBundle.presets.apis,
-                SwaggerUIStandalonePreset
-            ],
-            plugins: [
-                SwaggerUIBundle.plugins.DownloadUrl
-            ],
-        })
-        window.ui = ui
-    }
-</script>
+<!DOCTYPE html>
+<html>
+    <head>
+        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
+        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+        <title>Taiko Preconfirmation Block Server API</title>
+    </head>
+    <body>
+        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
+        <script>
+            window.onload = function () {
+                // Begin Swagger UI call region
+                const ui = SwaggerUIBundle({
+                    url: "swagger.json", //Location of Open API spec in the repo
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                })
+                window.ui = ui
+            }
+        </script>
+    </body>
+</html>

--- a/packages/taiko-client/docs/index.html
+++ b/packages/taiko-client/docs/index.html
@@ -1,29 +1,18 @@
-<html>
-    <head>
-        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
-        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
-        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
-        <title>Taiko Preconfirmation Block Server API</title>
-    </head>
-    <body>
-        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
-        <script>
-            window.onload = function () {
-                // Begin Swagger UI call region
-                const ui = SwaggerUIBundle({
-                    url: "swagger.json", //Location of Open API spec in the repo
-                    dom_id: '#swagger-ui',
-                    deepLinking: true,
-                    presets: [
-                        SwaggerUIBundle.presets.apis,
-                        SwaggerUIBundle.SwaggerUIStandalonePreset
-                    ],
-                    plugins: [
-                        SwaggerUIBundle.plugins.DownloadUrl
-                    ],
-                })
-                window.ui = ui
-            }
-        </script>
-    </body>
-</html>
+<script>
+    window.onload = function () {
+        // Begin Swagger UI call region
+        const ui = SwaggerUIBundle({
+            url: "swagger.json", //Location of Open API spec in the repo
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+        })
+        window.ui = ui
+    }
+</script>


### PR DESCRIPTION
Updated the import to use `SwaggerUIStandalonePreset` directly instead of `SwaggerUIBundle.SwaggerUIStandalonePreset`.
In recent Swagger UI versions, `SwaggerUIStandalonePreset` is no longer a property of `SwaggerUIBundle`, so this change ensures compatibility and prevents runtime errors.
