### PR TITLE
feat(protocol): simplify `anchorV4` parameter rules and update `DerivationSourceManifest`

### DIFF
--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -317,7 +317,7 @@ After all calculations above, an additional `1_000_000` gas units will be added 
 
 #### `bondInstructionsHash` and `bondInstructions` Validation
 
-The first block's anchor transaction in each proposal must process all bond instructions linked to transitions finalized by the parent proposal. Subsequent blocks carry the same bond instruction payload in their `anchorV4` parameters, but that data is ignored because bond settlement occurs only once per proposal. Bond instructions are defined as follows:
+The first block's anchor transaction in each proposal must process all bond instructions linked to transitions finalized by the parent proposal. Subsequent blocks carry the same bond instruction payload (`bondInstructionsHash` and `bondInstructions`) in their `anchorV4` parameters, but that data is ignored because bond settlement occurs only once per proposal. Bond instructions are defined as follows:
 
 ```solidity
 /// @notice Represents a bond instruction for processing in the anchor transaction


### PR DESCRIPTION
After today's Shasta Implementers call we reached some agreements to simpilfy the current derivation pipeline:
- Introduce `bytes proverAuthBytes;` into `DerivationSourceManifest`, so going forward, normal proposal and forced inclusion proposal will all use `DerivationSourceManifest` as the data structure to encode inside their blobs.
  - Before this change, forced inclusion submitters are using `DerivationSourceManifest`, and normal proposers are using `ProposalManifest` with `sources.length == 1`.
- Always pass same `proverAuth`, `bondInstructions`, `bondInstructionsHash` parameter in each block's anchor transaction within same proposal. 
- No matter `anchorBlockNumber == parent.metadata.anchorBlockNumber` or not, we always pass the corresponding  `anchorBlockHash` and `anchorStateRoot`.

All these changes should be safe since in `anchorV4`, we already have checks like:
```solidity
if (_blockParams.blockIndex == 0) {
            _validateProposal(_proposalParams);
}
```

and 

```solidity
if (_blockParams.anchorBlockNumber > _blockState.anchorBlockNumber) {
            checkpointStore.saveCheckpoint(
                ICheckpointStore.Checkpoint({
                    blockNumber: _blockParams.anchorBlockNumber,
                    blockHash: _blockParams.anchorBlockHash,
                    stateRoot: _blockParams.anchorStateRoot
                })
            );
            _blockState.anchorBlockNumber = _blockParams.anchorBlockNumber;
}
```