### PR TITLE
ci: update golangci-lint-action to v9

### DIFF
--- a/.github/workflows/eventindexer--test.yml
+++ b/.github/workflows/eventindexer--test.yml
@@ -34,7 +34,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.github/workflows/relayer--test.yml
+++ b/.github/workflows/relayer--test.yml
@@ -34,7 +34,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest


### PR DESCRIPTION
Updated [golangci-lint-action](https://github.com/golangci/golangci-lint-action/releases/tag/v9.0.0) from v8 to v9 in the lint workflow.
