### PR TITLE
feat(taiko-client): optimize Shasta event indexer historical mode fetching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -221,6 +221,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
+	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pion/datachannel v1.5.10 // indirect
 	github.com/pion/dtls/v2 v2.2.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -687,6 +687,8 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
+github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=

--- a/packages/taiko-client/bindings/encoding/input.go
+++ b/packages/taiko-client/bindings/encoding/input.go
@@ -146,9 +146,11 @@ var (
 	ProverSetPacayaABI      *abi.ABI
 
 	// Shasta fork
-	ShastaInboxABI  *abi.ABI
-	ShastaAnchorABI *abi.ABI
-	BondManagerABI  *abi.ABI
+	ShastaInboxABI           *abi.ABI
+	ShastaAnchorABI          *abi.ABI
+	BondManagerABI           *abi.ABI
+	ShastaProposedEventTopic common.Hash
+	ShastaProvedEventTopic   common.Hash
 
 	customErrorMaps []map[string]abi.Error
 )
@@ -234,6 +236,18 @@ func init() {
 
 	if ShastaInboxABI, err = shastaBindings.ShastaInboxClientMetaData.GetAbi(); err != nil {
 		log.Crit("Get Shasta Inbox ABI error", "error", err)
+	}
+
+	if proposedEvent, ok := ShastaInboxABI.Events["Proposed"]; ok {
+		ShastaProposedEventTopic = proposedEvent.ID
+	} else {
+		log.Crit("Proposed event not found in Shasta inbox ABI")
+	}
+
+	if provedEvent, ok := ShastaInboxABI.Events["Proved"]; ok {
+		ShastaProvedEventTopic = provedEvent.ID
+	} else {
+		log.Crit("Proved event not found in Shasta inbox ABI")
 	}
 
 	if ShastaAnchorABI, err = shastaBindings.ShastaAnchorMetaData.GetAbi(); err != nil {

--- a/packages/taiko-client/cmd/flags/common.go
+++ b/packages/taiko-client/cmd/flags/common.go
@@ -175,6 +175,20 @@ var (
 		Category: commonCategory,
 		EnvVars:  []string{"SHASTA_USE_LOCAL_DECODER"},
 	}
+	ShastaMaxRangeSize = &cli.Uint64Flag{
+		Name:     "shasta.indexer.maxRangeSize",
+		Usage:    "Maximum L1 block span per Shasta historical range",
+		Category: commonCategory,
+		Value:    1000,
+		EnvVars:  []string{"SHASTA_INDEXER_MAX_RANGE_SIZE"},
+	}
+	ShastaMaxRangesPerBatch = &cli.IntFlag{
+		Name:     "shasta.indexer.maxRangesPerBatch",
+		Usage:    "Maximum Shasta historical ranges fetched per batch",
+		Category: commonCategory,
+		Value:    32,
+		EnvVars:  []string{"SHASTA_INDEXER_MAX_RANGES_PER_BATCH"},
+	}
 )
 
 // CommonFlags All common flags.
@@ -197,6 +211,8 @@ var CommonFlags = []cli.Flag{
 	RPCTimeout,
 	L1PrivateEndpoint,
 	ShastaUseLocalDecoder,
+	ShastaMaxRangeSize,
+	ShastaMaxRangesPerBatch,
 }
 
 // MergeFlags merges the given flag slices.

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/cmd/flags"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/jwt"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
+	shastaIndexer "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/state_indexer"
 )
 
 // Config contains the configurations to initialize a Taiko driver.
@@ -39,6 +40,10 @@ type Config struct {
 // NewConfigFromCliContext creates a new config instance from
 // the command line inputs.
 func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
+	shastaIndexer.ConfigureHistoricalFetch(
+		c.Uint64(flags.ShastaMaxRangeSize.Name),
+		c.Int(flags.ShastaMaxRangesPerBatch.Name),
+	)
 	jwtSecret, err := jwt.ParseSecretFromFile(c.String(flags.JWTSecret.Name))
 	if err != nil {
 		return nil, fmt.Errorf("invalid JWT secret file: %w", err)

--- a/packages/taiko-client/pkg/rpc/client.go
+++ b/packages/taiko-client/pkg/rpc/client.go
@@ -41,6 +41,7 @@ type ShastaClients struct {
 	InboxCodec      *shastaBindings.CodecOptimizedClient
 	Anchor          *shastaBindings.ShastaAnchor
 	ComposeVerifier *shastaBindings.ComposeVerifier
+	InboxAddress    common.Address
 	// ForkTime is the Shasta hardfork activation timestamp (unix seconds). Optional.
 	ForkTime uint64
 	// UseLocalDecoder decides whether Shasta events should be decoded locally instead of via codec contract.
@@ -314,6 +315,7 @@ func (c *Client) initShastaClients(ctx context.Context, cfg *ClientConfig) error
 		InboxCodec:      inboxCodec,
 		Anchor:          shastaAnchor,
 		ComposeVerifier: composeVerifier,
+		InboxAddress:    cfg.ShastaInboxAddress,
 		ForkTime:        forkTime,
 		UseLocalDecoder: cfg.UseLocalShastaDecoder,
 	}

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -301,7 +301,6 @@ func (s *Indexer) batchFetchHistoricalRanges(ctx context.Context, ranges []propo
 }
 
 // buildShastaFilterArg constructs an eth_getLogs argument for the given topic and block interval.
-
 func (s *Indexer) buildShastaFilterArg(topic common.Hash, startHeight, endHeight *big.Int) map[string]interface{} {
 	return map[string]interface{}{
 		"address":   []common.Address{s.rpc.ShastaClients.InboxAddress},
@@ -392,7 +391,6 @@ func (s *Indexer) shouldStopHistoricalProposalFetch(bufferSize uint64) bool {
 }
 
 // onProvedEvent handles the Proved event.
-// NOT THREAD-SAFE
 func (s *Indexer) onProvedEvent(
 	ctx context.Context,
 	meta *shastaBindings.IInboxProvedEventPayload,
@@ -472,7 +470,6 @@ func (s *Indexer) liveIndexing() error {
 }
 
 // onProposedEvent handles the Proposed event.
-// NOT THREAD-SAFE
 func (s *Indexer) onProposedEvent(
 	ctx context.Context,
 	meta metadata.TaikoProposalMetaData,
@@ -513,7 +510,6 @@ func (s *Indexer) onProposedEvent(
 }
 
 // cleanupAfterEvents performs maintenance cleanup on proposals and transition records.
-// NOT THREAD-SAFE
 func (s *Indexer) cleanupAfterEvents() {
 	// Determine the latest proposal ID and the last finalized proposal ID
 	var (
@@ -660,7 +656,6 @@ func (s *Indexer) liveIndex(newHead *types.Header) error {
 
 // cleanupFinalizedTransitionRecords cleans up transition records that are older than the last finalized proposal ID
 // minus the buffer size.
-// NOT THREAD-SAFE
 func (s *Indexer) cleanupFinalizedTransitionRecords(lastFinalizedProposalId uint64) {
 	// We keep bufferSizeMultiplier times the buffer size of transition records to avoid future reorg handling.
 	threshold := s.bufferSize * bufferSizeMultiplier
@@ -673,7 +668,6 @@ func (s *Indexer) cleanupFinalizedTransitionRecords(lastFinalizedProposalId uint
 }
 
 // cleanupLegacyProposals cleans up proposals that are older than the last proposal ID minus the buffer size.
-// NOT THREAD-SAFE
 func (s *Indexer) cleanupLegacyProposals(lastProposalId uint64) {
 	// We keep bufferSizeMultiplier times the buffer size of proposals to avoid future reorg handling.
 	threshold := s.bufferSize * bufferSizeMultiplier

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -247,8 +247,8 @@ func (s *Indexer) batchFetchHistoricalRanges(ctx context.Context, ranges []propo
 	start := time.Now()
 	var (
 		results = make([]rangeLogs, len(ranges))
-		reqs    = make([]gethrpc.BatchElem, 0)
-		metas   = make([]rangeRequestMeta, 0)
+		reqs    = make([]gethrpc.BatchElem, 0, len(ranges)*2)
+		metas   = make([]rangeRequestMeta, 0, len(ranges)*2)
 	)
 	// Prepare batch requests for proposed and proved events.
 	for i, r := range ranges {

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -29,7 +29,7 @@ var (
 	// bufferSizeMultiplier determines how many times the buffer size to keep for historical data.
 	bufferSizeMultiplier uint64 = 2
 	// maxHistoricalProposalFetchConcurrency caps how many proposal ranges we fetch in parallel.
-	maxHistoricalProposalFetchConcurrency = 64
+	maxHistoricalProposalFetchConcurrency = 16
 )
 
 // ProposalPayload represents the payload in a Shasta Proposed event.
@@ -173,7 +173,7 @@ func (s *Indexer) fetchHistorical(toBlock *types.Header, bufferSize uint64) erro
 			batch = append(batch, proposalRange{startHeight: startHeight, endHeight: endHeight})
 
 			if startHeight.Cmp(common.Big0) == 0 {
-				log.Info("Reached the genesis block, stop fetching historical proposals", "cached", s.proposals.Count())
+				log.Info("Queued final Shasta proposal range (reached genesis)", "cached", s.proposals.Count())
 				stopRequested = true
 				break
 			}

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -35,8 +35,6 @@ var (
 	bufferSizeMultiplier uint64 = 2
 	// maxHistoricalProposalFetchConcurrency caps how many proposal ranges we fetch in parallel.
 	maxHistoricalProposalFetchConcurrency = 32
-	shastaProposedEventTopic              = encoding.ShastaProposedEventTopic
-	shastaProvedEventTopic                = encoding.ShastaProvedEventTopic
 )
 
 // ProposalPayload represents the payload in a Shasta Proposed event.
@@ -237,14 +235,14 @@ func (s *Indexer) batchFetchHistoricalRanges(ctx context.Context, ranges []propo
 	for i, r := range ranges {
 		reqs = append(reqs, gethrpc.BatchElem{
 			Method: "eth_getLogs",
-			Args:   []interface{}{s.buildShastaFilterArg(shastaProposedEventTopic, r.startHeight, r.endHeight)},
+			Args:   []interface{}{s.buildShastaFilterArg(encoding.ShastaProposedEventTopic, r.startHeight, r.endHeight)},
 			Result: &results[i].proposed,
 		})
 		metas = append(metas, rangeRequestMeta{typ: "proposed", rangeIdx: i})
 
 		reqs = append(reqs, gethrpc.BatchElem{
 			Method: "eth_getLogs",
-			Args:   []interface{}{s.buildShastaFilterArg(shastaProvedEventTopic, r.startHeight, r.endHeight)},
+			Args:   []interface{}{s.buildShastaFilterArg(encoding.ShastaProvedEventTopic, r.startHeight, r.endHeight)},
 			Result: &results[i].proved,
 		})
 		metas = append(metas, rangeRequestMeta{typ: "proved", rangeIdx: i})

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -37,6 +37,16 @@ var (
 	maxHistoricalProposalFetchConcurrency = 32
 )
 
+// ConfigureHistoricalFetch overrides the default historical fetch parameters.
+func ConfigureHistoricalFetch(maxFilter uint64, concurrency int) {
+	if maxFilter > 0 {
+		maxBlocksPerFilter = maxFilter
+	}
+	if concurrency > 0 {
+		maxHistoricalProposalFetchConcurrency = concurrency
+	}
+}
+
 // ProposalPayload represents the payload in a Shasta Proposed event.
 type ProposalPayload struct {
 	Proposal         *shastaBindings.IInboxProposal

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -19,6 +19,7 @@ import (
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/encoding"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
 	eventiterator "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/chain_iterator/event_iterator"
@@ -34,27 +35,9 @@ var (
 	bufferSizeMultiplier uint64 = 2
 	// maxHistoricalProposalFetchConcurrency caps how many proposal ranges we fetch in parallel.
 	maxHistoricalProposalFetchConcurrency = 32
-	shastaProposedEventTopic              common.Hash
-	shastaProvedEventTopic                common.Hash
+	shastaProposedEventTopic              = encoding.ShastaProposedEventTopic
+	shastaProvedEventTopic                = encoding.ShastaProvedEventTopic
 )
-
-// Initialize event topics from ABI.
-func init() {
-	abi, err := shastaBindings.ShastaInboxClientMetaData.GetAbi()
-	if err != nil {
-		log.Crit("Failed to parse Shasta inbox ABI", "err", err)
-	}
-	proposedEvent, ok := abi.Events["Proposed"]
-	if !ok {
-		log.Crit("Proposed event not found in Shasta inbox ABI")
-	}
-	provedEvent, ok := abi.Events["Proved"]
-	if !ok {
-		log.Crit("Proved event not found in Shasta inbox ABI")
-	}
-	shastaProposedEventTopic = proposedEvent.ID
-	shastaProvedEventTopic = provedEvent.ID
-}
 
 // ProposalPayload represents the payload in a Shasta Proposed event.
 type ProposalPayload struct {

--- a/packages/taiko-client/proposer/config.go
+++ b/packages/taiko-client/proposer/config.go
@@ -15,6 +15,7 @@ import (
 	pkgFlags "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/flags"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/jwt"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
+	shastaIndexer "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/state_indexer"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/utils"
 )
 
@@ -40,6 +41,10 @@ type Config struct {
 // NewConfigFromCliContext initializes a Config instance from
 // command line flags.
 func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
+	shastaIndexer.ConfigureHistoricalFetch(
+		c.Uint64(flags.ShastaMaxRangeSize.Name),
+		c.Int(flags.ShastaMaxRangesPerBatch.Name),
+	)
 	jwtSecret, err := jwt.ParseSecretFromFile(c.String(flags.JWTSecret.Name))
 	if err != nil {
 		return nil, fmt.Errorf("invalid JWT secret file: %w", err)

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/cmd/flags"
 	pkgFlags "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/flags"
+	shastaIndexer "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/state_indexer"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/utils"
 )
 
@@ -56,6 +57,10 @@ type Config struct {
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
 func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
+	shastaIndexer.ConfigureHistoricalFetch(
+		c.Uint64(flags.ShastaMaxRangeSize.Name),
+		c.Int(flags.ShastaMaxRangesPerBatch.Name),
+	)
 	var (
 		raikoApiKey []byte
 	)


### PR DESCRIPTION
 - restore thread-safe proposal/transition caches (cmap) so concurrent iterators can safely mutate shared state
 - Historical backfill now batches up to `maxHistoricalProposalFetchConcurrency` block ranges and issues a single JSON-RPC batch per slice; each range’s proposed/proved logs are decoded concurrently (errgroup), so network and CPU work stay parallel without spawning extra iterators.
  - All historical syncing is contained inside fetchHistorical; we removed the separate transition pass and rely on the batched replay loop’s existing stop conditions/logging, which simplified the control flow while preserving the same termination criteria.
  - improve accessors (e.g., GetLastProposal) and add comments/diagnostics to make cache handling clearer
  - Benchmark for scanning ~25000 L1 blocks for ~4000 events in devnet
    - Before: 840s
    - After: 9s
