### PR TITLE
fix(relayer): replace fmt.Println with structured logging in bridge

### DIFF
--- a/packages/relayer/bridge/bridge.go
+++ b/packages/relayer/bridge/bridge.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"fmt"
 	"log/slog"
 	"math/big"
 	"sync"
@@ -177,7 +176,7 @@ func (b *Bridge) estimateGas(
 
 	tx, err := b.srcBridge.SendMessage(auth, message)
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("Failed to send message for gas estimation", "error", err)
 		return 0, errors.Wrap(err, "rcBridge.SendMessage")
 	}
 
@@ -237,7 +236,7 @@ func (b *Bridge) submitBridgeTx(ctx context.Context) error {
 
 	tx, err := b.srcBridge.SendMessage(auth, message)
 	if err != nil {
-		fmt.Println("b.srcBridge.SendMessage", err)
+		slog.Error("Failed to send bridge message", "method", "b.srcBridge.SendMessage", "error", err)
 		return errors.Wrap(err, "rcBridge.SendMessage")
 	}
 


### PR DESCRIPTION
Replaced fmt.Println calls with slog.Error in bridge.go for consistency with the rest of the codebase. The two error cases (gas estimation and message sending) now use structured logging with proper error context.