### PR TITLE
chore(docs-site): add GoldRush LinkCard to developer tools section

### DIFF
--- a/packages/docs-site/src/content/docs/resources/developer-tools.mdx
+++ b/packages/docs-site/src/content/docs/resources/developer-tools.mdx
@@ -105,7 +105,7 @@ import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard
-    title="GoldRush(powered by Covalent)"
+    title="GoldRush (powered by Covalent)"
     description="GoldRush offers the most comprehensive Blockchain Data API suite for developers, analysts, and enterprises. Whether you are building a DeFi dashboard, a wallet, a trading bot, an AI agent or a compliance platform, the Data APIs provide fast, accurate, and developer-friendly access to   the essential on-chain data you need."
     href="https://goldrush.dev/docs/chains/taiko?utm_source=taiko&utm_medium=partner-docs"
   />

--- a/packages/docs-site/src/content/docs/resources/developer-tools.mdx
+++ b/packages/docs-site/src/content/docs/resources/developer-tools.mdx
@@ -105,6 +105,14 @@ import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard
+    title="GoldRush(powered by Covalent)"
+    description="GoldRush offers the most comprehensive Blockchain Data API suite for developers, analysts, and enterprises. Whether you are building a DeFi dashboard, a wallet, a trading bot, an AI agent or a compliance platform, the Data APIs provide fast, accurate, and developer-friendly access to   the essential on-chain data you need."
+    href="https://goldrush.dev/docs/chains/taiko?utm_source=taiko&utm_medium=partner-docs"
+  />
+</CardGrid>
+
+<CardGrid>
+  <LinkCard
     title="Goldsky"
     description="Goldsky offers high-performance subgraph hosting and realtime data replication pipelines (Mirror). Subgraphs allow for flexible indexing with typescript, with support for webhooks, and Mirror allows users to get live blockchain data in database or message queues with a single yaml config."
     href="https://docs.goldsky.com/chains/taiko/?utm_source=taiko&utm_medium=docs"


### PR DESCRIPTION
Added a new LinkCard for GoldRush (powered by Covalent) with a detailed description and link.