### PR TITLE
fix(prover): close HTTP response body on non-200 to prevent connection leaks

### DIFF
--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -125,6 +125,7 @@ func requestHTTPProofResponse[T any](
 			log.Error("Rate limit on L2 RPC has been reached. Using your own Taiko L2 node as RPC for Raiko is recommended")
 		}
 
+		res.Body.Close()
 		return nil, fmt.Errorf(
 			"failed to request proof, url: %s, statusCode: %d",
 			url,


### PR DESCRIPTION

### Summary
Closes HTTP response body on error path to avoid leaking connections and ensure the client’s connection pool is reused properly.

