### PR TITLE
fix(protocol): update MAX_BLOCK_GAS_LIMIT to 45,000,000 in derivation doc

### DIFF
--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -233,13 +233,13 @@ DerivationSourceManifest memory defaultSource;
 defaultSource.blocks = new BlockManifest[](1);  // Single block
 ```
 
-| Field               | Value                                                                       |
-| ------------------- | --------------------------------------------------------------------------- |
-| `timestamp`         | Protocol applies the timestamp validation lower bound afterward             |
-| `coinbase`          | Protocol substitutes `proposal.proposer`                                    |
-| `anchorBlockNumber` | Protocol inherits from the parent block                                     |
-| `gasLimit`          | Protocol inherits from the parent block                                     |
-| `transactions`      | Empty list (only includes the anchor transaction)                           |
+| Field               | Value                                                           |
+| ------------------- | --------------------------------------------------------------- |
+| `timestamp`         | Protocol applies the timestamp validation lower bound afterward |
+| `coinbase`          | Protocol substitutes `proposal.proposer`                        |
+| `anchorBlockNumber` | Protocol inherits from the parent block                         |
+| `gasLimit`          | Protocol inherits from the parent block                         |
+| `transactions`      | Empty list (only includes the anchor transaction)               |
 
 #### ProposalManifest Construction
 
@@ -257,13 +257,13 @@ manifest.sources = [sourceManifest0, sourceManifest1, ...];  // With defaults fo
 
 Users submit forced inclusion transactions directly to L1 by posting blob data containing a `DerivationSourceManifest` struct. To ensure valid forced inclusions that pass validation, the following `BlockManifest` fields must be set to zero, allowing the protocol to assign appropriate values:
 
-| Field               | Value                                                                       |
-| ------------------- | --------------------------------------------------------------------------- |
-| `timestamp`         | Protocol applies the timestamp validation lower bound afterward             |
-| `coinbase`          | Protocol substitutes `proposal.proposer`                                    |
-| `anchorBlockNumber` | Protocol inherits from the parent block                                     |
-| `gasLimit`          | Protocol inherits from the parent block                                     |
-| `transactions`      | User-provided list of L2 transactions to force-include                      |
+| Field               | Value                                                           |
+| ------------------- | --------------------------------------------------------------- |
+| `timestamp`         | Protocol applies the timestamp validation lower bound afterward |
+| `coinbase`          | Protocol substitutes `proposal.proposer`                        |
+| `anchorBlockNumber` | Protocol inherits from the parent block                         |
+| `gasLimit`          | Protocol inherits from the parent block                         |
+| `transactions`      | User-provided list of L2 transactions to force-include          |
 
 This design ensures forced inclusions integrate properly with the chain's metadata while allowing users to specify only their transactions without requiring knowledge of chain state parameters.
 
@@ -371,6 +371,7 @@ struct ProverAuth {
 The `_validateProverAuth` function processes prover authentication data with the following steps:
 
 - **Signature Verification**:
+
   - Validates the `ProverAuth` struct from the provided bytes
   - Decodes the `ProverAuth` containing: `proposalId`, `proposer`, `provingFee`, and ECDSA `signature`
   - Verifies the signature against the computed message digest
@@ -530,10 +531,12 @@ The function returns:
 The anchor transaction executes a carefully orchestrated sequence of operations:
 
 1. **Fork validation and duplicate prevention**
+
    - Verifies the current block number is at or after the Shasta fork height
    - Tracks parent block hash to prevent duplicate `anchorV4` calls within the same block
 
 2. **Proposal initialization** (first block with a higher `proposalId`)
+
    - Designates the prover for the proposal
    - Sets `isLowBondProposal` flag based on bond sufficiency
    - Stores designated prover and low-bond status in contract state
@@ -568,7 +571,7 @@ The following constants govern the block derivation process:
 | **TIMESTAMP_MAX_OFFSET**       | `384` (12 \* 32)              | The maximum number timestamp offset from the proposal origin timestamp.                                                                                                           |
 | **BLOCK_GAS_LIMIT_MAX_CHANGE** | `10`                          | The maximum block gas limit change per block, in millionths (1/1,000,000). For example, 10 = 10 / 1,000,000 = 0.001%.                                                             |
 | **MIN_BLOCK_GAS_LIMIT**        | `10,000,000`                  | The minimum block gas limit. This ensures block gas limit never drops below a critical threshold.                                                                                 |
-| **MAX_BLOCK_GAS_LIMIT**        | `100,000,000`                 | The maximum block gas limit. This ensures block gas limit never goes above a critical threshold.                                                                                  |
+| **MAX_BLOCK_GAS_LIMIT**        | `45,000,000`                  | The maximum block gas limit. This ensures block gas limit never goes above a critical threshold.                                                                                  |
 | **BOND_PROCESSING_DELAY**      | `6`                           | The delay in processing bond instructions relative to the current proposal. A value of 1 signifies that the bond instructions of the immediate parent proposal will be processed. |
 | **INITIAL_BASE_FEE**           | `0.025 gwei` (25,000,000 wei) | The initial base fee for the first Shasta block when the Shasta fork activated from genesis.                                                                                      |
 | **MIN_BASE_FEE**               | `0.005 gwei` (5,000,000 wei)  | The minimum base fee (inclusive) after Shasta fork.                                                                                                                               |


### PR DESCRIPTION
To reduce the prover’s exposure to spam