### PR TITLE
fix(taiko-client,taiko-client-rs): update gas-limit clamp

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
@@ -37,6 +37,9 @@ pub const MIN_BLOCK_GAS_LIMIT: u64 = 10_000_000;
 /// contracts/layer1/libs/LibManifest.sol.
 pub const MAX_BLOCK_GAS_LIMIT: u64 = 100_000_000;
 
+/// Denominator (parts per million) used when clamping gas limits.
+pub const GAS_LIMIT_DENOMINATOR: u64 = 1_000_000;
+
 /// The delay in processing bond instructions relative to the current proposal.
 /// NOTE: Should be same with `BOND_PROCESSING_DELAY` in
 /// contracts/layer1/libs/LibManifest.sol.

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
@@ -22,11 +22,6 @@ pub const MIN_ANCHOR_OFFSET: u64 = 2;
 /// contracts/layer1/libs/LibManifest.sol.
 pub const TIMESTAMP_MAX_OFFSET: u64 = 12 * 32;
 
-/// The maximum block gas limit change per block, expressed in millionths.
-/// NOTE: Should be same with `BLOCK_GAS_LIMIT_MAX_CHANGE` in
-/// contracts/layer1/libs/LibManifest.sol.
-pub const BLOCK_GAS_LIMIT_MAX_CHANGE: u64 = 10;
-
 /// The minimum block gas limit.
 /// NOTE: Should be same with `MIN_BLOCK_GAS_LIMIT` in
 /// contracts/layer1/libs/LibConstants.sol.
@@ -37,7 +32,12 @@ pub const MIN_BLOCK_GAS_LIMIT: u64 = 10_000_000;
 /// contracts/layer1/libs/LibManifest.sol.
 pub const MAX_BLOCK_GAS_LIMIT: u64 = 100_000_000;
 
-/// Denominator (parts per million) used when clamping gas limits.
+/// The maximum block gas limit change per block, expressed in millionths.
+/// NOTE: Should be same with `BLOCK_GAS_LIMIT_MAX_CHANGE` in
+/// contracts/layer1/libs/LibManifest.sol.
+pub const BLOCK_GAS_LIMIT_MAX_CHANGE: u64 = 10;
+
+/// Denominator (parts per million) used when clamping gas limits (10 ppm = 0.001%).
 pub const GAS_LIMIT_DENOMINATOR: u64 = 1_000_000;
 
 /// The delay in processing bond instructions relative to the current proposal.

--- a/packages/taiko-client/bindings/manifest/manifest.go
+++ b/packages/taiko-client/bindings/manifest/manifest.go
@@ -19,8 +19,10 @@ const (
 	AnchorMinOffset = 2
 	// AnchorMaxOffset The maximum anchor block number offset from the proposal origin block number, refer to LibManifest.MAX_ANCHOR_OFFSET.
 	AnchorMaxOffset = 128
-	// MaxBlockGasLimitChangePermyriad The maximum block gas limit change per block, in millionths (1/1,000,000), refer to LibManifest.MAX_BLOCK_GAS_LIMIT_CHANGE_PERMYRIAD.
-	MaxBlockGasLimitChangePermyriad = 10 // 0.1%
+	// MaxBlockGasLimitChangePermyriad The maximum block gas limit change per block, expressed in millionths (1/1,000,000), refer to LibManifest.MAX_BLOCK_GAS_LIMIT_CHANGE_PERMYRIAD.
+	MaxBlockGasLimitChangePermyriad = 10 // 0.001%
+	// GasLimitChangeDenominator Denominator used when clamping gas limits (parts per million).
+	GasLimitChangeDenominator = 1_000_000
 	// MinBlockGasLimit The minimum block gas limit, refer to LibManifest.MIN_BLOCK_GAS_LIMIT.
 	MinBlockGasLimit = 10_000_000
 	// MaxBlockGasLimit The maximum block gas limit, refer to LibManifest.MAX_BLOCK_GAS_LIMIT.

--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
@@ -464,11 +464,13 @@ func validateGasLimit(
 	}
 	for i := range sourcePayload.BlockPayloads {
 		lowerGasBound := max(
-			parentGasLimit*(10000-manifest.MaxBlockGasLimitChangePermyriad)/10000,
+			parentGasLimit*(manifest.GasLimitChangeDenominator-manifest.MaxBlockGasLimitChangePermyriad)/
+				manifest.GasLimitChangeDenominator,
 			manifest.MinBlockGasLimit,
 		)
 		upperGasBound := min(
-			parentGasLimit*(10000+manifest.MaxBlockGasLimitChangePermyriad)/10000,
+			parentGasLimit*(manifest.GasLimitChangeDenominator+manifest.MaxBlockGasLimitChangePermyriad)/
+				manifest.GasLimitChangeDenominator,
 			manifest.MaxBlockGasLimit,
 		)
 

--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta_test.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta_test.go
@@ -297,12 +297,14 @@ func (s *ShastaManifestFetcherTestSuite) TestValidateGasLimit() {
 	// Based on the log output, we can see the effective parent gas limit is 29,000,000 (0x1ba8140)
 	effectiveParentGasLimit := uint64(29_000_000) // This is what actually gets used
 
-	// Calculate expected bounds (0.1% change = 10 permyriad) based on effective parent gas limit
+	// Calculate expected bounds (0.001% change = 10 millionths) based on effective parent gas limit
 	expectedLowerBound := max(
-		effectiveParentGasLimit*(10000-manifest.MaxBlockGasLimitChangePermyriad)/10000,
+		effectiveParentGasLimit*(manifest.GasLimitChangeDenominator-manifest.MaxBlockGasLimitChangePermyriad)/
+			manifest.GasLimitChangeDenominator,
 		manifest.MinBlockGasLimit,
 	)
-	expectedUpperBound := effectiveParentGasLimit * (10000 + manifest.MaxBlockGasLimitChangePermyriad) / 10000
+	expectedUpperBound := effectiveParentGasLimit *
+		(manifest.GasLimitChangeDenominator + manifest.MaxBlockGasLimitChangePermyriad) / manifest.GasLimitChangeDenominator
 
 	// Test 1: Zero gas limit - should inherit parent
 	sourcePayload := &ShastaDerivationSourcePayload{


### PR DESCRIPTION
Switch both clients to clamp gas limits using the correct denominator from `manifest.GasLimitChangePermyriad`, expose `GasLimitChangeDenominator` in the bindings/protocol constants, and update the Go validator/tests plus the Rust validator to share that constant.

To match the description in https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/Derivation.md