### PR TITLE
fix(protocol): resolve sed platform compatibility in gen-layouts script

### DIFF
--- a/packages/protocol/script/gen-layouts.sh
+++ b/packages/protocol/script/gen-layouts.sh
@@ -103,7 +103,12 @@ update_contract_layout() {
             ((last_content_line--))
         done
 
-        sed -i '' "1,${last_content_line}!d" "$file_path"
+        # Use different sed syntax for macOS vs Linux
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "1,${last_content_line}!d" "$file_path"
+        else
+            sed -i "1,${last_content_line}!d" "$file_path"
+        fi
     fi
 
     # Append new storage layout


### PR DESCRIPTION
## Summary
- Fixes `sed: can't read 1,112!d: No such file or directory` error in CI
- Adds platform detection to use correct `sed -i` syntax for macOS vs Linux

## Problem
The `gen-layouts.sh` script was using macOS-specific `sed -i ''` syntax, which fails on Linux CI runners. On Linux, the empty string after `-i` is interpreted as a backup suffix rather than "no backup", causing sed to treat the pattern as a filename.

## Solution
Added `OSTYPE` detection:
- macOS (darwin): `sed -i ''` 
- Linux: `sed -i` (no empty string)

## Testing
- ✅ Tested locally on macOS
- ✅ All 16 layer1 contracts updated successfully
- ✅ Will resolve CI errors in workflow runs

Fixes the issue reported in: https://github.com/taikoxyz/taiko-mono/actions/runs/18877209091/job/53870126942