### PR TITLE
ci(taiko-client, taiko-client-rs): improve ci timeout

### DIFF
--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -90,8 +90,17 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Install pnpm dependencies
-        uses: ./.github/actions/install-pnpm-dependencies
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
 
       - name: Setup just
         uses: extractions/setup-just@v3

--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -62,7 +62,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     name: Tests
     runs-on: [ubuntu-latest]
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       PROTOCOL_FORK_DIR: protocol-taiko-mono
 

--- a/packages/taiko-client-rs/tests/deploy.sh
+++ b/packages/taiko-client-rs/tests/deploy.sh
@@ -14,4 +14,3 @@ cd "${PROTOCOL_DIR}" &&
     --ffi \
     --private-key "$PRIVATE_KEY" \
     --block-gas-limit 200000000 \
-    --legacy

--- a/packages/taiko-client-rs/tests/deploy.sh
+++ b/packages/taiko-client-rs/tests/deploy.sh
@@ -13,4 +13,4 @@ cd "${PROTOCOL_DIR}" &&
     --broadcast \
     --ffi \
     --private-key "$PRIVATE_KEY" \
-    --block-gas-limit 200000000 \
+    --block-gas-limit 200000000

--- a/packages/taiko-client-rs/tests/docker/docker-compose.test.yaml
+++ b/packages/taiko-client-rs/tests/docker/docker-compose.test.yaml
@@ -3,7 +3,7 @@ services:
     container_name: l1_node
     image: ghcr.io/foundry-rs/foundry:stable
     restart: unless-stopped
-    pull_policy: if_not_present
+    pull_policy: always
     ports:
       - "18545:8545"
     entrypoint:
@@ -17,7 +17,7 @@ services:
     container_name: l2_node
     image: us-docker.pkg.dev/evmchain/images/alethia-reth:main
     restart: unless-stopped
-    pull_policy: if_not_present
+    pull_policy: always
     volumes:
       - .:/host
     ports:

--- a/packages/taiko-client-rs/tests/docker/docker-compose.test.yaml
+++ b/packages/taiko-client-rs/tests/docker/docker-compose.test.yaml
@@ -3,7 +3,7 @@ services:
     container_name: l1_node
     image: ghcr.io/foundry-rs/foundry:stable
     restart: unless-stopped
-    pull_policy: always
+    pull_policy: if_not_present
     ports:
       - "18545:8545"
     entrypoint:
@@ -15,7 +15,7 @@ services:
     container_name: l2_node
     image: us-docker.pkg.dev/evmchain/images/alethia-reth:main
     restart: unless-stopped
-    pull_policy: always
+    pull_policy: if_not_present
     volumes:
       - .:/host
     ports:

--- a/packages/taiko-client-rs/tests/docker/docker-compose.test.yaml
+++ b/packages/taiko-client-rs/tests/docker/docker-compose.test.yaml
@@ -10,6 +10,8 @@ services:
       - anvil
       - --host
       - "0.0.0.0"
+      - --gas-limit
+      - "200000000"
 
   l2_node:
     container_name: l2_node

--- a/packages/taiko-client/integration_test/deploy_l1_contract.sh
+++ b/packages/taiko-client/integration_test/deploy_l1_contract.sh
@@ -12,8 +12,7 @@ cd ${PACAYA_FORK_TAIKO_MONO}/packages/protocol &&
     --ffi \
     --evm-version cancun \
     --private-key "$PRIVATE_KEY" \
-    --block-gas-limit 200000000 \
-    --legacy &&
+    --block-gas-limit 200000000 &&
   cd -
 
 # Get deployed contract address.


### PR DESCRIPTION
previously failing on forge script, likely due to invisible failures where txs don't get mined; inferred from failed runs not reaching `ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.` log. 

also extended timeout as we have encountered cases where compilation is the gating factor, ~15 should be enough for now