### PR TITLE
fix(taiko-client): eliminate errgroup data races by using local error variables

### DIFF
--- a/packages/taiko-client/proposer/transaction_builder/fallback.go
+++ b/packages/taiko-client/proposer/transaction_builder/fallback.go
@@ -120,35 +120,43 @@ func (b *TxBuilderWithFallback) BuildPacaya(
 	)
 
 	g.Go(func() error {
-		if txWithCalldata, err = b.calldataTransactionBuilder.BuildPacaya(
+		tx, e := b.calldataTransactionBuilder.BuildPacaya(
 			ctx,
 			txBatch,
 			forcedInclusion,
 			minTxsPerForcedInclusion,
 			parentMetahash,
 			preconfRouterAddress,
-		); err != nil {
-			return fmt.Errorf("failed to build type-2 transaction: %w", err)
+		)
+		if e != nil {
+			return fmt.Errorf("failed to build type-2 transaction: %w", e)
 		}
-		if costCalldata, err = b.estimateCandidateCost(ctx, txWithCalldata); err != nil {
-			return fmt.Errorf("failed to estimate type-2 transaction cost: %w", encoding.TryParsingCustomError(err))
+		txWithCalldata = tx
+		cost, e := b.estimateCandidateCost(ctx, txWithCalldata)
+		if e != nil {
+			return fmt.Errorf("failed to estimate type-2 transaction cost: %w", encoding.TryParsingCustomError(e))
 		}
+		costCalldata = cost
 		return nil
 	})
 	g.Go(func() error {
-		if txWithBlob, err = b.blobTransactionBuilder.BuildPacaya(
+		tx, e := b.blobTransactionBuilder.BuildPacaya(
 			ctx,
 			txBatch,
 			forcedInclusion,
 			minTxsPerForcedInclusion,
 			parentMetahash,
 			preconfRouterAddress,
-		); err != nil {
-			return fmt.Errorf("failed to build type-3 transaction: %w", err)
+		)
+		if e != nil {
+			return fmt.Errorf("failed to build type-3 transaction: %w", e)
 		}
-		if costBlob, err = b.estimateCandidateCost(ctx, txWithBlob); err != nil {
-			return fmt.Errorf("failed to estimate type-3 transaction cost: %w", encoding.TryParsingCustomError(err))
+		txWithBlob = tx
+		cost, e := b.estimateCandidateCost(ctx, txWithBlob)
+		if e != nil {
+			return fmt.Errorf("failed to estimate type-3 transaction cost: %w", encoding.TryParsingCustomError(e))
 		}
+		costBlob = cost
 		return nil
 	})
 


### PR DESCRIPTION
This change removes data races caused by concurrent writes to a captured outer err variable inside multiple errgroup goroutines. In GetProtocolStateVariablesPacaya and GetForcedInclusionPacaya within packages/taiko-client/pkg/rpc/methods.go, and in TxBuilderWithFallback.BuildPacaya within packages/taiko-client/proposer/transaction_builder/fallback.go, separate goroutines previously wrote to the same err value, which is racy under the Go memory model and reproducible with the race detector. The fix adopts a standard errgroup pattern: each goroutine uses a local error variable and returns it, while results are staged in local temporaries and only assigned to shared outer variables after successful completion or after g.Wait confirms no error. This preserves behavior, avoids synchronization overhead, and ensures correctness under -race without altering external APIs or semantics.