### PR TITLE
refactor(protocol): rename c to commitment and improve ProveInput documentation

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IInbox.sol
@@ -141,12 +141,26 @@ interface IInbox {
         Transition[] transitions;
     }
 
-    /// @notice Input data for the prove function
+    /// @notice Input data for the prove function.
+    /// @dev This struct contains two categories of data:
+    ///      1. Commitment data - What the prover is actually proving. This must be fully
+    ///         determined before proof generation and is the only input to the prover's
+    ///         guest program.
+    ///      2. Usage options - Parameters that can be decided after proof generation
+    ///         (e.g., whether to proactively write a checkpoint). The prover system can
+    ///         choose or adjust these options using additional data during or after
+    ///         proof generation.
     struct ProveInput {
+        // -------------------------------------------------------------------
+        // Commitment data (input to the prover's guest program)
+        // -------------------------------------------------------------------
         /// @notice The commitment data that the proof verifies.
         Commitment commitment;
+        // -------------------------------------------------------------------
+        // Usage options (can be adjusted after proof generation)
+        // -------------------------------------------------------------------
         /// @notice Whether to force syncing the last checkpoint even if the minimum
-        /// delay has not passed
+        /// delay has not passed.
         /// @dev This allows checkpoint synchronization ahead of schedule.
         bool forceCheckpointSync;
     }

--- a/packages/protocol/contracts/layer1/core/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IInbox.sol
@@ -151,14 +151,8 @@ interface IInbox {
     ///         choose or adjust these options using additional data during or after
     ///         proof generation.
     struct ProveInput {
-        // -------------------------------------------------------------------
-        // Commitment data (input to the prover's guest program)
-        // -------------------------------------------------------------------
         /// @notice The commitment data that the proof verifies.
         Commitment commitment;
-        // -------------------------------------------------------------------
-        // Usage options (can be adjusted after proof generation)
-        // -------------------------------------------------------------------
         /// @notice Whether to force syncing the last checkpoint even if the minimum
         /// delay has not passed.
         /// @dev This allows checkpoint synchronization ahead of schedule.


### PR DESCRIPTION
## Summary
- Renamed variable `c` to `commitment` in `Inbox.prove()` for improved code clarity
- Enhanced `ProveInput` struct documentation to distinguish between commitment data (prover input) and usage options (adjustable post-proof)