### PR TITLE
fix(protocol): resolve duplicate Storage Layout sections in gen-layouts script

### DIFF
--- a/packages/protocol/script/gen-layouts.sh
+++ b/packages/protocol/script/gen-layouts.sh
@@ -93,9 +93,9 @@ update_contract_layout() {
 
     # Remove everything from marker onwards (including preceding blank lines)
     if grep -q "$LAYOUT_MARKER" "$file_path"; then
-        # Find marker line, walk back past blank lines, delete from there to end
+        # Find first marker line, walk back past blank lines, delete from there to end
         local marker_line last_content_line
-        marker_line=$(grep -n "$LAYOUT_MARKER" "$file_path" | cut -d: -f1)
+        marker_line=$(grep -n "$LAYOUT_MARKER" "$file_path" | head -1 | cut -d: -f1)
         last_content_line=$((marker_line - 1))
 
         # Skip blank lines before marker


### PR DESCRIPTION
## Summary

- Fixed bug in `gen-layouts.sh` where multiple Storage Layout markers caused duplicates
- Script now correctly finds the **first** marker instead of returning multiple line numbers
- Added `head -1` to ensure only the first occurrence is processed

## Problem

The gen-layouts script had a bug where when a contract file already had duplicate Storage Layout sections, the `grep -n` command would return multiple line numbers. The script incorrectly handled this, causing it to fail to remove all old storage layout content, leading to duplicate sections accumulating on each run.

## Solution

Added `| head -1` to line 98 to explicitly select only the first Storage Layout marker:

```bash
marker_line=$(grep -n "$LAYOUT_MARKER" "$file_path" | head -1 | cut -d: -f1)
```

This ensures the script always removes content starting from the first marker, preventing duplicates.

## Testing

- Verified script now correctly processes contracts with existing duplicate sections
- Regenerated storage layouts for shared and layer2 contracts
- Confirmed only single Storage Layout section remains in all processed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>