### PR TITLE
fix: Dockerfile ENTRYPOINT to use exec-form for proper signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ ENV PACKAGE=${PACKAGE}
 
 RUN apk add --no-cache ca-certificates
 
-COPY --from=builder /taiko-mono/packages/${PACKAGE}/bin/${PACKAGE} /usr/local/bin/
+COPY --from=builder /taiko-mono/packages/${PACKAGE}/bin/${PACKAGE} /usr/local/bin/app
 
-ENTRYPOINT /usr/local/bin/${PACKAGE}
+ENTRYPOINT ["/usr/local/bin/app"]


### PR DESCRIPTION


## Description

**Problem**: The Dockerfile uses shell-form ENTRYPOINT which prevents proper signal handling in containers.

**Solution**: 
- Rename binary to stable name `/usr/local/bin/app` 
- Switch to exec-form ENTRYPOINT `["/usr/local/bin/app"]`

