### PR TITLE
chore: Remove Uncatchable os.Kill Signal from Balance Monitor CLI

### DIFF
--- a/packages/balance-monitor/cmd/utils/subcommand.go
+++ b/packages/balance-monitor/cmd/utils/subcommand.go
@@ -52,7 +52,6 @@ func SubcommandAction(app SubcommandApplication) cli.ActionFunc {
 		quitCh := make(chan os.Signal, 1)
 		signal.Notify(quitCh, []os.Signal{
 			os.Interrupt,
-			os.Kill,
 			syscall.SIGTERM,
 			syscall.SIGQUIT,
 		}...)


### PR DESCRIPTION
Drop os.Kill from the signal.Notify list in the balance monitor CLI utility because SIGKILL cannot be intercepted in Go; the change removes unreachable code without altering runtime behavior.