### PR TITLE
fix(taiko-client): prevent panic in NewFixedKSigner by using hexutil.Decode

### DIFF
--- a/packages/taiko-client/driver/signer/fixed_k_signer.go
+++ b/packages/taiko-client/driver/signer/fixed_k_signer.go
@@ -24,8 +24,12 @@ type FixedKSigner struct {
 // NewFixedKSigner creates a new FixedKSigner instance.
 func NewFixedKSigner(privKey string) (*FixedKSigner, error) {
 	var priv btcec.PrivateKey
-	if overflow := priv.Key.SetByteSlice(hexutil.MustDecode(privKey)); overflow || priv.Key.IsZero() {
-		return nil, fmt.Errorf("invalid private key %s", privKey)
+	decoded, err := hexutil.Decode(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key: %v", err)
+	}
+	if overflow := priv.Key.SetByteSlice(decoded); overflow || priv.Key.IsZero() {
+		return nil, fmt.Errorf("invalid private key")
 	}
 
 	return &FixedKSigner{privKey: &priv.Key}, nil


### PR DESCRIPTION
- Problem: NewFixedKSigner used hexutil.MustDecode(privKey), which panics on invalid/malformed hex, violating the function’s safe (FixedKSigner, error) contract and potentially crashing the process.
- Fix: Replace MustDecode with hexutil.Decode and propagate the returned error. Keep overflow/zero checks intact and avoid echoing the full private key in error messages.