### PR TITLE
chore(taiko-client): rename ErrBlobUnused to ErrNoBlobHashes

### DIFF
--- a/packages/taiko-client/driver/txlist_fetcher/blob.go
+++ b/packages/taiko-client/driver/txlist_fetcher/blob.go
@@ -30,7 +30,7 @@ func NewBlobFetcher(cli *rpc.Client, ds *rpc.BlobDataSource) *BlobFetcher {
 // FetchPacaya implements the TxListFetcher interface.
 func (d *BlobFetcher) FetchPacaya(ctx context.Context, meta metadata.TaikoBatchMetaDataPacaya) ([]byte, error) {
 	if len(meta.GetBlobHashes()) == 0 {
-		return nil, pkg.ErrBlobUnused
+		return nil, pkg.ErrNoBlobHashes
 	}
 
 	var blockNum uint64

--- a/packages/taiko-client/pkg/error.go
+++ b/packages/taiko-client/pkg/error.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	ErrBlobUsed           = errors.New("blob is used")
-	ErrBlobUnused         = errors.New("blob is not used")
+	ErrNoBlobHashes       = errors.New("no blob hashes provided")
 	ErrSidecarNotFound    = errors.New("sidecar not found")
 	ErrBeaconNotFound     = errors.New("beacon client not found")
 	ErrInvalidShastaBlobs = errors.New("invalid Shasta blobs")


### PR DESCRIPTION

Use a clearer error name when no blob hashes are provided.

