### PR TITLE
Enforce forced inclusion activation delay

### DIFF
--- a/packages/protocol/snapshots/shasta-propose.json
+++ b/packages/protocol/snapshots/shasta-propose.json
@@ -1,10 +1,4 @@
 {
-  "forced_inclusion_multiple_Inbox": "95541",
-  "forced_inclusion_multiple_InboxOptimized1": "97902",
-  "forced_inclusion_multiple_InboxOptimized2": "90167",
-  "forced_inclusion_single_Inbox": "91104",
-  "forced_inclusion_single_InboxOptimized1": "93459",
-  "forced_inclusion_single_InboxOptimized2": "86517",
   "propose_reuse_ring_buffer_Inbox": "64264",
   "propose_reuse_ring_buffer_InboxOptimized1": "64619",
   "propose_reuse_ring_buffer_InboxOptimized2": "49433",


### PR DESCRIPTION
Adds a 24-hour activation delay for forced inclusion to prevent immediate usage after the first proposal. This ensures blocks have been produced and the derivation pipeline can safely use parent block timestamps.

Changes the saveForcedInclusion function validation logic and renames the ACTIVATION_WINDOW constant to follow private naming conventions.

🤖 Generated with Claude Code