### PR TITLE
fix(taiko-client): update Shasta extraData size from 2 to 32 bytes

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -801,7 +801,7 @@ func encodeShastaExtraData(
 	basefeeSharingPctg uint8,
 	isLowBondProposal bool,
 ) ([]byte, error) {
-	// Create a 2-byte array for extraData
+	// Create a 32-byte array for extraData
 	extraData := make([]byte, 32)
 
 	// First byte: basefeeSharingPctg

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -802,16 +802,16 @@ func encodeShastaExtraData(
 	isLowBondProposal bool,
 ) ([]byte, error) {
 	// Create a 2-byte array for extraData
-	extraData := make([]byte, 2)
+	extraData := make([]byte, 32)
 
 	// First byte: basefeeSharingPctg
-	extraData[0] = basefeeSharingPctg
+	extraData[30] = basefeeSharingPctg
 
 	// Second byte: isLowBondProposal in the lowest bit
 	if isLowBondProposal {
-		extraData[1] = 0x01
+		extraData[31] = 0x01
 	} else {
-		extraData[1] = 0x00
+		extraData[31] = 0x00
 	}
 
 	return extraData, nil


### PR DESCRIPTION
Increase Shasta extraData size from 2 to 32 bytes to align with block.extraData size