### PR TITLE
fix(taiko-client): return sub in ResubscribeErr callback; remove waitSubErr and local Unsubscribe

### DIFF
--- a/packages/taiko-client/pkg/rpc/subscription.go
+++ b/packages/taiko-client/pkg/rpc/subscription.go
@@ -41,9 +41,7 @@ func SubscribeBatchesVerifiedPacaya(
 			return nil, err
 		}
 
-		defer sub.Unsubscribe()
-
-		return waitSubErr(ctx, sub)
+		return sub, nil
 	})
 }
 
@@ -59,9 +57,7 @@ func SubscribeBatchProposedPacaya(
 			return nil, err
 		}
 
-		defer sub.Unsubscribe()
-
-		return waitSubErr(ctx, sub)
+		return sub, nil
 	})
 }
 
@@ -77,9 +73,7 @@ func SubscribeBatchesProvedPacaya(
 			return nil, err
 		}
 
-		defer sub.Unsubscribe()
-
-		return waitSubErr(ctx, sub)
+		return sub, nil
 	})
 }
 
@@ -95,9 +89,7 @@ func SubscribeProposedShasta(
 			return nil, err
 		}
 
-		defer sub.Unsubscribe()
-
-		return waitSubErr(ctx, sub)
+		return sub, nil
 	})
 }
 
@@ -113,9 +105,7 @@ func SubscribeProvedShasta(
 			return nil, err
 		}
 
-		defer sub.Unsubscribe()
-
-		return waitSubErr(ctx, sub)
+		return sub, nil
 	})
 }
 
@@ -131,18 +121,6 @@ func SubscribeChainHead(
 			return nil, err
 		}
 
-		defer sub.Unsubscribe()
-
-		return waitSubErr(ctx, sub)
+		return sub, nil
 	})
-}
-
-// waitSubErr keeps waiting until the given subscription failed.
-func waitSubErr(ctx context.Context, sub event.Subscription) (event.Subscription, error) {
-	select {
-	case err := <-sub.Err():
-		return sub, err
-	case <-ctx.Done():
-		return sub, ctx.Err()
-	}
 }


### PR DESCRIPTION
This change corrects our use of go-ethereum’s event.ResubscribeErr by removing the blocking waitSubErr call and the local defer sub.Unsubscribe() from the resubscribe callback, and by returning the created subscription immediately. The previous pattern violated the contract of ResubscribeErr, which expects the wrapper—not the callback—to wait on sub.Err() and manage the subscription lifecycle; blocking in the callback and unsubscribing locally could delay cancellation and introduce unsubscribe races. With this update, the wrapper correctly handles retries and lifecycle, external callers manage Unsubscribe(), and the now-dead waitSubErr helper has been removed.