### PR TITLE
fix(tools): resume from last processed chunk

### DIFF
--- a/packages/tools/bridged-token-scanner/index.js
+++ b/packages/tools/bridged-token-scanner/index.js
@@ -24,7 +24,7 @@ async function getLastScannedBlock(dataDir, networkName, vaultName) {
     const files = await fs.readdir(dir);
     const chunkFiles = files.filter(f => f.startsWith("chunk_") && f.endsWith(".json"));
     const lastBlocks = chunkFiles.map(f => {
-      const match = f.match(/^chunk_(\d+)_\d+_BridgedTokenDeployed\.json$/);
+      const match = f.match(/^chunk_\d+_(\d+)_BridgedTokenDeployed\.json$/);
       return match ? parseInt(match[1]) : null;
     }).filter(Boolean);
     return lastBlocks.length > 0 ? Math.max(...lastBlocks) + 1 : null;


### PR DESCRIPTION
When the scanner restarts it now resumes from the last processed block instead of rereading old chunks. The regex pulls the chunk end height, so we skip the duplicated ranges that used to happen on reruns.