### PR TITLE
fix(repo): shell injection in deploy workflow and tighten websocket origins

### DIFF
--- a/.github/workflows/repo--vercel-deploy.yml
+++ b/.github/workflows/repo--vercel-deploy.yml
@@ -43,10 +43,19 @@ jobs:
         run: pnpm add --global vercel@latest
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.vercel_token }}
+        env:
+          VERCEL_ENV: ${{ inputs.environment }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: vercel pull --yes --environment="$VERCEL_ENV" --token="$VERCEL_TOKEN"
 
       - name: Build Project Artifacts
-        run: vercel build ${{ inputs.flags }} --token=${{ secrets.vercel_token }}
+        env:
+          VERCEL_FLAGS: ${{ inputs.flags }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: vercel build $VERCEL_FLAGS --token="$VERCEL_TOKEN"
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt ${{ inputs.flags }} --force --token=${{ secrets.vercel_token }}
+        env:
+          VERCEL_FLAGS: ${{ inputs.flags }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: vercel deploy --prebuilt $VERCEL_FLAGS --force --token="$VERCEL_TOKEN"

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -43,7 +43,7 @@ import (
 var (
 	errInvalidCurrOperator = errors.New("invalid operator: expected current operator in handover window")
 	errInvalidNextOperator = errors.New("invalid operator: expected next operator in handover window")
-	wsUpgrader             = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	wsUpgrader             = websocket.Upgrader{}
 )
 
 const requestSyncMargin = uint64(128) // Margin for requesting sync, to avoid requesting very old blocks.

--- a/packages/tools/bridged-token-scanner/index.js
+++ b/packages/tools/bridged-token-scanner/index.js
@@ -19,7 +19,8 @@ const BRIDGED_TOKEN_DEPLOYED_ABIS = {
 };
 
 async function getLastScannedBlock(dataDir, networkName, vaultName) {
-  const dir = path.join(dataDir, networkName.replaceAll(" ", "_"), `BridgedTokenDeployed_${vaultName}`);
+  const safeName = networkName.replace(/[^a-zA-Z0-9-_]/g, "_");
+  const dir = path.join(dataDir, safeName, `BridgedTokenDeployed_${vaultName}`);
   try {
     const files = await fs.readdir(dir);
     const chunkFiles = files.filter(f => f.startsWith("chunk_") && f.endsWith(".json"));
@@ -130,7 +131,7 @@ async function withRetry(fn, retries = 3, delayMs = 1000) {
           allEvents.push(...chunkRecords);
 
           const chunkLabel = `${startBlock}_${chunkEnd}`;
-          const safeName = name.replaceAll(" ", "_");
+          const safeName = name.replace(/[^a-zA-Z0-9-_]/g, "_");
           const chunkDir = path.join(outputDir, safeName, `BridgedTokenDeployed_${vault.name}`);
           await fs.mkdir(chunkDir, { recursive: true });
 


### PR DESCRIPTION
Refactored the Vercel deployment workflow to use intermediate environment variables for user-supplied inputs. Direct interpolation into `run:` steps is a known vector for command injection.

Modified the WebSocket upgrader in the preconfirmation block server to enforce origin validation. The previous permissive policy allowed connections from any origin, introducing unnecessary CSRF risk to the driver component.

Also added directory name sanitization in the bridged-token-scanner tool to prevent potential path traversal when handling network names with special characters.

Impact:
- Mitigates runner takeover risks in GitHub Actions.
- Protects the preconfirmation server from cross-site WebSocket hijacking.
- Ensures local tool scripts operate within their designated data directories.