### PR TITLE
fix(relayer): validate chain IDs are non-negative uint64 in GetBlockInfo

### DIFF
--- a/packages/relayer/pkg/http/get_block_info.go
+++ b/packages/relayer/pkg/http/get_block_info.go
@@ -51,6 +51,9 @@ func (srv *Server) GetBlockInfo(c echo.Context) error {
 		if !ok {
 			return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, errors.New("invalid src chain param"))
 		}
+		if srcChain.Sign() < 0 || !srcChain.IsUint64() {
+			return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, errors.New("invalid src chain param: must be a non-negative uint64"))
+		}
 
 		srcChainID = srcChain
 	}
@@ -65,8 +68,19 @@ func (srv *Server) GetBlockInfo(c echo.Context) error {
 		if !ok {
 			return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, errors.New("invalid dest chain param"))
 		}
+		if destChain.Sign() < 0 || !destChain.IsUint64() {
+			return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, errors.New("invalid dest chain param: must be a non-negative uint64"))
+		}
 
 		destChainID = destChain
+	}
+
+	if srcChainID.Sign() < 0 || !srcChainID.IsUint64() {
+		return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, errors.New("invalid src chain id"))
+	}
+
+	if destChainID.Sign() < 0 || !destChainID.IsUint64() {
+		return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, errors.New("invalid dest chain id"))
 	}
 
 	latestSrcBlock, err := srv.srcEthClient.BlockNumber(c.Request().Context())


### PR DESCRIPTION
This change hardens GetBlockInfo by rejecting negative or out-of-range chain IDs before converting big.Int to uint64. EIP-155 defines chainId as an unsigned integer, so accepting negative values is invalid. Previously, negative inputs would flow to Uint64(), which is undefined for values that cannot be represented as uint64 and, in practice, can coerce -1 to 1, causing silent misrouting of DB queries and misleading responses. The handler now validates parsed srcChainID and destChainID from query parameters using Sign() and IsUint64(), returning 422 for invalid input, and performs a final guard after resolving IDs (including RPC-derived values) to ensure only valid non-negative uint64 values are used. This eliminates undefined conversions, aligns behavior with EIP-155 semantics, and prevents incorrect repository lookups.