### PR TITLE
fix(relayer): avoid os.Exit in processor Start for graceful shutdown

### DIFF
--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -402,7 +401,8 @@ func (p *Processor) Start() error {
 			slog.Error(err.Error())
 		}
 
-		os.Exit(0)
+		// Exit early after single-target processing; caller controls process lifecycle.
+		return nil
 	}
 
 	// otherwise, we can start the queue, and process messages from it


### PR DESCRIPTION


Description:
### What
- Replace os.Exit(0) with return nil in `packages/relayer/processor/processor.go` (`Processor.Start`).
- Remove unused `os` import.

### Why
- Prevents abrupt process termination, ensuring defers run and resources close cleanly.
- Improves testability and lets callers control lifecycle.

### Impact
- Behavior when `targetTxHash` is set: the method returns instead of terminating the process. No breaking API changes.

