### PR TITLE
feat(taiko-client): replace BytesToHash(slice) with zero-copy common Hash

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -593,7 +593,7 @@ func (s *Syncer) checkLastVerifiedBlockMismatchPacaya(ctx context.Context) (*rpc
 				"Verified block matched, start reorging",
 				"currentHeightToCheck", batch.LastBlockId,
 				"chainBlockHash", header.Hash(),
-				"transitionBlockHash", common.BytesToHash(ts.BlockHash[:]),
+				"transitionBlockHash", common.Hash(ts.BlockHash),
 			)
 			reorgCheckResult.IsReorged = true
 			if reorgCheckResult.L1CurrentToReset, err = s.rpc.L1.HeaderByNumber(
@@ -610,7 +610,7 @@ func (s *Syncer) checkLastVerifiedBlockMismatchPacaya(ctx context.Context) (*rpc
 			"Verified block mismatch",
 			"currentHeightToCheck", batch.LastBlockId,
 			"chainBlockHash", header.Hash(),
-			"transitionBlockHash", common.BytesToHash(ts.BlockHash[:]),
+			"transitionBlockHash", common.Hash(ts.BlockHash),
 		)
 
 		lastVerifiedBatchID = previousBatch.BatchId
@@ -650,7 +650,7 @@ func (s *Syncer) checkLastVerifiedBlockMismatchShasta(
 		"Verified block mismatch",
 		"currentHeightToCheck", lastBlockInBatch.BlockID,
 		"chainBlockHash", lastBlockInBatch.L2BlockHash,
-		"transitionBlockHash", common.BytesToHash(record.Transition.Checkpoint.BlockHash[:]),
+		"transitionBlockHash", common.Hash(record.Transition.Checkpoint.BlockHash),
 	)
 
 	// For Shasta, we simply reset to genesis if there is a mismatch.

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -133,7 +133,7 @@ func (c *Client) ensureGenesisMatched(
 		}
 	}
 
-	log.Debug("Genesis hash", "node", nodeGenesis.Hash(), "contract", common.Hash(l2GenesisHash))
+	log.Debug("Genesis hash", "node", nodeGenesis.Hash(), "contract", l2GenesisHash)
 
 	if l2GenesisHash == (common.Hash{}) {
 		log.Warn("Genesis block not found in Taiko contract")
@@ -141,11 +141,11 @@ func (c *Client) ensureGenesisMatched(
 	}
 
 	// Node's genesis header and Taiko contract's genesis header must match.
-	if common.Hash(l2GenesisHash) != nodeGenesis.Hash() {
+	if l2GenesisHash != nodeGenesis.Hash() {
 		return fmt.Errorf(
 			"genesis header hash mismatch, node: %s, Taiko contract: %s",
 			nodeGenesis.Hash(),
-			common.Hash(l2GenesisHash),
+			l2GenesisHash,
 		)
 	}
 

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -133,7 +133,7 @@ func (c *Client) ensureGenesisMatched(
 		}
 	}
 
-	log.Debug("Genesis hash", "node", nodeGenesis.Hash(), "contract", common.BytesToHash(l2GenesisHash[:]))
+	log.Debug("Genesis hash", "node", nodeGenesis.Hash(), "contract", common.Hash(l2GenesisHash))
 
 	if l2GenesisHash == (common.Hash{}) {
 		log.Warn("Genesis block not found in Taiko contract")
@@ -141,11 +141,11 @@ func (c *Client) ensureGenesisMatched(
 	}
 
 	// Node's genesis header and Taiko contract's genesis header must match.
-	if common.BytesToHash(l2GenesisHash[:]) != nodeGenesis.Hash() {
+	if common.Hash(l2GenesisHash) != nodeGenesis.Hash() {
 		return fmt.Errorf(
 			"genesis header hash mismatch, node: %s, Taiko contract: %s",
 			nodeGenesis.Hash(),
-			common.BytesToHash(l2GenesisHash[:]),
+			common.Hash(l2GenesisHash),
 		)
 	}
 

--- a/packages/taiko-client/pkg/rpc/utils.go
+++ b/packages/taiko-client/pkg/rpc/utils.go
@@ -174,9 +174,9 @@ func GetBatchProofStatus(
 			"batchID", batchID,
 			"parent", parent.Hash().Hex(),
 			"localBlockHash", lastHeaderInBatch.Hash(),
-			"protocolTransitionBlockHash", common.BytesToHash(transition.BlockHash[:]),
+			"protocolTransitionBlockHash", common.Hash(transition.BlockHash),
 			"localStateRoot", lastHeaderInBatch.Root,
-			"protocolTransitionStateRoot", common.BytesToHash(transition.StateRoot[:]),
+			"protocolTransitionStateRoot", common.Hash(transition.StateRoot),
 		)
 		// Status 2, an invalid proof has been submitted.
 		return &BatchProofStatus{IsSubmitted: true, Invalid: true, ParentHeader: parent}, nil

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -277,11 +277,11 @@ func (s *Indexer) onProvedEvent(
 	log.Debug(
 		"New indexed Shasta transition record",
 		"proposalId", meta.ProposalId,
-		"transitionHash", common.BytesToHash(record.TransitionHash[:]),
-		"parentTransitionHash", common.BytesToHash(transition.ParentTransitionHash[:]),
+		"transitionHash", common.Hash(record.TransitionHash),
+		"parentTransitionHash", common.Hash(transition.ParentTransitionHash),
 		"checkpoint", transition.Checkpoint.BlockNumber,
-		"checkpointBlockHash", common.BytesToHash(transition.Checkpoint.BlockHash[:]),
-		"checkpointStateRoot", common.BytesToHash(transition.Checkpoint.StateRoot[:]),
+		"checkpointBlockHash", common.Hash(transition.Checkpoint.BlockHash),
+		"checkpointStateRoot", common.Hash(transition.Checkpoint.StateRoot),
 		"timeStamp", header.Time,
 	)
 

--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -418,7 +418,7 @@ func (p *Proposer) ProposeTxListPacaya(
 		log.Info(
 			"Forced inclusion",
 			"proposer", proposerAddress.Hex(),
-			"blobHash", common.BytesToHash(forcedInclusion.BlobHash[:]),
+			"blobHash", common.Hash(forcedInclusion.BlobHash),
 			"feeInGwei", forcedInclusion.FeeInGwei,
 			"createdAtBatchId", forcedInclusion.CreatedAtBatchId,
 			"blobByteOffset", forcedInclusion.BlobByteOffset,

--- a/packages/taiko-client/prover/event_handler/batches_verified.go
+++ b/packages/taiko-client/prover/event_handler/batches_verified.go
@@ -37,7 +37,7 @@ func (h *BatchesVerifiedEventHandler) HandlePacaya(
 		"New verified batch",
 		"batchID", e.BatchId,
 		"lastBlockID", batch.LastBlockId,
-		"hash", common.BytesToHash(e.BlockHash[:]),
+		"hash", common.Hash(e.BlockHash),
 	)
 	return nil
 }

--- a/packages/taiko-client/prover/event_handler/shasta_proposed.go
+++ b/packages/taiko-client/prover/event_handler/shasta_proposed.go
@@ -152,7 +152,7 @@ func (h *BatchProposedEventHandler) checkExpirationAndSubmitProofShasta(
 				"batchID", batchID,
 				"parentBlockHash", header.ParentHash,
 				"parentTransitionHash", parentTransitionHash,
-				"proposalHash", common.BytesToHash(record.Transition.ProposalHash[:]),
+				"proposalHash", common.Hash(record.Transition.ProposalHash),
 			)
 			return nil
 		}
@@ -162,7 +162,7 @@ func (h *BatchProposedEventHandler) checkExpirationAndSubmitProofShasta(
 			"batchID", batchID,
 			"parentBlockHash", header.ParentHash,
 			"parentTransitionHash", parentTransitionHash,
-			"proposalHash", common.BytesToHash(record.Transition.ProposalHash[:]),
+			"proposalHash", common.Hash(record.Transition.ProposalHash),
 		)
 		// We need to submit a valid proof.
 		h.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: meta}

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
@@ -420,7 +420,7 @@ func (s *ProofSubmitterShasta) WaitParentShastaTransitionHash(
 		case <-ticker.C:
 			transition := s.indexer.GetTransitionRecordByProposalID(proposalID.Uint64())
 			if transition != nil {
-				return common.BytesToHash(transition.TransitionRecord.TransitionHash[:]), nil
+				return common.Hash(transition.TransitionRecord.TransitionHash), nil
 			}
 			log.Debug("Transition record not found, keep retrying", "proposalID", proposalID)
 		}

--- a/packages/taiko-client/prover/proof_submitter/transaction/builder.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/builder.go
@@ -289,7 +289,7 @@ func BuildParentTransitionHash(
 			log.Debug(
 				"Using cached Shasta transition record",
 				"proposalId", transition.ProposalId,
-				"hash", common.BytesToHash(transition.TransitionRecord.TransitionHash[:]),
+				"hash", common.Hash(transition.TransitionRecord.TransitionHash),
 			)
 			var blockNumber *big.Int
 			if transition.Transition.Checkpoint.BlockNumber != nil {


### PR DESCRIPTION
Optimized hash conversions by replacing common.BytesToHash(e[:]) with common.Hash(e) when the source is a [32]byte. This removes unnecessary slice creation and copying, reduces allocations, and aligns with the codebase’s existing pattern (e.g., driver/state already uses common.Hash). Only runtime code was updated; tests were left untouched. No behavioral changes, just performance and consistency improvements.