### PR TITLE
docs(taiko-client): fix readme to actual directory structure

### DIFF
--- a/packages/taiko-client/README.md
+++ b/packages/taiko-client/README.md
@@ -15,13 +15,13 @@ Taiko Alethia protocol's client software implementation in Go. Learn more about 
 | `docs/`             | Documentation                                                                                                                            |
 | `driver/`           | Driver sub-command                                                                                                                       |
 | `integration_test/` | Scripts to do the integration testing of all client software                                                                             |
-| `metrics/`          | Metrics related                                                                                                                          |
+| `internal/metrics/` | Metrics related                                                                                                                          |
 | `pkg/`              | Library code which used by all sub-commands                                                                                              |
 | `proposer/`         | Proposer sub-command                                                                                                                     |
 | `prover/`           | Prover sub-command                                                                                                                       |
 | `scripts/`          | Helpful scripts                                                                                                                          |
-| `testutils/`        | Test utils                                                                                                                               |
-| `version/`          | Version information                                                                                                                      |
+| `internal/testutils/` | Test utils                                                                                                                             |
+| `internal/version/` | Version information                                                                                                                      |
 
 ## Build the source
 


### PR DESCRIPTION
Update taiko-client README project structure to reflect actual locations under internal/ (metrics, testutils, version) to match the repository’s current layout and maintain the existing documentation style without introducing a new aggregate internal/ row, because README tables in this monorepo list concrete paths rather than parent buckets.