### PR TITLE
fix(balance-monitor): fix variable shadowing in token decimals lookup

### DIFF
--- a/packages/balance-monitor/balance-monitor/balance_monitor.go
+++ b/packages/balance-monitor/balance-monitor/balance_monitor.go
@@ -112,7 +112,8 @@ func (b *BalanceMonitor) checkErc20Balance(ctx context.Context, client *ethclien
 	tokenDecimals, ok := b.erc20DecimalsCache[tokenAddress]
 	if !ok {
 		// If not in the cache, fetch the decimals from the contract
-		tokenDecimals, err := b.getErc20Decimals(ctx, client, tokenAddress)
+		var err error
+		tokenDecimals, err = b.getErc20Decimals(ctx, client, tokenAddress)
 		if err != nil {
 			slog.Warn(fmt.Sprintf("Failed to get %s ERC-20 decimals for token. Use default value: 18", clientLabel), "tokenAddress", tokenAddress.Hex(), "error", err)
 			tokenDecimals = 18


### PR DESCRIPTION
tokenDecimals was being shadowed inside the cache miss block, causing the outer variable to remain 0. This resulted in dividing balances by 10^0=1 instead of 10^decimals on first request for each token.