### PR TITLE
chore(protocol): remove unused constants from encoder fuzz tests

### DIFF
--- a/packages/protocol/test/layer1/shasta/libs/LibProposedEventEncoder.fuzz.t.sol
+++ b/packages/protocol/test/layer1/shasta/libs/LibProposedEventEncoder.fuzz.t.sol
@@ -13,7 +13,6 @@ contract LibProposedEventEncoderFuzzTest is Test {
     uint256 constant MAX_BLOB_HASHES = 100;
     uint48 constant MAX_UINT48 = type(uint48).max;
     uint24 constant MAX_UINT24 = type(uint24).max;
-    uint8 constant MAX_UINT8 = type(uint8).max;
 
     function testFuzz_encodeDecodeProposal_basicFields(
         uint48 _id,

--- a/packages/protocol/test/layer1/shasta/libs/LibProvedEventEncoder.fuzz.t.sol
+++ b/packages/protocol/test/layer1/shasta/libs/LibProvedEventEncoder.fuzz.t.sol
@@ -12,8 +12,6 @@ import { LibBonds } from "src/shared/shasta/libs/LibBonds.sol";
 contract LibProvedEventEncoderFuzzTest is Test {
     uint256 constant MAX_BOND_INSTRUCTIONS = 100;
     uint48 constant MAX_UINT48 = type(uint48).max;
-    uint16 constant MAX_UINT16 = type(uint16).max;
-    uint8 constant MAX_UINT8 = type(uint8).max;
 
     function testFuzz_encodeDecodeBasicFields(
         uint48 _proposalId,


### PR DESCRIPTION
- Remove unused MAX_UINT16 and MAX_UINT8 from packages/protocol/test/layer1/shasta/libs/LibProvedEventEncoder.fuzz.t.sol.
- Remove unused MAX_UINT8 from packages/protocol/test/layer1/shasta/libs/LibProposedEventEncoder.fuzz.t.sol.
- Reason: clean up dead code; improve readability; no functional changes.