### PR TITLE
fix(relayer): reuse cached chain IDs in HTTP handlers

### DIFF
--- a/packages/relayer/pkg/http/get_recommended_processing_fees.go
+++ b/packages/relayer/pkg/http/get_recommended_processing_fees.go
@@ -89,15 +89,8 @@ const (
 func (srv *Server) GetRecommendedProcessingFees(c echo.Context) error {
 	fees := make([]fee, 0)
 
-	srcChainID, err := srv.srcEthClient.ChainID(c.Request().Context())
-	if err != nil {
-		return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, err)
-	}
-
-	destChainID, err := srv.destEthClient.ChainID(c.Request().Context())
-	if err != nil {
-		return webutils.LogAndRenderErrors(c, http.StatusUnprocessableEntity, err)
-	}
+	srcChainID := srv.srcChainID
+	destChainID := srv.destChainID
 
 	srcGasTipCap, err := srv.srcEthClient.SuggestGasTipCap(c.Request().Context())
 	if err != nil {


### PR DESCRIPTION
Use the srcChainID and destChainID values cached on the Server instead of issuing new ChainID RPC calls on every HTTP request in GetRecommendedProcessingFees and GetBlockInfo. Chain IDs are immutable for a given network and already validated during server initialization, so calling ChainID again per request adds unnecessary latency and load without improving correctness.