### PR TITLE
fix(protocol): add HTTP client timeout to prevent hanging requests

### DIFF
--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -98,7 +98,8 @@ func requestHTTPProofResponse[T any](
 	apiKey string,
 	reqBody T,
 ) (*http.Response, error) {
-	client := &http.Client{}
+	// Set a client-side timeout to prevent hanging requests under network issues
+    client := &http.Client{Timeout: 30 * time.Second}
 
 	jsonValue, err := json.Marshal(reqBody)
 	if err != nil {


### PR DESCRIPTION


## Description

Add 30-second timeout to HTTP client in proof producer to prevent hanging requests under network issues.

**Change**: Added `Timeout: 30 * time.Second` to `http.Client{}`

