### PR TITLE
fix(protocol): prover auth using eip-712

### DIFF
--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -96,8 +96,9 @@ contract Anchor is EssentialContract {
     uint256 private constant ECDSA_SIGNATURE_LENGTH = 65;
 
     /// @dev EIP-712 domain/type hashes for prover authorization signatures.
-    bytes32 private constant PROVER_AUTH_DOMAIN_TYPEHASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant PROVER_AUTH_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
     bytes32 private constant PROVER_AUTH_TYPEHASH =
         keccak256("ProverAuth(uint48 proposalId,address proposer,uint256 provingFee)");
     bytes32 private constant PROVER_AUTH_DOMAIN_NAME_HASH = keccak256("TaikoAnchorProverAuth");

--- a/packages/protocol/test/layer2/core/Anchor.t.sol
+++ b/packages/protocol/test/layer2/core/Anchor.t.sol
@@ -23,8 +23,9 @@ contract AnchorTest is Test {
     uint256 private constant INITIAL_PROVER_BOND = 50 ether;
 
     // EIP-712 constants (must match Anchor.sol)
-    bytes32 private constant PROVER_AUTH_DOMAIN_TYPEHASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant PROVER_AUTH_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
     bytes32 private constant PROVER_AUTH_TYPEHASH =
         keccak256("ProverAuth(uint48 proposalId,address proposer,uint256 provingFee)");
     bytes32 private constant PROVER_AUTH_DOMAIN_NAME_HASH = keccak256("TaikoAnchorProverAuth");
@@ -361,7 +362,9 @@ contract AnchorTest is Test {
 
         // Proposer should be designated as prover (fallback behavior)
         Anchor.ProposalState memory state = anchor.getProposalState();
-        assertEq(state.designatedProver, proposer, "Should fall back to proposer as designated prover");
+        assertEq(
+            state.designatedProver, proposer, "Should fall back to proposer as designated prover"
+        );
     }
 
     // ---------------------------------------------------------------
@@ -403,8 +406,7 @@ contract AnchorTest is Test {
         uint256 provingFee = 3 ether;
         bytes memory proverAuth = _buildProverAuth(proposalId, provingFee);
 
-        (address signer, uint256 fee) =
-            anchor.validateProverAuth(proposalId, proposer, proverAuth);
+        (address signer, uint256 fee) = anchor.validateProverAuth(proposalId, proposer, proverAuth);
 
         assertEq(signer, proverCandidate, "Should recover prover candidate address");
         assertEq(fee, provingFee, "Should return correct proving fee");
@@ -419,8 +421,7 @@ contract AnchorTest is Test {
         uint256 wrongChainId = 1;
         bytes memory proverAuth = _buildProverAuthWithChainId(proposalId, provingFee, wrongChainId);
 
-        (address signer, uint256 fee) =
-            anchor.validateProverAuth(proposalId, proposer, proverAuth);
+        (address signer, uint256 fee) = anchor.validateProverAuth(proposalId, proposer, proverAuth);
 
         // Signature should be invalid - recovered address won't match proverCandidate
         assertTrue(signer != proverCandidate, "Should reject signature from wrong chain");
@@ -512,7 +513,10 @@ contract AnchorTest is Test {
     /// @param proposalId The proposal ID to authorize.
     /// @param provingFee The fee the prover will receive.
     /// @return Encoded ProverAuth with valid EIP-712 signature.
-    function _buildProverAuth(uint48 proposalId, uint256 provingFee)
+    function _buildProverAuth(
+        uint48 proposalId,
+        uint256 provingFee
+    )
         internal
         view
         returns (bytes memory)
@@ -525,17 +529,18 @@ contract AnchorTest is Test {
     /// @param provingFee The fee the prover will receive.
     /// @param chainId The chain ID to use in the domain separator.
     /// @return Encoded ProverAuth with signature for the specified chain.
-    function _buildProverAuthWithChainId(uint48 proposalId, uint256 provingFee, uint256 chainId)
+    function _buildProverAuthWithChainId(
+        uint48 proposalId,
+        uint256 provingFee,
+        uint256 chainId
+    )
         internal
         view
         returns (bytes memory)
     {
         // Build the ProverAuth struct (without signature initially)
         Anchor.ProverAuth memory auth = Anchor.ProverAuth({
-            proposalId: proposalId,
-            proposer: proposer,
-            provingFee: provingFee,
-            signature: ""
+            proposalId: proposalId, proposer: proposer, provingFee: provingFee, signature: ""
         });
 
         // Compute EIP-712 struct hash

--- a/packages/protocol/test/layer2/core/Anchor.t.sol
+++ b/packages/protocol/test/layer2/core/Anchor.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.24;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "forge-std/src/Test.sol";
 import { Anchor } from "src/layer2/core/Anchor.sol";
 import { BondManager } from "src/layer2/core/BondManager.sol";
@@ -12,23 +11,35 @@ import { SignalService } from "src/shared/signal/SignalService.sol";
 import { TestERC20 } from "test/mocks/TestERC20.sol";
 
 contract AnchorTest is Test {
+    // Bond configuration
     uint256 private constant LIVENESS_BOND = 5 ether;
     uint256 private constant PROVABILITY_BOND = 7 ether;
+
+    // Test setup constants
     uint64 private constant SHASTA_FORK_HEIGHT = 100;
     uint64 private constant L1_CHAIN_ID = 1;
+    address private constant GOLDEN_TOUCH = 0x0000777735367b36bC9B61C50022d9D0700dB4Ec;
+    uint256 private constant INITIAL_PROPOSER_BOND = 100 ether;
+    uint256 private constant INITIAL_PROVER_BOND = 50 ether;
 
+    // EIP-712 constants (must match Anchor.sol)
+    bytes32 private constant PROVER_AUTH_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant PROVER_AUTH_TYPEHASH =
+        keccak256("ProverAuth(uint48 proposalId,address proposer,uint256 provingFee)");
+    bytes32 private constant PROVER_AUTH_DOMAIN_NAME_HASH = keccak256("TaikoAnchorProverAuth");
+    bytes32 private constant PROVER_AUTH_DOMAIN_VERSION_HASH = keccak256("1");
+
+    // Contract instances
     Anchor internal anchor;
     BondManager internal bondManager;
     SignalService internal checkpointStore;
     TestERC20 internal token;
 
+    // Test actors
     address internal proposer;
     address internal proverCandidate;
     uint256 internal proverKey;
-
-    address internal constant GOLDEN_TOUCH = 0x0000777735367b36bC9B61C50022d9D0700dB4Ec;
-    uint256 internal constant INITIAL_PROPOSER_BOND = 100 ether;
-    uint256 internal constant INITIAL_PROVER_BOND = 50 ether;
 
     function setUp() external {
         token = new TestERC20("Mock", "MOCK");
@@ -296,6 +307,63 @@ contract AnchorTest is Test {
         );
     }
 
+    function test_anchorV4_IgnoresProverAuthWithInvalidSignature() external {
+        uint48 proposalId = 1;
+        (LibBonds.BondInstruction[] memory instructions, bytes32 expectedHash) =
+            _buildBondInstructions(proposalId);
+
+        uint256 provingFee = 5 ether;
+        uint256 proposerBalanceBefore = bondManager.getBondBalance(proposer);
+        uint256 proverBalanceBefore = bondManager.getBondBalance(proverCandidate);
+
+        // Create ProverAuth with invalid (empty) signature
+        Anchor.ProverAuth memory invalidAuth = Anchor.ProverAuth({
+            proposalId: proposalId,
+            proposer: proposer,
+            provingFee: provingFee,
+            signature: "" // Invalid empty signature
+        });
+
+        Anchor.ProposalParams memory proposalParams = Anchor.ProposalParams({
+            proposalId: proposalId,
+            proposer: proposer,
+            proverAuth: abi.encode(invalidAuth),
+            bondInstructionsHash: expectedHash,
+            bondInstructions: instructions
+        });
+
+        Anchor.BlockParams memory blockParams = Anchor.BlockParams({
+            anchorBlockNumber: 1000,
+            anchorBlockHash: bytes32(uint256(0x1234)),
+            anchorStateRoot: bytes32(uint256(0x5678))
+        });
+
+        vm.roll(SHASTA_FORK_HEIGHT);
+        vm.prank(GOLDEN_TOUCH);
+        anchor.anchorV4(proposalParams, blockParams);
+
+        // Key security property: Invalid signature should not transfer proving fee
+        // Prover candidate should not receive any funds
+        uint256 proverBalanceAfter = bondManager.getBondBalance(proverCandidate);
+        assertEq(
+            proverBalanceAfter,
+            proverBalanceBefore,
+            "Prover candidate should not receive fee with invalid signature"
+        );
+
+        // Proposer should only pay liveness and provability bonds
+        uint256 proposerBalanceAfter = bondManager.getBondBalance(proposer);
+        assertEq(
+            proposerBalanceAfter,
+            proposerBalanceBefore - LIVENESS_BOND - PROVABILITY_BOND,
+            "Proposer should only pay liveness/provability bonds, not proving fee"
+        );
+
+        // Proposer should be designated as prover (fallback behavior)
+        Anchor.ProposalState memory state = anchor.getProposalState();
+        assertEq(state.designatedProver, proposer, "Should fall back to proposer as designated prover");
+    }
+
     // ---------------------------------------------------------------
     // getDesignatedProver
     // ---------------------------------------------------------------
@@ -328,6 +396,62 @@ contract AnchorTest is Test {
         (address signer, uint256 fee) = anchor.validateProverAuth(1, proposer, abi.encode(auth));
         assertEq(signer, proposer);
         assertEq(fee, 0);
+    }
+
+    function test_validateProverAuth_AcceptsValidEIP712Signature() external view {
+        uint48 proposalId = 42;
+        uint256 provingFee = 3 ether;
+        bytes memory proverAuth = _buildProverAuth(proposalId, provingFee);
+
+        (address signer, uint256 fee) =
+            anchor.validateProverAuth(proposalId, proposer, proverAuth);
+
+        assertEq(signer, proverCandidate, "Should recover prover candidate address");
+        assertEq(fee, provingFee, "Should return correct proving fee");
+    }
+
+    function test_validateProverAuth_RejectsSignatureFromWrongChain() external view {
+        uint48 proposalId = 42;
+        uint256 provingFee = 3 ether;
+
+        // Create signature with wrong chain ID (simulating cross-chain replay attempt)
+        // Foundry default chainId is 31337, so use 1 (Ethereum mainnet) as the wrong chainId
+        uint256 wrongChainId = 1;
+        bytes memory proverAuth = _buildProverAuthWithChainId(proposalId, provingFee, wrongChainId);
+
+        (address signer, uint256 fee) =
+            anchor.validateProverAuth(proposalId, proposer, proverAuth);
+
+        // Signature should be invalid - recovered address won't match proverCandidate
+        assertTrue(signer != proverCandidate, "Should reject signature from wrong chain");
+        assertEq(fee, provingFee, "Fee should still be extracted from struct");
+    }
+
+    function test_validateProverAuth_RejectsSignatureForWrongProposal() external view {
+        uint48 proposalId = 42;
+        uint256 provingFee = 3 ether;
+        bytes memory proverAuth = _buildProverAuth(proposalId, provingFee);
+
+        // Try to use signature for different proposal ID
+        (address signer, uint256 fee) =
+            anchor.validateProverAuth(proposalId + 1, proposer, proverAuth);
+
+        assertEq(signer, proposer, "Should reject signature for wrong proposal ID");
+        assertEq(fee, 0, "Should return zero fee when context mismatch");
+    }
+
+    function test_validateProverAuth_RejectsSignatureForWrongProposer() external view {
+        uint48 proposalId = 42;
+        uint256 provingFee = 3 ether;
+        bytes memory proverAuth = _buildProverAuth(proposalId, provingFee);
+
+        // Try to use signature with different proposer
+        address wrongProposer = address(0xBAD);
+        (address signer, uint256 fee) =
+            anchor.validateProverAuth(proposalId, wrongProposer, proverAuth);
+
+        assertEq(signer, wrongProposer, "Should reject signature for wrong proposer");
+        assertEq(fee, 0, "Should return zero fee when context mismatch");
     }
 
     // ---------------------------------------------------------------
@@ -384,20 +508,56 @@ contract AnchorTest is Test {
         expectedHash = LibBonds.aggregateBondInstruction(expectedHash, instructions[1]);
     }
 
-    function _buildProverAuth(
-        uint48 proposalId,
-        uint256 provingFee
-    )
+    /// @dev Builds a properly signed ProverAuth using EIP-712 structured data signing.
+    /// @param proposalId The proposal ID to authorize.
+    /// @param provingFee The fee the prover will receive.
+    /// @return Encoded ProverAuth with valid EIP-712 signature.
+    function _buildProverAuth(uint48 proposalId, uint256 provingFee)
         internal
         view
         returns (bytes memory)
     {
+        return _buildProverAuthWithChainId(proposalId, provingFee, block.chainid);
+    }
+
+    /// @dev Builds a ProverAuth with a custom chainId for testing cross-chain replay protection.
+    /// @param proposalId The proposal ID to authorize.
+    /// @param provingFee The fee the prover will receive.
+    /// @param chainId The chain ID to use in the domain separator.
+    /// @return Encoded ProverAuth with signature for the specified chain.
+    function _buildProverAuthWithChainId(uint48 proposalId, uint256 provingFee, uint256 chainId)
+        internal
+        view
+        returns (bytes memory)
+    {
+        // Build the ProverAuth struct (without signature initially)
         Anchor.ProverAuth memory auth = Anchor.ProverAuth({
-            proposalId: proposalId, proposer: proposer, provingFee: provingFee, signature: ""
+            proposalId: proposalId,
+            proposer: proposer,
+            provingFee: provingFee,
+            signature: ""
         });
 
-        bytes32 messageHash = keccak256(abi.encode(proposalId, proposer, provingFee));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(proverKey, messageHash);
+        // Compute EIP-712 struct hash
+        bytes32 structHash =
+            keccak256(abi.encode(PROVER_AUTH_TYPEHASH, proposalId, proposer, provingFee));
+
+        // Compute EIP-712 domain separator
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                PROVER_AUTH_DOMAIN_TYPEHASH,
+                PROVER_AUTH_DOMAIN_NAME_HASH,
+                PROVER_AUTH_DOMAIN_VERSION_HASH,
+                chainId,
+                address(anchor)
+            )
+        );
+
+        // Compute final EIP-712 digest
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+
+        // Sign the digest with prover's private key
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(proverKey, digest);
         auth.signature = abi.encodePacked(r, s, v);
 
         return abi.encode(auth);


### PR DESCRIPTION
I think we topic we forgot to discuss is if we need EIP-712 or similar for the proverAuth in the anchor to both prevent replay attacks across chains(i.e. testnet and mainnet) and to make this more friendly for provers signing this message via a wallet. Since signatures are scoped to a specific `proposalId` and have a time they expire this is likely not an issue, but perhaps still worth fixing?

## Issue – ProverAuth signatures lack domain separation and are replayable across chains

### Description

`Anchor.validateProverAuth` accepts arbitrary signer signatures and hashes the payload with `EfficientHashLib.hash(proposalId, proposer, provingFee)` (`packages/protocol/contracts/layer2/core/Anchor.sol:322-357`, `_hashProverAuthMessage` at :511-516). The message omits a domain separator—there is no chain ID, contract address, fork identifier, nor proposal hash. A signature created for `(proposalId, proposer, provingFee)` on any Taiko deployment (e.g., testnet/devnet) is therefore valid on every other deployment once `proposalId` matches. An attacker can capture a prover’s signature elsewhere and replay it on mainnet to (i) force that prover to become the designated prover for a proposal they never agreed to, and (ii) siphon the proving fee via the bond transfer that `anchorV4` performs when the signature is accepted.

### Reproduction Steps

1. Obtain a legitimate designated-prover signature for some `(proposalId = N, proposer = X, provingFee = Y)` on any network (the signer need not interact with the target chain).
2. Wait until mainnet proposal `N` is created for proposer `X`.
3. Submit an `anchorV4` transaction (from the golden touch address) that sets `proposalParams.proverAuth =` the captured bytes.
4. `validateProverAuth` recovers the signer and assigns them as the designated prover on mainnet, even though they never signed for this chain, proving the replay.

### Impact

Replay lets adversaries impersonate provers across forks/chains, causing unauthorized bond debits/credits and forcing honest provers to handle proposals they never opted into. Because bond debits happen immediately in `anchorV4`, replaying signatures can directly steal a designated prover’s funds.

### Remediation

Hash prover authorizations over a domain-separated message. An EIP‑712 struct that embeds `(chainId, address(this), forkId, proposalHash)` would prevent cross-chain reuse. Existing signatures should be considered invalid once domain separation ships; clients must regenerate signer payloads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches prover authorization to EIP-712 typed-data with domain separation and updates tests to cover validity and replay protection cases.
> 
> - **Contracts (Anchor)**:
>   - Use EIP-712 for `ProverAuth` hashing: add domain/type hashes, domain separator, and struct hash helpers; replace raw hashing with `ECDSA.toTypedDataHash` in `_hashProverAuthMessage`.
>   - Change `validateProverAuth` from `pure` to `view` (uses chainId/contract in domain separator).
>   - Remove `EfficientHashLib` usage related to prover auth.
> - **Tests (Anchor.t.sol)**:
>   - Add EIP-712 signing utilities mirroring contract domain/type hashes.
>   - Update flows to sign/verify EIP-712 `ProverAuth`.
>   - New cases: accept valid EIP-712 signature; reject invalid/empty signature; reject signatures for wrong chain, proposal ID, or proposer; ensure `anchorV4` ignores invalid auth and fee not transferred.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d2b8864a4bfff6e94ed9a52def9476d3539a302. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->