### PR TITLE
chore(ci): disable Codecov integration in protocol workflow

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -91,22 +91,22 @@ jobs:
         working-directory: ./packages/protocol
         run: pnpm snapshot:l1 && pnpm layout:l1
 
-      - name: Generate coverage report
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
-        working-directory: ./packages/protocol
-        run: |
-          forge coverage --report lcov
-          mkdir -p coverage
-          mv lcov.info coverage/lcov.info
+      # - name: Generate coverage report
+      #   if: ${{ secrets.CODECOV_TOKEN != '' }}
+      #   working-directory: ./packages/protocol
+      #   run: |
+      #     forge coverage --report lcov
+      #     mkdir -p coverage
+      #     mv lcov.info coverage/lcov.info
 
-      - name: Upload coverage to Codecov
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./packages/protocol/coverage/lcov.info
-          flags: protocol
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # - name: Upload coverage to Codecov
+      #   if: ${{ secrets.CODECOV_TOKEN != '' }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     files: ./packages/protocol/coverage/lcov.info
+      #     flags: protocol
+      #   env:
+      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check for changes
         id: git_status


### PR DESCRIPTION
Temporarily disables the Codecov integration for the protocol package otherwise protocol.yml workflow is not triggered.
