### PR TITLE
fix(protocol): fix anchor natspec

### DIFF
--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -15,8 +15,6 @@ import "./Anchor_Layout.sol"; // DO NOT DELETE
 /// @title Anchor
 /// @notice Implements the Shasta fork's anchoring mechanism with advanced bond management,
 /// prover designation and checkpoint management.
-/// @dev IMPORTANT: This contract will be deployed behind the `AnchorRouter` contract, and that's why
-/// it's not upgradable itself.
 /// @dev This contract implements:
 ///      - Bond-based economic security for proposals and proofs
 ///      - Prover designation with signature authentication


### PR DESCRIPTION
The anchor is now actually upgradable, this commet is a leftover from a previous version of the code