### PR TITLE
refactor: reformat comments to wrap at 100 characters

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IForcedInclusionStore.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IForcedInclusionStore.sol
@@ -39,7 +39,8 @@ interface IForcedInclusionStore {
     /// @dev Returns an empty array if `_start` is outside the valid range [head, tail) or if
     ///      `_maxCount` is zero. Otherwise returns actual stored entries from the queue.
     /// @param _start The queue index to start reading from (must be in range [head, tail)).
-    /// @param _maxCount Maximum number of inclusions to return. Passing zero returns an empty array.
+    /// @param _maxCount Maximum number of inclusions to return. Passing zero returns an empty
+    ///        array.
     /// @return inclusions_ Forced inclusions from the queue starting at `_start`. The actual length
     ///         will be `min(_maxCount, tail - _start)`, or zero if `_start` is out of range.
     function getForcedInclusions(

--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -198,7 +198,8 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     ///      2. Process `input.numForcedInclusions` forced inclusions. The proposer is forced to
     ///         process at least `config.minForcedInclusionCount` if they are due.
     ///      3. Updates core state and emits `Proposed` event
-    /// NOTE: This function can only be called once per block to prevent spams that can fill the ring buffer.
+    /// NOTE: This function can only be called once per block to prevent spams that can fill the
+    /// ring buffer.
     function propose(bytes calldata _lookahead, bytes calldata _data) external onlyWhenActivated nonReentrant {
         unchecked {
             ProposeInput memory input = LibProposeInputCodec.decode(_data);
@@ -222,22 +223,24 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
 
     /// @dev Verifies a batch proof covering multiple consecutive proposals and finalizes them.
     ///
-    /// The proof covers a contiguous range of proposals. The input contains an array of ProposalState
-    /// structs, each with the proposal's metadata and block hash. The proof range can start
-    /// at or before the last finalized proposal to handle race conditions where proposals get
-    /// finalized between proof generation and submission.
+    /// The proof covers a contiguous range of proposals. The input contains an array of
+    /// ProposalState structs, each with the proposal's metadata and block hash. The proof range
+    /// can start at or before the last finalized proposal to handle race conditions where
+    /// proposals get finalized between proof generation and submission.
     ///
     /// Example: Proving proposals 3-7 when lastFinalizedProposalId=4
     ///
     ///       lastFinalizedProposalId                nextProposalId
-    ///                             ↓                             ↓
+    ///                             ┆                             ┆
+    ///                             ▼                             ▼
     ///     0     1     2     3     4     5     6     7     8     9
     ///     ■─────■─────■─────■─────■─────□─────□─────□─────□─────
-    ///                       └── input.proposalStates[] ─┘
-    ///                       ↑     ↑                     ↑
-    ///              firstProposalId |            lastProposalId
-    ///                           offset (proposalStates[0..offset-1] already finalized)
-    ///
+    ///                       ▲           ▲                 ▲
+    ///                       ┆<-offset-> ┆                 ┆
+    ///                       ┆                             ┆
+    ///                       ┆<-  input.proposalStates[] ->┆ 
+    ///         firstProposalId                             lastProposalId
+    ///                           
     /// Key validation rules:
     /// 1. firstProposalId <= lastFinalizedProposalId + 1 (can overlap with finalized range)
     /// 2. lastProposalId < nextProposalId (cannot prove unproposed blocks)
@@ -340,8 +343,9 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @inheritdoc IForcedInclusionStore
-    /// @dev This function will revert if called before the first non-activation proposal is submitted
-    /// to make sure blocks have been produced already and the derivation can use the parent's block timestamp.
+    /// @dev This function will revert if called before the first non-activation proposal is
+    /// submitted to make sure blocks have been produced already and the derivation can use the
+    /// parent's block timestamp.
     function saveForcedInclusion(LibBlobs.BlobReference memory _blobReference) external payable {
         bytes32 proposalHash = _proposalHashes[1];
         require(proposalHash != bytes32(0), IncorrectProposalCount());
@@ -391,8 +395,9 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     }
 
     /// @notice Retrieves the proposal hash for a given proposal ID
-    /// @dev Note that due to the ring buffer nature of the `_proposalHashes` mapping proposals may
-    /// have been overwritten by a new one. You should verify that the hash matches the expected proposal.
+    /// @dev Note that due to the ring buffer nature of the `_proposalHashes` mapping proposals
+    /// may have been overwritten by a new one. You should verify that the hash matches the
+    /// expected proposal.
     /// @param _proposalId The ID of the proposal to query
     /// @return proposalHash_ The keccak256 hash of the Proposal struct at the ring buffer slot
     function getProposalHash(uint48 _proposalId) external view returns (bytes32 proposalHash_) {
@@ -436,7 +441,8 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
     /// @param _nextProposalId The proposal ID to assign.
     /// @param _lastProposalBlockId The last block number where a proposal was made.
     /// @param _lastFinalizedProposalId The ID of the last finalized proposal.
-    /// @return proposal_ The proposal with final endOfSubmissionWindowTimestamp and derivation hash set.
+    /// @return proposal_ The proposal with final endOfSubmissionWindowTimestamp and derivation
+    /// hash set.
     /// @return derivation_ The derivation data for the proposal.
     function _buildProposal(
         ProposeInput memory _input,

--- a/packages/protocol/contracts/layer1/core/libs/LibBondInstruction.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibBondInstruction.sol
@@ -11,12 +11,14 @@ library LibBondInstruction {
     ///
     /// Bond logic:
     /// - If proof is on-time (proposalAge <= provingWindow): No bond transfer
-    /// - If proof is late but within extended window: LIVENESS bond (designatedProver pays actualProver)
+    /// - If proof is late but within extended window: LIVENESS bond (designatedProver pays
+    ///   actualProver)
     /// - If proof is after extended window: PROVABILITY bond (proposer pays actualProver)
     /// - If payer == payee: No bond transfer
     ///
     /// @param _proposalId The proposal ID.
-    /// @param _proposalAge Time elapsed since the proposal became ready (block.timestamp - readyTimestamp).
+    /// @param _proposalAge Time elapsed since the proposal became ready
+    ///        (block.timestamp - readyTimestamp).
     /// @param _proposer The proposer address.
     /// @param _designatedProver The designated prover address.
     /// @param _actualProver The actual prover address.

--- a/packages/protocol/contracts/layer1/core/libs/LibForcedInclusion.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibForcedInclusion.sol
@@ -99,7 +99,8 @@ library LibForcedInclusion {
     /// @dev Returns an empty array if `_start` is outside the valid range [head, tail) or if
     ///      `_maxCount` is zero. Otherwise returns actual stored entries from the queue.
     /// @param _start The queue index to start reading from (must be in range [head, tail)).
-    /// @param _maxCount Maximum number of inclusions to return. Passing zero returns an empty array.
+    /// @param _maxCount Maximum number of inclusions to return. Passing zero returns an empty
+    ///        array.
     /// @return inclusions_ Forced inclusions from the queue starting at `_start`. The actual length
     ///         will be `min(_maxCount, tail - _start)`, or zero if `_start` is out of range.
     function getForcedInclusions(

--- a/packages/protocol/contracts/layer1/core/libs/LibHashOptimized.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibHashOptimized.sol
@@ -33,8 +33,8 @@ library LibHashOptimized {
             // [5] sources length
             uint256 totalWords = 6 + sourcesLength;
 
-            // Each source contributes: element head (2) + blobSlice head (3) + blobHashes length (1)
-            // + blobHashes entries
+            // Each source contributes: element head (2) + blobSlice head (3) + blobHashes
+            // length (1) + blobHashes entries
             for (uint256 i; i < sourcesLength; ++i) {
                 totalWords += 6 + sources[i].blobSlice.blobHashes.length;
             }

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
@@ -25,7 +25,8 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist, IProposerChec
     /// @dev The number of epochs before a newly added operator becomes active.
     uint8 public constant OPERATOR_CHANGE_DELAY = 2;
     /// @dev The number of epochs to use as delay when selecting an operator.
-    ///      This needs to be 2 epochs or more to ensure the randomness seed source is stable across epochs.
+    ///      This needs to be 2 epochs or more to ensure the randomness seed source is stable
+    ///      across epochs.
     uint8 public constant RANDOMNESS_DELAY = 2;
 
     // ---------------------------------------------------------------
@@ -51,7 +52,8 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist, IProposerChec
     /// @dev Deprecated variable. Kept for storage compatibility.
     bool private _deprecatedHavingPerfectOperators;
     /// @notice The epoch when the latest operator was or will be activated.
-    /// @dev No need to reinitialize the contract, this value starts at 0(i.e. no pending activations)
+    /// @dev No need to reinitialize the contract, this value starts at 0
+    ///      (i.e. no pending activations)
     uint32 public latestActivationEpoch;
 
     /// @dev The addresses that can eject operators from the whitelist.
@@ -238,14 +240,16 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist, IProposerChec
     }
 
     /// @dev Returns the operator for the given epoch
-    /// This function is not affected by operators that are added mid-epoch, since it filters active ones.
+    /// This function is not affected by operators that are added mid-epoch, since it filters
+    /// active ones.
     /// NOTE: We optimize for the common case where all operators are active.
     /// In that case we don't scan the entire operator set or check if the operator is active.
     /// @param _epochTimestamp The timestamp of the epoch to get the operator for.
     /// @return The operator for the given epoch.
     function _getOperatorForEpoch(uint32 _epochTimestamp) internal view returns (address) {
         unchecked {
-            // Get epoch-stable randomness with a delayed applied. This avoids querying future beacon roots.
+            // Get epoch-stable randomness with a delayed applied. This avoids querying future
+            // beacon roots.
             uint256 delaySeconds = RANDOMNESS_DELAY * LibPreconfConstants.SECONDS_IN_EPOCH;
             uint256 ts = uint256(_epochTimestamp);
             uint32 randomnessTs = uint32(ts >= delaySeconds ? ts - delaySeconds : ts);
@@ -257,7 +261,8 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist, IProposerChec
             if (_operatorCount == 0) return address(0);
             uint256 randomNumber = _getRandomNumber(randomnessTs);
             if (_epochTimestamp >= _latestActivationEpoch) {
-                // Fast path: This means all operators are active, so we can just select one without checking
+                // Fast path: This means all operators are active, so we can just select one without
+                // checking
                 return operatorMapping[randomNumber % _operatorCount];
             }
 

--- a/packages/protocol/test/layer1/core/inbox/InboxPropose.t.sol
+++ b/packages/protocol/test/layer1/core/inbox/InboxPropose.t.sol
@@ -287,7 +287,8 @@ contract InboxProposeTest is InboxTestBase {
     // Boundary Tests - propose() conditions
     // =========================================================================
 
-    /// @notice Test propose succeeds at exact block boundary (block.number == lastProposalBlockId + 1)
+    /// @notice Test propose succeeds at exact block boundary
+    /// (block.number == lastProposalBlockId + 1)
     function test_propose_succeedsWhen_NextBlock() public {
         _setBlobHashes(2);
 
@@ -332,7 +333,8 @@ contract InboxProposeTest is InboxTestBase {
         inbox.propose(bytes(""), encodedInput);
     }
 
-    /// @notice Test permissionless proposal at exact boundary (timestamp == permissionlessTimestamp)
+    /// @notice Test permissionless proposal at exact boundary
+    /// (timestamp == permissionlessTimestamp)
     function test_propose_notPermissionlessWhen_AtExactPermissionlessTimestamp() public {
         _setBlobHashes(3);
         _proposeAndDecode(_defaultProposeInput());

--- a/packages/protocol/test/layer1/core/inbox/InboxProve.t.sol
+++ b/packages/protocol/test/layer1/core/inbox/InboxProve.t.sol
@@ -529,7 +529,8 @@ contract InboxProveTest is InboxTestBase {
     // Boundary Tests - Bond instruction timing
     // =========================================================================
 
-    /// @notice Test proving at exact provingWindow boundary (proposalAge == provingWindow) - no bond
+    /// @notice Test proving at exact provingWindow boundary (proposalAge == provingWindow)
+    /// - no bond
     function test_prove_noBondSignal_atExactProvingWindowBoundary() public {
         IInbox.ProposedEventPayload memory proposed = _proposeOne();
 
@@ -629,7 +630,8 @@ contract InboxProveTest is InboxTestBase {
 
         _prove(input);
 
-        // At exact extendedProvingWindow boundary (proposalAge <= extendedProvingWindow), LIVENESS bond
+        // At exact extendedProvingWindow boundary (proposalAge <= extendedProvingWindow),
+        // LIVENESS bond
         LibBonds.BondInstruction memory instruction = LibBonds.BondInstruction({
             proposalId: proposed.proposal.id,
             bondType: LibBonds.BondType.LIVENESS,
@@ -666,7 +668,8 @@ contract InboxProveTest is InboxTestBase {
 
         _prove(input);
 
-        // Past extendedProvingWindow triggers PROVABILITY bond (proposer pays, not designatedProver)
+        // Past extendedProvingWindow triggers PROVABILITY bond
+        // (proposer pays, not designatedProver)
         LibBonds.BondInstruction memory instruction = LibBonds.BondInstruction({
             proposalId: proposed.proposal.id,
             bondType: LibBonds.BondType.PROVABILITY,


### PR DESCRIPTION
## Summary
- Reformat long comment lines exceeding 100 character limit
- Improve diagram visualization in Inbox.sol using box-drawing characters (┆, ▼, ▲)
- Preserve special cases (URLs, diagrams, numeric constants)

## Test Plan
- Code compiles without errors
- Comments remain accurate and readable
- No functional changes