### PR TITLE
fix(eventindexer): correct transition contested error context

### DIFF
--- a/packages/eventindexer/indexer/save_transition_contested_event.go
+++ b/packages/eventindexer/indexer/save_transition_contested_event.go
@@ -29,7 +29,7 @@ func (i *Indexer) saveTransitionContestedEvents(
 		if err := i.saveTransitionContestedEvent(ctx, chainID, event); err != nil {
 			eventindexer.TransitionContestedEventsProcessedError.Inc()
 
-			return errors.Wrap(err, "i.saveBlockProvenEvent")
+			return errors.Wrap(err, "i.saveTransitionContestedEvent")
 		}
 
 		if !events.Next() {
@@ -98,7 +98,7 @@ func (i *Indexer) saveTransitionContestedEventsV2(
 		if err := i.saveTransitionContestedEventV2(ctx, chainID, event); err != nil {
 			eventindexer.TransitionContestedEventsProcessedError.Inc()
 
-			return errors.Wrap(err, "i.saveBlockProvenEvent")
+			return errors.Wrap(err, "i.saveTransitionContestedEventV2")
 		}
 
 		if !events.Next() {


### PR DESCRIPTION
The error wrapping messages in saveTransitionContestedEvents and saveTransitionContestedEventsV2 were copy-pasted from a different handler and referenced i.saveBlockProvenEvent. This makes logs and traces misleading when a transition contested event fails. The messages are updated to reference the correct functions, so operational debugging and metrics correlation point to the actual failing code paths.