### PR TITLE
fix(bridge-ui): provide SSR-safe storage fallback to prevent localStorage errors

### DIFF
--- a/packages/bridge-ui/src/libs/storage/index.ts
+++ b/packages/bridge-ui/src/libs/storage/index.ts
@@ -1,6 +1,18 @@
 import { BridgeTxService } from './BridgeTxService';
 import { CustomTokenService } from './CustomTokenService';
 
-export const bridgeTxService = new BridgeTxService(globalThis.localStorage);
+// Provide a no-op storage fallback for SSR environments where localStorage is unavailable
+const safeStorage: Storage = typeof globalThis !== 'undefined' && 'localStorage' in globalThis
+  ? (globalThis as any).localStorage
+  : ({
+      length: 0,
+      clear() {},
+      getItem(_key: string) { return null; },
+      key(_index: number) { return null; },
+      removeItem(_key: string) {},
+      setItem(_key: string, _value: string) {}
+    } as Storage);
 
-export const customTokenService = new CustomTokenService(globalThis.localStorage);
+export const bridgeTxService = new BridgeTxService(safeStorage);
+
+export const customTokenService = new CustomTokenService(safeStorage);


### PR DESCRIPTION

### Summary
- Replace direct `localStorage` usage with an SSR-safe fallback in `packages/bridge-ui/src/libs/storage/index.ts` to avoid runtime errors during server-side rendering.

### Why
- SvelteKit renders on the server where `localStorage` is undefined, causing crashes when services are instantiated at import-time.

### Changes
- Introduced a no-op `safeStorage` fallback and passed it to `BridgeTxService` and `CustomTokenService`.

