### PR TITLE
fix(protocol): fix missleading documentation identified by the audit

### DIFF
--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -299,6 +299,8 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @notice Retrieves the proposal hash for a given proposal ID
+    /// @dev Note that due to the ring buffer nature of the `_proposalHashes` mapping proposals may
+    /// have been overwritten by a new one. You should verify that the hash matches the expected proposal. 
     /// @param _proposalId The ID of the proposal to query
     /// @return proposalHash_ The keccak256 hash of the Proposal struct at the ring buffer slot
     function getProposalHash(uint48 _proposalId) external view returns (bytes32 proposalHash_) {

--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -300,7 +300,7 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
 
     /// @notice Retrieves the proposal hash for a given proposal ID
     /// @dev Note that due to the ring buffer nature of the `_proposalHashes` mapping proposals may
-    /// have been overwritten by a new one. You should verify that the hash matches the expected proposal. 
+    /// have been overwritten by a new one. You should verify that the hash matches the expected proposal.
     /// @param _proposalId The ID of the proposal to query
     /// @return proposalHash_ The keccak256 hash of the Proposal struct at the ring buffer slot
     function getProposalHash(uint48 _proposalId) external view returns (bytes32 proposalHash_) {

--- a/packages/protocol/contracts/layer1/verifiers/LibPublicInput.sol
+++ b/packages/protocol/contracts/layer1/verifiers/LibPublicInput.sol
@@ -11,14 +11,14 @@ library LibPublicInput {
     /// @notice Hashes the public input for the proof verification.
     /// @param _aggregatedProvingHash The aggregated proving hash from the inbox.
     /// @param _verifierContract The contract address which as current verifier.
-    /// @param _newInstance The new instance address. For SGX it is the new signer address, for ZK
-    /// this variable is not used and must have value address(0).
+    /// @param _proofSigner The address of the instance that signed this proof. For SGX it is the
+    /// signer address, for ZK this variable is not used and must have value address(0).
     /// @param _chainId The chain id.
     /// @return The public input hash.
     function hashPublicInputs(
         bytes32 _aggregatedProvingHash,
         address _verifierContract,
-        address _newInstance,
+        address _proofSigner,
         uint64 _chainId
     )
         internal
@@ -31,7 +31,7 @@ library LibPublicInput {
             bytes32(uint256(_chainId)),
             bytes32(uint256(uint160(_verifierContract))),
             _aggregatedProvingHash,
-            bytes32(uint256(uint160(_newInstance)))
+            bytes32(uint256(uint160(_proofSigner)))
         );
     }
 

--- a/packages/protocol/contracts/layer2/core/IBondManager.sol
+++ b/packages/protocol/contracts/layer2/core/IBondManager.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 /// @title IBondManager
-/// @notice Interface for managing bonds in the Based3 protocol
+/// @notice Interface for managing bonds in the Taiko protocol
 /// @custom:security-contact security@taiko.xyz
 interface IBondManager {
     // ---------------------------------------------------------------
@@ -88,8 +88,7 @@ interface IBondManager {
     function depositTo(address _recipient, uint256 _amount) external;
 
     /// @notice Withdraw bond to a recipient.
-    /// @dev On L1, withdrawal is subject to time-based security. On L2, withdrawals are
-    /// unrestricted.
+    /// @dev Withdrawals are subject to a delay so that bond operations can be resolved properly.
     /// @param _to The recipient of withdrawn funds.
     /// @param _amount The amount to withdraw.
     function withdraw(address _to, uint256 _amount) external;

--- a/packages/protocol/test/layer1/verifiers/LibPublicInput.t.sol
+++ b/packages/protocol/test/layer1/verifiers/LibPublicInput.t.sol
@@ -10,17 +10,17 @@ contract LibPublicInputTest is Test {
     function test_hashPublicInputs_ComputesExpectedHash() external pure {
         bytes32 aggregatedHash = bytes32(uint256(0x1234));
         address verifier = address(0xBEEF);
-        address newInstance = address(0xCAFE);
+        address proofSigner = address(0xCAFE);
         uint64 chainId = 167;
 
         bytes32 actual =
-            LibPublicInput.hashPublicInputs(aggregatedHash, verifier, newInstance, chainId);
+            LibPublicInput.hashPublicInputs(aggregatedHash, verifier, proofSigner, chainId);
         bytes32 expected = EfficientHashLib.hash(
             bytes32("VERIFY_PROOF"),
             bytes32(uint256(chainId)),
             bytes32(uint256(uint160(verifier))),
             aggregatedHash,
-            bytes32(uint256(uint160(newInstance)))
+            bytes32(uint256(uint160(proofSigner)))
         );
 
         assertEq(actual, expected);
@@ -34,13 +34,13 @@ contract LibPublicInputTest is Test {
     function _callHashPublicInputs(
         bytes32 aggregatedHash,
         address verifier,
-        address newInstance,
+        address proofSigner,
         uint64 chainId
     )
         external
         pure
         returns (bytes32)
     {
-        return LibPublicInput.hashPublicInputs(aggregatedHash, verifier, newInstance, chainId);
+        return LibPublicInput.hashPublicInputs(aggregatedHash, verifier, proofSigner, chainId);
     }
 }


### PR DESCRIPTION
Fixes #20931 

Some of the issues identified have been fixed by the changes in consecutive prove. This PR addresses the rest.

Non-enforced limit on forced inclusions in LibForcedInclusion has been addressed separately in PR #20781