### PR TITLE
fix(eventindexer): use Scan for unique proposers/provers queries

### DIFF
--- a/packages/eventindexer/pkg/repo/event.go
+++ b/packages/eventindexer/pkg/repo/event.go
@@ -170,8 +170,8 @@ func (r *EventRepository) FindUniqueProvers(
 	if err := r.db.GormDB().WithContext(ctx).
 		Raw("SELECT address, count(*) AS count FROM events WHERE event IN (?, ?) GROUP BY address",
 			eventindexer.EventNameTransitionProved, eventindexer.EventNameBatchesProven).
-		FirstOrInit(&addrs).Error; err != nil {
-		return nil, errors.Wrap(err, "r.db.FirstOrInit")
+		Scan(&addrs).Error; err != nil {
+		return nil, errors.Wrap(err, "r.db.Scan")
 	}
 
 	return addrs, nil
@@ -185,8 +185,8 @@ func (r *EventRepository) FindUniqueProposers(
 	if err := r.db.GormDB().WithContext(ctx).
 		Raw("SELECT address, count(*) AS count FROM events WHERE event IN (?, ?) GROUP BY address",
 			eventindexer.EventNameBlockProposed, eventindexer.EventNameBatchProposed).
-		FirstOrInit(&addrs).Error; err != nil {
-		return nil, errors.Wrap(err, "r.db.Find")
+		Scan(&addrs).Error; err != nil {
+		return nil, errors.Wrap(err, "r.db.Scan")
 	}
 
 	return addrs, nil

--- a/packages/eventindexer/pkg/repo/event_test.go
+++ b/packages/eventindexer/pkg/repo/event_test.go
@@ -70,6 +70,132 @@ func TestIntegration_Event_Save(t *testing.T) {
 	}
 }
 
+func TestIntegration_Event_FindUniqueProvers_MultipleAddresses(t *testing.T) {
+	db, close, err := testMysql(t)
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	eventRepo, err := NewEventRepository(db)
+	assert.Equal(t, nil, err)
+
+	addr1 := "0xaaaa"
+	addr2 := "0xbbbb"
+
+	_, err = eventRepo.Save(context.Background(), eventindexer.SaveEventOpts{
+		Name:         eventindexer.EventNameTransitionProved,
+		Address:      addr1,
+		Data:         "{\"data\":\"something\"}",
+		Event:        eventindexer.EventNameTransitionProved,
+		ChainID:      big.NewInt(1),
+		BlockID:      &blockID,
+		TransactedAt: time.Now(),
+	})
+	assert.Equal(t, nil, err)
+
+	_, err = eventRepo.Save(context.Background(), eventindexer.SaveEventOpts{
+		Name:         eventindexer.EventNameBatchesProven,
+		Address:      addr1,
+		Data:         "{\"data\":\"something\"}",
+		Event:        eventindexer.EventNameBatchesProven,
+		ChainID:      big.NewInt(1),
+		BlockID:      &blockID,
+		TransactedAt: time.Now(),
+	})
+	assert.Equal(t, nil, err)
+
+	_, err = eventRepo.Save(context.Background(), eventindexer.SaveEventOpts{
+		Name:         eventindexer.EventNameTransitionProved,
+		Address:      addr2,
+		Data:         "{\"data\":\"something\"}",
+		Event:        eventindexer.EventNameTransitionProved,
+		ChainID:      big.NewInt(1),
+		BlockID:      &blockID,
+		TransactedAt: time.Now(),
+	})
+	assert.Equal(t, nil, err)
+
+	resp, err := eventRepo.FindUniqueProvers(context.Background())
+	assert.Equal(t, nil, err)
+
+	expected := map[string]int{
+		addr1: 2,
+		addr2: 1,
+	}
+
+	assert.Equal(t, len(expected), len(resp))
+
+	actual := make(map[string]int)
+	for _, v := range resp {
+		actual[v.Address] = v.Count
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestIntegration_Event_FindUniqueProposers_MultipleAddresses(t *testing.T) {
+	db, close, err := testMysql(t)
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	eventRepo, err := NewEventRepository(db)
+	assert.Equal(t, nil, err)
+
+	addr1 := "0xcccc"
+	addr2 := "0xdddd"
+
+	_, err = eventRepo.Save(context.Background(), eventindexer.SaveEventOpts{
+		Name:         eventindexer.EventNameBlockProposed,
+		Address:      addr1,
+		Data:         "{\"data\":\"something\"}",
+		Event:        eventindexer.EventNameBlockProposed,
+		ChainID:      big.NewInt(1),
+		BlockID:      &blockID,
+		TransactedAt: time.Now(),
+	})
+	assert.Equal(t, nil, err)
+
+	_, err = eventRepo.Save(context.Background(), eventindexer.SaveEventOpts{
+		Name:         eventindexer.EventNameBatchProposed,
+		Address:      addr1,
+		Data:         "{\"data\":\"something\"}",
+		Event:        eventindexer.EventNameBatchProposed,
+		ChainID:      big.NewInt(1),
+		BlockID:      &blockID,
+		TransactedAt: time.Now(),
+	})
+	assert.Equal(t, nil, err)
+
+	_, err = eventRepo.Save(context.Background(), eventindexer.SaveEventOpts{
+		Name:         eventindexer.EventNameBlockProposed,
+		Address:      addr2,
+		Data:         "{\"data\":\"something\"}",
+		Event:        eventindexer.EventNameBlockProposed,
+		ChainID:      big.NewInt(1),
+		BlockID:      &blockID,
+		TransactedAt: time.Now(),
+	})
+	assert.Equal(t, nil, err)
+
+	resp, err := eventRepo.FindUniqueProposers(context.Background())
+	assert.Equal(t, nil, err)
+
+	expected := map[string]int{
+		addr1: 2,
+		addr2: 1,
+	}
+
+	assert.Equal(t, len(expected), len(resp))
+
+	actual := make(map[string]int)
+	for _, v := range resp {
+		actual[v.Address] = v.Count
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
 func TestIntegration_Event_FindUniqueProvers(t *testing.T) {
 	db, close, err := testMysql(t)
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
Replace FirstOrInit with Scan in FindUniqueProposers and FindUniqueProvers so that GORM returns all grouped rows instead of implicitly adding LIMIT 1. This aligns the repository methods with their API contract (return all unique addresses with counts), ensures the HTTP endpoints expose the full set of unique proposers/provers, and keeps error wrapping consistent with the actual query method.