### PR TITLE
feat(protocol): use fork router to keep anchor address stable

### DIFF
--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -118,13 +118,13 @@ contract Anchor is EssentialContract {
     // ---------------------------------------------------------------
     // Pacaya slots for storage compatibility
     // ---------------------------------------------------------------
-    
+
     /// @dev slot0:  _blockhashes
     ///      slot1: publicInputHash
     ///      slot2: parentGasExcess, lastSyncedBlock, parentTimestamp, parentGasTarget
     ///      slot3: l1ChainId
     uint256[4] private _pacayaSlots;
-    
+
     // ---------------------------------------------------------------
     // State variables
     // ---------------------------------------------------------------

--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -116,6 +116,12 @@ contract Anchor is EssentialContract {
     uint64 public immutable l1ChainId;
 
     // ---------------------------------------------------------------
+    // Pacaya state variables
+    // ---------------------------------------------------------------
+    
+    uint256[4] private _pacayaSlots;
+    
+    // ---------------------------------------------------------------
     // State variables
     // ---------------------------------------------------------------
 
@@ -126,7 +132,7 @@ contract Anchor is EssentialContract {
     BlockState internal _blockState;
 
     /// @notice Storage gap for upgrade safety.
-    uint256[46] private __gap;
+    uint256[42] private __gap;
 
     // ---------------------------------------------------------------
     // Events

--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -116,9 +116,13 @@ contract Anchor is EssentialContract {
     uint64 public immutable l1ChainId;
 
     // ---------------------------------------------------------------
-    // Pacaya state variables
+    // Pacaya slots for storage compatibility
     // ---------------------------------------------------------------
     
+    /// @dev slot0:  _blockhashes
+    ///      slot1: publicInputHash
+    ///      slot2: parentGasExcess, lastSyncedBlock, parentTimestamp, parentGasTarget
+    ///      slot3: l1ChainId
     uint256[4] private _pacayaSlots;
     
     // ---------------------------------------------------------------
@@ -212,7 +216,7 @@ contract Anchor is EssentialContract {
     ///      3. Anchors L1 block data for cross-chain verification
     /// @param _proposalParams Proposal-level parameters that define the overall batch.
     /// @param _blockParams Block-level parameters specific to this block in the proposal.
-    function anchor(
+    function anchorV4(
         ProposalParams calldata _proposalParams,
         BlockParams calldata _blockParams
     )

--- a/packages/protocol/contracts/layer2/core/AnchorForkRouter.sol
+++ b/packages/protocol/contracts/layer2/core/AnchorForkRouter.sol
@@ -19,13 +19,17 @@ interface IPacayaAnchorLegacy {
         uint32 _parentGasUsed,
         BaseFeeConfig calldata _baseFeeConfig,
         bytes32[] calldata _signalSlots
-    ) external;
+    )
+        external;
 
     function getBasefeeV2(
         uint32 _parentGasUsed,
         uint64 _blockTimestamp,
         BaseFeeConfig calldata _baseFeeConfig
-    ) external view returns (uint256, uint64, uint64);
+    )
+        external
+        view
+        returns (uint256, uint64, uint64);
 
     function getBlockHash(uint256 _blockId) external view returns (bytes32);
 

--- a/packages/protocol/contracts/layer2/core/AnchorForkRouter.sol
+++ b/packages/protocol/contracts/layer2/core/AnchorForkRouter.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { ForkRouter } from "src/shared/fork-router/ForkRouter.sol";
+
+/// @notice Interface exposing the legacy Pacaya anchor functionality used pre-fork.
+interface IPacayaAnchorLegacy {
+    struct BaseFeeConfig {
+        uint8 adjustmentQuotient;
+        uint8 sharingPctg;
+        uint32 gasIssuancePerSecond;
+        uint64 minGasExcess;
+        uint32 maxGasIssuancePerBlock;
+    }
+
+    function anchorV3(
+        uint64 _anchorBlockId,
+        bytes32 _anchorStateRoot,
+        uint32 _parentGasUsed,
+        BaseFeeConfig calldata _baseFeeConfig,
+        bytes32[] calldata _signalSlots
+    ) external;
+
+    function getBasefeeV2(
+        uint32 _parentGasUsed,
+        uint64 _blockTimestamp,
+        BaseFeeConfig calldata _baseFeeConfig
+    ) external view returns (uint256, uint64, uint64);
+
+    function getBlockHash(uint256 _blockId) external view returns (bytes32);
+
+    function skipFeeCheck() external pure returns (bool);
+
+    function publicInputHash() external view returns (bytes32);
+
+    function parentGasExcess() external view returns (uint64);
+
+    function parentTimestamp() external view returns (uint64);
+
+    function parentGasTarget() external view returns (uint64);
+
+    function signalService() external view returns (address);
+
+    function pacayaForkHeight() external view returns (uint64);
+}
+
+/// @title AnchorForkRouter
+/// @notice Routes calls between the Pacaya and Shasta anchor implementations.
+/// @custom:security-contact security@taiko.xyz
+contract AnchorForkRouter is ForkRouter {
+    constructor(address _oldFork, address _newFork) ForkRouter(_oldFork, _newFork) { }
+
+    function shouldRouteToOldFork(bytes4 _selector) public pure override returns (bool) {
+        if (
+            _selector == IPacayaAnchorLegacy.anchorV3.selector
+                || _selector == IPacayaAnchorLegacy.getBasefeeV2.selector
+                || _selector == IPacayaAnchorLegacy.getBlockHash.selector
+                || _selector == IPacayaAnchorLegacy.skipFeeCheck.selector
+                || _selector == IPacayaAnchorLegacy.publicInputHash.selector
+                || _selector == IPacayaAnchorLegacy.parentGasExcess.selector
+                || _selector == IPacayaAnchorLegacy.parentTimestamp.selector
+                || _selector == IPacayaAnchorLegacy.parentGasTarget.selector
+                || _selector == IPacayaAnchorLegacy.signalService.selector
+                || _selector == IPacayaAnchorLegacy.pacayaForkHeight.selector
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/packages/protocol/contracts/shared/fork-router/ForkRouter.sol
+++ b/packages/protocol/contracts/shared/fork-router/ForkRouter.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {
+    Ownable2StepUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 /// @title ForkRouter
 /// @notice Routes calls between the legacy and new fork implementations using delegatecall.
-/// 
+///
 ///                         +--> newFork
 /// PROXY -> FORK_ROUTER--|
 ///                         +--> oldFork

--- a/packages/protocol/contracts/shared/fork-router/ForkRouter.sol
+++ b/packages/protocol/contracts/shared/fork-router/ForkRouter.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+
+/// @title ForkRouter
+/// @notice Routes calls between the legacy and new fork implementations using delegatecall.
+/// 
+///                         +--> newFork
+/// PROXY -> FORK_ROUTER--|
+///                         +--> oldFork
+///
+/// @custom:security-contact security@taiko.xyz
+abstract contract ForkRouter is UUPSUpgradeable, Ownable2StepUpgradeable {
+    address public immutable oldFork;
+    address public immutable newFork;
+
+    error InvalidParams();
+    error ZeroForkAddress();
+
+    constructor(address _oldFork, address _newFork) {
+        require(_newFork != address(0), InvalidParams());
+        require(_newFork != _oldFork, InvalidParams());
+
+        oldFork = _oldFork;
+        newFork = _newFork;
+
+        _disableInitializers();
+    }
+
+    fallback() external payable virtual {
+        _fallback();
+    }
+
+    receive() external payable virtual {
+        _fallback();
+    }
+
+    /// @notice Returns true if a function should be routed to the old fork implementation.
+    /// @dev Override to provide fork-specific routing logic.
+    function shouldRouteToOldFork(bytes4) public view virtual returns (bool);
+
+    function _fallback() internal virtual {
+        address fork = shouldRouteToOldFork(msg.sig) ? oldFork : newFork;
+        require(fork != address(0), ZeroForkAddress());
+
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), fork, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    function _authorizeUpgrade(address) internal virtual override onlyOwner { }
+}

--- a/packages/protocol/layout/layer2-contracts.txt
+++ b/packages/protocol/layout/layer2-contracts.txt
@@ -133,11 +133,13 @@
 |
 | __gap                       | uint256[49]                 | 202  | 0      | 1568  |
 |
-| _proposalState              | struct Anchor.ProposalState | 251  | 0      | 64    |
+| _pacayaSlots                | uint256[4]                  | 251  | 0      | 128   |
 |
-| _blockState                 | struct Anchor.BlockState    | 253  | 0      | 64    |
+| _proposalState              | struct Anchor.ProposalState | 255  | 0      | 64    |
 |
-| __gap                       | uint256[46]                 | 255  | 0      | 1472  |
+| _blockState                 | struct Anchor.BlockState    | 257  | 0      | 64    |
+|
+| __gap                       | uint256[42]                 | 259  | 0      | 1344  |
 ╰-----------------------------+-----------------------------+------+--------+-------+-----------------------------------------╯
 
 

--- a/packages/protocol/test/layer2/AnchorForkRouter.t.sol
+++ b/packages/protocol/test/layer2/AnchorForkRouter.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Test } from "forge-std/src/Test.sol";
+import { AnchorForkRouter, IPacayaAnchorLegacy } from "src/layer2/core/AnchorForkRouter.sol";
+
+contract AnchorForkRouterTest is Test {
+    AnchorForkRouter private router;
+
+    function setUp() public {
+        router = new AnchorForkRouter(address(0x1), address(0x2));
+    }
+
+    function test_shouldRouteLegacySelectors() public view {
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.anchorV3.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.getBasefeeV2.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.getBlockHash.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.skipFeeCheck.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.publicInputHash.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.parentGasExcess.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.parentTimestamp.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.parentGasTarget.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.signalService.selector));
+        assertTrue(router.shouldRouteToOldFork(IPacayaAnchorLegacy.pacayaForkHeight.selector));
+    }
+
+    function test_shouldNotRouteNonLegacySelectors() public view {
+        assertFalse(router.shouldRouteToOldFork(bytes4(keccak256("withdraw(address,address)"))));
+        assertFalse(router.shouldRouteToOldFork(bytes4(keccak256("getProposalState()"))));
+        assertFalse(router.shouldRouteToOldFork(bytes4(keccak256("init(address)"))));
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces a fork router(now made a reusable abstract contract) similar to the one we had for the pacaya inbox to allow the anchor to:
- keep the same address
- don't have to inherit from the old contract, which would require restoring a lot of the old dependencies

This also changes the name of the anchor function to `anchorV4` to make things clearer

## Open Questions / Discussions
1. The current anchor contract is still upgradable. Now that we'll have a fork router as the entry point, do we still need to do so? we could have the anchor as immutable and just upgrade the fork router going forward
2. This PR does not introduce a shasta fork height and instead relies on function signatures to redirect to the right place. The responsibility lies on the client software to switch at the right fork height or timestamp. This seems ok to me, am I missing something?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a selector-based fork router to keep Anchor address stable across forks, introduces anchorV4, and updates storage layout for Pacaya compatibility with tests.
> 
> - **Fork Routing**:
>   - Introduces reusable `shared/fork-router/ForkRouter` (delegatecall-based, UUPS + Ownable).
>   - Adds `AnchorForkRouter` with legacy `IPacayaAnchorLegacy` interface and selector-based routing to old vs new fork.
> - **Anchor (Shasta)**:
>   - Renames entrypoint from `anchor` to `anchorV4`.
>   - Adds `_pacayaSlots` reserved storage for compatibility; reduces `__gap` from 46 to 42.
> - **Tests**:
>   - Adds `AnchorForkRouter.t.sol` to assert routing of legacy vs non-legacy selectors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efbecfdd23b61890941e8ede3f174ba5f4ff90fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->