### PR TITLE
feat(taiko-client): monitor stale proofs and try to aggregate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,11 +5,14 @@ on:
     # Only run the first time the PR is opened or when it is marked as ready for review
     # This is to avoid claude from automatically reviewing the PR every time there's a new commit
     types: [opened, ready_for_review]
+    branches-ignore:
+      - release-please--branches--**
+      - dependabot/**
 
 jobs:
   claude-review:
     # Run for non-draft PRs that are not marked to be skipped that are not on forks
-    if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'option.do-not-merge') && github.event.pull_request.head.repo.full_name == github.repository)
+    if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'option.do-not-merge') && github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot'))
     runs-on: [arc-runner-set]
     permissions:
       contents: read
@@ -19,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -35,36 +38,36 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          track_progress: true
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
-
-            Be constructive and helpful in your feedback. Don't be overly polite or verbose, it is ok to be direct.
-          # Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          use_sticky_comment: true
-
+            Be constructive and helpful in your feedback. Don't be overly polite or verbose, be direct.
+            Use `gh pr comment:*` for top-level comments.
+            Only your GitHub comments that you post will be seen, so don't submit your review as a normal message, just as comments.
           # Add specific tools for running tests or linting
-          allowed_tools: |
-            Bash(pnpm install)
-            Bash(pnpm test:*)
-            Bash(pnpm fmt:sol)
-            Bash(pnpm snapshot:*)
-            Bash(pnpm compile:*)
-            Bash(pnpm layout:*)
-            Bash(cat *)
-            Bash(find *)
-            Bash(grep *)
-            Bash(ls *)
-            WebFetch(domain:docs.anthropic.com)
+          claude_args: |
+            --allowedTools "
+              Bash(pnpm install),
+              Bash(pnpm test:*),
+              Bash(pnpm fmt:sol),
+              Bash(pnpm snapshot:*),
+              Bash(pnpm compile:*),
+              Bash(pnpm layout:*),
+              Bash(cat *),
+              Bash(find *),
+              Bash(grep *),
+              Bash(ls *),
+              Bash(gh pr comment:*),
+              Bash(gh pr diff:*),
+              Bash(gh pr view:*),
+              WebFetch(domain:docs.anthropic.com)
+            "
+          use_sticky_comment: true

--- a/.github/workflows/repo--typo-check.yml
+++ b/.github/workflows/repo--typo-check.yml
@@ -1,6 +1,9 @@
 name: Typo Check
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -166,6 +166,7 @@ func (p *Prover) initPacayaProofSubmitter(txBuilder *transaction.ProveBatchesTxB
 	}
 
 	if p.proofSubmitterPacaya, err = proofSubmitter.NewProofSubmitterPacaya(
+		p.ctx,
 		baseLevelProofProducer,
 		zkvmProducer,
 		p.batchProofGenerationCh,

--- a/packages/taiko-client/prover/proof_producer/proof_buffer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_buffer.go
@@ -70,7 +70,7 @@ func (pb *ProofBuffer) Len() int {
 	return len(pb.buffer)
 }
 
-// FirstItemAt returns the first item updated time of the buffer.
+// FirstItemAt returns the first item updated time of the buffer, only makes sense when Len() is greater than 0.
 func (pb *ProofBuffer) FirstItemAt() time.Time {
 	pb.mutex.RLock()
 	defer pb.mutex.RUnlock()

--- a/packages/taiko-client/prover/proof_producer/proof_buffer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_buffer.go
@@ -72,6 +72,8 @@ func (pb *ProofBuffer) Len() int {
 
 // FirstItemAt returns the first item updated time of the buffer.
 func (pb *ProofBuffer) FirstItemAt() time.Time {
+	pb.mutex.RLock()
+	defer pb.mutex.RUnlock()
 	return pb.firstItemAt
 }
 
@@ -98,15 +100,22 @@ func (pb *ProofBuffer) ClearItems(blockIDs ...uint64) int {
 
 	pb.buffer = newBuffer
 	pb.isAggregating = false
+	if len(pb.buffer) == 0 {
+		pb.firstItemAt = time.Time{}
+	}
 	return clearedCount
 }
 
 // MarkAggregating marks the proofs in this buffer are aggregating.
 func (pb *ProofBuffer) MarkAggregating() {
+	pb.mutex.Lock()
+	defer pb.mutex.Unlock()
 	pb.isAggregating = true
 }
 
 // IsAggregating returns if the proofs in this buffer are aggregating.
 func (pb *ProofBuffer) IsAggregating() bool {
+	pb.mutex.RLock()
+	defer pb.mutex.RUnlock()
 	return pb.isAggregating
 }

--- a/packages/taiko-client/prover/proof_producer/proof_buffer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_buffer.go
@@ -77,6 +77,13 @@ func (pb *ProofBuffer) FirstItemAt() time.Time {
 	return pb.firstItemAt
 }
 
+// ResetAggregating resets the aggregating status the buffer.
+func (pb *ProofBuffer) ResetAggregating() {
+	pb.mutex.Lock()
+	defer pb.mutex.Unlock()
+	pb.isAggregating = false
+}
+
 // ClearItems clears items that has given block ids in the buffer.
 func (pb *ProofBuffer) ClearItems(blockIDs ...uint64) int {
 	pb.mutex.Lock()
@@ -99,18 +106,22 @@ func (pb *ProofBuffer) ClearItems(blockIDs ...uint64) int {
 	}
 
 	pb.buffer = newBuffer
-	pb.isAggregating = false
 	if len(pb.buffer) == 0 {
 		pb.firstItemAt = time.Time{}
 	}
 	return clearedCount
 }
 
-// MarkAggregating marks the proofs in this buffer are aggregating.
-func (pb *ProofBuffer) MarkAggregating() {
+// MarkAggregatingIfNot marks the proofs in this buffer are aggregating if not.
+func (pb *ProofBuffer) MarkAggregatingIfNot() bool {
 	pb.mutex.Lock()
 	defer pb.mutex.Unlock()
+
+	if pb.isAggregating {
+		return false
+	}
 	pb.isAggregating = true
+	return true
 }
 
 // IsAggregating returns if the proofs in this buffer are aggregating.

--- a/packages/taiko-client/prover/proof_producer/proof_buffer_test.go
+++ b/packages/taiko-client/prover/proof_producer/proof_buffer_test.go
@@ -24,7 +24,7 @@ func TestProofBuffer(t *testing.T) {
 	}
 
 	// Mark its aggregating status.
-	b.MarkAggregating()
+	b.MarkAggregatingIfNot()
 	require.True(t, b.IsAggregating())
 
 	// Clear items from the buffer.
@@ -34,5 +34,6 @@ func TestProofBuffer(t *testing.T) {
 	}
 	require.Equal(t, bufferSize, b.ClearItems(blockIDs...))
 	require.Zero(t, b.Len())
+	b.ResetAggregating()
 	require.False(t, b.IsAggregating())
 }

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -281,6 +281,7 @@ func (s *ProofSubmitterPacaya) startProofBufferMonitors(ctx context.Context) {
 	if s.forceBatchProvingInterval <= 0 {
 		return
 	}
+	log.Info("Starting proof buffers monitors for Pacaya", "forceBatchProvingInterval", s.forceBatchProvingInterval)
 	for proofType, buffer := range s.proofBuffers {
 		go s.monitorProofBuffer(ctx, proofType, buffer)
 	}
@@ -291,16 +292,13 @@ func (s *ProofSubmitterPacaya) monitorProofBuffer(
 	proofType proofProducer.ProofType,
 	buffer *proofProducer.ProofBuffer,
 ) {
-	interval := s.forceBatchProvingInterval
-	if interval <= 0 {
-		interval = 30 * time.Minute
-	}
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(s.forceBatchProvingInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
+			log.Debug("context of proof buffer monitor is done")
 			return
 		case <-ticker.C:
 			s.TryAggregate(buffer, proofType)

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -400,6 +400,8 @@ func (s *ProofSubmitterPacaya) AggregateProofsByType(ctx context.Context, proofT
 	// If the buffer is empty, skip the aggregation.
 	if len(buffer) == 0 {
 		log.Debug("Buffer is empty now, skip aggregating")
+		// To mark isAggregating = false
+		proofBuffer.ClearItems()
 		return nil
 	}
 	if err := backoff.Retry(

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -282,8 +282,6 @@ func (s *ProofSubmitterPacaya) startProofBufferMonitors(ctx context.Context) {
 		return
 	}
 	for proofType, buffer := range s.proofBuffers {
-		proofType := proofType
-		buffer := buffer
 		go s.monitorProofBuffer(ctx, proofType, buffer)
 	}
 }

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -265,15 +265,16 @@ func (s *ProofSubmitterPacaya) RequestProof(ctx context.Context, meta metadata.T
 // TryAggregate tries to aggregate the proofs in the buffer, if the buffer is full,
 // or the forced aggregation interval has passed.
 func (s *ProofSubmitterPacaya) TryAggregate(buffer *proofProducer.ProofBuffer, proofType proofProducer.ProofType) bool {
-	if !buffer.IsAggregating() &&
-		(uint64(buffer.Len()) >= buffer.MaxLength ||
-			(buffer.Len() != 0 && time.Since(buffer.FirstItemAt()) > s.forceBatchProvingInterval)) {
-		buffer.MarkAggregating()
-		s.batchAggregationNotify <- proofType
-
-		return true
+	if buffer.MarkAggregatingIfNot() { // Returns true if successfully marked
+		if uint64(buffer.Len()) >= buffer.MaxLength ||
+			(buffer.Len() != 0 && time.Since(buffer.FirstItemAt()) > s.forceBatchProvingInterval) {
+			s.batchAggregationNotify <- proofType
+			return true
+		} else {
+			buffer.ResetAggregating() // Unmark if conditions not met
+			return false
+		}
 	}
-
 	return false
 }
 
@@ -337,6 +338,7 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 		// If there are invalid batches in the aggregation, we ignore these batches.
 		log.Warn("Invalid batches in an aggregation, ignore these batches", "batchIDs", invalidBatchIDs)
 		proofBuffer.ClearItems(invalidBatchIDs...)
+		proofBuffer.ResetAggregating()
 		return ErrInvalidProof
 	}
 
@@ -355,6 +357,7 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 		batchProof,
 	); err != nil {
 		proofBuffer.ClearItems(uint64BatchIDs...)
+		proofBuffer.ResetAggregating()
 		// Resend the proof request
 		for _, proofResp := range batchProof.ProofResponses {
 			s.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: proofResp.Meta}
@@ -371,6 +374,7 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 
 	// Clear the items in the buffer.
 	proofBuffer.ClearItems(uint64BatchIDs...)
+	proofBuffer.ResetAggregating()
 
 	return nil
 }
@@ -400,8 +404,7 @@ func (s *ProofSubmitterPacaya) AggregateProofsByType(ctx context.Context, proofT
 	// If the buffer is empty, skip the aggregation.
 	if len(buffer) == 0 {
 		log.Debug("Buffer is empty now, skip aggregating")
-		// To mark isAggregating = false
-		proofBuffer.ClearItems()
+		proofBuffer.ResetAggregating()
 		return nil
 	}
 	if err := backoff.Retry(

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_test.go
@@ -251,3 +251,32 @@ func TestProofRequestSuccessful(t *testing.T) {
 	require.Equal(t, proofProducer.ProofTypeOp, resp.ProofType)
 	require.Equal(t, 1, mockProducer.requestCount)
 }
+
+func TestProofBufferMonitorTriggersAggregate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	buffer := proofProducer.NewProofBuffer(2)
+	_, err := buffer.Write(&proofProducer.ProofResponse{BatchID: big.NewInt(1)})
+	require.NoError(t, err)
+
+	s := &ProofSubmitterPacaya{
+		proofBuffers: map[proofProducer.ProofType]*proofProducer.ProofBuffer{
+			proofProducer.ProofTypeOp: buffer,
+		},
+		batchAggregationNotify:    make(chan proofProducer.ProofType, 1),
+		forceBatchProvingInterval: 50 * time.Millisecond,
+		proofPollingInterval:      10 * time.Millisecond,
+	}
+
+	go s.monitorProofBuffer(ctx, proofProducer.ProofTypeOp, buffer)
+
+	select {
+	case proofType := <-s.batchAggregationNotify:
+		require.Equal(t, proofProducer.ProofTypeOp, proofType)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected aggregation signal but timed out")
+	}
+
+	require.True(t, buffer.IsAggregating())
+}

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -129,7 +129,7 @@ func InitFromConfig(
 	p.assignmentExpiredCh = make(chan metadata.TaikoProposalMetaData, chBufferSize)
 	p.proofSubmissionCh = make(chan *proofProducer.ProofRequestBody, chBufferSize)
 	p.proveNotify = make(chan struct{}, 1)
-	p.batchesAggregationNotify = make(chan proofProducer.ProofType, 1)
+	p.batchesAggregationNotify = make(chan proofProducer.ProofType, proofSubmitter.MaxNumSupportedProofTypes)
 
 	if err := p.initL1Current(cfg.StartingBatchID); err != nil {
 		return fmt.Errorf("initialize L1 current cursor error: %w", err)

--- a/packages/taiko-client/prover/prover_test.go
+++ b/packages/taiko-client/prover/prover_test.go
@@ -349,6 +349,7 @@ func (s *ProverTestSuite) TestAggregateProofsAlreadyProved() {
 		BackOffRetryInterval:  3 * time.Second,
 		BackOffMaxRetries:     12,
 		SGXProofBufferSize:    uint64(batchSize),
+		ZKVMProofBufferSize:   uint64(batchSize),
 	}, s.txmgr, s.txmgr))
 
 	for i := 0; i < batchSize; i++ {
@@ -405,6 +406,7 @@ func (s *ProverTestSuite) TestAggregateProofs() {
 		BackOffRetryInterval:  3 * time.Second,
 		BackOffMaxRetries:     12,
 		SGXProofBufferSize:    uint64(batchSize),
+		ZKVMProofBufferSize:   uint64(batchSize),
 	}, s.txmgr, s.txmgr))
 
 	for i := 0; i < batchSize; i++ {
@@ -458,6 +460,7 @@ func (s *ProverTestSuite) TestForceAggregate() {
 		BackOffRetryInterval:      3 * time.Second,
 		BackOffMaxRetries:         12,
 		SGXProofBufferSize:        uint64(batchSize),
+		ZKVMProofBufferSize:       uint64(batchSize),
 		ForceBatchProvingInterval: 5 * time.Second,
 	}, s.txmgr, s.txmgr))
 


### PR DESCRIPTION
From @linoscope feedback, we need to monitor the stale proofs in the buffer and submit them on chain in time.