### PR TITLE
fix: split L1/L2 ERC-20 balance metrics

### DIFF
--- a/packages/balance-monitor/balance-monitor/balance_monitor.go
+++ b/packages/balance-monitor/balance-monitor/balance_monitor.go
@@ -80,14 +80,16 @@ func (b *BalanceMonitor) Start() error {
 				b.checkEthBalance(context.Background(), b.l2EthClient, l2EthBalanceGauge, "L2", address)
 
 				// Check ERC-20 token balances
-				var balance float64 = 0
+				var l1Balance float64
+				var l2Balance float64
 				for _, tokenAddress := range b.erc20Addresses {
-					balance = balance + b.checkErc20Balance(context.Background(), b.l1EthClient, "L1", tokenAddress, address)
-					balance = balance + b.checkErc20Balance(context.Background(), b.l2EthClient, "L2", tokenAddress, address)
-
+					l1Balance += b.checkErc20Balance(context.Background(), b.l1EthClient, "L1", tokenAddress, address)
+					l2Balance += b.checkErc20Balance(context.Background(), b.l2EthClient, "L2", tokenAddress, address)
 				}
-				l1Erc20BalanceGauge.WithLabelValues(address.Hex()).Set(balance)
-				slog.Info("ERC-20 Balance", "address", address.Hex(), "balance", balance)
+				l1Erc20BalanceGauge.WithLabelValues(address.Hex()).Set(l1Balance)
+				l2Erc20BalanceGauge.WithLabelValues(address.Hex()).Set(l2Balance)
+				slog.Info("ERC-20 Balance", "network", "L1", "address", address.Hex(), "balance", l1Balance)
+				slog.Info("ERC-20 Balance", "network", "L2", "address", address.Hex(), "balance", l2Balance)
 			}
 		}
 	}

--- a/packages/balance-monitor/balance-monitor/prometheus.go
+++ b/packages/balance-monitor/balance-monitor/prometheus.go
@@ -15,7 +15,7 @@ var (
 	l1Erc20BalanceGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "l1_erc20_balance",
-			Help: "ERC-20 token balance of addresses",
+			Help: "ERC-20 token balance of addresses on L1",
 		},
 		[]string{"address"},
 	)
@@ -26,10 +26,18 @@ var (
 		},
 		[]string{"address"},
 	)
+	l2Erc20BalanceGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "l2_erc20_balance",
+			Help: "ERC-20 token balance of addresses on L2",
+		},
+		[]string{"address"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(l1EthBalanceGauge)
 	prometheus.MustRegister(l2EthBalanceGauge)
 	prometheus.MustRegister(l1Erc20BalanceGauge)
+	prometheus.MustRegister(l2Erc20BalanceGauge)
 }


### PR DESCRIPTION
Keep L1 and L2 ERC-20 balances separate so each Prometheus gauge reflects the correct network, and add the missing l2_erc20_balance metric to expose L2 data that was previously invisible.