### PR TITLE
refactor(taiko-client): make StatusRegistered a const

### DIFF
--- a/packages/taiko-client/prover/proof_producer/proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_producer.go
@@ -17,8 +17,9 @@ var (
 	ErrProofInProgress = errors.New("work_in_progress")
 	ErrRetry           = errors.New("retry")
 	ErrZkAnyNotDrawn   = errors.New("zk_any_not_drawn")
-	StatusRegistered   = "registered"
 )
+
+const StatusRegistered = "registered"
 
 // ProofRequestBody represents a request body to generate a proof.
 type ProofRequestBody struct {


### PR DESCRIPTION
Converted StatusRegistered from a package var to a const to reflect its immutable protocol token nature and avoid accidental mutation. This change is safe because StatusRegistered is only used in string comparisons (not assigned or address-taken) and is referenced by RaikoRequestProofBodyResponseV2.Validate in common.go to map the “registered” status to ErrRetry. Error sentinels remain vars since errors.New is not a constant expression. The update clarifies intent, slightly reduces runtime mutability, and aligns with idiomatic Go usage for fixed status strings without impacting behavior.