### PR TITLE
feat(protocol): add prevAnchorBlockNumber in anchor event to audit branch

### DIFF
--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -145,6 +145,7 @@ contract Anchor is EssentialContract {
         bytes32 bondInstructionsHash,
         address designatedProver,
         bool isLowBondProposal,
+        uint48 prevAnchorBlockNumber,
         uint48 anchorBlockNumber,
         bytes32 ancestorsHash
     );
@@ -228,6 +229,7 @@ contract Anchor is EssentialContract {
         if (_proposalParams.proposalId > lastProposalId) {
             _validateProposal(_proposalParams);
         }
+        uint48 prevAnchorBlockNumber = _blockState.anchorBlockNumber;
         _validateBlock(_blockParams);
 
         uint256 parentNumber = block.number - 1;
@@ -237,6 +239,7 @@ contract Anchor is EssentialContract {
             _proposalState.bondInstructionsHash,
             _proposalState.designatedProver,
             _proposalState.isLowBondProposal,
+            prevAnchorBlockNumber,
             _blockState.anchorBlockNumber,
             _blockState.ancestorsHash
         );


### PR DESCRIPTION
ref #20706 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `prevAnchorBlockNumber` to `Anchor.Anchored` event and emits the previous anchor block number from `anchorV4` before state update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3cd36bbd58f3e3ab3f47d4a2ffb53b0866219ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->