### PR TITLE
feat(overseer-rs): add color-eyre and strict clippy lints

### DIFF
--- a/packages/overseer-rs/Cargo.lock
+++ b/packages/overseer-rs/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,6 +1171,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1415,33 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1854,7 +1905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1877,6 +1928,16 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -2147,6 +2208,12 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -2670,6 +2737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,7 +3186,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3224,6 +3297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,6 +3369,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "color-eyre",
  "common",
  "hyper 0.14.32",
  "prometheus 0.13.4",
@@ -3296,6 +3379,12 @@ dependencies = [
  "tracing-subscriber",
  "urc",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parity-scale-codec"
@@ -3969,6 +4058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,7 +4103,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4917,7 +5012,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5249,6 +5344,16 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5693,7 +5798,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/overseer-rs/Cargo.toml
+++ b/packages/overseer-rs/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0"
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }
+color-eyre = "0.6"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal", "net"] }
 tracing = "0.1"
@@ -16,3 +17,13 @@ hyper = { version = "0.14", features = ["server", "http1"] }
 alloy = { version = "1.0", default-features = false, features = ["consensus", "contract", "providers", "provider-http", "reqwest-rustls-tls", "signer-local", "sol-types", "rpc-types"] }
 urc = { git = "https://github.com/NethermindEth/Catalyst", package = "urc", rev = "46a051d6cd833c20e9e57509e5ae5cc82751e263" }
 common = { git = "https://github.com/NethermindEth/Catalyst", package = "common", rev = "46a051d6cd833c20e9e57509e5ae5cc82751e263" }
+
+[lints.clippy]
+cast_lossless = "deny"
+cast_possible_truncation = "deny"
+cast_possible_wrap = "deny"
+cast_precision_loss = "deny"
+cast_sign_loss = "deny"
+needless_return = "deny"
+panicking_overflow_checks = "deny"
+unwrap_used = "deny"

--- a/packages/overseer-rs/src/criteria/block_timeliness.rs
+++ b/packages/overseer-rs/src/criteria/block_timeliness.rs
@@ -129,7 +129,10 @@ mod tests {
         };
 
         let criterion = BlockTimelinessCriterion::new();
-        let result = criterion.evaluate(&ctx).await.unwrap();
+        let result = criterion
+            .evaluate(&ctx)
+            .await
+            .expect("evaluation should succeed");
         assert!(result.is_some());
     }
 
@@ -146,7 +149,10 @@ mod tests {
         };
 
         let criterion = BlockTimelinessCriterion::new();
-        let result = criterion.evaluate(&ctx).await.unwrap();
+        let result = criterion
+            .evaluate(&ctx)
+            .await
+            .expect("evaluation should succeed");
         assert!(result.is_none());
     }
 }

--- a/packages/overseer-rs/src/criteria/mempool_stagnation.rs
+++ b/packages/overseer-rs/src/criteria/mempool_stagnation.rs
@@ -120,7 +120,7 @@ mod tests {
         let result = MempoolStagnationCriterion::new()
             .evaluate(&ctx)
             .await
-            .unwrap();
+            .expect("evaluation should succeed");
         assert!(result.is_some());
     }
 
@@ -137,7 +137,7 @@ mod tests {
         let result = MempoolStagnationCriterion::new()
             .evaluate(&ctx)
             .await
-            .unwrap();
+            .expect("evaluation should succeed");
         assert!(result.is_none());
     }
 }

--- a/packages/overseer-rs/src/criteria/pending_tx_age.rs
+++ b/packages/overseer-rs/src/criteria/pending_tx_age.rs
@@ -124,7 +124,7 @@ mod tests {
         let result = PendingTransactionAgeCriterion::new()
             .evaluate(&ctx)
             .await
-            .unwrap();
+            .expect("evaluation should succeed");
         assert!(result.is_some());
     }
 
@@ -143,7 +143,7 @@ mod tests {
         let result = PendingTransactionAgeCriterion::new()
             .evaluate(&ctx)
             .await
-            .unwrap();
+            .expect("evaluation should succeed");
         assert!(result.is_none());
     }
 }

--- a/packages/overseer-rs/src/main.rs
+++ b/packages/overseer-rs/src/main.rs
@@ -9,7 +9,7 @@ mod types;
 
 use std::sync::Arc;
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use clap::Parser;
 use tracing_subscriber::{fmt, EnvFilter};
 
@@ -35,7 +35,9 @@ use urc::monitor::db::DataBase as UrcDataBase;
 
 /// CLI entrypoint that wires dependencies and launches the monitor runtime.
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<()> {
+    color_eyre::install().expect("Failed to install color_eyre");
+
     init_tracing();
 
     let config_inputs = Config::parse();


### PR DESCRIPTION
adds color-eyre for better error diagnostics and clippy lints matching ejector's config (including unwrap_used = "deny"). fixed all existing unwrap() calls in tests by replacing with expect().

this brings overseer-rs in line with other rust services in the repo and should make debugging production issues easier for ops.