### PR TITLE
Refactor isOwnerSaved assignment in Inbox

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IInbox.sol
@@ -193,7 +193,7 @@ interface IInbox {
         /// @notice The metadata containing prover information.
         TransitionMetadata metadata;
         /// @notice Whether the transition was saved by the owner (overwrite).
-        bool isOwnerSaved;
+        bool isOverwrittenByOwner;
         /// @notice Whether this is a duplicate transition (same hash already exists).
         bool isDuplicate;
         /// @notice Whether this is a conflicting transition (different hash for same key).

--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -576,18 +576,17 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
         internal
         returns (bool isOwnerSaved_, bool isDuplicate_, bool isConflicting_)
     {
+        isOwnerSaved_ = _overwrittenByOwner;
         bytes26 existingRecordHash = _entry.recordHash;
 
         if (existingRecordHash == 0) {
             _entry.finalizationDeadline = _hashAndDeadline.finalizationDeadline;
             _entry.recordHash = _hashAndDeadline.recordHash;
         } else if (existingRecordHash == _hashAndDeadline.recordHash) {
-            isDuplicate_ = true;
-            // Skip writing recordHash - it's already the same value
+            isDuplicate_ = true; // Skip writing recordHash - it's already the same value
         } else {
             isConflicting_ = true;
-            if (_overwrittenByOwner) {
-                isOwnerSaved_ = true;
+            if (isOwnerSaved_) {
                 _entry.finalizationDeadline = _hashAndDeadline.finalizationDeadline;
             } else {
                 _entry.finalizationDeadline = type(uint48).max;

--- a/packages/protocol/contracts/layer1/core/impl/InboxOptimized1.sol
+++ b/packages/protocol/contracts/layer1/core/impl/InboxOptimized1.sol
@@ -62,7 +62,7 @@ contract InboxOptimized1 is Inbox {
     /// @param _parentTransitionHash Parent transition hash used as part of the key
     /// @param _hashAndDeadline The finalization metadata to persist
     /// @param _overwrittenByOwner Whether this transaction is called by the owner
-    /// @return isOwnerSaved_ True if the transition was saved by owner overwrite.
+    /// @return isOverwrittenByOwner True if the transition was saved by owner overwrite.
     /// @return isDuplicate_ True if this is a duplicate transition (same hash already exists).
     /// @return isConflicting_ True if this is a conflicting transition (different hash for same
     /// key).
@@ -74,7 +74,7 @@ contract InboxOptimized1 is Inbox {
     )
         internal
         override
-        returns (bool isOwnerSaved_, bool isDuplicate_, bool isConflicting_)
+        returns (bool isOverwrittenByOwner, bool isDuplicate_, bool isConflicting_)
     {
         uint256 bufferSlot = _proposalId % _ringBufferSize;
         ReusableTransitionRecord storage record = _reusableTransitionRecords[bufferSlot];

--- a/packages/protocol/contracts/layer1/core/libs/LibProvedEventEncoder.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibProvedEventEncoder.sol
@@ -48,9 +48,9 @@ library LibProvedEventEncoder {
         ptr = P.packAddress(ptr, _payload.metadata.designatedProver);
         ptr = P.packAddress(ptr, _payload.metadata.actualProver);
 
-        // Encode 3 bool flags packed into 1 byte (bits: isOwnerSaved, isDuplicate, isConflicting)
+        // Encode 3 bool flags packed into 1 byte (bits: isOverwrittenByOwner, isDuplicate, isConflicting)
         uint8 flags;
-        if (_payload.isOwnerSaved) flags |= 0x04;
+        if (_payload.isOverwrittenByOwner) flags |= 0x04;
         if (_payload.isDuplicate) flags |= 0x02;
         if (_payload.isConflicting) flags |= 0x01;
         ptr = P.packUint8(ptr, flags);
@@ -98,10 +98,10 @@ library LibProvedEventEncoder {
         (payload_.metadata.designatedProver, ptr) = P.unpackAddress(ptr);
         (payload_.metadata.actualProver, ptr) = P.unpackAddress(ptr);
 
-        // Decode 3 bool flags from 1 byte (bits: isOwnerSaved, isDuplicate, isConflicting)
+        // Decode 3 bool flags from 1 byte (bits: isOverwrittenByOwner, isDuplicate, isConflicting)
         uint8 flags;
         (flags, ptr) = P.unpackUint8(ptr);
-        payload_.isOwnerSaved = (flags & 0x04) != 0;
+        payload_.isOverwrittenByOwner = (flags & 0x04) != 0;
         payload_.isDuplicate = (flags & 0x02) != 0;
         payload_.isConflicting = (flags & 0x01) != 0;
 
@@ -140,7 +140,7 @@ library LibProvedEventEncoder {
             //        Checkpoint: number(6) + hash(32) + stateRoot(32) = 70
             // TransitionRecord: transitionHash(32) + checkpointHash(32) = 64
             // TransitionMetadata: designatedProver(20) + actualProver(20) = 40
-            // flags (isOwnerSaved, isDuplicate, isConflicting): 1
+            // flags (isOverwrittenByOwner, isDuplicate, isConflicting): 1
             // bondInstructions array length: 2
             // Total fixed: 6 + 64 + 70 + 64 + 40 + 1 + 2 = 247
 

--- a/packages/protocol/test/layer1/core/libs/LibProvedEventEncoder.t.sol
+++ b/packages/protocol/test/layer1/core/libs/LibProvedEventEncoder.t.sol
@@ -48,7 +48,7 @@ contract LibProvedEventEncoderTest is Test {
             transition: transition,
             transitionRecord: transitionRecord,
             metadata: metadata,
-            isOwnerSaved: false,
+            isOverwrittenByOwner: false,
             isDuplicate: false,
             isConflicting: false
         });
@@ -167,7 +167,7 @@ contract LibProvedEventEncoderTest is Test {
             metadata: IInbox.TransitionMetadata({
                 designatedProver: address(0x7777), actualProver: address(0x8888)
             }),
-            isOwnerSaved: true,
+            isOverwrittenByOwner: true,
             isDuplicate: false,
             isConflicting: true
         });
@@ -176,7 +176,7 @@ contract LibProvedEventEncoderTest is Test {
         IInbox.ProvedEventPayload memory decoded = LibProvedEventEncoder.decode(encoded);
 
         // Verify bool flags
-        assertEq(decoded.isOwnerSaved, payload.isOwnerSaved, "isOwnerSaved mismatch");
+        assertEq(decoded.isOverwrittenByOwner, payload.isOverwrittenByOwner, "isOverwrittenByOwner mismatch");
         assertEq(decoded.isDuplicate, payload.isDuplicate, "isDuplicate mismatch");
         assertEq(decoded.isConflicting, payload.isConflicting, "isConflicting mismatch");
 
@@ -237,7 +237,7 @@ contract LibProvedEventEncoderTest is Test {
             metadata: IInbox.TransitionMetadata({
                 designatedProver: address(0x9999), actualProver: address(0xAAAA)
             }),
-            isOwnerSaved: false,
+            isOverwrittenByOwner: false,
             isDuplicate: true,
             isConflicting: false
         });
@@ -274,7 +274,7 @@ contract LibProvedEventEncoderTest is Test {
             metadata: IInbox.TransitionMetadata({
                 designatedProver: address(0xDDDD), actualProver: address(0xEEEE)
             }),
-            isOwnerSaved: false,
+            isOverwrittenByOwner: false,
             isDuplicate: false,
             isConflicting: false
         });


### PR DESCRIPTION
Refactor the isOwnerSaved return value assignment to happen upfront from the _overwrittenByOwner parameter instead of conditionally in the conflict branch. This simplifies the logic by reducing code duplication and improving readability without changing behavior.

**Changes:**
- Assign isOwnerSaved_ at the start of _saveEntry
- Simplify the conditional check in the conflict branch
- Consolidate comment formatting for consistency