### PR TITLE
fix(taiko-client): fix LRU Keys iteration in `OnUnsafeL2Request`

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -540,8 +540,8 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Request(
 	}
 
 	endOfSequencing := false
-	for epoch := range s.sequencingEndedForEpochCache.Keys() {
-		if hash, ok := s.sequencingEndedForEpochCache.Get(uint64(epoch)); ok && hash == block.Hash() {
+	for _, epoch := range s.sequencingEndedForEpochCache.Keys() {
+		if hash, ok := s.sequencingEndedForEpochCache.Get(epoch); ok && hash == block.Hash() {
 			endOfSequencing = true
 			break
 		}


### PR DESCRIPTION
The end-of-sequencing detection loop used range over Keys() incorrectly:
it iterated indices instead of the key values. As a result, the code passed an index (0..n-1) into Get(uint64(epoch)), which rarely matched real epoch keys and caused endOfSequencing to remain false even when the epoch->hash entry existed. This change switches the loop to iterate over values: for , epoch : range cache.Keys() { Get(epoch) }, restoring correct EoS detection behavior.