### PR TITLE
fix(taiko-client,taiko-client-rs): update `TIMESTAMP_MAX_OFFSET`

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
@@ -15,7 +15,7 @@ pub const MAX_ANCHOR_OFFSET: u64 = 128;
 pub const MIN_ANCHOR_OFFSET: u64 = 2;
 
 /// The maximum timestamp offset from the proposal origin timestamp.
-pub const TIMESTAMP_MAX_OFFSET: u64 = 12 * 32;
+pub const TIMESTAMP_MAX_OFFSET: u64 = 12 * 128;
 
 /// The minimum block gas limit.
 pub const MIN_BLOCK_GAS_LIMIT: u64 = 10_000_000;

--- a/packages/taiko-client/bindings/manifest/manifest.go
+++ b/packages/taiko-client/bindings/manifest/manifest.go
@@ -14,7 +14,7 @@ const (
 	// ProposalMaxBlocks The maximum number of blocks allowed in a proposal.
 	ProposalMaxBlocks = 384
 	// TimestampMaxOffset The maximum number timestamp offset from the proposal origin timestamp.
-	TimestampMaxOffset = 12 * 32
+	TimestampMaxOffset = 12 * 128
 	// AnchorMinOffset The minimum anchor block number offset from the proposal origin block number.
 	AnchorMinOffset = 2
 	// AnchorMaxOffset The maximum anchor block number offset from the proposal origin block number.


### PR DESCRIPTION
Fix constants according to the [derivation spec](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v3.0.0/packages/protocol/docs/Derivation.md#constants)

Closes: https://github.com/taikoxyz/taiko-mono/pull/20910 , with the latest bindings changes to pass CI checks.