### PR TITLE
chore(protocol): remove unused env checks from DeployProtocolOnL1

### DIFF
--- a/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
@@ -66,8 +66,6 @@ contract DeployProtocolOnL1 is DeployCapability {
     }
 
     function run() external broadcast {
-        addressNotNull(vm.envAddress("TAIKO_ANCHOR_ADDRESS"), "TAIKO_ANCHOR_ADDRESS");
-        addressNotNull(vm.envAddress("L2_SIGNAL_SERVICE"), "L2_SIGNAL_SERVICE");
         addressNotNull(vm.envAddress("CONTRACT_OWNER"), "CONTRACT_OWNER");
 
         require(vm.envBytes32("L2_GENESIS_HASH") != 0, "L2_GENESIS_HASH");


### PR DESCRIPTION
Removed redundant env var checks for TAIKO_ANCHOR_ADDRESS and L2_SIGNAL_SERVICE in DeployProtocolOnL1.s.sol. These variables are not used anywhere in the script; keeping them blocked execution unnecessarily. Retained necessary checks (CONTRACT_OWNER, L2_GENESIS_HASH).