### PR TITLE
feat(taiko-client,taiko-client-rs): always normalize default Shasta manifests

### DIFF
--- a/.github/workflows/taiko-client-rs--docker.yml
+++ b/.github/workflows/taiko-client-rs--docker.yml
@@ -1,4 +1,4 @@
-name: "Build and Push Multi-Arch Docker Image"
+name: "Build and Push Multi-Arch Docker Image (taiko-client-rs)"
 permissions:
   contents: read
 

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/error.rs
@@ -10,8 +10,7 @@ use thiserror::Error;
 
 use crate::{
     derivation::{
-        manifest::ManifestFetcherError,
-        pipeline::shasta::{anchor::AnchorTxConstructorError, validation::ValidationError},
+        manifest::ManifestFetcherError, pipeline::shasta::anchor::AnchorTxConstructorError,
     },
     sync::error::EngineSubmissionError,
 };
@@ -25,9 +24,6 @@ pub enum DerivationError {
     /// Failure constructing anchor transactions.
     #[error(transparent)]
     Anchor(#[from] AnchorTxConstructorError),
-    /// Manifest validation failure.
-    #[error(transparent)]
-    Validation(#[from] ValidationError),
     /// Manifest fetch or decode failure.
     #[error(transparent)]
     Manifest(#[from] ManifestFetcherError),


### PR DESCRIPTION
  - Move the default-manifest handling into `ValidateMetadata`: anchor checks run first, proposer sources that fail are marked default, replaced with a single anchor-only block, and then continue through timestamp/coinbase/gas normalization just like any other payload.
  - Remove the syncer-level special-casing. Every derivation source (forced or default) now calls `ValidateMetadata`, so there’s a single place where manifest fallback happens and gets logged.