### PR TITLE
chore(protocol): update solidity version in vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
     "packages/ejector/Cargo.toml",
     "packages/urcindexer-rs/Cargo.toml"
   ],
-  "solidity.compileUsingRemoteVersion": "v0.8.24+commit.e11b9ed9",
+  "solidity.compileUsingRemoteVersion": "v0.8.30+commit.73712a01",
   "solidity.formatter": "forge",
   "i18n-ally.keystyle": "nested",
   "i18n-ally.localesPaths": ["packages/bridge-ui/src/i18n"]


### PR DESCRIPTION
Most files are using ^0.8.26, so it makes sense to update this to stop the linter from showing errors.