### PR TITLE
feat(protocol): add prevAnchorBlockNumber in anchor event

### DIFF
--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -145,6 +145,7 @@ contract Anchor is EssentialContract {
         bytes32 bondInstructionsHash,
         address designatedProver,
         bool isLowBondProposal,
+        uint48 prevAnchorBlockNumber,
         uint48 anchorBlockNumber,
         bytes32 ancestorsHash
     );
@@ -228,6 +229,7 @@ contract Anchor is EssentialContract {
         if (_proposalParams.proposalId > lastProposalId) {
             _validateProposal(_proposalParams);
         }
+        uint48 prevAnchorBlockNumber = _blockState.anchorBlockNumber;
         _validateBlock(_blockParams);
 
         uint256 parentNumber = block.number - 1;
@@ -237,6 +239,7 @@ contract Anchor is EssentialContract {
             _proposalState.bondInstructionsHash,
             _proposalState.designatedProver,
             _proposalState.isLowBondProposal,
+            prevAnchorBlockNumber,
             _blockState.anchorBlockNumber,
             _blockState.ancestorsHash
         );


### PR DESCRIPTION
Just came up with a simpler solution rather than https://github.com/taikoxyz/taiko-mono/pull/20678, which leads to changes in both protocol (derivation doc) & client. 
Now, if anchor emits the prev number, it's easy for prover to check if there is anything wrong. so the validation in prover is like:
if anchor_block_number is not correct, then prevBlockNumber must == _blockState.anchorBlockNumber(i.e., currBlockNumber), which has no historical access in prover side. And even better, no more changes in both client & derivation document.