### PR TITLE
fix(taiko-client-rs): rename proposal_id to batch_id

### DIFF
--- a/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs
@@ -56,22 +56,22 @@ impl<P: Provider + Clone> Client<P> {
     }
 
     /// Fetch the last L1 origin associated with the given batch id via the public engine API.
-    pub async fn last_l1_origin_by_batch_id(&self, proposal_id: U256) -> Result<Option<L1Origin>> {
+    pub async fn last_l1_origin_by_batch_id(&self, batch_id: U256) -> Result<Option<L1Origin>> {
         self.l2_provider
             .raw_request(
                 Cow::Borrowed(TaikoOriginMethod::LastL1OriginByBatchId.as_str()),
-                (proposal_id,),
+                (batch_id,),
             )
             .await
             .or_else(handle_not_found)
     }
 
     /// Fetch the last block id that corresponds to the provided batch id.
-    pub async fn last_block_id_by_batch_id(&self, proposal_id: U256) -> Result<Option<U256>> {
+    pub async fn last_block_id_by_batch_id(&self, batch_id: U256) -> Result<Option<U256>> {
         self.l2_provider
             .raw_request(
                 Cow::Borrowed(TaikoOriginMethod::LastBlockIdByBatchId.as_str()),
-                (proposal_id,),
+                (batch_id,),
             )
             .await
             .or_else(handle_not_found)


### PR DESCRIPTION
Renamed the proposal_id parameter to batch_id in last_l1_origin_by_batch_id and last_block_id_by_batch_id within 
packages/taiko-client-rs/crates/rpc/src/l1_origin.rs to align with the execution engine’s public RPC method names taiko_lastL1OriginByBatchID and taiko_lastBlockIDByBatchID and to maintain consistency with 
packages/taiko-client-rs/crates/rpc/src/auth.rs where batch_id is already used for engine-facing operations. Although Shasta semantics use “proposal” as the domain term, the engine API retains the legacy “batch” terminology, and the rest of the codebase (including the Shasta derivation pipeline) already passes proposal IDs to these “batch” endpoints.