### PR TITLE
docs(docs-site): add troubleshooting entry for genesis header hash mismatch

### DIFF
--- a/packages/docs-site/src/content/docs/guides/node-operators/node-troubleshooting.mdx
+++ b/packages/docs-site/src/content/docs/guides/node-operators/node-troubleshooting.mdx
@@ -111,3 +111,7 @@ Continue your prover with `docker compose up` (`-d` is optional). You should see
 You can search with the following command: `docker compose logs taiko_client_prover_relayer | grep "{YOUR_ASSIGNED_BLOCKID}"`, and then check your Raiko instance for logs pertaining to proof generation!
 
 If the solution fails, please reach out to us in Discord with your logs.
+
+### Failed to ensure genesis block matched: genesis header hash mismatch
+
+You're using the wrong docker-compose file for the network. Use the correct file for your target network, e.g., `docker compose -f docker-compose-hoodi.yml up -d` for Taiko Hoodi testnet.

--- a/packages/docs-site/src/content/docs/guides/node-operators/node-troubleshooting.mdx
+++ b/packages/docs-site/src/content/docs/guides/node-operators/node-troubleshooting.mdx
@@ -114,4 +114,4 @@ If the solution fails, please reach out to us in Discord with your logs.
 
 ### Failed to ensure genesis block matched: genesis header hash mismatch
 
-You're using the wrong docker-compose file for the network. Use the correct file for your target network, e.g., `docker compose -f docker-compose-hoodi.yml up -d` for Taiko Hoodi testnet.
+*(simple-taiko-node only)* You're using the wrong docker-compose file for the network. Use the correct file for your target network, e.g., `docker compose -f docker-compose-hoodi.yml up -d` for Taiko Hoodi testnet.


### PR DESCRIPTION
Hello
I noticed 
```failed to ensure genesis block matched: genesis header hash mismatch```

message in logs because I was trying Hoodi testnet .env with mainnet docker-compose file so I thought it can be useful to have it on troubleshooting docs