### PR TITLE
fix(taiko-client): respect derivation origin block for anchor checks

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -222,10 +222,11 @@ func isKnownCanonicalBatchPacaya(
 
 	// Check each block in the batch, and if the all blocks are preconfirmed, return the header of the last block.
 	for i := 0; i < len(metadata.Pacaya().GetBlocks()); i++ {
+		idx := i
 		g.Go(func() error {
-			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
+			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(idx)))
 			if err != nil {
-				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
+				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(idx), err)
 			}
 
 			createExecutionPayloadsMetaData, anchorTx, err := assembleCreateExecutionPayloadMetaPacaya(
@@ -235,7 +236,7 @@ func isKnownCanonicalBatchPacaya(
 				metadata,
 				allTxs,
 				parentHeader,
-				i,
+				idx,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to assemble execution payload creation metadata: %w", err)
@@ -246,7 +247,7 @@ func isKnownCanonicalBatchPacaya(
 				return fmt.Errorf("failed to RLP encode tx list: %w", err)
 			}
 
-			if headers[i], err = isKnownCanonicalBlock(
+			if headers[idx], err = isKnownCanonicalBlock(
 				ctx,
 				rpc,
 				&createPayloadAndSetHeadMetaData{
@@ -286,10 +287,11 @@ func isKnownCanonicalBatchShasta(
 
 	// Check each block in the batch, and if the all blocks are preconfirmed, return the header of the last block.
 	for i := 0; i < len(sourcePayload.BlockPayloads); i++ {
+		idx := i
 		g.Go(func() error {
-			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
+			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(idx)))
 			if err != nil {
-				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
+				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(idx), err)
 			}
 
 			createExecutionPayloadsMetaData, anchorTx, err := assembleCreateExecutionPayloadMetaShasta(
@@ -299,7 +301,7 @@ func isKnownCanonicalBatchShasta(
 				metadata,
 				sourcePayload,
 				parentHeader,
-				i,
+				idx,
 				sourcePayload.IsLowBondProposal,
 			)
 			if err != nil {
@@ -311,7 +313,7 @@ func isKnownCanonicalBatchShasta(
 				return fmt.Errorf("failed to RLP encode tx list: %w", err)
 			}
 
-			if headers[i], err = isKnownCanonicalBlock(
+			if headers[idx], err = isKnownCanonicalBlock(
 				ctx,
 				rpc,
 				&createPayloadAndSetHeadMetaData{

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -222,11 +222,10 @@ func isKnownCanonicalBatchPacaya(
 
 	// Check each block in the batch, and if the all blocks are preconfirmed, return the header of the last block.
 	for i := 0; i < len(metadata.Pacaya().GetBlocks()); i++ {
-		idx := i
 		g.Go(func() error {
-			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(idx)))
+			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
 			if err != nil {
-				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(idx), err)
+				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
 			}
 
 			createExecutionPayloadsMetaData, anchorTx, err := assembleCreateExecutionPayloadMetaPacaya(
@@ -236,7 +235,7 @@ func isKnownCanonicalBatchPacaya(
 				metadata,
 				allTxs,
 				parentHeader,
-				idx,
+				i,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to assemble execution payload creation metadata: %w", err)
@@ -247,7 +246,7 @@ func isKnownCanonicalBatchPacaya(
 				return fmt.Errorf("failed to RLP encode tx list: %w", err)
 			}
 
-			if headers[idx], err = isKnownCanonicalBlock(
+			if headers[i], err = isKnownCanonicalBlock(
 				ctx,
 				rpc,
 				&createPayloadAndSetHeadMetaData{
@@ -287,11 +286,10 @@ func isKnownCanonicalBatchShasta(
 
 	// Check each block in the batch, and if the all blocks are preconfirmed, return the header of the last block.
 	for i := 0; i < len(sourcePayload.BlockPayloads); i++ {
-		idx := i
 		g.Go(func() error {
-			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(idx)))
+			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
 			if err != nil {
-				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(idx), err)
+				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
 			}
 
 			createExecutionPayloadsMetaData, anchorTx, err := assembleCreateExecutionPayloadMetaShasta(
@@ -301,7 +299,7 @@ func isKnownCanonicalBatchShasta(
 				metadata,
 				sourcePayload,
 				parentHeader,
-				idx,
+				i,
 				sourcePayload.IsLowBondProposal,
 			)
 			if err != nil {
@@ -313,7 +311,7 @@ func isKnownCanonicalBatchShasta(
 				return fmt.Errorf("failed to RLP encode tx list: %w", err)
 			}
 
-			if headers[idx], err = isKnownCanonicalBlock(
+			if headers[i], err = isKnownCanonicalBlock(
 				ctx,
 				rpc,
 				&createPayloadAndSetHeadMetaData{

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -414,7 +414,7 @@ func (s *Syncer) processShastaProposal(
 				sourcePayload,
 				meta.GetDerivation().Sources[derivationIdx].IsForcedInclusion,
 				meta.GetProposal(),
-				meta.GetRawBlockHeight().Uint64(),
+				meta.GetDerivation().OriginBlockNumber.Uint64(),
 				latestProposalState.BondInstructionsHash,
 				lastAnchorBlockNumber,
 			); err != nil {


### PR DESCRIPTION
  - Anchor-window validation was using the raw L1 inclusion height (`meta.GetRawBlockHeight`) but the protocol defines `originBlockNumber = l1 height - 1`, so the check was off by one.
  - Pass `meta.GetDerivation().OriginBlockNumber` into `ValidateMetadata` so anchor bounds match the Inbox contract/spec.

To match the [Derivation process](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/Derivation.md):
> 
**Invalidation conditions** (sets `anchorBlockNumber` to `parent.metadata.anchorBlockNumber`):
- **Non-monotonic progression**: `manifest.blocks[i].anchorBlockNumber < parent.metadata.anchorBlockNumber`
- **Future reference**: `manifest.blocks[i].anchorBlockNumber >= proposal.originBlockNumber - MIN_ANCHOR_OFFSET`
- **Excessive lag**: `manifest.blocks[i].anchorBlockNumber < proposal.originBlockNumber - MAX_ANCHOR_OFFSET`