### PR TITLE
fix(taiko-client): fix `IsProvingWindowExpiredShasta` error message

### DIFF
--- a/packages/taiko-client/prover/event_handler/util.go
+++ b/packages/taiko-client/prover/event_handler/util.go
@@ -130,7 +130,7 @@ func IsProvingWindowExpiredShasta(
 ) (bool, time.Time, time.Duration, error) {
 	configs, err := rpc.GetProtocolConfigsShasta(nil)
 	if err != nil {
-		return false, time.Time{}, 0, fmt.Errorf("failed to get Pacaya protocol configs: %w", err)
+		return false, time.Time{}, 0, fmt.Errorf("failed to get Shasta protocol configs: %w", err)
 	}
 
 	var (


### PR DESCRIPTION
Correct the error message in IsProvingWindowExpiredShasta() to say “Shasta” instead of “Pacaya”.
This function calls rpc.GetProtocolConfigsShasta, so the prior wording was misleading