### PR TITLE
chore(taiko-client): propagate `errgroup` context to live iterators

### DIFF
--- a/packages/taiko-client/driver/anchor_tx_constructor/anchor_tx_constructor_test.go
+++ b/packages/taiko-client/driver/anchor_tx_constructor/anchor_tx_constructor_test.go
@@ -2,6 +2,7 @@ package anchortxconstructor
 
 import (
 	"context"
+	"math/big"
 	"os"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pacayaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/pacaya"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
@@ -37,6 +39,34 @@ func TestAssembleAnchorV3Tx(t *testing.T) {
 		&pacayaBindings.LibSharedDataBaseFeeConfig{},
 		[][32]byte{},
 		common.Big1,
+		common.Big256,
+	)
+	require.Nil(t, err)
+	require.NotNil(t, tx)
+}
+
+func TestAssembleAnchorV4Tx(t *testing.T) {
+	client := newTestClient(t)
+	l1Head, err := client.L1.HeaderByNumber(context.Background(), nil)
+	require.Nil(t, err)
+
+	c, err := New(client)
+	require.Nil(t, err)
+	head, err := client.L2.HeaderByNumber(context.Background(), nil)
+	require.Nil(t, err)
+	tx, err := c.AssembleAnchorV4Tx(
+		context.Background(),
+		head,
+		common.Big0,
+		head.Coinbase,
+		[]byte{},
+		common.Hash{},
+		[]shasta.LibBondsBondInstruction{},
+		l1Head.Number,
+		l1Head.Hash(),
+		l1Head.Root,
+		common.Big0,
+		new(big.Int).Add(head.Number, common.Big1),
 		common.Big256,
 	)
 	require.Nil(t, err)

--- a/packages/taiko-client/pkg/state_indexer/indexer.go
+++ b/packages/taiko-client/pkg/state_indexer/indexer.go
@@ -597,11 +597,11 @@ func (s *Indexer) liveIndex(newHead *types.Header) error {
 	log.Debug("Live indexing Shasta events", "from", startHeight, "to", newHead.Number)
 
 	// Run proposed and proved indexing in parallel.
-	g, _ := errgroup.WithContext(s.ctx)
+	g, gCtx := errgroup.WithContext(s.ctx)
 
 	// Proposed events iterator
 	g.Go(func() error {
-		iter, err := eventiterator.NewBatchProposedIterator(s.ctx, &eventiterator.BatchProposedIteratorConfig{
+		iter, err := eventiterator.NewBatchProposedIterator(gCtx, &eventiterator.BatchProposedIteratorConfig{
 			RpcClient:             s.rpc,
 			MaxBlocksReadPerEpoch: &maxBlocksPerFilter,
 			StartHeight:           startHeight,
@@ -619,7 +619,7 @@ func (s *Indexer) liveIndex(newHead *types.Header) error {
 
 	// Proved events iterator
 	g.Go(func() error {
-		iterProved, err := eventiterator.NewShastaProvedIterator(s.ctx, &eventiterator.ShastaProvedIteratorConfig{
+		iterProved, err := eventiterator.NewShastaProvedIterator(gCtx, &eventiterator.ShastaProvedIteratorConfig{
 			RpcClient:             s.rpc,
 			MaxBlocksReadPerEpoch: &maxBlocksPerFilter,
 			StartHeight:           startHeight,


### PR DESCRIPTION
  - Pass the errgroup-derived context into both live proposed/proved iterators so they cancel as soon as a sibling goroutine fails.
  - Prevent liveIndex from holding the state lock indefinitely when one iterator errors out.
  - Add a test for `TestAssembleAnchorV4Tx `