### PR TITLE
feat(protocol): add `SHASTA_FORK_TIME` to Shasta block `timestamp` lower bound calculation

### DIFF
--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -269,7 +269,7 @@ With the extracted `ProposalManifest`, metadata computation proceeds using both 
 Timestamp validation is performed collectively across all blocks and may result in block count reduction:
 
 1. **Upper bound enforcement**: If `metadata.timestamp > proposal.timestamp`, set `metadata.timestamp = proposal.timestamp`
-2. **Lower bound calculation**: `lowerBound = max(parent.metadata.timestamp + 1, proposal.timestamp - TIMESTAMP_MAX_OFFSET)`
+2. **Lower bound calculation**: `lowerBound = max(parent.metadata.timestamp + 1, proposal.timestamp - TIMESTAMP_MAX_OFFSET, SHASTA_FORK_TIME)`
 3. **Lower bound enforcement**: If `metadata.timestamp < lowerBound`, set `metadata.timestamp = lowerBound`
 
 #### `anchorBlockNumber` Validation
@@ -572,3 +572,4 @@ The following constants govern the block derivation process:
 | **MIN_BASE_FEE**               | `0.005 gwei` (5,000,000 wei)  | The minimum base fee (inclusive) after Shasta fork.                                                                                                                               |
 | **MAX_BASE_FEE**               | `1 gwei` (1,000,000,000 wei)  | The maximum base fee (inclusive) after Shasta fork.                                                                                                                               |
 | **BLOCK_TIME_TARGET**          | `2 seconds`                   | The block time target.                                                                                                                                                            |
+| **SHASTA_FORK_TIME**           | Hoodi/Mainnet: not scheduled  | The timestamp that determines when the fork should occur.                                                                                                                         |


### PR DESCRIPTION
To address:
> I'm thinking about one validation edge case, rn in the current Shasta derivation pipeline, we have a TIMESTAMP_MAX_OFFSET (384 atm and will be updated to 1536) in timestamp [lower bound validation](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/Derivation.md#timestamp-validation) , so it seems there is a chance (or edge case) that, during [SHASTA_FORK_TIME, SHASTA_FORK_TIME+TIMESTAMP_MAX_OFFSET), a preconfer / proposer can produce a Shasta block whose timestamp is earlier than the SHASTA_FORK_TIME , but still can pass the current validation rule?