### PR TITLE
chore(protocol): update layout file generation to use solidity 0.8.26

### DIFF
--- a/packages/protocol/contracts/layer1/automata-attestation/AutomataDcapV3Attestation_Layout.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/AutomataDcapV3Attestation_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title AutomataDcapV3AttestationLayout
 /// @notice Storage layout documentation for AutomataDcapV3Attestation

--- a/packages/protocol/contracts/layer1/core/impl/InboxOptimized1_Layout.sol
+++ b/packages/protocol/contracts/layer1/core/impl/InboxOptimized1_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title InboxOptimized1Layout
 /// @notice Storage layout documentation for InboxOptimized1

--- a/packages/protocol/contracts/layer1/core/impl/InboxOptimized2_Layout.sol
+++ b/packages/protocol/contracts/layer1/core/impl/InboxOptimized2_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title InboxOptimized2Layout
 /// @notice Storage layout documentation for InboxOptimized2

--- a/packages/protocol/contracts/layer1/core/impl/Inbox_Layout.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title InboxLayout
 /// @notice Storage layout documentation for Inbox

--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox_Layout.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title DevnetInboxLayout
 /// @notice Storage layout documentation for DevnetInbox

--- a/packages/protocol/contracts/layer1/mainnet/MainnetBridge_Layout.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetBridge_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title MainnetBridgeLayout
 /// @notice Storage layout documentation for MainnetBridge

--- a/packages/protocol/contracts/layer1/mainnet/MainnetDAOController_Layout.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetDAOController_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title MainnetDAOControllerLayout
 /// @notice Storage layout documentation for MainnetDAOController

--- a/packages/protocol/contracts/layer1/mainnet/MainnetERC1155Vault_Layout.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetERC1155Vault_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title MainnetERC1155VaultLayout
 /// @notice Storage layout documentation for MainnetERC1155Vault

--- a/packages/protocol/contracts/layer1/mainnet/MainnetERC20Vault_Layout.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetERC20Vault_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title MainnetERC20VaultLayout
 /// @notice Storage layout documentation for MainnetERC20Vault

--- a/packages/protocol/contracts/layer1/mainnet/MainnetERC721Vault_Layout.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetERC721Vault_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title MainnetERC721VaultLayout
 /// @notice Storage layout documentation for MainnetERC721Vault

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox_Layout.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title MainnetInboxLayout
 /// @notice Storage layout documentation for MainnetInbox

--- a/packages/protocol/contracts/layer1/mainnet/TaikoToken_Layout.sol
+++ b/packages/protocol/contracts/layer1/mainnet/TaikoToken_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title TaikoTokenLayout
 /// @notice Storage layout documentation for TaikoToken

--- a/packages/protocol/contracts/layer1/preconf/impl/LookaheadStore_Layout.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/LookaheadStore_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title LookaheadStoreLayout
 /// @notice Storage layout documentation for LookaheadStore

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist_Layout.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title PreconfWhitelistLayout
 /// @notice Storage layout documentation for PreconfWhitelist

--- a/packages/protocol/contracts/layer2/core/Anchor_Layout.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title AnchorLayout
 /// @notice Storage layout documentation for Anchor

--- a/packages/protocol/contracts/layer2/governance/DelegateController_Layout.sol
+++ b/packages/protocol/contracts/layer2/governance/DelegateController_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title DelegateControllerLayout
 /// @notice Storage layout documentation for DelegateController

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken_Layout.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title BridgedTaikoTokenLayout
 /// @notice Storage layout documentation for BridgedTaikoToken

--- a/packages/protocol/contracts/layer2/preconf/PreconfSlasherL2_Layout.sol
+++ b/packages/protocol/contracts/layer2/preconf/PreconfSlasherL2_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title PreconfSlasherL2Layout
 /// @notice Storage layout documentation for PreconfSlasherL2

--- a/packages/protocol/contracts/shared/bridge/Bridge_Layout.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title BridgeLayout
 /// @notice Storage layout documentation for Bridge

--- a/packages/protocol/contracts/shared/common/DefaultResolver_Layout.sol
+++ b/packages/protocol/contracts/shared/common/DefaultResolver_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title DefaultResolverLayout
 /// @notice Storage layout documentation for DefaultResolver

--- a/packages/protocol/contracts/shared/fork-router/ForkRouter_Layout.sol
+++ b/packages/protocol/contracts/shared/fork-router/ForkRouter_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title ForkRouterLayout
 /// @notice Storage layout documentation for ForkRouter

--- a/packages/protocol/contracts/shared/signal/SignalService_Layout.sol
+++ b/packages/protocol/contracts/shared/signal/SignalService_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title SignalServiceLayout
 /// @notice Storage layout documentation for SignalService

--- a/packages/protocol/contracts/shared/vault/BridgedERC1155_Layout.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC1155_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title BridgedERC1155Layout
 /// @notice Storage layout documentation for BridgedERC1155

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2_Layout.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title BridgedERC20V2Layout
 /// @notice Storage layout documentation for BridgedERC20V2

--- a/packages/protocol/contracts/shared/vault/BridgedERC20_Layout.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title BridgedERC20Layout
 /// @notice Storage layout documentation for BridgedERC20

--- a/packages/protocol/contracts/shared/vault/BridgedERC721_Layout.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC721_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title BridgedERC721Layout
 /// @notice Storage layout documentation for BridgedERC721

--- a/packages/protocol/contracts/shared/vault/ERC1155Vault_Layout.sol
+++ b/packages/protocol/contracts/shared/vault/ERC1155Vault_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title ERC1155VaultLayout
 /// @notice Storage layout documentation for ERC1155Vault

--- a/packages/protocol/contracts/shared/vault/ERC20Vault_Layout.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title ERC20VaultLayout
 /// @notice Storage layout documentation for ERC20Vault

--- a/packages/protocol/contracts/shared/vault/ERC721Vault_Layout.sol
+++ b/packages/protocol/contracts/shared/vault/ERC721Vault_Layout.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title ERC721VaultLayout
 /// @notice Storage layout documentation for ERC721Vault

--- a/packages/protocol/script/gen-layouts.sh
+++ b/packages/protocol/script/gen-layouts.sh
@@ -96,7 +96,7 @@ update_contract_layout() {
     # Create/overwrite the layout file
     cat > "$layout_file_path" << EOF
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.26;
 
 /// @title ${contract_name}Layout
 /// @notice Storage layout documentation for ${contract_name}


### PR DESCRIPTION
## Summary

Updates the gen-layouts.sh script to generate layout files with pragma solidity ^0.8.26 instead of ^0.8.24, ensuring all automatically generated layout files use the correct compiler version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)