### PR TITLE
chore(protocol): use custom errors in SgxVerifier constructor

### DIFF
--- a/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
@@ -71,9 +71,12 @@ contract SgxVerifier is IProofVerifier, Ownable2Step {
     error SGX_INVALID_ATTESTATION();
     error SGX_INVALID_INSTANCE();
     error SGX_INVALID_PROOF();
+    error INVALID_CHAIN_ID();
+    error INVALID_AUTOMATA_DCAP_ATTESTATION();
 
     constructor(uint64 _taikoChainId, address _owner, address _automataDcapAttestation) {
-        require(_taikoChainId != 0, "Invalid chain id");
+        if (_taikoChainId == 0) revert INVALID_CHAIN_ID();
+        if (_automataDcapAttestation == address(0)) revert INVALID_AUTOMATA_DCAP_ATTESTATION();
         taikoChainId = _taikoChainId;
         automataDcapAttestation = _automataDcapAttestation;
 


### PR DESCRIPTION
SgxVerifier already defines custom errors (SGX_* at lines 70-73) but its constructor still uses string errors. Replaced constructor string validation with INVALID_CHAIN_ID() and INVALID_AUTOMATA_DCAP_ATTESTATION() to match the contract's existing error pattern and save gas (4 bytes vs ~20+ bytes per error).