### PR TITLE
fix(taiko-client): correct difficulty calculation for Shasta preconfirmation

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -199,7 +199,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 
 	var difficulty []byte
 	if reqBody.ExecutableData.Timestamp >= s.rpc.ShastaClients.ForkTime {
-		if difficulty, err = encoding.CalculateShastaDifficulty(parent.Difficulty(), parent.Number()); err != nil {
+		if difficulty, err = encoding.CalculateShastaDifficulty(parent.Difficulty(), new(big.Int).SetUint64(reqBody.ExecutableData.Number)); err != nil {
 			return s.returnError(c, http.StatusBadRequest, err)
 		}
 	} else {

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -199,7 +199,10 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 
 	var difficulty []byte
 	if reqBody.ExecutableData.Timestamp >= s.rpc.ShastaClients.ForkTime {
-		if difficulty, err = encoding.CalculateShastaDifficulty(parent.Difficulty(), new(big.Int).SetUint64(reqBody.ExecutableData.Number)); err != nil {
+		if difficulty, err = encoding.CalculateShastaDifficulty(
+			parent.Difficulty(),
+			new(big.Int).SetUint64(reqBody.ExecutableData.Number),
+		); err != nil {
 			return s.returnError(c, http.StatusBadRequest, err)
 		}
 	} else {


### PR DESCRIPTION
Regarding `ShastaDifficultyInputArgs` we should calculate the difficulty using the parent difficulty and the current block number.
https://github.com/taikoxyz/taiko-mono/blob/94fc1b967d1607e0f601223001df91d73470efb2/packages/taiko-client/bindings/encoding/input.go#L103