### PR TITLE
fix(protocol): n-01-code-consistency

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -54,7 +54,7 @@ contract MainnetInbox is Inbox {
                 ringBufferSize: _RING_BUFFER_SIZE,
                 basefeeSharingPctg: 0,
                 minForcedInclusionCount: 1,
-                forcedInclusionDelay: 384, // 1 epoch
+                forcedInclusionDelay: 384 seconds, // 1 epoch
                 forcedInclusionFeeInGwei: 10_000_000, // 0.01 ETH base fee
                 forcedInclusionFeeDoubleThreshold: 50, // fee doubles at 50 pending
                 minCheckpointDelay: 384 seconds, // 1 epoch

--- a/packages/protocol/test/layer1/core/inbox/InboxTestBase.sol
+++ b/packages/protocol/test/layer1/core/inbox/InboxTestBase.sol
@@ -91,7 +91,7 @@ abstract contract InboxTestBase is CommonTest {
             ringBufferSize: 100,
             basefeeSharingPctg: 0,
             minForcedInclusionCount: 1,
-            forcedInclusionDelay: 384,
+            forcedInclusionDelay: 384 seconds,
             forcedInclusionFeeInGwei: 10_000_000,
             forcedInclusionFeeDoubleThreshold: 50,
             minCheckpointDelay: 60_000, // large enough for skipping checkpoints in prove benches


### PR DESCRIPTION
## Issue
- Forced inclusion delay was expressed as a raw literal while other durations use explicit time units.

## Fix
- Switched the config literals to `384 seconds` for clarity (mainnet config and test config).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns time unit usage for clarity and consistency.
> 
> - Update `forcedInclusionDelay` to `384 seconds` in `MainnetInbox.sol` and `InboxTestBase.sol`
> - No other behavior or interfaces changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99db63868b1287ea414a78df1325368ef08be9dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->