### PR TITLE
fix(taiko-client-rs): added commit hash to the alethia-reth dependencies

### DIFF
--- a/packages/ejector/Cargo.lock
+++ b/packages/ejector/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "ejector"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alloy",
  "alloy-serde 0.11.1",

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-block"
 version = "0.5.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?branch=main#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6ff4dea33acf33851d1c5d320d064c5bd4ad1d50#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "0.5.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?branch=main#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6ff4dea33acf33851d1c5d320d064c5bd4ad1d50#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "0.5.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?branch=main#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6ff4dea33acf33851d1c5d320d064c5bd4ad1d50#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-db"
 version = "0.5.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?branch=main#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6ff4dea33acf33851d1c5d320d064c5bd4ad1d50#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-primitives",
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-evm"
 version = "0.5.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?branch=main#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6ff4dea33acf33851d1c5d320d064c5bd4ad1d50#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "0.5.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?branch=main#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6ff4dea33acf33851d1c5d320d064c5bd4ad1d50#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
 dependencies = [
  "alethia-reth-chainspec",
  "alloy-primitives",
@@ -199,7 +199,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc"
 version = "0.5.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?branch=main#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6ff4dea33acf33851d1c5d320d064c5bd4ad1d50#6ff4dea33acf33851d1c5d320d064c5bd4ad1d50"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -71,12 +71,12 @@ alloy-transport-http = { version = "1.1.2", features = ["hyper", "jwt-auth"] }
 event-scanner = "=0.6.0-alpha"
 
 # taiko
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", branch = "main", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
-alethia-reth-evm = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-evm", branch = "main", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", branch = "main", features = [
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
+alethia-reth-evm = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-evm", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", features = [
     "serde",
 ], rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
-alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", branch = "main", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
+alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
 
 # types
 anyhow = "1"

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "4", features = ["derive", "env"] }
 # observability
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.15", default-features = false, features = [
-  "http-listener",
+    "http-listener",
 ] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -46,7 +46,7 @@ tower = { version = "0.4", features = ["util"] }
 # ethereum
 alloy = "1.1.2"
 alloy-consensus = { version = "1.1.2", default-features = false, features = [
-  "serde",
+    "serde",
 ] }
 alloy-contract = { version = "1.1.2", default-features = false }
 alloy-eips = { version = "1.1.2", default-features = false }
@@ -63,7 +63,7 @@ alloy-rpc-types-engine = { version = "1.1.2", default-features = false }
 alloy-rpc-types-eth = { version = "1.1.2", default-features = false }
 alloy-signer-local = { version = "1.1.2", default-features = false }
 alloy-sol-macro = { version = "1.4.1", default-features = false, features = [
-  "json",
+    "json",
 ] }
 alloy-sol-types = { version = "1.4.1", default-features = false }
 alloy-transport = { version = "1.1.2", default-features = false }
@@ -71,12 +71,12 @@ alloy-transport-http = { version = "1.1.2", features = ["hyper", "jwt-auth"] }
 event-scanner = "=0.6.0-alpha"
 
 # taiko
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", branch = "main" }
-alethia-reth-evm = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-evm", branch = "main" }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", branch = "main", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
+alethia-reth-evm = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-evm", branch = "main", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
 alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", branch = "main", features = [
-  "serde",
-] }
-alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", branch = "main" }
+    "serde",
+], rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
+alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", branch = "main", rev = "6ff4dea33acf33851d1c5d320d064c5bd4ad1d50" }
 
 # types
 anyhow = "1"


### PR DESCRIPTION
This is needed when we have taiko-client-rs as a dependency in Catalyst node. So we won't have dependencies conflict.