### PR TITLE
refactor(taiko-client-rs): avoid cloning preconfirmation execution payload

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/production/path.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/path.rs
@@ -66,10 +66,10 @@ where
     ) -> Result<Vec<EngineBlockOutcome>, DriverError> {
         match input {
             ProductionInput::Preconfirmation(preconf) => {
-                let payload = preconf.execution_payload().clone();
+                let payload = preconf.execution_payload();
                 let block_number = payload.execution_payload.block_number;
                 let outcome =
-                    self.injector.apply_execution_payload(&payload, None).await.map_err(|err| {
+                    self.injector.apply_execution_payload(payload, None).await.map_err(|err| {
                         DriverError::PreconfInjectionFailed { block_number, source: err }
                     })?;
                 Ok(vec![outcome])


### PR DESCRIPTION
The preconfirmation production path used to clone the entire ExecutionPayloadInputV2 even though ExecutionPayloadInjector only needs an immutable reference. This was wasteful for large payloads and contradicted the intent of wrapping them in Arc to avoid copies. Switch to passing a reference directly and reading the block number from the same reference, reducing unnecessary allocations without changing behavior.