### PR TITLE
fix(taiko-client,taiko-client-rs): fix lint & MaxBlockGasLimit

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/validation.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/validation.rs
@@ -2,8 +2,8 @@ use alethia_reth_consensus::validation::ANCHOR_V3_GAS_LIMIT;
 use alloy_primitives::Address;
 use protocol::shasta::{
     constants::{
-        ANCHOR_MAX_OFFSET, ANCHOR_MIN_OFFSET, BLOCK_GAS_LIMIT_MAX_CHANGE, MIN_BLOCK_GAS_LIMIT,
-        TIMESTAMP_MAX_OFFSET, MAX_BLOCK_GAS_LIMIT,
+        ANCHOR_MAX_OFFSET, ANCHOR_MIN_OFFSET, BLOCK_GAS_LIMIT_MAX_CHANGE, MAX_BLOCK_GAS_LIMIT,
+        MIN_BLOCK_GAS_LIMIT, TIMESTAMP_MAX_OFFSET,
     },
     manifest::DerivationSourceManifest,
 };

--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -239,7 +239,7 @@ func (p *Proposer) fetchPoolContent(allowEmptyPoolContent bool) ([]types.Transac
 	preBuiltTxList, err := p.rpc.GetPoolContent(
 		p.ctx,
 		p.proposerAddress,
-		p.protocolConfigs.BlockMaxGasLimit(),
+		manifest.MaxBlockGasLimit,
 		rpc.BlockMaxTxListBytes,
 		[]common.Address{},
 		p.MaxTxListsPerEpoch,


### PR DESCRIPTION
1. Fix lint
2. Since `p.protocolConfigs.BlockMaxGasLimit()` is greater than `manifest.MaxBlockGasLimit`, using a larger value may cause derivation issues when the txpool is full.