### PR TITLE
fix(taiko-client,taiko-client-rs): remove the `finalizationGracePeriod` check in `getTransitionsForFinalization`

### DIFF
--- a/packages/taiko-client-rs/crates/event-indexer/src/indexer.rs
+++ b/packages/taiko-client-rs/crates/event-indexer/src/indexer.rs
@@ -5,7 +5,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    time::{Duration, SystemTime},
+    time::Duration,
 };
 
 use alloy::{rpc::types::Log, sol_types::SolEvent};
@@ -338,8 +338,6 @@ impl ShastaEventIndexer {
         mut last_finalized_transition_hash: B256,
     ) -> Vec<ProvedEventPayload> {
         let mut transitions = Vec::new();
-        let now =
-            SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs();
 
         if self.max_finalization_count() == 0 {
             debug!("max_finalization_count is zero; no transitions eligible");
@@ -361,23 +359,6 @@ impl ShastaEventIndexer {
                     parent = ?payload.transition.parentTransitionHash,
                     expected = ?last_finalized_transition_hash,
                     "transition parent hash mismatch"
-                );
-                break;
-            }
-            let block_timestamp = match payload.log.block_timestamp {
-                Some(ts) => ts,
-                None => {
-                    warn!(?proposal_id, "proved payload missing block timestamp; deferring");
-                    break;
-                }
-            };
-            if block_timestamp.saturating_add(self.finalization_grace_period()) > now {
-                debug!(
-                    ?proposal_id,
-                    block_timestamp,
-                    grace_period = self.finalization_grace_period(),
-                    now,
-                    "transition still within grace period"
                 );
                 break;
             }

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
-	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -730,9 +729,7 @@ func (s *Indexer) getTransitionsForFinalization(
 			)
 		}
 
-		if !ok ||
-			transition.Transition.ParentTransitionHash != lastFinalizedTransitionHash ||
-			transition.RawBlockTimeStamp+s.finalizationGracePeriod > uint64(time.Now().Unix()) {
+		if !ok || transition.Transition.ParentTransitionHash != lastFinalizedTransitionHash {
 			break
 		}
 		transitions = append(transitions, transition)


### PR DESCRIPTION
In the current protocol impl: https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/contracts/layer1/core/impl/Inbox.sol#L977-L985 , we can finalize a proposal as soon as a transition has been submitted, no need to care about `finalizationGracePeriod` anymore.