### PR TITLE
feat(taiko-client-rs): wire finalized Shasta proposal into forkchoice updates

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/bundle.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/bundle.rs
@@ -20,6 +20,7 @@ pub struct ShastaProposalBundle {
 #[derive(Debug, Clone)]
 pub(super) struct BundleMeta {
     pub(super) proposal_id: u64,
+    pub(super) last_finalized_proposal_id: u64,
     pub(super) proposal_timestamp: u64,
     pub(super) origin_block_number: u64,
     pub(super) origin_block_hash: B256,

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -349,6 +349,9 @@ where
             sources: manifest_segments,
         };
 
+        gauge!(DriverMetrics::DERIVATION_LAST_FINALIZED_PROPOSAL_ID)
+            .set(bundle.meta.last_finalized_proposal_id as f64);
+
         self.cache_bond_instructions_from_payload(payload)?;
 
         info!(proposal_id, segment_count = bundle.sources.len(), "assembled proposal bundle");

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -337,6 +337,7 @@ where
         let bundle = ShastaProposalBundle {
             meta: BundleMeta {
                 proposal_id,
+                last_finalized_proposal_id: payload.coreState.lastFinalizedProposalId.to::<u64>(),
                 proposal_timestamp: payload.proposal.timestamp.to::<u64>(),
                 origin_block_number: payload.derivation.originBlockNumber.to::<u64>(),
                 origin_block_hash: B256::from(payload.derivation.originBlockHash),

--- a/packages/taiko-client-rs/crates/driver/src/metrics.rs
+++ b/packages/taiko-client-rs/crates/driver/src/metrics.rs
@@ -34,6 +34,9 @@ impl DriverMetrics {
     /// Counter tracking L1 origin rows written to the execution engine database.
     pub const DERIVATION_L1_ORIGIN_UPDATES_TOTAL: &'static str =
         "driver_derivation_l1_origin_updates_total";
+    /// Gauge tracking the last finalized proposal id advertised by the inbox core state.
+    pub const DERIVATION_LAST_FINALIZED_PROPOSAL_ID: &'static str =
+        "driver_derivation_last_finalized_proposal_id";
 
     /// Register metric descriptors and initialise gauges/counters.
     pub fn init() {
@@ -97,12 +100,13 @@ impl DriverMetrics {
             Unit::Count,
             "L1 origin updates written during derivation"
         );
+        metrics::describe_gauge!(
+            Self::DERIVATION_LAST_FINALIZED_PROPOSAL_ID,
+            Unit::Count,
+            "Last finalized proposal id observed from the core state"
+        );
 
-        metrics::gauge!(Self::BEACON_SYNC_LOCAL_HEAD_BLOCK).set(0.0);
-        metrics::gauge!(Self::BEACON_SYNC_CHECKPOINT_HEAD_BLOCK).set(0.0);
-        metrics::gauge!(Self::BEACON_SYNC_HEAD_LAG_BLOCKS).set(0.0);
-        metrics::gauge!(Self::DERIVATION_BOND_CACHE_DEPTH).set(0.0);
-
+        // Reset counters to zero.
         metrics::counter!(Self::BEACON_SYNC_REMOTE_SUBMISSIONS_TOTAL).absolute(0);
         metrics::counter!(Self::EVENT_SCANNER_BATCHES_TOTAL).absolute(0);
         metrics::counter!(Self::EVENT_SCANNER_ERRORS_TOTAL).absolute(0);


### PR DESCRIPTION
  - plumb `last_finalized_proposal_id` from proposal core state into bundle metadata
  - resolve finalized block hash via `last_block_id_by_batch_id` and use it when updating forkchoice `safe_block_hash`/`finalized_block_hash`, falling back to `zero` if unavailable
  - keep payload application non-failing when the mapping/header lookup is missing