### PR TITLE
fix(taiko-client): use parent envelope signature and forced inclusion

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1262,8 +1262,8 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 			parentID = new(big.Int).SetUint64(uint64(cachedParent.Payload.BlockNumber))
 
 			var sig [65]byte
-			if msg.Signature != nil {
-				sig = *msg.Signature
+			if cachedParent.Signature != nil {
+				sig = *cachedParent.Signature
 			}
 
 			// Update L1 Origin for the parent block via cached data.
@@ -1271,7 +1271,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 				BuildPayloadArgsID: payloadID,
 				BlockID:            parentID,
 				L2BlockHash:        msg.ExecutionPayload.ParentHash,
-				IsForcedInclusion:  msg.IsForcedInclusion != nil && *msg.IsForcedInclusion,
+				IsForcedInclusion:  cachedParent.IsForcedInclusion,
 				Signature:          sig,
 			}); err != nil {
 				return false, fmt.Errorf("failed to update L1 origin: %w", err)


### PR DESCRIPTION
Update TryImportingPayload orphan handling to use cachedParent.Signature and cachedParent.IsForcedInclusion when updating the parent’s L1Origin.
Previously, the code incorrectly used the child envelope’s Signature and IsForcedInclusion. L1Origin fields are per-block; using the child’s values writes incorrect metadata for the parent. Other parts of the codebase (e.g., InsertPreconfBlockFromEnvelope, updateL1OriginForBlocks) treat signatures as per-block, so this change aligns orphan handling with the intended semantics.