### PR TITLE
fix(relayer): respect context for IsMessageReceived and EstimateGas

### DIFF
--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -478,7 +478,7 @@ func (p *Processor) sendProcessMessageCall(
 ) (*types.Receipt, error) {
 	defer p.logRelayerBalance(ctx)
 
-	received, err := p.destBridge.IsMessageReceived(nil, event.Message, proof)
+	received, err := p.destBridge.IsMessageReceived(&bind.CallOpts{Context: ctx}, event.Message, proof)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (p *Processor) sendProcessMessageCall(
 			Data: data,
 		}
 
-		gasUsed, err := p.destEthClient.EstimateGas(context.Background(), msg)
+		gasUsed, err := p.destEthClient.EstimateGas(ctx, msg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Use the provided request context when performing RPCs in sendProcessMessageCall by passing &bind.CallOpts{Context: ctx} to 
IsMessageReceived and by using ctx instead of context.Background() for EstimateGas. This aligns with how other calls in processor already propagate context (e.g., MessageStatus, Paused, SuggestGasTipCap, CodeAt) and prevents indefinite hangs when nodes stall or when the worker is being canceled (shutdown, backoff, or fork-window pauses). The generated binding explicitly accepts *bind.CallOpts, and our ethClient interface supports EstimateGas(ctx, ...), so this is the intended usage rather than passing nil or Background.