### PR TITLE
fix(eventindexer): include genesis block by adjusting startingBlock to GenesisHeight-1

### DIFF
--- a/packages/eventindexer/indexer/set_initial_processing_block_height.go
+++ b/packages/eventindexer/indexer/set_initial_processing_block_height.go
@@ -26,12 +26,24 @@ func (i *Indexer) setInitialIndexingBlockByMode(
 					return errors.Wrap(err, "i.taikoInbox.GetStats1")
 				}
 
-				startingBlock = stats1.GenesisHeight
+				if stats1.GenesisHeight > 0 {
+					startingBlock = stats1.GenesisHeight - 1
+				} else {
+					startingBlock = 0
+				}
 			} else {
-				startingBlock = slotA.GenesisHeight
+				if slotA.GenesisHeight > 0 {
+					startingBlock = slotA.GenesisHeight - 1
+				} else {
+					startingBlock = 0
+				}
 			}
 		} else {
-			startingBlock = slotA.GenesisHeight
+			if slotA.GenesisHeight > 0 {
+				startingBlock = slotA.GenesisHeight - 1
+			} else {
+				startingBlock = 0
+			}
 		}
 	}
 


### PR DESCRIPTION
The event indexer was skipping the genesis block on L1 because the initial cursor was set to GenesisHeight while the filter loop starts from latestIndexedBlockNumber+1. As a result, the first processed block became GenesisHeight+1, dropping genesis events. This change aligns the event indexer with the relayer’s initialization pattern and the taiko-client’s usage, subtracting one from GenesisHeight (safely clamped to zero) when deriving the initial startingBlock from L1 contract state across v1, v2, and v3. With this fix, the first batch processed begins exactly at GenesisHeight, ensuring genesis events are indexed.