### PR TITLE
chore(taiko-client): reduce monitor interval

### DIFF
--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -25,7 +25,10 @@ var (
 	MaxNumSupportedProofTypes = 4
 )
 
-const maxProofRequestTimeout = 1 * time.Hour
+const (
+	maxProofRequestTimeout = 1 * time.Hour
+	monitorInterval        = 5 * time.Minute
+)
 
 // ProofSubmitterPacaya is responsible requesting proofs for the given L2
 // blocks, and submitting the generated proofs to the TaikoInbox smart contract.
@@ -279,10 +282,7 @@ func (s *ProofSubmitterPacaya) TryAggregate(buffer *proofProducer.ProofBuffer, p
 }
 
 func (s *ProofSubmitterPacaya) startProofBufferMonitors(ctx context.Context) {
-	if s.forceBatchProvingInterval <= 0 {
-		return
-	}
-	log.Info("Starting proof buffers monitors for Pacaya", "forceBatchProvingInterval", s.forceBatchProvingInterval)
+	log.Info("Starting proof buffers monitors for Pacaya", "monitorInterval", monitorInterval)
 	for proofType, buffer := range s.proofBuffers {
 		go s.monitorProofBuffer(ctx, proofType, buffer)
 	}
@@ -293,7 +293,7 @@ func (s *ProofSubmitterPacaya) monitorProofBuffer(
 	proofType proofProducer.ProofType,
 	buffer *proofProducer.ProofBuffer,
 ) {
-	ticker := time.NewTicker(s.forceBatchProvingInterval)
+	ticker := time.NewTicker(monitorInterval)
 	defer ticker.Stop()
 
 	for {

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -284,7 +284,7 @@ func (s *ProofSubmitterPacaya) TryAggregate(buffer *proofProducer.ProofBuffer, p
 func (s *ProofSubmitterPacaya) startProofBufferMonitors(ctx context.Context) {
 	log.Info("Starting proof buffers monitors for Pacaya", "monitorInterval", monitorInterval)
 	for proofType, buffer := range s.proofBuffers {
-		go s.monitorProofBuffer(ctx, proofType, buffer)
+		go s.monitorProofBuffer(ctx, proofType, buffer, monitorInterval)
 	}
 }
 
@@ -292,6 +292,7 @@ func (s *ProofSubmitterPacaya) monitorProofBuffer(
 	ctx context.Context,
 	proofType proofProducer.ProofType,
 	buffer *proofProducer.ProofBuffer,
+	monitorInterval time.Duration,
 ) {
 	ticker := time.NewTicker(monitorInterval)
 	defer ticker.Stop()

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_test.go
@@ -269,7 +269,7 @@ func TestProofBufferMonitorTriggersAggregate(t *testing.T) {
 		proofPollingInterval:      10 * time.Millisecond,
 	}
 
-	go s.monitorProofBuffer(ctx, proofProducer.ProofTypeOp, buffer)
+	go s.monitorProofBuffer(ctx, proofProducer.ProofTypeOp, buffer, 50*time.Millisecond)
 
 	select {
 	case proofType := <-s.batchAggregationNotify:


### PR DESCRIPTION
Currently, the stalled-proof detection threshold is 30 minutes. If the monitoring interval is also set to 30 minutes, it is easy to exceed the proving window. Therefore, we reduce the monitoring interval to 5 minutes.