### PR TITLE
fix(taiko-client): initialize random seed to prevent predictable jitter

### DIFF
--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -95,6 +95,9 @@ func (p *Proposer) InitFromConfig(
 	p.Config = cfg
 	p.lastProposedAt = time.Now()
 
+	/ Seed the global PRNG once to avoid predictable jitter across restarts.
+    rand.Seed(time.Now().UnixNano())
+	
 	// RPC clients
 	if p.rpc, err = rpc.NewClient(p.ctx, cfg.ClientConfig); err != nil {
 		return fmt.Errorf("initialize rpc clients error: %w", err)


### PR DESCRIPTION


### Description

Fixes predictable proposer interval jitter by initializing the global `math/rand` seed in `InitFromConfig`. 

**Problem**: The proposer's random interval jitter (12-120 seconds) was deterministic across process restarts, leading to:
- Synchronized proposal attempts from multiple instances
- Increased collision probability 
- Potential MEV exploitation through predictable timing

**Solution**: Added `rand.Seed(time.Now().UnixNano())` during proposer initialization to ensure truly random jitter between restarts.

**Impact**: Improves network stability and reduces proposal conflicts by making each proposer instance's timing unpredictable.