### PR TITLE
fix(repo): peg version for buildx temporarily

### DIFF
--- a/.github/workflows/blobindexer-rs--docker.yml
+++ b/.github/workflows/blobindexer-rs--docker.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta
@@ -108,7 +109,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/ejector--docker.yml
+++ b/.github/workflows/ejector--docker.yml
@@ -54,7 +54,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker metadata
         id: meta
@@ -114,7 +115,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker metadata
         id: meta

--- a/.github/workflows/eventindexer--docker.yml
+++ b/.github/workflows/eventindexer--docker.yml
@@ -38,6 +38,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
+        with:
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/overseer-rs--docker.yml
+++ b/.github/workflows/overseer-rs--docker.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta
@@ -108,7 +109,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/relayer--docker.yml
+++ b/.github/workflows/relayer--docker.yml
@@ -38,6 +38,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
+        with:
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta
@@ -104,7 +105,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/taiko-client-rs--docker.yml
+++ b/.github/workflows/taiko-client-rs--docker.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta
@@ -106,7 +107,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/urcindexer-rs--docker.yml
+++ b/.github/workflows/urcindexer-rs--docker.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta
@@ -108,7 +109,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
         with:
-          version: latest
+          version: v0.29.1
+          cache-binary: false
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
known bug with the new containerd v2.2 that affects docker buildx v0.30.0, peg version temporarily before a fix is merged