### PR TITLE
chore(protocol): replace string error messages with custom errors

### DIFF
--- a/packages/protocol/contracts/layer1/automata-attestation/utils/Asn1Decode.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/utils/Asn1Decode.sol
@@ -39,6 +39,9 @@ library Asn1Decode {
     using NodePtr for uint256;
     using BytesUtils for bytes;
 
+    error ASN1_NOT_OCTET_STRING();
+    error ASN1_NOT_CONSTRUCTED_TYPE();
+
     /*
     * @dev Get the root node. First step in traversing an ASN1 structure
     * @param der The DER-encoded ASN1 structure
@@ -61,7 +64,7 @@ library Asn1Decode {
         pure
         returns (uint256)
     {
-        require(der[ptr.ixs()] == 0x04, "Not type OCTET STRING");
+        if (der[ptr.ixs()] != 0x04) revert ASN1_NOT_OCTET_STRING();
         return _readNodeLength(der, ptr.ixf());
     }
 
@@ -82,7 +85,7 @@ library Asn1Decode {
     * @return A pointer to the first child node
     */
     function firstChildOf(bytes memory der, uint256 ptr) internal pure returns (uint256) {
-        require(der[ptr.ixs()] & 0x20 == 0x20, "Not a constructed type");
+        if (der[ptr.ixs()] & 0x20 != 0x20) revert ASN1_NOT_CONSTRUCTED_TYPE();
         return _readNodeLength(der, ptr.ixf());
     }
 

--- a/packages/protocol/contracts/layer1/automata-attestation/utils/BytesUtils.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/utils/BytesUtils.sol
@@ -6,6 +6,10 @@ pragma solidity ^0.8.24;
 /// @title BytesUtils
 /// @custom:security-contact security@taiko.xyz
 library BytesUtils {
+    error BYTES_INVALID_OFFSET();
+    error BYTES_INVALID_IDX();
+    error BYTES_UNEXPECTED_LEN();
+    error BYTES_UNEXPECTED_IDX();
     /*
     * @dev Returns the keccak-256 hash of a byte range.
     * @param self The byte string to hash.
@@ -22,7 +26,7 @@ library BytesUtils {
         pure
         returns (bytes32 ret)
     {
-        require(offset + len <= self.length, "invalid offset");
+        if (offset + len > self.length) revert BYTES_INVALID_OFFSET();
         assembly {
             ret := keccak256(add(add(self, 32), offset), len)
         }
@@ -68,7 +72,7 @@ library BytesUtils {
     * @return The specified 16 bits of the string, interpreted as an integer.
     */
     function readUint16(bytes memory self, uint256 idx) internal pure returns (uint16 ret) {
-        require(idx + 2 <= self.length, "invalid idx");
+        if (idx + 2 > self.length) revert BYTES_INVALID_IDX();
         assembly {
             ret := and(mload(add(add(self, 2), idx)), 0xFFFF)
         }
@@ -90,8 +94,8 @@ library BytesUtils {
         pure
         returns (bytes32 ret)
     {
-        require(len <= 32, "unexpected len");
-        require(idx + len <= self.length, "unexpected idx");
+        if (len > 32) revert BYTES_UNEXPECTED_LEN();
+        if (idx + len > self.length) revert BYTES_UNEXPECTED_IDX();
         assembly {
             let mask := not(sub(exp(256, sub(32, len)), 1))
             ret := and(mload(add(add(self, 32), idx)), mask)
@@ -119,7 +123,7 @@ library BytesUtils {
         pure
         returns (bytes memory)
     {
-        require(offset + len <= self.length, "unexpected offset");
+        if (offset + len > self.length) revert BYTES_INVALID_OFFSET();
 
         bytes memory ret = new bytes(len);
         uint256 dest;

--- a/packages/protocol/contracts/layer1/automata-attestation/utils/BytesUtils.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/utils/BytesUtils.sol
@@ -10,6 +10,7 @@ library BytesUtils {
     error BYTES_INVALID_IDX();
     error BYTES_UNEXPECTED_LEN();
     error BYTES_UNEXPECTED_IDX();
+
     /*
     * @dev Returns the keccak-256 hash of a byte range.
     * @param self The byte string to hash.

--- a/packages/protocol/contracts/layer1/devnet/OpVerifier.sol
+++ b/packages/protocol/contracts/layer1/devnet/OpVerifier.sol
@@ -8,6 +8,9 @@ import "src/layer1/verifiers/IProofVerifier.sol";
 /// @dev ONLY FOR TESTING - DO NOT USE IN PRODUCTION
 /// @custom:security-contact security@taiko.xyz
 contract OpVerifier is IProofVerifier {
+    error InvalidHashToProve();
+    error InvalidProof();
+
     /// @inheritdoc IProofVerifier
     /// @dev This is a dummy implementation that always succeeds
     function verifyProof(
@@ -20,7 +23,7 @@ contract OpVerifier is IProofVerifier {
     {
         // Dummy verifier - no actual verification
         // Just check that we received some data to avoid misuse
-        require(_hashToProve != bytes32(0), "Invalid hash to prove");
-        require(_proof.length > 0, "Invalid proof");
+        if (_hashToProve == bytes32(0)) revert InvalidHashToProve();
+        if (_proof.length == 0) revert InvalidProof();
     }
 }

--- a/packages/protocol/contracts/layer1/preconf/libs/LibBLS12381.sol
+++ b/packages/protocol/contracts/layer1/preconf/libs/LibBLS12381.sol
@@ -8,6 +8,9 @@ pragma solidity ^0.8.24;
 library LibBLS12381 {
     using LibBLS12381 for *;
 
+    error BLS_LEN_IN_BYTES_TOO_LARGE();
+    error BLS_DST_TOO_LONG();
+
     struct FieldPoint2 {
         uint256[2] u;
         uint256[2] u_I;
@@ -322,11 +325,11 @@ library LibBLS12381 {
         uint256 ell = (lenInBytes - 1) / 32 + 1;
 
         // 2.  ABORT if ell > 255 or len_in_bytes > 65535 or len(DST) > 255
-        require(ell <= 255, "len_in_bytes too large for sha256");
+        if (ell > 255) revert BLS_LEN_IN_BYTES_TOO_LARGE();
         // Not really needed because of parameter type
         // require(lenInBytes <= 65535, "len_in_bytes too large");
         // no length normalizing via hashing
-        require(dst.length <= 255, "dst too long");
+        if (dst.length > 255) revert BLS_DST_TOO_LONG();
 
         bytes memory dstPrime = bytes.concat(dst, bytes1(uint8(dst.length)));
 

--- a/packages/protocol/contracts/layer1/verifiers/Risc0Verifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/Risc0Verifier.sol
@@ -29,10 +29,12 @@ contract Risc0Verifier is IProofVerifier, Ownable2Step {
     error RISC_ZERO_INVALID_BLOCK_PROOF_IMAGE_ID();
     error RISC_ZERO_INVALID_AGGREGATION_IMAGE_ID();
     error RISC_ZERO_INVALID_PROOF();
+    error RISC_ZERO_INVALID_CHAIN_ID();
+    error RISC_ZERO_INVALID_GROTH16_VERIFIER();
 
     constructor(uint64 _taikoChainId, address _riscoGroth16Verifier, address _owner) {
-        require(_taikoChainId != 0, "Invalid chain id");
-        require(_riscoGroth16Verifier != address(0), "Invalid risc0 groth16 verifier");
+        if (_taikoChainId == 0) revert RISC_ZERO_INVALID_CHAIN_ID();
+        if (_riscoGroth16Verifier == address(0)) revert RISC_ZERO_INVALID_GROTH16_VERIFIER();
         taikoChainId = _taikoChainId;
         riscoGroth16Verifier = _riscoGroth16Verifier;
 

--- a/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
@@ -71,9 +71,10 @@ contract SgxVerifier is IProofVerifier, Ownable2Step {
     error SGX_INVALID_ATTESTATION();
     error SGX_INVALID_INSTANCE();
     error SGX_INVALID_PROOF();
+    error SGX_INVALID_CHAIN_ID();
 
     constructor(uint64 _taikoChainId, address _owner, address _automataDcapAttestation) {
-        require(_taikoChainId != 0, "Invalid chain id");
+        if (_taikoChainId == 0) revert SGX_INVALID_CHAIN_ID();
         taikoChainId = _taikoChainId;
         automataDcapAttestation = _automataDcapAttestation;
 


### PR DESCRIPTION
## Summary

Convert require statements with string messages to custom errors across verifier and utility contracts. This improves gas efficiency and provides clearer error handling.

## Changes

- Updated OpVerifier to use custom errors for validation
- Updated Risc0Verifier and SgxVerifier with chain ID validation errors
- Updated LibBLS12381 with custom errors for length validation
- Updated Asn1Decode with custom errors for ASN.1 type validation
- Updated BytesUtils with custom errors for offset/index validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)