### PR TITLE
fix(relayer): keep queue message body format when requeuing

### DIFF
--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"context"
 	"crypto/ecdsa"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -585,18 +584,9 @@ func (p *Processor) eventLoop(ctx context.Context) {
 				}
 
 				if shouldRequeue {
-					// we want to negatively acknowledge the message
+					// we want to negatively acknowledge the message and let the broker requeue it
 					if err := p.queue.Nack(ctx, m, true); err != nil {
 						slog.Error("Err nacking message", "err", err.Error())
-					}
-
-					marshalledMsg, err := json.Marshal(msg)
-					if err != nil {
-						slog.Error("err marshaling queue message", "err", err.Error())
-					} else {
-						if err := p.queue.Publish(ctx, p.queueName(), marshalledMsg, nil, nil); err != nil {
-							slog.Error("err publishing to queue", "err", err.Error())
-						}
 					}
 				} else {
 					// otherwise if no error, we can acknowledge it successfully.


### PR DESCRIPTION
Fixed the processor requeue path so that messages keep using the QueueMessageSentBody JSON format expected by processMessage. Previously, eventLoop marshalled the whole queue.Message struct and republished it, which broke JSON decoding on the next attempt and effectively caused such messages to be dropped into the DLX instead of being retried.

Now, when processMessage returns shouldRequeue == true, the processor only calls Nack(requeue=true) and lets the broker requeue the original delivery without touching its body.