### PR TITLE
Emit finalized bond instructions with Proposed event

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IInbox.sol
@@ -178,6 +178,8 @@ interface IInbox {
         Derivation derivation;
         /// @notice The core state after the proposal.
         CoreState coreState;
+        /// @notice Bond instructions finalized while processing this proposal.
+        LibBonds.BondInstruction[] finalizedBondInstructions;
     }
 
     /// @notice Payload data emitted in the Proved event

--- a/packages/protocol/test/layer1/core/benchmark/LibProposedEventEncoderGas.t.sol
+++ b/packages/protocol/test/layer1/core/benchmark/LibProposedEventEncoderGas.t.sol
@@ -6,6 +6,7 @@ import { console2 } from "forge-std/src/console2.sol";
 import { IInbox } from "src/layer1/core/iface/IInbox.sol";
 import { LibBlobs } from "src/layer1/core/libs/LibBlobs.sol";
 import { LibProposedEventEncoder } from "src/layer1/core/libs/LibProposedEventEncoder.sol";
+import { LibBonds } from "src/shared/libs/LibBonds.sol";
 
 /// @title LibProposedEventEncoderGas
 /// @notice Gas comparison between optimized LibEncoder and abi.encode
@@ -206,6 +207,20 @@ contract LibProposedEventEncoderGas is Test {
             lastCheckpointTimestamp: 0,
             lastFinalizedTransitionHash: keccak256("lastTransition"),
             bondInstructionsHash: keccak256("bondInstructions")
+        });
+
+        payload_.finalizedBondInstructions = new LibBonds.BondInstruction[](2);
+        payload_.finalizedBondInstructions[0] = LibBonds.BondInstruction({
+            proposalId: 1,
+            bondType: LibBonds.BondType.PROVABILITY,
+            payer: address(0x5555),
+            payee: address(0x6666)
+        });
+        payload_.finalizedBondInstructions[1] = LibBonds.BondInstruction({
+            proposalId: 2,
+            bondType: LibBonds.BondType.LIVENESS,
+            payer: address(0x7777),
+            payee: address(0x8888)
         });
     }
 }

--- a/packages/protocol/test/layer1/core/inbox/common/InboxTestHelper.sol
+++ b/packages/protocol/test/layer1/core/inbox/common/InboxTestHelper.sol
@@ -12,6 +12,7 @@ import { IProposerChecker } from "src/layer1/core/iface/IProposerChecker.sol";
 import { Inbox } from "src/layer1/core/impl/Inbox.sol";
 import { LibBlobs } from "src/layer1/core/libs/LibBlobs.sol";
 import { IProofVerifier } from "src/layer1/verifiers/IProofVerifier.sol";
+import { LibBonds } from "src/shared/libs/LibBonds.sol";
 import { ICheckpointStore } from "src/shared/signal/ICheckpointStore.sol";
 import { SignalService } from "src/shared/signal/SignalService.sol";
 import { CommonTest } from "test/shared/CommonTest.sol";
@@ -225,7 +226,10 @@ abstract contract InboxTestHelper is CommonTest {
         });
 
         return IInbox.ProposedEventPayload({
-            proposal: expectedProposal, derivation: expectedDerivation, coreState: expectedCoreState
+            proposal: expectedProposal,
+            derivation: expectedDerivation,
+            coreState: expectedCoreState,
+            finalizedBondInstructions: new LibBonds.BondInstruction[](0)
         });
     }
 


### PR DESCRIPTION
## Summary
- return finalized bond instructions from `_finalize` and include them when emitting `Proposed`
- extend `ProposedEventPayload` encoding and decoding to pack the flattened bond instructions
- update event helper builders and encoder tests to cover the new bond instruction payload

## Testing
- pnpm test *(fails: node_modules dependencies missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690249a5687483238bc6107c5ab76d1a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Emits finalized bond instructions with `Proposed` and extends compact encoder/decoder and tests to handle them.
> 
> - **Core (Inbox)**:
>   - `_finalize` now returns `(CoreState, LibBonds.BondInstruction[])`, aggregating finalized bond instructions across finalized transitions.
>   - `propose` and `_activateInbox` emit `Proposed` with flattened `finalizedBondInstructions` via updated `_emitProposedEvent`.
> - **Interface (`IInbox`)**:
>   - Extend `ProposedEventPayload` with `finalizedBondInstructions: LibBonds.BondInstruction[]`.
> - **Encoding (`LibProposedEventEncoder`)**:
>   - Add compact encoding/decoding for `finalizedBondInstructions` (length + per-instruction fields) and adjust size calc.
> - **Tests**:
>   - Update helpers and add/extend unit, fuzz, and gas benchmarks to construct, encode/decode, and assert on `finalizedBondInstructions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d116443f8be0e6c84ba91a65fa7851c8f5332706. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->