### PR TITLE
snaefell-ui: rename misleading variable nounId to tokenId in mint.ts

### DIFF
--- a/packages/snaefell-ui/src/lib/token/mint.ts
+++ b/packages/snaefell-ui/src/lib/token/mint.ts
@@ -42,7 +42,8 @@ export async function mint({
     onTransaction(tx);
   }
 
-  let nounId: number = 0;
+  // tokenId of the minted NFT(s); renamed from nounId for clarity
+  let tokenId: number = 0;
 
   const receipt = await waitForTransactionReceipt(config, { hash: tx });
 
@@ -61,8 +62,8 @@ export async function mint({
           to: string;
           tokenId: bigint;
         } = decoded.args as any;
-        nounId = parseInt(args.tokenId.toString());
-        tokenIds.push(nounId);
+        tokenId = parseInt(args.tokenId.toString());
+        tokenIds.push(tokenId);
       }
     } catch (e: any) {
       throw new FilterLogsError(e.message);


### PR DESCRIPTION

### Description
- Summary: Align variable name with emitted `tokenId` and `tokenIds` array for clarity.
- Change: Renamed local `nounId` → `tokenId` and updated its usages in `packages/snaefell-ui/src/lib/token/mint.ts`; added a brief inline comment.
- Rationale: “nounId” implies Nouns-specific semantics; this code handles generic token IDs.
