### PR TITLE
fix(protocol): update DERIVATION_SOURCE_MAX_BLOCKS on Derivation

### DIFF
--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -251,6 +251,7 @@ Gas limit adjustments are constrained by `BLOCK_GAS_LIMIT_MAX_CHANGE` parts per 
 **Validation process**:
 
 1. **Define bounds**:
+
    - `upperBound = min(parent.metadata.gasLimit * (1_000_000 + BLOCK_GAS_LIMIT_MAX_CHANGE) / 1_000_000, MAX_BLOCK_GAS_LIMIT)`
    - `lowerBound = min(max(parent.metadata.gasLimit * (1_000_000 - BLOCK_GAS_LIMIT_MAX_CHANGE) / 1_000_000, MIN_BLOCK_GAS_LIMIT), upperBound)`
 
@@ -328,6 +329,7 @@ The anchor transaction serves as a privileged system transaction responsible for
 The anchor transaction executes a carefully orchestrated sequence of operations:
 
 1. **Fork validation and duplicate prevention**
+
    - Verifies the current block number is at or after the Shasta fork height
    - Tracks parent block hash to prevent duplicate `anchorV4` calls within the same block
 
@@ -356,7 +358,7 @@ The following constants govern the block derivation process:
 
 | Constant                         | Value                         | Description                                                                                                                                                                |
 | -------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **DERIVATION_SOURCE_MAX_BLOCKS** | `384`                         | The per-derivation-source block limit. If we assume block time is as small as one second, 384 blocks will cover an Ethereum epoch.                                         |
+| **DERIVATION_SOURCE_MAX_BLOCKS** | `192`                         | The per-derivation-source block limit. If we assume block times of seconds,192 blocks will cover an Ethereum epoch.                                                        |
 | **MAX_ANCHOR_OFFSET**            | `128`                         | The maximum anchor block number offset from the proposal origin block number.                                                                                              |
 | **TIMESTAMP_MAX_OFFSET**         | `1536` (12 \* 128)            | The maximum number timestamp offset from the proposal origin timestamp. This is set to longer than an epoch to allow the next proposer to recover without causing a reorg. |
 | **BLOCK_GAS_LIMIT_MAX_CHANGE**   | `200`                         | The maximum block gas limit change per block, in millionths (1/1,000,000). For example, 200 = 200 / 1,000,000 = 0.02%.                                                     |


### PR DESCRIPTION
After our discussion, we don't expect or want proposals to span more than one epoch, and with the current preconf block time of 2s that is 192 blocks. Since we'll introduce zk gas, having this number smaller(192 instead of 384) allows for less constraining gas limits(since you can split the full zk gas of the entire proposal among fewer blocks). We can still update this in a future hard fork when we decide to lower the block times

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Change overview**
> 
> - Set `DERIVATION_SOURCE_MAX_BLOCKS` to `192` in `Derivation.md` (constants table) to reflect 2s block times per epoch.
> - Minor documentation cleanups: clarified bullets in `gasLimit` bounds and anchor transaction flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acabbf53ad6c54c3c8df87eb611b5212f02b4f4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->