### PR TITLE
test(anchor): deploy behind proxy and restore withdraw tests

### DIFF
--- a/packages/protocol/contracts/layer1/core/impl/InboxOptimized1.sol
+++ b/packages/protocol/contracts/layer1/core/impl/InboxOptimized1.sol
@@ -55,10 +55,6 @@ contract InboxOptimized1 is Inbox {
     // Internal Functions - Overrides
     // ---------------------------------------------------------------
 
-    // ---------------------------------------------------------------
-    // Internal Functions
-    // ---------------------------------------------------------------
-
     /// @inheritdoc Inbox
     /// @dev Optimized transition record building with automatic aggregation.
     ///      Strategy:


### PR DESCRIPTION
Deploy Anchor contract behind ERC1967Proxy in tests to match production deployment model. Restore previously deleted withdraw tests for ETH and ERC20 token withdrawals.

- Anchor now instantiated as implementation contract then wrapped in ERC1967Proxy
- Proxy initialized with `Anchor.init(owner)` for proper owner setup
- All 15 existing tests pass with new proxy-based deployment