### PR TITLE
fix(relayer): update error messages to match actual db operations

### DIFF
--- a/packages/relayer/pkg/repo/event.go
+++ b/packages/relayer/pkg/repo/event.go
@@ -99,7 +99,7 @@ func (r *EventRepository) UpdateFeesAndProfitability(
 	}).Error
 
 	if err != nil {
-		return errors.Wrap(err, "r.db.Commit")
+		return errors.Wrap(err, "tx.Updates")
 	}
 
 	return nil
@@ -121,7 +121,7 @@ func (r *EventRepository) UpdateStatus(ctx context.Context, id int, status relay
 	}
 
 	if err := tx.Update("status", status).Error; err != nil {
-		return errors.Wrap(err, "tx.Commit")
+		return errors.Wrap(err, "tx.Update")
 	}
 
 	return nil


### PR DESCRIPTION
Changed error wrapping in UpdateFeesAndProfitability and UpdateStatus to reflect the actual operation (Updates/Update instead of Commit). Makes debugging easier.