### PR TITLE
fix(ejector): simplify parent_missing logic in ChainReorgTracker

### DIFF
--- a/packages/ejector/src/monitor_reorg.rs
+++ b/packages/ejector/src/monitor_reorg.rs
@@ -64,10 +64,9 @@ impl ChainReorgTracker {
             break;
         }
 
-        let parent_missing = match self.history.back() {
-            Some(last) => last.hash != block.parent_hash,
-            None => !outcome.reorged.is_empty(),
-        };
+        // If history is not empty, we exited the loop via break, meaning parent was found.
+        // If history is empty and reorged is not empty, parent was not found.
+        let parent_missing = self.history.back().is_none() && !outcome.reorged.is_empty();
 
         if parent_missing {
             outcome.parent_not_found = true;


### PR DESCRIPTION
## What

Removed dead code in `ChainReorgTracker::apply()` that checked `last.hash != block.parent_hash` after exiting the loop via `break`. This check was always `false` since we only reach it when the parent hash matches.

## Why

The redundant `match` expression with an unreachable branch made the code harder to understand and maintain. Simplified logic now directly checks if history is empty and reorged blocks exist to determine if parent is missing.