### PR TITLE
fix: seed proposer jitter PRNG to avoid synchronized timers

### DIFF
--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -98,6 +98,7 @@ func (p *Proposer) InitFromConfig(
 	p.ctx = ctx
 	p.Config = cfg
 	p.lastProposedAt = time.Now()
+	rand.Seed(time.Now().UnixNano())
 
 	// RPC clients
 	if p.rpc, err = rpc.NewClient(p.ctx, cfg.ClientConfig); err != nil {


### PR DESCRIPTION

## Summary
- seed the proposer’s non-cryptographic PRNG during configuration to keep jitter random across restarts


