### PR TITLE
fix(taiko-client): remove redundant IsShasta guard in HandleShasta

### DIFF
--- a/packages/taiko-client/prover/event_handler/shasta_proposed.go
+++ b/packages/taiko-client/prover/event_handler/shasta_proposed.go
@@ -23,10 +23,6 @@ func (h *BatchProposedEventHandler) HandleShasta(
 	meta metadata.TaikoProposalMetaData,
 	end eventIterator.EndBatchProposedEventIterFunc,
 ) error {
-	if !meta.IsShasta() {
-		log.Debug("Skip non-Shasta Proposed event", "batchID", meta.Pacaya().GetBatchID())
-		return nil
-	}
 	if meta.Shasta().GetProposal().Id.Cmp(common.Big0) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Removed an unreachable !meta.IsShasta() guard from HandleShasta, since the public Handle method already routes only Shasta metadata to this helper.