### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/blobindexer-rs--ci.yml
+++ b/.github/workflows/blobindexer-rs--ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -68,7 +68,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/blobindexer-rs--docker.yml
+++ b/.github/workflows/blobindexer-rs--docker.yml
@@ -38,7 +38,7 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Login to GAR
         uses: docker/login-action@v3

--- a/.github/workflows/bridge-ui--ci.yml
+++ b/.github/workflows/bridge-ui--ci.yml
@@ -12,7 +12,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       # Check out the repo to access release-please-config.json
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Clean up old releases
         shell: bash

--- a/.github/workflows/docs-site--preview.yml
+++ b/.github/workflows/docs-site--preview.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [arc-runner-set]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/docs-site--production.yml
+++ b/.github/workflows/docs-site--production.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [arc-runner-set]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/ejector--docker.yml
+++ b/.github/workflows/ejector--docker.yml
@@ -39,7 +39,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Login to GAR
         uses: docker/login-action@v3

--- a/.github/workflows/ejector--test.yml
+++ b/.github/workflows/ejector--test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Toolchain + components (rustfmt, clippy)
       - name: Install Rust
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/eventindexer--docker.yml
+++ b/.github/workflows/eventindexer--docker.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/eventindexer--test.yml
+++ b/.github/workflows/eventindexer--test.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
     runs-on: [arc-runner-set]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -52,7 +52,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/fork-diff--preview.yml
+++ b/.github/workflows/fork-diff--preview.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [arc-runner-set]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/fork-diff--production.yml
+++ b/.github/workflows/fork-diff--production.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [arc-runner-set]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/nfts.yml
+++ b/.github/workflows/nfts.yml
@@ -24,7 +24,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/overseer-rs--ci.yml
+++ b/.github/workflows/overseer-rs--ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -68,7 +68,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/overseer-rs--docker.yml
+++ b/.github/workflows/overseer-rs--docker.yml
@@ -38,7 +38,7 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Login to GAR
         uses: docker/login-action@v3

--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -41,7 +41,7 @@ jobs:
         uses: alessbell/pull-request-comment-branch@v2.1.0
         id: comment-branch
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # account for forked repos case
           ref: ${{ steps.comment-branch.outputs.head_ref }}
@@ -149,7 +149,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/relayer--docker.yml
+++ b/.github/workflows/relayer--docker.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/relayer--test.yml
+++ b/.github/workflows/relayer--test.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot')}}
     runs-on: [arc-runner-set]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -52,7 +52,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/repo--check-links.yml
+++ b/.github/workflows/repo--check-links.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/repo--claude.yml
+++ b/.github/workflows/repo--claude.yml
@@ -19,7 +19,7 @@ jobs:
         uses: alessbell/pull-request-comment-branch@v2.1.0
         id: comment-branch
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # SECURITY: Pin to exact commit at comment time to prevent TOCTOU attacks
           ref: ${{ steps.comment-branch.outputs.head_sha }}

--- a/.github/workflows/repo--typo-check.yml
+++ b/.github/workflows/repo--typo-check.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install wget
         run: sudo apt-get update && sudo apt-get install -y wget

--- a/.github/workflows/repo--vercel-deploy.yml
+++ b/.github/workflows/repo--vercel-deploy.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Vercel Project ID: ${{ env.VERCEL_PROJECT_ID }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/snaefell-ui--ci.yml
+++ b/.github/workflows/snaefell-ui--ci.yml
@@ -12,7 +12,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/supplementary-contracts.yml
+++ b/.github/workflows/supplementary-contracts.yml
@@ -23,7 +23,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -35,7 +35,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Login to GAR
         uses: docker/login-action@v3

--- a/.github/workflows/taiko-client--hive-test.yml
+++ b/.github/workflows/taiko-client--hive-test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/taiko-client--pages.yml
+++ b/.github/workflows/taiko-client--pages.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [ubuntu-latest]
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -57,7 +57,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -71,7 +71,7 @@ jobs:
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: taikoxyz/taiko-mono
           path: ${{ env.PACAYA_FORK_TAIKO_MONO_DIR }}

--- a/.github/workflows/taiko-client-rs--docker.yml
+++ b/.github/workflows/taiko-client-rs--docker.yml
@@ -37,7 +37,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Login to GAR
         uses: docker/login-action@v3

--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [ubuntu-latest]
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -70,7 +70,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
 
       - name: Setup Rust cache

--- a/.github/workflows/taikoon-ui--ci.yml
+++ b/.github/workflows/taikoon-ui--ci.yml
@@ -12,7 +12,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/ui-lib--ci.yml
+++ b/.github/workflows/ui-lib--ci.yml
@@ -12,7 +12,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/urcindexer-rs--ci.yml
+++ b/.github/workflows/urcindexer-rs--ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -68,7 +68,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/urcindexer-rs--docker.yml
+++ b/.github/workflows/urcindexer-rs--docker.yml
@@ -38,7 +38,7 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Login to GAR
         uses: docker/login-action@v3


### PR DESCRIPTION
Updates `actions/checkout` to v6 in CI workflows. No code changes.

https://github.com/actions/checkout/releases/tag/v6.0.0