### PR TITLE
fix(taiko-client): ensure duplicate writes succeed even when buffer is full

### DIFF
--- a/packages/taiko-client/prover/proof_producer/proof_buffer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_buffer.go
@@ -40,16 +40,16 @@ func (pb *ProofBuffer) Write(item *ProofResponse) (int, error) {
 		return len(pb.buffer), ErrNilBatchID
 	}
 
-	if len(pb.buffer)+1 > int(pb.MaxLength) {
-		return len(pb.buffer), ErrBufferOverflow
-	}
-
 	// Check for duplicate BatchID (idempotency check)
 	// If duplicate found, return success without adding the item
 	for _, existingItem := range pb.buffer {
 		if existingItem.BatchID.Cmp(item.BatchID) == 0 {
 			return len(pb.buffer), nil
 		}
+	}
+
+	if len(pb.buffer)+1 > int(pb.MaxLength) {
+		return len(pb.buffer), ErrBufferOverflow
 	}
 
 	if len(pb.buffer) == 0 {

--- a/packages/taiko-client/prover/proof_producer/proof_buffer_test.go
+++ b/packages/taiko-client/prover/proof_producer/proof_buffer_test.go
@@ -155,3 +155,17 @@ func TestProofBuffer_LargeBatchID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, b.Len())
 }
+
+func TestProofBuffer_DuplicateWhenFull(t *testing.T) {
+	b := NewProofBuffer(3)
+
+	for i := 1; i <= 3; i++ {
+		_, err := b.Write(&ProofResponse{BatchID: new(big.Int).SetUint64(uint64(i))})
+		require.NoError(t, err)
+	}
+	require.Equal(t, 3, b.Len())
+
+	_, err := b.Write(&ProofResponse{BatchID: new(big.Int).SetUint64(2)})
+	require.NoError(t, err)
+	require.Equal(t, 3, b.Len())
+}


### PR DESCRIPTION
Fixed a functional bug in ProofBuffer.Write() where a duplicate BatchID write returned ErrBufferOverflow when the buffer was full. The intended semantics (per code comment and caller logic in ProofSubmitterPacaya) are that duplicate writes are idempotent no-ops and should succeed regardless of capacity. Reordered checks to validate duplicates before checking overflow. Added a unit test TestProofBuffer_DuplicateWhenFull to lock in the behavior.