### PR TITLE
chore(taiko-client-rs): remove reth as dependency of event-indexer

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -3362,7 +3362,6 @@ dependencies = [
  "dashmap 6.1.0",
  "event-scanner",
  "metrics 0.24.2",
- "rpc",
  "thiserror 2.0.16",
  "tokio",
  "tokio-retry",

--- a/packages/taiko-client-rs/crates/event-indexer/Cargo.toml
+++ b/packages/taiko-client-rs/crates/event-indexer/Cargo.toml
@@ -28,7 +28,6 @@ alloy-sol-types = { workspace = true }
 # taiko
 bindings = { path = "../bindings" }
 event-scanner = { workspace = true }
-rpc = { path = "../rpc" }
 
 # types
 anyhow = { workspace = true }

--- a/packages/taiko-client-rs/crates/event-indexer/examples/example.rs
+++ b/packages/taiko-client-rs/crates/event-indexer/examples/example.rs
@@ -1,17 +1,14 @@
-use std::str::FromStr;
-
-use alloy::{eips::BlockNumberOrTag, transports::http::reqwest::Url};
+use alloy::eips::BlockNumberOrTag;
 use alloy_primitives::Address;
 use event_indexer::{
     indexer::{ShastaEventIndexer, ShastaEventIndexerConfig},
     interface::ShastaProposeInputReader,
 };
-use rpc::SubscriptionSource;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let config = ShastaEventIndexerConfig {
-        l1_subscription_source: SubscriptionSource::Ws(Url::from_str("ws://127.0.0.1:8546")?),
+        l1_subscription_connection_string: "ws://127.0.0.1:8546".to_string(),
         inbox_address: Address::ZERO,
     };
 

--- a/packages/taiko-client-rs/crates/event-indexer/src/error.rs
+++ b/packages/taiko-client-rs/crates/event-indexer/src/error.rs
@@ -3,7 +3,6 @@
 use alloy::transports::TransportErrorKind;
 use alloy_json_rpc::RpcError;
 use event_scanner::event_scanner::EventScannerError;
-use rpc::RpcClientError;
 use std::result::Result as StdResult;
 use thiserror::Error;
 
@@ -45,12 +44,5 @@ impl From<RpcError<TransportErrorKind>> for IndexerError {
 impl From<alloy_sol_types::Error> for IndexerError {
     fn from(err: alloy_sol_types::Error) -> Self {
         IndexerError::LogDecode(err.to_string())
-    }
-}
-
-// Manual From implementation for RpcClientError
-impl From<RpcClientError> for IndexerError {
-    fn from(err: RpcClientError) -> Self {
-        IndexerError::Rpc(err.to_string())
     }
 }

--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -48,7 +48,7 @@ impl Proposer {
 
         // Initialize RPC client.
         let indexer = ShastaEventIndexer::new(ShastaEventIndexerConfig {
-            l1_subscription_source: cfg.l1_provider_source.clone(),
+            l1_subscription_connection_string: cfg.l1_provider_source.to_string(),
             inbox_address: cfg.inbox_address,
         })
         .await?;

--- a/packages/taiko-client-rs/crates/rpc/src/lib.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/lib.rs
@@ -130,6 +130,15 @@ impl TryFrom<&str> for SubscriptionSource {
     }
 }
 
+impl std::fmt::Display for SubscriptionSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SubscriptionSource::Ipc(path) => write!(f, "{}", path.to_string_lossy()),
+            SubscriptionSource::Ws(url) => write!(f, "{url}"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Currently, the event-indexer depends from the `rpc` crate which depends on `alethia-reth`. This is not great for downstream consumers of this crate because it adds a lot of crate version clashes and compilation time.

The only type used from the `rpc` crate is `SubscriptionSource`. 

With this PR, I removed the `rpc` dependency by parsing the connection string directly in the event-indexer crate instead.
This is just one option; a probably more robust option would be to move `SubscriptionSource` to a different crate that doesn't depend on `alethia-reth`.

Please let me know if the current approach is acceptable or if you prefer to have a different crate, such as `primitives` or similar, where to put `SubscriptionSource`. 

cc @davidtaikocha 