### PR TITLE
fix(taiko-client): check Shasta metadata in prover `event_handler`

### DIFF
--- a/packages/taiko-client/integration_test/deploy_l1_contract.sh
+++ b/packages/taiko-client/integration_test/deploy_l1_contract.sh
@@ -31,11 +31,10 @@ cat "L1 contracts deployed:
 "
 
 cd ../protocol &&
-  FOUNDRY_PROFILE=layer1o PRIVATE_KEY=$PRIVATE_KEY forge script script/layer1/core/DeployProtocolOnL1.s.sol:DeployProtocolOnL1 \
+  FOUNDRY_PROFILE=layer1 PRIVATE_KEY=$PRIVATE_KEY forge script script/layer1/core/DeployProtocolOnL1.s.sol:DeployProtocolOnL1 \
     --fork-url "$L1_HTTP" \
     --broadcast \
     --ffi \
     -vvvvv \
     --private-key "$PRIVATE_KEY" \
     --block-gas-limit 200000000 \
-    --legacy

--- a/packages/taiko-client/prover/event_handler/assignment_expired.go
+++ b/packages/taiko-client/prover/event_handler/assignment_expired.go
@@ -32,6 +32,16 @@ func (h *AssignmentExpiredEventHandler) Handle(
 	ctx context.Context,
 	meta metadata.TaikoProposalMetaData,
 ) error {
+	if meta.IsShasta() {
+		log.Info(
+			"Proof assignment window expired",
+			"proposalID", meta.Shasta().GetProposal().Id,
+			"assignedProver", meta.GetProposer(),
+		)
+		go func() { h.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: meta} }()
+		return nil
+	}
+
 	var (
 		proofStatus *rpc.BatchProofStatus
 		err         error

--- a/packages/taiko-client/prover/event_handler/assignment_expired.go
+++ b/packages/taiko-client/prover/event_handler/assignment_expired.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
@@ -74,7 +73,7 @@ func (h *AssignmentExpiredEventHandler) Handle(
 				log.Info(
 					"Valid Shasta proof already on-chain, skip submission",
 					"proposalID", proposalID,
-					"proposalHash", common.Hash(proposalHash),
+					"proposalHash", proposalHash,
 					"blockNumber", record.Transition.Checkpoint.BlockNumber,
 					"blockHash", record.Transition.Checkpoint.BlockHash,
 				)

--- a/packages/taiko-client/prover/event_handler/assignment_expired.go
+++ b/packages/taiko-client/prover/event_handler/assignment_expired.go
@@ -2,27 +2,34 @@ package handler
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
+	shastaIndexer "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/state_indexer"
 	proofProducer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
 )
 
 // AssignmentExpiredEventHandler is responsible for handling the expiration of proof assignments.
 type AssignmentExpiredEventHandler struct {
 	rpc               *rpc.Client
+	indexer           *shastaIndexer.Indexer
 	proofSubmissionCh chan<- *proofProducer.ProofRequestBody
 }
 
 // NewAssignmentExpiredEventHandler creates a new AssignmentExpiredEventHandler instance.
 func NewAssignmentExpiredEventHandler(
 	rpc *rpc.Client,
+	indexer *shastaIndexer.Indexer,
 	proofSubmissionCh chan *proofProducer.ProofRequestBody,
 ) *AssignmentExpiredEventHandler {
 	return &AssignmentExpiredEventHandler{
 		rpc,
+		indexer,
 		proofSubmissionCh,
 	}
 }
@@ -33,9 +40,51 @@ func (h *AssignmentExpiredEventHandler) Handle(
 	meta metadata.TaikoProposalMetaData,
 ) error {
 	if meta.IsShasta() {
+		proposalID := meta.Shasta().GetProposal().Id
+
+		// If the proposal is already finalized, skip it.
+		if coreState := h.indexer.GetLastCoreState(); coreState != nil &&
+			proposalID.Cmp(coreState.LastFinalizedProposalId) <= 0 {
+			log.Info(
+				"Shasta batch already finalized, skip proof submission",
+				"proposalID", proposalID,
+				"lastFinalizedProposalId", coreState.LastFinalizedProposalId,
+			)
+			return nil
+		}
+
+		// Otherwise, check if there is already a valid proof on-chain.
+		if record := h.indexer.GetTransitionRecordByProposalID(proposalID.Uint64()); record != nil {
+			header, err := h.rpc.L2.HeaderByNumber(ctx, record.Transition.Checkpoint.BlockNumber)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to fetch Shasta header for proposal %d: %w",
+					record.Transition.Checkpoint.BlockNumber,
+					err,
+				)
+			}
+			proposalHash, err := h.rpc.GetShastaProposalHash(&bind.CallOpts{Context: ctx}, proposalID)
+			if err != nil {
+				return fmt.Errorf("failed to get Shasta proposal hash: %w", err)
+			}
+
+			if record.Transition.Checkpoint.BlockHash == header.Hash() &&
+				record.Transition.Checkpoint.StateRoot == header.Root &&
+				record.Transition.ProposalHash == proposalHash {
+				log.Info(
+					"Valid Shasta proof already on-chain, skip submission",
+					"proposalID", proposalID,
+					"proposalHash", common.Hash(proposalHash),
+					"blockNumber", record.Transition.Checkpoint.BlockNumber,
+					"blockHash", record.Transition.Checkpoint.BlockHash,
+				)
+				return nil
+			}
+		}
+
 		log.Info(
 			"Proof assignment window expired",
-			"proposalID", meta.Shasta().GetProposal().Id,
+			"proposalID", proposalID,
 			"assignedProver", meta.GetProposer(),
 		)
 		go func() { h.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: meta} }()

--- a/packages/taiko-client/prover/event_handler/assignment_expired_test.go
+++ b/packages/taiko-client/prover/event_handler/assignment_expired_test.go
@@ -9,6 +9,7 @@ import (
 func (s *EventHandlerTestSuite) TestAssignmentExpiredEventHandlerHandle() {
 	handler := NewAssignmentExpiredEventHandler(
 		s.RPCClient,
+		s.ShastaStateIndexer,
 		make(chan *proofProducer.ProofRequestBody, 1024),
 	)
 	s.Nil(handler.Handle(context.Background(), s.ProposeAndInsertValidBlock(s.proposer, s.eventSyncer)))

--- a/packages/taiko-client/prover/event_handler/batch_proposed.go
+++ b/packages/taiko-client/prover/event_handler/batch_proposed.go
@@ -292,18 +292,31 @@ func (h *BatchProposedEventHandler) checkL1Reorg(
 	}
 
 	if reorgCheckResult.IsReorged {
+		lastHandledOld := h.sharedState.GetLastHandledPacayaBatchID()
+		if meta.IsShasta() {
+			lastHandledOld = h.sharedState.GetLastHandledShastaBatchID()
+		}
+
 		log.Info(
 			"Reset L1Current cursor due to reorg",
 			"l1CurrentHeightOld", h.sharedState.GetL1Current().Number,
 			"l1CurrentHeightNew", reorgCheckResult.L1CurrentToReset.Number,
-			"lastHandledBatchIDOld", h.sharedState.GetLastHandledPacayaBatchID(),
+			"lastHandledBatchIDOld", lastHandledOld,
 			"lastHandledBatchIDNew", reorgCheckResult.LastHandledBatchIDToReset,
 		)
 		h.sharedState.SetL1Current(reorgCheckResult.L1CurrentToReset)
-		if reorgCheckResult.LastHandledBatchIDToReset == nil {
-			h.sharedState.SetLastHandledPacayaBatchID(0)
+		if meta.IsShasta() {
+			if reorgCheckResult.LastHandledBatchIDToReset == nil {
+				h.sharedState.SetLastHandledShastaBatchID(0)
+			} else {
+				h.sharedState.SetLastHandledShastaBatchID(reorgCheckResult.LastHandledBatchIDToReset.Uint64())
+			}
 		} else {
-			h.sharedState.SetLastHandledPacayaBatchID(reorgCheckResult.LastHandledBatchIDToReset.Uint64())
+			if reorgCheckResult.LastHandledBatchIDToReset == nil {
+				h.sharedState.SetLastHandledPacayaBatchID(0)
+			} else {
+				h.sharedState.SetLastHandledPacayaBatchID(reorgCheckResult.LastHandledBatchIDToReset.Uint64())
+			}
 		}
 		return errL1Reorged
 	}

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -489,6 +489,7 @@ func (p *Prover) initEventHandlers() error {
 	// ------- AssignmentExpired -------
 	p.eventHandlers.assignmentExpiredHandler = handler.NewAssignmentExpiredEventHandler(
 		p.rpc,
+		p.shastaIndexer,
 		p.proofSubmissionCh,
 	)
 	// ------- BatchesVerified -------


### PR DESCRIPTION
## Summary

Fix two issues in prover:
   - `prover/event_handler/assignment_expired.go:40-63` dereferences `meta.Pacaya()` for every expiry. Shasta proposals push into this handler (`shasta_proposed.go:200-212`), so `meta.Pacaya()` is nil → panic and no fallback to Shasta proof-state. Branch by fork: Pacaya keeps current logic; Shasta should query Shasta transition/proposal status or skip and let Shasta-specific path handle expiry.
   - `prover/event_handler/batch_proposed.go:265-307` resets only Pacaya `lastHandledBatchID` on reorg. Shasta handler uses `lastHandledShastaBatchID` to skip duplicates; after an L1 reorg it remains stale, so replayed Shasta proposals are skipped. Reset the Shasta counter when `meta.IsShasta()` (or maintain per-fork cursor).