### PR TITLE
fix(protocol): fix signal service proof issue (backport to v3.0.0)

### DIFF
--- a/packages/protocol/contracts/shared/libs/LibTrieProof.sol
+++ b/packages/protocol/contracts/shared/libs/LibTrieProof.sol
@@ -3,6 +3,15 @@ pragma solidity ^0.8.26;
 
 import "@optimism/packages/contracts-bedrock/src/libraries/rlp/RLPReader.sol";
 import "@optimism/packages/contracts-bedrock/src/libraries/rlp/RLPWriter.sol";
+
+// SECURITY: Always use SecureMerkleTrie, never MerkleTrie directly.
+// The underlying MerkleTrie library has a known vulnerability (Optimism issue #4845)
+// involving an off-by-one error at the 32-byte boundary in node size checks.
+// This vulnerability is NOT exploitable when using SecureMerkleTrie because:
+// 1. SecureMerkleTrie hashes all keys via keccak256 before trie traversal
+// 2. The attack requires constructing specific trie structures with "near" keys
+// 3. With heccak256 keys, this requires a partial preimage attack (2^128 complexity)
+// See: https://github.com/ethereum-optimism/optimism/issues/4845
 import "@optimism/packages/contracts-bedrock/src/libraries/trie/SecureMerkleTrie.sol";
 
 /// @title LibTrieProof

--- a/packages/protocol/contracts/shared/signal/SignalService.sol
+++ b/packages/protocol/contracts/shared/signal/SignalService.sol
@@ -253,6 +253,10 @@ contract SignalService is EssentialContract, ISignalService {
             revert SS_EMPTY_PROOF();
         }
 
+        if (proof.blockId > type(uint48).max) {
+            revert SS_INVALID_BLOCK_ID();
+        }
+
         Checkpoint memory checkpoint = _getCheckpoint(uint48(proof.blockId));
         if (checkpoint.stateRoot != proof.rootHash) {
             revert SS_INVALID_CHECKPOINT();
@@ -272,10 +276,11 @@ contract SignalService is EssentialContract, ISignalService {
     // Errors
     // ---------------------------------------------------------------
 
-    error SS_EMPTY_PROOF();
-    error SS_INVALID_PROOF_LENGTH();
-    error SS_INVALID_CHECKPOINT();
     error SS_CHECKPOINT_NOT_FOUND();
-    error SS_UNAUTHORIZED();
+    error SS_EMPTY_PROOF();
+    error SS_INVALID_BLOCK_ID();
+    error SS_INVALID_CHECKPOINT();
+    error SS_INVALID_PROOF_LENGTH();
     error SS_SIGNAL_NOT_RECEIVED();
+    error SS_UNAUTHORIZED();
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #21129 to `taiko-alethia-protocol-v3.0.0`.
