### PR TITLE
refactor(taiko-client): make canonical batch checks return known/unknown instead of only errors

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -374,7 +374,7 @@ func isKnownCanonicalBlock(
 ) (*types.Header, bool, error) {
 	var blockID = new(big.Int).Add(meta.Parent.Number, common.Big1)
 	block, err := rpc.L2.BlockByNumber(ctx, blockID)
-	if err != nil {
+	if err != nil && !errors.Is(err, ethereum.NotFound) {
 		return nil, false, fmt.Errorf("failed to get block by number %d: %w", blockID, err)
 	}
 

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -31,6 +31,9 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/utils"
 )
 
+// errBatchNotKnown is returned when a batch is not known in the canonical chain.
+var errBatchNotKnown = errors.New("batch not known in canonical chain")
+
 // createPayloadAndSetHead tries to insert a new head block to the L2 execution engine's local
 // block chain through Engine APIs.
 func createPayloadAndSetHead(
@@ -216,13 +219,13 @@ func isKnownCanonicalBatchPacaya(
 	metadata metadata.TaikoProposalMetaData,
 	allTxs []*types.Transaction,
 	parent *types.Header,
-) (*types.Header, error) {
+) (*types.Header, bool, error) {
 	var (
 		headers = make([]*types.Header, len(metadata.Pacaya().GetBlocks()))
 		g       = new(errgroup.Group)
 	)
 
-	// Check each block in the batch, and if the all blocks are preconfirmed, return the header of the last block.
+	// Check each block in the batch, and if all blocks are preconfirmed, return the header of the last block.
 	for i := 0; i < len(metadata.Pacaya().GetBlocks()); i++ {
 		g.Go(func() error {
 			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
@@ -248,7 +251,8 @@ func isKnownCanonicalBatchPacaya(
 				return fmt.Errorf("failed to RLP encode tx list: %w", err)
 			}
 
-			if headers[i], err = isKnownCanonicalBlock(
+			var known bool
+			if headers[i], known, err = isKnownCanonicalBlock(
 				ctx,
 				rpc,
 				&createPayloadAndSetHeadMetaData{
@@ -258,14 +262,24 @@ func isKnownCanonicalBatchPacaya(
 				b,
 				anchorTx,
 			); err != nil {
-				return fmt.Errorf("block %d is an unknown block, reason: %w", createExecutionPayloadsMetaData.BlockID, err)
+				return err
 			}
-
+			if !known {
+				return errBatchNotKnown
+			}
 			return nil
 		})
 	}
 
-	return headers[len(headers)-1], g.Wait()
+	// Wait for all goroutines to finish, and check for errors.
+	if err := g.Wait(); err != nil {
+		if errors.Is(err, errBatchNotKnown) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	return headers[len(headers)-1], true, nil
 }
 
 // isKnownCanonicalBatchShasta checks if all blocks in the given Shasta batch are in the canonical chain already,
@@ -277,16 +291,16 @@ func isKnownCanonicalBatchShasta(
 	metadata metadata.TaikoProposalMetaData,
 	sourcePayload *shastaManifest.ShastaDerivationSourcePayload,
 	parent *types.Header,
-) (*types.Header, error) {
+) (*types.Header, bool, error) {
 	if !metadata.IsShasta() {
-		return nil, fmt.Errorf("metadata is not for Shasta fork blocks")
+		return nil, false, fmt.Errorf("metadata is not for Shasta fork blocks")
 	}
 	var (
 		headers = make([]*types.Header, len(sourcePayload.BlockPayloads))
 		g       = new(errgroup.Group)
 	)
 
-	// Check each block in the batch, and if the all blocks are preconfirmed, return the header of the last block.
+	// Check each block in the batch, and if all blocks are preconfirmed, return the header of the last block.
 	for i := 0; i < len(sourcePayload.BlockPayloads); i++ {
 		g.Go(func() error {
 			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
@@ -313,7 +327,8 @@ func isKnownCanonicalBatchShasta(
 				return fmt.Errorf("failed to RLP encode tx list: %w", err)
 			}
 
-			if headers[i], err = isKnownCanonicalBlock(
+			var known bool
+			if headers[i], known, err = isKnownCanonicalBlock(
 				ctx,
 				rpc,
 				&createPayloadAndSetHeadMetaData{
@@ -323,16 +338,24 @@ func isKnownCanonicalBatchShasta(
 				b,
 				anchorTx,
 			); err != nil {
-				return fmt.Errorf(
-					"block %d is an unknown Shasta block, reason: %w", createExecutionPayloadsMetaData.BlockID, err,
-				)
+				return err
 			}
-
+			if !known {
+				return errBatchNotKnown
+			}
 			return nil
 		})
 	}
 
-	return headers[len(headers)-1], g.Wait()
+	// Wait for all goroutines to finish, and check for errors.
+	if err := g.Wait(); err != nil {
+		if errors.Is(err, errBatchNotKnown) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	return headers[len(headers)-1], true, nil
 }
 
 // isKnownCanonicalBlock checks if the block is in canonical chain already.
@@ -342,15 +365,25 @@ func isKnownCanonicalBlock(
 	meta *createPayloadAndSetHeadMetaData,
 	txListBytes []byte,
 	anchorTx *types.Transaction,
-) (*types.Header, error) {
+) (*types.Header, bool, error) {
 	var blockID = new(big.Int).Add(meta.Parent.Number, common.Big1)
 	block, err := rpc.L2.BlockByNumber(ctx, blockID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get block by number %d: %w", blockID, err)
+		return nil, false, fmt.Errorf("failed to get block by number %d: %w", blockID, err)
+	}
+
+	// Helper function to log unknown block reasons.
+	logUnknown := func(reason string) {
+		fields := []interface{}{"blockID", blockID, "reason", reason}
+		if block != nil {
+			fields = append(fields, "coinbase", block.Coinbase())
+		}
+		log.Warn("Unknown block for the canonical chain", fields...)
 	}
 
 	if block == nil {
-		return nil, fmt.Errorf("block not found by number %d", blockID)
+		logUnknown("block not found")
+		return nil, false, nil
 	}
 
 	var (
@@ -376,24 +409,17 @@ func isKnownCanonicalBlock(
 
 	l1Origin, err := rpc.L2.L1OriginByID(ctx, blockID)
 	if err != nil && !errors.Is(err, ethereum.NotFound) {
-		return nil, fmt.Errorf("failed to get L1Origin by ID %d: %w", blockID, err)
+		return nil, false, fmt.Errorf("failed to get L1Origin by ID %d: %w", blockID, err)
 	}
 	// If L1Origin is not found, it means this block is synced from beacon sync.
 	if l1Origin == nil {
-		return nil, fmt.Errorf("L1Origin not found by ID %d", blockID)
+		logUnknown("L1Origin not found")
+		return nil, false, nil
 	}
 	// If the payload ID matches, it means this block is already in the canonical chain.
 	if l1Origin.BuildPayloadArgsID != [8]byte{} && !bytes.Equal(l1Origin.BuildPayloadArgsID[:], id[:]) {
-		return nil, fmt.Errorf(
-			`payload ID for block %d mismatch,
-			l1Origin payload id: %s,
-			current payload id %s,
-			parentHash: %s,
-			timestamp: %d,
-			suggestedFeeRecipient: %s,
-			difficulty: %s,
-			txListHash: %s`,
-			blockID,
+		logUnknown(fmt.Sprintf(
+			`payload ID mismatch: l1Origin payload id: %s, current payload id %s, parentHash: %s, timestamp: %d, suggestedFeeRecipient: %s, difficulty: %s, txListHash: %s`,
 			engine.PayloadID(l1Origin.BuildPayloadArgsID),
 			id,
 			meta.Parent.Hash().Hex(),
@@ -401,68 +427,64 @@ func isKnownCanonicalBlock(
 			meta.SuggestedFeeRecipient.Hex(),
 			meta.Difficulty.Hex(),
 			txListHash.Hex(),
-		)
+		))
+		return nil, false, nil
 	}
-	defer func() {
-		if err != nil {
-			log.Warn("Unknown block for the canonical chain", "blockID", blockID, "coinbase", block.Coinbase(), "reason", err)
-		}
-	}()
 
 	if block.ParentHash() != meta.Parent.Hash() {
-		err = fmt.Errorf("parent hash mismatch: %s != %s", block.ParentHash(), meta.Parent.Hash())
-		return nil, err
+		logUnknown(fmt.Sprintf("parent hash mismatch: %s != %s", block.ParentHash(), meta.Parent.Hash()))
+		return nil, false, nil
 	}
 	if block.Transactions().Len() == 0 {
-		err = errors.New("transactions list is empty")
-		return nil, err
+		logUnknown("transactions list is empty")
+		return nil, false, nil
 	}
 	if block.Transactions()[0].Hash() != anchorTx.Hash() {
-		err = fmt.Errorf("anchor transaction mismatch: %s != %s", block.Transactions()[0].Hash(), anchorTx.Hash())
-		return nil, err
+		logUnknown(fmt.Sprintf("anchor transaction mismatch: %s != %s", block.Transactions()[0].Hash(), anchorTx.Hash()))
+		return nil, false, nil
 	}
 	if block.UncleHash() != types.EmptyUncleHash {
-		err = fmt.Errorf("uncle hash mismatch: %s != %s", block.UncleHash(), types.EmptyUncleHash)
-		return nil, err
+		logUnknown(fmt.Sprintf("uncle hash mismatch: %s != %s", block.UncleHash(), types.EmptyUncleHash))
+		return nil, false, nil
 	}
 	if block.Coinbase() != meta.SuggestedFeeRecipient {
-		err = fmt.Errorf("coinbase mismatch: %s != %s", block.Coinbase(), meta.SuggestedFeeRecipient)
-		return nil, err
+		logUnknown(fmt.Sprintf("coinbase mismatch: %s != %s", block.Coinbase(), meta.SuggestedFeeRecipient))
+		return nil, false, nil
 	}
 	if block.Difficulty().Cmp(common.Big0) != 0 {
-		err = fmt.Errorf("difficulty mismatch: %s != 0", block.Difficulty())
-		return nil, err
+		logUnknown(fmt.Sprintf("difficulty mismatch: %s != 0", block.Difficulty()))
+		return nil, false, nil
 	}
 	if block.MixDigest() != meta.Difficulty {
-		err = fmt.Errorf("mixDigest mismatch: %s != %s", block.MixDigest(), meta.Difficulty)
-		return nil, err
+		logUnknown(fmt.Sprintf("mixDigest mismatch: %s != %s", block.MixDigest(), meta.Difficulty))
+		return nil, false, nil
 	}
 	if block.Number().Uint64() != meta.BlockID.Uint64() {
-		err = fmt.Errorf("block number mismatch: %d != %d", block.Number(), meta.BlockID)
-		return nil, err
+		logUnknown(fmt.Sprintf("block number mismatch: %d != %d", block.Number(), meta.BlockID))
+		return nil, false, nil
 	}
 	if block.GasLimit() != meta.GasLimit+consensus.AnchorV3V4GasLimit {
-		err = fmt.Errorf("gas limit mismatch: %d != %d", block.GasLimit(), meta.GasLimit+consensus.AnchorV3V4GasLimit)
-		return nil, err
+		logUnknown(fmt.Sprintf("gas limit mismatch: %d != %d", block.GasLimit(), meta.GasLimit+consensus.AnchorV3V4GasLimit))
+		return nil, false, nil
 	}
 	if block.Time() != meta.Timestamp {
-		err = fmt.Errorf("timestamp mismatch: %d != %d", block.Time(), meta.Timestamp)
-		return nil, err
+		logUnknown(fmt.Sprintf("timestamp mismatch: %d != %d", block.Time(), meta.Timestamp))
+		return nil, false, nil
 	}
 	if !bytes.Equal(block.Extra(), meta.ExtraData) {
-		err = fmt.Errorf("extra data mismatch: %s != %s", block.Extra(), meta.ExtraData)
-		return nil, err
+		logUnknown(fmt.Sprintf("extra data mismatch: %s != %s", block.Extra(), meta.ExtraData))
+		return nil, false, nil
 	}
 	if block.BaseFee().Cmp(meta.BaseFee) != 0 {
-		err = fmt.Errorf("base fee mismatch: %s != %s", block.BaseFee(), meta.BaseFee)
-		return nil, err
+		logUnknown(fmt.Sprintf("base fee mismatch: %s != %s", block.BaseFee(), meta.BaseFee))
+		return nil, false, nil
 	}
 	if block.Withdrawals().Len() != 0 {
-		err = fmt.Errorf("withdrawals mismatch: %d != 0", block.Withdrawals().Len())
-		return nil, err
+		logUnknown(fmt.Sprintf("withdrawals mismatch: %d != 0", block.Withdrawals().Len()))
+		return nil, false, nil
 	}
 
-	return block.Header(), nil
+	return block.Header(), true, nil
 }
 
 // assembleCreateExecutionPayloadMetaPacaya assembles the metadata for creating an execution payload,

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -308,6 +308,9 @@ func isKnownCanonicalBatchShasta(
 		g.Go(func() error {
 			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
 			if err != nil {
+				if errors.Is(err, ethereum.NotFound) {
+					return errBatchNotKnown
+				}
 				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
 			}
 

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -230,6 +230,9 @@ func isKnownCanonicalBatchPacaya(
 		g.Go(func() error {
 			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
 			if err != nil {
+				if errors.Is(err, ethereum.NotFound) {
+					return errBatchNotKnown
+				}
 				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
 			}
 

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -419,7 +419,8 @@ func isKnownCanonicalBlock(
 	// If the payload ID matches, it means this block is already in the canonical chain.
 	if l1Origin.BuildPayloadArgsID != [8]byte{} && !bytes.Equal(l1Origin.BuildPayloadArgsID[:], id[:]) {
 		logUnknown(fmt.Sprintf(
-			`payload ID mismatch: l1Origin payload id: %s, current payload id %s, parentHash: %s, timestamp: %d, suggestedFeeRecipient: %s, difficulty: %s, txListHash: %s`,
+			"payload ID mismatch: l1Origin payload id: %s, current payload id %s, parentHash: %s, "+
+				"timestamp: %d, suggestedFeeRecipient: %s, difficulty: %s, txListHash: %s",
 			engine.PayloadID(l1Origin.BuildPayloadArgsID),
 			id,
 			meta.Parent.Hash().Hex(),

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
@@ -181,7 +181,7 @@ func (i *Pacaya) InsertBlocks(
 				parent,
 			)
 			if err != nil {
-				return fmt.Errorf("failed to check if Pcaya batch is known in canonical chain: %w", err)
+				return fmt.Errorf("failed to check if Pacaya batch is known in canonical chain: %w", err)
 			}
 			if isKnown && lastBlockHeader != nil {
 				log.Info(

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/pacaya.go
@@ -172,7 +172,7 @@ func (i *Pacaya) InsertBlocks(
 				"parentHash", parent.Hash(),
 			)
 
-			lastBlockHeader, err := isKnownCanonicalBatchPacaya(
+			lastBlockHeader, isKnown, err := isKnownCanonicalBatchPacaya(
 				ctx,
 				i.rpc,
 				i.anchorConstructor,
@@ -181,10 +181,11 @@ func (i *Pacaya) InsertBlocks(
 				parent,
 			)
 			if err != nil {
-				log.Info("Unknown batch for the current canonical chain", "batchID", meta.GetBatchID(), "reason", err)
-			} else if lastBlockHeader != nil {
+				return fmt.Errorf("failed to check if Pcaya batch is known in canonical chain: %w", err)
+			}
+			if isKnown && lastBlockHeader != nil {
 				log.Info(
-					"🧬 Known batch in canonical chain",
+					"🧬 Known Pacaya batch in canonical chain",
 					"batchID", meta.GetBatchID(),
 					"lastBlockID", meta.GetLastBlockID(),
 					"lastBlockHash", lastBlockHeader.Hash(),

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
@@ -141,7 +141,7 @@ func (i *Shasta) InsertBlocksWithManifest(
 				"parentHash", parent.Hash(),
 			)
 
-			lastBlockHeader, err := isKnownCanonicalBatchShasta(
+			lastBlockHeader, isKnown, err := isKnownCanonicalBatchShasta(
 				ctx,
 				i.rpc,
 				i.anchorConstructor,
@@ -150,13 +150,9 @@ func (i *Shasta) InsertBlocksWithManifest(
 				parent,
 			)
 			if err != nil {
-				log.Info(
-					"Unknown Shasta batch for the current canonical chain",
-					"batchID", meta.GetProposal().Id,
-					"proposer", meta.GetProposal().Proposer,
-					"reason", err,
-				)
-			} else if lastBlockHeader != nil {
+				return nil, fmt.Errorf("failed to check if Shasta batch is known in canonical chain: %w", err)
+			}
+			if isKnown && lastBlockHeader != nil {
 				log.Info(
 					"🧬 Known Shasta batch in canonical chain",
 					"batchID", meta.GetProposal().Id,


### PR DESCRIPTION
- Adjust canonical batch checks to return a known/unknown flag instead of surfacing benign mismatches as errors
- Improve logs for the reason why the batch is unknown
- Driver will automatically retry only on real errors; known batches no longer emit errors that could trigger unnecessary reorg handling

This is [an alternative approach](https://github.com/taikoxyz/taiko-mono/pull/20887#discussion_r2579334424) to addressing the issue that #20887 aims to resolve.
