### PR TITLE
feat(protocol): remove designatedProver in Transition

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IInbox.sol
@@ -115,8 +115,6 @@ interface IInbox {
     struct Transition {
         /// @notice Address of the proposer.
         address proposer;
-        /// @notice Address of the designated prover.
-        address designatedProver;
         /// @notice Timestamp of the proposal.
         uint48 timestamp;
         /// @notice end block hash for the proposal.

--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -691,7 +691,7 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, IBondManager, Essential
             }
 
             _bondStorage.settleLivenessBond(
-                _commitment.transitions[_offset].designatedProver,
+                _commitment.transitions[_offset].proposer,
                 _commitment.actualProver,
                 _livenessBond
             );


### PR DESCRIPTION
@ggonzalez94 @davidtaikocha It seems that we can remove the `designatedProver` in `Transition` with the new approach?

I opened this PR just for suggestions, so I haven't remove the related code in Codec and test.