### PR TITLE
refactor(taiko-client-rs): introduce `DriverApiError` for driver preconf RPC errors

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -7170,6 +7170,7 @@ dependencies = [
  "alethia-reth-consensus",
  "alethia-reth-primitives",
  "alloy-consensus",
+ "alloy-contract",
  "alloy-eips",
  "alloy-primitives",
  "alloy-provider",

--- a/packages/taiko-client-rs/crates/preconfirmation-client/Cargo.toml
+++ b/packages/taiko-client-rs/crates/preconfirmation-client/Cargo.toml
@@ -9,12 +9,14 @@ license.workspace = true
 alethia-reth-consensus = { workspace = true }
 alethia-reth-primitives = { workspace = true }
 alloy-consensus = { workspace = true }
+alloy-contract = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true }
 alloy-rlp = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-rpc-types-engine = { workspace = true }
+alloy-transport = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
@@ -34,7 +36,6 @@ protocol = { path = "../protocol" }
 rpc = { path = "../rpc" }
 
 [dev-dependencies]
-alloy-transport = { workspace = true }
 rand = { workspace = true }
 secp256k1 = { version = "0.30", features = ["recovery", "rand"] }
 tokio = { workspace = true, features = ["full"] }

--- a/packages/taiko-client-rs/crates/preconfirmation-client/src/driver_interface/jsonrpc.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-client/src/driver_interface/jsonrpc.rs
@@ -95,7 +95,13 @@ impl JsonRpcDriverClientConfig {
         l2_rpc_url: Url,
         inbox_address: Address,
     ) -> Self {
-        Self::with_http_endpoint(driver_rpc_url, driver_jwt_secret, l1_rpc_url, l2_rpc_url, inbox_address)
+        Self::with_http_endpoint(
+            driver_rpc_url,
+            driver_jwt_secret,
+            l1_rpc_url,
+            l2_rpc_url,
+            inbox_address,
+        )
     }
 
     /// Construct a config with an HTTP endpoint (requires JWT).

--- a/packages/taiko-client-rs/crates/preconfirmation-client/src/driver_interface/payload.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-client/src/driver_interface/payload.rs
@@ -148,9 +148,8 @@ pub async fn build_taiko_payload_attributes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::PreconfirmationClientError;
+    use crate::error::{DriverApiError, PreconfirmationClientError};
     use alloy_consensus::Header;
-    use crate::error::DriverApiError;
     use preconfirmation_types::{
         Bytes20, Bytes32, Bytes65, PreconfCommitment, Preconfirmation, SignedCommitment,
     };

--- a/packages/taiko-client-rs/crates/preconfirmation-client/src/error.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-client/src/error.rs
@@ -1,5 +1,9 @@
 //! Error types for the preconfirmation client SDK.
 
+use alloy_contract::Error as ContractError;
+use alloy_transport::TransportError;
+use rpc::RpcClientError;
+use std::path::PathBuf;
 use thiserror::Error;
 
 /// Result alias for preconfirmation client operations.
@@ -17,9 +21,9 @@ pub enum PreconfirmationClientError {
     /// Storage layer failure (in-memory or persistent).
     #[error("storage error: {0}")]
     Storage(String),
-    /// Error returned by the driver client callback.
-    #[error("driver client error: {0}")]
-    DriverClient(String),
+    /// Error during driver interface operations (RPC, contract, or payload setup).
+    #[error(transparent)]
+    DriverInterface(#[from] DriverApiError),
     /// Codec error while decoding a txlist payload.
     #[error("codec error: {0}")]
     Codec(String),
@@ -32,6 +36,59 @@ pub enum PreconfirmationClientError {
     /// Invalid configuration parameter.
     #[error("config error: {0}")]
     Config(String),
+}
+
+/// Errors produced by driver interface operations.
+#[derive(Debug, Error)]
+pub enum DriverApiError {
+    /// JSON-RPC error returned by the provider transport.
+    #[error("rpc error: {0}")]
+    Rpc(#[from] TransportError),
+    /// Contract call error while fetching on-chain state.
+    #[error("contract error: {0}")]
+    Contract(#[from] ContractError),
+    /// IPC connection failure when building the driver provider.
+    #[error("IPC connection failed for {path}: {source}")]
+    IpcConnectionFailed {
+        /// IPC socket path.
+        path: PathBuf,
+        /// Underlying RPC client error.
+        #[source]
+        source: RpcClientError,
+    },
+    /// HTTP endpoint configuration missing a JWT secret path.
+    #[error("HTTP endpoint requires JWT secret path")]
+    MissingJwtSecret,
+    /// Failed to read the JWT secret file.
+    #[error("failed to read jwt secret from {path}")]
+    JwtSecretReadError {
+        /// JWT secret path.
+        path: PathBuf,
+    },
+    /// Requested block was not found.
+    #[error("missing block {block_number}")]
+    MissingBlock {
+        /// Block number that was not found.
+        block_number: u64,
+    },
+    /// Parent block missing the base fee field.
+    #[error("missing base fee for parent block {parent_block_number}")]
+    MissingBaseFee {
+        /// Parent block number.
+        parent_block_number: u64,
+    },
+    /// Safe block not found on the L2 provider.
+    #[error("missing safe block")]
+    MissingSafeBlock,
+    /// Latest block not found on the L2 provider.
+    #[error("missing latest block")]
+    MissingLatestBlock,
+    /// Missing transactions in the preconfirmation input.
+    #[error("missing transactions for execution payload")]
+    MissingTransactions,
+    /// Proposal id exceeds the uint48 limit.
+    #[error("proposal_id does not fit into uint48")]
+    ProposalIdOverflow,
 }
 
 impl From<preconfirmation_net::NetworkError> for PreconfirmationClientError {
@@ -50,12 +107,21 @@ impl From<protocol::preconfirmation::LookaheadError> for PreconfirmationClientEr
 
 #[cfg(test)]
 mod tests {
-    use super::PreconfirmationClientError;
+    use super::{DriverApiError, PreconfirmationClientError};
 
     #[test]
     fn error_display_works() {
         // Create a validation error for formatting.
         let err = PreconfirmationClientError::Validation("bad signature".into());
         assert!(!err.to_string().is_empty());
+    }
+
+    #[test]
+    fn driver_interface_error_display_works() {
+        let err = DriverApiError::MissingBlock { block_number: 42 };
+        assert_eq!(err.to_string(), "missing block 42");
+
+        let wrapped = PreconfirmationClientError::DriverInterface(err);
+        assert!(wrapped.to_string().contains("missing block 42"));
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-client/src/lib.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-client/src/lib.rs
@@ -31,5 +31,5 @@ pub mod validation;
 pub use client::{EventLoop, PreconfirmationClient};
 pub use config::PreconfirmationClientConfig;
 pub use driver_interface::{DriverClient, PreconfirmationInput};
-pub use error::{PreconfirmationClientError, Result};
+pub use error::{DriverApiError, PreconfirmationClientError, Result};
 pub use metrics::PreconfirmationClientMetrics;

--- a/packages/taiko-client-rs/crates/preconfirmation-client/src/subscription/event_handler.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-client/src/subscription/event_handler.rs
@@ -395,7 +395,7 @@ mod tests {
     use crate::{
         codec::ZlibTxListCodec,
         driver_interface::{DriverClient, PreconfirmationInput},
-    error::{DriverApiError, PreconfirmationClientError, Result},
+        error::{DriverApiError, PreconfirmationClientError, Result},
         storage::{CommitmentStore, InMemoryCommitmentStore},
     };
     use preconfirmation_types::{
@@ -512,10 +512,7 @@ mod tests {
         let sk = SecretKey::from_slice(&[1u8; 32]).expect("secret key");
         let commitment = build_signed_commitment(&sk, 2, parent_hash, 100, 200);
 
-        let err = handler
-            .submit_if_ready(commitment)
-            .await
-            .expect_err("expected driver error");
+        let err = handler.submit_if_ready(commitment).await.expect_err("expected driver error");
 
         assert!(matches!(
             err,

--- a/packages/taiko-client-rs/crates/preconfirmation-client/src/subscription/event_handler.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-client/src/subscription/event_handler.rs
@@ -306,7 +306,7 @@ where
                 Err(err) => {
                     metrics::counter!(PreconfirmationClientMetrics::DRIVER_SUBMIT_FAILURE_TOTAL)
                         .increment(1);
-                    return Err(PreconfirmationClientError::DriverClient(err.to_string()));
+                    return Err(err);
                 }
             }
             return Ok(true);
@@ -336,7 +336,7 @@ where
             Err(err) => {
                 metrics::counter!(PreconfirmationClientMetrics::DRIVER_SUBMIT_FAILURE_TOTAL)
                     .increment(1);
-                return Err(PreconfirmationClientError::DriverClient(err.to_string()));
+                return Err(err);
             }
         }
         Ok(true)
@@ -352,8 +352,7 @@ where
 
         // Only advance the head when this commitment is newer than the stored head.
         let new_block = uint256_to_u256(&head.block_number);
-        let current_head = self.store.head().map(|head| uint256_to_u256(&head.block_number));
-        if current_head.map(|current| new_block <= current).unwrap_or(false) {
+        if self.store.head().is_some_and(|h| new_block <= uint256_to_u256(&h.block_number)) {
             return;
         }
 
@@ -396,7 +395,7 @@ mod tests {
     use crate::{
         codec::ZlibTxListCodec,
         driver_interface::{DriverClient, PreconfirmationInput},
-        error::Result,
+    error::{DriverApiError, PreconfirmationClientError, Result},
         storage::{CommitmentStore, InMemoryCommitmentStore},
     };
     use preconfirmation_types::{
@@ -467,6 +466,63 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn submit_if_ready_propagates_driver_error() {
+        struct ErrorDriver;
+
+        #[async_trait]
+        impl DriverClient for ErrorDriver {
+            async fn submit_preconfirmation(&self, _input: PreconfirmationInput) -> Result<()> {
+                Err(PreconfirmationClientError::DriverInterface(
+                    DriverApiError::MissingTransactions,
+                ))
+            }
+
+            async fn wait_event_sync(&self) -> Result<()> {
+                Ok(())
+            }
+
+            async fn event_sync_tip(&self) -> Result<U256> {
+                Ok(U256::ZERO)
+            }
+
+            async fn preconf_tip(&self) -> Result<U256> {
+                Ok(U256::ZERO)
+            }
+        }
+
+        let store = Arc::new(InMemoryCommitmentStore::new());
+        let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
+        let driver = Arc::new(ErrorDriver);
+        let lookahead_resolver = Arc::new(MockResolver);
+        let (event_tx, _event_rx) = broadcast::channel(16);
+        let (command_sender, _command_rx) = mpsc::channel(8);
+
+        let handler = EventHandler::new(
+            store,
+            codec,
+            driver,
+            None,
+            event_tx,
+            command_sender,
+            lookahead_resolver,
+        );
+
+        let parent_hash = Bytes32::try_from(vec![1u8; 32]).expect("parent hash");
+        let sk = SecretKey::from_slice(&[1u8; 32]).expect("secret key");
+        let commitment = build_signed_commitment(&sk, 2, parent_hash, 100, 200);
+
+        let err = handler
+            .submit_if_ready(commitment)
+            .await
+            .expect_err("expected driver error");
+
+        assert!(matches!(
+            err,
+            PreconfirmationClientError::DriverInterface(DriverApiError::MissingTransactions)
+        ));
+    }
+
     /// Build a signed commitment for tests.
     fn build_signed_commitment(
         sk: &SecretKey,
@@ -495,26 +551,6 @@ mod tests {
 
     #[async_trait]
     impl PreconfSignerResolver for MockResolver {
-        async fn signer_for_timestamp(
-            &self,
-            _l2_block_timestamp: U256,
-        ) -> protocol::preconfirmation::Result<Address> {
-            Ok(Address::ZERO)
-        }
-
-        async fn slot_info_for_timestamp(
-            &self,
-            _l2_block_timestamp: U256,
-        ) -> protocol::preconfirmation::Result<PreconfSlotInfo> {
-            Ok(PreconfSlotInfo { signer: Address::ZERO, submission_window_end: U256::ZERO })
-        }
-    }
-
-    /// Resolver that intentionally mismatches lookahead expectations.
-    struct MismatchResolver;
-
-    #[async_trait]
-    impl PreconfSignerResolver for MismatchResolver {
         async fn signer_for_timestamp(
             &self,
             _l2_block_timestamp: U256,
@@ -598,7 +634,7 @@ mod tests {
         let store = Arc::new(InMemoryCommitmentStore::new());
         let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
         let driver = Arc::new(TestDriver::new());
-        let lookahead_resolver = Arc::new(MismatchResolver);
+        let lookahead_resolver = Arc::new(MockResolver);
         let (event_tx, _event_rx) = broadcast::channel(16);
         let (command_sender, _command_rx) = mpsc::channel(8);
 
@@ -629,7 +665,7 @@ mod tests {
         let store = Arc::new(InMemoryCommitmentStore::new());
         let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
         let driver = Arc::new(TestDriver::new());
-        let lookahead_resolver = Arc::new(MismatchResolver);
+        let lookahead_resolver = Arc::new(MockResolver);
         let (event_tx, _event_rx) = broadcast::channel(16);
         let (command_sender, _command_rx) = mpsc::channel(8);
 


### PR DESCRIPTION
   ### Summary
   - Replace string-based driver interface errors with structured `DriverApiError` variants.
   - Map JSON-RPC/contract/JWT/IPC failures to concrete error types and propagate without re-wrapping.
   - Update payload builder and event handler error paths; add tests for overflow/missing txs/propagation.