### PR TITLE
feat(protocol): update `DeployProtocolOnL1` to support upgrade existed `whitelist`

### DIFF
--- a/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol
@@ -167,11 +167,16 @@ contract DeployProtocolOnL1 is DeployCapability {
         returns (address shastaInbox)
     {
         // Deploy whitelist
-        address whitelist = deployProxy({
-            name: "preconf_whitelist",
-            impl: address(new PreconfWhitelist()),
-            data: abi.encodeCall(PreconfWhitelist.init, (config.contractOwner))
-        });
+        address whitelist = config.preconfWhitelist;
+        if (whitelist == address(0)) {
+            whitelist = deployProxy({
+                name: "preconf_whitelist",
+                impl: address(new PreconfWhitelist()),
+                data: abi.encodeCall(PreconfWhitelist.init, (config.contractOwner))
+            });
+        } else {
+            PreconfWhitelist(whitelist).upgradeTo(address(new PreconfWhitelist()));
+        }
 
         PreconfWhitelist(whitelist).addOperator(config.proposerAddress, config.proposerAddress);
 
@@ -194,9 +199,7 @@ contract DeployProtocolOnL1 is DeployCapability {
         shastaInbox = deployProxy({
             name: "shasta_inbox",
             impl: address(
-                new DevnetInbox(
-                    proofVerifier, whitelist, signalService, address(new CodecOptimized())
-                )
+                new DevnetInbox(proofVerifier, whitelist, signalService, address(new CodecOptimized()))
             ),
             data: abi.encodeCall(Inbox.init, (msg.sender))
         });
@@ -206,8 +209,9 @@ contract DeployProtocolOnL1 is DeployCapability {
         }
         console2.log("ShastaInbox deployed:", shastaInbox);
 
-        SignalService(signalService)
-            .upgradeTo(address(new SignalService(shastaInbox, config.remoteSigSvc)));
+        SignalService(signalService).upgradeTo(
+            address(new SignalService(shastaInbox, config.remoteSigSvc))
+        );
         console2.log("SignalService upgraded with Shasta inbox authorized syncer");
 
         if (config.contractOwner != msg.sender) {
@@ -278,8 +282,9 @@ contract DeployProtocolOnL1 is DeployCapability {
     }
 
     function _deployBridge(address sharedResolver, DeploymentConfig memory config) private {
-        address signalService = IResolver(sharedResolver)
-            .resolve(uint64(block.chainid), LibNames.B_SIGNAL_SERVICE, false);
+        address signalService = IResolver(sharedResolver).resolve(
+            uint64(block.chainid), LibNames.B_SIGNAL_SERVICE, false
+        );
 
         address bridge = deployProxy({
             name: "bridge",
@@ -344,8 +349,7 @@ contract DeployProtocolOnL1 is DeployCapability {
             name: "automata_dcap_attestation",
             impl: address(new AutomataDcapV3Attestation()),
             data: abi.encodeCall(
-                AutomataDcapV3Attestation.init,
-                (owner, address(sigVerifyLib), address(pemCertChainLib))
+                AutomataDcapV3Attestation.init, (owner, address(sigVerifyLib), address(pemCertChainLib))
             )
         });
         // Deploy sgx-geth automata attestation proxy
@@ -353,8 +357,7 @@ contract DeployProtocolOnL1 is DeployCapability {
             name: "sgx_geth_automata_dcap_attestation",
             impl: address(new AutomataDcapV3Attestation()),
             data: abi.encodeCall(
-                AutomataDcapV3Attestation.init,
-                (owner, address(sigVerifyLib), address(pemCertChainLib))
+                AutomataDcapV3Attestation.init, (owner, address(sigVerifyLib), address(pemCertChainLib))
             )
         });
     }


### PR DESCRIPTION
We have this feature in [`main` branch's `DeployProtocolOnL1`](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol#L179). Added it back to `consecutive-proofs` branch since Nehtermind is still using it.