### PR TITLE
feat(protocol): make taiko cheaper

### DIFF
--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -40,7 +40,7 @@ contract DevnetInbox is TaikoInbox {
                 adjustmentQuotient: 8,
                 sharingPctg: 75,
                 gasIssuancePerSecond: 5_000_000,
-                minGasExcess: 1_344_899_430, // 0.01 gwei
+                minGasExcess: 1_289_447_652, // 0.0025 gwei
                 maxGasIssuancePerBlock: 600_000_000
             }),
             provingWindow: 2 hours,

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -95,7 +95,7 @@ contract HeklaInbox is TaikoInbox {
                 adjustmentQuotient: 8,
                 sharingPctg: 75,
                 gasIssuancePerSecond: 5_000_000,
-                minGasExcess: 1_344_899_430, // 0.01 gwei
+                minGasExcess: 1_289_447_652, // 0.0025 gwei
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
             provingWindow: 2 hours,

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -40,7 +40,7 @@ contract MainnetInbox is TaikoInbox {
                 adjustmentQuotient: 8,
                 sharingPctg: 75,
                 gasIssuancePerSecond: 5_000_000,
-                minGasExcess: 1_344_899_430, // 0.01 gwei
+                minGasExcess: 1_289_447_652, // 0.0025 gwei
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 2 hours,

--- a/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
@@ -29,7 +29,6 @@ contract TaikoAnchor is EssentialContract, IBlockHashProvider, TaikoAnchorDeprec
 
     /// @notice Golden touch address is the only address that can do the anchor transaction.
     address public constant GOLDEN_TOUCH_ADDRESS = 0x0000777735367b36bC9B61C50022d9D0700dB4Ec;
-    uint256 public constant BASEFEE_MIN_VALUE = 25_000_000; //  0.025 gwei
 
     ISignalService public immutable signalService;
     uint64 public immutable pacayaForkHeight;
@@ -265,10 +264,6 @@ contract TaikoAnchor is EssentialContract, IBlockHashProvider, TaikoAnchorDeprec
         (basefee_, newGasExcess_) = LibEIP1559.calc1559BaseFee(
             newGasTarget_, newGasExcess_, gasIssuance, _parentGasUsed, _baseFeeConfig.minGasExcess
         );
-
-        if (basefee_ < BASEFEE_MIN_VALUE) {
-            basefee_ = BASEFEE_MIN_VALUE;
-        }
     }
 
     /// @inheritdoc IBlockHashProvider

--- a/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
@@ -29,6 +29,7 @@ contract TaikoAnchor is EssentialContract, IBlockHashProvider, TaikoAnchorDeprec
 
     /// @notice Golden touch address is the only address that can do the anchor transaction.
     address public constant GOLDEN_TOUCH_ADDRESS = 0x0000777735367b36bC9B61C50022d9D0700dB4Ec;
+    uint256 public constant BASEFEE_MIN_VALUE = 2_500_000; // 0.0025 gwei
 
     ISignalService public immutable signalService;
     uint64 public immutable pacayaForkHeight;
@@ -264,6 +265,10 @@ contract TaikoAnchor is EssentialContract, IBlockHashProvider, TaikoAnchorDeprec
         (basefee_, newGasExcess_) = LibEIP1559.calc1559BaseFee(
             newGasTarget_, newGasExcess_, gasIssuance, _parentGasUsed, _baseFeeConfig.minGasExcess
         );
+
+        if (basefee_ < BASEFEE_MIN_VALUE) {
+            basefee_ = BASEFEE_MIN_VALUE;
+        }
     }
 
     /// @inheritdoc IBlockHashProvider

--- a/packages/protocol/test/layer2/LibEIP1559.t.sol
+++ b/packages/protocol/test/layer2/LibEIP1559.t.sol
@@ -37,7 +37,7 @@ contract TestLibEIP1559 is Layer2Test {
             "Mainnet minimal basefee ontake: ", LibEIP1559.basefee(5_000_000 * 8, 1_340_000_000)
         );
         console2.log(
-            "Mainnet minimal basefee pacaya: ", LibEIP1559.basefee(5_000_000 * 8, 1_344_899_430)
+            "Mainnet minimal basefee pacaya: ", LibEIP1559.basefee(5_000_000 * 8, 1_289_447_652)
         );
     }
 


### PR DESCRIPTION
Current base fee = 0.025 gwei(https://taikoscan.io/gastracker)

Reduce minimum base fee to `0.0025 gwei` now that L1 is much cheaper and remove hardcoded `BASEFEE_MIN_VALUE` since the minimum calculated by the EIP-1559 curve is now smaller.

Script for the DAO proposal coming soon.

@davidtaikocha @dantaik please review the changes carefully since this is a part of the codebase I'm not familiar with

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers the base fee floor to 0.0025 gwei by reducing `BASEFEE_MIN_VALUE` and updating `minGasExcess` in L1 configs, with tests adjusted accordingly.
> 
> - **Protocol**:
>   - **L2**:
>     - Reduce `BASEFEE_MIN_VALUE` in `packages/protocol/contracts/layer2/based/TaikoAnchor.sol` from `25_000_000` (0.025 gwei) to `2_500_000` (0.0025 gwei).
>   - **L1 Configs**:
>     - Update `baseFeeConfig.minGasExcess` to `1_289_447_652` (was `1_344_899_430`) in:
>       - `packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol`
>       - `packages/protocol/contracts/layer1/hekla/HeklaInbox.sol`
>       - `packages/protocol/contracts/layer1/devnet/DevnetInbox.sol`
> - **Tests**:
>   - Adjust `test_mainnet_min_basefee` in `packages/protocol/test/layer2/LibEIP1559.t.sol` to use new `minGasExcess` value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9779eae0c7884ee0e7d48434f16d1b14cd5f185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->