### PR TITLE
ci(taiko-client): fix linting job before we upgrade go version

### DIFF
--- a/packages/taiko-client/Makefile
+++ b/packages/taiko-client/Makefile
@@ -13,7 +13,7 @@ clean:
 	@rm -rf bin/*
 
 lint:
-	@go install golang.org/x/tools/cmd/goimports@latest \
+	@go install golang.org/x/tools/cmd/goimports@v0.36.0 \
 	&& go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 \
 	&& goimports -local "github.com/taikoxyz/taiko-mono/packages/taiko-client" -w ./ \
 	&& golangci-lint run --timeout 5m


### PR DESCRIPTION
golang.org/x/tools/cmd/goimports@latest requires go >= 1.24.0, temporarily peg version before we upgrade go version across repo