### PR TITLE
fix(eventindexer): use correct event name for BlockVerifiedV2

### DIFF
--- a/packages/eventindexer/indexer/save_block_verified_event.go
+++ b/packages/eventindexer/indexer/save_block_verified_event.go
@@ -146,10 +146,10 @@ func (i *Indexer) saveBlockVerifiedEventV2(
 	}
 
 	_, err = i.eventRepo.Save(ctx, eventindexer.SaveEventOpts{
-		Name:           eventindexer.EventNameBatchesVerified,
+		Name:           eventindexer.EventNameBlockVerified,
 		Data:           string(marshaled),
 		ChainID:        chainID,
-		Event:          eventindexer.EventNameBatchesVerified,
+		Event:          eventindexer.EventNameBlockVerified,
 		Address:        "",
 		BlockID:        &blockID,
 		TransactedAt:   time.Unix(int64(block.Time()), 0),


### PR DESCRIPTION
Fixed wrong event name in saveBlockVerifiedEventV2 function. It was saving BlockVerifiedV2 events as "BatchesVerified" instead of "BlockVerified". This was a copy-paste mistake that caused V2 block verification events to be stored with incorrect type in the database.