### PR TITLE
docs(protocol): improve natspec of BondManager to resolve audit issue

### DIFF
--- a/packages/protocol/contracts/layer2/core/IBondManager.sol
+++ b/packages/protocol/contracts/layer2/core/IBondManager.sol
@@ -79,10 +79,14 @@ interface IBondManager {
     function getBondBalance(address _address) external view returns (uint256);
 
     /// @notice Deposit ERC20 bond tokens into the manager.
+    /// @dev Does not cancel a pending withdrawal; callers must invoke `cancelWithdrawal` to
+    /// reactivate their bond status.
     /// @param _amount The amount to deposit.
     function deposit(uint256 _amount) external;
 
     /// @notice Deposit ERC20 bond tokens for another address.
+    /// @dev Does not cancel the recipient's pending withdrawal; the recipient must call
+    /// `cancelWithdrawal` to reactivate their bond status.
     /// @param _recipient The address to credit the bond to.
     /// @param _amount The amount to deposit.
     function depositTo(address _recipient, uint256 _amount) external;
@@ -107,7 +111,9 @@ interface IBondManager {
         returns (bool);
 
     /// @notice Request to start the withdrawal process
-    /// @dev Account cannot perform bond-restricted actions after requesting withdrawal
+    /// @dev Account cannot perform bond-restricted actions after requesting withdrawal. Proposers
+    /// should self-eject before calling to avoid having subsequent proposals classified as
+    /// low-bond.
     function requestWithdrawal() external;
 
     /// @notice Cancel withdrawal request to reactivate the account

--- a/packages/protocol/test/layer2/core/BondManager.t.sol
+++ b/packages/protocol/test/layer2/core/BondManager.t.sol
@@ -123,6 +123,21 @@ contract BondManagerTest is Test {
         assertEq(bondManager.getBondBalance(Alice), 50 ether);
     }
 
+    function test_deposit_DoesNotCancelWithdrawalRequest() external {
+        vm.prank(Alice);
+        bondManager.deposit(MIN_BOND);
+
+        vm.prank(Alice);
+        bondManager.requestWithdrawal();
+
+        vm.prank(Alice);
+        bondManager.deposit(1 ether);
+
+        (, uint48 requestedAt) = bondManager.bond(Alice);
+        assertGt(requestedAt, 0);
+        assertFalse(bondManager.hasSufficientBond(Alice, 0));
+    }
+
     function test_deposit_RevertWhen_ZeroAmountApproval() external {
         vm.prank(Alice);
         bondToken.approve(address(bondManager), 0);
@@ -167,6 +182,21 @@ contract BondManagerTest is Test {
         bondManager.depositTo(Carol, 20 ether);
 
         assertEq(bondManager.getBondBalance(Carol), 50 ether);
+    }
+
+    function test_depositTo_DoesNotCancelWithdrawalRequest() external {
+        vm.prank(Bob);
+        bondManager.depositTo(Carol, MIN_BOND);
+
+        vm.prank(Carol);
+        bondManager.requestWithdrawal();
+
+        vm.prank(Bob);
+        bondManager.depositTo(Carol, 1 ether);
+
+        (, uint48 requestedAt) = bondManager.bond(Carol);
+        assertGt(requestedAt, 0);
+        assertFalse(bondManager.hasSufficientBond(Carol, 0));
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Fixes #20998

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies IBondManager deposit/withdrawal semantics and adds tests verifying deposits don’t cancel pending withdrawals.
> 
> - **Protocol**:
>   - **`contracts/layer2/core/IBondManager.sol`**: Clarify Natspec for `deposit`/`depositTo` that deposits do not cancel a pending withdrawal and require `cancelWithdrawal` to reactivate; expand `requestWithdrawal` notes advising proposers to self-eject to avoid low-bond classification.
> - **Tests**:
>   - **`test/layer2/core/BondManager.t.sol`**: Add tests ensuring `deposit` and `depositTo` do not cancel a pending withdrawal and that `hasSufficientBond` remains false until cancellation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 383b6836f1ec82d4a24f405d6d4d2b714827658f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->