### PR TITLE
feat(taiko-client,taiko-client-rs): update blob offset validation for Shasta proposals

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
@@ -1,7 +1,7 @@
 //! Shasta protocol constants and limits.
 
 use crate::shasta::error::{ForkConfigResult, ShastaForkConfigError};
-use alloy_eips::eip4844::{FIELD_ELEMENTS_PER_BLOB, USABLE_BITS_PER_FIELD_ELEMENT};
+use alloy_eips::eip4844::BYTES_PER_BLOB;
 use alloy_hardforks::ForkCondition;
 
 /// The maximum number of blocks allowed in a proposal. If we assume block time is as
@@ -33,8 +33,7 @@ pub const BOND_PROCESSING_DELAY: u64 = 6;
 pub const SHASTA_PAYLOAD_VERSION: u8 = 0x1;
 
 /// The maximum size of a blob data, in bytes.
-pub const PROPOSAL_MAX_BLOB_BYTES: usize =
-    (USABLE_BITS_PER_FIELD_ELEMENT - 1) * FIELD_ELEMENTS_PER_BLOB as usize;
+pub const PROPOSAL_MAX_BLOB_BYTES: usize = BYTES_PER_BLOB;
 
 /// Shasta fork activation on Taiko Devnet.
 pub const SHASTA_FORK_DEVNET: ForkCondition = ForkCondition::Timestamp(0);

--- a/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/manifest/shasta.go
@@ -51,11 +51,10 @@ func (f *ShastaDerivationSourceFetcher) Fetch(
 	meta metadata.TaikoProposalMetaDataShasta,
 	derivationIdx int,
 ) (*ShastaDerivationSourcePayload, error) {
-	// If there is no blob hash, or its length exceeds PROPOSAL_MAX_BLOBS, or its offset is invalid,
-	// return the default payload.
+	// If there is no blob hash, or its offset is invalid, return the default payload.
 	if len(meta.GetBlobHashes(derivationIdx)) == 0 ||
 		meta.GetEventData().Sources[derivationIdx].BlobSlice.Offset.Uint64() >
-			uint64(manifest.BlobBytes*len(meta.GetBlobHashes(derivationIdx))-64) {
+			uint64(manifest.BlobBytes-64) {
 		return &ShastaDerivationSourcePayload{Default: true}, nil
 	}
 


### PR DESCRIPTION
  ## Summary
  - Update blob offset validation from `offset <= BLOB_BYTES * blobHashes.length - 64` to `offset <= BLOB_BYTES - 64`, to match https://github.com/taikoxyz/taiko-mono/pull/21147
  - Add missing offset validation check in taiko-client-rs
  - Fix `PROPOSAL_MAX_BLOB_BYTES` constant in Rust (was using wrong formula)

  ## Changes

  ### taiko-client (Go)
  - `driver/chain_syncer/event/manifest/shasta.go`: Update offset bound check

  ### taiko-client-rs (Rust)
  - `crates/protocol/src/shasta/constants.rs`: Fix `PROPOSAL_MAX_BLOB_BYTES` to use `BYTES_PER_BLOB` (131072) instead of incorrect formula
  - `crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs`: Add early offset validation to align with Go implementation