### PR TITLE
chore(protocol): remove unused checkpointManager and MockCheckpointProvider

### DIFF
--- a/packages/protocol/test/layer1/shasta/inbox/suite2/common/InboxTestHelper.sol
+++ b/packages/protocol/test/layer1/shasta/inbox/suite2/common/InboxTestHelper.sol
@@ -11,7 +11,7 @@ import { IProofVerifier } from "src/layer1/shasta/iface/IProofVerifier.sol";
 import { IProposerChecker } from "src/layer1/shasta/iface/IProposerChecker.sol";
 import { Inbox } from "src/layer1/shasta/impl/Inbox.sol";
 import { LibBlobs } from "src/layer1/shasta/libs/LibBlobs.sol";
-import { MockERC20, MockCheckpointProvider, MockProofVerifier } from "../mocks/MockContracts.sol";
+import { MockERC20, MockProofVerifier } from "../mocks/MockContracts.sol";
 import { PreconfWhitelistSetup } from "./PreconfWhitelistSetup.sol";
 
 /// @title InboxTestHelper
@@ -53,9 +53,6 @@ abstract contract InboxTestHelper is CommonTest {
 
     /// @notice Mock bond token for testing
     IERC20 internal bondToken;
-
-    /// @notice Mock checkpoint manager (unused but required for interface compatibility)
-    ICheckpointStore internal checkpointManager;
 
     /// @notice Mock proof verifier for testing
     IProofVerifier internal proofVerifier;
@@ -369,7 +366,6 @@ abstract contract InboxTestHelper is CommonTest {
     /// or are well-tested externally (e.g. ERC20 tokens)
     function _setupMocks() internal {
         bondToken = new MockERC20();
-        checkpointManager = new MockCheckpointProvider();
         proofVerifier = new MockProofVerifier();
     }
 


### PR DESCRIPTION
- Delete unused checkpointManager field and its initialization in _setupMocks.
- Drop MockCheckpointProvider from imports.
- This code was not used anywhere: the Inbox persists checkpoints internally via LibCheckpointStore, and tests construct ICheckpointStore.Checkpoint structs directly without a manager instance. Keeping the mock created dead code and added confusion