### PR TITLE
fix(relayer): process correct target block in crawl mode

### DIFF
--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -402,9 +402,15 @@ func (i *Indexer) filter(ctx context.Context) error {
 		if i.targetBlockNumber != nil {
 			slog.Info("targetBlockNumber is set", "targetBlockNumber", *i.targetBlockNumber)
 
-			i.latestIndexedBlockNumber = *i.targetBlockNumber
+			if *i.targetBlockNumber == 0 {
+				slog.Error("invalid targetBlockNumber, must be greater than 0", "targetBlockNumber", *i.targetBlockNumber)
 
-			endBlockID = i.latestIndexedBlockNumber + 1
+				return errors.New("targetBlockNumber must be greater than 0")
+			}
+
+			i.latestIndexedBlockNumber = *i.targetBlockNumber - 1
+
+			endBlockID = *i.targetBlockNumber
 		} else {
 			// set the initial processing block back to either 0 or the genesis block again.
 			if err := i.setInitialIndexingBlockByMode(i.syncMode, i.srcChainId); err != nil {


### PR DESCRIPTION
The indexer was using the targetBlockNumber value as the last indexed block in CrawlPastBlocks mode, which caused it to scan targetBlockNumber+1 instead of the intended block. This change aligns the logic with the documented behavior and CLI flag description by treating latestIndexedBlockNumber as the last processed block (target-1) and setting the end block to the exact target. It also rejects targetBlockNumber == 0 to avoid uint64 underflow and make the API contract explicit.