### PR TITLE
chore(taiko-client): fix incorrect comments in `ProofRequestOptions` interface methods

### DIFF
--- a/packages/taiko-client/prover/proof_producer/interface.go
+++ b/packages/taiko-client/prover/proof_producer/interface.go
@@ -59,7 +59,7 @@ func (o *ProofRequestOptionsPacaya) PacayaOptions() *ProofRequestOptionsPacaya {
 	return o
 }
 
-// PacayaOptions implements the ProofRequestOptions interface.
+// ShastaOptions implements the ProofRequestOptions interface.
 func (o *ProofRequestOptionsPacaya) ShastaOptions() *ProofRequestOptionsShasta {
 	return nil
 }
@@ -97,7 +97,7 @@ func (o *ProofRequestOptionsShasta) PacayaOptions() *ProofRequestOptionsPacaya {
 	return nil
 }
 
-// PacayaOptions implements the ProofRequestOptions interface.
+// ShastaOptions implements the ProofRequestOptions interface.
 func (o *ProofRequestOptionsShasta) ShastaOptions() *ProofRequestOptionsShasta {
 	return o
 }


### PR DESCRIPTION


Corrected misleading comments in the ProofRequestOptions interface implementation where method names in comments didn't match the actual implemented methods. 

This affects both ProofRequestOptionsPacaya and ProofRequestOptionsShasta structs where ShastaOptions method comments were incorrectly labeled as PacayaOptions.
