### PR TITLE
feat(taiko-client): remove duplicate buffer-size stop condition

### DIFF
--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -188,11 +188,6 @@ func (s *Indexer) fetchHistoricalProposals(toBlock *types.Header, bufferSize uin
 			break
 		}
 
-		if !s.historicalFetchCompleted && uint64(s.proposals.Count()) >= s.bufferSize {
-			log.Info("Cached enough Shasta proposals, stop fetching historical proposals", "cached", s.proposals.Count())
-			break
-		}
-
 		// Update currentHeader for next iteration
 		currentHeader, err = s.rpc.L1.HeaderByNumber(s.ctx, startHeight)
 		if err != nil {


### PR DESCRIPTION
This change deletes a redundant check in fetchHistoricalProposals that duplicated the existing buffer-size stop condition. The function already stops when Count() >= bufferSize (passed as s.bufferSize by Start), so the additional check using !historicalFetchCompleted && Count() >= s.bufferSize was functionally equivalent during the initial historical fetch and never provided additional safety.