### PR TITLE
fix(relayer): correct ChainDataSynced log text to reference signal

### DIFF
--- a/packages/relayer/indexer/handle_chain_data_synced_event.go
+++ b/packages/relayer/indexer/handle_chain_data_synced_event.go
@@ -18,7 +18,7 @@ func (i *Indexer) handleChainDataSyncedEvent(
 	event *signalservice.SignalServiceChainDataSynced,
 	waitForConfirmations bool,
 ) error {
-	slog.Info("chainDataSynced event found for msgHash",
+	slog.Info("chainDataSynced event found for signal",
 		"signal", common.Hash(event.Signal).Hex(),
 		"chainID", event.ChainId,
 		"blockID", event.BlockId,


### PR DESCRIPTION
Fix misleading logging in handle_chain_data_synced_event.go where the message said “for msgHash” but the logged value was the event’s signal. The ChainDataSynced event does not have a msgHash field (per ABI); it exposes Signal [32]byte. We now say “for signal” while keeping the "signal" key and value unchanged.