### PR TITLE
feat(protocol): update `blobSlice.offset` validation in derivation pipeline

### DIFF
--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -152,7 +152,7 @@ For each `DerivationSource[i]`, the validator performs:
 
 1. **Blob Validation**: Verify `blobSlice.blobHashes.length > 0`
    - Let `BLOB_BYTES = 4096 * 32 = 131072` (bytes per blob as defined by EIP-4844)
-2. **Offset Validation**: Verify `blobSlice.offset <= BLOB_BYTES * blobSlice.blobHashes.length - 64`
+2. **Offset Validation**: Verify `blobSlice.offset <= BLOB_BYTES - 64`
 3. **Version Extraction**: Extract version from bytes `[offset, offset+32)` and verify it equals `0x1`
 4. **Size Extraction**: Extract data size from bytes `[offset+32, offset+64)`
 5. **Decompression**: Apply ZLIB decompression to bytes `[offset+64, offset+64+size)`


### PR DESCRIPTION
As we discussed in Slack, there is no need to allow the offset to be larger than `BLOB_BYTES`  (ie. it skips over the entire first blob). In such a case,  the proposer can just change the `BlobReference` to increase `blobStartIndex`, so we can simplify the validation rule to `blobSlice.offset <= BLOB_BYTES - 64`.