### PR TITLE
chore(protocol):  improve gas cost in Inbox.sol

### DIFF
--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -883,7 +883,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     function _finalize(ProposeInput memory _input) private returns (CoreState memory) {
         unchecked {
             CoreState memory coreState = _input.coreState;
-            TransitionRecord memory lastFinalizedRecord;
+           uint lastFinalizedRecordIdx;
             TransitionRecord memory emptyRecord;
             uint48 proposalId = coreState.lastFinalizedProposalId + 1;
             uint256 finalizedCount;
@@ -905,14 +905,14 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
                 if (!finalized) break;
 
                 // Update state for successful finalization
-                lastFinalizedRecord = _input.transitionRecords[i];
+                lastFinalizedRecordIdx = i;
                 ++finalizedCount;
             }
 
             // Update checkpoint if any proposals were finalized and minimum delay has passed
             if (finalizedCount > 0) {
                 _syncCheckpointIfNeeded(
-                    _input.checkpoint, lastFinalizedRecord.checkpointHash, coreState
+                    _input.checkpoint, _input.transitionRecords[lastFinalizedRecordIdx].checkpointHash, coreState
                 );
             }
 


### PR DESCRIPTION
## Background
The `_finalize` function in `Inbox.sol` was incorrectly updating the checkpoint using a potentially uninitialized `lastFinalizedRecord`. This could lead to incorrect state synchronization.

## Changes
- Modified `Inbox.sol`:
  - Replaced `TransitionRecord memory lastFinalizedRecord;` with `uint lastFinalizedRecordIdx;`.
  - Changed `lastFinalizedRecord = _input.transitionRecords[i];` to `lastFinalizedRecordIdx = i;`.
  - Updated the `_syncCheckpointIfNeeded` call to use `_input.transitionRecords[lastFinalizedRecordIdx].checkpointHash` instead of `lastFinalizedRecord.checkpointHash`.

## Testing
- [ ] Manually test the `_finalize` function with various scenarios, including cases with no finalized proposals and cases with multiple finalized proposals.
- [ ] Verify that the checkpoint is correctly synchronized after successful finalizations.
- [ ] Ensure no new revert reasons are introduced.
