### PR TITLE
fix(taiko-client): correctly handle wrong blob data

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
@@ -63,7 +63,7 @@ func (f *ShastaDerivationSourceFetcher) Fetch(
 
 	blobBytes, err := f.fetchBlobs(ctx, meta, derivationIdx)
 	if err != nil {
-		if errors.Is(err, rpc.ErrEmptyBlock) {
+		if errors.Is(err, rpc.ErrInvalidBlobBytes) {
 			return &ShastaDerivationSourcePayload{Default: true}, nil
 		}
 		return nil, fmt.Errorf("failed to fetch blobs: %w", err)

--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
@@ -2,22 +2,19 @@ package manifest
 
 import (
 	"context"
-	"crypto/sha256"
+	"errors"
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	consensus "github.com/ethereum/go-ethereum/consensus/taiko"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/manifest"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
-	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/utils"
 )
@@ -66,6 +63,9 @@ func (f *ShastaDerivationSourceFetcher) Fetch(
 
 	blobBytes, err := f.fetchBlobs(ctx, meta, derivationIdx)
 	if err != nil {
+		if errors.Is(err, rpc.ErrEmptyBlock) {
+			return &ShastaDerivationSourcePayload{Default: true}, nil
+		}
 		return nil, fmt.Errorf("failed to fetch blobs: %w", err)
 	}
 
@@ -176,50 +176,16 @@ func (f *ShastaDerivationSourceFetcher) fetchBlobs(
 ) ([]byte, error) {
 	blobHashes := meta.GetBlobHashes(derivationIdx)
 	// Fetch the L1 block sidecars.
-	sidecars, err := f.dataSource.GetBlobs(ctx, meta.GetBlobTimestamp(derivationIdx), blobHashes)
+	b, err := f.dataSource.GetBlobBytes(ctx, meta.GetBlobTimestamp(derivationIdx), blobHashes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get blobs, errs: %w", err)
 	}
-
-	if len(sidecars) != len(blobHashes) {
-		return nil, fmt.Errorf("blob sidecar count mismatch: expected %d, got %d", len(blobHashes), len(sidecars))
-	}
-
 	log.Info(
 		"Fetch sidecars",
 		"proposalID", meta.GetEventData().Id,
 		"l1Height", meta.GetRawBlockHeight(),
-		"sidecars", len(sidecars),
+		"sidecars", len(blobHashes),
 	)
-	// Build a map of blobHash -> blobBytes for O(1) lookup.
-	blobMap := make(map[common.Hash][]byte, len(sidecars))
-	for _, sidecar := range sidecars {
-		commitment := kzg4844.Commitment(common.FromHex(sidecar.KzgCommitment))
-		hash := kzg4844.CalcBlobHashV1(sha256.New(), &commitment)
-
-		blob := eth.Blob(common.FromHex(sidecar.Blob))
-		bytes, err := blob.ToData()
-		if err != nil {
-			return nil, err
-		}
-		blobMap[hash] = bytes
-	}
-
-	// Append in the order of blobHashes to preserve semantics.
-	var b []byte
-	for _, h := range blobHashes {
-		bytes, ok := blobMap[h]
-		if !ok {
-			// If any requested blob is missing, surface a clear error.
-			return nil, fmt.Errorf("requested blob hash %s not found in sidecars", h.Hex())
-		}
-		b = append(b, bytes...)
-	}
-
-	if len(b) == 0 {
-		return nil, pkg.ErrSidecarNotFound
-	}
-
 	return b, nil
 }
 

--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
@@ -193,13 +193,7 @@ func (f *ShastaDerivationSourceFetcher) fetchBlobs(
 	)
 	// Build a map of blobHash -> blobBytes for O(1) lookup.
 	blobMap := make(map[common.Hash][]byte, len(sidecars))
-	for j, sidecar := range sidecars {
-		log.Debug(
-			"Block sidecar",
-			"index", j,
-			"KzgCommitment", sidecar.KzgCommitment,
-		)
-
+	for _, sidecar := range sidecars {
 		commitment := kzg4844.Commitment(common.FromHex(sidecar.KzgCommitment))
 		hash := kzg4844.CalcBlobHashV1(sha256.New(), &commitment)
 

--- a/packages/taiko-client/driver/txlist_fetcher/blob.go
+++ b/packages/taiko-client/driver/txlist_fetcher/blob.go
@@ -46,7 +46,7 @@ func (d *BlobFetcher) FetchPacaya(ctx context.Context, meta metadata.TaikoBatchM
 	// Fetch the L1 block sidecars.
 	b, err := d.dataSource.GetBlobBytes(ctx, l1Header.Time, meta.GetBlobHashes())
 	if err != nil {
-		if errors.Is(err, rpc.ErrEmptyBlock) {
+		if errors.Is(err, rpc.ErrInvalidBlobBytes) {
 			return []byte{}, nil
 		}
 		return nil, fmt.Errorf("failed to get blobs, errs: %w", err)

--- a/packages/taiko-client/driver/txlist_fetcher/blob.go
+++ b/packages/taiko-client/driver/txlist_fetcher/blob.go
@@ -2,13 +2,11 @@ package txlistfetcher
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
@@ -55,29 +53,14 @@ func (d *BlobFetcher) FetchPacaya(ctx context.Context, meta metadata.TaikoBatchM
 	log.Info("Fetch sidecars", "blockNumber", blockNum, "sidecars", len(sidecars))
 
 	var b []byte
-	for _, blobHash := range meta.GetBlobHashes() {
-		// Compare the blob hash with the sidecar's kzg commitment.
-		for j, sidecar := range sidecars {
-			log.Debug(
-				"Block sidecar",
-				"index", j,
-				"KzgCommitment", sidecar.KzgCommitment,
-				"blobHash", blobHash,
-			)
 
-			commitment := kzg4844.Commitment(common.FromHex(sidecar.KzgCommitment))
-			if kzg4844.CalcBlobHashV1(sha256.New(), &commitment) == blobHash {
-				blob := eth.Blob(common.FromHex(sidecar.Blob))
-				bytes, err := blob.ToData()
-				if err != nil {
-					return nil, fmt.Errorf("failed to convert blob to data: %w", err)
-				}
-
-				b = append(b, bytes...)
-				// Exit the loop as the matching sidecar has been found and processed.
-				break
-			}
+	for _, sidecar := range sidecars {
+		blob := eth.Blob(common.FromHex(sidecar.Blob))
+		bytes, err := blob.ToData()
+		if err != nil {
+			return nil, err
 		}
+		b = append(b, bytes...)
 	}
 	if len(b) == 0 {
 		return nil, pkg.ErrSidecarNotFound

--- a/packages/taiko-client/pkg/rpc/blob_datasource.go
+++ b/packages/taiko-client/pkg/rpc/blob_datasource.go
@@ -18,7 +18,7 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg"
 )
 
-var ErrEmptyBlock = errors.New("should produce empty block")
+var ErrInvalidBlobBytes = errors.New("invalid blob bytes")
 
 type BlobDataSource struct {
 	ctx                context.Context
@@ -89,7 +89,7 @@ func (ds *BlobDataSource) GetBlobBytes(
 		blob := eth.Blob(common.FromHex(sidecar.Blob))
 		bytes, err := blob.ToData()
 		if err != nil {
-			return nil, errors.Join(ErrEmptyBlock, err)
+			return nil, errors.Join(ErrInvalidBlobBytes, err)
 		}
 		b = append(b, bytes...)
 	}

--- a/packages/taiko-client/pkg/rpc/blob_datasource.go
+++ b/packages/taiko-client/pkg/rpc/blob_datasource.go
@@ -111,7 +111,7 @@ func (ds *BlobDataSource) GetSidecars(
 		err         error
 	)
 	if ds.client.L1Beacon == nil {
-		allSidecars, err = nil, pkg.ErrBeaconNotFound
+		err = pkg.ErrBeaconNotFound
 	} else {
 		allSidecars, err = ds.client.L1Beacon.GetBlobs(ctx, timestamp)
 	}


### PR DESCRIPTION
When blob data was filled with arbitrary bytes, which violates EIP-4844 field element constraints and causes blob decoding failures, we need to correctly handle this case(produce empty block).