### PR TITLE
fix(protocol): address comments on PR #21009

### DIFF
--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -308,7 +308,9 @@ contract Inbox is IInbox, IForcedInclusionStore, EssentialContract {
             // ---------------------------------------------------------
             // 6. Verify the proof
             // ---------------------------------------------------------
-            uint256 proposalAge = block.timestamp - commitment.transitions[offset].timestamp;
+            // We count the proposalAge as the time since it became available for proving.
+            uint256 proposalAge = block.timestamp - 
+                commitment.transitions[offset].timestamp.max(state.lastFinalizedTimestamp);
             _proofVerifier.verifyProof(
                 proposalAge, LibHashOptimized.hashCommitment(commitment), _proof
             );

--- a/packages/protocol/contracts/layer2/core/BondManager.sol
+++ b/packages/protocol/contracts/layer2/core/BondManager.sol
@@ -127,14 +127,14 @@ contract BondManager is EssentialContract, IBondManager, IBondProcessor {
     }
 
     /// @inheritdoc IBondManager
-    function deposit(address _recipient, uint256 _amount) external nonReentrant {
-        address recipient = _recipient == address(0) ? msg.sender : _recipient;
+    function deposit(uint256 _amount) external nonReentrant {
+        _deposit(msg.sender, msg.sender, _amount);
+    }
 
-        bondToken.safeTransferFrom(msg.sender, address(this), _amount);
-
-        _creditBond(recipient, _amount);
-
-        emit BondDeposited(msg.sender, recipient, _amount);
+    /// @inheritdoc IBondManager
+    function depositTo(address _recipient, uint256 _amount) external nonReentrant {
+        require(_recipient != address(0), InvalidAddress());
+        _deposit(msg.sender, _recipient, _amount);
     }
 
     /// @inheritdoc IBondManager
@@ -243,6 +243,16 @@ contract BondManager is EssentialContract, IBondManager, IBondProcessor {
     // ---------------------------------------------------------------
     // Internal Functions
     // ---------------------------------------------------------------
+
+    /// @dev Internal implementation for depositing bonds.
+    /// @param _depositor The address providing the tokens.
+    /// @param _recipient The address receiving the bond credit.
+    /// @param _amount The amount to deposit.
+    function _deposit(address _depositor, address _recipient, uint256 _amount) internal {
+        bondToken.safeTransferFrom(_depositor, address(this), _amount);
+        _creditBond(_recipient, _amount);
+        emit BondDeposited(_depositor, _recipient, _amount);
+    }
 
     /// @dev Internal implementation for debiting a bond
     /// @param _address The address to debit the bond from

--- a/packages/protocol/contracts/layer2/core/BondManager.sol
+++ b/packages/protocol/contracts/layer2/core/BondManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import { IBondManager } from "./IBondManager.sol";
+import { IBondProcessor } from "./IBondProcessor.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { EssentialContract } from "src/shared/common/EssentialContract.sol";
@@ -16,7 +17,7 @@ import "./BondManager_Layout.sol"; // DO NOT DELETE
 ///      - Standard deposit/withdraw logic with optional minimum bond and withdrawal delay.
 ///      - Processes proved L1 bond signals (provability/liveness) with best-effort debits/credits.
 /// @custom:security-contact security@taiko.xyz
-contract BondManager is EssentialContract, IBondManager {
+contract BondManager is EssentialContract, IBondManager, IBondProcessor {
     using SafeERC20 for IERC20;
 
     // ---------------------------------------------------------------
@@ -171,7 +172,7 @@ contract BondManager is EssentialContract, IBondManager {
         emit WithdrawalCancelled(msg.sender);
     }
 
-    /// @inheritdoc IBondManager
+    /// @inheritdoc IBondProcessor
     /// @dev Slashes 50% of the debited bond.
     /// - When payer != payee, the remaining 50% goes to the payee.
     /// - When payer == payee, 40% is refunded and 10% is awarded to the caller of this function.

--- a/packages/protocol/contracts/layer2/core/IBondManager.sol
+++ b/packages/protocol/contracts/layer2/core/IBondManager.sol
@@ -68,12 +68,18 @@ interface IBondManager {
     /// @param _bond The amount of bond to credit
     function creditBond(address _address, uint256 _bond) external;
 
-    /// @notice Deposit ERC20 bond tokens for an address.
-    /// @dev Does not cancel the recipient's pending withdrawal; the recipient must call
+    /// @notice Deposit ERC20 bond tokens for the caller.
+    /// @dev Does not cancel the caller's pending withdrawal; the caller must call
     /// `cancelWithdrawal` to reactivate their bond status.
-    /// @param _recipient The address to credit the bond to. If zero, credits msg.sender.
     /// @param _amount The amount to deposit.
-    function deposit(address _recipient, uint256 _amount) external;
+    function deposit(uint256 _amount) external;
+
+    /// @notice Deposit ERC20 bond tokens for a recipient.
+    /// @dev Recipient must be non-zero. Does not cancel the recipient's pending withdrawal; the
+    /// recipient must call `cancelWithdrawal` to reactivate their bond status.
+    /// @param _recipient The address to credit the bond to.
+    /// @param _amount The amount to deposit.
+    function depositTo(address _recipient, uint256 _amount) external;
 
     /// @notice Withdraw bond to a recipient.
     /// @dev Withdrawals are subject to a delay so that bond operations can be resolved properly.

--- a/packages/protocol/contracts/layer2/core/IBondManager.sol
+++ b/packages/protocol/contracts/layer2/core/IBondManager.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { LibBonds } from "src/shared/libs/LibBonds.sol";
-
 /// @title IBondManager
 /// @notice Interface for managing bonds in the Taiko protocol
 /// @custom:security-contact security@taiko.xyz
@@ -48,11 +46,6 @@ interface IBondManager {
     /// @notice Emitted when a withdrawal request is cancelled
     event WithdrawalCancelled(address indexed account);
 
-    /// @notice Emitted when a bond instruction is processed.
-    event BondInstructionProcessed(
-        bytes32 indexed signal, LibBonds.BondInstruction instruction, uint256 debitedAmount
-    );
-
     // ---------------------------------------------------------------
     // Transactional Functions
     // ---------------------------------------------------------------
@@ -97,15 +90,6 @@ interface IBondManager {
     /// @notice Cancel withdrawal request to reactivate the account
     /// @dev Can be called during or after the withdrawal delay period
     function cancelWithdrawal() external;
-
-    /// @notice Processes a proved bond instruction from L1 with best-effort debits/credits.
-    /// @param _instruction Bond instruction tied to the signal.
-    /// @param _proof Merkle proof that the signal was sent on L1.
-    function processBondInstruction(
-        LibBonds.BondInstruction calldata _instruction,
-        bytes calldata _proof
-    )
-        external;
 
     // ---------------------------------------------------------------
     // View Functions

--- a/packages/protocol/contracts/layer2/core/IBondProcessor.sol
+++ b/packages/protocol/contracts/layer2/core/IBondProcessor.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { LibBonds } from "src/shared/libs/LibBonds.sol";
+
+/// @title IBondProcessor
+/// @notice Interface for processing proved bond instructions on L2.
+/// @custom:security-contact security@taiko.xyz
+interface IBondProcessor {
+    /// @notice Emitted when a bond instruction is processed.
+    /// @param signal The L1 signal hash associated with the instruction.
+    /// @param instruction The processed bond instruction.
+    /// @param debitedAmount The amount debited from the payer.
+    event BondInstructionProcessed(
+        bytes32 indexed signal, LibBonds.BondInstruction instruction, uint256 debitedAmount
+    );
+
+    /// @notice Processes a proved bond instruction from L1 with best-effort debits/credits.
+    /// @param _instruction Bond instruction tied to the signal.
+    /// @param _proof Merkle proof that the signal was sent on L1.
+    function processBondInstruction(
+        LibBonds.BondInstruction calldata _instruction,
+        bytes calldata _proof
+    )
+        external;
+}

--- a/packages/protocol/snapshots/shasta-prove.json
+++ b/packages/protocol/snapshots/shasta-prove.json
@@ -1,7 +1,7 @@
 {
-  "prove_batch_10": "46329",
-  "prove_batch_2": "31244",
-  "prove_batch_3": "33253",
-  "prove_batch_5": "37005",
-  "prove_single": "29525"
+  "prove_batch_10": "46441",
+  "prove_batch_2": "31356",
+  "prove_batch_3": "33365",
+  "prove_batch_5": "37117",
+  "prove_single": "29637"
 }

--- a/packages/protocol/test/layer2/core/Anchor.t.sol
+++ b/packages/protocol/test/layer2/core/Anchor.t.sol
@@ -87,13 +87,13 @@ contract AnchorTest is Test {
         token.mint(proposer, INITIAL_PROPOSER_BOND);
         vm.startPrank(proposer);
         token.approve(address(bondManager), type(uint256).max);
-        bondManager.deposit(address(0), INITIAL_PROPOSER_BOND);
+        bondManager.deposit(INITIAL_PROPOSER_BOND);
         vm.stopPrank();
 
         token.mint(proverCandidate, INITIAL_PROVER_BOND);
         vm.startPrank(proverCandidate);
         token.approve(address(bondManager), type(uint256).max);
-        bondManager.deposit(address(0), INITIAL_PROVER_BOND);
+        bondManager.deposit(INITIAL_PROVER_BOND);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
Addresses the suggestions on #21009

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `proposalAge` to count from availability for proving; extracts bond processing to `IBondProcessor`, updates `BondManager` with `deposit`/`depositTo`, and refreshes tests and snapshots.
> 
> - **L1 (Inbox)**
>   - Compute `proposalAge` as `now - max(transition.timestamp, lastFinalizedTimestamp)` before `_proofVerifier.verifyProof`.
> - **L2 (Bonds)**
>   - **Interface split**: Move bond instruction event/method to new `IBondProcessor`; slim `IBondManager` to bond accounting APIs.
>   - **BondManager**:
>     - Implement `IBondProcessor` and keep `processBondInstruction` behavior.
>     - Replace `deposit(address,uint256)` with `deposit(uint256)` and new `depositTo(address,uint256)`; add internal `_deposit`.
> - **Tests**
>   - Update all deposit calls to new API and add zero-recipient revert case; adjust Anchor tests accordingly.
> - **Snapshots**
>   - Bump `shasta-prove.json` gas/cost figures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62f3f37fe2d92801ccc66876befbbefb9948f42e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->