### PR TITLE
fix(protocol): use _input.coreState in finalization loop

### DIFF
--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -896,7 +896,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
 
                 // Try to finalize the current proposal
                 (bytes26 recordHash, uint48 finalizationDeadline) = _getTransitionRecordHashAndDeadline(
-                    proposalId, coreState.lastFinalizedTransitionHash
+                    proposalId,  _input.coreState.lastFinalizedTransitionHash
                 );
 
                 if (i >= transitionCount) {


### PR DESCRIPTION
## Summary

- Fixes incorrect variable reference in `Inbox.sol` finalization loop
- Changes `coreState.lastFinalizedTransitionHash` to `_input.coreState.lastFinalizedTransitionHash` at line 899

## Details

The finalization loop was incorrectly referencing the local `coreState` variable instead of the `_input.coreState` parameter when calling `_getTransitionRecordHashAndDeadline()`. This fix ensures the function uses the correct state reference.

## Test plan

- [ ] Verify contract compilation succeeds
- [ ] Run existing Inbox tests to ensure no regressions
- [ ] Review the change aligns with the intended finalization logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)