### PR TITLE
fix(taiko-client): remove unreachable L2-specific error from waitHeader

### DIFF
--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -412,8 +412,6 @@ func waitHeader(ctx context.Context, ethClient *EthClient, blockID *big.Int) (*t
 
 		return header, nil
 	}
-
-	return nil, fmt.Errorf("failed to fetch block header from L2 execution engine, blockID: %d", blockID)
 }
 
 // WaitShastaHeader keeps waiting for the Shasta block header of the given batch ID from the L2 execution engine.


### PR DESCRIPTION
The final error return in waitHeader was unreachable due to the infinite polling loop, yet contained an L2 execution engine-specific message. This could mislead readers and future maintainers, and it could become visible if the loop structure changed. Removing it eliminates dead code and prevents confusion without altering runtime behavior, since waitHeader already returns the header on success or the context error (deadline/cancel) on failure.