### PR TITLE
fix(taiko-client): correct remaining duration in proving window helpers

### DIFF
--- a/packages/taiko-client/prover/event_handler/util.go
+++ b/packages/taiko-client/prover/event_handler/util.go
@@ -114,7 +114,11 @@ func IsProvingWindowExpired(
 		now       = uint64(time.Now().Unix())
 		expiredAt = timestamp + uint64(provingWindow.Seconds())
 	)
-	return now > expiredAt, time.Unix(int64(expiredAt), 0), time.Duration(expiredAt-now) * time.Second, nil
+	remainingSeconds := int64(expiredAt) - int64(now)
+	if remainingSeconds < 0 {
+		remainingSeconds = 0
+	}
+	return now > expiredAt, time.Unix(int64(expiredAt), 0), time.Duration(remainingSeconds) * time.Second, nil
 }
 
 // IsProvingWindowExpiredShasta returns true as the first return parameter if the assigned prover
@@ -133,5 +137,9 @@ func IsProvingWindowExpiredShasta(
 		now       = uint64(time.Now().Unix())
 		expiredAt = metadata.Shasta().GetProposal().Timestamp.Uint64() + configs.ProvingWindow.Uint64()
 	)
-	return now > expiredAt, time.Unix(int64(expiredAt), 0), time.Duration(expiredAt-now) * time.Second, nil
+	remainingSeconds := int64(expiredAt) - int64(now)
+	if remainingSeconds < 0 {
+		remainingSeconds = 0
+	}
+	return now > expiredAt, time.Unix(int64(expiredAt), 0), time.Duration(remainingSeconds) * time.Second, nil
 }

--- a/packages/taiko-client/prover/event_handler/util_test.go
+++ b/packages/taiko-client/prover/event_handler/util_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 	pacayaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/pacaya"
+	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
 )
 
@@ -53,6 +56,71 @@ func (s *ProverEventHandlerTestSuite) TestIsProvingWindowExpired() {
 	s.Nil(err)
 	s.False(expired)
 	s.Equal(time.Unix(int64(uint64(timestamp)+uint64(provingWindow.Seconds())), 0), expiredAt)
+}
+
+func (s *ProverEventHandlerTestSuite) TestIsProvingWindowExpired_PacayaExpiredZeroRemaining() {
+	protocolConfigs, err := s.RPCClient.GetProtocolConfigs(nil)
+	s.Nil(err)
+
+	provingWindow, err := protocolConfigs.ProvingWindow()
+	s.Nil(err)
+
+	now := time.Now().Unix()
+	pastTs := now - int64(provingWindow.Seconds()) - 5
+
+	expired, _, remaining, err := IsProvingWindowExpired(
+		s.RPCClient,
+		metadata.NewTaikoDataBlockMetadataPacaya(
+			&pacayaBindings.TaikoInboxClientBatchProposed{
+				Meta: pacayaBindings.ITaikoInboxBatchMetadata{ProposedAt: uint64(pastTs)},
+			},
+		),
+	)
+	s.Nil(err)
+	s.True(expired)
+	s.Equal(time.Duration(0), remaining)
+}
+
+func (s *ProverEventHandlerTestSuite) TestIsProvingWindowExpiredShasta_Remaining() {
+	configs, err := s.RPCClient.GetProtocolConfigsShasta(nil)
+	s.Nil(err)
+
+	pw := configs.ProvingWindow.Uint64()
+	now := uint64(time.Now().Unix())
+
+	notExpiredTs := int64(now + pw - 5)
+	meta := metadata.NewTaikoProposalMetadataShasta(
+		&shastaBindings.IInboxProposedEventPayload{
+			Proposal: shastaBindings.IInboxProposal{
+				Id:        big.NewInt(1),
+				Timestamp: big.NewInt(notExpiredTs),
+				Proposer:  common.Address{},
+			},
+		},
+		types.Log{},
+	)
+
+	expired, _, remaining, err := IsProvingWindowExpiredShasta(s.RPCClient, meta)
+	s.Nil(err)
+	s.False(expired)
+	s.True(remaining > 0)
+
+	expiredTs := int64(now - pw - 5)
+	metaExpired := metadata.NewTaikoProposalMetadataShasta(
+		&shastaBindings.IInboxProposedEventPayload{
+			Proposal: shastaBindings.IInboxProposal{
+				Id:        big.NewInt(2),
+				Timestamp: big.NewInt(expiredTs),
+				Proposer:  common.Address{},
+			},
+		},
+		types.Log{},
+	)
+
+	expired2, _, remaining2, err := IsProvingWindowExpiredShasta(s.RPCClient, metaExpired)
+	s.Nil(err)
+	s.True(expired2)
+	s.Equal(time.Duration(0), remaining2)
 }
 
 func TestProverEventHandlerTestSuite(t *testing.T) {


### PR DESCRIPTION
Fix unsigned underflow in remaining duration calculation for both Pacaya and Shasta proving window helpers in util.go by computing a signed difference and clamping at zero when expired. This aligns with the documented function contract (“time remaining”) and prevents returning a huge positive duration when already expired. Added unit tests to validate not-expired (positive remaining) and expired (zero remaining) behavior and to guard against regressions.