### PR TITLE
feat(protocol): introduce `bondProcessingProposalHash` in `TransitionMetadata`

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IInbox.sol
@@ -110,6 +110,8 @@ interface IInbox {
         address designatedProver;
         /// @notice The actual prover who submitted the proof.
         address actualProver;
+        /// @notice Hash of the proposal at `id - BOND_PROCESSING_DELAY` used for bond processing.
+        bytes32 bondProcessingProposalHash;
     }
 
     /// @notice Represents a record of a transition with additional metadata.

--- a/packages/protocol/contracts/layer1/core/libs/LibHashOptimized.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibHashOptimized.sol
@@ -313,10 +313,9 @@ library LibHashOptimized {
             bytes32(uint256(_source.blobSlice.timestamp))
         );
 
-        return
-            EfficientHashLib.hash(
-                bytes32(uint256(_source.isForcedInclusion ? 1 : 0)), blobSliceHash
-            );
+        return EfficientHashLib.hash(
+            bytes32(uint256(_source.isForcedInclusion ? 1 : 0)), blobSliceHash
+        );
     }
 
     /// @notice Safely hashes a single bond instruction to avoid collisions
@@ -355,7 +354,8 @@ library LibHashOptimized {
             _transition.parentTransitionHash,
             hashCheckpoint(_transition.checkpoint),
             bytes32(uint256(uint160(_metadata.designatedProver))),
-            bytes32(uint256(uint160(_metadata.actualProver)))
+            bytes32(uint256(uint160(_metadata.actualProver))),
+            _metadata.bondProcessingProposalHash
         );
     }
 

--- a/packages/protocol/contracts/layer1/core/libs/LibHashSimple.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibHashSimple.sol
@@ -107,7 +107,8 @@ library LibHashSimple {
                 abi.encodePacked(
                     hashTransition(_transitions[i]),
                     _metadata[i].designatedProver,
-                    _metadata[i].actualProver
+                    _metadata[i].actualProver,
+                    _metadata[i].bondProcessingProposalHash
                 )
             );
         }

--- a/packages/protocol/contracts/layer1/core/libs/LibManifest.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibManifest.sol
@@ -5,6 +5,13 @@ pragma solidity ^0.8.24;
 /// @custom:security-contact security@taiko.xyz
 library LibManifest {
     // ---------------------------------------------------------------
+    // Constants
+    // ---------------------------------------------------------------
+
+    /// @notice Delay (in proposals) before processing bond instructions.
+    uint256 public constant BOND_PROCESSING_DELAY = 6;
+
+    // ---------------------------------------------------------------
     // Structs
     // ---------------------------------------------------------------
 

--- a/packages/protocol/contracts/layer1/core/libs/LibProveInputDecoder.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibProveInputDecoder.sol
@@ -16,7 +16,11 @@ library LibProveInputDecoder {
     /// @notice Encodes prove input data using compact encoding
     /// @param _input The ProveInput to encode
     /// @return encoded_ The encoded data
-    function encode(IInbox.ProveInput memory _input) internal pure returns (bytes memory encoded_) {
+    function encode(IInbox.ProveInput memory _input)
+        internal
+        pure
+        returns (bytes memory encoded_)
+    {
         // Calculate total size needed
         uint256 bufferSize =
             _calculateProveDataSize(_input.proposals, _input.transitions, _input.metadata);
@@ -154,6 +158,7 @@ library LibProveInputDecoder {
     {
         newPtr_ = P.packAddress(_ptr, _metadata.designatedProver);
         newPtr_ = P.packAddress(newPtr_, _metadata.actualProver);
+        newPtr_ = P.packBytes32(newPtr_, _metadata.bondProcessingProposalHash);
     }
 
     /// @notice Decode a single TransitionMetadata
@@ -164,6 +169,7 @@ library LibProveInputDecoder {
     {
         (metadata_.designatedProver, newPtr_) = P.unpackAddress(_ptr);
         (metadata_.actualProver, newPtr_) = P.unpackAddress(newPtr_);
+        (metadata_.bondProcessingProposalHash, newPtr_) = P.unpackBytes32(newPtr_);
     }
 
     /// @notice Calculate the size needed for encoding
@@ -194,7 +200,10 @@ library LibProveInputDecoder {
             //
             // Metadata - each has fixed size: designatedProver(20) + actualProver(20) = 40
             //
-            size_ += _proposals.length * (102 + 134 + 40);
+            // Metadata - each has fixed size:
+            // designatedProver(20) + actualProver(20) + bondProcessingProposalHash(32) = 72
+            //
+            size_ += _proposals.length * (102 + 134 + 72);
         }
     }
 

--- a/packages/protocol/contracts/layer1/core/libs/LibProvedEventEncoder.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibProvedEventEncoder.sol
@@ -48,6 +48,7 @@ library LibProvedEventEncoder {
         // Encode TransitionMetadata
         ptr = P.packAddress(ptr, _payload.metadata.designatedProver);
         ptr = P.packAddress(ptr, _payload.metadata.actualProver);
+        ptr = P.packBytes32(ptr, _payload.metadata.bondProcessingProposalHash);
 
         // Encode bond instructions array length (uint16)
         P.checkArrayLength(_payload.transitionRecord.bondInstructions.length);
@@ -92,6 +93,7 @@ library LibProvedEventEncoder {
         // Decode TransitionMetadata
         (payload_.metadata.designatedProver, ptr) = P.unpackAddress(ptr);
         (payload_.metadata.actualProver, ptr) = P.unpackAddress(ptr);
+        (payload_.metadata.bondProcessingProposalHash, ptr) = P.unpackBytes32(ptr);
 
         // Decode bond instructions array length (uint16)
         uint16 arrayLength;
@@ -122,18 +124,19 @@ library LibProvedEventEncoder {
         returns (uint256 size_)
     {
         unchecked {
-            // Fixed size: 247 bytes
+            // Fixed size: 279 bytes
             // proposalId: 6
             // Transition: proposalHash(32) + parentTransitionHash(32) = 64
             //        Checkpoint: number(6) + hash(32) + stateRoot(32) = 70
             // TransitionRecord: span(1) + transitionHash(32) + checkpointHash(32) = 65
-            // TransitionMetadata: designatedProver(20) + actualProver(20) = 40
+            // TransitionMetadata: designatedProver(20) + actualProver(20) +
+            // bondProcessingProposalHash(32) = 72
             // bondInstructions array length: 2
-            // Total fixed: 6 + 64 + 70 + 65 + 40 + 2 = 247
+            // Total fixed: 6 + 64 + 70 + 65 + 72 + 2 = 279
 
             // Variable size: each bond instruction is 47 bytes
             // proposalId(6) + bondType(1) + payer(20) + receiver(20) = 47
-            size_ = 247 + (_bondInstructionsCount * 47);
+            size_ = 279 + (_bondInstructionsCount * 47);
         }
     }
 


### PR DESCRIPTION
To solve the proving issue raised by @smtmfft : https://www.notion.so/taikoxyz/Bond-Processing-in-Prover-2b69673143d680718715cc4fb8b6315d , and avoid changing the current protocol / derivation consensus.

## Summary

Add delayed bond-processing hash to metadata and enforce validation in `Inbox`.

## Description

- expose `BOND_PROCESSING_DELAY` in `LibManifest` and carry `bondProcessingProposalHash` through `TransitionMetadata` encoding/decoding and hashing (simple/optimized).
- in Inbox prove flow, require each provided bond-processing proposal hash to match the stored hash of `id - BOND_PROCESSING_DELAY`, reverting with `BondProcessingProposalHashMismatch` otherwise; keep hashing unchanged.

## TODO

Fix tests if it looks good to the reviewers.