### PR TITLE
chore(bridge): add validation for non-zero _message.from

### DIFF
--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -84,6 +84,7 @@ contract Bridge is EssentialResolverContract, IBridge {
     error B_INVALID_CONTEXT();
     error B_INVALID_FEE();
     error B_INVALID_GAS_LIMIT();
+    error B_INVALID_SENDER();
     error B_INVALID_STATUS();
     error B_INVALID_VALUE();
     error B_INSUFFICIENT_GAS();
@@ -240,6 +241,8 @@ contract Bridge is EssentialResolverContract, IBridge {
         if (_message.srcChainId == 0 || _message.srcChainId == block.chainid) {
             revert B_INVALID_CHAINID();
         }
+
+        if (_message.from == address(0)) revert B_INVALID_SENDER();
 
         ProcessingStats memory stats;
         stats.processedByRelayer = msg.sender != _message.destOwner;

--- a/packages/protocol/test/shared/bridge/Bridge2_failMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_failMessage.t.sol
@@ -12,6 +12,7 @@ contract TestBridge2_failMessage is TestBridge2Base {
         IBridge.Message memory message;
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
         message.gasLimit = 1_000_000;
         message.fee = 1000;
         message.value = 2 ether;
@@ -32,6 +33,7 @@ contract TestBridge2_failMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.fee = 0;
         message.value = 2 ether;
@@ -67,6 +69,7 @@ contract TestBridge2_failMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 0;
         message.fee = 1_000_000;

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -47,6 +47,10 @@ contract TestBridge2_processMessage is TestBridge2Base {
         eBridge.processMessage(message, FAKE_PROOF);
 
         message.srcChainId = taikoChainId + 1;
+        vm.expectRevert(Bridge.B_INVALID_SENDER.selector);
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        message.from = Alice;
         vm.expectRevert(Bridge.B_PERMISSION_DENIED.selector);
         eBridge.processMessage(message, FAKE_PROOF);
 
@@ -84,6 +88,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 1_000_000;
         message.fee = 0;
@@ -122,6 +127,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 0;
         message.fee = 0;
@@ -168,6 +174,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 1;
         message.fee = 5_000_000;
@@ -203,6 +210,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 0;
         message.fee = 5_000_000;
@@ -228,6 +236,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 1_000_000;
         message.fee = 0;
@@ -255,6 +264,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 0;
         message.fee = 0;
@@ -280,6 +290,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 1_000_000;
         message.fee = 5_000_000;
@@ -308,6 +319,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 0;
         message.fee = 1_000_000;
@@ -332,6 +344,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.gasLimit = 1_000_000;
         message.fee = 0;

--- a/packages/protocol/test/shared/bridge/Bridge2_retryMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_retryMessage.t.sol
@@ -29,6 +29,7 @@ contract TestBridge2_retryMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.fee = 0;
         message.value = 2 ether;
@@ -70,6 +71,7 @@ contract TestBridge2_retryMessage is TestBridge2Base {
 
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
+        message.from = Alice;
 
         message.fee = 0;
         message.value = 2 ether;


### PR DESCRIPTION
## Summary

Add defense-in-depth validation to ensure `_message.from` is never zero when processing bridge messages. This prevents potential downstream issues in contracts relying on `context().from` even though the field is normally set during `sendMessage`. Also updates test messages to properly initialize the `from` field.

## Test Plan

- [x] All existing Bridge tests pass (36 tests)
- [x] Full protocol test suite passes (109 tests)
- [x] New validation correctly rejects messages with zero `from` address

🤖 Generated with [Claude Code](https://claude.com/claude-code)