### PR TITLE
fix(protocol): l-01-misleading-documentation

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IInbox.sol
@@ -44,7 +44,7 @@ interface IInbox {
         /// @notice Queue size at which the fee doubles
         uint64 forcedInclusionFeeDoubleThreshold;
         /// @notice The minimum delay between checkpoints in seconds
-        /// @dev Must be less than or equal to finalization grace period
+        /// @dev Used to rate-limit checkpoint syncing in `prove`.
         uint16 minCheckpointDelay;
         /// @notice The multiplier to determine when a forced inclusion is too old so that proposing
         /// becomes permissionless

--- a/packages/protocol/contracts/shared/signal/ICheckpointStore.sol
+++ b/packages/protocol/contracts/shared/signal/ICheckpointStore.sol
@@ -13,9 +13,9 @@ interface ICheckpointStore {
     struct Checkpoint {
         /// @notice The block number associated with the checkpoint.
         uint48 blockNumber;
-        /// @notice The block hash for the end (last) L2 block in this proposal.
+        /// @notice The block hash for the referenced block.
         bytes32 blockHash;
-        /// @notice The state root for the end (last) L2 block in this proposal.
+        /// @notice The state root for the referenced block.
         bytes32 stateRoot;
     }
 

--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -21,16 +21,16 @@ Throughout this document, metadata references follow the notation `metadata.fiel
 
 ### Proposal-level Metadata
 
-| **Metadata Component**             | **Description**                                                         |
-| ---------------------------------- | ----------------------------------------------------------------------- |
-| **id**                             | A unique, sequential identifier for the proposal                        |
-| **proposer**                       | The address that proposed the proposal                                  |
-| **timestamp**                      | The timestamp when the proposal was accepted on L1                      |
-| **endOfSubmissionWindowTimestamp** | The last slot timestamp where the current preconfer can propose         |
-| **parentProposalHash**             | The hash of the parent proposal                                         |
-| **originBlockNumber**              | The L1 block number from **one block before** the proposal was accepted |
-| **originBlockHash**                | The hash of `originBlockNumber` block                                   |
-| **basefeeSharingPctg**             | The percentage of base fee paid to coinbase                             |
+| **Metadata Component**             | **Description**                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **id**                             | A unique, sequential identifier for the proposal                                                      |
+| **proposer**                       | The address that proposed the proposal                                                                |
+| **timestamp**                      | The timestamp when the proposal was accepted on L1                                                    |
+| **endOfSubmissionWindowTimestamp** | The last slot timestamp where the current preconfer can propose. `0` for whitelisted preconfirmations |
+| **parentProposalHash**             | The hash of the parent proposal                                                                       |
+| **originBlockNumber**              | The L1 block number from **one block before** the proposal was accepted                               |
+| **originBlockHash**                | The hash of `originBlockNumber` block                                                                 |
+| **basefeeSharingPctg**             | The percentage of base fee paid to coinbase                                                           |
 
 ### Derivation Source-level Metadata
 


### PR DESCRIPTION
## Issue
Throughout the codebase, multiple instances of misleading documentation were identified. For instance, the Derivation.md description:

- [incorrectly states](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/docs/Derivation.md?plain=1#L231) that - isForcedInclusion should be false when discussing forced inclusion sources
- still [refers](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/docs/Derivation.md?plain=1#L259) to the obsolete "bond instruction" concept. It correctly describes the L1 behavior, but it is listed as a subsection under "Metadata Validation and Computation"
- [references](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/docs/Derivation.md?plain=1#L319) a non-existent ShastaAnchor contract
- [omits](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/docs/Derivation.md?plain=1#L22) the parentProposalHash and endOfSubmissionWindowTimestamp fields from its proposal-level metadata tables, despite these being present in the on-chain [Proposal struct](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/contracts/layer1/core/iface/IInbox.sol#L68-L73) and [Proposed event](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/contracts/layer1/core/iface/IInbox.sol#L191-L192).

In addition, the [Checkpoint struct](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/contracts/shared/signal/ICheckpointStore.sol#L12-L20) fields are described as L2 data, but it is [also used](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/contracts/layer2/core/Anchor.sol#L173) for L1 checkpoints.

Lastly, the minCheckpointDelay is [described as less than](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/contracts/layer1/core/iface/IInbox.sol#L47) a "finalization grace period", but it is [configured](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol#L53-L60) to be larger than maxProofSubmissionDelay and it is not clear which other variable the grace period refers to. Any such requirement should be enforced when [validating the configuration](https://github.com/taikoxyz/taiko-mono/blob/18c7ab01bc74eea7071f964e8b7cd4bf288df6f6/packages/protocol/contracts/layer1/core/libs/LibInboxSetup.sol#L24).

Consider updating the documentation accordingly.

## Fix
- Updated Derivation.md tables and wording, corrected the forced inclusion flag and anchor contract reference, moved the liveness bond text to an L1 proof section, and made checkpoint/minCheckpointDelay docs accurate.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies and corrects protocol documentation and interface comments to match on-chain behavior and current architecture.
> 
> - Updates `Derivation.md`:
>   - Adds missing proposal fields `endOfSubmissionWindowTimestamp` and `parentProposalHash`; adjusts event-derived assignments
>   - Fixes forced inclusion flag logic (`isForcedInclusion == true`) and removes obsolete bond subsection, moving it under a new **L1 Proof and Liveness Bond Settlement** section
>   - Updates anchor call target to `Anchor` (via `AnchorForkRouter`) and minor wording (derive from L1 only)
> - Refines comments in `IInbox.Config.minCheckpointDelay` to note it rate-limits checkpoint syncing in `prove`
> - Generalizes `ICheckpointStore.Checkpoint` comments to reference the L1/L2 "referenced block" instead of the prior L2-specific phrasing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f54b2858e11fea2fe8600ac9166a56d10cc5bd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->