### PR TITLE
chore(taiko-client): remove Shasta `Proved` event handling in prover

### DIFF
--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           repository: taikoxyz/taiko-mono
           path: ${{ env.SHASTA_FORK_TAIKO_MONO_DIR }}
-          ref: consecutive-proofs-2
+          ref: consecutive-proofs
 
       - name: Install pnpm dependencies for pacaya fork taiko-mono
         working-directory: ${{ env.PACAYA_FORK_TAIKO_MONO_DIR }}

--- a/packages/taiko-client/driver/state/state.go
+++ b/packages/taiko-client/driver/state/state.go
@@ -149,6 +149,7 @@ func (s *State) eventLoop(ctx context.Context) {
 				"checkpointNumber", payload.Transition.Checkpoint.BlockNumber,
 				"checkpointHash", common.Hash(payload.Transition.Checkpoint.BlockHash),
 			)
+			metrics.DriverL2VerifiedHeightGauge.Set(float64(payload.Transition.Checkpoint.BlockNumber.Uint64()))
 		case e := <-batchesVerifiedPacayaCh:
 			log.Info(
 				"📈 Pacaya batches verified",

--- a/packages/taiko-client/driver/state/state.go
+++ b/packages/taiko-client/driver/state/state.go
@@ -121,7 +121,6 @@ func (s *State) eventLoop(ctx context.Context) {
 		)
 		l2BatchesProvedPacayaSub = rpc.SubscribeBatchesProvedPacaya(s.rpc.PacayaClients.TaikoInbox, batchesProvedPacayaCh)
 		l2ProposedShastaSub      = rpc.SubscribeProposedShasta(s.rpc.ShastaClients.Inbox, proposedShastaCh)
-		l2ProvedShastaSub        = rpc.SubscribeProvedShasta(s.rpc.ShastaClients.Inbox, provedShastaCh)
 	)
 
 	defer func() {
@@ -130,7 +129,6 @@ func (s *State) eventLoop(ctx context.Context) {
 		l2BatchesVerifiedPacayaSub.Unsubscribe()
 		l2BatchesProvedPacayaSub.Unsubscribe()
 		l2ProposedShastaSub.Unsubscribe()
-		l2ProvedShastaSub.Unsubscribe()
 	}()
 
 	for {

--- a/packages/taiko-client/internal/docker/nodes/docker-compose.yml
+++ b/packages/taiko-client/internal/docker/nodes/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   l2_geth:
     container_name: l2_geth
-    image: us-docker.pkg.dev/evmchain/images/taiko-geth:new-anchor-v4
+    image: us-docker.pkg.dev/evmchain/images/taiko-geth:taiko
     restart: unless-stopped
     pull_policy: always
     volumes:

--- a/packages/taiko-client/pkg/rpc/subscription.go
+++ b/packages/taiko-client/pkg/rpc/subscription.go
@@ -101,24 +101,6 @@ func SubscribeProposedShasta(
 	})
 }
 
-// SubscribeProvedShasta subscribes the Shasta protocol's Proved events.
-func SubscribeProvedShasta(
-	taikoInbox *shastaBindings.ShastaInboxClient,
-	ch chan *shastaBindings.ShastaInboxClientProved,
-) event.Subscription {
-	return SubscribeEvent("Proved", func(ctx context.Context) (event.Subscription, error) {
-		sub, err := taikoInbox.WatchProved(nil, ch)
-		if err != nil {
-			log.Error("Create Shasta Inbox.Proved subscription error", "error", err)
-			return nil, err
-		}
-
-		defer sub.Unsubscribe()
-
-		return waitSubErr(ctx, sub)
-	})
-}
-
 // SubscribeChainHead subscribes the new chain heads.
 func SubscribeChainHead(
 	client *EthClient,

--- a/packages/taiko-client/prover/event_handler/batches_proved.go
+++ b/packages/taiko-client/prover/event_handler/batches_proved.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/log"
 
 	pacayaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/pacaya"
-	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/metrics"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 	proofProducer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
@@ -66,26 +64,6 @@ func (h *BatchesProvedEventHandler) HandlePacaya(
 
 		h.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: meta}
 	}
-
-	return nil
-}
-
-// HandleShasta implements the BatchesProvedHandler interface.
-func (h *BatchesProvedEventHandler) HandleShasta(
-	ctx context.Context,
-	e *shastaBindings.ShastaInboxClientProved,
-) error {
-	payload, err := h.rpc.DecodeProvedEventPayload(&bind.CallOpts{Context: ctx}, e.Data)
-	if err != nil {
-		return fmt.Errorf("failed to decode proved payload: %w", err)
-	}
-
-	header, err := h.rpc.L2.HeaderByNumber(ctx, payload.Transition.Checkpoint.BlockNumber)
-	if err != nil {
-		return fmt.Errorf("failed to get header by number: %w", err)
-	}
-
-	log.Info("New valid proven Shasta batch received", "batchID", payload.ProposalId, "lastBatchID", header.Number)
 
 	return nil
 }

--- a/packages/taiko-client/prover/event_handler/interface.go
+++ b/packages/taiko-client/prover/event_handler/interface.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 	pacayaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/pacaya"
-	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
 	eventIterator "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/chain_iterator/event_iterator"
 )
 
@@ -21,7 +20,6 @@ type BatchProposedHandler interface {
 // BatchesProvedHandler is the interface for handling `TaikoInbox.BatchesProved` events.
 type BatchesProvedHandler interface {
 	HandlePacaya(ctx context.Context, e *pacayaBindings.TaikoInboxClientBatchesProved) error
-	HandleShasta(ctx context.Context, e *shastaBindings.ShastaInboxClientProved) error
 }
 
 // BatchesVerifiedHandler is the interface for handling `TaikoInbox.BatchesVerified` events.

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -229,20 +229,17 @@ func (p *Prover) eventLoop() {
 	batchesVerifiedCh := make(chan *pacayaBindings.TaikoInboxClientBatchesVerified, chBufferSize)
 	batchesProvedCh := make(chan *pacayaBindings.TaikoInboxClientBatchesProved, chBufferSize)
 	shastaProposedCh := make(chan *shastaBindings.ShastaInboxClientProposed, chBufferSize)
-	shastaProvedCh := make(chan *shastaBindings.ShastaInboxClientProved, chBufferSize)
 
 	// Subscriptions
 	batchProposedSub := rpc.SubscribeBatchProposedPacaya(p.rpc.PacayaClients.TaikoInbox, batchProposedCh)
 	batchesVerifiedSub := rpc.SubscribeBatchesVerifiedPacaya(p.rpc.PacayaClients.TaikoInbox, batchesVerifiedCh)
 	batchesProvedSub := rpc.SubscribeBatchesProvedPacaya(p.rpc.PacayaClients.TaikoInbox, batchesProvedCh)
 	shastaProposedSub := rpc.SubscribeProposedShasta(p.rpc.ShastaClients.Inbox, shastaProposedCh)
-	shastaProvedSub := rpc.SubscribeProvedShasta(p.rpc.ShastaClients.Inbox, shastaProvedCh)
 	defer func() {
 		batchProposedSub.Unsubscribe()
 		batchesVerifiedSub.Unsubscribe()
 		batchesProvedSub.Unsubscribe()
 		shastaProposedSub.Unsubscribe()
-		shastaProvedSub.Unsubscribe()
 	}()
 
 	for {
@@ -273,8 +270,6 @@ func (p *Prover) eventLoop() {
 			reqProving()
 		case <-shastaProposedCh:
 			reqProving()
-		case e := <-shastaProvedCh:
-			p.withRetry(func() error { return p.eventHandlers.batchesProvedHandler.HandleShasta(p.ctx, e) })
 		case <-forceProvingTicker.C:
 			reqProving()
 		}


### PR DESCRIPTION
Since for the new protocol design: https://github.com/taikoxyz/taiko-mono/pull/20884 , all proofs will be finalized when landed on-chain, so the prover client doesn't need to monitor that `Proved` event anymore to see if there is a need to submit a new proof to contest.