### PR TITLE
fix(taiko-client): advance Shasta derivations by final inserted block

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/interface.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/interface.go
@@ -25,7 +25,7 @@ type Inserter interface {
 		metadata metadata.TaikoProposalMetaData,
 		sourcePayload *shastaManifest.ShastaDerivationSourcePayload,
 		endIter eventIterator.EndBatchProposedEventIterFunc,
-	) error
+	) (*big.Int, error)
 }
 
 // createExecutionPayloadsMetaData is a struct that contains all the necessary metadata

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
@@ -273,8 +273,8 @@ func (i *Pacaya) InsertBlocksWithManifest(
 	_ metadata.TaikoProposalMetaData,
 	_ *shastaManifest.ShastaDerivationSourcePayload,
 	_ eventIterator.EndBatchProposedEventIterFunc,
-) error {
-	return errors.New("not supported in Pacaya")
+) (*big.Int, error) {
+	return nil, errors.New("not supported in Pacaya")
 }
 
 // InsertPreconfBlocksFromEnvelopes inserts preconfirmation blocks from the given envelopes.

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
@@ -63,9 +63,9 @@ func (i *Shasta) InsertBlocksWithManifest(
 	metadata metadata.TaikoProposalMetaData,
 	sourcePayload *shastaManifest.ShastaDerivationSourcePayload,
 	endIter eventIterator.EndBatchProposedEventIterFunc,
-) (err error) {
+) (*big.Int, error) {
 	if !metadata.IsShasta() {
-		return errors.New("metadata is not for Shasta fork blocks")
+		return nil, errors.New("metadata is not for Shasta fork blocks")
 	}
 
 	i.mutex.Lock()
@@ -146,10 +146,10 @@ func (i *Shasta) InsertBlocksWithManifest(
 
 				// Update the L1 origin for each block in the batch.
 				if err := updateL1OriginForBatchShasta(ctx, i.rpc, parent, metadata, sourcePayload); err != nil {
-					return fmt.Errorf("failed to update L1 origin for batch (%d): %w", meta.GetProposal().Id, err)
+					return nil, fmt.Errorf("failed to update L1 origin for batch (%d): %w", meta.GetProposal().Id, err)
 				}
 
-				return nil
+				return lastBlockHeader.Number, nil
 			}
 		}
 
@@ -165,7 +165,7 @@ func (i *Shasta) InsertBlocksWithManifest(
 			sourcePayload.IsLowBondProposal,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to assemble execution payload creation metadata: %w", err)
+			return nil, fmt.Errorf("failed to assemble execution payload creation metadata: %w", err)
 		}
 
 		// Decompress the transactions list and try to insert a new head block to L2 EE.
@@ -178,14 +178,14 @@ func (i *Shasta) InsertBlocksWithManifest(
 			},
 			anchorTx,
 		); err != nil {
-			return fmt.Errorf("failed to insert new head to L2 execution engine: %w", err)
+			return nil, fmt.Errorf("failed to insert new head to L2 execution engine: %w", err)
 		}
 
 		log.Debug("Payload data", "hash", lastPayloadData.BlockHash, "txs", len(lastPayloadData.Transactions))
 
 		// Wait till the corresponding L2 header to be existed in the L2 EE.
 		if parent, err = i.rpc.WaitL2Header(ctx, new(big.Int).SetUint64(lastPayloadData.Number)); err != nil {
-			return fmt.Errorf("failed to wait for L2 header (%d): %w", lastPayloadData.Number, err)
+			return nil, fmt.Errorf("failed to wait for L2 header (%d): %w", lastPayloadData.Number, err)
 		}
 
 		log.Info(
@@ -214,7 +214,7 @@ func (i *Shasta) InsertBlocksWithManifest(
 	latestSeenProposal.PreconfChainReorged = true
 	go i.sendLatestSeenProposal(latestSeenProposal)
 
-	return nil
+	return new(big.Int).SetUint64(latestSeenProposal.LastBlockID), nil
 }
 
 // InsertPreconfBlocksFromEnvelopes inserts preconfirmation blocks from the given envelopes.

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -461,15 +461,16 @@ func (s *Syncer) processShastaProposal(
 		}
 
 		// Insert new blocks to L2 EE's chain.
-		if err := s.blocksInserterShasta.InsertBlocksWithManifest(
+		lastInsertedBlockID, err := s.blocksInserterShasta.InsertBlocksWithManifest(
 			ctx,
 			metadata,
 			sourcePayload,
 			endIter,
-		); err != nil {
+		)
+		if err != nil {
 			return fmt.Errorf("failed to insert Shasta blocks: %w", err)
 		}
-		if parent, err = s.rpc.WaitL2Block(ctx, new(big.Int).Add(parent.Number(), common.Big1)); err != nil {
+		if parent, err = s.rpc.WaitL2Block(ctx, lastInsertedBlockID); err != nil {
 			log.Warn("Failed to fetch the new parent block", "error", err)
 			return err
 		}


### PR DESCRIPTION
  - Update the Shasta blocks inserter (and its interface) to return the last block number it actually inserted; propagate the `*big.Int` up through the syncer.
  - Teach `processShastaProposal` to reuse that returned header as the parent for the next derivation source, preventing multi-block manifests from rebuilding on stale parents and eliminating duplicate block numbers/NewPayload conflicts.
  - Update the test to cover this case.