### PR TITLE
fix(protocol): fix bond manager vulnerability

### DIFF
--- a/packages/protocol/contracts/layer2/core/BondManager.sol
+++ b/packages/protocol/contracts/layer2/core/BondManager.sol
@@ -201,9 +201,9 @@ contract BondManager is EssentialContract, IBondManager {
     /// @param _to The recipient address
     /// @param _amount The amount to withdraw
     function _withdraw(address _from, address _to, uint256 _amount) internal {
-        _debitBond(_from, _amount);
-        bondToken.safeTransfer(_to, _amount);
-        emit BondWithdrawn(_from, _amount);
+        uint256 debited = _debitBond(_from, _amount);
+        bondToken.safeTransfer(_to, debited);
+        emit BondWithdrawn(_from, debited);
     }
 
     /// @dev Internal implementation for getting the bond balance


### PR DESCRIPTION
This was actually discovered by codex. Following @dantaik suggestion I fed it our old audit reports and asked it to review our shasta code for vulnerabilities. This was the full audit report for reference:

# Codex Shasta Internal Review

- **Date:** 2025-10-20
- **Author:** Codex (senior rollup auditor)
- **Scope:**  
  `packages/protocol/contracts/layer1/core`  
  `packages/protocol/contracts/layer1/verifiers`  
  `packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol`  
  `packages/protocol/contracts/shared/signal`  
  `packages/protocol/contracts/layer2/core`

## Methodology
- Reviewed historical findings from prior engagements (Code4rena Mar‑2024, OpenZeppelin Jun‑2024 & Nov‑2024, Halborn, Sigma Prime, Quill) to understand recurring risk themes around bond accounting, forced inclusion, and checkpoint sync.  
- Performed targeted manual review focusing on economic security flows (bond accounting, slashing), proof lifecycle (propose → prove → finalize), checkpoint propagation, and fork routing.  
- Reasoned about adversarial sequences and L1/L2 trust assumptions; attempted to construct minimal PoCs for each suspected issue.

## Executive Summary
- **Critical vulnerability discovered** in the Shasta `BondManager` that allows any withdrawing account to drain the entire bond token balance from the contract once their withdrawal delay elapses. Exploitation results in full loss of all bonded collateral, breaking the protocol’s economic security guarantees.  
- No additional exploitable issues were identified in the reviewed scope. Historical concerns (e.g., base fee accounting, signal proofs) were reassessed against current code and considered addressed.

## Findings

### [C-01] Matured withdrawals can steal all bonded funds  
- **Severity:** Critical  
- **Confidence:** High  
- **Affected components:** `packages/protocol/contracts/layer2/core/BondManager.sol:203`  

#### Impact
Once an operator’s withdrawal delay expires, they can request an arbitrarily large withdrawal and the contract will transfer the requested amount—even if it exceeds their actual bond balance. An attacker can drain the entire ERC20 bond reserve, causing permanent loss of all collateral and eliminating the deterrent for malicious proposers/provers.

#### Technical Details
```solidity
function _withdraw(address _from, address _to, uint256 _amount) internal {
    _debitBond(_from, _amount);          // best-effort: caps at caller balance
    bondToken.safeTransfer(_to, _amount); // always transfers the requested amount
}
```

`_debitBond` returns the actual amount removed from storage, but `_withdraw` ignores the return value and always transfers `_amount`. When the caller’s withdrawal is mature (`withdrawalRequestedAt != 0` and delay satisfied), the guard in `withdraw` skips the `balance - _amount` underflow check, so `_amount` is unconstrained.

#### Exploitation Scenario
1. Operator deposits the minimum bond.  
2. Calls `requestWithdrawal()` and waits `withdrawalDelay`.  
3. Queries `bondToken.balanceOf(address(bondManager))` to learn the contract’s total reserves `T`.  
4. Calls `withdraw(attacker, T)`. `_debitBond` zeroes the attacker’s balance, but `safeTransfer` sends `T` tokens to the attacker, draining every depositor’s funds.

#### Remediation
Transfer only the actual debited amount. For example:
```solidity
function _withdraw(address _from, address _to, uint256 _amount) internal {
    uint256 debited = _debitBond(_from, _amount);
    bondToken.safeTransfer(_to, debited);
}
```
Optionally add an explicit `require(debited == _amount)` if over-withdrawals should always revert.

## Residual Risks & Recommendations
- Re‑audit all bond and accounting flows after fixing C‑01; this bug may have masked other logic that relies on correct bond balances.  
- Consider adding assertions around major economic state transitions (e.g., bond debits/credits, checkpoint persistence) to aid formal verification.  
- Keep monitoring forced inclusion queue economics—ensure fee accounting cannot be manipulated once bond safety is restored.

## Acknowledgements
Thanks to prior auditors whose reports highlighted bond and checkpoint concerns; that context guided the targeted review that surfaced C‑01.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `BondManager._withdraw` to transfer and emit the actual debited amount returned by `_debitBond`, preventing over-withdrawals.
> 
> - **Protocol (L2 Core)**
>   - **`BondManager.sol`**:
>     - `/_withdraw/`: use the value returned by `_debitBond` for transfer and event emission (`debited`), instead of the requested `_amount`.
>     - Prevents transferring more than the caller’s available bond balance during withdrawals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 933b38fca55e38bc840eb9e3ec9824a7258f9b3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->