### PR TITLE
test(taiko-client): add more Shasta driver tests

### DIFF
--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -239,6 +239,7 @@ func (p *Proposer) fetchPoolContent(allowEmptyPoolContent bool) ([]types.Transac
 		minTip = 0
 	}
 
+	// For Shasta proposals submission in current implementation, we always use the parent block's gas limit.
 	l2Head, err := p.rpc.L2.HeaderByNumber(p.ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get L2 head: %w", err)

--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -239,11 +239,16 @@ func (p *Proposer) fetchPoolContent(allowEmptyPoolContent bool) ([]types.Transac
 		minTip = 0
 	}
 
+	l2Head, err := p.rpc.L2.HeaderByNumber(p.ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get L2 head: %w", err)
+	}
+
 	// Fetch the pool content.
 	preBuiltTxList, err := p.rpc.GetPoolContent(
 		p.ctx,
 		p.proposerAddress,
-		manifest.MaxBlockGasLimit,
+		uint32(l2Head.GasLimit),
 		rpc.BlockMaxTxListBytes,
 		[]common.Address{},
 		p.MaxTxListsPerEpoch,
@@ -295,7 +300,6 @@ func (p *Proposer) ProposeOp(ctx context.Context) error {
 	}
 
 	ok, err := p.shouldPropose(ctx)
-
 	if err != nil {
 		return fmt.Errorf("failed to check if proposer should propose: %w", err)
 	} else if !ok {


### PR DESCRIPTION
Expand `ChainSyncerTestSuite` with Shasta fork scenarios covering multi-block proposals, multi-blob batches up to the configured maximum, and an over-limit case.