### PR TITLE
fix(relayer): use canonical zero address constant in processor

### DIFF
--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -28,7 +28,6 @@ import (
 )
 
 var (
-	zeroAddress          = common.HexToAddress("0x0000000000000000000000000000000000000000")
 	errUnprocessable     = errors.New("message is unprocessable")
 	errAlreadyProcessing = errors.New("already processing txHash")
 )
@@ -202,7 +201,7 @@ func (p *Processor) processMessage(
 		// don't check quota for NFTs
 		if eventType == relayer.EventTypeSendERC20 || eventType == relayer.EventTypeSendETH {
 			// default to ETH (zero address) and msg value, overwrite if ERC20
-			var tokenAddress = zeroAddress
+			var tokenAddress = relayer.ZeroAddress
 
 			var value = msgBody.Event.Message.Value
 


### PR DESCRIPTION
Use the canonical `relayer.ZeroAddress` in the message processor instead of a locally redefined zero address.
Removes duplicated sentinel values and keeps a single source of truth for the zero address across the relayer codebase.

