### PR TITLE
fix(bridge-ui): shadowed address validation state in AddCustomERC20

### DIFF
--- a/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -91,9 +91,10 @@
   };
 
   async function onAddressValidation(event: CustomEvent<{ isValidEthereumAddress: boolean; addr: Address }>) {
-    const { isValidEthereumAddress, addr } = event.detail;
+    const { isValidEthereumAddress: isValidAddress, addr } = event.detail;
+    isValidEthereumAddress = isValidAddress;
     tokenAddress = addr;
-    if (isValidEthereumAddress) {
+    if (isValidAddress) {
       await onAddressChange(tokenAddress as Address);
     } else {
       tokenAddress = addr;


### PR DESCRIPTION


Fix a real UI logic bug caused by variable shadowing in `AddCustomERC20.svelte`, where the component-level `isValidEthereumAddress` flag was never updated.

