### PR TITLE
refactor(ui-lib): remove legacy test color token and usage

### DIFF
--- a/packages/ui-lib/src/routes/+page.svelte
+++ b/packages/ui-lib/src/routes/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 </script>
 
-<div class="text-legacy">Purple?</div>
+<!-- Demo text color removed: legacy token was for testing only -->
+<div>Purple?</div>
 <div class="text-3xl">Welcome to your library project</div>
 <p>Create your package using @sveltejs/package and preview/showcase your work with SvelteKit</p>
 <p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>

--- a/packages/ui-lib/tailwind.config.js
+++ b/packages/ui-lib/tailwind.config.js
@@ -127,8 +127,6 @@ export default {
 				// Custom
 				'discord-purple': '#5765f1',
 
-				// testing
-				legacy: 'var(--primary-brand)'
 			}
 		}
 	},


### PR DESCRIPTION
Cleanup: Remove unused test color token

**Problem:**
A `legacy` color token was defined in `tailwind.config.js` for testing purposes and used via `text-legacy` class in the demo page. This represents unused code that should be cleaned up.

**Changes:**
- **`packages/ui-lib/tailwind.config.js`**: Removed `legacy: 'var(--primary-brand)'` token definition
- **`packages/ui-lib/src/routes/+page.svelte`**: Replaced `text-legacy` class with plain div and added explanatory comment

