### PR TITLE
Chore: remove redundant Vec import from BlobCoder

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/shasta/blob_coder.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/blob_coder.rs
@@ -5,7 +5,6 @@ use alloy_eips::eip4844::{
     builder::{PartialSidecar, SidecarCoder},
     utils::WholeFe,
 };
-use std::vec::Vec;
 
 /// The blob encoding version expected by the Kona decoder.
 const BLOB_ENCODING_VERSION: u8 = 0;


### PR DESCRIPTION
Drop the unnecessary `use std::vec::Vec;` from `BlobCoder`rely on the standard prelude import of `Vec`, keeping the module tidy