### PR TITLE
feat(taiko-client-rs): add IPC transport alongside HTTP preconfirmation JSON-RPC

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "proposer",
  "protocol",
  "rand 0.8.5",
+ "reth-ipc",
  "rpc",
  "serde",
  "serde_json",

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -79,6 +79,7 @@ alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", pa
   "serde",
 ] }
 alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", rev = "e07c13fc011798adfa5436f24646b7305337cdf3" }
+reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 
 # types
 anyhow = "1"

--- a/packages/taiko-client-rs/bin/client/src/commands/driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/driver.rs
@@ -61,7 +61,8 @@ impl DriverSubCommand {
 
         cfg.rpc_listen_addr = self.driver_flags.rpc_listen_addr;
         cfg.rpc_jwt_secret = self.driver_flags.rpc_jwt_secret.clone();
-        cfg.preconfirmation_enabled = cfg.rpc_listen_addr.is_some();
+        cfg.rpc_ipc_path = self.driver_flags.rpc_ipc_path.clone();
+        cfg.preconfirmation_enabled = cfg.has_rpc_endpoint();
 
         Ok(cfg)
     }

--- a/packages/taiko-client-rs/bin/client/src/flags/driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/flags/driver.rs
@@ -48,9 +48,16 @@ pub struct DriverArgs {
     #[clap(
         long = "driver.rpc.jwt.secret",
         env = "DRIVER_RPC_JWT_SECRET",
-        help = "Path to the JWT secret used by the driver JSON-RPC server"
+        help = "Path to the JWT secret used by the driver JSON-RPC server (HTTP only)"
     )]
     pub rpc_jwt_secret: Option<PathBuf>,
+    /// Path for the IPC socket used by the driver JSON-RPC server.
+    #[clap(
+        long = "driver.rpc.ipc.path",
+        env = "DRIVER_RPC_IPC_PATH",
+        help = "Path for the IPC socket used by the driver JSON-RPC server (no JWT required)"
+    )]
+    pub rpc_ipc_path: Option<PathBuf>,
 }
 
 impl DriverArgs {

--- a/packages/taiko-client-rs/crates/driver/Cargo.toml
+++ b/packages/taiko-client-rs/crates/driver/Cargo.toml
@@ -24,6 +24,7 @@ flate2 = { workspace = true }
 jsonrpsee = { version = "0.26", features = ["server"] }
 k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 metrics = { workspace = true }
+reth-ipc = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"

--- a/packages/taiko-client-rs/crates/driver/src/config.rs
+++ b/packages/taiko-client-rs/crates/driver/src/config.rs
@@ -21,16 +21,21 @@ pub struct DriverConfig {
     /// Enable preconfirmation handling (disabled by default).
     /// NOTE: will be changed to be decided by flag in future.
     pub preconfirmation_enabled: bool,
-    /// Optional driver JSON-RPC server listen address.
+    /// Optional driver JSON-RPC server listen address (HTTP, JWT-protected).
     ///
     /// When configured, the driver exposes JWT-protected JSON-RPC methods that allow external
-    /// components to submit preconfirmation payloads.
+    /// components to submit preconfirmation payloads over HTTP.
     pub rpc_listen_addr: Option<SocketAddr>,
-    /// Optional JWT secret path for the driver JSON-RPC server.
+    /// Optional JWT secret path for the driver JSON-RPC server (HTTP only).
     ///
-    /// When set, the driver RPC server authenticates requests using this secret instead of the
-    /// L2 auth JWT secret.
+    /// When set, the driver RPC server authenticates HTTP requests using this secret instead of
+    /// the L2 auth JWT secret.
     pub rpc_jwt_secret: Option<PathBuf>,
+    /// Optional IPC socket path for the driver JSON-RPC server.
+    ///
+    /// When configured, the driver exposes JSON-RPC methods over a Unix domain socket.
+    /// IPC uses filesystem permissions for access control (no JWT authentication).
+    pub rpc_ipc_path: Option<PathBuf>,
 }
 
 impl DriverConfig {
@@ -54,6 +59,83 @@ impl DriverConfig {
             preconfirmation_enabled: false,
             rpc_listen_addr: None,
             rpc_jwt_secret: None,
+            rpc_ipc_path: None,
         }
+    }
+
+    /// Returns `true` if at least one RPC endpoint (HTTP or IPC) is configured.
+    pub fn has_rpc_endpoint(&self) -> bool {
+        self.rpc_listen_addr.is_some() || self.rpc_ipc_path.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn dummy_client_config() -> ClientConfig {
+        use rpc::SubscriptionSource;
+        ClientConfig {
+            l1_provider_source: SubscriptionSource::Ws(
+                "ws://localhost:8545".parse().expect("ws url"),
+            ),
+            l2_provider_url: "http://localhost:8546".parse().expect("l2 url"),
+            l2_auth_provider_url: "http://localhost:8551".parse().expect("auth url"),
+            jwt_secret: PathBuf::from("/tmp/jwt.hex"),
+            inbox_address: Default::default(),
+        }
+    }
+
+    #[test]
+    fn has_rpc_endpoint_returns_false_when_neither_configured() {
+        let cfg = DriverConfig::new(
+            dummy_client_config(),
+            Duration::from_secs(12),
+            "http://localhost:5052".parse().expect("beacon url"),
+            None,
+            None,
+        );
+        assert!(!cfg.has_rpc_endpoint());
+    }
+
+    #[test]
+    fn has_rpc_endpoint_returns_true_when_http_configured() {
+        let mut cfg = DriverConfig::new(
+            dummy_client_config(),
+            Duration::from_secs(12),
+            "http://localhost:5052".parse().expect("beacon url"),
+            None,
+            None,
+        );
+        cfg.rpc_listen_addr = Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080));
+        assert!(cfg.has_rpc_endpoint());
+    }
+
+    #[test]
+    fn has_rpc_endpoint_returns_true_when_ipc_configured() {
+        let mut cfg = DriverConfig::new(
+            dummy_client_config(),
+            Duration::from_secs(12),
+            "http://localhost:5052".parse().expect("beacon url"),
+            None,
+            None,
+        );
+        cfg.rpc_ipc_path = Some(PathBuf::from("/tmp/driver.ipc"));
+        assert!(cfg.has_rpc_endpoint());
+    }
+
+    #[test]
+    fn has_rpc_endpoint_returns_true_when_both_configured() {
+        let mut cfg = DriverConfig::new(
+            dummy_client_config(),
+            Duration::from_secs(12),
+            "http://localhost:5052".parse().expect("beacon url"),
+            None,
+            None,
+        );
+        cfg.rpc_listen_addr = Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080));
+        cfg.rpc_ipc_path = Some(PathBuf::from("/tmp/driver.ipc"));
+        assert!(cfg.has_rpc_endpoint());
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/driver.rs
+++ b/packages/taiko-client-rs/crates/driver/src/driver.rs
@@ -2,7 +2,7 @@
 
 use alloy_provider::{RootProvider, fillers::FillProvider, utils::JoinedRecommendedFillers};
 use std::sync::Arc;
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 
 use crate::{
     config::DriverConfig,
@@ -60,7 +60,7 @@ impl Driver {
             info!("preconfirmation ingress is ready; starting RPC server");
         }
 
-        let api: Arc<dyn DriverRpcApi> = pipeline.event_syncer();
+        let api: Arc<dyn DriverRpcApi> = event_syncer.clone();
 
         // Start HTTP RPC server (JWT-protected) if configured.
         let http_server = if let Some(listen_addr) = self.cfg.rpc_listen_addr {
@@ -84,14 +84,7 @@ impl Driver {
                     return Err(DriverError::DriverRpcJwtSecretReadFailed);
                 }
             };
-            Some(
-                DriverRpcServer::start(
-                    listen_addr,
-                    jwt_secret,
-                    event_syncer as Arc<dyn DriverRpcApi>,
-                )
-                .await?,
-            )
+            Some(DriverRpcServer::start(listen_addr, jwt_secret, Arc::clone(&api)).await?)
         } else {
             None
         };
@@ -119,7 +112,7 @@ impl Driver {
             info!("driver RPC server disabled (no HTTP or IPC endpoint configured)");
         }
 
-        let result = pipeline.run().await;
+        let result = pipeline_future.await;
 
         if let Some(ipc) = ipc_server {
             info!("stopping driver IPC RPC server");
@@ -130,7 +123,7 @@ impl Driver {
             http.stop().await;
         }
 
-        pipeline_future.await?;
+        result?;
         Ok(())
     }
 

--- a/packages/taiko-client-rs/crates/driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/error.rs
@@ -1,6 +1,6 @@
 //! Driver specific error types.
 
-use std::{io, result::Result as StdResult, time::Duration};
+use std::{io, path::PathBuf, result::Result as StdResult, time::Duration};
 
 use anyhow::Error as AnyhowError;
 use reth_ipc::server::IpcServerStartError;
@@ -39,6 +39,17 @@ pub enum DriverError {
     /// IPC server failed to start.
     #[error("failed to start IPC server: {0}")]
     IpcServerStart(#[from] IpcServerStartError),
+
+    /// A non-socket file exists at the IPC socket path.
+    #[error("non-socket file exists at IPC path: {0}")]
+    IpcPathNotSocket(PathBuf),
+
+    /// IPC socket is already in use by another running server.
+    #[error("IPC socket already in use: {path}")]
+    IpcSocketInUse {
+        /// Path to the socket that is already in use.
+        path: PathBuf,
+    },
 
     /// Preconfirmation support is disabled in the driver configuration.
     #[error("preconfirmation is not enabled in driver config")]

--- a/packages/taiko-client-rs/crates/driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/error.rs
@@ -3,6 +3,7 @@
 use std::{io, result::Result as StdResult, time::Duration};
 
 use anyhow::Error as AnyhowError;
+use reth_ipc::server::IpcServerStartError;
 use rpc::error::RpcClientError;
 use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
@@ -34,6 +35,10 @@ pub enum DriverError {
     /// Failed to read the JWT secret configured for the driver RPC server.
     #[error("failed to read jwt secret for driver RPC server")]
     DriverRpcJwtSecretReadFailed,
+
+    /// IPC server failed to start.
+    #[error("failed to start IPC server: {0}")]
+    IpcServerStart(#[from] IpcServerStartError),
 
     /// Preconfirmation support is disabled in the driver configuration.
     #[error("preconfirmation is not enabled in driver config")]

--- a/packages/taiko-client-rs/crates/driver/src/jsonrpc/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/jsonrpc/mod.rs
@@ -125,17 +125,16 @@ impl DriverIpcServer {
         prepare_ipc_socket(&ipc_path).await?;
 
         let server = IpcBuilder::default().build(ipc_path.to_string_lossy().into_owned());
-        let path = ipc_path.clone();
 
         let module = build_rpc_module(api);
         let handle = server.start(module).await?;
 
         info!(path = ?ipc_path, "started driver IPC JSON-RPC server");
-        Ok(Self { path, handle })
+        Ok(Self { path: ipc_path, handle })
     }
 
     /// Return the IPC socket path.
-    pub fn ipc_path(&self) -> &PathBuf {
+    pub fn ipc_path(&self) -> &Path {
         &self.path
     }
 

--- a/packages/taiko-client-rs/crates/driver/src/jsonrpc/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/jsonrpc/mod.rs
@@ -169,11 +169,12 @@ impl DriverIpcServer {
 
 /// Ensure the parent directory for the IPC socket path exists.
 fn ensure_ipc_parent_dir(ipc_path: &Path) -> DriverResult<()> {
-    if let Some(parent) = ipc_path.parent()
-        && !parent.exists() {
-            info!(path = ?parent, "creating IPC socket parent directory");
-            create_dir_all(parent)?;
-        }
+    if let Some(parent) = ipc_path.parent() &&
+        !parent.exists()
+    {
+        info!(path = ?parent, "creating IPC socket parent directory");
+        create_dir_all(parent)?;
+    }
     Ok(())
 }
 

--- a/packages/taiko-client-rs/crates/driver/src/jsonrpc/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/jsonrpc/mod.rs
@@ -1,9 +1,11 @@
 //! JSON-RPC server for driving preconfirmation injection.
 
 use std::{
+    fs::create_dir_all,
     future::Future,
+    io::ErrorKind,
     net::SocketAddr,
-    path::PathBuf,
+    path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -21,7 +23,7 @@ use jsonrpsee::{
 use metrics::{counter, histogram};
 use reth_ipc::server::Builder as IpcBuilder;
 use tower::{Service, ServiceBuilder};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     error::{DriverError, Result as DriverResult},
@@ -128,7 +130,18 @@ impl DriverIpcServer {
     /// Start an IPC JSON-RPC server (no JWT authentication).
     ///
     /// IPC uses filesystem permissions for access control.
+    ///
+    /// This method will:
+    /// - Auto-create missing parent directories for the socket path
+    /// - Remove stale socket files on startup (unix only)
+    /// - Error if a non-socket file exists at the path (unix only)
+    /// - Error if the socket is already in use (unix only)
     pub async fn start(ipc_path: PathBuf, api: Arc<dyn DriverRpcApi>) -> DriverResult<Self> {
+        ensure_ipc_parent_dir(&ipc_path)?;
+
+        #[cfg(unix)]
+        prepare_ipc_socket(&ipc_path).await?;
+
         let server = IpcBuilder::default().build(ipc_path.to_string_lossy().into_owned());
         let path = ipc_path.clone();
 
@@ -144,12 +157,118 @@ impl DriverIpcServer {
         &self.path
     }
 
-    /// Stop the server.
+    /// Stop the server and remove the socket file.
     pub async fn stop(self) {
         if let Err(err) = self.handle.stop() {
             warn!(error = %err, "driver IPC JSON-RPC server already stopped");
         }
         let _ = self.handle.stopped().await;
+        cleanup_ipc_socket(&self.path);
+    }
+}
+
+/// Ensure the parent directory for the IPC socket path exists.
+fn ensure_ipc_parent_dir(ipc_path: &Path) -> DriverResult<()> {
+    if let Some(parent) = ipc_path.parent()
+        && !parent.exists() {
+            info!(path = ?parent, "creating IPC socket parent directory");
+            create_dir_all(parent)?;
+        }
+    Ok(())
+}
+
+/// Prepare the IPC socket path by removing stale sockets if necessary.
+#[cfg(unix)]
+async fn prepare_ipc_socket(ipc_path: &Path) -> DriverResult<()> {
+    match inspect_ipc_path(ipc_path)? {
+        Some(true) => {
+            if socket_in_use(ipc_path).await? {
+                error!(path = ?ipc_path, "IPC socket already in use");
+                return Err(DriverError::IpcSocketInUse { path: ipc_path.to_path_buf() });
+            }
+            info!(path = ?ipc_path, "removing stale IPC socket");
+            remove_socket_file(ipc_path)?;
+        }
+        Some(false) => {
+            error!(path = ?ipc_path, "non-socket file exists at IPC path");
+            return Err(DriverError::IpcPathNotSocket(ipc_path.to_path_buf()));
+        }
+        None => {}
+    }
+    Ok(())
+}
+
+/// Inspect the IPC path to determine if it exists and whether it is a socket.
+#[cfg(unix)]
+fn inspect_ipc_path(ipc_path: &Path) -> DriverResult<Option<bool>> {
+    use std::os::unix::fs::FileTypeExt;
+
+    match std::fs::metadata(ipc_path) {
+        Ok(metadata) => Ok(Some(metadata.file_type().is_socket())),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Check if the IPC socket is currently in use.
+#[cfg(unix)]
+async fn socket_in_use(ipc_path: &Path) -> DriverResult<bool> {
+    use tokio::{
+        net::UnixStream,
+        time::{Duration, timeout},
+    };
+
+    const CONNECT_TIMEOUT: Duration = Duration::from_millis(100);
+
+    match timeout(CONNECT_TIMEOUT, UnixStream::connect(ipc_path)).await {
+        Ok(Ok(_stream)) => Ok(true),
+        Ok(Err(err)) => match err.kind() {
+            ErrorKind::NotFound | ErrorKind::ConnectionRefused => Ok(false),
+            _ => Err(err.into()),
+        },
+        Err(_) => Ok(true),
+    }
+}
+
+/// Remove the IPC socket file.
+#[cfg(unix)]
+fn remove_socket_file(ipc_path: &Path) -> DriverResult<()> {
+    match std::fs::remove_file(ipc_path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Clean up the IPC socket file on server shutdown.
+#[cfg(unix)]
+fn cleanup_ipc_socket(ipc_path: &Path) {
+    match inspect_ipc_path(ipc_path) {
+        Ok(Some(true)) => match remove_socket_file(ipc_path) {
+            Ok(()) => info!(path = ?ipc_path, "removed IPC socket file"),
+            Err(err) => {
+                warn!(path = ?ipc_path, error = %err, "failed to remove IPC socket file");
+            }
+        },
+        Ok(Some(false)) => {
+            warn!(path = ?ipc_path, "IPC path is not a socket; skipping removal");
+        }
+        Ok(None) => {}
+        Err(err) => {
+            warn!(path = ?ipc_path, error = %err, "failed to stat IPC socket file");
+        }
+    }
+}
+
+/// Clean up the IPC socket file on server shutdown.
+#[cfg(not(unix))]
+fn cleanup_ipc_socket(ipc_path: &Path) {
+    match std::fs::remove_file(ipc_path) {
+        Ok(()) => info!(path = ?ipc_path, "removed IPC socket file"),
+        Err(err) if err.kind() == ErrorKind::NotFound => {}
+        Err(err) => {
+            warn!(path = ?ipc_path, error = %err, "failed to remove IPC socket file");
+        }
     }
 }
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -55,7 +55,7 @@ const RESUME_REORG_CUSHION_SLOTS: u64 = 2 * EPOCH_SLOTS;
 /// Default timeout for preconfirmation payload submission.
 ///
 /// Covers both the enqueue operation and awaiting the processing response.
-const PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT: Duration = Duration::from_secs(24);
+const PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT: Duration = Duration::from_secs(12);
 
 /// Responsible for following inbox events and updating the L2 execution engine accordingly.
 pub struct EventSyncer<P>
@@ -754,5 +754,14 @@ mod tests {
             .expect_err("expected ingress not ready error");
 
         assert!(matches!(err, DriverError::PreconfIngressNotReady));
+    }
+
+    #[test]
+    fn preconfirmation_submit_timeout_defaults_to_12_seconds() {
+        assert_eq!(
+            PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT,
+            Duration::from_secs(12),
+            "preconfirmation submit timeout should default to 12 seconds"
+        );
     }
 }

--- a/packages/taiko-client-rs/crates/driver/tests/driver_rpc_server.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/driver_rpc_server.rs
@@ -115,7 +115,111 @@ async fn ipc_server_starts_and_stops() -> TestResult {
     assert_eq!(server.ipc_path(), &ipc_path);
 
     server.stop().await;
+    assert!(!ipc_path.exists(), "IPC socket should be removed on shutdown");
+    Ok(())
+}
+
+/// Ensure the IPC server auto-creates missing parent directories.
+#[tokio::test]
+async fn ipc_server_creates_parent_directory() -> TestResult {
+    let base_dir = PathBuf::from(format!("/tmp/driver-test-nested-{}/subdir", std::process::id()));
+    let ipc_path = base_dir.join("driver.ipc");
+
+    let _ = std::fs::remove_dir_all(&base_dir);
+    assert!(!base_dir.exists(), "Parent directory should not exist before test");
+
+    let api = Arc::new(StubApi::default());
+    let server = DriverIpcServer::start(ipc_path.clone(), api).await?;
+
+    assert!(base_dir.exists(), "IPC server should auto-create missing parent directories");
+    assert!(ipc_path.exists(), "IPC socket should exist after start");
+
+    server.stop().await;
+
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "/tmp/driver-test-nested-{}",
+        std::process::id()
+    )));
+    Ok(())
+}
+
+/// Ensure the IPC server removes a stale socket file on startup.
+#[cfg(unix)]
+#[tokio::test]
+async fn ipc_server_removes_stale_socket_on_startup() -> TestResult {
+    use std::os::unix::net::UnixListener;
+
+    let ipc_path = PathBuf::from(format!("/tmp/driver-test-stale-{}.ipc", std::process::id()));
+
+    {
+        let _ = std::fs::remove_file(&ipc_path);
+        let _listener = UnixListener::bind(&ipc_path)?;
+    }
+    assert!(ipc_path.exists(), "Stale socket should exist before test");
+
+    let api = Arc::new(StubApi::default());
+    let server = DriverIpcServer::start(ipc_path.clone(), api).await?;
+
+    assert!(ipc_path.exists(), "New IPC socket should exist after start");
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Ensure starting a second IPC server on an active socket fails.
+#[cfg(unix)]
+#[tokio::test]
+async fn ipc_server_rejects_active_socket() -> TestResult {
+    let ipc_path = PathBuf::from(format!("/tmp/driver-test-active-{}.ipc", std::process::id()));
+    let _ = std::fs::remove_file(&ipc_path);
+
+    let api = Arc::new(StubApi::default());
+    let server = DriverIpcServer::start(ipc_path.clone(), api).await?;
+
+    let api2 = Arc::new(StubApi::default());
+    let result = DriverIpcServer::start(ipc_path.clone(), api2).await;
+
+    assert!(
+        matches!(result, Err(DriverError::IpcSocketInUse { .. })),
+        "expected IpcSocketInUse error"
+    );
+    assert!(ipc_path.exists(), "socket should not be removed while in use");
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Ensure the IPC server errors if a non-socket file exists at the path.
+#[cfg(unix)]
+#[tokio::test]
+async fn ipc_server_errors_on_non_socket_file() -> TestResult {
+    let ipc_path = PathBuf::from(format!("/tmp/driver-test-regular-{}.ipc", std::process::id()));
+
+    std::fs::write(&ipc_path, "not a socket")?;
+    assert!(ipc_path.exists(), "Regular file should exist before test");
+
+    let api = Arc::new(StubApi::default());
+    let result = DriverIpcServer::start(ipc_path.clone(), api).await;
+
+    assert!(result.is_err(), "IPC server should error if non-socket file exists at path");
 
     let _ = std::fs::remove_file(&ipc_path);
+    Ok(())
+}
+
+/// Ensure the IPC socket file is removed on shutdown.
+#[tokio::test]
+async fn ipc_socket_removed_on_shutdown() -> TestResult {
+    let ipc_path = PathBuf::from(format!("/tmp/driver-test-cleanup-{}.ipc", std::process::id()));
+    let _ = std::fs::remove_file(&ipc_path);
+
+    let api = Arc::new(StubApi::default());
+    let server = DriverIpcServer::start(ipc_path.clone(), api).await?;
+
+    assert!(ipc_path.exists(), "IPC socket should exist after start");
+
+    server.stop().await;
+
+    assert!(!ipc_path.exists(), "IPC socket should be removed after stop()");
     Ok(())
 }

--- a/packages/taiko-client-rs/crates/rpc/src/client.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/client.rs
@@ -220,9 +220,10 @@ mod tests {
 
     #[test]
     fn test_default_http_timeout_covers_preconfirmation_budget() {
-        assert!(
-            DEFAULT_HTTP_TIMEOUT >= Duration::from_secs(24),
-            "DEFAULT_HTTP_TIMEOUT should cover preconfirmation submit timeout"
+        assert_eq!(
+            DEFAULT_HTTP_TIMEOUT,
+            Duration::from_secs(12),
+            "DEFAULT_HTTP_TIMEOUT should default to 12 seconds"
         );
     }
 }

--- a/packages/taiko-client-rs/crates/rpc/src/client.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/client.rs
@@ -7,7 +7,8 @@ use alloy::{eips::BlockNumberOrTag, rpc::client::RpcClient, transports::http::re
 use alloy_eips::{BlockId, eip1898::RpcBlockHash};
 use alloy_primitives::{Address, B256};
 use alloy_provider::{
-    Provider, ProviderBuilder, RootProvider, fillers::FillProvider, utils::JoinedRecommendedFillers,
+    IpcConnect, Provider, ProviderBuilder, RootProvider, fillers::FillProvider,
+    utils::JoinedRecommendedFillers,
 };
 use alloy_rpc_types::engine::JwtSecret;
 use alloy_transport_http::{AuthLayer, Http, HyperClient};
@@ -170,6 +171,16 @@ pub fn build_jwt_http_provider(url: Url, secret: JwtSecret) -> RootProvider {
     ProviderBuilder::default().connect_client(RpcClient::new(http_hyper, true))
 }
 
+/// Builds a [`RootProvider`] backed by an IPC transport.
+///
+/// IPC does not require JWT authentication; security relies on filesystem permissions.
+pub async fn build_ipc_provider(path: PathBuf) -> Result<RootProvider> {
+    ProviderBuilder::default()
+        .connect_ipc(IpcConnect::new(path))
+        .await
+        .map_err(|e| RpcClientError::Connection(e.to_string()))
+}
+
 /// Returns the JWT secret for the engine API
 /// using the provided [PathBuf]. If the file is not found, it will return [None].
 pub fn read_jwt_secret(path: PathBuf) -> Option<JwtSecret> {
@@ -205,5 +216,13 @@ mod tests {
         // Should return None for non-existent file
         let secret = read_jwt_secret(jwt_path);
         assert!(secret.is_none());
+    }
+
+    #[test]
+    fn test_default_http_timeout_covers_preconfirmation_budget() {
+        assert!(
+            DEFAULT_HTTP_TIMEOUT >= Duration::from_secs(24),
+            "DEFAULT_HTTP_TIMEOUT should cover preconfirmation submit timeout"
+        );
     }
 }


### PR DESCRIPTION
   Summary
   - Add IPC JSON-RPC support for the driver server while keeping HTTP+JWT unchanged.
   - Allow running HTTP and IPC concurrently; IPC uses filesystem permissions (no JWT).
   - Extend preconfirmation client to connect via HTTP or IPC.

   Key Changes
   - Driver config/CLI: new driver.rpc.ipc.path; accept HTTP, IPC, or both.
   - Driver server: start HTTP (JWT) and IPC (no JWT) side-by-side; log both endpoints.
   - Preconfirmation client: new DriverEndpoint enum and async client init for IPC.
   - RPC helper: build_ipc_provider added for IPC RootProvider creation.
   - Tests: IPC server smoke test + config/endpoint unit tests.