### PR TITLE
fix(taiko-client): allow L2 blocks to have the same timestamps

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
@@ -336,7 +336,7 @@ func validateMetadataTimestamp(sourcePayload *ShastaDerivationSourcePayload, pro
 		}
 
 		// Calculate lower bound for timestamp.
-		lowerBound := max(parentTimestamp+1, proposal.Timestamp.Uint64()-manifest.TimestampMaxOffset)
+		lowerBound := max(parentTimestamp, proposal.Timestamp.Uint64()-manifest.TimestampMaxOffset)
 		if sourcePayload.BlockPayloads[i].Timestamp < lowerBound {
 			log.Info(
 				"Adjusting block timestamp to lower bound",


### PR DESCRIPTION
Fix lower bound calculation for block timestamp. Allow L2 blocks to have the same timestamps.