### PR TITLE
fix(taiko-client,taiko-client-rs): only apply default low-bond manifests for normal proposer sources

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
@@ -217,7 +217,12 @@ where
         let mut decoded_manifest = segment.manifest;
         let is_low_bond_proposal = self.detect_low_bond_proposal(state, meta).await?;
 
-        if !manifest_is_default(&decoded_manifest) && is_low_bond_proposal {
+        // If this is a low-bond proposal and its not a forced inclusion segment,
+        // override the manifest to be the default payload.
+        if !segment.is_forced_inclusion &&
+            !manifest_is_default(&decoded_manifest) &&
+            is_low_bond_proposal
+        {
             info!(
                 proposal_id = meta.proposal_id,
                 "low-bond proposal detected; using default manifest for segment processing"

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -766,6 +766,7 @@ func applyLowBondProposalRules(
 		Default:           true,
 		IsLowBondProposal: true,
 		ParentBlock:       payload.ParentBlock,
+		ProverAuthBytes:   payload.ProverAuthBytes,
 	}
 }
 

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -368,17 +368,12 @@ func (s *Syncer) processShastaProposal(
 			"proverAuth", common.Bytes2Hex(sourcePayload.ProverAuthBytes[:]),
 		)
 
-		if designatedProverInfo.IsLowBondProposal {
-			if !sourcePayload.Default {
-				sourcePayload = &shastaManifest.ShastaDerivationSourcePayload{
-					Default:           true,
-					IsLowBondProposal: true,
-					ParentBlock:       sourcePayload.ParentBlock,
-				}
-			} else {
-				sourcePayload.IsLowBondProposal = true
-			}
-		}
+		// Apply low-bond proposal rules to the derivation payload.
+		sourcePayload = applyLowBondProposalRules(
+			sourcePayload,
+			!meta.GetDerivation().Sources[derivationIdx].IsForcedInclusion,
+			designatedProverInfo.IsLowBondProposal,
+		)
 
 		// If the proposal is not a default one, we need to do some extra validations for
 		// the proposer and `isLowBondProposal` flag.
@@ -716,6 +711,33 @@ func (s *Syncer) checkReorgShasta(
 	}
 
 	return reorgCheckResult, nil
+}
+
+// applyLowBondProposalRules enforces default manifest rules for low-bond proposals.
+func applyLowBondProposalRules(
+	payload *shastaManifest.ShastaDerivationSourcePayload,
+	isProposerSource bool,
+	isLowBondProposal bool,
+) *shastaManifest.ShastaDerivationSourcePayload {
+	// If not a low-bond proposal, return directly.
+	if payload == nil || !isLowBondProposal {
+		return payload
+	}
+
+	// For low-bond proposals, we always enforce the default manifest rules.
+	// If the source is a forced inclusion source, we keep the original payload but
+	// set the `isLowBondProposal` flag to true.
+	if payload.Default || !isProposerSource {
+		payload.IsLowBondProposal = true
+		return payload
+	}
+
+	// For the normal proposal source, we replace the payload with a default one.
+	return &shastaManifest.ShastaDerivationSourcePayload{
+		Default:           true,
+		IsLowBondProposal: true,
+		ParentBlock:       payload.ParentBlock,
+	}
 }
 
 // BlocksInserterPacaya returns the Pacaya blocks inserter.


### PR DESCRIPTION
To match the description in [Derivation Process](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/Derivation.md):
>
**Default Manifest Replacement**: When `isLowBondProposal = true`, the **only the proposer's manifest** is replaced with the default manifest, minimizing proving costs and disincentivizing spam. Forced inclusion manifests are still processed.
