### PR TITLE
refactor(bridge-ui): extract duplicate switch chain error handling to shared utility

### DIFF
--- a/packages/bridge-ui/src/components/ChainSelectors/ChainSelector.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/ChainSelector.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import { switchChain } from '@wagmi/core';
-  import { t } from 'svelte-i18n';
-  import { type Chain, SwitchChainError, UserRejectedRequestError } from 'viem';
+  import { type Chain } from 'viem';
 
   import { destNetwork } from '$components/Bridge/state';
-  import { warningToast } from '$components/NotificationToast';
   import { OnAccount } from '$components/OnAccount';
   import { OnNetwork } from '$components/OnNetwork';
+  import { handleSwitchChainError } from '$libs/network/handleSwitchChainError';
   import { setAlternateNetwork } from '$libs/network/setAlternateNetwork';
   import { config } from '$libs/wagmi';
   import { connectedSourceChain, switchingNetwork } from '$stores/network';
@@ -36,17 +35,7 @@
           setAlternateNetwork();
         }
       } catch (err) {
-        if (err instanceof SwitchChainError) {
-          warningToast({
-            title: $t('messages.network.pending.title'),
-            message: $t('messages.network.pending.message'),
-          });
-        } else if (err instanceof UserRejectedRequestError) {
-          warningToast({
-            title: $t('messages.network.rejected.title'),
-            message: $t('messages.network.rejected.message'),
-          });
-        } else {
+        if (!handleSwitchChainError(err)) {
           console.error(err);
         }
       } finally {

--- a/packages/bridge-ui/src/components/ChainSelectors/SwitchChainsButton/SwitchChainsButton.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/SwitchChainsButton/SwitchChainsButton.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { switchChain } from '@wagmi/core';
-  import { t } from 'svelte-i18n';
-  import { SwitchChainError, UserRejectedRequestError } from 'viem';
 
   import { destNetwork } from '$components/Bridge/state';
   import { Icon } from '$components/Icon';
-  import { warningToast } from '$components/NotificationToast';
+  import { handleSwitchChainError } from '$libs/network/handleSwitchChainError';
   import { setAlternateNetwork } from '$libs/network/setAlternateNetwork';
   import { config } from '$libs/wagmi';
 
@@ -19,14 +17,7 @@
       setAlternateNetwork();
     } catch (err) {
       console.error(err);
-      if (err instanceof SwitchChainError) {
-        warningToast({ title: $t('messages.network.pending.title'), message: $t('messages.network.pending.message') });
-      } else if (err instanceof UserRejectedRequestError) {
-        warningToast({
-          title: $t('messages.network.rejected.title'),
-          message: $t('messages.network.rejected.message'),
-        });
-      }
+      handleSwitchChainError(err);
     }
   }
 </script>

--- a/packages/bridge-ui/src/components/Faucet/Faucet.svelte
+++ b/packages/bridge-ui/src/components/Faucet/Faucet.svelte
@@ -2,7 +2,7 @@
   import { switchChain } from '@wagmi/core';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
-  import { type Chain, ContractFunctionExecutionError, SwitchChainError, UserRejectedRequestError } from 'viem';
+  import { type Chain, ContractFunctionExecutionError, UserRejectedRequestError } from 'viem';
 
   import { chainConfig } from '$chainConfig';
   import { Alert } from '$components/Alert';
@@ -15,6 +15,7 @@
   import { web3modal } from '$libs/connect';
   import { InsufficientBalanceError, MintError, TokenMintedError } from '$libs/error';
   import { getAlternateNetwork } from '$libs/network';
+  import { handleSwitchChainError } from '$libs/network/handleSwitchChainError';
   import { checkMintable, isMintable, mint, testERC20Tokens, testNFT, type Token } from '$libs/token';
   import { config } from '$libs/wagmi';
   import { account, connectedSourceChain, pendingTransactions } from '$stores';
@@ -150,16 +151,8 @@
       }
       await switchChain(config, { chainId: alternateChain });
     } catch (err) {
-      if (err instanceof SwitchChainError) {
-        warningToast({
-          title: $t('messages.network.pending.title'),
-          message: $t('messages.network.pending.message'),
-        });
-      } else if (err instanceof UserRejectedRequestError) {
-        warningToast({
-          title: $t('messages.network.rejected.title'),
-          message: $t('messages.network.rejected.message'),
-        });
+      const handled = handleSwitchChainError(err);
+      if (handled && err instanceof UserRejectedRequestError) {
         console.error(err);
       }
     } finally {

--- a/packages/bridge-ui/src/components/SwitchChainModal/SwitchChainModal.svelte
+++ b/packages/bridge-ui/src/components/SwitchChainModal/SwitchChainModal.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { switchChain } from '@wagmi/core';
   import { t } from 'svelte-i18n';
-  import { type Chain, SwitchChainError, UserRejectedRequestError } from 'viem';
+  import { type Chain } from 'viem';
 
   import { chainConfig } from '$chainConfig';
   import { LoadingMask } from '$components/LoadingMask';
-  import { warningToast } from '$components/NotificationToast';
   import { chains } from '$libs/chain';
+  import { handleSwitchChainError } from '$libs/network/handleSwitchChainError';
   import { config } from '$libs/wagmi';
   import { switchChainModal } from '$stores/modal';
 
@@ -29,15 +29,7 @@
       closeModal();
     } catch (err) {
       console.error(err);
-      if (err instanceof SwitchChainError) {
-        warningToast({ title: $t('messages.network.pending.title'), message: $t('messages.network.pending.message') });
-      }
-      if (err instanceof UserRejectedRequestError) {
-        warningToast({
-          title: $t('messages.network.rejected.title'),
-          message: $t('messages.network.rejected.message'),
-        });
-      }
+      handleSwitchChainError(err);
     } finally {
       switchingNetwork = false;
     }

--- a/packages/bridge-ui/src/libs/network/handleSwitchChainError.ts
+++ b/packages/bridge-ui/src/libs/network/handleSwitchChainError.ts
@@ -1,0 +1,25 @@
+import { get } from 'svelte/store';
+import { t } from 'svelte-i18n';
+import { SwitchChainError, UserRejectedRequestError } from 'viem';
+
+import { warningToast } from '$components/NotificationToast';
+
+export const handleSwitchChainError = (error: unknown): boolean => {
+  if (error instanceof SwitchChainError) {
+    warningToast({
+      title: get(t)('messages.network.pending.title'),
+      message: get(t)('messages.network.pending.message'),
+    });
+    return true;
+  }
+
+  if (error instanceof UserRejectedRequestError) {
+    warningToast({
+      title: get(t)('messages.network.rejected.title'),
+      message: get(t)('messages.network.rejected.message'),
+    });
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION

Extracts duplicate error handling logic for `switchChain` calls into a shared utility function. The same error handling code (checking for `SwitchChainError` and `UserRejectedRequestError` with identical toast notifications) was duplicated across multiple components.

