### PR TITLE
fix(taiko-client,taiko-client-rs): ensure forced inclusion manifests reuse proposer auth

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta_test.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta_test.go
@@ -345,7 +345,7 @@ func (s *ShastaManifestFetcherTestSuite) TestValidateGasLimit() {
 	s.Equal(expectedUpperBound, sourcePayload.BlockPayloads[0].GasLimit)
 
 	// Test 4: Valid gas limit within bounds - should remain unchanged
-	validGasLimit := effectiveParentGasLimit + 20000 // 29,020,000, within bounds
+	validGasLimit := expectedLowerBound + 20000 // Slightly above lower bound, within range
 	sourcePayload = &ShastaDerivationSourcePayload{
 		BlockPayloads: []*ShastaBlockPayload{
 			{BlockManifest: manifest.BlockManifest{
@@ -358,8 +358,8 @@ func (s *ShastaManifestFetcherTestSuite) TestValidateGasLimit() {
 	s.Equal(validGasLimit, sourcePayload.BlockPayloads[0].GasLimit)
 
 	// Test 5: Sequential blocks - parent gas limit should update
-	firstBlockGasLimit := effectiveParentGasLimit + 15000 // 29,015,000, within bounds
-	secondBlockGasLimit := uint64(0)                      // Should inherit from first block
+	firstBlockGasLimit := expectedLowerBound + 15000
+	secondBlockGasLimit := uint64(0) // Should inherit from first block
 
 	sourcePayload = &ShastaDerivationSourcePayload{
 		BlockPayloads: []*ShastaBlockPayload{

--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta_test.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta_test.go
@@ -345,7 +345,12 @@ func (s *ShastaManifestFetcherTestSuite) TestValidateGasLimit() {
 	s.Equal(expectedUpperBound, sourcePayload.BlockPayloads[0].GasLimit)
 
 	// Test 4: Valid gas limit within bounds - should remain unchanged
-	validGasLimit := expectedLowerBound + 20000 // Slightly above lower bound, within range
+	validGasLimit := expectedLowerBound
+	if expectedUpperBound > expectedLowerBound {
+		span := expectedUpperBound - expectedLowerBound
+		increment := max(uint64(1), span/2)
+		validGasLimit = min(expectedUpperBound, expectedLowerBound+increment)
+	}
 	sourcePayload = &ShastaDerivationSourcePayload{
 		BlockPayloads: []*ShastaBlockPayload{
 			{BlockManifest: manifest.BlockManifest{
@@ -358,7 +363,7 @@ func (s *ShastaManifestFetcherTestSuite) TestValidateGasLimit() {
 	s.Equal(validGasLimit, sourcePayload.BlockPayloads[0].GasLimit)
 
 	// Test 5: Sequential blocks - parent gas limit should update
-	firstBlockGasLimit := expectedLowerBound + 15000
+	firstBlockGasLimit := validGasLimit
 	secondBlockGasLimit := uint64(0) // Should inherit from first block
 
 	sourcePayload = &ShastaDerivationSourcePayload{

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -300,6 +300,35 @@ func (s *Syncer) processShastaProposal(
 		}
 	}
 
+	// Prefetch all derivation source payloads, and set the proposer auth bytes.
+	var (
+		sourcePayloads = make([]*shastaManifest.ShastaDerivationSourcePayload, len(meta.GetDerivation().Sources))
+		proposerAuth   []byte
+	)
+	if len(meta.GetDerivation().Sources) > 0 {
+		// Fetch the last derivation source payload first, and set the proposer auth bytes.
+		payload, err := s.derivationSourceFetcher.Fetch(ctx, meta, len(meta.GetDerivation().Sources)-1)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to fetch Shasta derivation payload for index %d: %w",
+				len(meta.GetDerivation().Sources)-1,
+				err,
+			)
+		}
+		sourcePayloads[len(meta.GetDerivation().Sources)-1] = payload
+		proposerAuth = payload.ProverAuthBytes
+		// Fetch other derivation source payloads.
+		for i := 0; i < len(meta.GetDerivation().Sources)-1; i++ {
+			p, err := s.derivationSourceFetcher.Fetch(ctx, meta, i)
+			if err != nil {
+				return fmt.Errorf("failed to fetch Shasta derivation payload for index %d: %w", i, err)
+			}
+			// Set the proposer auth bytes for the non-last source payloads as well.
+			p.ProverAuthBytes = proposerAuth
+			sourcePayloads[i] = p
+		}
+	}
+
 	for derivationIdx := range meta.GetDerivation().Sources {
 		log.Info(
 			"Processing Shasta derivation source",
@@ -309,10 +338,10 @@ func (s *Syncer) processShastaProposal(
 			"l1Height", meta.GetRawBlockHeight(),
 			"l1Hash", meta.GetRawBlockHash(),
 		)
-		// Fetch and parse the derivation payload from blobs.
-		sourcePayload, err := s.derivationSourceFetcher.Fetch(ctx, meta, derivationIdx)
-		if err != nil {
-			return err
+		// Reuse the prefetched derivation payload.
+		sourcePayload := sourcePayloads[derivationIdx]
+		if sourcePayload == nil {
+			return fmt.Errorf("missing Shasta derivation payload for index %d", derivationIdx)
 		}
 		sourcePayload.ParentBlock = parent
 
@@ -374,6 +403,7 @@ func (s *Syncer) processShastaProposal(
 				sourcePayload = &shastaManifest.ShastaDerivationSourcePayload{
 					Default:           true,
 					IsLowBondProposal: true,
+					ProverAuthBytes:   sourcePayload.ProverAuthBytes,
 					ParentBlock:       sourcePayload.ParentBlock,
 				}
 			}


### PR DESCRIPTION
  - Prefetch proposals so the proposer’s manifest is decoded once, then copy the proposal level `proverAuthBytes` into every earlier (forced) source before processing blocks.
  - Mirror the same behavior in taiko-client-rs so Rust pipelines inject the proposer’s auth bytes into forced-inclusion manifests before deriving payloads.