### PR TITLE
fix(relayer): use correct metrics counter for ChainDataSynced indexing errors

### DIFF
--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -684,7 +684,7 @@ func (i *Indexer) indexChainDataSyncedEvents(ctx context.Context,
 		group.Go(func() error {
 			err := i.handleChainDataSyncedEvent(ctx, event, true)
 			if err != nil {
-				relayer.MessageStatusChangedEventsIndexingErrors.Inc()
+				relayer.ChainDataSyncedEventsIndexingErrors.Inc()
 
 				// log error but always return nil to keep other goroutines active
 				slog.Error("error handling chainDataSynced", "err", err.Error())


### PR DESCRIPTION
Use the dedicated `ChainDataSyncedEventsIndexingErrors` counter when `handleChainDataSyncedEvent` fails instead of incrementing `MessageStatusChangedEventsIndexingErrors`. This fixes a copy‑paste bug and ensures Prometheus metrics accurately reflect errors while indexing `ChainDataSynced` events, consistent with the existing pattern used for other event types and with `ChainDataSyncedEventsAfterRetryErrorCount`.