### PR TITLE
fix(taiko-client): handle genesis parent hash for first shasta proposal

### DIFF
--- a/packages/taiko-client/prover/proof_submitter/transaction/builder.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/builder.go
@@ -157,15 +157,19 @@ func (a *ProveBatchesTxBuilder) BuildProveBatchesShasta(
 
 			// Set first proposal information.
 			if i == 0 {
-				lastOriginInLastProposal, err := a.rpc.LastL1OriginInBatchShasta(
-					ctx,
-					new(big.Int).Sub(proposals[i].Id, common.Big1),
-				)
-				if err != nil {
-					return nil, err
-				}
 				input.Commitment.FirstProposalId = proposals[i].Id
-				input.Commitment.FirstProposalParentBlockHash = lastOriginInLastProposal.L2BlockHash
+				if proposals[i].Id.Cmp(common.Big1) == 0 {
+					input.Commitment.FirstProposalParentBlockHash = proofResponse.Opts.ShastaOptions().Headers[0].ParentHash
+				} else {
+					lastOriginInLastProposal, err := a.rpc.LastL1OriginInBatchShasta(
+						ctx,
+						new(big.Int).Sub(proposals[i].Id, common.Big1),
+					)
+					if err != nil {
+						return nil, err
+					}
+					input.Commitment.FirstProposalParentBlockHash = lastOriginInLastProposal.L2BlockHash
+				}
 			}
 
 			// Set last proposal information.


### PR DESCRIPTION
 When building prove batches for Shasta, use the header parent hash if the first proposal ID is 1. Otherwise fallback to LastL1OriginInBatchShasta.