### PR TITLE
ci(taiko-client-rs): update ci workflow

### DIFF
--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           repository: taikoxyz/taiko-mono
           path: ${{ env.PROTOCOL_FORK_DIR }}
-          ref: consecutive-proofs-2
+          ref: consecutive-proofs
 
       - name: Install pnpm dependencies for protocol taiko-mono for testing
         working-directory: ${{ env.PROTOCOL_FORK_DIR }}


### PR DESCRIPTION
Since [this PR with deployment changes](https://github.com/taikoxyz/taiko-mono/pull/20917) has been merged, so we should use  [`consecutive-proofs` branch](https://github.com/taikoxyz/taiko-mono/pull/20884) in tests now.