### PR TITLE
feat(protocol): set base fee floor to 0.01 gwei to avoid reorgs and changes to sidecars

### DIFF
--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -40,7 +40,7 @@ contract DevnetInbox is TaikoInbox {
                 adjustmentQuotient: 8,
                 sharingPctg: 75,
                 gasIssuancePerSecond: 5_000_000,
-                minGasExcess: 1_289_447_652, // 0.0025 gwei
+                minGasExcess: 1_344_899_430, // 0.01 gwei
                 maxGasIssuancePerBlock: 600_000_000
             }),
             provingWindow: 2 hours,

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -95,7 +95,7 @@ contract HeklaInbox is TaikoInbox {
                 adjustmentQuotient: 8,
                 sharingPctg: 75,
                 gasIssuancePerSecond: 5_000_000,
-                minGasExcess: 1_289_447_652, // 0.0025 gwei
+                minGasExcess: 1_344_899_430, // 0.01 gwei
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
             provingWindow: 2 hours,

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -40,7 +40,7 @@ contract MainnetInbox is TaikoInbox {
                 adjustmentQuotient: 8,
                 sharingPctg: 75,
                 gasIssuancePerSecond: 5_000_000,
-                minGasExcess: 1_289_447_652, // 0.0025 gwei
+                minGasExcess: 1_344_899_430, // 0.01 gwei
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
             provingWindow: 2 hours,

--- a/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
@@ -29,7 +29,7 @@ contract TaikoAnchor is EssentialContract, IBlockHashProvider, TaikoAnchorDeprec
 
     /// @notice Golden touch address is the only address that can do the anchor transaction.
     address public constant GOLDEN_TOUCH_ADDRESS = 0x0000777735367b36bC9B61C50022d9D0700dB4Ec;
-    uint256 public constant BASEFEE_MIN_VALUE = 2_500_000; // 0.0025 gwei
+    uint256 public constant BASEFEE_MIN_VALUE = 10_000_000; // 0.01 gwei
 
     ISignalService public immutable signalService;
     uint64 public immutable pacayaForkHeight;

--- a/packages/protocol/test/layer2/LibEIP1559.t.sol
+++ b/packages/protocol/test/layer2/LibEIP1559.t.sol
@@ -37,7 +37,7 @@ contract TestLibEIP1559 is Layer2Test {
             "Mainnet minimal basefee ontake: ", LibEIP1559.basefee(5_000_000 * 8, 1_340_000_000)
         );
         console2.log(
-            "Mainnet minimal basefee pacaya: ", LibEIP1559.basefee(5_000_000 * 8, 1_289_447_652)
+            "Mainnet minimal basefee pacaya: ", LibEIP1559.basefee(5_000_000 * 8, 1_344_899_430)
         );
     }
 


### PR DESCRIPTION
This PR is the result of the feedback from sidecar implementers, after realizing changing the inbox would result in reorgs during the transition and would require changes to the sidecar implementations. It reverts some of the changes in #20959.

In order to minimize this, this PR proposes using the existing L1 EIP-1559 floor(`0.01 gwei`) and only adjust the Anchor contract(which does not require changes off-chain). Additional reduction of the base fee can still be pushed with shasta.

The anchor contract has already been deployed and verified [here](https://taikoscan.io/address/0x442DBaF14EB7a602a910D4e6f00CC867A4efdc24)

**_NOTE this is still a 2.5x reduction from the current base fee._**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets L2 base fee floor to 0.01 gwei and updates minGasExcess across L1 inbox configs, with tests adjusted accordingly.
> 
> - **Protocol (Layer 2)**:
>   - `TaikoAnchor`: set `BASEFEE_MIN_VALUE` to `10_000_000` (0.01 gwei).
> - **Protocol (Layer 1)**:
>   - `DevnetInbox`, `HeklaInbox`, `MainnetInbox`: update `baseFeeConfig.minGasExcess` to `1_344_899_430` (0.01 gwei).
> - **Tests**:
>   - `test/layer2/LibEIP1559.t.sol`: adjust expected `pacaya` minimal basefee to reflect new `minGasExcess`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7492388e18c573c5e6fc80ea04be128245411313. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->