### PR TITLE
fix(protocol): l-03-incorrect-storage-gap

### DIFF
--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -69,7 +69,7 @@ contract Anchor is EssentialContract {
     BlockState internal _blockState;
 
     /// @notice Storage gap for upgrade safety.
-    uint256[41] private __gap;
+    uint256[43] private __gap;
 
     // ---------------------------------------------------------------
     // Events

--- a/packages/protocol/contracts/layer2/core/Anchor_Layout.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor_Layout.sol
@@ -22,4 +22,4 @@ pragma solidity ^0.8.26;
 //   _pacayaSlots                   | uint256[3]                                         | Slot: 252  | Offset: 0    | Bytes: 96  
 //   _lastProposalId                | uint48                                             | Slot: 255  | Offset: 0    | Bytes: 6   
 //   _blockState                    | struct Anchor.BlockState                           | Slot: 256  | Offset: 0    | Bytes: 64  
-//   __gap                          | uint256[41]                                        | Slot: 258  | Offset: 0    | Bytes: 1312
+//   __gap                          | uint256[43]                                        | Slot: 258  | Offset: 0    | Bytes: 1376


### PR DESCRIPTION
## Issue
- Anchor's storage gap did not reserve the standard 50 slots given the current state variables.

## Fix
- Increased the gap size and regenerated the layer2 storage layout file.

## Assumptions
- Base branch `taiko-alethia-protocol-v3.0.0` used because `taiko-alethia-v3.0.0` is not present on origin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures storage layout safety by aligning the reserved gap with current variables.
> 
> - Changes `Anchor.sol` storage gap `__gap` from `uint256[41]` to `uint256[43]`
> - Regenerates `Anchor_Layout.sol` to reflect the new gap size and updated byte counts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0636d881d3c0d63d63ea49b36588191630111785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->