### PR TITLE
fix(taiko-client,taiko-client-rs): ensure Shasta low-bond proposals set `block.extradata` bit even for default payloads

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
@@ -215,7 +215,7 @@ where
 
         // Sanitize the manifest before deriving payload attributes.
         let mut decoded_manifest = segment.manifest;
-        let mut is_low_bond_proposal = self.detect_low_bond_proposal(state, meta).await?;
+        let is_low_bond_proposal = self.detect_low_bond_proposal(state, meta).await?;
 
         if !manifest_is_default(&decoded_manifest) && is_low_bond_proposal {
             info!(

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
@@ -215,17 +215,14 @@ where
 
         // Sanitize the manifest before deriving payload attributes.
         let mut decoded_manifest = segment.manifest;
-        let mut is_low_bond_proposal = false;
+        let mut is_low_bond_proposal = self.detect_low_bond_proposal(state, meta).await?;
 
-        if !manifest_is_default(&decoded_manifest) {
-            is_low_bond_proposal = self.detect_low_bond_proposal(state, meta).await?;
-            if is_low_bond_proposal {
-                info!(
-                    proposal_id = meta.proposal_id,
-                    "low-bond proposal detected; using default manifest for segment processing"
-                );
-                decoded_manifest = DerivationSourceManifest::default();
-            }
+        if !manifest_is_default(&decoded_manifest) && is_low_bond_proposal {
+            info!(
+                proposal_id = meta.proposal_id,
+                "low-bond proposal detected; using default manifest for segment processing"
+            );
+            decoded_manifest = DerivationSourceManifest::default();
         }
 
         let validation_ctx = state.build_validation_context(meta, segment.is_forced_inclusion);

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -369,13 +369,14 @@ func (s *Syncer) processShastaProposal(
 		)
 
 		if designatedProverInfo.IsLowBondProposal {
-			sourcePayload.IsLowBondProposal = true
 			if !sourcePayload.Default {
 				sourcePayload = &shastaManifest.ShastaDerivationSourcePayload{
 					Default:           true,
 					IsLowBondProposal: true,
 					ParentBlock:       sourcePayload.ParentBlock,
 				}
+			} else {
+				sourcePayload.IsLowBondProposal = true
 			}
 		}
 

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -340,44 +340,48 @@ func (s *Syncer) processShastaProposal(
 				return err
 			}
 		}
-		// If the proposal is not a default one, we need to do some extra validations for
-		// the proposer and `isLowBondProposal` flag.
-		if !sourcePayload.Default {
-			opts := &bind.CallOpts{BlockHash: sourcePayload.ParentBlock.Hash(), Context: ctx}
-			proposalState, err := s.rpc.ShastaClients.Anchor.GetProposalState(opts)
-			if err != nil {
-				return err
-			}
-			designatedProverInfo, err := s.rpc.ShastaClients.Anchor.GetDesignatedProver(
-				opts,
-				meta.GetProposal().Id,
-				meta.GetProposal().Proposer,
-				sourcePayload.ProverAuthBytes,
-				proposalState.DesignatedProver,
-			)
-			if err != nil {
-				return err
-			}
+		opts := &bind.CallOpts{BlockHash: sourcePayload.ParentBlock.Hash(), Context: ctx}
+		proposalState, err := s.rpc.ShastaClients.Anchor.GetProposalState(opts)
+		if err != nil {
+			return err
+		}
 
-			log.Info(
-				"Designated prover info",
-				"proposalID", meta.GetProposal().Id,
-				"blocks", len(sourcePayload.BlockPayloads),
-				"proposer", meta.GetProposal().Proposer,
-				"prover", designatedProverInfo.DesignatedProver,
-				"isLowBondProposal", designatedProverInfo.IsLowBondProposal,
-				"provingFeeToTransfer", designatedProverInfo.ProvingFeeToTransfer,
-				"proverAuth", common.Bytes2Hex(sourcePayload.ProverAuthBytes[:]),
-			)
+		designatedProverInfo, err := s.rpc.ShastaClients.Anchor.GetDesignatedProver(
+			opts,
+			meta.GetProposal().Id,
+			meta.GetProposal().Proposer,
+			sourcePayload.ProverAuthBytes,
+			proposalState.DesignatedProver,
+		)
+		if err != nil {
+			return err
+		}
 
-			if designatedProverInfo.IsLowBondProposal {
+		log.Info(
+			"Designated prover info",
+			"proposalID", meta.GetProposal().Id,
+			"blocks", len(sourcePayload.BlockPayloads),
+			"proposer", meta.GetProposal().Proposer,
+			"prover", designatedProverInfo.DesignatedProver,
+			"isLowBondProposal", designatedProverInfo.IsLowBondProposal,
+			"provingFeeToTransfer", designatedProverInfo.ProvingFeeToTransfer,
+			"proverAuth", common.Bytes2Hex(sourcePayload.ProverAuthBytes[:]),
+		)
+
+		if designatedProverInfo.IsLowBondProposal {
+			sourcePayload.IsLowBondProposal = true
+			if !sourcePayload.Default {
 				sourcePayload = &shastaManifest.ShastaDerivationSourcePayload{
 					Default:           true,
 					IsLowBondProposal: true,
 					ParentBlock:       sourcePayload.ParentBlock,
 				}
 			}
+		}
 
+		// If the proposal is not a default one, we need to do some extra validations for
+		// the proposer and `isLowBondProposal` flag.
+		if !sourcePayload.Default {
 			// Check block-level metadata and reset some incorrect value.
 			if err := shastaManifest.ValidateMetadata(
 				ctx,


### PR DESCRIPTION
  - Always query `getDesignatedProver` in the Go syncer and propagate the `IsLowBondProposal` flag even when the manifest fetcher already returned a default payload or a forced-inclusion segment. Only swap the manifest for the synthetic default when a non-default payload turns out to be low-bond.
  - Mirror the same behavior in the Rust driver pipeline so every segment calls the low-bond detector, ensuring the extra-data encoder sets the bit for default/forced manifests as well.

To match the description in https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/Derivation.md