### PR TITLE
Chore: drop redundant eslint suppression in whitelist mint count

### DIFF
--- a/packages/taikoon-ui/src/lib/user/totalWhitelistMintCount.ts
+++ b/packages/taikoon-ui/src/lib/user/totalWhitelistMintCount.ts
@@ -8,8 +8,7 @@ import { whitelist } from '../whitelist';
 export async function totalWhitelistMintCount(address: Address): Promise<number> {
   try {
     const tree = StandardMerkleTree.load(whitelist[chainId]);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for (const [_, [leafAddress, amount]] of tree.entries()) {
+    for (const [, [leafAddress, amount]] of tree.entries()) {
       if (getAddress(leafAddress) === getAddress(address)) {
         return parseInt(amount);
       }


### PR DESCRIPTION
Remove the unused-variable suppression comment from totalWhitelistMintCount rely on tuple destructuring to ignore the first entry without lint overrides keep the loop logic intact while aligning with eslint expectations