### PR TITLE
test: verify violation content in pending_tx_age criterion

### DIFF
--- a/packages/overseer-rs/src/criteria/pending_tx_age.rs
+++ b/packages/overseer-rs/src/criteria/pending_tx_age.rs
@@ -126,6 +126,13 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_some());
+
+        let violation = result.unwrap();
+        assert_eq!(violation.criterion, "pending_tx_age");
+        assert!(violation.reason.contains("1 pending transactions"));
+        assert!(violation.reason.contains("older than 10s"));
+        assert!(violation.reason.contains("0xabc"));
+        assert!(violation.reason.contains("aged 30s"));
     }
 
     /// Ensures that the absence of stalled transactions yields no violation.


### PR DESCRIPTION
Add assertions to verify violation.criterion and violation.reason in the pending_tx_age test. 

This ensures the violation message format is correct and helps catch regressions in violation construction.