### PR TITLE
docs(eventindexer): fix README mixed with relayer package

### DIFF
--- a/packages/eventindexer/README.md
+++ b/packages/eventindexer/README.md
@@ -1,4 +1,4 @@
-[![Relayer](https://codecov.io/gh/taikoxyz/taiko-mono/branch/main/graph/badge.svg?token=E468X2PTJC&flag=relayer)](https://codecov.io/gh/taikoxyz/taiko-mono)
+[![Event Indexer](https://codecov.io/gh/taikoxyz/taiko-mono/branch/main/graph/badge.svg?token=E468X2PTJC&flag=relayer)](https://codecov.io/gh/taikoxyz/taiko-mono)
 
 # Indexer
 
@@ -6,9 +6,9 @@ Catches events, stores them in the database to be queried via API.
 
 ## Running the app
 
-run `cp .default.env .env`, and add your own private key as `RELAYER_ECDSA_KEY` in `.env`. You need to be running a MySQL instance, and replace all the `MYSQL_` env vars with yours.
+run `cp .default.env .env`, and configure your environment variables. You need to be running a MySQL instance, and replace all the `MYSQL_` env vars with yours.
 
-Run `go run cmd/main.go --help` to see a list of possible configuration flags, or `go run cmd/main.go` to run with defaults, which will process messages from L1 to L2, and from L2 to L1, and start indexing blocks from 0.
+Run `go run cmd/main.go --help` to see a list of possible configuration flags, or `go run cmd/main.go` to run with defaults, which will start indexing events and blocks from block 0.
 
 # Block data
 

--- a/packages/eventindexer/README.md
+++ b/packages/eventindexer/README.md
@@ -1,4 +1,4 @@
-[![Event Indexer](https://codecov.io/gh/taikoxyz/taiko-mono/branch/main/graph/badge.svg?token=E468X2PTJC&flag=relayer)](https://codecov.io/gh/taikoxyz/taiko-mono)
+[![Event Indexer](https://app.codecov.io/gh/taikoxyz/taiko-mono/flags/main?flags%5B0%5D=eventindexer)](https://codecov.io/gh/taikoxyz/taiko-mono)
 
 # Indexer
 


### PR DESCRIPTION
Fix incorrect documentation in eventindexer README that was mixed with the relayer package but dont have any related.
