### PR TITLE
fix(taiko-client): remove redundant firstItemAt initialization in ProofBuffer

### DIFF
--- a/packages/taiko-client/prover/proof_producer/proof_buffer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_buffer.go
@@ -25,7 +25,6 @@ type ProofBuffer struct {
 func NewProofBuffer(maxLength uint64) *ProofBuffer {
 	return &ProofBuffer{
 		buffer:      make([]*ProofResponse, 0, maxLength),
-		firstItemAt: time.Now(),
 		MaxLength:   maxLength,
 	}
 }


### PR DESCRIPTION
Removes redundant `firstItemAt` initialization in `NewProofBuffer` constructor that duplicates logic already present in `Write()` method.

The `firstItemAt` field was being initialized to `time.Now()` in the constructor, but `Write()` already sets this value when the first item is added to an empty buffer. 