### PR TITLE
fix(taiko-client): remove duplicate AnchorTxValidator construction

### DIFF
--- a/packages/taiko-client/prover/anchor_tx_validator/anchor_tx_validator.go
+++ b/packages/taiko-client/prover/anchor_tx_validator/anchor_tx_validator.go
@@ -28,19 +28,15 @@ func New(taikoAnchor common.Address, chainID *big.Int, rpc *rpc.Client) (*Anchor
 		err                error
 	)
 
-	if rpc.ShastaClients != nil && rpc.ShastaClients.Anchor != nil {
-		if goldenTouchAddress, err = rpc.ShastaClients.Anchor.GOLDENTOUCHADDRESS(nil); err == nil {
-			return &AnchorTxValidator{
-				taikoAnchorAddress: taikoAnchor,
-				goldenTouchAddress: goldenTouchAddress,
-				chainID:            chainID,
-				rpc:                rpc,
-			}, nil
-		}
+	hasShastaAnchor := rpc.ShastaClients != nil && rpc.ShastaClients.Anchor != nil
+	if hasShastaAnchor {
+		goldenTouchAddress, err = rpc.ShastaClients.Anchor.GOLDENTOUCHADDRESS(nil)
 	}
 
-	if goldenTouchAddress, err = rpc.PacayaClients.TaikoAnchor.GOLDENTOUCHADDRESS(nil); err != nil {
-		return nil, fmt.Errorf("failed to get golden touch address: %w", err)
+	if !hasShastaAnchor || err != nil {
+		if goldenTouchAddress, err = rpc.PacayaClients.TaikoAnchor.GOLDENTOUCHADDRESS(nil); err != nil {
+			return nil, fmt.Errorf("failed to get golden touch address: %w", err)
+		}
 	}
 
 	return &AnchorTxValidator{

--- a/packages/taiko-client/prover/anchor_tx_validator/anchor_tx_validator_test.go
+++ b/packages/taiko-client/prover/anchor_tx_validator/anchor_tx_validator_test.go
@@ -46,7 +46,7 @@ func (s *AnchorTxValidatorTestSuite) TestValidateAnchorTx() {
 	s.ErrorContains(s.v.ValidateAnchorTx(tx), "invalid anchor transaction recipient")
 
 	// invalid sender
-	dynamicFeeTxTx := &types.DynamicFeeTx{
+	dynamicFeeTx := &types.DynamicFeeTx{
 		ChainID:    s.v.rpc.L2.ChainID,
 		Nonce:      0,
 		GasTipCap:  common.Big1,
@@ -59,14 +59,14 @@ func (s *AnchorTxValidatorTestSuite) TestValidateAnchorTx() {
 	}
 
 	signer := types.LatestSignerForChainID(s.v.rpc.L2.ChainID)
-	tx = types.MustSignNewTx(wrongPrivKey, signer, dynamicFeeTxTx)
+	tx = types.MustSignNewTx(wrongPrivKey, signer, dynamicFeeTx)
 
 	s.ErrorContains(
 		s.v.ValidateAnchorTx(tx), "invalid anchor transaction sender",
 	)
 
 	// invalid method selector
-	tx = types.MustSignNewTx(goldenTouchPriKey, signer, dynamicFeeTxTx)
+	tx = types.MustSignNewTx(goldenTouchPriKey, signer, dynamicFeeTx)
 	s.ErrorContains(s.v.ValidateAnchorTx(tx), "failed to get anchor transaction method")
 }
 


### PR DESCRIPTION
The function previously had two separate `return &AnchorTxValidator{...}` statements in different code paths (Shasta vs Pacaya clients), creating a maintenance risk. If the struct definition changes in the future, both return statements would need to be updated separately, which could lead to inconsistencies.

