### PR TITLE
refactor(taiko-client-rs): avoid pruning fallback timeline in resolve_fallback

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/preconfirmation/lookahead/resolver/core.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/preconfirmation/lookahead/resolver/core.rs
@@ -492,7 +492,6 @@ impl LookaheadResolver {
         epoch_start: u64,
         baseline: Address,
     ) -> Result<Address> {
-        self.fallback_timeline.prune_before(earliest_allowed_timestamp(self.genesis_timestamp)?);
         self.fallback_timeline.ensure_baseline(epoch_start, baseline);
         Ok(self.fallback_timeline.operator_at(ts).unwrap_or(baseline))
     }


### PR DESCRIPTION
Removed the prune_before call from resolve_fallback, which was cloning the fallback timeline on every signer resolution. Timeline pruning now only happens on write paths (store_epoch, synthetic_empty_epoch, whitelist events), matching the blacklist timeline pattern and keeping the history bounded without extra COW work on the hot read path.