### PR TITLE
refactor(protocol): remove layer1o foundry profile

### DIFF
--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -89,12 +89,6 @@ src = "contracts/layer1"
 test = "test/layer1"
 script = "script/layer1"
 out = "out/layer1"
-
-[profile.layer1o]
-src = "contracts/layer1"
-test = "test/layer1"
-script = "script/layer1"
-out = "out/layer1"
 via_ir = true
 
 [profile.layer2]

--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -5,6 +5,7 @@ gas_limit = "18446744073709551615" # u64::MAX
 optimizer = true
 optimizer_runs = 200
 ffi = true
+via_ir = true
 memory_limit = 4_294_967_296
 solc_version = "0.8.30"
 evm_version = "prague"
@@ -89,7 +90,6 @@ src = "contracts/layer1"
 test = "test/layer1"
 script = "script/layer1"
 out = "out/layer1"
-via_ir = true
 
 [profile.layer2]
 src = "contracts/layer2"

--- a/packages/taiko-client/integration_test/deploy_l1_contract.sh
+++ b/packages/taiko-client/integration_test/deploy_l1_contract.sh
@@ -29,7 +29,7 @@ cat "L1 contracts deployed:
 "
 
 cd ../protocol &&
-  FOUNDRY_PROFILE=layer1o PRIVATE_KEY=$PRIVATE_KEY forge script script/layer1/core/DeployProtocolOnL1.s.sol:DeployProtocolOnL1 \
+  FOUNDRY_PROFILE=layer1 PRIVATE_KEY=$PRIVATE_KEY forge script script/layer1/core/DeployProtocolOnL1.s.sol:DeployProtocolOnL1 \
     --fork-url "$L1_HTTP" \
     --broadcast \
     --ffi \


### PR DESCRIPTION
## Summary
- Removes the redundant `layer1o` profile from `foundry.toml`
- Updates integration test deployment script to use the standard `layer1` profile

## Test plan
- [ ] Verify protocol tests pass with the standard `layer1` profile
- [ ] Run integration tests to ensure deployment script works correctly
- [ ] Confirm no other scripts reference the `layer1o` profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)