### PR TITLE
feat(taiko-client): check `designatedProver` by calling `Anchor`

### DIFF
--- a/packages/taiko-client/prover/event_handler/shasta_proposed.go
+++ b/packages/taiko-client/prover/event_handler/shasta_proposed.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"slices"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -49,6 +48,12 @@ func (h *BatchProposedEventHandler) HandleShasta(
 		return err
 	}
 
+	// Get the proposal state from the Shasta Anchor contract.
+	_, proposalState, err := h.rpc.GetShastaAnchorState(&bind.CallOpts{Context: ctx, BlockHash: header.Hash()})
+	if err != nil {
+		return fmt.Errorf("failed to get Shasta proposal state (batchID %d): %w", meta.Shasta().GetProposal().Id, err)
+	}
+
 	// If the current batch is handled, just skip it.
 	if meta.Shasta().GetProposal().Id.Uint64() <= h.sharedState.GetLastHandledShastaBatchID() {
 		return nil
@@ -61,6 +66,7 @@ func (h *BatchProposedEventHandler) HandleShasta(
 		"batchID", meta.Shasta().GetProposal().Id,
 		"lastBlockID", header.Number,
 		"proposer", meta.GetProposer(),
+		"designatedProver", proposalState.DesignatedProver,
 		"proposalTimestamp", meta.Shasta().GetProposal().Timestamp,
 		"derivationSources", len(meta.Shasta().GetDerivation().Sources),
 	)
@@ -79,7 +85,12 @@ func (h *BatchProposedEventHandler) HandleShasta(
 	go func() {
 		if err := backoff.Retry(
 			func() error {
-				if err := h.checkExpirationAndSubmitProofShasta(ctx, meta, meta.Shasta().GetProposal().Id); err != nil {
+				if err := h.checkExpirationAndSubmitProofShasta(
+					ctx,
+					meta,
+					meta.Shasta().GetProposal().Id,
+					proposalState.DesignatedProver,
+				); err != nil {
 					log.Error(
 						"Failed to check Shasta proof status and submit proof",
 						"batchID", meta.Shasta().GetProposal().Id,
@@ -110,6 +121,7 @@ func (h *BatchProposedEventHandler) checkExpirationAndSubmitProofShasta(
 	ctx context.Context,
 	meta metadata.TaikoProposalMetaData,
 	batchID *big.Int,
+	designatedProver common.Address,
 ) error {
 	// Check whether the batch has been verified.
 	var (
@@ -176,14 +188,11 @@ func (h *BatchProposedEventHandler) checkExpirationAndSubmitProofShasta(
 
 	// If the proving window is not expired, we need to check if the current prover is the assigned prover,
 	// if no and the current prover wants to prove unassigned blocks, then we should wait for its expiration.
-	if !windowExpired &&
-		meta.GetProposer() != h.proverAddress &&
-		meta.GetProposer() != h.proverSetAddress &&
-		!slices.Contains(h.localProposerAddresses, meta.GetProposer()) {
+	if !windowExpired && !h.shouldProve(designatedProver) {
 		log.Info(
 			"Proposed Shasta batch is not provable by current prover at the moment",
 			"batchID", meta.Shasta().GetProposal().Id,
-			"prover", meta.GetProposer(),
+			"designatedProver", designatedProver,
 			"timeToExpire", timeToExpire,
 			"localProposerAddresses", h.localProposerAddresses,
 		)
@@ -192,7 +201,7 @@ func (h *BatchProposedEventHandler) checkExpirationAndSubmitProofShasta(
 			log.Info(
 				"Add proposed Shasta batch to wait for proof window expiration",
 				"batchID", meta.Shasta().GetProposal().Id,
-				"assignProver", meta.GetProposer(),
+				"designatedProver", designatedProver,
 				"timeToExpire", timeToExpire,
 				"localProposerAddresses", h.localProposerAddresses,
 			)
@@ -208,16 +217,13 @@ func (h *BatchProposedEventHandler) checkExpirationAndSubmitProofShasta(
 
 	// If the current prover is not the assigned prover, and `--prover.proveUnassignedBlocks` is not set,
 	// we should skip proving this batch.
-	if !h.proveUnassignedBlocks &&
-		meta.GetProposer() != h.proverAddress &&
-		meta.GetProposer() != h.proverSetAddress &&
-		!slices.Contains(h.localProposerAddresses, meta.GetProposer()) {
+	if !h.proveUnassignedBlocks && !h.shouldProve(designatedProver) {
 		log.Info(
 			"Expired Shasta batch is not provable by current prover",
 			"batchID", meta.Shasta().GetProposal().Id,
 			"currentProver", h.proverAddress,
 			"currentProverSet", h.proverSetAddress,
-			"assignProver", meta.GetProposer(),
+			"designatedProver", designatedProver,
 			"localProposerAddresses", h.localProposerAddresses,
 		)
 		return nil
@@ -226,7 +232,7 @@ func (h *BatchProposedEventHandler) checkExpirationAndSubmitProofShasta(
 	log.Info(
 		"Proposed Shasta batch is provable",
 		"batchID", meta.Shasta().GetProposal().Id,
-		"assignProver", meta.GetProposer(),
+		"designatedProver", designatedProver,
 		"localProposerAddresses", h.localProposerAddresses,
 	)
 


### PR DESCRIPTION
For Shasta proposals, we should check `designatedProver` by calling `Anchor.sol` instead of getting from `meta. GetProposer()`.