### PR TITLE
chore(protocol): improve NatSpec documentation and fix function visibility

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IForcedInclusionStore.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IForcedInclusionStore.sol
@@ -18,7 +18,7 @@ interface IForcedInclusionStore {
     event ForcedInclusionSaved(ForcedInclusion forcedInclusion);
 
     /// @notice Saves a forced inclusion request
-    /// The priority fee must be paid to the contract
+    /// A priority fee must be paid to the contract
     /// @param _blobReference The blob locator that contains the transaction data
     function saveForcedInclusion(LibBlobs.BlobReference memory _blobReference) external payable;
 

--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -1015,8 +1015,8 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
         }
     }
 
-    /// @dev Syncs checkpoint to storage if conditions are met (voluntary or forced sync).
-    /// @notice Validates checkpoint hash and updates checkpoint storage and timestamp.
+    /// @dev Syncs checkpoint to storage when voluntary or forced sync conditions are met.
+    ///      Validates the checkpoint hash, persists it, and refreshes the timestamp in core state.
     /// @param _checkpoint The checkpoint data to sync.
     /// @param _expectedCheckpointHash The expected hash to validate against.
     /// @param _coreState Core state to update with new checkpoint timestamp.

--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -20,13 +20,13 @@ import { ICheckpointStore } from "src/shared/signal/ICheckpointStore.sol";
 import "./Inbox_Layout.sol"; // DO NOT DELETE
 
 /// @title Inbox
-/// @notice Core contract for managing L2 proposals, proofs, verification and forced inclusion in
+/// @notice Core contract for managing L2 proposals, proof verification, and forced inclusion in
 /// Taiko's based rollup architecture.
 /// @dev This contract implements the fundamental inbox logic including:
 ///      - Proposal submission with forced inclusion support
 ///      - Proof verification with transition record management
 ///      - Ring buffer storage for efficient state management
-///      - Bond instruction processing for economic security
+///      - Bond instruction calculation(but actual funds are managed on L2)
 ///      - Finalization of proven proposals with checkpoint rate limiting
 /// @custom:security-contact security@taiko.xyz
 contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
@@ -196,14 +196,13 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     /// @inheritdoc IInbox
     /// @notice Proposes new L2 blocks and forced inclusions to the rollup using blobs for DA.
     /// @dev Key behaviors:
-    ///      1. Validates proposer authorization via ProposerChecker
+    ///      1. Validates proposer authorization via `IProposerChecker`
     ///      2. Finalizes eligible proposals up to `config.maxFinalizationCount` to free ring buffer
     ///         space.
     ///      3. Process `input.numForcedInclusions` forced inclusions. The proposer is forced to
     ///         process at least `config.minForcedInclusionCount` if they are due.
     ///      4. Updates core state and emits `Proposed` event
-    /// @dev IMPORTANT: The regular proposal might not be included if there is not enough capacity
-    ///      available(i.e forced inclusions are prioritized).
+    /// NOTE: This function can only be called once per block to prevent spams that can fill the ring buffer.
     function propose(bytes calldata _lookahead, bytes calldata _data) external nonReentrant {
         unchecked {
             // Decode and validate input data
@@ -310,16 +309,15 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
         }
     }
 
+    // ---------------------------------------------------------------
+    // External View Functions
+    // ---------------------------------------------------------------
     /// @inheritdoc IForcedInclusionStore
     function getCurrentForcedInclusionFee() external view returns (uint64 feeInGwei_) {
         return LibForcedInclusion.getCurrentForcedInclusionFee(
             _forcedInclusionStorage, _forcedInclusionFeeInGwei, _forcedInclusionFeeDoubleThreshold
         );
     }
-
-    // ---------------------------------------------------------------
-    // External View Functions
-    // ---------------------------------------------------------------
 
     /// @inheritdoc IForcedInclusionStore
     function getForcedInclusions(
@@ -396,7 +394,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     // ---------------------------------------------------------------
 
     /// @dev Activates the inbox with genesis state so that it can start accepting proposals.
-    /// @notice Sets up the initial proposal and core state with genesis block
+    /// Sets up the initial proposal and core state with genesis block
     /// @param _genesisBlockHash The hash of the genesis block
     function _activateInbox(bytes32 _genesisBlockHash) internal {
         Transition memory transition;
@@ -424,7 +422,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Builds and persists transition records for batch proof submissions
-    /// @notice Validates transitions, calculates bond instructions, and stores records
+    /// Validates transitions, calculates bond instructions, and stores records
     /// @dev Virtual function that can be overridden for optimization (e.g., transition aggregation)
     /// @param _input The ProveInput containing arrays of proposals, transitions, and metadata
     function _buildAndSaveTransitionRecords(ProveInput memory _input) internal virtual {
@@ -434,7 +432,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Processes a single transition at the specified index
-    /// @notice Reusable function for validating, building, and storing individual transitions
+    /// Reusable function for validating, building, and storing individual transitions
     /// @param _input The ProveInput containing all transition data
     /// @param _index The index of the transition to process
     function _processSingleTransitionAtIndex(
@@ -458,13 +456,13 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Stores a proposal hash in the ring buffer
-    /// @notice Overwrites any existing hash at the calculated buffer slot
+    /// Overwrites any existing hash at the calculated buffer slot
     function _setProposalHash(uint48 _proposalId, bytes32 _proposalHash) internal {
         _proposalHashes[_proposalId % _ringBufferSize] = _proposalHash;
     }
 
-    /// @dev Stores transition record hash and emits Proved event
-    /// @notice Virtual function to allow optimization in derived contracts
+    /// @dev Stores transition record hash and emits `Proved` event
+    /// Virtual function to allow optimization in derived contracts
     /// @dev Uses composite key for unique transition identification
     /// @param _proposalId The ID of the proposal being proven
     /// @param _transition The transition data to include in the event
@@ -496,7 +494,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Persists transition record metadata in storage.
-    /// @notice Returns false when an identical record already exists, avoiding redundant event
+    /// Returns false when an identical record already exists, avoiding redundant event
     /// emissions.
     /// @param _proposalId The proposal identifier.
     /// @param _parentTransitionHash Hash of the parent transition for uniqueness.
@@ -549,7 +547,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Validates transition consistency with its corresponding proposal
-    /// @notice Ensures the transition references the correct proposal hash
+    /// Ensures the transition references the correct proposal hash
     /// @param _proposal The proposal being proven
     /// @param _transition The transition to validate against the proposal
     function _validateTransition(
@@ -564,7 +562,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Validates proposal hash against stored value
-    /// @notice Reverts with ProposalHashMismatch if hashes don't match
+    /// Reverts with ProposalHashMismatch if hashes don't match
     /// @param _proposal The proposal to validate
     /// @return proposalHash_ The computed hash of the proposal
     function _checkProposalHash(Proposal memory _proposal)
@@ -618,7 +616,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Computes composite key for transition record storage
-    /// @notice Creates unique identifier for proposal-parent transition pairs
+    /// Creates unique identifier for proposal-parent transition pairs
     /// @param _proposalId The ID of the proposal
     /// @param _parentTransitionHash Hash of the parent transition
     /// @return _ Keccak256 hash of encoded parameters
@@ -1047,7 +1045,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Calculates remaining capacity for new proposals
-    /// @notice Subtracts unfinalized proposals from total capacity
+    /// Subtracts unfinalized proposals from total capacity
     /// @param _coreState Current state with proposal counters
     /// @return _ Number of additional proposals that can be submitted
     function _getAvailableCapacity(CoreState memory _coreState) private view returns (uint256) {
@@ -1059,7 +1057,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Validates propose function inputs
-    /// @notice Checks deadline, proposal array, and state consistency
+    /// Checks deadline, proposal array, and state consistency
     /// @param _input The ProposeInput to validate
     function _validateProposeInput(ProposeInput memory _input) private view {
         require(_input.deadline == 0 || block.timestamp <= _input.deadline, DeadlineExceeded());
@@ -1072,7 +1070,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @dev Verifies that parentProposals[0] is the current chain head
-    /// @notice Requires 1 element if next slot empty, 2 if occupied with older proposal
+    /// Requires 1 element if next slot empty, 2 if occupied with older proposal
     /// @param _parentProposals Array of 1-2 proposals to verify chain head
     function _verifyChainHead(Proposal[] memory _parentProposals) private view {
         unchecked {

--- a/packages/protocol/contracts/layer1/core/impl/InboxOptimized1.sol
+++ b/packages/protocol/contracts/layer1/core/impl/InboxOptimized1.sol
@@ -60,11 +60,11 @@ contract InboxOptimized1 is Inbox {
     // ---------------------------------------------------------------
 
     /// @inheritdoc Inbox
-    /// @notice Optimized transition record building with automatic aggregation
-    /// @dev Optimization strategy:
-    ///      - Single transitions: Use optimized storage lookup
-    ///      - Multiple transitions: Apply aggregation to group consecutive proposals
-    ///      - Aggregation: Merges bond instructions and increases span value
+    /// @dev Optimized transition record building with automatic aggregation.
+    ///      Strategy:
+    ///      - Single transitions: use the parent implementation's optimized lookup
+    ///      - Multiple transitions: aggregate consecutive proposals into a single record
+    ///      - Aggregation merges bond instructions and increases the span value
     /// @param _input ProveInput containing arrays of proposals and transitions to process
     function _buildAndSaveTransitionRecords(ProveInput memory _input) internal override {
         if (_input.proposals.length == 0) return;
@@ -77,11 +77,11 @@ contract InboxOptimized1 is Inbox {
     }
 
     /// @inheritdoc Inbox
-    /// @dev Stores transition record hash with optimized slot reuse
-    /// @notice Storage strategy:
-    ///         1. New proposal ID: Overwrites reusable slot
-    ///         2. Same ID, same parent: Check for duplicate/conflict and handle accordingly
-    ///         3. Same ID, different parent: Uses composite key mapping
+    /// @dev Stores transition record hash with optimized slot reuse.
+    ///      Storage strategy:
+    ///      1. New proposal ID: overwrite the reusable slot.
+    ///      2. Same ID and parent: detect duplicates or conflicts and update accordingly.
+    ///      3. Same ID but different parent: fall back to the composite key mapping.
     /// @param _proposalId The proposal ID for this transition record
     /// @param _parentTransitionHash Parent transition hash used as part of the key
     /// @param _recordHash The keccak hash representing the transition record
@@ -132,12 +132,12 @@ contract InboxOptimized1 is Inbox {
     // ---------------------------------------------------------------
 
     /// @inheritdoc Inbox
-    /// @dev Optimized retrieval using ring buffer with collision detection
-    /// @notice Lookup strategy (gas-optimized order):
-    ///         1. Ring buffer slot lookup (cheapest - single SLOAD)
-    ///         2. Proposal ID verification (cached in memory)
-    ///         3. Partial parent hash comparison (single comparison)
-    ///         4. Fallback to composite key mapping (most expensive)
+    /// @dev Optimized retrieval using ring buffer with collision detection.
+    ///      Lookup strategy (gas-optimized order):
+    ///      1. Ring buffer slot lookup (single SLOAD).
+    ///      2. Proposal ID verification (cached in memory).
+    ///      3. Partial parent hash comparison (single comparison).
+    ///      4. Fallback to composite key mapping (most expensive).
     /// @param _proposalId The proposal ID to look up
     /// @param _parentTransitionHash Parent transition hash for verification
     /// @return recordHash_ The hash of the transition record

--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -500,7 +500,7 @@ contract Anchor is EssentialContract {
         uint48 _proposalId,
         address _proposer
     )
-        public
+        private
         pure
         returns (bool)
     {


### PR DESCRIPTION
## Summary

- Enhanced NatSpec documentation across core contracts for improved clarity and consistency
- Standardized documentation format (proper use of `@dev`, `@notice`, and inline comments)
- Fixed `_isMatchingProverAuthContext` visibility from `public` to `private` in Anchor.sol
- Minor grammar improvements in forced inclusion documentation

## Changes

**IForcedInclusionStore.sol**
- Grammar fix: "The priority fee" → "A priority fee"

**Inbox.sol**
- Improved contract-level documentation with clearer descriptions of core functionality
- Clarified that bond instructions are calculated but actual funds are managed on L2
- Standardized function documentation format across external, internal, and private functions
- Enhanced descriptions for transition validation and finalization logic
- Better organized code sections

**InboxOptimized1.sol**
- Reformatted NatSpec for optimization strategies with clearer bullet points
- Improved documentation of storage strategy and lookup order

**Anchor.sol**
- Changed `_isMatchingProverAuthContext` visibility from `public` to `private`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves NatSpec docs and a function’s visibility, fixes event indexer fork-bound handling, simplifies proposer preconfirmation gating, and updates release-please configs; minor script address addition.
> 
> - **Protocol (contracts)**:
>   - NatSpec cleanups across `Inbox.sol`, `InboxOptimized1.sol`, and `IForcedInclusionStore.sol` (no logic changes).
>   - Change `Anchor._isMatchingProverAuthContext` visibility from `public` to `private`.
> - **Client (taiko-client)**:
>   - Proposer: simplify preconfirmation gating by checking only `PreconfRouter.FallbackPreconfer` and timing; remove `GetAllActiveOperators` usage.
>   - RPC: remove `GetAllActiveOperators`; retain whitelist helpers (`GetAllPreconfOperators`, etc.).
> - **Indexer**:
>   - Fix fork boundary in `eventindexer/indexer/filter.go` by using `< end` for Pacaya/Ontake fork checks to avoid splitting on the end block.
> - **Scripts**:
>   - `PostGenesisConfig.s.sol`: add `bridge` address constant.
> - **Release**:
>   - Update `.release-please-manifest.json` and `release-please-config.json`: remove `packages/ejector` config; add `release-as` for `overseer-rs` and `urcindexer-rs`; drop related CHANGELOG files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e4c3dd36e9b6ade9edc7cfbfa824486cd4a42e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->