### PR TITLE
refactor(protocol): make ShastaAnchor inherit EssentialContract directly

### DIFF
--- a/.github/workflows/ejector--docker.yml
+++ b/.github/workflows/ejector--docker.yml
@@ -17,8 +17,7 @@ concurrency:
 env:
   # where to push
   REGISTRY_IMAGE: us-docker.pkg.dev/evmchain/images/ejector
-  # build context MUST be repo root for cargo workspace
-  BUILD_CONTEXT: .
+  BUILD_CONTEXT: packages/ejector
   DOCKERFILE: packages/ejector/Dockerfile
 
 jobs:

--- a/packages/ejector/Dockerfile
+++ b/packages/ejector/Dockerfile
@@ -4,17 +4,14 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-COPY Cargo.toml Cargo.lock ./
-COPY packages ./packages
-RUN cargo build -p ejector --release
 
-# Use the repo root as build context so we can copy the workspace files:
-# (This lets cargo resolve all path deps and workspace members.)
+# Copy ejector package files (build context is packages/ejector)
 COPY Cargo.toml Cargo.lock ./
-COPY packages ./packages
+COPY src ./src
+COPY bin ./bin
 
-# Build just this crate
-RUN cargo build -p ejector --release
+# Build the ejector binary
+RUN cargo build --release --bin ejector
 
 FROM debian:bookworm-slim AS runtime
 RUN useradd -m -u 10001 appuser && \

--- a/packages/protocol/contracts/layer2/based/BondManager.sol
+++ b/packages/protocol/contracts/layer2/based/BondManager.sol
@@ -29,7 +29,7 @@ contract BondManager is EssentialContract, IBondManager {
     /// @dev WARNING: In theory operations can remain unfinalized indefinitely, but in practice
     /// after
     ///      the `extendedProvingWindow` the incentives are very strong for finalization.
-    ///      A safe value for this is `extendedProvingWindow` + buffer.
+    ///      A safe value for this is `extendedProvingWindow` + buffer, for example, 7 days.
     uint48 public immutable withdrawalDelay;
 
     /// @notice Per-account bond state

--- a/packages/protocol/contracts/layer2/based/BondManager.sol
+++ b/packages/protocol/contracts/layer2/based/BondManager.sol
@@ -29,7 +29,7 @@ contract BondManager is EssentialContract, IBondManager {
     /// @dev WARNING: In theory operations can remain unfinalized indefinitely, but in practice
     /// after
     ///      the `extendedProvingWindow` the incentives are very strong for finalization.
-    ///      A safe value for this is `extendedProvingWindow` + buffer, for example, 7 days.
+    ///      A safe value for this is `extendedProvingWindow` + buffer, for example, 2 weeks.
     uint48 public immutable withdrawalDelay;
 
     /// @notice Per-account bond state

--- a/packages/protocol/contracts/layer2/based/ShastaAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/ShastaAnchor.sol
@@ -492,9 +492,9 @@ contract ShastaAnchor is EssentialContract {
         returns (address signer_, uint48 provingFeeGwei_)
     {
         // Check if _proverAuth has minimum required length for ProverAuth struct
-        // ProverAuth: uint48 (6) + address (20) + uint48 (6) + dynamic bytes offset (32) +
-        // bytes length (32) + minimum signature data (65) = 161 bytes minimum
-        if (_proverAuth.length < 161) {
+        // ABI-encoded ProverAuth: uint48 (32 padded) + address (32 padded) + uint48 (32 padded) +
+        // bytes offset (32) + bytes length (32) + minimum signature data (65) = 225 bytes minimum
+        if (_proverAuth.length < 225) {
             return (_proposer, 0);
         }
 

--- a/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./ShastaAnchor.sol";
-import { IBondManager as IShastaBondManager } from "./IBondManager.sol";
+import "./PacayaAnchor.sol";
 
 /// @title TaikoAnchor
 /// @notice TaikoAnchor is a smart contract that handles cross-layer message
@@ -13,7 +12,20 @@ import { IBondManager as IShastaBondManager } from "./IBondManager.sol";
 /// @dev This contract receives a portion of L2 base fees, while the remainder is directed to
 /// L2 block's coinbase address.
 /// @custom:security-contact security@taiko.xyz
-contract TaikoAnchor is ShastaAnchor {
+contract TaikoAnchor is PacayaAnchor {
+    // -------------------------------------------------------------------
+    // Immutables (for compatibility, unused in PacayaAnchor)
+    // -------------------------------------------------------------------
+
+    /// @notice Bond amount in Gwei for liveness guarantees (stored for compatibility).
+    uint48 public immutable livenessBondGwei;
+
+    /// @notice Bond amount in Gwei for provability guarantees (stored for compatibility).
+    uint48 public immutable provabilityBondGwei;
+
+    /// @notice Bond manager address (stored for compatibility).
+    address public immutable bondManager;
+
     // -------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------
@@ -25,15 +37,12 @@ contract TaikoAnchor is ShastaAnchor {
         uint64 _shastaForkHeight,
         address _bondManager
     )
-        ShastaAnchor(
-            _livenessBondGwei,
-            _provabilityBondGwei,
-            _signalService,
-            _pacayaForkHeight,
-            _shastaForkHeight,
-            IShastaBondManager(_bondManager)
-        )
-    { }
+        PacayaAnchor(_signalService, _pacayaForkHeight, _shastaForkHeight)
+    {
+        livenessBondGwei = _livenessBondGwei;
+        provabilityBondGwei = _provabilityBondGwei;
+        bondManager = _bondManager;
+    }
 
     // -------------------------------------------------------------------
     // External functions

--- a/packages/taiko-client-rs/crates/bindings/Cargo.toml
+++ b/packages/taiko-client-rs/crates/bindings/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bindings"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [lib]
 doctest = false

--- a/packages/taiko-client-rs/crates/event-indexer/Cargo.toml
+++ b/packages/taiko-client-rs/crates/event-indexer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "event-indexer"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/packages/taiko-client-rs/crates/proposer/Cargo.toml
+++ b/packages/taiko-client-rs/crates/proposer/Cargo.toml
@@ -3,6 +3,7 @@ name = "proposer"
 version.workspace = true
 edition.workspace = true
 publish = false
+license.workspace = true
 
 [dependencies]
 # async

--- a/packages/taiko-client-rs/crates/protocol/Cargo.toml
+++ b/packages/taiko-client-rs/crates/protocol/Cargo.toml
@@ -3,6 +3,7 @@ name = "protocol"
 version.workspace = true
 edition.workspace = true
 publish = false
+license.workspace = true
 
 [dependencies]
 # ethereum

--- a/packages/taiko-client-rs/crates/rpc/Cargo.toml
+++ b/packages/taiko-client-rs/crates/rpc/Cargo.toml
@@ -3,6 +3,7 @@ name = "rpc"
 version.workspace = true
 edition.workspace = true
 publish = false
+license.workspace = true
 
 [dependencies]
 # observability


### PR DESCRIPTION
## Summary

Refactors ShastaAnchor to inherit directly from EssentialContract instead of PacayaAnchor, consolidating the inheritance hierarchy and improving code organization.

**Key changes:**
- Changed ShastaAnchor inheritance from PacayaAnchor to EssentialContract
- Moved necessary state variables and functions from PacayaAnchor to ShastaAnchor
- Converted State struct from storage to return-only struct with optimized slot packing (5 slots + 45 gap = 50 total)
- Renamed `signalService` to `checkpointStore` using ICheckpointStore interface
- Renamed `updateState` to `anchor` for clarity
- Merged `getDesignatedProver` and `_getDesignatedProver` into single public function
- Made TaikoAnchor inherit from PacayaAnchor instead

**Cleanup:**
- Removed unused code: `getBasefeeV2`, `skipFeeCheck`, `IBlockHashProvider`, `_trackParentBlockHash`, `getState`, `_blockhashes`
- Updated error naming convention from `L2_ABC_XYZ` to `AbcXyz` format
- Improved BondManager documentation for `withdrawalDelay`

**Storage optimization:**
- Optimal slot packing: `address(20) + uint48(6) + uint48(6) = 32 bytes`
- Maintains 50 total storage slots for upgradability

## Test plan

- [x] Verify all contracts compile successfully
- [ ] Run protocol test suite: `pnpm --filter @taiko/protocol test`
- [ ] Verify ShastaAnchor functionality with integration tests
- [ ] Validate storage layout matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)