### PR TITLE
feat(protocol): revert pacaya proposals after shasta fork timestamp

### DIFF
--- a/packages/protocol/contracts/shared/tokenvault/BaseNFTVault.sol
+++ b/packages/protocol/contracts/shared/tokenvault/BaseNFTVault.sol
@@ -19,7 +19,7 @@ abstract contract BaseNFTVault is BaseVault {
         string name;
     }
 
-    /// @devStruct representing the details of a bridged token transfer operation.
+    /// @dev representing the details of a bridged token transfer operation.
     /// 5 slots
     struct BridgeTransferOp {
         // Destination chain ID.

--- a/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
@@ -640,7 +640,12 @@ contract DeployProtocolOnL1 is DeployCapability {
         router = deployProxy({
             name: "preconf_router",
             impl: address(
-                new PreconfRouter(taikoWrapper, whitelist, vm.envOr("FALLBACK_PRECONF", address(0)))
+                new PreconfRouter(
+                    taikoWrapper,
+                    whitelist,
+                    vm.envOr("FALLBACK_PRECONF", address(0)),
+                    type(uint64).max
+                )
             ),
             data: abi.encodeCall(PreconfRouter.init, (owner)),
             registerTo: rollupResolver

--- a/packages/protocol/script/layer1/based/deploy_protocol_on_l1.sh
+++ b/packages/protocol/script/layer1/based/deploy_protocol_on_l1.sh
@@ -22,6 +22,7 @@ PRECONF_INBOX=false \
 INCLUSION_WINDOW=24 \
 INCLUSION_FEE_IN_GWEI=100 \
 DUMMY_VERIFIERS=true \
+GENESIS_TIMESTAMP=0 \
 forge script ./script/layer1/based/DeployProtocolOnL1.s.sol:DeployProtocolOnL1 \
     --fork-url http://localhost:8545 \
     --broadcast \

--- a/packages/protocol/script/layer1/hekla/DeployHeklaPreconf.s.sol
+++ b/packages/protocol/script/layer1/hekla/DeployHeklaPreconf.s.sol
@@ -39,8 +39,11 @@ contract DeployHeklaPreconf is DeployCapability {
         //
         //        address router = deployProxy({
         //            name: "preconf_router",
-        //            impl: address(new PreconfRouter(taikoWrapper, whitelist,
-        // fallbackPreconfProposer)),
+        //            impl: address(
+        //                new PreconfRouter(
+        //                    taikoWrapper, whitelist, fallbackPreconfProposer, type(uint64).max
+        //                )
+        //            ),
         //            data: abi.encodeCall(PreconfRouter.init, (address(0))),
         //            registerTo: rollupResolver
         //        });

--- a/packages/protocol/script/layer1/hekla/UpgradeHekla.s.sol
+++ b/packages/protocol/script/layer1/hekla/UpgradeHekla.s.sol
@@ -32,9 +32,15 @@ contract UpgradeHekla is DeployCapability {
         address preconfRouter = 0xce04A91Db63aDBe26c83c761f99933CE5f09cf6C;
         address preconfWhitelist = 0x4aA38A15109eAbbf09b7967009A2e00D2D15cb84;
 
-        UUPSUpgradeable(taikoWrapper).upgradeTo(address(new TaikoWrapper(taikoInbox, store, preconfRouter)));
+        UUPSUpgradeable(taikoWrapper).upgradeTo(
+            address(new TaikoWrapper(taikoInbox, store, preconfRouter))
+        );
         UUPSUpgradeable(preconfRouter).upgradeTo(
-        address(new PreconfRouter(taikoWrapper, preconfWhitelist, fallbackPreconfProposer))
+            address(
+                new PreconfRouter(
+                    taikoWrapper, preconfWhitelist, fallbackPreconfProposer, type(uint64).max
+                )
+            )
         );
         UUPSUpgradeable(preconfWhitelist).upgradeTo(address(new PreconfWhitelist()));
 

--- a/packages/protocol/script/layer1/mainnet/DeployMainnetPreconf.s.sol
+++ b/packages/protocol/script/layer1/mainnet/DeployMainnetPreconf.s.sol
@@ -43,7 +43,11 @@ contract DeployMainnetPreconf is DeployCapability {
 
         address router = deployProxy({
             name: "preconf_router",
-            impl: address(new PreconfRouter(taikoWrapper, whitelist, fallbackPreconfProposer)),
+            impl: address(
+                new PreconfRouter(
+                    taikoWrapper, whitelist, fallbackPreconfProposer, type(uint64).max
+                )
+            ),
             data: abi.encodeCall(PreconfRouter.init, (contractOwner))
         });
         address wrapper = address(new TaikoWrapper(taikoInbox, store, router));

--- a/packages/protocol/script/layer1/mainnet/DeployWLAndWrapper.s.sol
+++ b/packages/protocol/script/layer1/mainnet/DeployWLAndWrapper.s.sol
@@ -43,7 +43,8 @@ contract DeployWLAndWrapper is DeployCapability {
             abi.encodeCall(PreconfWhitelist.addOperator, (chainBoundSequencer, chainBoundSequencer))
         );
 
-        address routerImpl = address(new PreconfRouter(taikoWrapper, whitelist, fallbackProposer));
+        address routerImpl =
+            address(new PreconfRouter(taikoWrapper, whitelist, fallbackProposer, type(uint64).max));
         console2.log("Upgrading router calldata: ");
 
         console2.logBytes(abi.encodeCall(UUPSUpgradeable.upgradeTo, (routerImpl)));

--- a/packages/protocol/script/layer1/preconf/DeployPreconfContracts.s.sol
+++ b/packages/protocol/script/layer1/preconf/DeployPreconfContracts.s.sol
@@ -35,7 +35,11 @@ contract DeployPreconfContracts is BaseScript {
         // Deploy PreconfRouter
         deploy(
             "preconf_router",
-            address(new PreconfRouter(taikoWrapper, preconfWhitelist, fallbackPreconf)),
+            address(
+                new PreconfRouter(
+                    taikoWrapper, preconfWhitelist, fallbackPreconf, type(uint64).max
+                )
+            ),
             abi.encodeCall(PreconfRouter.init, (contractOwner))
         );
     }

--- a/packages/protocol/test/layer1/preconf/router/PreconfRouter.t.sol
+++ b/packages/protocol/test/layer1/preconf/router/PreconfRouter.t.sol
@@ -53,7 +53,8 @@ contract PreconfRouterForkTest is ForkTestBase {
         address owner = Ownable2StepUpgradeable(MAINNET_ROUTER).owner();
 
         // Deploy optimized implementations
-        PreconfRouter routerImpl = new PreconfRouter(MAINNET_WRAPPER, MAINNET_WHITELIST, address(0));
+        PreconfRouter routerImpl =
+            new PreconfRouter(MAINNET_WRAPPER, MAINNET_WHITELIST, address(0), type(uint64).max);
         TaikoWrapper wrapperImpl =
             new TaikoWrapper(MAINNET_INBOX, MAINNET_FORCED_INCLUSION, MAINNET_ROUTER);
         address forkImpl =

--- a/packages/protocol/test/layer1/preconf/router/PreconfRouterTestBase.sol
+++ b/packages/protocol/test/layer1/preconf/router/PreconfRouterTestBase.sol
@@ -105,7 +105,12 @@ abstract contract PreconfRouterTestBase is Layer1Test {
             deploy({
                 name: "preconf_router",
                 impl: address(
-                    new PreconfRouter(address(taikoWrapper), address(whitelist), fallbackPreconfer)
+                    new PreconfRouter(
+                        address(taikoWrapper),
+                        address(whitelist),
+                        fallbackPreconfer,
+                        type(uint64).max
+                    )
                 ),
                 data: abi.encodeCall(PreconfRouter.init, (routerOwner))
             })


### PR DESCRIPTION
Fixes #20636

But reverts on the fork router instead of the inbox, since it is already the entrypoint so easier to just do it there and not having to deploy the inbox again.

I also updated all existing scripts and tests to set `_shastaForkTimestamp = type(uint64).max` to signal fork will not happen so that existing tests and more work.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> PreconfRouter now reverts proposals at/after a configurable Shasta fork timestamp; all deploy/upgrade scripts and tests pass type(uint64).max by default.
> 
> - **Contracts**
>   - **`PreconfRouter`**: 
>     - Add immutable `shastaForkTimestamp` and `ShastaForkAlreadyActivated` error.
>     - Guard `_proposeBatch` to revert once `block.timestamp >= shastaForkTimestamp`.
>     - Update constructor to accept `_shastaForkTimestamp`.
> - **Scripts**
>   - Update all preconf deployment/upgrade scripts to pass `type(uint64).max` for `shastaForkTimestamp`.
>   - based deploy script: add `GENESIS_TIMESTAMP` env var wiring to whitelist deployment.
> - **Tests**
>   - Adjust tests to use new `PreconfRouter` constructor arg and ensure router/wrapper/fork upgrades align.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30752c9aa8968b58d6812ae631f05e4e4499ac7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->