### PR TITLE
feat(eventindexer): introduce Shasta inbox for starting block search without beacon RPC dependency

### DIFF
--- a/.github/workflows/eventindexer--docker.yml
+++ b/.github/workflows/eventindexer--docker.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [main, ei-get_block_by_timestamp]
+    branches: [main]
     tags:
       - "eventindexer-v*"
     paths:

--- a/.github/workflows/eventindexer--docker.yml
+++ b/.github/workflows/eventindexer--docker.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [main, ei-get_block_by_timestamp]
     tags:
       - "eventindexer-v*"
     paths:

--- a/packages/eventindexer/contracts/shasta/inbox/Inbox.go
+++ b/packages/eventindexer/contracts/shasta/inbox/Inbox.go
@@ -67,11 +67,9 @@ type IInboxConfig struct {
 	MaxProofSubmissionDelay           *big.Int
 	RingBufferSize                    *big.Int
 	BasefeeSharingPctg                uint8
-	MinForcedInclusionCount           *big.Int
 	ForcedInclusionDelay              uint16
 	ForcedInclusionFeeInGwei          uint64
 	ForcedInclusionFeeDoubleThreshold uint64
-	MinCheckpointDelay                uint16
 	PermissionlessInclusionMultiplier uint8
 }
 
@@ -108,13 +106,12 @@ type IInboxProposal struct {
 type IInboxProposeInput struct {
 	Deadline            *big.Int
 	BlobReference       LibBlobsBlobReference
-	NumForcedInclusions uint8
+	NumForcedInclusions uint16
 }
 
 // IInboxProveInput is an auto generated low-level Go binding around an user-defined struct.
 type IInboxProveInput struct {
-	Commitment          IInboxCommitment
-	ForceCheckpointSync bool
+	Commitment IInboxCommitment
 }
 
 // IInboxTransition is an auto generated low-level Go binding around an user-defined struct.
@@ -138,113 +135,113 @@ type LibBlobsBlobSlice struct {
 	Timestamp  *big.Int
 }
 
-// InboxMetaData contains all meta data concerning the Inbox contract.
-var InboxMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_config\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Config\",\"components\":[{\"name\":\"proofVerifier\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proposerChecker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proverWhitelist\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"signalService\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"bondToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"minBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"provingWindow\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"permissionlessProvingDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"maxProofSubmissionDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"ringBufferSize\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"minForcedInclusionCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"forcedInclusionDelay\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"forcedInclusionFeeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"forcedInclusionFeeDoubleThreshold\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"minCheckpointDelay\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"permissionlessInclusionMultiplier\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"activate\",\"inputs\":[{\"name\":\"_lastPacayaBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"activationTimestamp\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"cancelWithdrawal\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"decodeProposeInput\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"input_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProposeInput\",\"components\":[{\"name\":\"deadline\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]},{\"name\":\"numForcedInclusions\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"decodeProveInput\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"input_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProveInput\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]},{\"name\":\"forceCheckpointSync\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"deposit\",\"inputs\":[{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"depositTo\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"encodeProposeInput\",\"inputs\":[{\"name\":\"_input\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProposeInput\",\"components\":[{\"name\":\"deadline\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]},{\"name\":\"numForcedInclusions\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"outputs\":[{\"name\":\"encoded_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"encodeProveInput\",\"inputs\":[{\"name\":\"_input\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProveInput\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]},{\"name\":\"forceCheckpointSync\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"outputs\":[{\"name\":\"encoded_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"getBond\",\"inputs\":[{\"name\":\"_address\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"bond_\",\"type\":\"tuple\",\"internalType\":\"structIBondManager.Bond\",\"components\":[{\"name\":\"balance\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalRequestedAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getConfig\",\"inputs\":[],\"outputs\":[{\"name\":\"config_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Config\",\"components\":[{\"name\":\"proofVerifier\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proposerChecker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proverWhitelist\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"signalService\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"bondToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"minBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"provingWindow\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"permissionlessProvingDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"maxProofSubmissionDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"ringBufferSize\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"minForcedInclusionCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"forcedInclusionDelay\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"forcedInclusionFeeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"forcedInclusionFeeDoubleThreshold\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"minCheckpointDelay\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"permissionlessInclusionMultiplier\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCoreState\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIInbox.CoreState\",\"components\":[{\"name\":\"nextProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastProposalBlockId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastCheckpointTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCurrentForcedInclusionFee\",\"inputs\":[],\"outputs\":[{\"name\":\"feeInGwei_\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getForcedInclusionState\",\"inputs\":[],\"outputs\":[{\"name\":\"head_\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"tail_\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getForcedInclusions\",\"inputs\":[{\"name\":\"_start\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"_maxCount\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"outputs\":[{\"name\":\"inclusions_\",\"type\":\"tuple[]\",\"internalType\":\"structIForcedInclusionStore.ForcedInclusion[]\",\"components\":[{\"name\":\"feeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProposalHash\",\"inputs\":[{\"name\":\"_proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"hashCommitment\",\"inputs\":[{\"name\":\"_commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"hashProposal\",\"inputs\":[{\"name\":\"_proposal\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Proposal\",\"components\":[{\"name\":\"id\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endOfSubmissionWindowTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"parentProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"originBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"originBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"sources\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.DerivationSource[]\",\"components\":[{\"name\":\"isForcedInclusion\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"impl\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"inNonReentrant\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"init\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"propose\",\"inputs\":[{\"name\":\"_lookahead\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"prove\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestWithdrawal\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"resolver\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"saveForcedInclusion\",\"inputs\":[{\"name\":\"_blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeTo\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"withdraw\",\"inputs\":[{\"name\":\"_to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"AdminChanged\",\"inputs\":[{\"name\":\"previousAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BeaconUpgraded\",\"inputs\":[{\"name\":\"beacon\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BondDeposited\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BondWithdrawn\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ForcedInclusionSaved\",\"inputs\":[{\"name\":\"forcedInclusion\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIForcedInclusionStore.ForcedInclusion\",\"components\":[{\"name\":\"feeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"InboxActivated\",\"inputs\":[{\"name\":\"lastPacayaBlockHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"LivenessBondSettled\",\"inputs\":[{\"name\":\"payer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"credited\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"slashed\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Proposed\",\"inputs\":[{\"name\":\"id\",\"type\":\"uint48\",\"indexed\":true,\"internalType\":\"uint48\"},{\"name\":\"proposer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"parentProposalHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"endOfSubmissionWindowTimestamp\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"},{\"name\":\"sources\",\"type\":\"tuple[]\",\"indexed\":false,\"internalType\":\"structIInbox.DerivationSource[]\",\"components\":[{\"name\":\"isForcedInclusion\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Proved\",\"inputs\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"firstNewProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"lastProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"actualProver\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"checkpointSynced\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalCancelled\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalRequested\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"withdrawableAt\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ACCESS_DENIED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ActivationRequired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"BlobNotFound\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CannotProposeInCurrentBlock\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CheckpointDelayHasPassed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DeadlineExceeded\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ETH_TRANSFER_FAILED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EmptyBatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FUNC_NOT_IMPLEMENTED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FirstProposalIdTooLarge\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"INVALID_PAUSE_STATUS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectProposalCount\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InsufficientBond\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalAlreadyFinalized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalHashMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalIdTooLarge\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LengthExceedsUint16\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MustMaintainMinBond\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoBlobs\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoBondToWithdraw\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoWithdrawalRequested\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotEnoughCapacity\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ParentBlockHashMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ProverNotWhitelisted\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"REENTRANT_CALL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnprocessedForcedInclusionIsDue\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalAlreadyRequested\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_ADDRESS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_VALUE\",\"inputs\":[]}]",
+// ShastaInboxClientMetaData contains all meta data concerning the ShastaInboxClient contract.
+var ShastaInboxClientMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_proofVerifier\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_proposerChecker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_proverWhitelist\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_bondToken\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"activate\",\"inputs\":[{\"name\":\"_lastPacayaBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"activationTimestamp\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"cancelWithdrawal\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"decodeProposeInput\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"input_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProposeInput\",\"components\":[{\"name\":\"deadline\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]},{\"name\":\"numForcedInclusions\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"decodeProveInput\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"input_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProveInput\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"deposit\",\"inputs\":[{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"depositTo\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"encodeProposeInput\",\"inputs\":[{\"name\":\"_input\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProposeInput\",\"components\":[{\"name\":\"deadline\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]},{\"name\":\"numForcedInclusions\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]}],\"outputs\":[{\"name\":\"encoded_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"encodeProveInput\",\"inputs\":[{\"name\":\"_input\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProveInput\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}]}],\"outputs\":[{\"name\":\"encoded_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"getBond\",\"inputs\":[{\"name\":\"_address\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"bond_\",\"type\":\"tuple\",\"internalType\":\"structIBondManager.Bond\",\"components\":[{\"name\":\"balance\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalRequestedAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getConfig\",\"inputs\":[],\"outputs\":[{\"name\":\"config_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Config\",\"components\":[{\"name\":\"proofVerifier\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proposerChecker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proverWhitelist\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"signalService\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"bondToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"minBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"provingWindow\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"permissionlessProvingDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"maxProofSubmissionDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"ringBufferSize\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"forcedInclusionDelay\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"forcedInclusionFeeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"forcedInclusionFeeDoubleThreshold\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"permissionlessInclusionMultiplier\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCoreState\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIInbox.CoreState\",\"components\":[{\"name\":\"nextProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastProposalBlockId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastCheckpointTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCurrentForcedInclusionFee\",\"inputs\":[],\"outputs\":[{\"name\":\"feeInGwei_\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getForcedInclusionState\",\"inputs\":[],\"outputs\":[{\"name\":\"head_\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"tail_\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getForcedInclusions\",\"inputs\":[{\"name\":\"_start\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"_maxCount\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"outputs\":[{\"name\":\"inclusions_\",\"type\":\"tuple[]\",\"internalType\":\"structIForcedInclusionStore.ForcedInclusion[]\",\"components\":[{\"name\":\"feeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProposalHash\",\"inputs\":[{\"name\":\"_proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"hashCommitment\",\"inputs\":[{\"name\":\"_commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"hashProposal\",\"inputs\":[{\"name\":\"_proposal\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Proposal\",\"components\":[{\"name\":\"id\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endOfSubmissionWindowTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"parentProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"originBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"originBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"sources\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.DerivationSource[]\",\"components\":[{\"name\":\"isForcedInclusion\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"impl\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"inNonReentrant\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"init\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"propose\",\"inputs\":[{\"name\":\"_lookahead\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"prove\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestWithdrawal\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"resolver\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"saveForcedInclusion\",\"inputs\":[{\"name\":\"_blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeTo\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"withdraw\",\"inputs\":[{\"name\":\"_to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"AdminChanged\",\"inputs\":[{\"name\":\"previousAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BeaconUpgraded\",\"inputs\":[{\"name\":\"beacon\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BondDeposited\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BondWithdrawn\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ForcedInclusionSaved\",\"inputs\":[{\"name\":\"forcedInclusion\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIForcedInclusionStore.ForcedInclusion\",\"components\":[{\"name\":\"feeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"InboxActivated\",\"inputs\":[{\"name\":\"lastPacayaBlockHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"LivenessBondSettled\",\"inputs\":[{\"name\":\"payer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"credited\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"slashed\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Proposed\",\"inputs\":[{\"name\":\"id\",\"type\":\"uint48\",\"indexed\":true,\"internalType\":\"uint48\"},{\"name\":\"proposer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"parentProposalHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"endOfSubmissionWindowTimestamp\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"},{\"name\":\"sources\",\"type\":\"tuple[]\",\"indexed\":false,\"internalType\":\"structIInbox.DerivationSource[]\",\"components\":[{\"name\":\"isForcedInclusion\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Proved\",\"inputs\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"firstNewProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"lastProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"actualProver\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalCancelled\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalRequested\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"withdrawableAt\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ACCESS_DENIED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ActivationRequired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"BlobNotFound\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CannotProposeInCurrentBlock\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DeadlineExceeded\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ETH_TRANSFER_FAILED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EmptyBatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FUNC_NOT_IMPLEMENTED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FirstProposalIdTooLarge\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"INVALID_PAUSE_STATUS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectProposalCount\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InsufficientBond\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalAlreadyFinalized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalHashMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalIdTooLarge\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LengthExceedsUint16\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MustMaintainMinBond\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoBlobs\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoBondToWithdraw\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoWithdrawalRequested\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotEnoughCapacity\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ParentBlockHashMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ProverNotWhitelisted\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"REENTRANT_CALL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnprocessedForcedInclusionIsDue\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalAlreadyRequested\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_ADDRESS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_VALUE\",\"inputs\":[]}]",
 }
 
-// InboxABI is the input ABI used to generate the binding from.
-// Deprecated: Use InboxMetaData.ABI instead.
-var InboxABI = InboxMetaData.ABI
+// ShastaInboxClientABI is the input ABI used to generate the binding from.
+// Deprecated: Use ShastaInboxClientMetaData.ABI instead.
+var ShastaInboxClientABI = ShastaInboxClientMetaData.ABI
 
-// Inbox is an auto generated Go binding around an Ethereum contract.
-type Inbox struct {
-	InboxCaller     // Read-only binding to the contract
-	InboxTransactor // Write-only binding to the contract
-	InboxFilterer   // Log filterer for contract events
+// ShastaInboxClient is an auto generated Go binding around an Ethereum contract.
+type ShastaInboxClient struct {
+	ShastaInboxClientCaller     // Read-only binding to the contract
+	ShastaInboxClientTransactor // Write-only binding to the contract
+	ShastaInboxClientFilterer   // Log filterer for contract events
 }
 
-// InboxCaller is an auto generated read-only Go binding around an Ethereum contract.
-type InboxCaller struct {
+// ShastaInboxClientCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ShastaInboxClientCaller struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// InboxTransactor is an auto generated write-only Go binding around an Ethereum contract.
-type InboxTransactor struct {
+// ShastaInboxClientTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ShastaInboxClientTransactor struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// InboxFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
-type InboxFilterer struct {
+// ShastaInboxClientFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ShastaInboxClientFilterer struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// InboxSession is an auto generated Go binding around an Ethereum contract,
+// ShastaInboxClientSession is an auto generated Go binding around an Ethereum contract,
 // with pre-set call and transact options.
-type InboxSession struct {
-	Contract     *Inbox            // Generic contract binding to set the session for
-	CallOpts     bind.CallOpts     // Call options to use throughout this session
-	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+type ShastaInboxClientSession struct {
+	Contract     *ShastaInboxClient // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
 }
 
-// InboxCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// ShastaInboxClientCallerSession is an auto generated read-only Go binding around an Ethereum contract,
 // with pre-set call options.
-type InboxCallerSession struct {
-	Contract *InboxCaller  // Generic contract caller binding to set the session for
-	CallOpts bind.CallOpts // Call options to use throughout this session
+type ShastaInboxClientCallerSession struct {
+	Contract *ShastaInboxClientCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
 }
 
-// InboxTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// ShastaInboxClientTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
 // with pre-set transact options.
-type InboxTransactorSession struct {
-	Contract     *InboxTransactor  // Generic contract transactor binding to set the session for
-	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+type ShastaInboxClientTransactorSession struct {
+	Contract     *ShastaInboxClientTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
 }
 
-// InboxRaw is an auto generated low-level Go binding around an Ethereum contract.
-type InboxRaw struct {
-	Contract *Inbox // Generic contract binding to access the raw methods on
+// ShastaInboxClientRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ShastaInboxClientRaw struct {
+	Contract *ShastaInboxClient // Generic contract binding to access the raw methods on
 }
 
-// InboxCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
-type InboxCallerRaw struct {
-	Contract *InboxCaller // Generic read-only contract binding to access the raw methods on
+// ShastaInboxClientCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ShastaInboxClientCallerRaw struct {
+	Contract *ShastaInboxClientCaller // Generic read-only contract binding to access the raw methods on
 }
 
-// InboxTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
-type InboxTransactorRaw struct {
-	Contract *InboxTransactor // Generic write-only contract binding to access the raw methods on
+// ShastaInboxClientTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ShastaInboxClientTransactorRaw struct {
+	Contract *ShastaInboxClientTransactor // Generic write-only contract binding to access the raw methods on
 }
 
-// NewInbox creates a new instance of Inbox, bound to a specific deployed contract.
-func NewInbox(address common.Address, backend bind.ContractBackend) (*Inbox, error) {
-	contract, err := bindInbox(address, backend, backend, backend)
+// NewShastaInboxClient creates a new instance of ShastaInboxClient, bound to a specific deployed contract.
+func NewShastaInboxClient(address common.Address, backend bind.ContractBackend) (*ShastaInboxClient, error) {
+	contract, err := bindShastaInboxClient(address, backend, backend, backend)
 	if err != nil {
 		return nil, err
 	}
-	return &Inbox{InboxCaller: InboxCaller{contract: contract}, InboxTransactor: InboxTransactor{contract: contract}, InboxFilterer: InboxFilterer{contract: contract}}, nil
+	return &ShastaInboxClient{ShastaInboxClientCaller: ShastaInboxClientCaller{contract: contract}, ShastaInboxClientTransactor: ShastaInboxClientTransactor{contract: contract}, ShastaInboxClientFilterer: ShastaInboxClientFilterer{contract: contract}}, nil
 }
 
-// NewInboxCaller creates a new read-only instance of Inbox, bound to a specific deployed contract.
-func NewInboxCaller(address common.Address, caller bind.ContractCaller) (*InboxCaller, error) {
-	contract, err := bindInbox(address, caller, nil, nil)
+// NewShastaInboxClientCaller creates a new read-only instance of ShastaInboxClient, bound to a specific deployed contract.
+func NewShastaInboxClientCaller(address common.Address, caller bind.ContractCaller) (*ShastaInboxClientCaller, error) {
+	contract, err := bindShastaInboxClient(address, caller, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxCaller{contract: contract}, nil
+	return &ShastaInboxClientCaller{contract: contract}, nil
 }
 
-// NewInboxTransactor creates a new write-only instance of Inbox, bound to a specific deployed contract.
-func NewInboxTransactor(address common.Address, transactor bind.ContractTransactor) (*InboxTransactor, error) {
-	contract, err := bindInbox(address, nil, transactor, nil)
+// NewShastaInboxClientTransactor creates a new write-only instance of ShastaInboxClient, bound to a specific deployed contract.
+func NewShastaInboxClientTransactor(address common.Address, transactor bind.ContractTransactor) (*ShastaInboxClientTransactor, error) {
+	contract, err := bindShastaInboxClient(address, nil, transactor, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxTransactor{contract: contract}, nil
+	return &ShastaInboxClientTransactor{contract: contract}, nil
 }
 
-// NewInboxFilterer creates a new log filterer instance of Inbox, bound to a specific deployed contract.
-func NewInboxFilterer(address common.Address, filterer bind.ContractFilterer) (*InboxFilterer, error) {
-	contract, err := bindInbox(address, nil, nil, filterer)
+// NewShastaInboxClientFilterer creates a new log filterer instance of ShastaInboxClient, bound to a specific deployed contract.
+func NewShastaInboxClientFilterer(address common.Address, filterer bind.ContractFilterer) (*ShastaInboxClientFilterer, error) {
+	contract, err := bindShastaInboxClient(address, nil, nil, filterer)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxFilterer{contract: contract}, nil
+	return &ShastaInboxClientFilterer{contract: contract}, nil
 }
 
-// bindInbox binds a generic wrapper to an already deployed contract.
-func bindInbox(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := InboxMetaData.GetAbi()
+// bindShastaInboxClient binds a generic wrapper to an already deployed contract.
+func bindShastaInboxClient(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ShastaInboxClientMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
@@ -255,46 +252,46 @@ func bindInbox(address common.Address, caller bind.ContractCaller, transactor bi
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Inbox *InboxRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
-	return _Inbox.Contract.InboxCaller.contract.Call(opts, result, method, params...)
+func (_ShastaInboxClient *ShastaInboxClientRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ShastaInboxClient.Contract.ShastaInboxClientCaller.contract.Call(opts, result, method, params...)
 }
 
 // Transfer initiates a plain transaction to move funds to the contract, calling
 // its default method if one is available.
-func (_Inbox *InboxRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _Inbox.Contract.InboxTransactor.contract.Transfer(opts)
+func (_ShastaInboxClient *ShastaInboxClientRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.ShastaInboxClientTransactor.contract.Transfer(opts)
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Inbox *InboxRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
-	return _Inbox.Contract.InboxTransactor.contract.Transact(opts, method, params...)
+func (_ShastaInboxClient *ShastaInboxClientRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.ShastaInboxClientTransactor.contract.Transact(opts, method, params...)
 }
 
 // Call invokes the (constant) contract method with params as input values and
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Inbox *InboxCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
-	return _Inbox.Contract.contract.Call(opts, result, method, params...)
+func (_ShastaInboxClient *ShastaInboxClientCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ShastaInboxClient.Contract.contract.Call(opts, result, method, params...)
 }
 
 // Transfer initiates a plain transaction to move funds to the contract, calling
 // its default method if one is available.
-func (_Inbox *InboxTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _Inbox.Contract.contract.Transfer(opts)
+func (_ShastaInboxClient *ShastaInboxClientTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.contract.Transfer(opts)
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Inbox *InboxTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
-	return _Inbox.Contract.contract.Transact(opts, method, params...)
+func (_ShastaInboxClient *ShastaInboxClientTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.contract.Transact(opts, method, params...)
 }
 
 // ActivationTimestamp is a free data retrieval call binding the contract method 0x0423c7de.
 //
 // Solidity: function activationTimestamp() view returns(uint48)
-func (_Inbox *InboxCaller) ActivationTimestamp(opts *bind.CallOpts) (*big.Int, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) ActivationTimestamp(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "activationTimestamp")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "activationTimestamp")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -309,23 +306,23 @@ func (_Inbox *InboxCaller) ActivationTimestamp(opts *bind.CallOpts) (*big.Int, e
 // ActivationTimestamp is a free data retrieval call binding the contract method 0x0423c7de.
 //
 // Solidity: function activationTimestamp() view returns(uint48)
-func (_Inbox *InboxSession) ActivationTimestamp() (*big.Int, error) {
-	return _Inbox.Contract.ActivationTimestamp(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) ActivationTimestamp() (*big.Int, error) {
+	return _ShastaInboxClient.Contract.ActivationTimestamp(&_ShastaInboxClient.CallOpts)
 }
 
 // ActivationTimestamp is a free data retrieval call binding the contract method 0x0423c7de.
 //
 // Solidity: function activationTimestamp() view returns(uint48)
-func (_Inbox *InboxCallerSession) ActivationTimestamp() (*big.Int, error) {
-	return _Inbox.Contract.ActivationTimestamp(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) ActivationTimestamp() (*big.Int, error) {
+	return _ShastaInboxClient.Contract.ActivationTimestamp(&_ShastaInboxClient.CallOpts)
 }
 
 // DecodeProposeInput is a free data retrieval call binding the contract method 0xafb63ad4.
 //
-// Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint8) input_)
-func (_Inbox *InboxCaller) DecodeProposeInput(opts *bind.CallOpts, _data []byte) (IInboxProposeInput, error) {
+// Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint16) input_)
+func (_ShastaInboxClient *ShastaInboxClientCaller) DecodeProposeInput(opts *bind.CallOpts, _data []byte) (IInboxProposeInput, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "decodeProposeInput", _data)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "decodeProposeInput", _data)
 
 	if err != nil {
 		return *new(IInboxProposeInput), err
@@ -339,24 +336,24 @@ func (_Inbox *InboxCaller) DecodeProposeInput(opts *bind.CallOpts, _data []byte)
 
 // DecodeProposeInput is a free data retrieval call binding the contract method 0xafb63ad4.
 //
-// Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint8) input_)
-func (_Inbox *InboxSession) DecodeProposeInput(_data []byte) (IInboxProposeInput, error) {
-	return _Inbox.Contract.DecodeProposeInput(&_Inbox.CallOpts, _data)
+// Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint16) input_)
+func (_ShastaInboxClient *ShastaInboxClientSession) DecodeProposeInput(_data []byte) (IInboxProposeInput, error) {
+	return _ShastaInboxClient.Contract.DecodeProposeInput(&_ShastaInboxClient.CallOpts, _data)
 }
 
 // DecodeProposeInput is a free data retrieval call binding the contract method 0xafb63ad4.
 //
-// Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint8) input_)
-func (_Inbox *InboxCallerSession) DecodeProposeInput(_data []byte) (IInboxProposeInput, error) {
-	return _Inbox.Contract.DecodeProposeInput(&_Inbox.CallOpts, _data)
+// Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint16) input_)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) DecodeProposeInput(_data []byte) (IInboxProposeInput, error) {
+	return _ShastaInboxClient.Contract.DecodeProposeInput(&_ShastaInboxClient.CallOpts, _data)
 }
 
 // DecodeProveInput is a free data retrieval call binding the contract method 0xedbacd44.
 //
-// Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]),bool) input_)
-func (_Inbox *InboxCaller) DecodeProveInput(opts *bind.CallOpts, _data []byte) (IInboxProveInput, error) {
+// Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) input_)
+func (_ShastaInboxClient *ShastaInboxClientCaller) DecodeProveInput(opts *bind.CallOpts, _data []byte) (IInboxProveInput, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "decodeProveInput", _data)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "decodeProveInput", _data)
 
 	if err != nil {
 		return *new(IInboxProveInput), err
@@ -370,24 +367,24 @@ func (_Inbox *InboxCaller) DecodeProveInput(opts *bind.CallOpts, _data []byte) (
 
 // DecodeProveInput is a free data retrieval call binding the contract method 0xedbacd44.
 //
-// Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]),bool) input_)
-func (_Inbox *InboxSession) DecodeProveInput(_data []byte) (IInboxProveInput, error) {
-	return _Inbox.Contract.DecodeProveInput(&_Inbox.CallOpts, _data)
+// Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) input_)
+func (_ShastaInboxClient *ShastaInboxClientSession) DecodeProveInput(_data []byte) (IInboxProveInput, error) {
+	return _ShastaInboxClient.Contract.DecodeProveInput(&_ShastaInboxClient.CallOpts, _data)
 }
 
 // DecodeProveInput is a free data retrieval call binding the contract method 0xedbacd44.
 //
-// Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]),bool) input_)
-func (_Inbox *InboxCallerSession) DecodeProveInput(_data []byte) (IInboxProveInput, error) {
-	return _Inbox.Contract.DecodeProveInput(&_Inbox.CallOpts, _data)
+// Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) input_)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) DecodeProveInput(_data []byte) (IInboxProveInput, error) {
+	return _ShastaInboxClient.Contract.DecodeProveInput(&_ShastaInboxClient.CallOpts, _data)
 }
 
-// EncodeProposeInput is a free data retrieval call binding the contract method 0x2f1969b0.
+// EncodeProposeInput is a free data retrieval call binding the contract method 0x1275a673.
 //
-// Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint8) _input) pure returns(bytes encoded_)
-func (_Inbox *InboxCaller) EncodeProposeInput(opts *bind.CallOpts, _input IInboxProposeInput) ([]byte, error) {
+// Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint16) _input) pure returns(bytes encoded_)
+func (_ShastaInboxClient *ShastaInboxClientCaller) EncodeProposeInput(opts *bind.CallOpts, _input IInboxProposeInput) ([]byte, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "encodeProposeInput", _input)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "encodeProposeInput", _input)
 
 	if err != nil {
 		return *new([]byte), err
@@ -399,26 +396,26 @@ func (_Inbox *InboxCaller) EncodeProposeInput(opts *bind.CallOpts, _input IInbox
 
 }
 
-// EncodeProposeInput is a free data retrieval call binding the contract method 0x2f1969b0.
+// EncodeProposeInput is a free data retrieval call binding the contract method 0x1275a673.
 //
-// Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint8) _input) pure returns(bytes encoded_)
-func (_Inbox *InboxSession) EncodeProposeInput(_input IInboxProposeInput) ([]byte, error) {
-	return _Inbox.Contract.EncodeProposeInput(&_Inbox.CallOpts, _input)
+// Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint16) _input) pure returns(bytes encoded_)
+func (_ShastaInboxClient *ShastaInboxClientSession) EncodeProposeInput(_input IInboxProposeInput) ([]byte, error) {
+	return _ShastaInboxClient.Contract.EncodeProposeInput(&_ShastaInboxClient.CallOpts, _input)
 }
 
-// EncodeProposeInput is a free data retrieval call binding the contract method 0x2f1969b0.
+// EncodeProposeInput is a free data retrieval call binding the contract method 0x1275a673.
 //
-// Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint8) _input) pure returns(bytes encoded_)
-func (_Inbox *InboxCallerSession) EncodeProposeInput(_input IInboxProposeInput) ([]byte, error) {
-	return _Inbox.Contract.EncodeProposeInput(&_Inbox.CallOpts, _input)
+// Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint16) _input) pure returns(bytes encoded_)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) EncodeProposeInput(_input IInboxProposeInput) ([]byte, error) {
+	return _ShastaInboxClient.Contract.EncodeProposeInput(&_ShastaInboxClient.CallOpts, _input)
 }
 
-// EncodeProveInput is a free data retrieval call binding the contract method 0x8301d56d.
+// EncodeProveInput is a free data retrieval call binding the contract method 0xc5954597.
 //
-// Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]),bool) _input) pure returns(bytes encoded_)
-func (_Inbox *InboxCaller) EncodeProveInput(opts *bind.CallOpts, _input IInboxProveInput) ([]byte, error) {
+// Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) _input) pure returns(bytes encoded_)
+func (_ShastaInboxClient *ShastaInboxClientCaller) EncodeProveInput(opts *bind.CallOpts, _input IInboxProveInput) ([]byte, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "encodeProveInput", _input)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "encodeProveInput", _input)
 
 	if err != nil {
 		return *new([]byte), err
@@ -430,26 +427,26 @@ func (_Inbox *InboxCaller) EncodeProveInput(opts *bind.CallOpts, _input IInboxPr
 
 }
 
-// EncodeProveInput is a free data retrieval call binding the contract method 0x8301d56d.
+// EncodeProveInput is a free data retrieval call binding the contract method 0xc5954597.
 //
-// Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]),bool) _input) pure returns(bytes encoded_)
-func (_Inbox *InboxSession) EncodeProveInput(_input IInboxProveInput) ([]byte, error) {
-	return _Inbox.Contract.EncodeProveInput(&_Inbox.CallOpts, _input)
+// Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) _input) pure returns(bytes encoded_)
+func (_ShastaInboxClient *ShastaInboxClientSession) EncodeProveInput(_input IInboxProveInput) ([]byte, error) {
+	return _ShastaInboxClient.Contract.EncodeProveInput(&_ShastaInboxClient.CallOpts, _input)
 }
 
-// EncodeProveInput is a free data retrieval call binding the contract method 0x8301d56d.
+// EncodeProveInput is a free data retrieval call binding the contract method 0xc5954597.
 //
-// Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]),bool) _input) pure returns(bytes encoded_)
-func (_Inbox *InboxCallerSession) EncodeProveInput(_input IInboxProveInput) ([]byte, error) {
-	return _Inbox.Contract.EncodeProveInput(&_Inbox.CallOpts, _input)
+// Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) _input) pure returns(bytes encoded_)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) EncodeProveInput(_input IInboxProveInput) ([]byte, error) {
+	return _ShastaInboxClient.Contract.EncodeProveInput(&_ShastaInboxClient.CallOpts, _input)
 }
 
 // GetBond is a free data retrieval call binding the contract method 0x0d8912f3.
 //
 // Solidity: function getBond(address _address) view returns((uint64,uint48) bond_)
-func (_Inbox *InboxCaller) GetBond(opts *bind.CallOpts, _address common.Address) (IBondManagerBond, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) GetBond(opts *bind.CallOpts, _address common.Address) (IBondManagerBond, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "getBond", _address)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "getBond", _address)
 
 	if err != nil {
 		return *new(IBondManagerBond), err
@@ -464,23 +461,23 @@ func (_Inbox *InboxCaller) GetBond(opts *bind.CallOpts, _address common.Address)
 // GetBond is a free data retrieval call binding the contract method 0x0d8912f3.
 //
 // Solidity: function getBond(address _address) view returns((uint64,uint48) bond_)
-func (_Inbox *InboxSession) GetBond(_address common.Address) (IBondManagerBond, error) {
-	return _Inbox.Contract.GetBond(&_Inbox.CallOpts, _address)
+func (_ShastaInboxClient *ShastaInboxClientSession) GetBond(_address common.Address) (IBondManagerBond, error) {
+	return _ShastaInboxClient.Contract.GetBond(&_ShastaInboxClient.CallOpts, _address)
 }
 
 // GetBond is a free data retrieval call binding the contract method 0x0d8912f3.
 //
 // Solidity: function getBond(address _address) view returns((uint64,uint48) bond_)
-func (_Inbox *InboxCallerSession) GetBond(_address common.Address) (IBondManagerBond, error) {
-	return _Inbox.Contract.GetBond(&_Inbox.CallOpts, _address)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetBond(_address common.Address) (IBondManagerBond, error) {
+	return _ShastaInboxClient.Contract.GetBond(&_ShastaInboxClient.CallOpts, _address)
 }
 
 // GetConfig is a free data retrieval call binding the contract method 0xc3f909d4.
 //
-// Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint256,uint16,uint64,uint64,uint16,uint8) config_)
-func (_Inbox *InboxCaller) GetConfig(opts *bind.CallOpts) (IInboxConfig, error) {
+// Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint16,uint64,uint64,uint8) config_)
+func (_ShastaInboxClient *ShastaInboxClientCaller) GetConfig(opts *bind.CallOpts) (IInboxConfig, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "getConfig")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "getConfig")
 
 	if err != nil {
 		return *new(IInboxConfig), err
@@ -494,24 +491,24 @@ func (_Inbox *InboxCaller) GetConfig(opts *bind.CallOpts) (IInboxConfig, error) 
 
 // GetConfig is a free data retrieval call binding the contract method 0xc3f909d4.
 //
-// Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint256,uint16,uint64,uint64,uint16,uint8) config_)
-func (_Inbox *InboxSession) GetConfig() (IInboxConfig, error) {
-	return _Inbox.Contract.GetConfig(&_Inbox.CallOpts)
+// Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint16,uint64,uint64,uint8) config_)
+func (_ShastaInboxClient *ShastaInboxClientSession) GetConfig() (IInboxConfig, error) {
+	return _ShastaInboxClient.Contract.GetConfig(&_ShastaInboxClient.CallOpts)
 }
 
 // GetConfig is a free data retrieval call binding the contract method 0xc3f909d4.
 //
-// Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint256,uint16,uint64,uint64,uint16,uint8) config_)
-func (_Inbox *InboxCallerSession) GetConfig() (IInboxConfig, error) {
-	return _Inbox.Contract.GetConfig(&_Inbox.CallOpts)
+// Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint16,uint64,uint64,uint8) config_)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetConfig() (IInboxConfig, error) {
+	return _ShastaInboxClient.Contract.GetConfig(&_ShastaInboxClient.CallOpts)
 }
 
 // GetCoreState is a free data retrieval call binding the contract method 0x6aa6a01a.
 //
 // Solidity: function getCoreState() view returns((uint48,uint48,uint48,uint48,uint48,bytes32))
-func (_Inbox *InboxCaller) GetCoreState(opts *bind.CallOpts) (IInboxCoreState, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) GetCoreState(opts *bind.CallOpts) (IInboxCoreState, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "getCoreState")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "getCoreState")
 
 	if err != nil {
 		return *new(IInboxCoreState), err
@@ -526,23 +523,23 @@ func (_Inbox *InboxCaller) GetCoreState(opts *bind.CallOpts) (IInboxCoreState, e
 // GetCoreState is a free data retrieval call binding the contract method 0x6aa6a01a.
 //
 // Solidity: function getCoreState() view returns((uint48,uint48,uint48,uint48,uint48,bytes32))
-func (_Inbox *InboxSession) GetCoreState() (IInboxCoreState, error) {
-	return _Inbox.Contract.GetCoreState(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) GetCoreState() (IInboxCoreState, error) {
+	return _ShastaInboxClient.Contract.GetCoreState(&_ShastaInboxClient.CallOpts)
 }
 
 // GetCoreState is a free data retrieval call binding the contract method 0x6aa6a01a.
 //
 // Solidity: function getCoreState() view returns((uint48,uint48,uint48,uint48,uint48,bytes32))
-func (_Inbox *InboxCallerSession) GetCoreState() (IInboxCoreState, error) {
-	return _Inbox.Contract.GetCoreState(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetCoreState() (IInboxCoreState, error) {
+	return _ShastaInboxClient.Contract.GetCoreState(&_ShastaInboxClient.CallOpts)
 }
 
 // GetCurrentForcedInclusionFee is a free data retrieval call binding the contract method 0xe3053335.
 //
 // Solidity: function getCurrentForcedInclusionFee() view returns(uint64 feeInGwei_)
-func (_Inbox *InboxCaller) GetCurrentForcedInclusionFee(opts *bind.CallOpts) (uint64, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) GetCurrentForcedInclusionFee(opts *bind.CallOpts) (uint64, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "getCurrentForcedInclusionFee")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "getCurrentForcedInclusionFee")
 
 	if err != nil {
 		return *new(uint64), err
@@ -557,26 +554,26 @@ func (_Inbox *InboxCaller) GetCurrentForcedInclusionFee(opts *bind.CallOpts) (ui
 // GetCurrentForcedInclusionFee is a free data retrieval call binding the contract method 0xe3053335.
 //
 // Solidity: function getCurrentForcedInclusionFee() view returns(uint64 feeInGwei_)
-func (_Inbox *InboxSession) GetCurrentForcedInclusionFee() (uint64, error) {
-	return _Inbox.Contract.GetCurrentForcedInclusionFee(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) GetCurrentForcedInclusionFee() (uint64, error) {
+	return _ShastaInboxClient.Contract.GetCurrentForcedInclusionFee(&_ShastaInboxClient.CallOpts)
 }
 
 // GetCurrentForcedInclusionFee is a free data retrieval call binding the contract method 0xe3053335.
 //
 // Solidity: function getCurrentForcedInclusionFee() view returns(uint64 feeInGwei_)
-func (_Inbox *InboxCallerSession) GetCurrentForcedInclusionFee() (uint64, error) {
-	return _Inbox.Contract.GetCurrentForcedInclusionFee(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetCurrentForcedInclusionFee() (uint64, error) {
+	return _ShastaInboxClient.Contract.GetCurrentForcedInclusionFee(&_ShastaInboxClient.CallOpts)
 }
 
 // GetForcedInclusionState is a free data retrieval call binding the contract method 0x5ccc1718.
 //
 // Solidity: function getForcedInclusionState() view returns(uint48 head_, uint48 tail_)
-func (_Inbox *InboxCaller) GetForcedInclusionState(opts *bind.CallOpts) (struct {
+func (_ShastaInboxClient *ShastaInboxClientCaller) GetForcedInclusionState(opts *bind.CallOpts) (struct {
 	Head *big.Int
 	Tail *big.Int
 }, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "getForcedInclusionState")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "getForcedInclusionState")
 
 	outstruct := new(struct {
 		Head *big.Int
@@ -596,29 +593,29 @@ func (_Inbox *InboxCaller) GetForcedInclusionState(opts *bind.CallOpts) (struct 
 // GetForcedInclusionState is a free data retrieval call binding the contract method 0x5ccc1718.
 //
 // Solidity: function getForcedInclusionState() view returns(uint48 head_, uint48 tail_)
-func (_Inbox *InboxSession) GetForcedInclusionState() (struct {
+func (_ShastaInboxClient *ShastaInboxClientSession) GetForcedInclusionState() (struct {
 	Head *big.Int
 	Tail *big.Int
 }, error) {
-	return _Inbox.Contract.GetForcedInclusionState(&_Inbox.CallOpts)
+	return _ShastaInboxClient.Contract.GetForcedInclusionState(&_ShastaInboxClient.CallOpts)
 }
 
 // GetForcedInclusionState is a free data retrieval call binding the contract method 0x5ccc1718.
 //
 // Solidity: function getForcedInclusionState() view returns(uint48 head_, uint48 tail_)
-func (_Inbox *InboxCallerSession) GetForcedInclusionState() (struct {
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetForcedInclusionState() (struct {
 	Head *big.Int
 	Tail *big.Int
 }, error) {
-	return _Inbox.Contract.GetForcedInclusionState(&_Inbox.CallOpts)
+	return _ShastaInboxClient.Contract.GetForcedInclusionState(&_ShastaInboxClient.CallOpts)
 }
 
 // GetForcedInclusions is a free data retrieval call binding the contract method 0x40df9866.
 //
 // Solidity: function getForcedInclusions(uint48 _start, uint48 _maxCount) view returns((uint64,(bytes32[],uint24,uint48))[] inclusions_)
-func (_Inbox *InboxCaller) GetForcedInclusions(opts *bind.CallOpts, _start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) GetForcedInclusions(opts *bind.CallOpts, _start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "getForcedInclusions", _start, _maxCount)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "getForcedInclusions", _start, _maxCount)
 
 	if err != nil {
 		return *new([]IForcedInclusionStoreForcedInclusion), err
@@ -633,23 +630,23 @@ func (_Inbox *InboxCaller) GetForcedInclusions(opts *bind.CallOpts, _start *big.
 // GetForcedInclusions is a free data retrieval call binding the contract method 0x40df9866.
 //
 // Solidity: function getForcedInclusions(uint48 _start, uint48 _maxCount) view returns((uint64,(bytes32[],uint24,uint48))[] inclusions_)
-func (_Inbox *InboxSession) GetForcedInclusions(_start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
-	return _Inbox.Contract.GetForcedInclusions(&_Inbox.CallOpts, _start, _maxCount)
+func (_ShastaInboxClient *ShastaInboxClientSession) GetForcedInclusions(_start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
+	return _ShastaInboxClient.Contract.GetForcedInclusions(&_ShastaInboxClient.CallOpts, _start, _maxCount)
 }
 
 // GetForcedInclusions is a free data retrieval call binding the contract method 0x40df9866.
 //
 // Solidity: function getForcedInclusions(uint48 _start, uint48 _maxCount) view returns((uint64,(bytes32[],uint24,uint48))[] inclusions_)
-func (_Inbox *InboxCallerSession) GetForcedInclusions(_start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
-	return _Inbox.Contract.GetForcedInclusions(&_Inbox.CallOpts, _start, _maxCount)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetForcedInclusions(_start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
+	return _ShastaInboxClient.Contract.GetForcedInclusions(&_ShastaInboxClient.CallOpts, _start, _maxCount)
 }
 
 // GetProposalHash is a free data retrieval call binding the contract method 0xa834725a.
 //
 // Solidity: function getProposalHash(uint256 _proposalId) view returns(bytes32)
-func (_Inbox *InboxCaller) GetProposalHash(opts *bind.CallOpts, _proposalId *big.Int) ([32]byte, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) GetProposalHash(opts *bind.CallOpts, _proposalId *big.Int) ([32]byte, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "getProposalHash", _proposalId)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "getProposalHash", _proposalId)
 
 	if err != nil {
 		return *new([32]byte), err
@@ -664,23 +661,23 @@ func (_Inbox *InboxCaller) GetProposalHash(opts *bind.CallOpts, _proposalId *big
 // GetProposalHash is a free data retrieval call binding the contract method 0xa834725a.
 //
 // Solidity: function getProposalHash(uint256 _proposalId) view returns(bytes32)
-func (_Inbox *InboxSession) GetProposalHash(_proposalId *big.Int) ([32]byte, error) {
-	return _Inbox.Contract.GetProposalHash(&_Inbox.CallOpts, _proposalId)
+func (_ShastaInboxClient *ShastaInboxClientSession) GetProposalHash(_proposalId *big.Int) ([32]byte, error) {
+	return _ShastaInboxClient.Contract.GetProposalHash(&_ShastaInboxClient.CallOpts, _proposalId)
 }
 
 // GetProposalHash is a free data retrieval call binding the contract method 0xa834725a.
 //
 // Solidity: function getProposalHash(uint256 _proposalId) view returns(bytes32)
-func (_Inbox *InboxCallerSession) GetProposalHash(_proposalId *big.Int) ([32]byte, error) {
-	return _Inbox.Contract.GetProposalHash(&_Inbox.CallOpts, _proposalId)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetProposalHash(_proposalId *big.Int) ([32]byte, error) {
+	return _ShastaInboxClient.Contract.GetProposalHash(&_ShastaInboxClient.CallOpts, _proposalId)
 }
 
 // HashCommitment is a free data retrieval call binding the contract method 0xf954ab92.
 //
 // Solidity: function hashCommitment((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]) _commitment) pure returns(bytes32)
-func (_Inbox *InboxCaller) HashCommitment(opts *bind.CallOpts, _commitment IInboxCommitment) ([32]byte, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) HashCommitment(opts *bind.CallOpts, _commitment IInboxCommitment) ([32]byte, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "hashCommitment", _commitment)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "hashCommitment", _commitment)
 
 	if err != nil {
 		return *new([32]byte), err
@@ -695,23 +692,23 @@ func (_Inbox *InboxCaller) HashCommitment(opts *bind.CallOpts, _commitment IInbo
 // HashCommitment is a free data retrieval call binding the contract method 0xf954ab92.
 //
 // Solidity: function hashCommitment((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]) _commitment) pure returns(bytes32)
-func (_Inbox *InboxSession) HashCommitment(_commitment IInboxCommitment) ([32]byte, error) {
-	return _Inbox.Contract.HashCommitment(&_Inbox.CallOpts, _commitment)
+func (_ShastaInboxClient *ShastaInboxClientSession) HashCommitment(_commitment IInboxCommitment) ([32]byte, error) {
+	return _ShastaInboxClient.Contract.HashCommitment(&_ShastaInboxClient.CallOpts, _commitment)
 }
 
 // HashCommitment is a free data retrieval call binding the contract method 0xf954ab92.
 //
 // Solidity: function hashCommitment((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]) _commitment) pure returns(bytes32)
-func (_Inbox *InboxCallerSession) HashCommitment(_commitment IInboxCommitment) ([32]byte, error) {
-	return _Inbox.Contract.HashCommitment(&_Inbox.CallOpts, _commitment)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) HashCommitment(_commitment IInboxCommitment) ([32]byte, error) {
+	return _ShastaInboxClient.Contract.HashCommitment(&_ShastaInboxClient.CallOpts, _commitment)
 }
 
 // HashProposal is a free data retrieval call binding the contract method 0xb28e824e.
 //
 // Solidity: function hashProposal((uint48,uint48,uint48,address,bytes32,uint48,bytes32,uint8,(bool,(bytes32[],uint24,uint48))[]) _proposal) pure returns(bytes32)
-func (_Inbox *InboxCaller) HashProposal(opts *bind.CallOpts, _proposal IInboxProposal) ([32]byte, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) HashProposal(opts *bind.CallOpts, _proposal IInboxProposal) ([32]byte, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "hashProposal", _proposal)
+	err := _ShastaInboxClient.contract.Call(opts, &out, "hashProposal", _proposal)
 
 	if err != nil {
 		return *new([32]byte), err
@@ -726,23 +723,23 @@ func (_Inbox *InboxCaller) HashProposal(opts *bind.CallOpts, _proposal IInboxPro
 // HashProposal is a free data retrieval call binding the contract method 0xb28e824e.
 //
 // Solidity: function hashProposal((uint48,uint48,uint48,address,bytes32,uint48,bytes32,uint8,(bool,(bytes32[],uint24,uint48))[]) _proposal) pure returns(bytes32)
-func (_Inbox *InboxSession) HashProposal(_proposal IInboxProposal) ([32]byte, error) {
-	return _Inbox.Contract.HashProposal(&_Inbox.CallOpts, _proposal)
+func (_ShastaInboxClient *ShastaInboxClientSession) HashProposal(_proposal IInboxProposal) ([32]byte, error) {
+	return _ShastaInboxClient.Contract.HashProposal(&_ShastaInboxClient.CallOpts, _proposal)
 }
 
 // HashProposal is a free data retrieval call binding the contract method 0xb28e824e.
 //
 // Solidity: function hashProposal((uint48,uint48,uint48,address,bytes32,uint48,bytes32,uint8,(bool,(bytes32[],uint24,uint48))[]) _proposal) pure returns(bytes32)
-func (_Inbox *InboxCallerSession) HashProposal(_proposal IInboxProposal) ([32]byte, error) {
-	return _Inbox.Contract.HashProposal(&_Inbox.CallOpts, _proposal)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) HashProposal(_proposal IInboxProposal) ([32]byte, error) {
+	return _ShastaInboxClient.Contract.HashProposal(&_ShastaInboxClient.CallOpts, _proposal)
 }
 
 // Impl is a free data retrieval call binding the contract method 0x8abf6077.
 //
 // Solidity: function impl() view returns(address)
-func (_Inbox *InboxCaller) Impl(opts *bind.CallOpts) (common.Address, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) Impl(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "impl")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "impl")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -757,23 +754,23 @@ func (_Inbox *InboxCaller) Impl(opts *bind.CallOpts) (common.Address, error) {
 // Impl is a free data retrieval call binding the contract method 0x8abf6077.
 //
 // Solidity: function impl() view returns(address)
-func (_Inbox *InboxSession) Impl() (common.Address, error) {
-	return _Inbox.Contract.Impl(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) Impl() (common.Address, error) {
+	return _ShastaInboxClient.Contract.Impl(&_ShastaInboxClient.CallOpts)
 }
 
 // Impl is a free data retrieval call binding the contract method 0x8abf6077.
 //
 // Solidity: function impl() view returns(address)
-func (_Inbox *InboxCallerSession) Impl() (common.Address, error) {
-	return _Inbox.Contract.Impl(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) Impl() (common.Address, error) {
+	return _ShastaInboxClient.Contract.Impl(&_ShastaInboxClient.CallOpts)
 }
 
 // InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
 //
 // Solidity: function inNonReentrant() view returns(bool)
-func (_Inbox *InboxCaller) InNonReentrant(opts *bind.CallOpts) (bool, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) InNonReentrant(opts *bind.CallOpts) (bool, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "inNonReentrant")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "inNonReentrant")
 
 	if err != nil {
 		return *new(bool), err
@@ -788,23 +785,23 @@ func (_Inbox *InboxCaller) InNonReentrant(opts *bind.CallOpts) (bool, error) {
 // InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
 //
 // Solidity: function inNonReentrant() view returns(bool)
-func (_Inbox *InboxSession) InNonReentrant() (bool, error) {
-	return _Inbox.Contract.InNonReentrant(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) InNonReentrant() (bool, error) {
+	return _ShastaInboxClient.Contract.InNonReentrant(&_ShastaInboxClient.CallOpts)
 }
 
 // InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
 //
 // Solidity: function inNonReentrant() view returns(bool)
-func (_Inbox *InboxCallerSession) InNonReentrant() (bool, error) {
-	return _Inbox.Contract.InNonReentrant(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) InNonReentrant() (bool, error) {
+	return _ShastaInboxClient.Contract.InNonReentrant(&_ShastaInboxClient.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_Inbox *InboxCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "owner")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "owner")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -819,23 +816,23 @@ func (_Inbox *InboxCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_Inbox *InboxSession) Owner() (common.Address, error) {
-	return _Inbox.Contract.Owner(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) Owner() (common.Address, error) {
+	return _ShastaInboxClient.Contract.Owner(&_ShastaInboxClient.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_Inbox *InboxCallerSession) Owner() (common.Address, error) {
-	return _Inbox.Contract.Owner(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) Owner() (common.Address, error) {
+	return _ShastaInboxClient.Contract.Owner(&_ShastaInboxClient.CallOpts)
 }
 
 // Paused is a free data retrieval call binding the contract method 0x5c975abb.
 //
 // Solidity: function paused() view returns(bool)
-func (_Inbox *InboxCaller) Paused(opts *bind.CallOpts) (bool, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) Paused(opts *bind.CallOpts) (bool, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "paused")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "paused")
 
 	if err != nil {
 		return *new(bool), err
@@ -850,23 +847,23 @@ func (_Inbox *InboxCaller) Paused(opts *bind.CallOpts) (bool, error) {
 // Paused is a free data retrieval call binding the contract method 0x5c975abb.
 //
 // Solidity: function paused() view returns(bool)
-func (_Inbox *InboxSession) Paused() (bool, error) {
-	return _Inbox.Contract.Paused(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) Paused() (bool, error) {
+	return _ShastaInboxClient.Contract.Paused(&_ShastaInboxClient.CallOpts)
 }
 
 // Paused is a free data retrieval call binding the contract method 0x5c975abb.
 //
 // Solidity: function paused() view returns(bool)
-func (_Inbox *InboxCallerSession) Paused() (bool, error) {
-	return _Inbox.Contract.Paused(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) Paused() (bool, error) {
+	return _ShastaInboxClient.Contract.Paused(&_ShastaInboxClient.CallOpts)
 }
 
 // PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
 //
 // Solidity: function pendingOwner() view returns(address)
-func (_Inbox *InboxCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "pendingOwner")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "pendingOwner")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -881,23 +878,23 @@ func (_Inbox *InboxCaller) PendingOwner(opts *bind.CallOpts) (common.Address, er
 // PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
 //
 // Solidity: function pendingOwner() view returns(address)
-func (_Inbox *InboxSession) PendingOwner() (common.Address, error) {
-	return _Inbox.Contract.PendingOwner(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) PendingOwner() (common.Address, error) {
+	return _ShastaInboxClient.Contract.PendingOwner(&_ShastaInboxClient.CallOpts)
 }
 
 // PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
 //
 // Solidity: function pendingOwner() view returns(address)
-func (_Inbox *InboxCallerSession) PendingOwner() (common.Address, error) {
-	return _Inbox.Contract.PendingOwner(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) PendingOwner() (common.Address, error) {
+	return _ShastaInboxClient.Contract.PendingOwner(&_ShastaInboxClient.CallOpts)
 }
 
 // ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
-func (_Inbox *InboxCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "proxiableUUID")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "proxiableUUID")
 
 	if err != nil {
 		return *new([32]byte), err
@@ -912,23 +909,23 @@ func (_Inbox *InboxCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) 
 // ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
-func (_Inbox *InboxSession) ProxiableUUID() ([32]byte, error) {
-	return _Inbox.Contract.ProxiableUUID(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) ProxiableUUID() ([32]byte, error) {
+	return _ShastaInboxClient.Contract.ProxiableUUID(&_ShastaInboxClient.CallOpts)
 }
 
 // ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
-func (_Inbox *InboxCallerSession) ProxiableUUID() ([32]byte, error) {
-	return _Inbox.Contract.ProxiableUUID(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _ShastaInboxClient.Contract.ProxiableUUID(&_ShastaInboxClient.CallOpts)
 }
 
 // Resolver is a free data retrieval call binding the contract method 0x04f3bcec.
 //
 // Solidity: function resolver() view returns(address)
-func (_Inbox *InboxCaller) Resolver(opts *bind.CallOpts) (common.Address, error) {
+func (_ShastaInboxClient *ShastaInboxClientCaller) Resolver(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _Inbox.contract.Call(opts, &out, "resolver")
+	err := _ShastaInboxClient.contract.Call(opts, &out, "resolver")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -943,377 +940,377 @@ func (_Inbox *InboxCaller) Resolver(opts *bind.CallOpts) (common.Address, error)
 // Resolver is a free data retrieval call binding the contract method 0x04f3bcec.
 //
 // Solidity: function resolver() view returns(address)
-func (_Inbox *InboxSession) Resolver() (common.Address, error) {
-	return _Inbox.Contract.Resolver(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) Resolver() (common.Address, error) {
+	return _ShastaInboxClient.Contract.Resolver(&_ShastaInboxClient.CallOpts)
 }
 
 // Resolver is a free data retrieval call binding the contract method 0x04f3bcec.
 //
 // Solidity: function resolver() view returns(address)
-func (_Inbox *InboxCallerSession) Resolver() (common.Address, error) {
-	return _Inbox.Contract.Resolver(&_Inbox.CallOpts)
+func (_ShastaInboxClient *ShastaInboxClientCallerSession) Resolver() (common.Address, error) {
+	return _ShastaInboxClient.Contract.Resolver(&_ShastaInboxClient.CallOpts)
 }
 
 // AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
 //
 // Solidity: function acceptOwnership() returns()
-func (_Inbox *InboxTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "acceptOwnership")
+func (_ShastaInboxClient *ShastaInboxClientTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "acceptOwnership")
 }
 
 // AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
 //
 // Solidity: function acceptOwnership() returns()
-func (_Inbox *InboxSession) AcceptOwnership() (*types.Transaction, error) {
-	return _Inbox.Contract.AcceptOwnership(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) AcceptOwnership() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.AcceptOwnership(&_ShastaInboxClient.TransactOpts)
 }
 
 // AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
 //
 // Solidity: function acceptOwnership() returns()
-func (_Inbox *InboxTransactorSession) AcceptOwnership() (*types.Transaction, error) {
-	return _Inbox.Contract.AcceptOwnership(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.AcceptOwnership(&_ShastaInboxClient.TransactOpts)
 }
 
 // Activate is a paid mutator transaction binding the contract method 0x59db6e85.
 //
 // Solidity: function activate(bytes32 _lastPacayaBlockHash) returns()
-func (_Inbox *InboxTransactor) Activate(opts *bind.TransactOpts, _lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "activate", _lastPacayaBlockHash)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) Activate(opts *bind.TransactOpts, _lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "activate", _lastPacayaBlockHash)
 }
 
 // Activate is a paid mutator transaction binding the contract method 0x59db6e85.
 //
 // Solidity: function activate(bytes32 _lastPacayaBlockHash) returns()
-func (_Inbox *InboxSession) Activate(_lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
-	return _Inbox.Contract.Activate(&_Inbox.TransactOpts, _lastPacayaBlockHash)
+func (_ShastaInboxClient *ShastaInboxClientSession) Activate(_lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Activate(&_ShastaInboxClient.TransactOpts, _lastPacayaBlockHash)
 }
 
 // Activate is a paid mutator transaction binding the contract method 0x59db6e85.
 //
 // Solidity: function activate(bytes32 _lastPacayaBlockHash) returns()
-func (_Inbox *InboxTransactorSession) Activate(_lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
-	return _Inbox.Contract.Activate(&_Inbox.TransactOpts, _lastPacayaBlockHash)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Activate(_lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Activate(&_ShastaInboxClient.TransactOpts, _lastPacayaBlockHash)
 }
 
 // CancelWithdrawal is a paid mutator transaction binding the contract method 0x22611280.
 //
 // Solidity: function cancelWithdrawal() returns()
-func (_Inbox *InboxTransactor) CancelWithdrawal(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "cancelWithdrawal")
+func (_ShastaInboxClient *ShastaInboxClientTransactor) CancelWithdrawal(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "cancelWithdrawal")
 }
 
 // CancelWithdrawal is a paid mutator transaction binding the contract method 0x22611280.
 //
 // Solidity: function cancelWithdrawal() returns()
-func (_Inbox *InboxSession) CancelWithdrawal() (*types.Transaction, error) {
-	return _Inbox.Contract.CancelWithdrawal(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) CancelWithdrawal() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.CancelWithdrawal(&_ShastaInboxClient.TransactOpts)
 }
 
 // CancelWithdrawal is a paid mutator transaction binding the contract method 0x22611280.
 //
 // Solidity: function cancelWithdrawal() returns()
-func (_Inbox *InboxTransactorSession) CancelWithdrawal() (*types.Transaction, error) {
-	return _Inbox.Contract.CancelWithdrawal(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) CancelWithdrawal() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.CancelWithdrawal(&_ShastaInboxClient.TransactOpts)
 }
 
 // Deposit is a paid mutator transaction binding the contract method 0x13765838.
 //
 // Solidity: function deposit(uint64 _amount) returns()
-func (_Inbox *InboxTransactor) Deposit(opts *bind.TransactOpts, _amount uint64) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "deposit", _amount)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) Deposit(opts *bind.TransactOpts, _amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "deposit", _amount)
 }
 
 // Deposit is a paid mutator transaction binding the contract method 0x13765838.
 //
 // Solidity: function deposit(uint64 _amount) returns()
-func (_Inbox *InboxSession) Deposit(_amount uint64) (*types.Transaction, error) {
-	return _Inbox.Contract.Deposit(&_Inbox.TransactOpts, _amount)
+func (_ShastaInboxClient *ShastaInboxClientSession) Deposit(_amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Deposit(&_ShastaInboxClient.TransactOpts, _amount)
 }
 
 // Deposit is a paid mutator transaction binding the contract method 0x13765838.
 //
 // Solidity: function deposit(uint64 _amount) returns()
-func (_Inbox *InboxTransactorSession) Deposit(_amount uint64) (*types.Transaction, error) {
-	return _Inbox.Contract.Deposit(&_Inbox.TransactOpts, _amount)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Deposit(_amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Deposit(&_ShastaInboxClient.TransactOpts, _amount)
 }
 
 // DepositTo is a paid mutator transaction binding the contract method 0xefba83c9.
 //
 // Solidity: function depositTo(address _recipient, uint64 _amount) returns()
-func (_Inbox *InboxTransactor) DepositTo(opts *bind.TransactOpts, _recipient common.Address, _amount uint64) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "depositTo", _recipient, _amount)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) DepositTo(opts *bind.TransactOpts, _recipient common.Address, _amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "depositTo", _recipient, _amount)
 }
 
 // DepositTo is a paid mutator transaction binding the contract method 0xefba83c9.
 //
 // Solidity: function depositTo(address _recipient, uint64 _amount) returns()
-func (_Inbox *InboxSession) DepositTo(_recipient common.Address, _amount uint64) (*types.Transaction, error) {
-	return _Inbox.Contract.DepositTo(&_Inbox.TransactOpts, _recipient, _amount)
+func (_ShastaInboxClient *ShastaInboxClientSession) DepositTo(_recipient common.Address, _amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.DepositTo(&_ShastaInboxClient.TransactOpts, _recipient, _amount)
 }
 
 // DepositTo is a paid mutator transaction binding the contract method 0xefba83c9.
 //
 // Solidity: function depositTo(address _recipient, uint64 _amount) returns()
-func (_Inbox *InboxTransactorSession) DepositTo(_recipient common.Address, _amount uint64) (*types.Transaction, error) {
-	return _Inbox.Contract.DepositTo(&_Inbox.TransactOpts, _recipient, _amount)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) DepositTo(_recipient common.Address, _amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.DepositTo(&_ShastaInboxClient.TransactOpts, _recipient, _amount)
 }
 
 // Init is a paid mutator transaction binding the contract method 0x19ab453c.
 //
 // Solidity: function init(address _owner) returns()
-func (_Inbox *InboxTransactor) Init(opts *bind.TransactOpts, _owner common.Address) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "init", _owner)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) Init(opts *bind.TransactOpts, _owner common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "init", _owner)
 }
 
 // Init is a paid mutator transaction binding the contract method 0x19ab453c.
 //
 // Solidity: function init(address _owner) returns()
-func (_Inbox *InboxSession) Init(_owner common.Address) (*types.Transaction, error) {
-	return _Inbox.Contract.Init(&_Inbox.TransactOpts, _owner)
+func (_ShastaInboxClient *ShastaInboxClientSession) Init(_owner common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Init(&_ShastaInboxClient.TransactOpts, _owner)
 }
 
 // Init is a paid mutator transaction binding the contract method 0x19ab453c.
 //
 // Solidity: function init(address _owner) returns()
-func (_Inbox *InboxTransactorSession) Init(_owner common.Address) (*types.Transaction, error) {
-	return _Inbox.Contract.Init(&_Inbox.TransactOpts, _owner)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Init(_owner common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Init(&_ShastaInboxClient.TransactOpts, _owner)
 }
 
 // Pause is a paid mutator transaction binding the contract method 0x8456cb59.
 //
 // Solidity: function pause() returns()
-func (_Inbox *InboxTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "pause")
+func (_ShastaInboxClient *ShastaInboxClientTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "pause")
 }
 
 // Pause is a paid mutator transaction binding the contract method 0x8456cb59.
 //
 // Solidity: function pause() returns()
-func (_Inbox *InboxSession) Pause() (*types.Transaction, error) {
-	return _Inbox.Contract.Pause(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) Pause() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Pause(&_ShastaInboxClient.TransactOpts)
 }
 
 // Pause is a paid mutator transaction binding the contract method 0x8456cb59.
 //
 // Solidity: function pause() returns()
-func (_Inbox *InboxTransactorSession) Pause() (*types.Transaction, error) {
-	return _Inbox.Contract.Pause(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Pause() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Pause(&_ShastaInboxClient.TransactOpts)
 }
 
 // Propose is a paid mutator transaction binding the contract method 0x9791e644.
 //
 // Solidity: function propose(bytes _lookahead, bytes _data) returns()
-func (_Inbox *InboxTransactor) Propose(opts *bind.TransactOpts, _lookahead []byte, _data []byte) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "propose", _lookahead, _data)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) Propose(opts *bind.TransactOpts, _lookahead []byte, _data []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "propose", _lookahead, _data)
 }
 
 // Propose is a paid mutator transaction binding the contract method 0x9791e644.
 //
 // Solidity: function propose(bytes _lookahead, bytes _data) returns()
-func (_Inbox *InboxSession) Propose(_lookahead []byte, _data []byte) (*types.Transaction, error) {
-	return _Inbox.Contract.Propose(&_Inbox.TransactOpts, _lookahead, _data)
+func (_ShastaInboxClient *ShastaInboxClientSession) Propose(_lookahead []byte, _data []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Propose(&_ShastaInboxClient.TransactOpts, _lookahead, _data)
 }
 
 // Propose is a paid mutator transaction binding the contract method 0x9791e644.
 //
 // Solidity: function propose(bytes _lookahead, bytes _data) returns()
-func (_Inbox *InboxTransactorSession) Propose(_lookahead []byte, _data []byte) (*types.Transaction, error) {
-	return _Inbox.Contract.Propose(&_Inbox.TransactOpts, _lookahead, _data)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Propose(_lookahead []byte, _data []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Propose(&_ShastaInboxClient.TransactOpts, _lookahead, _data)
 }
 
 // Prove is a paid mutator transaction binding the contract method 0xea191743.
 //
 // Solidity: function prove(bytes _data, bytes _proof) returns()
-func (_Inbox *InboxTransactor) Prove(opts *bind.TransactOpts, _data []byte, _proof []byte) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "prove", _data, _proof)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) Prove(opts *bind.TransactOpts, _data []byte, _proof []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "prove", _data, _proof)
 }
 
 // Prove is a paid mutator transaction binding the contract method 0xea191743.
 //
 // Solidity: function prove(bytes _data, bytes _proof) returns()
-func (_Inbox *InboxSession) Prove(_data []byte, _proof []byte) (*types.Transaction, error) {
-	return _Inbox.Contract.Prove(&_Inbox.TransactOpts, _data, _proof)
+func (_ShastaInboxClient *ShastaInboxClientSession) Prove(_data []byte, _proof []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Prove(&_ShastaInboxClient.TransactOpts, _data, _proof)
 }
 
 // Prove is a paid mutator transaction binding the contract method 0xea191743.
 //
 // Solidity: function prove(bytes _data, bytes _proof) returns()
-func (_Inbox *InboxTransactorSession) Prove(_data []byte, _proof []byte) (*types.Transaction, error) {
-	return _Inbox.Contract.Prove(&_Inbox.TransactOpts, _data, _proof)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Prove(_data []byte, _proof []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Prove(&_ShastaInboxClient.TransactOpts, _data, _proof)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_Inbox *InboxTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "renounceOwnership")
+func (_ShastaInboxClient *ShastaInboxClientTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "renounceOwnership")
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_Inbox *InboxSession) RenounceOwnership() (*types.Transaction, error) {
-	return _Inbox.Contract.RenounceOwnership(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) RenounceOwnership() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.RenounceOwnership(&_ShastaInboxClient.TransactOpts)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_Inbox *InboxTransactorSession) RenounceOwnership() (*types.Transaction, error) {
-	return _Inbox.Contract.RenounceOwnership(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.RenounceOwnership(&_ShastaInboxClient.TransactOpts)
 }
 
 // RequestWithdrawal is a paid mutator transaction binding the contract method 0xdbaf2145.
 //
 // Solidity: function requestWithdrawal() returns()
-func (_Inbox *InboxTransactor) RequestWithdrawal(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "requestWithdrawal")
+func (_ShastaInboxClient *ShastaInboxClientTransactor) RequestWithdrawal(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "requestWithdrawal")
 }
 
 // RequestWithdrawal is a paid mutator transaction binding the contract method 0xdbaf2145.
 //
 // Solidity: function requestWithdrawal() returns()
-func (_Inbox *InboxSession) RequestWithdrawal() (*types.Transaction, error) {
-	return _Inbox.Contract.RequestWithdrawal(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) RequestWithdrawal() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.RequestWithdrawal(&_ShastaInboxClient.TransactOpts)
 }
 
 // RequestWithdrawal is a paid mutator transaction binding the contract method 0xdbaf2145.
 //
 // Solidity: function requestWithdrawal() returns()
-func (_Inbox *InboxTransactorSession) RequestWithdrawal() (*types.Transaction, error) {
-	return _Inbox.Contract.RequestWithdrawal(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) RequestWithdrawal() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.RequestWithdrawal(&_ShastaInboxClient.TransactOpts)
 }
 
 // SaveForcedInclusion is a paid mutator transaction binding the contract method 0xdf596d9e.
 //
 // Solidity: function saveForcedInclusion((uint16,uint16,uint24) _blobReference) payable returns()
-func (_Inbox *InboxTransactor) SaveForcedInclusion(opts *bind.TransactOpts, _blobReference LibBlobsBlobReference) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "saveForcedInclusion", _blobReference)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) SaveForcedInclusion(opts *bind.TransactOpts, _blobReference LibBlobsBlobReference) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "saveForcedInclusion", _blobReference)
 }
 
 // SaveForcedInclusion is a paid mutator transaction binding the contract method 0xdf596d9e.
 //
 // Solidity: function saveForcedInclusion((uint16,uint16,uint24) _blobReference) payable returns()
-func (_Inbox *InboxSession) SaveForcedInclusion(_blobReference LibBlobsBlobReference) (*types.Transaction, error) {
-	return _Inbox.Contract.SaveForcedInclusion(&_Inbox.TransactOpts, _blobReference)
+func (_ShastaInboxClient *ShastaInboxClientSession) SaveForcedInclusion(_blobReference LibBlobsBlobReference) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.SaveForcedInclusion(&_ShastaInboxClient.TransactOpts, _blobReference)
 }
 
 // SaveForcedInclusion is a paid mutator transaction binding the contract method 0xdf596d9e.
 //
 // Solidity: function saveForcedInclusion((uint16,uint16,uint24) _blobReference) payable returns()
-func (_Inbox *InboxTransactorSession) SaveForcedInclusion(_blobReference LibBlobsBlobReference) (*types.Transaction, error) {
-	return _Inbox.Contract.SaveForcedInclusion(&_Inbox.TransactOpts, _blobReference)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) SaveForcedInclusion(_blobReference LibBlobsBlobReference) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.SaveForcedInclusion(&_ShastaInboxClient.TransactOpts, _blobReference)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_Inbox *InboxTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "transferOwnership", newOwner)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "transferOwnership", newOwner)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_Inbox *InboxSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _Inbox.Contract.TransferOwnership(&_Inbox.TransactOpts, newOwner)
+func (_ShastaInboxClient *ShastaInboxClientSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.TransferOwnership(&_ShastaInboxClient.TransactOpts, newOwner)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_Inbox *InboxTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _Inbox.Contract.TransferOwnership(&_Inbox.TransactOpts, newOwner)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.TransferOwnership(&_ShastaInboxClient.TransactOpts, newOwner)
 }
 
 // Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
 //
 // Solidity: function unpause() returns()
-func (_Inbox *InboxTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "unpause")
+func (_ShastaInboxClient *ShastaInboxClientTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "unpause")
 }
 
 // Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
 //
 // Solidity: function unpause() returns()
-func (_Inbox *InboxSession) Unpause() (*types.Transaction, error) {
-	return _Inbox.Contract.Unpause(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientSession) Unpause() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Unpause(&_ShastaInboxClient.TransactOpts)
 }
 
 // Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
 //
 // Solidity: function unpause() returns()
-func (_Inbox *InboxTransactorSession) Unpause() (*types.Transaction, error) {
-	return _Inbox.Contract.Unpause(&_Inbox.TransactOpts)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Unpause() (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Unpause(&_ShastaInboxClient.TransactOpts)
 }
 
 // UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
 //
 // Solidity: function upgradeTo(address newImplementation) returns()
-func (_Inbox *InboxTransactor) UpgradeTo(opts *bind.TransactOpts, newImplementation common.Address) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "upgradeTo", newImplementation)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) UpgradeTo(opts *bind.TransactOpts, newImplementation common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "upgradeTo", newImplementation)
 }
 
 // UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
 //
 // Solidity: function upgradeTo(address newImplementation) returns()
-func (_Inbox *InboxSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
-	return _Inbox.Contract.UpgradeTo(&_Inbox.TransactOpts, newImplementation)
+func (_ShastaInboxClient *ShastaInboxClientSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.UpgradeTo(&_ShastaInboxClient.TransactOpts, newImplementation)
 }
 
 // UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
 //
 // Solidity: function upgradeTo(address newImplementation) returns()
-func (_Inbox *InboxTransactorSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
-	return _Inbox.Contract.UpgradeTo(&_Inbox.TransactOpts, newImplementation)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.UpgradeTo(&_ShastaInboxClient.TransactOpts, newImplementation)
 }
 
 // UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
 //
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
-func (_Inbox *InboxTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
 }
 
 // UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
 //
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
-func (_Inbox *InboxSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
-	return _Inbox.Contract.UpgradeToAndCall(&_Inbox.TransactOpts, newImplementation, data)
+func (_ShastaInboxClient *ShastaInboxClientSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.UpgradeToAndCall(&_ShastaInboxClient.TransactOpts, newImplementation, data)
 }
 
 // UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
 //
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
-func (_Inbox *InboxTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
-	return _Inbox.Contract.UpgradeToAndCall(&_Inbox.TransactOpts, newImplementation, data)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.UpgradeToAndCall(&_ShastaInboxClient.TransactOpts, newImplementation, data)
 }
 
 // Withdraw is a paid mutator transaction binding the contract method 0xd6dad060.
 //
 // Solidity: function withdraw(address _to, uint64 _amount) returns()
-func (_Inbox *InboxTransactor) Withdraw(opts *bind.TransactOpts, _to common.Address, _amount uint64) (*types.Transaction, error) {
-	return _Inbox.contract.Transact(opts, "withdraw", _to, _amount)
+func (_ShastaInboxClient *ShastaInboxClientTransactor) Withdraw(opts *bind.TransactOpts, _to common.Address, _amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.contract.Transact(opts, "withdraw", _to, _amount)
 }
 
 // Withdraw is a paid mutator transaction binding the contract method 0xd6dad060.
 //
 // Solidity: function withdraw(address _to, uint64 _amount) returns()
-func (_Inbox *InboxSession) Withdraw(_to common.Address, _amount uint64) (*types.Transaction, error) {
-	return _Inbox.Contract.Withdraw(&_Inbox.TransactOpts, _to, _amount)
+func (_ShastaInboxClient *ShastaInboxClientSession) Withdraw(_to common.Address, _amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Withdraw(&_ShastaInboxClient.TransactOpts, _to, _amount)
 }
 
 // Withdraw is a paid mutator transaction binding the contract method 0xd6dad060.
 //
 // Solidity: function withdraw(address _to, uint64 _amount) returns()
-func (_Inbox *InboxTransactorSession) Withdraw(_to common.Address, _amount uint64) (*types.Transaction, error) {
-	return _Inbox.Contract.Withdraw(&_Inbox.TransactOpts, _to, _amount)
+func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Withdraw(_to common.Address, _amount uint64) (*types.Transaction, error) {
+	return _ShastaInboxClient.Contract.Withdraw(&_ShastaInboxClient.TransactOpts, _to, _amount)
 }
 
-// InboxAdminChangedIterator is returned from FilterAdminChanged and is used to iterate over the raw logs and unpacked data for AdminChanged events raised by the Inbox contract.
-type InboxAdminChangedIterator struct {
-	Event *InboxAdminChanged // Event containing the contract specifics and raw log
+// ShastaInboxClientAdminChangedIterator is returned from FilterAdminChanged and is used to iterate over the raw logs and unpacked data for AdminChanged events raised by the ShastaInboxClient contract.
+type ShastaInboxClientAdminChangedIterator struct {
+	Event *ShastaInboxClientAdminChanged // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1327,7 +1324,7 @@ type InboxAdminChangedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxAdminChangedIterator) Next() bool {
+func (it *ShastaInboxClientAdminChangedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1336,7 +1333,7 @@ func (it *InboxAdminChangedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxAdminChanged)
+			it.Event = new(ShastaInboxClientAdminChanged)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1351,7 +1348,7 @@ func (it *InboxAdminChangedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxAdminChanged)
+		it.Event = new(ShastaInboxClientAdminChanged)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1367,19 +1364,19 @@ func (it *InboxAdminChangedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxAdminChangedIterator) Error() error {
+func (it *ShastaInboxClientAdminChangedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxAdminChangedIterator) Close() error {
+func (it *ShastaInboxClientAdminChangedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxAdminChanged represents a AdminChanged event raised by the Inbox contract.
-type InboxAdminChanged struct {
+// ShastaInboxClientAdminChanged represents a AdminChanged event raised by the ShastaInboxClient contract.
+type ShastaInboxClientAdminChanged struct {
 	PreviousAdmin common.Address
 	NewAdmin      common.Address
 	Raw           types.Log // Blockchain specific contextual infos
@@ -1388,21 +1385,21 @@ type InboxAdminChanged struct {
 // FilterAdminChanged is a free log retrieval operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
 //
 // Solidity: event AdminChanged(address previousAdmin, address newAdmin)
-func (_Inbox *InboxFilterer) FilterAdminChanged(opts *bind.FilterOpts) (*InboxAdminChangedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterAdminChanged(opts *bind.FilterOpts) (*ShastaInboxClientAdminChangedIterator, error) {
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "AdminChanged")
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "AdminChanged")
 	if err != nil {
 		return nil, err
 	}
-	return &InboxAdminChangedIterator{contract: _Inbox.contract, event: "AdminChanged", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientAdminChangedIterator{contract: _ShastaInboxClient.contract, event: "AdminChanged", logs: logs, sub: sub}, nil
 }
 
 // WatchAdminChanged is a free log subscription operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
 //
 // Solidity: event AdminChanged(address previousAdmin, address newAdmin)
-func (_Inbox *InboxFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<- *InboxAdminChanged) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientAdminChanged) (event.Subscription, error) {
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "AdminChanged")
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "AdminChanged")
 	if err != nil {
 		return nil, err
 	}
@@ -1412,8 +1409,8 @@ func (_Inbox *InboxFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<-
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxAdminChanged)
-				if err := _Inbox.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+				event := new(ShastaInboxClientAdminChanged)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "AdminChanged", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1437,18 +1434,18 @@ func (_Inbox *InboxFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<-
 // ParseAdminChanged is a log parse operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
 //
 // Solidity: event AdminChanged(address previousAdmin, address newAdmin)
-func (_Inbox *InboxFilterer) ParseAdminChanged(log types.Log) (*InboxAdminChanged, error) {
-	event := new(InboxAdminChanged)
-	if err := _Inbox.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseAdminChanged(log types.Log) (*ShastaInboxClientAdminChanged, error) {
+	event := new(ShastaInboxClientAdminChanged)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "AdminChanged", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxBeaconUpgradedIterator is returned from FilterBeaconUpgraded and is used to iterate over the raw logs and unpacked data for BeaconUpgraded events raised by the Inbox contract.
-type InboxBeaconUpgradedIterator struct {
-	Event *InboxBeaconUpgraded // Event containing the contract specifics and raw log
+// ShastaInboxClientBeaconUpgradedIterator is returned from FilterBeaconUpgraded and is used to iterate over the raw logs and unpacked data for BeaconUpgraded events raised by the ShastaInboxClient contract.
+type ShastaInboxClientBeaconUpgradedIterator struct {
+	Event *ShastaInboxClientBeaconUpgraded // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1462,7 +1459,7 @@ type InboxBeaconUpgradedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxBeaconUpgradedIterator) Next() bool {
+func (it *ShastaInboxClientBeaconUpgradedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1471,7 +1468,7 @@ func (it *InboxBeaconUpgradedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxBeaconUpgraded)
+			it.Event = new(ShastaInboxClientBeaconUpgraded)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1486,7 +1483,7 @@ func (it *InboxBeaconUpgradedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxBeaconUpgraded)
+		it.Event = new(ShastaInboxClientBeaconUpgraded)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1502,19 +1499,19 @@ func (it *InboxBeaconUpgradedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxBeaconUpgradedIterator) Error() error {
+func (it *ShastaInboxClientBeaconUpgradedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxBeaconUpgradedIterator) Close() error {
+func (it *ShastaInboxClientBeaconUpgradedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxBeaconUpgraded represents a BeaconUpgraded event raised by the Inbox contract.
-type InboxBeaconUpgraded struct {
+// ShastaInboxClientBeaconUpgraded represents a BeaconUpgraded event raised by the ShastaInboxClient contract.
+type ShastaInboxClientBeaconUpgraded struct {
 	Beacon common.Address
 	Raw    types.Log // Blockchain specific contextual infos
 }
@@ -1522,31 +1519,31 @@ type InboxBeaconUpgraded struct {
 // FilterBeaconUpgraded is a free log retrieval operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
 //
 // Solidity: event BeaconUpgraded(address indexed beacon)
-func (_Inbox *InboxFilterer) FilterBeaconUpgraded(opts *bind.FilterOpts, beacon []common.Address) (*InboxBeaconUpgradedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterBeaconUpgraded(opts *bind.FilterOpts, beacon []common.Address) (*ShastaInboxClientBeaconUpgradedIterator, error) {
 
 	var beaconRule []interface{}
 	for _, beaconItem := range beacon {
 		beaconRule = append(beaconRule, beaconItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "BeaconUpgraded", beaconRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "BeaconUpgraded", beaconRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxBeaconUpgradedIterator{contract: _Inbox.contract, event: "BeaconUpgraded", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientBeaconUpgradedIterator{contract: _ShastaInboxClient.contract, event: "BeaconUpgraded", logs: logs, sub: sub}, nil
 }
 
 // WatchBeaconUpgraded is a free log subscription operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
 //
 // Solidity: event BeaconUpgraded(address indexed beacon)
-func (_Inbox *InboxFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan<- *InboxBeaconUpgraded, beacon []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientBeaconUpgraded, beacon []common.Address) (event.Subscription, error) {
 
 	var beaconRule []interface{}
 	for _, beaconItem := range beacon {
 		beaconRule = append(beaconRule, beaconItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "BeaconUpgraded", beaconRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "BeaconUpgraded", beaconRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1556,8 +1553,8 @@ func (_Inbox *InboxFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxBeaconUpgraded)
-				if err := _Inbox.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+				event := new(ShastaInboxClientBeaconUpgraded)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1581,18 +1578,18 @@ func (_Inbox *InboxFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan
 // ParseBeaconUpgraded is a log parse operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
 //
 // Solidity: event BeaconUpgraded(address indexed beacon)
-func (_Inbox *InboxFilterer) ParseBeaconUpgraded(log types.Log) (*InboxBeaconUpgraded, error) {
-	event := new(InboxBeaconUpgraded)
-	if err := _Inbox.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseBeaconUpgraded(log types.Log) (*ShastaInboxClientBeaconUpgraded, error) {
+	event := new(ShastaInboxClientBeaconUpgraded)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxBondDepositedIterator is returned from FilterBondDeposited and is used to iterate over the raw logs and unpacked data for BondDeposited events raised by the Inbox contract.
-type InboxBondDepositedIterator struct {
-	Event *InboxBondDeposited // Event containing the contract specifics and raw log
+// ShastaInboxClientBondDepositedIterator is returned from FilterBondDeposited and is used to iterate over the raw logs and unpacked data for BondDeposited events raised by the ShastaInboxClient contract.
+type ShastaInboxClientBondDepositedIterator struct {
+	Event *ShastaInboxClientBondDeposited // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1606,7 +1603,7 @@ type InboxBondDepositedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxBondDepositedIterator) Next() bool {
+func (it *ShastaInboxClientBondDepositedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1615,7 +1612,7 @@ func (it *InboxBondDepositedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxBondDeposited)
+			it.Event = new(ShastaInboxClientBondDeposited)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1630,7 +1627,7 @@ func (it *InboxBondDepositedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxBondDeposited)
+		it.Event = new(ShastaInboxClientBondDeposited)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1646,19 +1643,19 @@ func (it *InboxBondDepositedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxBondDepositedIterator) Error() error {
+func (it *ShastaInboxClientBondDepositedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxBondDepositedIterator) Close() error {
+func (it *ShastaInboxClientBondDepositedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxBondDeposited represents a BondDeposited event raised by the Inbox contract.
-type InboxBondDeposited struct {
+// ShastaInboxClientBondDeposited represents a BondDeposited event raised by the ShastaInboxClient contract.
+type ShastaInboxClientBondDeposited struct {
 	Depositor common.Address
 	Recipient common.Address
 	Amount    uint64
@@ -1668,7 +1665,7 @@ type InboxBondDeposited struct {
 // FilterBondDeposited is a free log retrieval operation binding the contract event 0xe5e95641fa87bdfef3ce0d39f0c9a37c200f3bf59f53623b3de21e03ed33e3d2.
 //
 // Solidity: event BondDeposited(address indexed depositor, address indexed recipient, uint64 amount)
-func (_Inbox *InboxFilterer) FilterBondDeposited(opts *bind.FilterOpts, depositor []common.Address, recipient []common.Address) (*InboxBondDepositedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterBondDeposited(opts *bind.FilterOpts, depositor []common.Address, recipient []common.Address) (*ShastaInboxClientBondDepositedIterator, error) {
 
 	var depositorRule []interface{}
 	for _, depositorItem := range depositor {
@@ -1679,17 +1676,17 @@ func (_Inbox *InboxFilterer) FilterBondDeposited(opts *bind.FilterOpts, deposito
 		recipientRule = append(recipientRule, recipientItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "BondDeposited", depositorRule, recipientRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "BondDeposited", depositorRule, recipientRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxBondDepositedIterator{contract: _Inbox.contract, event: "BondDeposited", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientBondDepositedIterator{contract: _ShastaInboxClient.contract, event: "BondDeposited", logs: logs, sub: sub}, nil
 }
 
 // WatchBondDeposited is a free log subscription operation binding the contract event 0xe5e95641fa87bdfef3ce0d39f0c9a37c200f3bf59f53623b3de21e03ed33e3d2.
 //
 // Solidity: event BondDeposited(address indexed depositor, address indexed recipient, uint64 amount)
-func (_Inbox *InboxFilterer) WatchBondDeposited(opts *bind.WatchOpts, sink chan<- *InboxBondDeposited, depositor []common.Address, recipient []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondDeposited(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientBondDeposited, depositor []common.Address, recipient []common.Address) (event.Subscription, error) {
 
 	var depositorRule []interface{}
 	for _, depositorItem := range depositor {
@@ -1700,7 +1697,7 @@ func (_Inbox *InboxFilterer) WatchBondDeposited(opts *bind.WatchOpts, sink chan<
 		recipientRule = append(recipientRule, recipientItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "BondDeposited", depositorRule, recipientRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "BondDeposited", depositorRule, recipientRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1710,8 +1707,8 @@ func (_Inbox *InboxFilterer) WatchBondDeposited(opts *bind.WatchOpts, sink chan<
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxBondDeposited)
-				if err := _Inbox.contract.UnpackLog(event, "BondDeposited", log); err != nil {
+				event := new(ShastaInboxClientBondDeposited)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "BondDeposited", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1735,18 +1732,18 @@ func (_Inbox *InboxFilterer) WatchBondDeposited(opts *bind.WatchOpts, sink chan<
 // ParseBondDeposited is a log parse operation binding the contract event 0xe5e95641fa87bdfef3ce0d39f0c9a37c200f3bf59f53623b3de21e03ed33e3d2.
 //
 // Solidity: event BondDeposited(address indexed depositor, address indexed recipient, uint64 amount)
-func (_Inbox *InboxFilterer) ParseBondDeposited(log types.Log) (*InboxBondDeposited, error) {
-	event := new(InboxBondDeposited)
-	if err := _Inbox.contract.UnpackLog(event, "BondDeposited", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseBondDeposited(log types.Log) (*ShastaInboxClientBondDeposited, error) {
+	event := new(ShastaInboxClientBondDeposited)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "BondDeposited", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxBondWithdrawnIterator is returned from FilterBondWithdrawn and is used to iterate over the raw logs and unpacked data for BondWithdrawn events raised by the Inbox contract.
-type InboxBondWithdrawnIterator struct {
-	Event *InboxBondWithdrawn // Event containing the contract specifics and raw log
+// ShastaInboxClientBondWithdrawnIterator is returned from FilterBondWithdrawn and is used to iterate over the raw logs and unpacked data for BondWithdrawn events raised by the ShastaInboxClient contract.
+type ShastaInboxClientBondWithdrawnIterator struct {
+	Event *ShastaInboxClientBondWithdrawn // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1760,7 +1757,7 @@ type InboxBondWithdrawnIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxBondWithdrawnIterator) Next() bool {
+func (it *ShastaInboxClientBondWithdrawnIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1769,7 +1766,7 @@ func (it *InboxBondWithdrawnIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxBondWithdrawn)
+			it.Event = new(ShastaInboxClientBondWithdrawn)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1784,7 +1781,7 @@ func (it *InboxBondWithdrawnIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxBondWithdrawn)
+		it.Event = new(ShastaInboxClientBondWithdrawn)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1800,19 +1797,19 @@ func (it *InboxBondWithdrawnIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxBondWithdrawnIterator) Error() error {
+func (it *ShastaInboxClientBondWithdrawnIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxBondWithdrawnIterator) Close() error {
+func (it *ShastaInboxClientBondWithdrawnIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxBondWithdrawn represents a BondWithdrawn event raised by the Inbox contract.
-type InboxBondWithdrawn struct {
+// ShastaInboxClientBondWithdrawn represents a BondWithdrawn event raised by the ShastaInboxClient contract.
+type ShastaInboxClientBondWithdrawn struct {
 	Account common.Address
 	Amount  uint64
 	Raw     types.Log // Blockchain specific contextual infos
@@ -1821,31 +1818,31 @@ type InboxBondWithdrawn struct {
 // FilterBondWithdrawn is a free log retrieval operation binding the contract event 0x3362c96009316515fccd3dd29c7036c305ad9e892d83dd5681845ac9edb0c9a8.
 //
 // Solidity: event BondWithdrawn(address indexed account, uint64 amount)
-func (_Inbox *InboxFilterer) FilterBondWithdrawn(opts *bind.FilterOpts, account []common.Address) (*InboxBondWithdrawnIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterBondWithdrawn(opts *bind.FilterOpts, account []common.Address) (*ShastaInboxClientBondWithdrawnIterator, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "BondWithdrawn", accountRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "BondWithdrawn", accountRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxBondWithdrawnIterator{contract: _Inbox.contract, event: "BondWithdrawn", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientBondWithdrawnIterator{contract: _ShastaInboxClient.contract, event: "BondWithdrawn", logs: logs, sub: sub}, nil
 }
 
 // WatchBondWithdrawn is a free log subscription operation binding the contract event 0x3362c96009316515fccd3dd29c7036c305ad9e892d83dd5681845ac9edb0c9a8.
 //
 // Solidity: event BondWithdrawn(address indexed account, uint64 amount)
-func (_Inbox *InboxFilterer) WatchBondWithdrawn(opts *bind.WatchOpts, sink chan<- *InboxBondWithdrawn, account []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondWithdrawn(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientBondWithdrawn, account []common.Address) (event.Subscription, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "BondWithdrawn", accountRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "BondWithdrawn", accountRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1855,8 +1852,8 @@ func (_Inbox *InboxFilterer) WatchBondWithdrawn(opts *bind.WatchOpts, sink chan<
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxBondWithdrawn)
-				if err := _Inbox.contract.UnpackLog(event, "BondWithdrawn", log); err != nil {
+				event := new(ShastaInboxClientBondWithdrawn)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "BondWithdrawn", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1880,18 +1877,18 @@ func (_Inbox *InboxFilterer) WatchBondWithdrawn(opts *bind.WatchOpts, sink chan<
 // ParseBondWithdrawn is a log parse operation binding the contract event 0x3362c96009316515fccd3dd29c7036c305ad9e892d83dd5681845ac9edb0c9a8.
 //
 // Solidity: event BondWithdrawn(address indexed account, uint64 amount)
-func (_Inbox *InboxFilterer) ParseBondWithdrawn(log types.Log) (*InboxBondWithdrawn, error) {
-	event := new(InboxBondWithdrawn)
-	if err := _Inbox.contract.UnpackLog(event, "BondWithdrawn", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseBondWithdrawn(log types.Log) (*ShastaInboxClientBondWithdrawn, error) {
+	event := new(ShastaInboxClientBondWithdrawn)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "BondWithdrawn", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxForcedInclusionSavedIterator is returned from FilterForcedInclusionSaved and is used to iterate over the raw logs and unpacked data for ForcedInclusionSaved events raised by the Inbox contract.
-type InboxForcedInclusionSavedIterator struct {
-	Event *InboxForcedInclusionSaved // Event containing the contract specifics and raw log
+// ShastaInboxClientForcedInclusionSavedIterator is returned from FilterForcedInclusionSaved and is used to iterate over the raw logs and unpacked data for ForcedInclusionSaved events raised by the ShastaInboxClient contract.
+type ShastaInboxClientForcedInclusionSavedIterator struct {
+	Event *ShastaInboxClientForcedInclusionSaved // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1905,7 +1902,7 @@ type InboxForcedInclusionSavedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxForcedInclusionSavedIterator) Next() bool {
+func (it *ShastaInboxClientForcedInclusionSavedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1914,7 +1911,7 @@ func (it *InboxForcedInclusionSavedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxForcedInclusionSaved)
+			it.Event = new(ShastaInboxClientForcedInclusionSaved)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1929,7 +1926,7 @@ func (it *InboxForcedInclusionSavedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxForcedInclusionSaved)
+		it.Event = new(ShastaInboxClientForcedInclusionSaved)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1945,19 +1942,19 @@ func (it *InboxForcedInclusionSavedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxForcedInclusionSavedIterator) Error() error {
+func (it *ShastaInboxClientForcedInclusionSavedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxForcedInclusionSavedIterator) Close() error {
+func (it *ShastaInboxClientForcedInclusionSavedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxForcedInclusionSaved represents a ForcedInclusionSaved event raised by the Inbox contract.
-type InboxForcedInclusionSaved struct {
+// ShastaInboxClientForcedInclusionSaved represents a ForcedInclusionSaved event raised by the ShastaInboxClient contract.
+type ShastaInboxClientForcedInclusionSaved struct {
 	ForcedInclusion IForcedInclusionStoreForcedInclusion
 	Raw             types.Log // Blockchain specific contextual infos
 }
@@ -1965,21 +1962,21 @@ type InboxForcedInclusionSaved struct {
 // FilterForcedInclusionSaved is a free log retrieval operation binding the contract event 0x18c4fc1e6ac628dbb537b0375bf0efabf1ff2528af1ec22faa74d2da95c29471.
 //
 // Solidity: event ForcedInclusionSaved((uint64,(bytes32[],uint24,uint48)) forcedInclusion)
-func (_Inbox *InboxFilterer) FilterForcedInclusionSaved(opts *bind.FilterOpts) (*InboxForcedInclusionSavedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterForcedInclusionSaved(opts *bind.FilterOpts) (*ShastaInboxClientForcedInclusionSavedIterator, error) {
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "ForcedInclusionSaved")
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "ForcedInclusionSaved")
 	if err != nil {
 		return nil, err
 	}
-	return &InboxForcedInclusionSavedIterator{contract: _Inbox.contract, event: "ForcedInclusionSaved", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientForcedInclusionSavedIterator{contract: _ShastaInboxClient.contract, event: "ForcedInclusionSaved", logs: logs, sub: sub}, nil
 }
 
 // WatchForcedInclusionSaved is a free log subscription operation binding the contract event 0x18c4fc1e6ac628dbb537b0375bf0efabf1ff2528af1ec22faa74d2da95c29471.
 //
 // Solidity: event ForcedInclusionSaved((uint64,(bytes32[],uint24,uint48)) forcedInclusion)
-func (_Inbox *InboxFilterer) WatchForcedInclusionSaved(opts *bind.WatchOpts, sink chan<- *InboxForcedInclusionSaved) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchForcedInclusionSaved(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientForcedInclusionSaved) (event.Subscription, error) {
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "ForcedInclusionSaved")
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "ForcedInclusionSaved")
 	if err != nil {
 		return nil, err
 	}
@@ -1989,8 +1986,8 @@ func (_Inbox *InboxFilterer) WatchForcedInclusionSaved(opts *bind.WatchOpts, sin
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxForcedInclusionSaved)
-				if err := _Inbox.contract.UnpackLog(event, "ForcedInclusionSaved", log); err != nil {
+				event := new(ShastaInboxClientForcedInclusionSaved)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "ForcedInclusionSaved", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2014,18 +2011,18 @@ func (_Inbox *InboxFilterer) WatchForcedInclusionSaved(opts *bind.WatchOpts, sin
 // ParseForcedInclusionSaved is a log parse operation binding the contract event 0x18c4fc1e6ac628dbb537b0375bf0efabf1ff2528af1ec22faa74d2da95c29471.
 //
 // Solidity: event ForcedInclusionSaved((uint64,(bytes32[],uint24,uint48)) forcedInclusion)
-func (_Inbox *InboxFilterer) ParseForcedInclusionSaved(log types.Log) (*InboxForcedInclusionSaved, error) {
-	event := new(InboxForcedInclusionSaved)
-	if err := _Inbox.contract.UnpackLog(event, "ForcedInclusionSaved", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseForcedInclusionSaved(log types.Log) (*ShastaInboxClientForcedInclusionSaved, error) {
+	event := new(ShastaInboxClientForcedInclusionSaved)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "ForcedInclusionSaved", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxInboxActivatedIterator is returned from FilterInboxActivated and is used to iterate over the raw logs and unpacked data for InboxActivated events raised by the Inbox contract.
-type InboxInboxActivatedIterator struct {
-	Event *InboxInboxActivated // Event containing the contract specifics and raw log
+// ShastaInboxClientInboxActivatedIterator is returned from FilterInboxActivated and is used to iterate over the raw logs and unpacked data for InboxActivated events raised by the ShastaInboxClient contract.
+type ShastaInboxClientInboxActivatedIterator struct {
+	Event *ShastaInboxClientInboxActivated // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2039,7 +2036,7 @@ type InboxInboxActivatedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxInboxActivatedIterator) Next() bool {
+func (it *ShastaInboxClientInboxActivatedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2048,7 +2045,7 @@ func (it *InboxInboxActivatedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxInboxActivated)
+			it.Event = new(ShastaInboxClientInboxActivated)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2063,7 +2060,7 @@ func (it *InboxInboxActivatedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxInboxActivated)
+		it.Event = new(ShastaInboxClientInboxActivated)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2079,19 +2076,19 @@ func (it *InboxInboxActivatedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxInboxActivatedIterator) Error() error {
+func (it *ShastaInboxClientInboxActivatedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxInboxActivatedIterator) Close() error {
+func (it *ShastaInboxClientInboxActivatedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxInboxActivated represents a InboxActivated event raised by the Inbox contract.
-type InboxInboxActivated struct {
+// ShastaInboxClientInboxActivated represents a InboxActivated event raised by the ShastaInboxClient contract.
+type ShastaInboxClientInboxActivated struct {
 	LastPacayaBlockHash [32]byte
 	Raw                 types.Log // Blockchain specific contextual infos
 }
@@ -2099,21 +2096,21 @@ type InboxInboxActivated struct {
 // FilterInboxActivated is a free log retrieval operation binding the contract event 0xe4356761c97932c05c3ee0859fb1a5e4f91f7a1d7a3752c7d5a72d5cc6ecb2d2.
 //
 // Solidity: event InboxActivated(bytes32 lastPacayaBlockHash)
-func (_Inbox *InboxFilterer) FilterInboxActivated(opts *bind.FilterOpts) (*InboxInboxActivatedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterInboxActivated(opts *bind.FilterOpts) (*ShastaInboxClientInboxActivatedIterator, error) {
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "InboxActivated")
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "InboxActivated")
 	if err != nil {
 		return nil, err
 	}
-	return &InboxInboxActivatedIterator{contract: _Inbox.contract, event: "InboxActivated", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientInboxActivatedIterator{contract: _ShastaInboxClient.contract, event: "InboxActivated", logs: logs, sub: sub}, nil
 }
 
 // WatchInboxActivated is a free log subscription operation binding the contract event 0xe4356761c97932c05c3ee0859fb1a5e4f91f7a1d7a3752c7d5a72d5cc6ecb2d2.
 //
 // Solidity: event InboxActivated(bytes32 lastPacayaBlockHash)
-func (_Inbox *InboxFilterer) WatchInboxActivated(opts *bind.WatchOpts, sink chan<- *InboxInboxActivated) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchInboxActivated(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientInboxActivated) (event.Subscription, error) {
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "InboxActivated")
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "InboxActivated")
 	if err != nil {
 		return nil, err
 	}
@@ -2123,8 +2120,8 @@ func (_Inbox *InboxFilterer) WatchInboxActivated(opts *bind.WatchOpts, sink chan
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxInboxActivated)
-				if err := _Inbox.contract.UnpackLog(event, "InboxActivated", log); err != nil {
+				event := new(ShastaInboxClientInboxActivated)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "InboxActivated", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2148,18 +2145,18 @@ func (_Inbox *InboxFilterer) WatchInboxActivated(opts *bind.WatchOpts, sink chan
 // ParseInboxActivated is a log parse operation binding the contract event 0xe4356761c97932c05c3ee0859fb1a5e4f91f7a1d7a3752c7d5a72d5cc6ecb2d2.
 //
 // Solidity: event InboxActivated(bytes32 lastPacayaBlockHash)
-func (_Inbox *InboxFilterer) ParseInboxActivated(log types.Log) (*InboxInboxActivated, error) {
-	event := new(InboxInboxActivated)
-	if err := _Inbox.contract.UnpackLog(event, "InboxActivated", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseInboxActivated(log types.Log) (*ShastaInboxClientInboxActivated, error) {
+	event := new(ShastaInboxClientInboxActivated)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "InboxActivated", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Inbox contract.
-type InboxInitializedIterator struct {
-	Event *InboxInitialized // Event containing the contract specifics and raw log
+// ShastaInboxClientInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the ShastaInboxClient contract.
+type ShastaInboxClientInitializedIterator struct {
+	Event *ShastaInboxClientInitialized // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2173,7 +2170,7 @@ type InboxInitializedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxInitializedIterator) Next() bool {
+func (it *ShastaInboxClientInitializedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2182,7 +2179,7 @@ func (it *InboxInitializedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxInitialized)
+			it.Event = new(ShastaInboxClientInitialized)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2197,7 +2194,7 @@ func (it *InboxInitializedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxInitialized)
+		it.Event = new(ShastaInboxClientInitialized)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2213,19 +2210,19 @@ func (it *InboxInitializedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxInitializedIterator) Error() error {
+func (it *ShastaInboxClientInitializedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxInitializedIterator) Close() error {
+func (it *ShastaInboxClientInitializedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxInitialized represents a Initialized event raised by the Inbox contract.
-type InboxInitialized struct {
+// ShastaInboxClientInitialized represents a Initialized event raised by the ShastaInboxClient contract.
+type ShastaInboxClientInitialized struct {
 	Version uint8
 	Raw     types.Log // Blockchain specific contextual infos
 }
@@ -2233,21 +2230,21 @@ type InboxInitialized struct {
 // FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
 //
 // Solidity: event Initialized(uint8 version)
-func (_Inbox *InboxFilterer) FilterInitialized(opts *bind.FilterOpts) (*InboxInitializedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterInitialized(opts *bind.FilterOpts) (*ShastaInboxClientInitializedIterator, error) {
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Initialized")
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Initialized")
 	if err != nil {
 		return nil, err
 	}
-	return &InboxInitializedIterator{contract: _Inbox.contract, event: "Initialized", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientInitializedIterator{contract: _ShastaInboxClient.contract, event: "Initialized", logs: logs, sub: sub}, nil
 }
 
 // WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
 //
 // Solidity: event Initialized(uint8 version)
-func (_Inbox *InboxFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *InboxInitialized) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientInitialized) (event.Subscription, error) {
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Initialized")
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Initialized")
 	if err != nil {
 		return nil, err
 	}
@@ -2257,8 +2254,8 @@ func (_Inbox *InboxFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- 
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxInitialized)
-				if err := _Inbox.contract.UnpackLog(event, "Initialized", log); err != nil {
+				event := new(ShastaInboxClientInitialized)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "Initialized", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2282,18 +2279,18 @@ func (_Inbox *InboxFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- 
 // ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
 //
 // Solidity: event Initialized(uint8 version)
-func (_Inbox *InboxFilterer) ParseInitialized(log types.Log) (*InboxInitialized, error) {
-	event := new(InboxInitialized)
-	if err := _Inbox.contract.UnpackLog(event, "Initialized", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseInitialized(log types.Log) (*ShastaInboxClientInitialized, error) {
+	event := new(ShastaInboxClientInitialized)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "Initialized", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxLivenessBondSettledIterator is returned from FilterLivenessBondSettled and is used to iterate over the raw logs and unpacked data for LivenessBondSettled events raised by the Inbox contract.
-type InboxLivenessBondSettledIterator struct {
-	Event *InboxLivenessBondSettled // Event containing the contract specifics and raw log
+// ShastaInboxClientLivenessBondSettledIterator is returned from FilterLivenessBondSettled and is used to iterate over the raw logs and unpacked data for LivenessBondSettled events raised by the ShastaInboxClient contract.
+type ShastaInboxClientLivenessBondSettledIterator struct {
+	Event *ShastaInboxClientLivenessBondSettled // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2307,7 +2304,7 @@ type InboxLivenessBondSettledIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxLivenessBondSettledIterator) Next() bool {
+func (it *ShastaInboxClientLivenessBondSettledIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2316,7 +2313,7 @@ func (it *InboxLivenessBondSettledIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxLivenessBondSettled)
+			it.Event = new(ShastaInboxClientLivenessBondSettled)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2331,7 +2328,7 @@ func (it *InboxLivenessBondSettledIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxLivenessBondSettled)
+		it.Event = new(ShastaInboxClientLivenessBondSettled)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2347,19 +2344,19 @@ func (it *InboxLivenessBondSettledIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxLivenessBondSettledIterator) Error() error {
+func (it *ShastaInboxClientLivenessBondSettledIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxLivenessBondSettledIterator) Close() error {
+func (it *ShastaInboxClientLivenessBondSettledIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxLivenessBondSettled represents a LivenessBondSettled event raised by the Inbox contract.
-type InboxLivenessBondSettled struct {
+// ShastaInboxClientLivenessBondSettled represents a LivenessBondSettled event raised by the ShastaInboxClient contract.
+type ShastaInboxClientLivenessBondSettled struct {
 	Payer        common.Address
 	Payee        common.Address
 	LivenessBond uint64
@@ -2371,7 +2368,7 @@ type InboxLivenessBondSettled struct {
 // FilterLivenessBondSettled is a free log retrieval operation binding the contract event 0xaa22f5157944b5fa6846460e159d57ea9c3878e71fda274af372fa2ccf285aa0.
 //
 // Solidity: event LivenessBondSettled(address indexed payer, address indexed payee, uint64 livenessBond, uint64 credited, uint64 slashed)
-func (_Inbox *InboxFilterer) FilterLivenessBondSettled(opts *bind.FilterOpts, payer []common.Address, payee []common.Address) (*InboxLivenessBondSettledIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterLivenessBondSettled(opts *bind.FilterOpts, payer []common.Address, payee []common.Address) (*ShastaInboxClientLivenessBondSettledIterator, error) {
 
 	var payerRule []interface{}
 	for _, payerItem := range payer {
@@ -2382,17 +2379,17 @@ func (_Inbox *InboxFilterer) FilterLivenessBondSettled(opts *bind.FilterOpts, pa
 		payeeRule = append(payeeRule, payeeItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "LivenessBondSettled", payerRule, payeeRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "LivenessBondSettled", payerRule, payeeRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxLivenessBondSettledIterator{contract: _Inbox.contract, event: "LivenessBondSettled", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientLivenessBondSettledIterator{contract: _ShastaInboxClient.contract, event: "LivenessBondSettled", logs: logs, sub: sub}, nil
 }
 
 // WatchLivenessBondSettled is a free log subscription operation binding the contract event 0xaa22f5157944b5fa6846460e159d57ea9c3878e71fda274af372fa2ccf285aa0.
 //
 // Solidity: event LivenessBondSettled(address indexed payer, address indexed payee, uint64 livenessBond, uint64 credited, uint64 slashed)
-func (_Inbox *InboxFilterer) WatchLivenessBondSettled(opts *bind.WatchOpts, sink chan<- *InboxLivenessBondSettled, payer []common.Address, payee []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchLivenessBondSettled(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientLivenessBondSettled, payer []common.Address, payee []common.Address) (event.Subscription, error) {
 
 	var payerRule []interface{}
 	for _, payerItem := range payer {
@@ -2403,7 +2400,7 @@ func (_Inbox *InboxFilterer) WatchLivenessBondSettled(opts *bind.WatchOpts, sink
 		payeeRule = append(payeeRule, payeeItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "LivenessBondSettled", payerRule, payeeRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "LivenessBondSettled", payerRule, payeeRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2413,8 +2410,8 @@ func (_Inbox *InboxFilterer) WatchLivenessBondSettled(opts *bind.WatchOpts, sink
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxLivenessBondSettled)
-				if err := _Inbox.contract.UnpackLog(event, "LivenessBondSettled", log); err != nil {
+				event := new(ShastaInboxClientLivenessBondSettled)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "LivenessBondSettled", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2438,18 +2435,18 @@ func (_Inbox *InboxFilterer) WatchLivenessBondSettled(opts *bind.WatchOpts, sink
 // ParseLivenessBondSettled is a log parse operation binding the contract event 0xaa22f5157944b5fa6846460e159d57ea9c3878e71fda274af372fa2ccf285aa0.
 //
 // Solidity: event LivenessBondSettled(address indexed payer, address indexed payee, uint64 livenessBond, uint64 credited, uint64 slashed)
-func (_Inbox *InboxFilterer) ParseLivenessBondSettled(log types.Log) (*InboxLivenessBondSettled, error) {
-	event := new(InboxLivenessBondSettled)
-	if err := _Inbox.contract.UnpackLog(event, "LivenessBondSettled", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseLivenessBondSettled(log types.Log) (*ShastaInboxClientLivenessBondSettled, error) {
+	event := new(ShastaInboxClientLivenessBondSettled)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "LivenessBondSettled", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the Inbox contract.
-type InboxOwnershipTransferStartedIterator struct {
-	Event *InboxOwnershipTransferStarted // Event containing the contract specifics and raw log
+// ShastaInboxClientOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the ShastaInboxClient contract.
+type ShastaInboxClientOwnershipTransferStartedIterator struct {
+	Event *ShastaInboxClientOwnershipTransferStarted // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2463,7 +2460,7 @@ type InboxOwnershipTransferStartedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxOwnershipTransferStartedIterator) Next() bool {
+func (it *ShastaInboxClientOwnershipTransferStartedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2472,7 +2469,7 @@ func (it *InboxOwnershipTransferStartedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxOwnershipTransferStarted)
+			it.Event = new(ShastaInboxClientOwnershipTransferStarted)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2487,7 +2484,7 @@ func (it *InboxOwnershipTransferStartedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxOwnershipTransferStarted)
+		it.Event = new(ShastaInboxClientOwnershipTransferStarted)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2503,19 +2500,19 @@ func (it *InboxOwnershipTransferStartedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxOwnershipTransferStartedIterator) Error() error {
+func (it *ShastaInboxClientOwnershipTransferStartedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxOwnershipTransferStartedIterator) Close() error {
+func (it *ShastaInboxClientOwnershipTransferStartedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the Inbox contract.
-type InboxOwnershipTransferStarted struct {
+// ShastaInboxClientOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the ShastaInboxClient contract.
+type ShastaInboxClientOwnershipTransferStarted struct {
 	PreviousOwner common.Address
 	NewOwner      common.Address
 	Raw           types.Log // Blockchain specific contextual infos
@@ -2524,7 +2521,7 @@ type InboxOwnershipTransferStarted struct {
 // FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-func (_Inbox *InboxFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*InboxOwnershipTransferStartedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ShastaInboxClientOwnershipTransferStartedIterator, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -2535,17 +2532,17 @@ func (_Inbox *InboxFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpt
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxOwnershipTransferStartedIterator{contract: _Inbox.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientOwnershipTransferStartedIterator{contract: _ShastaInboxClient.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
 }
 
 // WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-func (_Inbox *InboxFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *InboxOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -2556,7 +2553,7 @@ func (_Inbox *InboxFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts,
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2566,8 +2563,8 @@ func (_Inbox *InboxFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts,
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxOwnershipTransferStarted)
-				if err := _Inbox.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+				event := new(ShastaInboxClientOwnershipTransferStarted)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2591,18 +2588,18 @@ func (_Inbox *InboxFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts,
 // ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-func (_Inbox *InboxFilterer) ParseOwnershipTransferStarted(log types.Log) (*InboxOwnershipTransferStarted, error) {
-	event := new(InboxOwnershipTransferStarted)
-	if err := _Inbox.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseOwnershipTransferStarted(log types.Log) (*ShastaInboxClientOwnershipTransferStarted, error) {
+	event := new(ShastaInboxClientOwnershipTransferStarted)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Inbox contract.
-type InboxOwnershipTransferredIterator struct {
-	Event *InboxOwnershipTransferred // Event containing the contract specifics and raw log
+// ShastaInboxClientOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the ShastaInboxClient contract.
+type ShastaInboxClientOwnershipTransferredIterator struct {
+	Event *ShastaInboxClientOwnershipTransferred // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2616,7 +2613,7 @@ type InboxOwnershipTransferredIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxOwnershipTransferredIterator) Next() bool {
+func (it *ShastaInboxClientOwnershipTransferredIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2625,7 +2622,7 @@ func (it *InboxOwnershipTransferredIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxOwnershipTransferred)
+			it.Event = new(ShastaInboxClientOwnershipTransferred)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2640,7 +2637,7 @@ func (it *InboxOwnershipTransferredIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxOwnershipTransferred)
+		it.Event = new(ShastaInboxClientOwnershipTransferred)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2656,19 +2653,19 @@ func (it *InboxOwnershipTransferredIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxOwnershipTransferredIterator) Error() error {
+func (it *ShastaInboxClientOwnershipTransferredIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxOwnershipTransferredIterator) Close() error {
+func (it *ShastaInboxClientOwnershipTransferredIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxOwnershipTransferred represents a OwnershipTransferred event raised by the Inbox contract.
-type InboxOwnershipTransferred struct {
+// ShastaInboxClientOwnershipTransferred represents a OwnershipTransferred event raised by the ShastaInboxClient contract.
+type ShastaInboxClientOwnershipTransferred struct {
 	PreviousOwner common.Address
 	NewOwner      common.Address
 	Raw           types.Log // Blockchain specific contextual infos
@@ -2677,7 +2674,7 @@ type InboxOwnershipTransferred struct {
 // FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_Inbox *InboxFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*InboxOwnershipTransferredIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ShastaInboxClientOwnershipTransferredIterator, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -2688,17 +2685,17 @@ func (_Inbox *InboxFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, p
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxOwnershipTransferredIterator{contract: _Inbox.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientOwnershipTransferredIterator{contract: _ShastaInboxClient.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
 }
 
 // WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_Inbox *InboxFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *InboxOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -2709,7 +2706,7 @@ func (_Inbox *InboxFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sin
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2719,8 +2716,8 @@ func (_Inbox *InboxFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sin
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxOwnershipTransferred)
-				if err := _Inbox.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+				event := new(ShastaInboxClientOwnershipTransferred)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2744,18 +2741,18 @@ func (_Inbox *InboxFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sin
 // ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_Inbox *InboxFilterer) ParseOwnershipTransferred(log types.Log) (*InboxOwnershipTransferred, error) {
-	event := new(InboxOwnershipTransferred)
-	if err := _Inbox.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseOwnershipTransferred(log types.Log) (*ShastaInboxClientOwnershipTransferred, error) {
+	event := new(ShastaInboxClientOwnershipTransferred)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the Inbox contract.
-type InboxPausedIterator struct {
-	Event *InboxPaused // Event containing the contract specifics and raw log
+// ShastaInboxClientPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the ShastaInboxClient contract.
+type ShastaInboxClientPausedIterator struct {
+	Event *ShastaInboxClientPaused // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2769,7 +2766,7 @@ type InboxPausedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxPausedIterator) Next() bool {
+func (it *ShastaInboxClientPausedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2778,7 +2775,7 @@ func (it *InboxPausedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxPaused)
+			it.Event = new(ShastaInboxClientPaused)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2793,7 +2790,7 @@ func (it *InboxPausedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxPaused)
+		it.Event = new(ShastaInboxClientPaused)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2809,19 +2806,19 @@ func (it *InboxPausedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxPausedIterator) Error() error {
+func (it *ShastaInboxClientPausedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxPausedIterator) Close() error {
+func (it *ShastaInboxClientPausedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxPaused represents a Paused event raised by the Inbox contract.
-type InboxPaused struct {
+// ShastaInboxClientPaused represents a Paused event raised by the ShastaInboxClient contract.
+type ShastaInboxClientPaused struct {
 	Account common.Address
 	Raw     types.Log // Blockchain specific contextual infos
 }
@@ -2829,21 +2826,21 @@ type InboxPaused struct {
 // FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
 //
 // Solidity: event Paused(address account)
-func (_Inbox *InboxFilterer) FilterPaused(opts *bind.FilterOpts) (*InboxPausedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterPaused(opts *bind.FilterOpts) (*ShastaInboxClientPausedIterator, error) {
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Paused")
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Paused")
 	if err != nil {
 		return nil, err
 	}
-	return &InboxPausedIterator{contract: _Inbox.contract, event: "Paused", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientPausedIterator{contract: _ShastaInboxClient.contract, event: "Paused", logs: logs, sub: sub}, nil
 }
 
 // WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
 //
 // Solidity: event Paused(address account)
-func (_Inbox *InboxFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *InboxPaused) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientPaused) (event.Subscription, error) {
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Paused")
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Paused")
 	if err != nil {
 		return nil, err
 	}
@@ -2853,8 +2850,8 @@ func (_Inbox *InboxFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *Inbo
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxPaused)
-				if err := _Inbox.contract.UnpackLog(event, "Paused", log); err != nil {
+				event := new(ShastaInboxClientPaused)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "Paused", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2878,18 +2875,18 @@ func (_Inbox *InboxFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *Inbo
 // ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
 //
 // Solidity: event Paused(address account)
-func (_Inbox *InboxFilterer) ParsePaused(log types.Log) (*InboxPaused, error) {
-	event := new(InboxPaused)
-	if err := _Inbox.contract.UnpackLog(event, "Paused", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParsePaused(log types.Log) (*ShastaInboxClientPaused, error) {
+	event := new(ShastaInboxClientPaused)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "Paused", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxProposedIterator is returned from FilterProposed and is used to iterate over the raw logs and unpacked data for Proposed events raised by the Inbox contract.
-type InboxProposedIterator struct {
-	Event *InboxProposed // Event containing the contract specifics and raw log
+// ShastaInboxClientProposedIterator is returned from FilterProposed and is used to iterate over the raw logs and unpacked data for Proposed events raised by the ShastaInboxClient contract.
+type ShastaInboxClientProposedIterator struct {
+	Event *ShastaInboxClientProposed // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2903,7 +2900,7 @@ type InboxProposedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxProposedIterator) Next() bool {
+func (it *ShastaInboxClientProposedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2912,7 +2909,7 @@ func (it *InboxProposedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxProposed)
+			it.Event = new(ShastaInboxClientProposed)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2927,7 +2924,7 @@ func (it *InboxProposedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxProposed)
+		it.Event = new(ShastaInboxClientProposed)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2943,19 +2940,19 @@ func (it *InboxProposedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxProposedIterator) Error() error {
+func (it *ShastaInboxClientProposedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxProposedIterator) Close() error {
+func (it *ShastaInboxClientProposedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxProposed represents a Proposed event raised by the Inbox contract.
-type InboxProposed struct {
+// ShastaInboxClientProposed represents a Proposed event raised by the ShastaInboxClient contract.
+type ShastaInboxClientProposed struct {
 	Id                             *big.Int
 	Proposer                       common.Address
 	ParentProposalHash             [32]byte
@@ -2968,7 +2965,7 @@ type InboxProposed struct {
 // FilterProposed is a free log retrieval operation binding the contract event 0x7c4c4523e17533e451df15762a093e0693a2cd8b279fe54c6cd3777ed5771213.
 //
 // Solidity: event Proposed(uint48 indexed id, address indexed proposer, bytes32 parentProposalHash, uint48 endOfSubmissionWindowTimestamp, uint8 basefeeSharingPctg, (bool,(bytes32[],uint24,uint48))[] sources)
-func (_Inbox *InboxFilterer) FilterProposed(opts *bind.FilterOpts, id []*big.Int, proposer []common.Address) (*InboxProposedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterProposed(opts *bind.FilterOpts, id []*big.Int, proposer []common.Address) (*ShastaInboxClientProposedIterator, error) {
 
 	var idRule []interface{}
 	for _, idItem := range id {
@@ -2979,17 +2976,17 @@ func (_Inbox *InboxFilterer) FilterProposed(opts *bind.FilterOpts, id []*big.Int
 		proposerRule = append(proposerRule, proposerItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Proposed", idRule, proposerRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Proposed", idRule, proposerRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxProposedIterator{contract: _Inbox.contract, event: "Proposed", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientProposedIterator{contract: _ShastaInboxClient.contract, event: "Proposed", logs: logs, sub: sub}, nil
 }
 
 // WatchProposed is a free log subscription operation binding the contract event 0x7c4c4523e17533e451df15762a093e0693a2cd8b279fe54c6cd3777ed5771213.
 //
 // Solidity: event Proposed(uint48 indexed id, address indexed proposer, bytes32 parentProposalHash, uint48 endOfSubmissionWindowTimestamp, uint8 basefeeSharingPctg, (bool,(bytes32[],uint24,uint48))[] sources)
-func (_Inbox *InboxFilterer) WatchProposed(opts *bind.WatchOpts, sink chan<- *InboxProposed, id []*big.Int, proposer []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProposed(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientProposed, id []*big.Int, proposer []common.Address) (event.Subscription, error) {
 
 	var idRule []interface{}
 	for _, idItem := range id {
@@ -3000,7 +2997,7 @@ func (_Inbox *InboxFilterer) WatchProposed(opts *bind.WatchOpts, sink chan<- *In
 		proposerRule = append(proposerRule, proposerItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Proposed", idRule, proposerRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Proposed", idRule, proposerRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3010,8 +3007,8 @@ func (_Inbox *InboxFilterer) WatchProposed(opts *bind.WatchOpts, sink chan<- *In
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxProposed)
-				if err := _Inbox.contract.UnpackLog(event, "Proposed", log); err != nil {
+				event := new(ShastaInboxClientProposed)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "Proposed", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3035,18 +3032,18 @@ func (_Inbox *InboxFilterer) WatchProposed(opts *bind.WatchOpts, sink chan<- *In
 // ParseProposed is a log parse operation binding the contract event 0x7c4c4523e17533e451df15762a093e0693a2cd8b279fe54c6cd3777ed5771213.
 //
 // Solidity: event Proposed(uint48 indexed id, address indexed proposer, bytes32 parentProposalHash, uint48 endOfSubmissionWindowTimestamp, uint8 basefeeSharingPctg, (bool,(bytes32[],uint24,uint48))[] sources)
-func (_Inbox *InboxFilterer) ParseProposed(log types.Log) (*InboxProposed, error) {
-	event := new(InboxProposed)
-	if err := _Inbox.contract.UnpackLog(event, "Proposed", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseProposed(log types.Log) (*ShastaInboxClientProposed, error) {
+	event := new(ShastaInboxClientProposed)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "Proposed", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxProvedIterator is returned from FilterProved and is used to iterate over the raw logs and unpacked data for Proved events raised by the Inbox contract.
-type InboxProvedIterator struct {
-	Event *InboxProved // Event containing the contract specifics and raw log
+// ShastaInboxClientProvedIterator is returned from FilterProved and is used to iterate over the raw logs and unpacked data for Proved events raised by the ShastaInboxClient contract.
+type ShastaInboxClientProvedIterator struct {
+	Event *ShastaInboxClientProved // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3060,7 +3057,7 @@ type InboxProvedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxProvedIterator) Next() bool {
+func (it *ShastaInboxClientProvedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3069,7 +3066,7 @@ func (it *InboxProvedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxProved)
+			it.Event = new(ShastaInboxClientProved)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3084,7 +3081,7 @@ func (it *InboxProvedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxProved)
+		it.Event = new(ShastaInboxClientProved)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3100,55 +3097,54 @@ func (it *InboxProvedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxProvedIterator) Error() error {
+func (it *ShastaInboxClientProvedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxProvedIterator) Close() error {
+func (it *ShastaInboxClientProvedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxProved represents a Proved event raised by the Inbox contract.
-type InboxProved struct {
+// ShastaInboxClientProved represents a Proved event raised by the ShastaInboxClient contract.
+type ShastaInboxClientProved struct {
 	FirstProposalId    *big.Int
 	FirstNewProposalId *big.Int
 	LastProposalId     *big.Int
 	ActualProver       common.Address
-	CheckpointSynced   bool
 	Raw                types.Log // Blockchain specific contextual infos
 }
 
-// FilterProved is a free log retrieval operation binding the contract event 0x7ca0f1e30099488c4ee24e86a6b2c6802e9add6d530919af7aa17db3bcc1cff1.
+// FilterProved is a free log retrieval operation binding the contract event 0xa274dcaff3629ec7d69d144038e97732516ff306fcbf8a2bc9423d106779a2f0.
 //
-// Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver, bool checkpointSynced)
-func (_Inbox *InboxFilterer) FilterProved(opts *bind.FilterOpts, actualProver []common.Address) (*InboxProvedIterator, error) {
+// Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver)
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterProved(opts *bind.FilterOpts, actualProver []common.Address) (*ShastaInboxClientProvedIterator, error) {
 
 	var actualProverRule []interface{}
 	for _, actualProverItem := range actualProver {
 		actualProverRule = append(actualProverRule, actualProverItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Proved", actualProverRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Proved", actualProverRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxProvedIterator{contract: _Inbox.contract, event: "Proved", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientProvedIterator{contract: _ShastaInboxClient.contract, event: "Proved", logs: logs, sub: sub}, nil
 }
 
-// WatchProved is a free log subscription operation binding the contract event 0x7ca0f1e30099488c4ee24e86a6b2c6802e9add6d530919af7aa17db3bcc1cff1.
+// WatchProved is a free log subscription operation binding the contract event 0xa274dcaff3629ec7d69d144038e97732516ff306fcbf8a2bc9423d106779a2f0.
 //
-// Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver, bool checkpointSynced)
-func (_Inbox *InboxFilterer) WatchProved(opts *bind.WatchOpts, sink chan<- *InboxProved, actualProver []common.Address) (event.Subscription, error) {
+// Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver)
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProved(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientProved, actualProver []common.Address) (event.Subscription, error) {
 
 	var actualProverRule []interface{}
 	for _, actualProverItem := range actualProver {
 		actualProverRule = append(actualProverRule, actualProverItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Proved", actualProverRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Proved", actualProverRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3158,8 +3154,8 @@ func (_Inbox *InboxFilterer) WatchProved(opts *bind.WatchOpts, sink chan<- *Inbo
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxProved)
-				if err := _Inbox.contract.UnpackLog(event, "Proved", log); err != nil {
+				event := new(ShastaInboxClientProved)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "Proved", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3180,21 +3176,21 @@ func (_Inbox *InboxFilterer) WatchProved(opts *bind.WatchOpts, sink chan<- *Inbo
 	}), nil
 }
 
-// ParseProved is a log parse operation binding the contract event 0x7ca0f1e30099488c4ee24e86a6b2c6802e9add6d530919af7aa17db3bcc1cff1.
+// ParseProved is a log parse operation binding the contract event 0xa274dcaff3629ec7d69d144038e97732516ff306fcbf8a2bc9423d106779a2f0.
 //
-// Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver, bool checkpointSynced)
-func (_Inbox *InboxFilterer) ParseProved(log types.Log) (*InboxProved, error) {
-	event := new(InboxProved)
-	if err := _Inbox.contract.UnpackLog(event, "Proved", log); err != nil {
+// Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver)
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseProved(log types.Log) (*ShastaInboxClientProved, error) {
+	event := new(ShastaInboxClientProved)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "Proved", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the Inbox contract.
-type InboxUnpausedIterator struct {
-	Event *InboxUnpaused // Event containing the contract specifics and raw log
+// ShastaInboxClientUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the ShastaInboxClient contract.
+type ShastaInboxClientUnpausedIterator struct {
+	Event *ShastaInboxClientUnpaused // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3208,7 +3204,7 @@ type InboxUnpausedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxUnpausedIterator) Next() bool {
+func (it *ShastaInboxClientUnpausedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3217,7 +3213,7 @@ func (it *InboxUnpausedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxUnpaused)
+			it.Event = new(ShastaInboxClientUnpaused)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3232,7 +3228,7 @@ func (it *InboxUnpausedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxUnpaused)
+		it.Event = new(ShastaInboxClientUnpaused)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3248,19 +3244,19 @@ func (it *InboxUnpausedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxUnpausedIterator) Error() error {
+func (it *ShastaInboxClientUnpausedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxUnpausedIterator) Close() error {
+func (it *ShastaInboxClientUnpausedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxUnpaused represents a Unpaused event raised by the Inbox contract.
-type InboxUnpaused struct {
+// ShastaInboxClientUnpaused represents a Unpaused event raised by the ShastaInboxClient contract.
+type ShastaInboxClientUnpaused struct {
 	Account common.Address
 	Raw     types.Log // Blockchain specific contextual infos
 }
@@ -3268,21 +3264,21 @@ type InboxUnpaused struct {
 // FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
 //
 // Solidity: event Unpaused(address account)
-func (_Inbox *InboxFilterer) FilterUnpaused(opts *bind.FilterOpts) (*InboxUnpausedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterUnpaused(opts *bind.FilterOpts) (*ShastaInboxClientUnpausedIterator, error) {
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Unpaused")
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Unpaused")
 	if err != nil {
 		return nil, err
 	}
-	return &InboxUnpausedIterator{contract: _Inbox.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientUnpausedIterator{contract: _ShastaInboxClient.contract, event: "Unpaused", logs: logs, sub: sub}, nil
 }
 
 // WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
 //
 // Solidity: event Unpaused(address account)
-func (_Inbox *InboxFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *InboxUnpaused) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientUnpaused) (event.Subscription, error) {
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Unpaused")
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Unpaused")
 	if err != nil {
 		return nil, err
 	}
@@ -3292,8 +3288,8 @@ func (_Inbox *InboxFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *In
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxUnpaused)
-				if err := _Inbox.contract.UnpackLog(event, "Unpaused", log); err != nil {
+				event := new(ShastaInboxClientUnpaused)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "Unpaused", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3317,18 +3313,18 @@ func (_Inbox *InboxFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *In
 // ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
 //
 // Solidity: event Unpaused(address account)
-func (_Inbox *InboxFilterer) ParseUnpaused(log types.Log) (*InboxUnpaused, error) {
-	event := new(InboxUnpaused)
-	if err := _Inbox.contract.UnpackLog(event, "Unpaused", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseUnpaused(log types.Log) (*ShastaInboxClientUnpaused, error) {
+	event := new(ShastaInboxClientUnpaused)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "Unpaused", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the Inbox contract.
-type InboxUpgradedIterator struct {
-	Event *InboxUpgraded // Event containing the contract specifics and raw log
+// ShastaInboxClientUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the ShastaInboxClient contract.
+type ShastaInboxClientUpgradedIterator struct {
+	Event *ShastaInboxClientUpgraded // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3342,7 +3338,7 @@ type InboxUpgradedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxUpgradedIterator) Next() bool {
+func (it *ShastaInboxClientUpgradedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3351,7 +3347,7 @@ func (it *InboxUpgradedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxUpgraded)
+			it.Event = new(ShastaInboxClientUpgraded)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3366,7 +3362,7 @@ func (it *InboxUpgradedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxUpgraded)
+		it.Event = new(ShastaInboxClientUpgraded)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3382,19 +3378,19 @@ func (it *InboxUpgradedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxUpgradedIterator) Error() error {
+func (it *ShastaInboxClientUpgradedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxUpgradedIterator) Close() error {
+func (it *ShastaInboxClientUpgradedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxUpgraded represents a Upgraded event raised by the Inbox contract.
-type InboxUpgraded struct {
+// ShastaInboxClientUpgraded represents a Upgraded event raised by the ShastaInboxClient contract.
+type ShastaInboxClientUpgraded struct {
 	Implementation common.Address
 	Raw            types.Log // Blockchain specific contextual infos
 }
@@ -3402,31 +3398,31 @@ type InboxUpgraded struct {
 // FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
 //
 // Solidity: event Upgraded(address indexed implementation)
-func (_Inbox *InboxFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*InboxUpgradedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*ShastaInboxClientUpgradedIterator, error) {
 
 	var implementationRule []interface{}
 	for _, implementationItem := range implementation {
 		implementationRule = append(implementationRule, implementationItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Upgraded", implementationRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxUpgradedIterator{contract: _Inbox.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientUpgradedIterator{contract: _ShastaInboxClient.contract, event: "Upgraded", logs: logs, sub: sub}, nil
 }
 
 // WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
 //
 // Solidity: event Upgraded(address indexed implementation)
-func (_Inbox *InboxFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *InboxUpgraded, implementation []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientUpgraded, implementation []common.Address) (event.Subscription, error) {
 
 	var implementationRule []interface{}
 	for _, implementationItem := range implementation {
 		implementationRule = append(implementationRule, implementationItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Upgraded", implementationRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3436,8 +3432,8 @@ func (_Inbox *InboxFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *In
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxUpgraded)
-				if err := _Inbox.contract.UnpackLog(event, "Upgraded", log); err != nil {
+				event := new(ShastaInboxClientUpgraded)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "Upgraded", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3461,18 +3457,18 @@ func (_Inbox *InboxFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *In
 // ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
 //
 // Solidity: event Upgraded(address indexed implementation)
-func (_Inbox *InboxFilterer) ParseUpgraded(log types.Log) (*InboxUpgraded, error) {
-	event := new(InboxUpgraded)
-	if err := _Inbox.contract.UnpackLog(event, "Upgraded", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseUpgraded(log types.Log) (*ShastaInboxClientUpgraded, error) {
+	event := new(ShastaInboxClientUpgraded)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "Upgraded", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxWithdrawalCancelledIterator is returned from FilterWithdrawalCancelled and is used to iterate over the raw logs and unpacked data for WithdrawalCancelled events raised by the Inbox contract.
-type InboxWithdrawalCancelledIterator struct {
-	Event *InboxWithdrawalCancelled // Event containing the contract specifics and raw log
+// ShastaInboxClientWithdrawalCancelledIterator is returned from FilterWithdrawalCancelled and is used to iterate over the raw logs and unpacked data for WithdrawalCancelled events raised by the ShastaInboxClient contract.
+type ShastaInboxClientWithdrawalCancelledIterator struct {
+	Event *ShastaInboxClientWithdrawalCancelled // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3486,7 +3482,7 @@ type InboxWithdrawalCancelledIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxWithdrawalCancelledIterator) Next() bool {
+func (it *ShastaInboxClientWithdrawalCancelledIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3495,7 +3491,7 @@ func (it *InboxWithdrawalCancelledIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxWithdrawalCancelled)
+			it.Event = new(ShastaInboxClientWithdrawalCancelled)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3510,7 +3506,7 @@ func (it *InboxWithdrawalCancelledIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxWithdrawalCancelled)
+		it.Event = new(ShastaInboxClientWithdrawalCancelled)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3526,19 +3522,19 @@ func (it *InboxWithdrawalCancelledIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxWithdrawalCancelledIterator) Error() error {
+func (it *ShastaInboxClientWithdrawalCancelledIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxWithdrawalCancelledIterator) Close() error {
+func (it *ShastaInboxClientWithdrawalCancelledIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxWithdrawalCancelled represents a WithdrawalCancelled event raised by the Inbox contract.
-type InboxWithdrawalCancelled struct {
+// ShastaInboxClientWithdrawalCancelled represents a WithdrawalCancelled event raised by the ShastaInboxClient contract.
+type ShastaInboxClientWithdrawalCancelled struct {
 	Account common.Address
 	Raw     types.Log // Blockchain specific contextual infos
 }
@@ -3546,31 +3542,31 @@ type InboxWithdrawalCancelled struct {
 // FilterWithdrawalCancelled is a free log retrieval operation binding the contract event 0xc51fdb96728de385ec7859819e3997bc618362ef0dbca0ad051d856866cda3db.
 //
 // Solidity: event WithdrawalCancelled(address indexed account)
-func (_Inbox *InboxFilterer) FilterWithdrawalCancelled(opts *bind.FilterOpts, account []common.Address) (*InboxWithdrawalCancelledIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterWithdrawalCancelled(opts *bind.FilterOpts, account []common.Address) (*ShastaInboxClientWithdrawalCancelledIterator, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "WithdrawalCancelled", accountRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "WithdrawalCancelled", accountRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxWithdrawalCancelledIterator{contract: _Inbox.contract, event: "WithdrawalCancelled", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientWithdrawalCancelledIterator{contract: _ShastaInboxClient.contract, event: "WithdrawalCancelled", logs: logs, sub: sub}, nil
 }
 
 // WatchWithdrawalCancelled is a free log subscription operation binding the contract event 0xc51fdb96728de385ec7859819e3997bc618362ef0dbca0ad051d856866cda3db.
 //
 // Solidity: event WithdrawalCancelled(address indexed account)
-func (_Inbox *InboxFilterer) WatchWithdrawalCancelled(opts *bind.WatchOpts, sink chan<- *InboxWithdrawalCancelled, account []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchWithdrawalCancelled(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientWithdrawalCancelled, account []common.Address) (event.Subscription, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "WithdrawalCancelled", accountRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "WithdrawalCancelled", accountRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3580,8 +3576,8 @@ func (_Inbox *InboxFilterer) WatchWithdrawalCancelled(opts *bind.WatchOpts, sink
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxWithdrawalCancelled)
-				if err := _Inbox.contract.UnpackLog(event, "WithdrawalCancelled", log); err != nil {
+				event := new(ShastaInboxClientWithdrawalCancelled)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "WithdrawalCancelled", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3605,18 +3601,18 @@ func (_Inbox *InboxFilterer) WatchWithdrawalCancelled(opts *bind.WatchOpts, sink
 // ParseWithdrawalCancelled is a log parse operation binding the contract event 0xc51fdb96728de385ec7859819e3997bc618362ef0dbca0ad051d856866cda3db.
 //
 // Solidity: event WithdrawalCancelled(address indexed account)
-func (_Inbox *InboxFilterer) ParseWithdrawalCancelled(log types.Log) (*InboxWithdrawalCancelled, error) {
-	event := new(InboxWithdrawalCancelled)
-	if err := _Inbox.contract.UnpackLog(event, "WithdrawalCancelled", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseWithdrawalCancelled(log types.Log) (*ShastaInboxClientWithdrawalCancelled, error) {
+	event := new(ShastaInboxClientWithdrawalCancelled)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "WithdrawalCancelled", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// InboxWithdrawalRequestedIterator is returned from FilterWithdrawalRequested and is used to iterate over the raw logs and unpacked data for WithdrawalRequested events raised by the Inbox contract.
-type InboxWithdrawalRequestedIterator struct {
-	Event *InboxWithdrawalRequested // Event containing the contract specifics and raw log
+// ShastaInboxClientWithdrawalRequestedIterator is returned from FilterWithdrawalRequested and is used to iterate over the raw logs and unpacked data for WithdrawalRequested events raised by the ShastaInboxClient contract.
+type ShastaInboxClientWithdrawalRequestedIterator struct {
+	Event *ShastaInboxClientWithdrawalRequested // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3630,7 +3626,7 @@ type InboxWithdrawalRequestedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *InboxWithdrawalRequestedIterator) Next() bool {
+func (it *ShastaInboxClientWithdrawalRequestedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3639,7 +3635,7 @@ func (it *InboxWithdrawalRequestedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(InboxWithdrawalRequested)
+			it.Event = new(ShastaInboxClientWithdrawalRequested)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3654,7 +3650,7 @@ func (it *InboxWithdrawalRequestedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(InboxWithdrawalRequested)
+		it.Event = new(ShastaInboxClientWithdrawalRequested)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3670,19 +3666,19 @@ func (it *InboxWithdrawalRequestedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *InboxWithdrawalRequestedIterator) Error() error {
+func (it *ShastaInboxClientWithdrawalRequestedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *InboxWithdrawalRequestedIterator) Close() error {
+func (it *ShastaInboxClientWithdrawalRequestedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// InboxWithdrawalRequested represents a WithdrawalRequested event raised by the Inbox contract.
-type InboxWithdrawalRequested struct {
+// ShastaInboxClientWithdrawalRequested represents a WithdrawalRequested event raised by the ShastaInboxClient contract.
+type ShastaInboxClientWithdrawalRequested struct {
 	Account        common.Address
 	WithdrawableAt *big.Int
 	Raw            types.Log // Blockchain specific contextual infos
@@ -3691,31 +3687,31 @@ type InboxWithdrawalRequested struct {
 // FilterWithdrawalRequested is a free log retrieval operation binding the contract event 0x3bbe41cfdd142e0f9b2224dac18c6efd2a6966e35a9ec23ab57ce63a60b33604.
 //
 // Solidity: event WithdrawalRequested(address indexed account, uint48 withdrawableAt)
-func (_Inbox *InboxFilterer) FilterWithdrawalRequested(opts *bind.FilterOpts, account []common.Address) (*InboxWithdrawalRequestedIterator, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterWithdrawalRequested(opts *bind.FilterOpts, account []common.Address) (*ShastaInboxClientWithdrawalRequestedIterator, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _Inbox.contract.FilterLogs(opts, "WithdrawalRequested", accountRule)
+	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "WithdrawalRequested", accountRule)
 	if err != nil {
 		return nil, err
 	}
-	return &InboxWithdrawalRequestedIterator{contract: _Inbox.contract, event: "WithdrawalRequested", logs: logs, sub: sub}, nil
+	return &ShastaInboxClientWithdrawalRequestedIterator{contract: _ShastaInboxClient.contract, event: "WithdrawalRequested", logs: logs, sub: sub}, nil
 }
 
 // WatchWithdrawalRequested is a free log subscription operation binding the contract event 0x3bbe41cfdd142e0f9b2224dac18c6efd2a6966e35a9ec23ab57ce63a60b33604.
 //
 // Solidity: event WithdrawalRequested(address indexed account, uint48 withdrawableAt)
-func (_Inbox *InboxFilterer) WatchWithdrawalRequested(opts *bind.WatchOpts, sink chan<- *InboxWithdrawalRequested, account []common.Address) (event.Subscription, error) {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchWithdrawalRequested(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientWithdrawalRequested, account []common.Address) (event.Subscription, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _Inbox.contract.WatchLogs(opts, "WithdrawalRequested", accountRule)
+	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "WithdrawalRequested", accountRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3725,8 +3721,8 @@ func (_Inbox *InboxFilterer) WatchWithdrawalRequested(opts *bind.WatchOpts, sink
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(InboxWithdrawalRequested)
-				if err := _Inbox.contract.UnpackLog(event, "WithdrawalRequested", log); err != nil {
+				event := new(ShastaInboxClientWithdrawalRequested)
+				if err := _ShastaInboxClient.contract.UnpackLog(event, "WithdrawalRequested", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3750,9 +3746,9 @@ func (_Inbox *InboxFilterer) WatchWithdrawalRequested(opts *bind.WatchOpts, sink
 // ParseWithdrawalRequested is a log parse operation binding the contract event 0x3bbe41cfdd142e0f9b2224dac18c6efd2a6966e35a9ec23ab57ce63a60b33604.
 //
 // Solidity: event WithdrawalRequested(address indexed account, uint48 withdrawableAt)
-func (_Inbox *InboxFilterer) ParseWithdrawalRequested(log types.Log) (*InboxWithdrawalRequested, error) {
-	event := new(InboxWithdrawalRequested)
-	if err := _Inbox.contract.UnpackLog(event, "WithdrawalRequested", log); err != nil {
+func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseWithdrawalRequested(log types.Log) (*ShastaInboxClientWithdrawalRequested, error) {
+	event := new(ShastaInboxClientWithdrawalRequested)
+	if err := _ShastaInboxClient.contract.UnpackLog(event, "WithdrawalRequested", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/packages/eventindexer/contracts/shasta/inbox/Inbox.go
+++ b/packages/eventindexer/contracts/shasta/inbox/Inbox.go
@@ -135,113 +135,113 @@ type LibBlobsBlobSlice struct {
 	Timestamp  *big.Int
 }
 
-// ShastaInboxClientMetaData contains all meta data concerning the ShastaInboxClient contract.
-var ShastaInboxClientMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_proofVerifier\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_proposerChecker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_proverWhitelist\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_bondToken\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"activate\",\"inputs\":[{\"name\":\"_lastPacayaBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"activationTimestamp\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"cancelWithdrawal\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"decodeProposeInput\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"input_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProposeInput\",\"components\":[{\"name\":\"deadline\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]},{\"name\":\"numForcedInclusions\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"decodeProveInput\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"input_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProveInput\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"deposit\",\"inputs\":[{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"depositTo\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"encodeProposeInput\",\"inputs\":[{\"name\":\"_input\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProposeInput\",\"components\":[{\"name\":\"deadline\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]},{\"name\":\"numForcedInclusions\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]}],\"outputs\":[{\"name\":\"encoded_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"encodeProveInput\",\"inputs\":[{\"name\":\"_input\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProveInput\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}]}],\"outputs\":[{\"name\":\"encoded_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"getBond\",\"inputs\":[{\"name\":\"_address\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"bond_\",\"type\":\"tuple\",\"internalType\":\"structIBondManager.Bond\",\"components\":[{\"name\":\"balance\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalRequestedAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getConfig\",\"inputs\":[],\"outputs\":[{\"name\":\"config_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Config\",\"components\":[{\"name\":\"proofVerifier\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proposerChecker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proverWhitelist\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"signalService\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"bondToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"minBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"provingWindow\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"permissionlessProvingDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"maxProofSubmissionDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"ringBufferSize\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"forcedInclusionDelay\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"forcedInclusionFeeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"forcedInclusionFeeDoubleThreshold\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"permissionlessInclusionMultiplier\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCoreState\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIInbox.CoreState\",\"components\":[{\"name\":\"nextProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastProposalBlockId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastCheckpointTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCurrentForcedInclusionFee\",\"inputs\":[],\"outputs\":[{\"name\":\"feeInGwei_\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getForcedInclusionState\",\"inputs\":[],\"outputs\":[{\"name\":\"head_\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"tail_\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getForcedInclusions\",\"inputs\":[{\"name\":\"_start\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"_maxCount\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"outputs\":[{\"name\":\"inclusions_\",\"type\":\"tuple[]\",\"internalType\":\"structIForcedInclusionStore.ForcedInclusion[]\",\"components\":[{\"name\":\"feeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProposalHash\",\"inputs\":[{\"name\":\"_proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"hashCommitment\",\"inputs\":[{\"name\":\"_commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"hashProposal\",\"inputs\":[{\"name\":\"_proposal\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Proposal\",\"components\":[{\"name\":\"id\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endOfSubmissionWindowTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"parentProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"originBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"originBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"sources\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.DerivationSource[]\",\"components\":[{\"name\":\"isForcedInclusion\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"impl\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"inNonReentrant\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"init\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"propose\",\"inputs\":[{\"name\":\"_lookahead\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"prove\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestWithdrawal\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"resolver\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"saveForcedInclusion\",\"inputs\":[{\"name\":\"_blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeTo\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"withdraw\",\"inputs\":[{\"name\":\"_to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"AdminChanged\",\"inputs\":[{\"name\":\"previousAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BeaconUpgraded\",\"inputs\":[{\"name\":\"beacon\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BondDeposited\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BondWithdrawn\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ForcedInclusionSaved\",\"inputs\":[{\"name\":\"forcedInclusion\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIForcedInclusionStore.ForcedInclusion\",\"components\":[{\"name\":\"feeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"InboxActivated\",\"inputs\":[{\"name\":\"lastPacayaBlockHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"LivenessBondSettled\",\"inputs\":[{\"name\":\"payer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"credited\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"slashed\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Proposed\",\"inputs\":[{\"name\":\"id\",\"type\":\"uint48\",\"indexed\":true,\"internalType\":\"uint48\"},{\"name\":\"proposer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"parentProposalHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"endOfSubmissionWindowTimestamp\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"},{\"name\":\"sources\",\"type\":\"tuple[]\",\"indexed\":false,\"internalType\":\"structIInbox.DerivationSource[]\",\"components\":[{\"name\":\"isForcedInclusion\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Proved\",\"inputs\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"firstNewProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"lastProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"actualProver\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalCancelled\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalRequested\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"withdrawableAt\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ACCESS_DENIED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ActivationRequired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"BlobNotFound\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CannotProposeInCurrentBlock\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DeadlineExceeded\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ETH_TRANSFER_FAILED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EmptyBatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FUNC_NOT_IMPLEMENTED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FirstProposalIdTooLarge\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"INVALID_PAUSE_STATUS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectProposalCount\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InsufficientBond\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalAlreadyFinalized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalHashMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalIdTooLarge\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LengthExceedsUint16\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MustMaintainMinBond\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoBlobs\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoBondToWithdraw\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoWithdrawalRequested\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotEnoughCapacity\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ParentBlockHashMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ProverNotWhitelisted\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"REENTRANT_CALL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnprocessedForcedInclusionIsDue\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalAlreadyRequested\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_ADDRESS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_VALUE\",\"inputs\":[]}]",
+// InboxMetaData contains all meta data concerning the Inbox contract.
+var InboxMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_config\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Config\",\"components\":[{\"name\":\"proofVerifier\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proposerChecker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proverWhitelist\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"signalService\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"bondToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"minBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"provingWindow\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"permissionlessProvingDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"maxProofSubmissionDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"ringBufferSize\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"forcedInclusionDelay\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"forcedInclusionFeeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"forcedInclusionFeeDoubleThreshold\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"permissionlessInclusionMultiplier\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"activate\",\"inputs\":[{\"name\":\"_lastPacayaBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"activationTimestamp\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"cancelWithdrawal\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"decodeProposeInput\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"input_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProposeInput\",\"components\":[{\"name\":\"deadline\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]},{\"name\":\"numForcedInclusions\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"decodeProveInput\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"input_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProveInput\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"deposit\",\"inputs\":[{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"depositTo\",\"inputs\":[{\"name\":\"_recipient\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"encodeProposeInput\",\"inputs\":[{\"name\":\"_input\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProposeInput\",\"components\":[{\"name\":\"deadline\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]},{\"name\":\"numForcedInclusions\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]}],\"outputs\":[{\"name\":\"encoded_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"encodeProveInput\",\"inputs\":[{\"name\":\"_input\",\"type\":\"tuple\",\"internalType\":\"structIInbox.ProveInput\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}]}],\"outputs\":[{\"name\":\"encoded_\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"getBond\",\"inputs\":[{\"name\":\"_address\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"bond_\",\"type\":\"tuple\",\"internalType\":\"structIBondManager.Bond\",\"components\":[{\"name\":\"balance\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalRequestedAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getConfig\",\"inputs\":[],\"outputs\":[{\"name\":\"config_\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Config\",\"components\":[{\"name\":\"proofVerifier\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proposerChecker\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"proverWhitelist\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"signalService\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"bondToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"minBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"withdrawalDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"provingWindow\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"permissionlessProvingDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"maxProofSubmissionDelay\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"ringBufferSize\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"forcedInclusionDelay\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"forcedInclusionFeeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"forcedInclusionFeeDoubleThreshold\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"permissionlessInclusionMultiplier\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCoreState\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structIInbox.CoreState\",\"components\":[{\"name\":\"nextProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastProposalBlockId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastCheckpointTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"lastFinalizedBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getCurrentForcedInclusionFee\",\"inputs\":[],\"outputs\":[{\"name\":\"feeInGwei_\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getForcedInclusionState\",\"inputs\":[],\"outputs\":[{\"name\":\"head_\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"tail_\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getForcedInclusions\",\"inputs\":[{\"name\":\"_start\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"_maxCount\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"outputs\":[{\"name\":\"inclusions_\",\"type\":\"tuple[]\",\"internalType\":\"structIForcedInclusionStore.ForcedInclusion[]\",\"components\":[{\"name\":\"feeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProposalHash\",\"inputs\":[{\"name\":\"_proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"hashCommitment\",\"inputs\":[{\"name\":\"_commitment\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Commitment\",\"components\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"firstProposalParentBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"actualProver\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endStateRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"transitions\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.Transition[]\",\"components\":[{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"blockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"hashProposal\",\"inputs\":[{\"name\":\"_proposal\",\"type\":\"tuple\",\"internalType\":\"structIInbox.Proposal\",\"components\":[{\"name\":\"id\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"endOfSubmissionWindowTimestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"proposer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"parentProposalHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"originBlockNumber\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"originBlockHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"sources\",\"type\":\"tuple[]\",\"internalType\":\"structIInbox.DerivationSource[]\",\"components\":[{\"name\":\"isForcedInclusion\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"impl\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"inNonReentrant\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"init\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"propose\",\"inputs\":[{\"name\":\"_lookahead\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"prove\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestWithdrawal\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"resolver\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"saveForcedInclusion\",\"inputs\":[{\"name\":\"_blobReference\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobReference\",\"components\":[{\"name\":\"blobStartIndex\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"numBlobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"}]}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeTo\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"withdraw\",\"inputs\":[{\"name\":\"_to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"AdminChanged\",\"inputs\":[{\"name\":\"previousAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BeaconUpgraded\",\"inputs\":[{\"name\":\"beacon\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BondDeposited\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BondWithdrawn\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ForcedInclusionSaved\",\"inputs\":[{\"name\":\"forcedInclusion\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIForcedInclusionStore.ForcedInclusion\",\"components\":[{\"name\":\"feeInGwei\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"InboxActivated\",\"inputs\":[{\"name\":\"lastPacayaBlockHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"LivenessBondSettled\",\"inputs\":[{\"name\":\"payer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"livenessBond\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"credited\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"},{\"name\":\"slashed\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Proposed\",\"inputs\":[{\"name\":\"id\",\"type\":\"uint48\",\"indexed\":true,\"internalType\":\"uint48\"},{\"name\":\"proposer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"parentProposalHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"endOfSubmissionWindowTimestamp\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"basefeeSharingPctg\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"},{\"name\":\"sources\",\"type\":\"tuple[]\",\"indexed\":false,\"internalType\":\"structIInbox.DerivationSource[]\",\"components\":[{\"name\":\"isForcedInclusion\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"blobSlice\",\"type\":\"tuple\",\"internalType\":\"structLibBlobs.BlobSlice\",\"components\":[{\"name\":\"blobHashes\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"},{\"name\":\"offset\",\"type\":\"uint24\",\"internalType\":\"uint24\"},{\"name\":\"timestamp\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Proved\",\"inputs\":[{\"name\":\"firstProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"firstNewProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"lastProposalId\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"actualProver\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalCancelled\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"WithdrawalRequested\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"withdrawableAt\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ACCESS_DENIED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ActivationRequired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"BlobNotFound\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"CannotProposeInCurrentBlock\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DeadlineExceeded\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ETH_TRANSFER_FAILED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EmptyBatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FUNC_NOT_IMPLEMENTED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FirstProposalIdTooLarge\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"INVALID_PAUSE_STATUS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"IncorrectProposalCount\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InsufficientBond\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalAlreadyFinalized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalHashMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LastProposalIdTooLarge\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"LengthExceedsUint16\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MustMaintainMinBond\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoBlobs\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoBondToWithdraw\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoWithdrawalRequested\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotEnoughCapacity\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ParentBlockHashMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ProverNotWhitelisted\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"REENTRANT_CALL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnprocessedForcedInclusionIsDue\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WithdrawalAlreadyRequested\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_ADDRESS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_VALUE\",\"inputs\":[]}]",
 }
 
-// ShastaInboxClientABI is the input ABI used to generate the binding from.
-// Deprecated: Use ShastaInboxClientMetaData.ABI instead.
-var ShastaInboxClientABI = ShastaInboxClientMetaData.ABI
+// InboxABI is the input ABI used to generate the binding from.
+// Deprecated: Use InboxMetaData.ABI instead.
+var InboxABI = InboxMetaData.ABI
 
-// ShastaInboxClient is an auto generated Go binding around an Ethereum contract.
-type ShastaInboxClient struct {
-	ShastaInboxClientCaller     // Read-only binding to the contract
-	ShastaInboxClientTransactor // Write-only binding to the contract
-	ShastaInboxClientFilterer   // Log filterer for contract events
+// Inbox is an auto generated Go binding around an Ethereum contract.
+type Inbox struct {
+	InboxCaller     // Read-only binding to the contract
+	InboxTransactor // Write-only binding to the contract
+	InboxFilterer   // Log filterer for contract events
 }
 
-// ShastaInboxClientCaller is an auto generated read-only Go binding around an Ethereum contract.
-type ShastaInboxClientCaller struct {
+// InboxCaller is an auto generated read-only Go binding around an Ethereum contract.
+type InboxCaller struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// ShastaInboxClientTransactor is an auto generated write-only Go binding around an Ethereum contract.
-type ShastaInboxClientTransactor struct {
+// InboxTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type InboxTransactor struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// ShastaInboxClientFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
-type ShastaInboxClientFilterer struct {
+// InboxFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type InboxFilterer struct {
 	contract *bind.BoundContract // Generic contract wrapper for the low level calls
 }
 
-// ShastaInboxClientSession is an auto generated Go binding around an Ethereum contract,
+// InboxSession is an auto generated Go binding around an Ethereum contract,
 // with pre-set call and transact options.
-type ShastaInboxClientSession struct {
-	Contract     *ShastaInboxClient // Generic contract binding to set the session for
-	CallOpts     bind.CallOpts      // Call options to use throughout this session
-	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+type InboxSession struct {
+	Contract     *Inbox            // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
 }
 
-// ShastaInboxClientCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// InboxCallerSession is an auto generated read-only Go binding around an Ethereum contract,
 // with pre-set call options.
-type ShastaInboxClientCallerSession struct {
-	Contract *ShastaInboxClientCaller // Generic contract caller binding to set the session for
-	CallOpts bind.CallOpts            // Call options to use throughout this session
+type InboxCallerSession struct {
+	Contract *InboxCaller  // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
 }
 
-// ShastaInboxClientTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// InboxTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
 // with pre-set transact options.
-type ShastaInboxClientTransactorSession struct {
-	Contract     *ShastaInboxClientTransactor // Generic contract transactor binding to set the session for
-	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+type InboxTransactorSession struct {
+	Contract     *InboxTransactor  // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
 }
 
-// ShastaInboxClientRaw is an auto generated low-level Go binding around an Ethereum contract.
-type ShastaInboxClientRaw struct {
-	Contract *ShastaInboxClient // Generic contract binding to access the raw methods on
+// InboxRaw is an auto generated low-level Go binding around an Ethereum contract.
+type InboxRaw struct {
+	Contract *Inbox // Generic contract binding to access the raw methods on
 }
 
-// ShastaInboxClientCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
-type ShastaInboxClientCallerRaw struct {
-	Contract *ShastaInboxClientCaller // Generic read-only contract binding to access the raw methods on
+// InboxCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type InboxCallerRaw struct {
+	Contract *InboxCaller // Generic read-only contract binding to access the raw methods on
 }
 
-// ShastaInboxClientTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
-type ShastaInboxClientTransactorRaw struct {
-	Contract *ShastaInboxClientTransactor // Generic write-only contract binding to access the raw methods on
+// InboxTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type InboxTransactorRaw struct {
+	Contract *InboxTransactor // Generic write-only contract binding to access the raw methods on
 }
 
-// NewShastaInboxClient creates a new instance of ShastaInboxClient, bound to a specific deployed contract.
-func NewShastaInboxClient(address common.Address, backend bind.ContractBackend) (*ShastaInboxClient, error) {
-	contract, err := bindShastaInboxClient(address, backend, backend, backend)
+// NewInbox creates a new instance of Inbox, bound to a specific deployed contract.
+func NewInbox(address common.Address, backend bind.ContractBackend) (*Inbox, error) {
+	contract, err := bindInbox(address, backend, backend, backend)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClient{ShastaInboxClientCaller: ShastaInboxClientCaller{contract: contract}, ShastaInboxClientTransactor: ShastaInboxClientTransactor{contract: contract}, ShastaInboxClientFilterer: ShastaInboxClientFilterer{contract: contract}}, nil
+	return &Inbox{InboxCaller: InboxCaller{contract: contract}, InboxTransactor: InboxTransactor{contract: contract}, InboxFilterer: InboxFilterer{contract: contract}}, nil
 }
 
-// NewShastaInboxClientCaller creates a new read-only instance of ShastaInboxClient, bound to a specific deployed contract.
-func NewShastaInboxClientCaller(address common.Address, caller bind.ContractCaller) (*ShastaInboxClientCaller, error) {
-	contract, err := bindShastaInboxClient(address, caller, nil, nil)
+// NewInboxCaller creates a new read-only instance of Inbox, bound to a specific deployed contract.
+func NewInboxCaller(address common.Address, caller bind.ContractCaller) (*InboxCaller, error) {
+	contract, err := bindInbox(address, caller, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientCaller{contract: contract}, nil
+	return &InboxCaller{contract: contract}, nil
 }
 
-// NewShastaInboxClientTransactor creates a new write-only instance of ShastaInboxClient, bound to a specific deployed contract.
-func NewShastaInboxClientTransactor(address common.Address, transactor bind.ContractTransactor) (*ShastaInboxClientTransactor, error) {
-	contract, err := bindShastaInboxClient(address, nil, transactor, nil)
+// NewInboxTransactor creates a new write-only instance of Inbox, bound to a specific deployed contract.
+func NewInboxTransactor(address common.Address, transactor bind.ContractTransactor) (*InboxTransactor, error) {
+	contract, err := bindInbox(address, nil, transactor, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientTransactor{contract: contract}, nil
+	return &InboxTransactor{contract: contract}, nil
 }
 
-// NewShastaInboxClientFilterer creates a new log filterer instance of ShastaInboxClient, bound to a specific deployed contract.
-func NewShastaInboxClientFilterer(address common.Address, filterer bind.ContractFilterer) (*ShastaInboxClientFilterer, error) {
-	contract, err := bindShastaInboxClient(address, nil, nil, filterer)
+// NewInboxFilterer creates a new log filterer instance of Inbox, bound to a specific deployed contract.
+func NewInboxFilterer(address common.Address, filterer bind.ContractFilterer) (*InboxFilterer, error) {
+	contract, err := bindInbox(address, nil, nil, filterer)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientFilterer{contract: contract}, nil
+	return &InboxFilterer{contract: contract}, nil
 }
 
-// bindShastaInboxClient binds a generic wrapper to an already deployed contract.
-func bindShastaInboxClient(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := ShastaInboxClientMetaData.GetAbi()
+// bindInbox binds a generic wrapper to an already deployed contract.
+func bindInbox(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := InboxMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
@@ -252,46 +252,46 @@ func bindShastaInboxClient(address common.Address, caller bind.ContractCaller, t
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_ShastaInboxClient *ShastaInboxClientRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
-	return _ShastaInboxClient.Contract.ShastaInboxClientCaller.contract.Call(opts, result, method, params...)
+func (_Inbox *InboxRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Inbox.Contract.InboxCaller.contract.Call(opts, result, method, params...)
 }
 
 // Transfer initiates a plain transaction to move funds to the contract, calling
 // its default method if one is available.
-func (_ShastaInboxClient *ShastaInboxClientRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.ShastaInboxClientTransactor.contract.Transfer(opts)
+func (_Inbox *InboxRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Inbox.Contract.InboxTransactor.contract.Transfer(opts)
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_ShastaInboxClient *ShastaInboxClientRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.ShastaInboxClientTransactor.contract.Transact(opts, method, params...)
+func (_Inbox *InboxRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Inbox.Contract.InboxTransactor.contract.Transact(opts, method, params...)
 }
 
 // Call invokes the (constant) contract method with params as input values and
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_ShastaInboxClient *ShastaInboxClientCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
-	return _ShastaInboxClient.Contract.contract.Call(opts, result, method, params...)
+func (_Inbox *InboxCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Inbox.Contract.contract.Call(opts, result, method, params...)
 }
 
 // Transfer initiates a plain transaction to move funds to the contract, calling
 // its default method if one is available.
-func (_ShastaInboxClient *ShastaInboxClientTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.contract.Transfer(opts)
+func (_Inbox *InboxTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Inbox.Contract.contract.Transfer(opts)
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_ShastaInboxClient *ShastaInboxClientTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.contract.Transact(opts, method, params...)
+func (_Inbox *InboxTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Inbox.Contract.contract.Transact(opts, method, params...)
 }
 
 // ActivationTimestamp is a free data retrieval call binding the contract method 0x0423c7de.
 //
 // Solidity: function activationTimestamp() view returns(uint48)
-func (_ShastaInboxClient *ShastaInboxClientCaller) ActivationTimestamp(opts *bind.CallOpts) (*big.Int, error) {
+func (_Inbox *InboxCaller) ActivationTimestamp(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "activationTimestamp")
+	err := _Inbox.contract.Call(opts, &out, "activationTimestamp")
 
 	if err != nil {
 		return *new(*big.Int), err
@@ -306,23 +306,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) ActivationTimestamp(opts *bin
 // ActivationTimestamp is a free data retrieval call binding the contract method 0x0423c7de.
 //
 // Solidity: function activationTimestamp() view returns(uint48)
-func (_ShastaInboxClient *ShastaInboxClientSession) ActivationTimestamp() (*big.Int, error) {
-	return _ShastaInboxClient.Contract.ActivationTimestamp(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) ActivationTimestamp() (*big.Int, error) {
+	return _Inbox.Contract.ActivationTimestamp(&_Inbox.CallOpts)
 }
 
 // ActivationTimestamp is a free data retrieval call binding the contract method 0x0423c7de.
 //
 // Solidity: function activationTimestamp() view returns(uint48)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) ActivationTimestamp() (*big.Int, error) {
-	return _ShastaInboxClient.Contract.ActivationTimestamp(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) ActivationTimestamp() (*big.Int, error) {
+	return _Inbox.Contract.ActivationTimestamp(&_Inbox.CallOpts)
 }
 
 // DecodeProposeInput is a free data retrieval call binding the contract method 0xafb63ad4.
 //
 // Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint16) input_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) DecodeProposeInput(opts *bind.CallOpts, _data []byte) (IInboxProposeInput, error) {
+func (_Inbox *InboxCaller) DecodeProposeInput(opts *bind.CallOpts, _data []byte) (IInboxProposeInput, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "decodeProposeInput", _data)
+	err := _Inbox.contract.Call(opts, &out, "decodeProposeInput", _data)
 
 	if err != nil {
 		return *new(IInboxProposeInput), err
@@ -337,23 +337,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) DecodeProposeInput(opts *bind
 // DecodeProposeInput is a free data retrieval call binding the contract method 0xafb63ad4.
 //
 // Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint16) input_)
-func (_ShastaInboxClient *ShastaInboxClientSession) DecodeProposeInput(_data []byte) (IInboxProposeInput, error) {
-	return _ShastaInboxClient.Contract.DecodeProposeInput(&_ShastaInboxClient.CallOpts, _data)
+func (_Inbox *InboxSession) DecodeProposeInput(_data []byte) (IInboxProposeInput, error) {
+	return _Inbox.Contract.DecodeProposeInput(&_Inbox.CallOpts, _data)
 }
 
 // DecodeProposeInput is a free data retrieval call binding the contract method 0xafb63ad4.
 //
 // Solidity: function decodeProposeInput(bytes _data) pure returns((uint48,(uint16,uint16,uint24),uint16) input_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) DecodeProposeInput(_data []byte) (IInboxProposeInput, error) {
-	return _ShastaInboxClient.Contract.DecodeProposeInput(&_ShastaInboxClient.CallOpts, _data)
+func (_Inbox *InboxCallerSession) DecodeProposeInput(_data []byte) (IInboxProposeInput, error) {
+	return _Inbox.Contract.DecodeProposeInput(&_Inbox.CallOpts, _data)
 }
 
 // DecodeProveInput is a free data retrieval call binding the contract method 0xedbacd44.
 //
 // Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) input_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) DecodeProveInput(opts *bind.CallOpts, _data []byte) (IInboxProveInput, error) {
+func (_Inbox *InboxCaller) DecodeProveInput(opts *bind.CallOpts, _data []byte) (IInboxProveInput, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "decodeProveInput", _data)
+	err := _Inbox.contract.Call(opts, &out, "decodeProveInput", _data)
 
 	if err != nil {
 		return *new(IInboxProveInput), err
@@ -368,23 +368,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) DecodeProveInput(opts *bind.C
 // DecodeProveInput is a free data retrieval call binding the contract method 0xedbacd44.
 //
 // Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) input_)
-func (_ShastaInboxClient *ShastaInboxClientSession) DecodeProveInput(_data []byte) (IInboxProveInput, error) {
-	return _ShastaInboxClient.Contract.DecodeProveInput(&_ShastaInboxClient.CallOpts, _data)
+func (_Inbox *InboxSession) DecodeProveInput(_data []byte) (IInboxProveInput, error) {
+	return _Inbox.Contract.DecodeProveInput(&_Inbox.CallOpts, _data)
 }
 
 // DecodeProveInput is a free data retrieval call binding the contract method 0xedbacd44.
 //
 // Solidity: function decodeProveInput(bytes _data) pure returns(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) input_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) DecodeProveInput(_data []byte) (IInboxProveInput, error) {
-	return _ShastaInboxClient.Contract.DecodeProveInput(&_ShastaInboxClient.CallOpts, _data)
+func (_Inbox *InboxCallerSession) DecodeProveInput(_data []byte) (IInboxProveInput, error) {
+	return _Inbox.Contract.DecodeProveInput(&_Inbox.CallOpts, _data)
 }
 
 // EncodeProposeInput is a free data retrieval call binding the contract method 0x1275a673.
 //
 // Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint16) _input) pure returns(bytes encoded_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) EncodeProposeInput(opts *bind.CallOpts, _input IInboxProposeInput) ([]byte, error) {
+func (_Inbox *InboxCaller) EncodeProposeInput(opts *bind.CallOpts, _input IInboxProposeInput) ([]byte, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "encodeProposeInput", _input)
+	err := _Inbox.contract.Call(opts, &out, "encodeProposeInput", _input)
 
 	if err != nil {
 		return *new([]byte), err
@@ -399,23 +399,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) EncodeProposeInput(opts *bind
 // EncodeProposeInput is a free data retrieval call binding the contract method 0x1275a673.
 //
 // Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint16) _input) pure returns(bytes encoded_)
-func (_ShastaInboxClient *ShastaInboxClientSession) EncodeProposeInput(_input IInboxProposeInput) ([]byte, error) {
-	return _ShastaInboxClient.Contract.EncodeProposeInput(&_ShastaInboxClient.CallOpts, _input)
+func (_Inbox *InboxSession) EncodeProposeInput(_input IInboxProposeInput) ([]byte, error) {
+	return _Inbox.Contract.EncodeProposeInput(&_Inbox.CallOpts, _input)
 }
 
 // EncodeProposeInput is a free data retrieval call binding the contract method 0x1275a673.
 //
 // Solidity: function encodeProposeInput((uint48,(uint16,uint16,uint24),uint16) _input) pure returns(bytes encoded_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) EncodeProposeInput(_input IInboxProposeInput) ([]byte, error) {
-	return _ShastaInboxClient.Contract.EncodeProposeInput(&_ShastaInboxClient.CallOpts, _input)
+func (_Inbox *InboxCallerSession) EncodeProposeInput(_input IInboxProposeInput) ([]byte, error) {
+	return _Inbox.Contract.EncodeProposeInput(&_Inbox.CallOpts, _input)
 }
 
 // EncodeProveInput is a free data retrieval call binding the contract method 0xc5954597.
 //
 // Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) _input) pure returns(bytes encoded_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) EncodeProveInput(opts *bind.CallOpts, _input IInboxProveInput) ([]byte, error) {
+func (_Inbox *InboxCaller) EncodeProveInput(opts *bind.CallOpts, _input IInboxProveInput) ([]byte, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "encodeProveInput", _input)
+	err := _Inbox.contract.Call(opts, &out, "encodeProveInput", _input)
 
 	if err != nil {
 		return *new([]byte), err
@@ -430,23 +430,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) EncodeProveInput(opts *bind.C
 // EncodeProveInput is a free data retrieval call binding the contract method 0xc5954597.
 //
 // Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) _input) pure returns(bytes encoded_)
-func (_ShastaInboxClient *ShastaInboxClientSession) EncodeProveInput(_input IInboxProveInput) ([]byte, error) {
-	return _ShastaInboxClient.Contract.EncodeProveInput(&_ShastaInboxClient.CallOpts, _input)
+func (_Inbox *InboxSession) EncodeProveInput(_input IInboxProveInput) ([]byte, error) {
+	return _Inbox.Contract.EncodeProveInput(&_Inbox.CallOpts, _input)
 }
 
 // EncodeProveInput is a free data retrieval call binding the contract method 0xc5954597.
 //
 // Solidity: function encodeProveInput(((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[])) _input) pure returns(bytes encoded_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) EncodeProveInput(_input IInboxProveInput) ([]byte, error) {
-	return _ShastaInboxClient.Contract.EncodeProveInput(&_ShastaInboxClient.CallOpts, _input)
+func (_Inbox *InboxCallerSession) EncodeProveInput(_input IInboxProveInput) ([]byte, error) {
+	return _Inbox.Contract.EncodeProveInput(&_Inbox.CallOpts, _input)
 }
 
 // GetBond is a free data retrieval call binding the contract method 0x0d8912f3.
 //
 // Solidity: function getBond(address _address) view returns((uint64,uint48) bond_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) GetBond(opts *bind.CallOpts, _address common.Address) (IBondManagerBond, error) {
+func (_Inbox *InboxCaller) GetBond(opts *bind.CallOpts, _address common.Address) (IBondManagerBond, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "getBond", _address)
+	err := _Inbox.contract.Call(opts, &out, "getBond", _address)
 
 	if err != nil {
 		return *new(IBondManagerBond), err
@@ -461,23 +461,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) GetBond(opts *bind.CallOpts, 
 // GetBond is a free data retrieval call binding the contract method 0x0d8912f3.
 //
 // Solidity: function getBond(address _address) view returns((uint64,uint48) bond_)
-func (_ShastaInboxClient *ShastaInboxClientSession) GetBond(_address common.Address) (IBondManagerBond, error) {
-	return _ShastaInboxClient.Contract.GetBond(&_ShastaInboxClient.CallOpts, _address)
+func (_Inbox *InboxSession) GetBond(_address common.Address) (IBondManagerBond, error) {
+	return _Inbox.Contract.GetBond(&_Inbox.CallOpts, _address)
 }
 
 // GetBond is a free data retrieval call binding the contract method 0x0d8912f3.
 //
 // Solidity: function getBond(address _address) view returns((uint64,uint48) bond_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetBond(_address common.Address) (IBondManagerBond, error) {
-	return _ShastaInboxClient.Contract.GetBond(&_ShastaInboxClient.CallOpts, _address)
+func (_Inbox *InboxCallerSession) GetBond(_address common.Address) (IBondManagerBond, error) {
+	return _Inbox.Contract.GetBond(&_Inbox.CallOpts, _address)
 }
 
 // GetConfig is a free data retrieval call binding the contract method 0xc3f909d4.
 //
 // Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint16,uint64,uint64,uint8) config_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) GetConfig(opts *bind.CallOpts) (IInboxConfig, error) {
+func (_Inbox *InboxCaller) GetConfig(opts *bind.CallOpts) (IInboxConfig, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "getConfig")
+	err := _Inbox.contract.Call(opts, &out, "getConfig")
 
 	if err != nil {
 		return *new(IInboxConfig), err
@@ -492,23 +492,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) GetConfig(opts *bind.CallOpts
 // GetConfig is a free data retrieval call binding the contract method 0xc3f909d4.
 //
 // Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint16,uint64,uint64,uint8) config_)
-func (_ShastaInboxClient *ShastaInboxClientSession) GetConfig() (IInboxConfig, error) {
-	return _ShastaInboxClient.Contract.GetConfig(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) GetConfig() (IInboxConfig, error) {
+	return _Inbox.Contract.GetConfig(&_Inbox.CallOpts)
 }
 
 // GetConfig is a free data retrieval call binding the contract method 0xc3f909d4.
 //
 // Solidity: function getConfig() view returns((address,address,address,address,address,uint64,uint64,uint48,uint48,uint48,uint48,uint48,uint8,uint16,uint64,uint64,uint8) config_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetConfig() (IInboxConfig, error) {
-	return _ShastaInboxClient.Contract.GetConfig(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) GetConfig() (IInboxConfig, error) {
+	return _Inbox.Contract.GetConfig(&_Inbox.CallOpts)
 }
 
 // GetCoreState is a free data retrieval call binding the contract method 0x6aa6a01a.
 //
 // Solidity: function getCoreState() view returns((uint48,uint48,uint48,uint48,uint48,bytes32))
-func (_ShastaInboxClient *ShastaInboxClientCaller) GetCoreState(opts *bind.CallOpts) (IInboxCoreState, error) {
+func (_Inbox *InboxCaller) GetCoreState(opts *bind.CallOpts) (IInboxCoreState, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "getCoreState")
+	err := _Inbox.contract.Call(opts, &out, "getCoreState")
 
 	if err != nil {
 		return *new(IInboxCoreState), err
@@ -523,23 +523,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) GetCoreState(opts *bind.CallO
 // GetCoreState is a free data retrieval call binding the contract method 0x6aa6a01a.
 //
 // Solidity: function getCoreState() view returns((uint48,uint48,uint48,uint48,uint48,bytes32))
-func (_ShastaInboxClient *ShastaInboxClientSession) GetCoreState() (IInboxCoreState, error) {
-	return _ShastaInboxClient.Contract.GetCoreState(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) GetCoreState() (IInboxCoreState, error) {
+	return _Inbox.Contract.GetCoreState(&_Inbox.CallOpts)
 }
 
 // GetCoreState is a free data retrieval call binding the contract method 0x6aa6a01a.
 //
 // Solidity: function getCoreState() view returns((uint48,uint48,uint48,uint48,uint48,bytes32))
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetCoreState() (IInboxCoreState, error) {
-	return _ShastaInboxClient.Contract.GetCoreState(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) GetCoreState() (IInboxCoreState, error) {
+	return _Inbox.Contract.GetCoreState(&_Inbox.CallOpts)
 }
 
 // GetCurrentForcedInclusionFee is a free data retrieval call binding the contract method 0xe3053335.
 //
 // Solidity: function getCurrentForcedInclusionFee() view returns(uint64 feeInGwei_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) GetCurrentForcedInclusionFee(opts *bind.CallOpts) (uint64, error) {
+func (_Inbox *InboxCaller) GetCurrentForcedInclusionFee(opts *bind.CallOpts) (uint64, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "getCurrentForcedInclusionFee")
+	err := _Inbox.contract.Call(opts, &out, "getCurrentForcedInclusionFee")
 
 	if err != nil {
 		return *new(uint64), err
@@ -554,26 +554,26 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) GetCurrentForcedInclusionFee(
 // GetCurrentForcedInclusionFee is a free data retrieval call binding the contract method 0xe3053335.
 //
 // Solidity: function getCurrentForcedInclusionFee() view returns(uint64 feeInGwei_)
-func (_ShastaInboxClient *ShastaInboxClientSession) GetCurrentForcedInclusionFee() (uint64, error) {
-	return _ShastaInboxClient.Contract.GetCurrentForcedInclusionFee(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) GetCurrentForcedInclusionFee() (uint64, error) {
+	return _Inbox.Contract.GetCurrentForcedInclusionFee(&_Inbox.CallOpts)
 }
 
 // GetCurrentForcedInclusionFee is a free data retrieval call binding the contract method 0xe3053335.
 //
 // Solidity: function getCurrentForcedInclusionFee() view returns(uint64 feeInGwei_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetCurrentForcedInclusionFee() (uint64, error) {
-	return _ShastaInboxClient.Contract.GetCurrentForcedInclusionFee(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) GetCurrentForcedInclusionFee() (uint64, error) {
+	return _Inbox.Contract.GetCurrentForcedInclusionFee(&_Inbox.CallOpts)
 }
 
 // GetForcedInclusionState is a free data retrieval call binding the contract method 0x5ccc1718.
 //
 // Solidity: function getForcedInclusionState() view returns(uint48 head_, uint48 tail_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) GetForcedInclusionState(opts *bind.CallOpts) (struct {
+func (_Inbox *InboxCaller) GetForcedInclusionState(opts *bind.CallOpts) (struct {
 	Head *big.Int
 	Tail *big.Int
 }, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "getForcedInclusionState")
+	err := _Inbox.contract.Call(opts, &out, "getForcedInclusionState")
 
 	outstruct := new(struct {
 		Head *big.Int
@@ -593,29 +593,29 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) GetForcedInclusionState(opts 
 // GetForcedInclusionState is a free data retrieval call binding the contract method 0x5ccc1718.
 //
 // Solidity: function getForcedInclusionState() view returns(uint48 head_, uint48 tail_)
-func (_ShastaInboxClient *ShastaInboxClientSession) GetForcedInclusionState() (struct {
+func (_Inbox *InboxSession) GetForcedInclusionState() (struct {
 	Head *big.Int
 	Tail *big.Int
 }, error) {
-	return _ShastaInboxClient.Contract.GetForcedInclusionState(&_ShastaInboxClient.CallOpts)
+	return _Inbox.Contract.GetForcedInclusionState(&_Inbox.CallOpts)
 }
 
 // GetForcedInclusionState is a free data retrieval call binding the contract method 0x5ccc1718.
 //
 // Solidity: function getForcedInclusionState() view returns(uint48 head_, uint48 tail_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetForcedInclusionState() (struct {
+func (_Inbox *InboxCallerSession) GetForcedInclusionState() (struct {
 	Head *big.Int
 	Tail *big.Int
 }, error) {
-	return _ShastaInboxClient.Contract.GetForcedInclusionState(&_ShastaInboxClient.CallOpts)
+	return _Inbox.Contract.GetForcedInclusionState(&_Inbox.CallOpts)
 }
 
 // GetForcedInclusions is a free data retrieval call binding the contract method 0x40df9866.
 //
 // Solidity: function getForcedInclusions(uint48 _start, uint48 _maxCount) view returns((uint64,(bytes32[],uint24,uint48))[] inclusions_)
-func (_ShastaInboxClient *ShastaInboxClientCaller) GetForcedInclusions(opts *bind.CallOpts, _start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
+func (_Inbox *InboxCaller) GetForcedInclusions(opts *bind.CallOpts, _start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "getForcedInclusions", _start, _maxCount)
+	err := _Inbox.contract.Call(opts, &out, "getForcedInclusions", _start, _maxCount)
 
 	if err != nil {
 		return *new([]IForcedInclusionStoreForcedInclusion), err
@@ -630,23 +630,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) GetForcedInclusions(opts *bin
 // GetForcedInclusions is a free data retrieval call binding the contract method 0x40df9866.
 //
 // Solidity: function getForcedInclusions(uint48 _start, uint48 _maxCount) view returns((uint64,(bytes32[],uint24,uint48))[] inclusions_)
-func (_ShastaInboxClient *ShastaInboxClientSession) GetForcedInclusions(_start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
-	return _ShastaInboxClient.Contract.GetForcedInclusions(&_ShastaInboxClient.CallOpts, _start, _maxCount)
+func (_Inbox *InboxSession) GetForcedInclusions(_start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
+	return _Inbox.Contract.GetForcedInclusions(&_Inbox.CallOpts, _start, _maxCount)
 }
 
 // GetForcedInclusions is a free data retrieval call binding the contract method 0x40df9866.
 //
 // Solidity: function getForcedInclusions(uint48 _start, uint48 _maxCount) view returns((uint64,(bytes32[],uint24,uint48))[] inclusions_)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetForcedInclusions(_start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
-	return _ShastaInboxClient.Contract.GetForcedInclusions(&_ShastaInboxClient.CallOpts, _start, _maxCount)
+func (_Inbox *InboxCallerSession) GetForcedInclusions(_start *big.Int, _maxCount *big.Int) ([]IForcedInclusionStoreForcedInclusion, error) {
+	return _Inbox.Contract.GetForcedInclusions(&_Inbox.CallOpts, _start, _maxCount)
 }
 
 // GetProposalHash is a free data retrieval call binding the contract method 0xa834725a.
 //
 // Solidity: function getProposalHash(uint256 _proposalId) view returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientCaller) GetProposalHash(opts *bind.CallOpts, _proposalId *big.Int) ([32]byte, error) {
+func (_Inbox *InboxCaller) GetProposalHash(opts *bind.CallOpts, _proposalId *big.Int) ([32]byte, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "getProposalHash", _proposalId)
+	err := _Inbox.contract.Call(opts, &out, "getProposalHash", _proposalId)
 
 	if err != nil {
 		return *new([32]byte), err
@@ -661,23 +661,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) GetProposalHash(opts *bind.Ca
 // GetProposalHash is a free data retrieval call binding the contract method 0xa834725a.
 //
 // Solidity: function getProposalHash(uint256 _proposalId) view returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientSession) GetProposalHash(_proposalId *big.Int) ([32]byte, error) {
-	return _ShastaInboxClient.Contract.GetProposalHash(&_ShastaInboxClient.CallOpts, _proposalId)
+func (_Inbox *InboxSession) GetProposalHash(_proposalId *big.Int) ([32]byte, error) {
+	return _Inbox.Contract.GetProposalHash(&_Inbox.CallOpts, _proposalId)
 }
 
 // GetProposalHash is a free data retrieval call binding the contract method 0xa834725a.
 //
 // Solidity: function getProposalHash(uint256 _proposalId) view returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) GetProposalHash(_proposalId *big.Int) ([32]byte, error) {
-	return _ShastaInboxClient.Contract.GetProposalHash(&_ShastaInboxClient.CallOpts, _proposalId)
+func (_Inbox *InboxCallerSession) GetProposalHash(_proposalId *big.Int) ([32]byte, error) {
+	return _Inbox.Contract.GetProposalHash(&_Inbox.CallOpts, _proposalId)
 }
 
 // HashCommitment is a free data retrieval call binding the contract method 0xf954ab92.
 //
 // Solidity: function hashCommitment((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]) _commitment) pure returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientCaller) HashCommitment(opts *bind.CallOpts, _commitment IInboxCommitment) ([32]byte, error) {
+func (_Inbox *InboxCaller) HashCommitment(opts *bind.CallOpts, _commitment IInboxCommitment) ([32]byte, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "hashCommitment", _commitment)
+	err := _Inbox.contract.Call(opts, &out, "hashCommitment", _commitment)
 
 	if err != nil {
 		return *new([32]byte), err
@@ -692,23 +692,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) HashCommitment(opts *bind.Cal
 // HashCommitment is a free data retrieval call binding the contract method 0xf954ab92.
 //
 // Solidity: function hashCommitment((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]) _commitment) pure returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientSession) HashCommitment(_commitment IInboxCommitment) ([32]byte, error) {
-	return _ShastaInboxClient.Contract.HashCommitment(&_ShastaInboxClient.CallOpts, _commitment)
+func (_Inbox *InboxSession) HashCommitment(_commitment IInboxCommitment) ([32]byte, error) {
+	return _Inbox.Contract.HashCommitment(&_Inbox.CallOpts, _commitment)
 }
 
 // HashCommitment is a free data retrieval call binding the contract method 0xf954ab92.
 //
 // Solidity: function hashCommitment((uint48,bytes32,bytes32,address,uint48,bytes32,(address,uint48,bytes32)[]) _commitment) pure returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) HashCommitment(_commitment IInboxCommitment) ([32]byte, error) {
-	return _ShastaInboxClient.Contract.HashCommitment(&_ShastaInboxClient.CallOpts, _commitment)
+func (_Inbox *InboxCallerSession) HashCommitment(_commitment IInboxCommitment) ([32]byte, error) {
+	return _Inbox.Contract.HashCommitment(&_Inbox.CallOpts, _commitment)
 }
 
 // HashProposal is a free data retrieval call binding the contract method 0xb28e824e.
 //
 // Solidity: function hashProposal((uint48,uint48,uint48,address,bytes32,uint48,bytes32,uint8,(bool,(bytes32[],uint24,uint48))[]) _proposal) pure returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientCaller) HashProposal(opts *bind.CallOpts, _proposal IInboxProposal) ([32]byte, error) {
+func (_Inbox *InboxCaller) HashProposal(opts *bind.CallOpts, _proposal IInboxProposal) ([32]byte, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "hashProposal", _proposal)
+	err := _Inbox.contract.Call(opts, &out, "hashProposal", _proposal)
 
 	if err != nil {
 		return *new([32]byte), err
@@ -723,23 +723,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) HashProposal(opts *bind.CallO
 // HashProposal is a free data retrieval call binding the contract method 0xb28e824e.
 //
 // Solidity: function hashProposal((uint48,uint48,uint48,address,bytes32,uint48,bytes32,uint8,(bool,(bytes32[],uint24,uint48))[]) _proposal) pure returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientSession) HashProposal(_proposal IInboxProposal) ([32]byte, error) {
-	return _ShastaInboxClient.Contract.HashProposal(&_ShastaInboxClient.CallOpts, _proposal)
+func (_Inbox *InboxSession) HashProposal(_proposal IInboxProposal) ([32]byte, error) {
+	return _Inbox.Contract.HashProposal(&_Inbox.CallOpts, _proposal)
 }
 
 // HashProposal is a free data retrieval call binding the contract method 0xb28e824e.
 //
 // Solidity: function hashProposal((uint48,uint48,uint48,address,bytes32,uint48,bytes32,uint8,(bool,(bytes32[],uint24,uint48))[]) _proposal) pure returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) HashProposal(_proposal IInboxProposal) ([32]byte, error) {
-	return _ShastaInboxClient.Contract.HashProposal(&_ShastaInboxClient.CallOpts, _proposal)
+func (_Inbox *InboxCallerSession) HashProposal(_proposal IInboxProposal) ([32]byte, error) {
+	return _Inbox.Contract.HashProposal(&_Inbox.CallOpts, _proposal)
 }
 
 // Impl is a free data retrieval call binding the contract method 0x8abf6077.
 //
 // Solidity: function impl() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientCaller) Impl(opts *bind.CallOpts) (common.Address, error) {
+func (_Inbox *InboxCaller) Impl(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "impl")
+	err := _Inbox.contract.Call(opts, &out, "impl")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -754,23 +754,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) Impl(opts *bind.CallOpts) (co
 // Impl is a free data retrieval call binding the contract method 0x8abf6077.
 //
 // Solidity: function impl() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientSession) Impl() (common.Address, error) {
-	return _ShastaInboxClient.Contract.Impl(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) Impl() (common.Address, error) {
+	return _Inbox.Contract.Impl(&_Inbox.CallOpts)
 }
 
 // Impl is a free data retrieval call binding the contract method 0x8abf6077.
 //
 // Solidity: function impl() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) Impl() (common.Address, error) {
-	return _ShastaInboxClient.Contract.Impl(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) Impl() (common.Address, error) {
+	return _Inbox.Contract.Impl(&_Inbox.CallOpts)
 }
 
 // InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
 //
 // Solidity: function inNonReentrant() view returns(bool)
-func (_ShastaInboxClient *ShastaInboxClientCaller) InNonReentrant(opts *bind.CallOpts) (bool, error) {
+func (_Inbox *InboxCaller) InNonReentrant(opts *bind.CallOpts) (bool, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "inNonReentrant")
+	err := _Inbox.contract.Call(opts, &out, "inNonReentrant")
 
 	if err != nil {
 		return *new(bool), err
@@ -785,23 +785,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) InNonReentrant(opts *bind.Cal
 // InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
 //
 // Solidity: function inNonReentrant() view returns(bool)
-func (_ShastaInboxClient *ShastaInboxClientSession) InNonReentrant() (bool, error) {
-	return _ShastaInboxClient.Contract.InNonReentrant(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) InNonReentrant() (bool, error) {
+	return _Inbox.Contract.InNonReentrant(&_Inbox.CallOpts)
 }
 
 // InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
 //
 // Solidity: function inNonReentrant() view returns(bool)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) InNonReentrant() (bool, error) {
-	return _ShastaInboxClient.Contract.InNonReentrant(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) InNonReentrant() (bool, error) {
+	return _Inbox.Contract.InNonReentrant(&_Inbox.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+func (_Inbox *InboxCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "owner")
+	err := _Inbox.contract.Call(opts, &out, "owner")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -816,23 +816,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) Owner(opts *bind.CallOpts) (c
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientSession) Owner() (common.Address, error) {
-	return _ShastaInboxClient.Contract.Owner(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) Owner() (common.Address, error) {
+	return _Inbox.Contract.Owner(&_Inbox.CallOpts)
 }
 
 // Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
 //
 // Solidity: function owner() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) Owner() (common.Address, error) {
-	return _ShastaInboxClient.Contract.Owner(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) Owner() (common.Address, error) {
+	return _Inbox.Contract.Owner(&_Inbox.CallOpts)
 }
 
 // Paused is a free data retrieval call binding the contract method 0x5c975abb.
 //
 // Solidity: function paused() view returns(bool)
-func (_ShastaInboxClient *ShastaInboxClientCaller) Paused(opts *bind.CallOpts) (bool, error) {
+func (_Inbox *InboxCaller) Paused(opts *bind.CallOpts) (bool, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "paused")
+	err := _Inbox.contract.Call(opts, &out, "paused")
 
 	if err != nil {
 		return *new(bool), err
@@ -847,23 +847,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) Paused(opts *bind.CallOpts) (
 // Paused is a free data retrieval call binding the contract method 0x5c975abb.
 //
 // Solidity: function paused() view returns(bool)
-func (_ShastaInboxClient *ShastaInboxClientSession) Paused() (bool, error) {
-	return _ShastaInboxClient.Contract.Paused(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) Paused() (bool, error) {
+	return _Inbox.Contract.Paused(&_Inbox.CallOpts)
 }
 
 // Paused is a free data retrieval call binding the contract method 0x5c975abb.
 //
 // Solidity: function paused() view returns(bool)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) Paused() (bool, error) {
-	return _ShastaInboxClient.Contract.Paused(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) Paused() (bool, error) {
+	return _Inbox.Contract.Paused(&_Inbox.CallOpts)
 }
 
 // PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
 //
 // Solidity: function pendingOwner() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+func (_Inbox *InboxCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "pendingOwner")
+	err := _Inbox.contract.Call(opts, &out, "pendingOwner")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -878,23 +878,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) PendingOwner(opts *bind.CallO
 // PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
 //
 // Solidity: function pendingOwner() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientSession) PendingOwner() (common.Address, error) {
-	return _ShastaInboxClient.Contract.PendingOwner(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) PendingOwner() (common.Address, error) {
+	return _Inbox.Contract.PendingOwner(&_Inbox.CallOpts)
 }
 
 // PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
 //
 // Solidity: function pendingOwner() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) PendingOwner() (common.Address, error) {
-	return _ShastaInboxClient.Contract.PendingOwner(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) PendingOwner() (common.Address, error) {
+	return _Inbox.Contract.PendingOwner(&_Inbox.CallOpts)
 }
 
 // ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+func (_Inbox *InboxCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "proxiableUUID")
+	err := _Inbox.contract.Call(opts, &out, "proxiableUUID")
 
 	if err != nil {
 		return *new([32]byte), err
@@ -909,23 +909,23 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) ProxiableUUID(opts *bind.Call
 // ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientSession) ProxiableUUID() ([32]byte, error) {
-	return _ShastaInboxClient.Contract.ProxiableUUID(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) ProxiableUUID() ([32]byte, error) {
+	return _Inbox.Contract.ProxiableUUID(&_Inbox.CallOpts)
 }
 
 // ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) ProxiableUUID() ([32]byte, error) {
-	return _ShastaInboxClient.Contract.ProxiableUUID(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _Inbox.Contract.ProxiableUUID(&_Inbox.CallOpts)
 }
 
 // Resolver is a free data retrieval call binding the contract method 0x04f3bcec.
 //
 // Solidity: function resolver() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientCaller) Resolver(opts *bind.CallOpts) (common.Address, error) {
+func (_Inbox *InboxCaller) Resolver(opts *bind.CallOpts) (common.Address, error) {
 	var out []interface{}
-	err := _ShastaInboxClient.contract.Call(opts, &out, "resolver")
+	err := _Inbox.contract.Call(opts, &out, "resolver")
 
 	if err != nil {
 		return *new(common.Address), err
@@ -940,377 +940,377 @@ func (_ShastaInboxClient *ShastaInboxClientCaller) Resolver(opts *bind.CallOpts)
 // Resolver is a free data retrieval call binding the contract method 0x04f3bcec.
 //
 // Solidity: function resolver() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientSession) Resolver() (common.Address, error) {
-	return _ShastaInboxClient.Contract.Resolver(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxSession) Resolver() (common.Address, error) {
+	return _Inbox.Contract.Resolver(&_Inbox.CallOpts)
 }
 
 // Resolver is a free data retrieval call binding the contract method 0x04f3bcec.
 //
 // Solidity: function resolver() view returns(address)
-func (_ShastaInboxClient *ShastaInboxClientCallerSession) Resolver() (common.Address, error) {
-	return _ShastaInboxClient.Contract.Resolver(&_ShastaInboxClient.CallOpts)
+func (_Inbox *InboxCallerSession) Resolver() (common.Address, error) {
+	return _Inbox.Contract.Resolver(&_Inbox.CallOpts)
 }
 
 // AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
 //
 // Solidity: function acceptOwnership() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "acceptOwnership")
+func (_Inbox *InboxTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "acceptOwnership")
 }
 
 // AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
 //
 // Solidity: function acceptOwnership() returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) AcceptOwnership() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.AcceptOwnership(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Inbox.Contract.AcceptOwnership(&_Inbox.TransactOpts)
 }
 
 // AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
 //
 // Solidity: function acceptOwnership() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) AcceptOwnership() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.AcceptOwnership(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Inbox.Contract.AcceptOwnership(&_Inbox.TransactOpts)
 }
 
 // Activate is a paid mutator transaction binding the contract method 0x59db6e85.
 //
 // Solidity: function activate(bytes32 _lastPacayaBlockHash) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) Activate(opts *bind.TransactOpts, _lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "activate", _lastPacayaBlockHash)
+func (_Inbox *InboxTransactor) Activate(opts *bind.TransactOpts, _lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "activate", _lastPacayaBlockHash)
 }
 
 // Activate is a paid mutator transaction binding the contract method 0x59db6e85.
 //
 // Solidity: function activate(bytes32 _lastPacayaBlockHash) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) Activate(_lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Activate(&_ShastaInboxClient.TransactOpts, _lastPacayaBlockHash)
+func (_Inbox *InboxSession) Activate(_lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
+	return _Inbox.Contract.Activate(&_Inbox.TransactOpts, _lastPacayaBlockHash)
 }
 
 // Activate is a paid mutator transaction binding the contract method 0x59db6e85.
 //
 // Solidity: function activate(bytes32 _lastPacayaBlockHash) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Activate(_lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Activate(&_ShastaInboxClient.TransactOpts, _lastPacayaBlockHash)
+func (_Inbox *InboxTransactorSession) Activate(_lastPacayaBlockHash [32]byte) (*types.Transaction, error) {
+	return _Inbox.Contract.Activate(&_Inbox.TransactOpts, _lastPacayaBlockHash)
 }
 
 // CancelWithdrawal is a paid mutator transaction binding the contract method 0x22611280.
 //
 // Solidity: function cancelWithdrawal() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) CancelWithdrawal(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "cancelWithdrawal")
+func (_Inbox *InboxTransactor) CancelWithdrawal(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "cancelWithdrawal")
 }
 
 // CancelWithdrawal is a paid mutator transaction binding the contract method 0x22611280.
 //
 // Solidity: function cancelWithdrawal() returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) CancelWithdrawal() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.CancelWithdrawal(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxSession) CancelWithdrawal() (*types.Transaction, error) {
+	return _Inbox.Contract.CancelWithdrawal(&_Inbox.TransactOpts)
 }
 
 // CancelWithdrawal is a paid mutator transaction binding the contract method 0x22611280.
 //
 // Solidity: function cancelWithdrawal() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) CancelWithdrawal() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.CancelWithdrawal(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxTransactorSession) CancelWithdrawal() (*types.Transaction, error) {
+	return _Inbox.Contract.CancelWithdrawal(&_Inbox.TransactOpts)
 }
 
 // Deposit is a paid mutator transaction binding the contract method 0x13765838.
 //
 // Solidity: function deposit(uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) Deposit(opts *bind.TransactOpts, _amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "deposit", _amount)
+func (_Inbox *InboxTransactor) Deposit(opts *bind.TransactOpts, _amount uint64) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "deposit", _amount)
 }
 
 // Deposit is a paid mutator transaction binding the contract method 0x13765838.
 //
 // Solidity: function deposit(uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) Deposit(_amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Deposit(&_ShastaInboxClient.TransactOpts, _amount)
+func (_Inbox *InboxSession) Deposit(_amount uint64) (*types.Transaction, error) {
+	return _Inbox.Contract.Deposit(&_Inbox.TransactOpts, _amount)
 }
 
 // Deposit is a paid mutator transaction binding the contract method 0x13765838.
 //
 // Solidity: function deposit(uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Deposit(_amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Deposit(&_ShastaInboxClient.TransactOpts, _amount)
+func (_Inbox *InboxTransactorSession) Deposit(_amount uint64) (*types.Transaction, error) {
+	return _Inbox.Contract.Deposit(&_Inbox.TransactOpts, _amount)
 }
 
 // DepositTo is a paid mutator transaction binding the contract method 0xefba83c9.
 //
 // Solidity: function depositTo(address _recipient, uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) DepositTo(opts *bind.TransactOpts, _recipient common.Address, _amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "depositTo", _recipient, _amount)
+func (_Inbox *InboxTransactor) DepositTo(opts *bind.TransactOpts, _recipient common.Address, _amount uint64) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "depositTo", _recipient, _amount)
 }
 
 // DepositTo is a paid mutator transaction binding the contract method 0xefba83c9.
 //
 // Solidity: function depositTo(address _recipient, uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) DepositTo(_recipient common.Address, _amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.DepositTo(&_ShastaInboxClient.TransactOpts, _recipient, _amount)
+func (_Inbox *InboxSession) DepositTo(_recipient common.Address, _amount uint64) (*types.Transaction, error) {
+	return _Inbox.Contract.DepositTo(&_Inbox.TransactOpts, _recipient, _amount)
 }
 
 // DepositTo is a paid mutator transaction binding the contract method 0xefba83c9.
 //
 // Solidity: function depositTo(address _recipient, uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) DepositTo(_recipient common.Address, _amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.DepositTo(&_ShastaInboxClient.TransactOpts, _recipient, _amount)
+func (_Inbox *InboxTransactorSession) DepositTo(_recipient common.Address, _amount uint64) (*types.Transaction, error) {
+	return _Inbox.Contract.DepositTo(&_Inbox.TransactOpts, _recipient, _amount)
 }
 
 // Init is a paid mutator transaction binding the contract method 0x19ab453c.
 //
 // Solidity: function init(address _owner) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) Init(opts *bind.TransactOpts, _owner common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "init", _owner)
+func (_Inbox *InboxTransactor) Init(opts *bind.TransactOpts, _owner common.Address) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "init", _owner)
 }
 
 // Init is a paid mutator transaction binding the contract method 0x19ab453c.
 //
 // Solidity: function init(address _owner) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) Init(_owner common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Init(&_ShastaInboxClient.TransactOpts, _owner)
+func (_Inbox *InboxSession) Init(_owner common.Address) (*types.Transaction, error) {
+	return _Inbox.Contract.Init(&_Inbox.TransactOpts, _owner)
 }
 
 // Init is a paid mutator transaction binding the contract method 0x19ab453c.
 //
 // Solidity: function init(address _owner) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Init(_owner common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Init(&_ShastaInboxClient.TransactOpts, _owner)
+func (_Inbox *InboxTransactorSession) Init(_owner common.Address) (*types.Transaction, error) {
+	return _Inbox.Contract.Init(&_Inbox.TransactOpts, _owner)
 }
 
 // Pause is a paid mutator transaction binding the contract method 0x8456cb59.
 //
 // Solidity: function pause() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "pause")
+func (_Inbox *InboxTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "pause")
 }
 
 // Pause is a paid mutator transaction binding the contract method 0x8456cb59.
 //
 // Solidity: function pause() returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) Pause() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Pause(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxSession) Pause() (*types.Transaction, error) {
+	return _Inbox.Contract.Pause(&_Inbox.TransactOpts)
 }
 
 // Pause is a paid mutator transaction binding the contract method 0x8456cb59.
 //
 // Solidity: function pause() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Pause() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Pause(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxTransactorSession) Pause() (*types.Transaction, error) {
+	return _Inbox.Contract.Pause(&_Inbox.TransactOpts)
 }
 
 // Propose is a paid mutator transaction binding the contract method 0x9791e644.
 //
 // Solidity: function propose(bytes _lookahead, bytes _data) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) Propose(opts *bind.TransactOpts, _lookahead []byte, _data []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "propose", _lookahead, _data)
+func (_Inbox *InboxTransactor) Propose(opts *bind.TransactOpts, _lookahead []byte, _data []byte) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "propose", _lookahead, _data)
 }
 
 // Propose is a paid mutator transaction binding the contract method 0x9791e644.
 //
 // Solidity: function propose(bytes _lookahead, bytes _data) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) Propose(_lookahead []byte, _data []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Propose(&_ShastaInboxClient.TransactOpts, _lookahead, _data)
+func (_Inbox *InboxSession) Propose(_lookahead []byte, _data []byte) (*types.Transaction, error) {
+	return _Inbox.Contract.Propose(&_Inbox.TransactOpts, _lookahead, _data)
 }
 
 // Propose is a paid mutator transaction binding the contract method 0x9791e644.
 //
 // Solidity: function propose(bytes _lookahead, bytes _data) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Propose(_lookahead []byte, _data []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Propose(&_ShastaInboxClient.TransactOpts, _lookahead, _data)
+func (_Inbox *InboxTransactorSession) Propose(_lookahead []byte, _data []byte) (*types.Transaction, error) {
+	return _Inbox.Contract.Propose(&_Inbox.TransactOpts, _lookahead, _data)
 }
 
 // Prove is a paid mutator transaction binding the contract method 0xea191743.
 //
 // Solidity: function prove(bytes _data, bytes _proof) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) Prove(opts *bind.TransactOpts, _data []byte, _proof []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "prove", _data, _proof)
+func (_Inbox *InboxTransactor) Prove(opts *bind.TransactOpts, _data []byte, _proof []byte) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "prove", _data, _proof)
 }
 
 // Prove is a paid mutator transaction binding the contract method 0xea191743.
 //
 // Solidity: function prove(bytes _data, bytes _proof) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) Prove(_data []byte, _proof []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Prove(&_ShastaInboxClient.TransactOpts, _data, _proof)
+func (_Inbox *InboxSession) Prove(_data []byte, _proof []byte) (*types.Transaction, error) {
+	return _Inbox.Contract.Prove(&_Inbox.TransactOpts, _data, _proof)
 }
 
 // Prove is a paid mutator transaction binding the contract method 0xea191743.
 //
 // Solidity: function prove(bytes _data, bytes _proof) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Prove(_data []byte, _proof []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Prove(&_ShastaInboxClient.TransactOpts, _data, _proof)
+func (_Inbox *InboxTransactorSession) Prove(_data []byte, _proof []byte) (*types.Transaction, error) {
+	return _Inbox.Contract.Prove(&_Inbox.TransactOpts, _data, _proof)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "renounceOwnership")
+func (_Inbox *InboxTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "renounceOwnership")
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) RenounceOwnership() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.RenounceOwnership(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Inbox.Contract.RenounceOwnership(&_Inbox.TransactOpts)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
 //
 // Solidity: function renounceOwnership() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) RenounceOwnership() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.RenounceOwnership(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Inbox.Contract.RenounceOwnership(&_Inbox.TransactOpts)
 }
 
 // RequestWithdrawal is a paid mutator transaction binding the contract method 0xdbaf2145.
 //
 // Solidity: function requestWithdrawal() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) RequestWithdrawal(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "requestWithdrawal")
+func (_Inbox *InboxTransactor) RequestWithdrawal(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "requestWithdrawal")
 }
 
 // RequestWithdrawal is a paid mutator transaction binding the contract method 0xdbaf2145.
 //
 // Solidity: function requestWithdrawal() returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) RequestWithdrawal() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.RequestWithdrawal(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxSession) RequestWithdrawal() (*types.Transaction, error) {
+	return _Inbox.Contract.RequestWithdrawal(&_Inbox.TransactOpts)
 }
 
 // RequestWithdrawal is a paid mutator transaction binding the contract method 0xdbaf2145.
 //
 // Solidity: function requestWithdrawal() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) RequestWithdrawal() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.RequestWithdrawal(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxTransactorSession) RequestWithdrawal() (*types.Transaction, error) {
+	return _Inbox.Contract.RequestWithdrawal(&_Inbox.TransactOpts)
 }
 
 // SaveForcedInclusion is a paid mutator transaction binding the contract method 0xdf596d9e.
 //
 // Solidity: function saveForcedInclusion((uint16,uint16,uint24) _blobReference) payable returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) SaveForcedInclusion(opts *bind.TransactOpts, _blobReference LibBlobsBlobReference) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "saveForcedInclusion", _blobReference)
+func (_Inbox *InboxTransactor) SaveForcedInclusion(opts *bind.TransactOpts, _blobReference LibBlobsBlobReference) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "saveForcedInclusion", _blobReference)
 }
 
 // SaveForcedInclusion is a paid mutator transaction binding the contract method 0xdf596d9e.
 //
 // Solidity: function saveForcedInclusion((uint16,uint16,uint24) _blobReference) payable returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) SaveForcedInclusion(_blobReference LibBlobsBlobReference) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.SaveForcedInclusion(&_ShastaInboxClient.TransactOpts, _blobReference)
+func (_Inbox *InboxSession) SaveForcedInclusion(_blobReference LibBlobsBlobReference) (*types.Transaction, error) {
+	return _Inbox.Contract.SaveForcedInclusion(&_Inbox.TransactOpts, _blobReference)
 }
 
 // SaveForcedInclusion is a paid mutator transaction binding the contract method 0xdf596d9e.
 //
 // Solidity: function saveForcedInclusion((uint16,uint16,uint24) _blobReference) payable returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) SaveForcedInclusion(_blobReference LibBlobsBlobReference) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.SaveForcedInclusion(&_ShastaInboxClient.TransactOpts, _blobReference)
+func (_Inbox *InboxTransactorSession) SaveForcedInclusion(_blobReference LibBlobsBlobReference) (*types.Transaction, error) {
+	return _Inbox.Contract.SaveForcedInclusion(&_Inbox.TransactOpts, _blobReference)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "transferOwnership", newOwner)
+func (_Inbox *InboxTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "transferOwnership", newOwner)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.TransferOwnership(&_ShastaInboxClient.TransactOpts, newOwner)
+func (_Inbox *InboxSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Inbox.Contract.TransferOwnership(&_Inbox.TransactOpts, newOwner)
 }
 
 // TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
 //
 // Solidity: function transferOwnership(address newOwner) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.TransferOwnership(&_ShastaInboxClient.TransactOpts, newOwner)
+func (_Inbox *InboxTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Inbox.Contract.TransferOwnership(&_Inbox.TransactOpts, newOwner)
 }
 
 // Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
 //
 // Solidity: function unpause() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "unpause")
+func (_Inbox *InboxTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "unpause")
 }
 
 // Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
 //
 // Solidity: function unpause() returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) Unpause() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Unpause(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxSession) Unpause() (*types.Transaction, error) {
+	return _Inbox.Contract.Unpause(&_Inbox.TransactOpts)
 }
 
 // Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
 //
 // Solidity: function unpause() returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Unpause() (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Unpause(&_ShastaInboxClient.TransactOpts)
+func (_Inbox *InboxTransactorSession) Unpause() (*types.Transaction, error) {
+	return _Inbox.Contract.Unpause(&_Inbox.TransactOpts)
 }
 
 // UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
 //
 // Solidity: function upgradeTo(address newImplementation) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) UpgradeTo(opts *bind.TransactOpts, newImplementation common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "upgradeTo", newImplementation)
+func (_Inbox *InboxTransactor) UpgradeTo(opts *bind.TransactOpts, newImplementation common.Address) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "upgradeTo", newImplementation)
 }
 
 // UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
 //
 // Solidity: function upgradeTo(address newImplementation) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.UpgradeTo(&_ShastaInboxClient.TransactOpts, newImplementation)
+func (_Inbox *InboxSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _Inbox.Contract.UpgradeTo(&_Inbox.TransactOpts, newImplementation)
 }
 
 // UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
 //
 // Solidity: function upgradeTo(address newImplementation) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.UpgradeTo(&_ShastaInboxClient.TransactOpts, newImplementation)
+func (_Inbox *InboxTransactorSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _Inbox.Contract.UpgradeTo(&_Inbox.TransactOpts, newImplementation)
 }
 
 // UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
 //
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+func (_Inbox *InboxTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
 }
 
 // UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
 //
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.UpgradeToAndCall(&_ShastaInboxClient.TransactOpts, newImplementation, data)
+func (_Inbox *InboxSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Inbox.Contract.UpgradeToAndCall(&_Inbox.TransactOpts, newImplementation, data)
 }
 
 // UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
 //
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.UpgradeToAndCall(&_ShastaInboxClient.TransactOpts, newImplementation, data)
+func (_Inbox *InboxTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Inbox.Contract.UpgradeToAndCall(&_Inbox.TransactOpts, newImplementation, data)
 }
 
 // Withdraw is a paid mutator transaction binding the contract method 0xd6dad060.
 //
 // Solidity: function withdraw(address _to, uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactor) Withdraw(opts *bind.TransactOpts, _to common.Address, _amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.contract.Transact(opts, "withdraw", _to, _amount)
+func (_Inbox *InboxTransactor) Withdraw(opts *bind.TransactOpts, _to common.Address, _amount uint64) (*types.Transaction, error) {
+	return _Inbox.contract.Transact(opts, "withdraw", _to, _amount)
 }
 
 // Withdraw is a paid mutator transaction binding the contract method 0xd6dad060.
 //
 // Solidity: function withdraw(address _to, uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientSession) Withdraw(_to common.Address, _amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Withdraw(&_ShastaInboxClient.TransactOpts, _to, _amount)
+func (_Inbox *InboxSession) Withdraw(_to common.Address, _amount uint64) (*types.Transaction, error) {
+	return _Inbox.Contract.Withdraw(&_Inbox.TransactOpts, _to, _amount)
 }
 
 // Withdraw is a paid mutator transaction binding the contract method 0xd6dad060.
 //
 // Solidity: function withdraw(address _to, uint64 _amount) returns()
-func (_ShastaInboxClient *ShastaInboxClientTransactorSession) Withdraw(_to common.Address, _amount uint64) (*types.Transaction, error) {
-	return _ShastaInboxClient.Contract.Withdraw(&_ShastaInboxClient.TransactOpts, _to, _amount)
+func (_Inbox *InboxTransactorSession) Withdraw(_to common.Address, _amount uint64) (*types.Transaction, error) {
+	return _Inbox.Contract.Withdraw(&_Inbox.TransactOpts, _to, _amount)
 }
 
-// ShastaInboxClientAdminChangedIterator is returned from FilterAdminChanged and is used to iterate over the raw logs and unpacked data for AdminChanged events raised by the ShastaInboxClient contract.
-type ShastaInboxClientAdminChangedIterator struct {
-	Event *ShastaInboxClientAdminChanged // Event containing the contract specifics and raw log
+// InboxAdminChangedIterator is returned from FilterAdminChanged and is used to iterate over the raw logs and unpacked data for AdminChanged events raised by the Inbox contract.
+type InboxAdminChangedIterator struct {
+	Event *InboxAdminChanged // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1324,7 +1324,7 @@ type ShastaInboxClientAdminChangedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientAdminChangedIterator) Next() bool {
+func (it *InboxAdminChangedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1333,7 +1333,7 @@ func (it *ShastaInboxClientAdminChangedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientAdminChanged)
+			it.Event = new(InboxAdminChanged)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1348,7 +1348,7 @@ func (it *ShastaInboxClientAdminChangedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientAdminChanged)
+		it.Event = new(InboxAdminChanged)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1364,19 +1364,19 @@ func (it *ShastaInboxClientAdminChangedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientAdminChangedIterator) Error() error {
+func (it *InboxAdminChangedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientAdminChangedIterator) Close() error {
+func (it *InboxAdminChangedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientAdminChanged represents a AdminChanged event raised by the ShastaInboxClient contract.
-type ShastaInboxClientAdminChanged struct {
+// InboxAdminChanged represents a AdminChanged event raised by the Inbox contract.
+type InboxAdminChanged struct {
 	PreviousAdmin common.Address
 	NewAdmin      common.Address
 	Raw           types.Log // Blockchain specific contextual infos
@@ -1385,21 +1385,21 @@ type ShastaInboxClientAdminChanged struct {
 // FilterAdminChanged is a free log retrieval operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
 //
 // Solidity: event AdminChanged(address previousAdmin, address newAdmin)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterAdminChanged(opts *bind.FilterOpts) (*ShastaInboxClientAdminChangedIterator, error) {
+func (_Inbox *InboxFilterer) FilterAdminChanged(opts *bind.FilterOpts) (*InboxAdminChangedIterator, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "AdminChanged")
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "AdminChanged")
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientAdminChangedIterator{contract: _ShastaInboxClient.contract, event: "AdminChanged", logs: logs, sub: sub}, nil
+	return &InboxAdminChangedIterator{contract: _Inbox.contract, event: "AdminChanged", logs: logs, sub: sub}, nil
 }
 
 // WatchAdminChanged is a free log subscription operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
 //
 // Solidity: event AdminChanged(address previousAdmin, address newAdmin)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientAdminChanged) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<- *InboxAdminChanged) (event.Subscription, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "AdminChanged")
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "AdminChanged")
 	if err != nil {
 		return nil, err
 	}
@@ -1409,8 +1409,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchAdminChanged(opts *bin
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientAdminChanged)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+				event := new(InboxAdminChanged)
+				if err := _Inbox.contract.UnpackLog(event, "AdminChanged", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1434,18 +1434,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchAdminChanged(opts *bin
 // ParseAdminChanged is a log parse operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
 //
 // Solidity: event AdminChanged(address previousAdmin, address newAdmin)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseAdminChanged(log types.Log) (*ShastaInboxClientAdminChanged, error) {
-	event := new(ShastaInboxClientAdminChanged)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+func (_Inbox *InboxFilterer) ParseAdminChanged(log types.Log) (*InboxAdminChanged, error) {
+	event := new(InboxAdminChanged)
+	if err := _Inbox.contract.UnpackLog(event, "AdminChanged", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientBeaconUpgradedIterator is returned from FilterBeaconUpgraded and is used to iterate over the raw logs and unpacked data for BeaconUpgraded events raised by the ShastaInboxClient contract.
-type ShastaInboxClientBeaconUpgradedIterator struct {
-	Event *ShastaInboxClientBeaconUpgraded // Event containing the contract specifics and raw log
+// InboxBeaconUpgradedIterator is returned from FilterBeaconUpgraded and is used to iterate over the raw logs and unpacked data for BeaconUpgraded events raised by the Inbox contract.
+type InboxBeaconUpgradedIterator struct {
+	Event *InboxBeaconUpgraded // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1459,7 +1459,7 @@ type ShastaInboxClientBeaconUpgradedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientBeaconUpgradedIterator) Next() bool {
+func (it *InboxBeaconUpgradedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1468,7 +1468,7 @@ func (it *ShastaInboxClientBeaconUpgradedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientBeaconUpgraded)
+			it.Event = new(InboxBeaconUpgraded)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1483,7 +1483,7 @@ func (it *ShastaInboxClientBeaconUpgradedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientBeaconUpgraded)
+		it.Event = new(InboxBeaconUpgraded)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1499,19 +1499,19 @@ func (it *ShastaInboxClientBeaconUpgradedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientBeaconUpgradedIterator) Error() error {
+func (it *InboxBeaconUpgradedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientBeaconUpgradedIterator) Close() error {
+func (it *InboxBeaconUpgradedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientBeaconUpgraded represents a BeaconUpgraded event raised by the ShastaInboxClient contract.
-type ShastaInboxClientBeaconUpgraded struct {
+// InboxBeaconUpgraded represents a BeaconUpgraded event raised by the Inbox contract.
+type InboxBeaconUpgraded struct {
 	Beacon common.Address
 	Raw    types.Log // Blockchain specific contextual infos
 }
@@ -1519,31 +1519,31 @@ type ShastaInboxClientBeaconUpgraded struct {
 // FilterBeaconUpgraded is a free log retrieval operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
 //
 // Solidity: event BeaconUpgraded(address indexed beacon)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterBeaconUpgraded(opts *bind.FilterOpts, beacon []common.Address) (*ShastaInboxClientBeaconUpgradedIterator, error) {
+func (_Inbox *InboxFilterer) FilterBeaconUpgraded(opts *bind.FilterOpts, beacon []common.Address) (*InboxBeaconUpgradedIterator, error) {
 
 	var beaconRule []interface{}
 	for _, beaconItem := range beacon {
 		beaconRule = append(beaconRule, beaconItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "BeaconUpgraded", beaconRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "BeaconUpgraded", beaconRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientBeaconUpgradedIterator{contract: _ShastaInboxClient.contract, event: "BeaconUpgraded", logs: logs, sub: sub}, nil
+	return &InboxBeaconUpgradedIterator{contract: _Inbox.contract, event: "BeaconUpgraded", logs: logs, sub: sub}, nil
 }
 
 // WatchBeaconUpgraded is a free log subscription operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
 //
 // Solidity: event BeaconUpgraded(address indexed beacon)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientBeaconUpgraded, beacon []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan<- *InboxBeaconUpgraded, beacon []common.Address) (event.Subscription, error) {
 
 	var beaconRule []interface{}
 	for _, beaconItem := range beacon {
 		beaconRule = append(beaconRule, beaconItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "BeaconUpgraded", beaconRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "BeaconUpgraded", beaconRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1553,8 +1553,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBeaconUpgraded(opts *b
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientBeaconUpgraded)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+				event := new(InboxBeaconUpgraded)
+				if err := _Inbox.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1578,18 +1578,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBeaconUpgraded(opts *b
 // ParseBeaconUpgraded is a log parse operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
 //
 // Solidity: event BeaconUpgraded(address indexed beacon)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseBeaconUpgraded(log types.Log) (*ShastaInboxClientBeaconUpgraded, error) {
-	event := new(ShastaInboxClientBeaconUpgraded)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+func (_Inbox *InboxFilterer) ParseBeaconUpgraded(log types.Log) (*InboxBeaconUpgraded, error) {
+	event := new(InboxBeaconUpgraded)
+	if err := _Inbox.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientBondDepositedIterator is returned from FilterBondDeposited and is used to iterate over the raw logs and unpacked data for BondDeposited events raised by the ShastaInboxClient contract.
-type ShastaInboxClientBondDepositedIterator struct {
-	Event *ShastaInboxClientBondDeposited // Event containing the contract specifics and raw log
+// InboxBondDepositedIterator is returned from FilterBondDeposited and is used to iterate over the raw logs and unpacked data for BondDeposited events raised by the Inbox contract.
+type InboxBondDepositedIterator struct {
+	Event *InboxBondDeposited // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1603,7 +1603,7 @@ type ShastaInboxClientBondDepositedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientBondDepositedIterator) Next() bool {
+func (it *InboxBondDepositedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1612,7 +1612,7 @@ func (it *ShastaInboxClientBondDepositedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientBondDeposited)
+			it.Event = new(InboxBondDeposited)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1627,7 +1627,7 @@ func (it *ShastaInboxClientBondDepositedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientBondDeposited)
+		it.Event = new(InboxBondDeposited)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1643,19 +1643,19 @@ func (it *ShastaInboxClientBondDepositedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientBondDepositedIterator) Error() error {
+func (it *InboxBondDepositedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientBondDepositedIterator) Close() error {
+func (it *InboxBondDepositedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientBondDeposited represents a BondDeposited event raised by the ShastaInboxClient contract.
-type ShastaInboxClientBondDeposited struct {
+// InboxBondDeposited represents a BondDeposited event raised by the Inbox contract.
+type InboxBondDeposited struct {
 	Depositor common.Address
 	Recipient common.Address
 	Amount    uint64
@@ -1665,7 +1665,7 @@ type ShastaInboxClientBondDeposited struct {
 // FilterBondDeposited is a free log retrieval operation binding the contract event 0xe5e95641fa87bdfef3ce0d39f0c9a37c200f3bf59f53623b3de21e03ed33e3d2.
 //
 // Solidity: event BondDeposited(address indexed depositor, address indexed recipient, uint64 amount)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterBondDeposited(opts *bind.FilterOpts, depositor []common.Address, recipient []common.Address) (*ShastaInboxClientBondDepositedIterator, error) {
+func (_Inbox *InboxFilterer) FilterBondDeposited(opts *bind.FilterOpts, depositor []common.Address, recipient []common.Address) (*InboxBondDepositedIterator, error) {
 
 	var depositorRule []interface{}
 	for _, depositorItem := range depositor {
@@ -1676,17 +1676,17 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterBondDeposited(opts *b
 		recipientRule = append(recipientRule, recipientItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "BondDeposited", depositorRule, recipientRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "BondDeposited", depositorRule, recipientRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientBondDepositedIterator{contract: _ShastaInboxClient.contract, event: "BondDeposited", logs: logs, sub: sub}, nil
+	return &InboxBondDepositedIterator{contract: _Inbox.contract, event: "BondDeposited", logs: logs, sub: sub}, nil
 }
 
 // WatchBondDeposited is a free log subscription operation binding the contract event 0xe5e95641fa87bdfef3ce0d39f0c9a37c200f3bf59f53623b3de21e03ed33e3d2.
 //
 // Solidity: event BondDeposited(address indexed depositor, address indexed recipient, uint64 amount)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondDeposited(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientBondDeposited, depositor []common.Address, recipient []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchBondDeposited(opts *bind.WatchOpts, sink chan<- *InboxBondDeposited, depositor []common.Address, recipient []common.Address) (event.Subscription, error) {
 
 	var depositorRule []interface{}
 	for _, depositorItem := range depositor {
@@ -1697,7 +1697,7 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondDeposited(opts *bi
 		recipientRule = append(recipientRule, recipientItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "BondDeposited", depositorRule, recipientRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "BondDeposited", depositorRule, recipientRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1707,8 +1707,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondDeposited(opts *bi
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientBondDeposited)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "BondDeposited", log); err != nil {
+				event := new(InboxBondDeposited)
+				if err := _Inbox.contract.UnpackLog(event, "BondDeposited", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1732,18 +1732,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondDeposited(opts *bi
 // ParseBondDeposited is a log parse operation binding the contract event 0xe5e95641fa87bdfef3ce0d39f0c9a37c200f3bf59f53623b3de21e03ed33e3d2.
 //
 // Solidity: event BondDeposited(address indexed depositor, address indexed recipient, uint64 amount)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseBondDeposited(log types.Log) (*ShastaInboxClientBondDeposited, error) {
-	event := new(ShastaInboxClientBondDeposited)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "BondDeposited", log); err != nil {
+func (_Inbox *InboxFilterer) ParseBondDeposited(log types.Log) (*InboxBondDeposited, error) {
+	event := new(InboxBondDeposited)
+	if err := _Inbox.contract.UnpackLog(event, "BondDeposited", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientBondWithdrawnIterator is returned from FilterBondWithdrawn and is used to iterate over the raw logs and unpacked data for BondWithdrawn events raised by the ShastaInboxClient contract.
-type ShastaInboxClientBondWithdrawnIterator struct {
-	Event *ShastaInboxClientBondWithdrawn // Event containing the contract specifics and raw log
+// InboxBondWithdrawnIterator is returned from FilterBondWithdrawn and is used to iterate over the raw logs and unpacked data for BondWithdrawn events raised by the Inbox contract.
+type InboxBondWithdrawnIterator struct {
+	Event *InboxBondWithdrawn // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1757,7 +1757,7 @@ type ShastaInboxClientBondWithdrawnIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientBondWithdrawnIterator) Next() bool {
+func (it *InboxBondWithdrawnIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1766,7 +1766,7 @@ func (it *ShastaInboxClientBondWithdrawnIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientBondWithdrawn)
+			it.Event = new(InboxBondWithdrawn)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1781,7 +1781,7 @@ func (it *ShastaInboxClientBondWithdrawnIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientBondWithdrawn)
+		it.Event = new(InboxBondWithdrawn)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1797,19 +1797,19 @@ func (it *ShastaInboxClientBondWithdrawnIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientBondWithdrawnIterator) Error() error {
+func (it *InboxBondWithdrawnIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientBondWithdrawnIterator) Close() error {
+func (it *InboxBondWithdrawnIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientBondWithdrawn represents a BondWithdrawn event raised by the ShastaInboxClient contract.
-type ShastaInboxClientBondWithdrawn struct {
+// InboxBondWithdrawn represents a BondWithdrawn event raised by the Inbox contract.
+type InboxBondWithdrawn struct {
 	Account common.Address
 	Amount  uint64
 	Raw     types.Log // Blockchain specific contextual infos
@@ -1818,31 +1818,31 @@ type ShastaInboxClientBondWithdrawn struct {
 // FilterBondWithdrawn is a free log retrieval operation binding the contract event 0x3362c96009316515fccd3dd29c7036c305ad9e892d83dd5681845ac9edb0c9a8.
 //
 // Solidity: event BondWithdrawn(address indexed account, uint64 amount)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterBondWithdrawn(opts *bind.FilterOpts, account []common.Address) (*ShastaInboxClientBondWithdrawnIterator, error) {
+func (_Inbox *InboxFilterer) FilterBondWithdrawn(opts *bind.FilterOpts, account []common.Address) (*InboxBondWithdrawnIterator, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "BondWithdrawn", accountRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "BondWithdrawn", accountRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientBondWithdrawnIterator{contract: _ShastaInboxClient.contract, event: "BondWithdrawn", logs: logs, sub: sub}, nil
+	return &InboxBondWithdrawnIterator{contract: _Inbox.contract, event: "BondWithdrawn", logs: logs, sub: sub}, nil
 }
 
 // WatchBondWithdrawn is a free log subscription operation binding the contract event 0x3362c96009316515fccd3dd29c7036c305ad9e892d83dd5681845ac9edb0c9a8.
 //
 // Solidity: event BondWithdrawn(address indexed account, uint64 amount)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondWithdrawn(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientBondWithdrawn, account []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchBondWithdrawn(opts *bind.WatchOpts, sink chan<- *InboxBondWithdrawn, account []common.Address) (event.Subscription, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "BondWithdrawn", accountRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "BondWithdrawn", accountRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1852,8 +1852,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondWithdrawn(opts *bi
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientBondWithdrawn)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "BondWithdrawn", log); err != nil {
+				event := new(InboxBondWithdrawn)
+				if err := _Inbox.contract.UnpackLog(event, "BondWithdrawn", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -1877,18 +1877,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchBondWithdrawn(opts *bi
 // ParseBondWithdrawn is a log parse operation binding the contract event 0x3362c96009316515fccd3dd29c7036c305ad9e892d83dd5681845ac9edb0c9a8.
 //
 // Solidity: event BondWithdrawn(address indexed account, uint64 amount)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseBondWithdrawn(log types.Log) (*ShastaInboxClientBondWithdrawn, error) {
-	event := new(ShastaInboxClientBondWithdrawn)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "BondWithdrawn", log); err != nil {
+func (_Inbox *InboxFilterer) ParseBondWithdrawn(log types.Log) (*InboxBondWithdrawn, error) {
+	event := new(InboxBondWithdrawn)
+	if err := _Inbox.contract.UnpackLog(event, "BondWithdrawn", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientForcedInclusionSavedIterator is returned from FilterForcedInclusionSaved and is used to iterate over the raw logs and unpacked data for ForcedInclusionSaved events raised by the ShastaInboxClient contract.
-type ShastaInboxClientForcedInclusionSavedIterator struct {
-	Event *ShastaInboxClientForcedInclusionSaved // Event containing the contract specifics and raw log
+// InboxForcedInclusionSavedIterator is returned from FilterForcedInclusionSaved and is used to iterate over the raw logs and unpacked data for ForcedInclusionSaved events raised by the Inbox contract.
+type InboxForcedInclusionSavedIterator struct {
+	Event *InboxForcedInclusionSaved // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -1902,7 +1902,7 @@ type ShastaInboxClientForcedInclusionSavedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientForcedInclusionSavedIterator) Next() bool {
+func (it *InboxForcedInclusionSavedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -1911,7 +1911,7 @@ func (it *ShastaInboxClientForcedInclusionSavedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientForcedInclusionSaved)
+			it.Event = new(InboxForcedInclusionSaved)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -1926,7 +1926,7 @@ func (it *ShastaInboxClientForcedInclusionSavedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientForcedInclusionSaved)
+		it.Event = new(InboxForcedInclusionSaved)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -1942,19 +1942,19 @@ func (it *ShastaInboxClientForcedInclusionSavedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientForcedInclusionSavedIterator) Error() error {
+func (it *InboxForcedInclusionSavedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientForcedInclusionSavedIterator) Close() error {
+func (it *InboxForcedInclusionSavedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientForcedInclusionSaved represents a ForcedInclusionSaved event raised by the ShastaInboxClient contract.
-type ShastaInboxClientForcedInclusionSaved struct {
+// InboxForcedInclusionSaved represents a ForcedInclusionSaved event raised by the Inbox contract.
+type InboxForcedInclusionSaved struct {
 	ForcedInclusion IForcedInclusionStoreForcedInclusion
 	Raw             types.Log // Blockchain specific contextual infos
 }
@@ -1962,21 +1962,21 @@ type ShastaInboxClientForcedInclusionSaved struct {
 // FilterForcedInclusionSaved is a free log retrieval operation binding the contract event 0x18c4fc1e6ac628dbb537b0375bf0efabf1ff2528af1ec22faa74d2da95c29471.
 //
 // Solidity: event ForcedInclusionSaved((uint64,(bytes32[],uint24,uint48)) forcedInclusion)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterForcedInclusionSaved(opts *bind.FilterOpts) (*ShastaInboxClientForcedInclusionSavedIterator, error) {
+func (_Inbox *InboxFilterer) FilterForcedInclusionSaved(opts *bind.FilterOpts) (*InboxForcedInclusionSavedIterator, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "ForcedInclusionSaved")
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "ForcedInclusionSaved")
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientForcedInclusionSavedIterator{contract: _ShastaInboxClient.contract, event: "ForcedInclusionSaved", logs: logs, sub: sub}, nil
+	return &InboxForcedInclusionSavedIterator{contract: _Inbox.contract, event: "ForcedInclusionSaved", logs: logs, sub: sub}, nil
 }
 
 // WatchForcedInclusionSaved is a free log subscription operation binding the contract event 0x18c4fc1e6ac628dbb537b0375bf0efabf1ff2528af1ec22faa74d2da95c29471.
 //
 // Solidity: event ForcedInclusionSaved((uint64,(bytes32[],uint24,uint48)) forcedInclusion)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchForcedInclusionSaved(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientForcedInclusionSaved) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchForcedInclusionSaved(opts *bind.WatchOpts, sink chan<- *InboxForcedInclusionSaved) (event.Subscription, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "ForcedInclusionSaved")
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "ForcedInclusionSaved")
 	if err != nil {
 		return nil, err
 	}
@@ -1986,8 +1986,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchForcedInclusionSaved(o
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientForcedInclusionSaved)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "ForcedInclusionSaved", log); err != nil {
+				event := new(InboxForcedInclusionSaved)
+				if err := _Inbox.contract.UnpackLog(event, "ForcedInclusionSaved", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2011,18 +2011,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchForcedInclusionSaved(o
 // ParseForcedInclusionSaved is a log parse operation binding the contract event 0x18c4fc1e6ac628dbb537b0375bf0efabf1ff2528af1ec22faa74d2da95c29471.
 //
 // Solidity: event ForcedInclusionSaved((uint64,(bytes32[],uint24,uint48)) forcedInclusion)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseForcedInclusionSaved(log types.Log) (*ShastaInboxClientForcedInclusionSaved, error) {
-	event := new(ShastaInboxClientForcedInclusionSaved)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "ForcedInclusionSaved", log); err != nil {
+func (_Inbox *InboxFilterer) ParseForcedInclusionSaved(log types.Log) (*InboxForcedInclusionSaved, error) {
+	event := new(InboxForcedInclusionSaved)
+	if err := _Inbox.contract.UnpackLog(event, "ForcedInclusionSaved", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientInboxActivatedIterator is returned from FilterInboxActivated and is used to iterate over the raw logs and unpacked data for InboxActivated events raised by the ShastaInboxClient contract.
-type ShastaInboxClientInboxActivatedIterator struct {
-	Event *ShastaInboxClientInboxActivated // Event containing the contract specifics and raw log
+// InboxInboxActivatedIterator is returned from FilterInboxActivated and is used to iterate over the raw logs and unpacked data for InboxActivated events raised by the Inbox contract.
+type InboxInboxActivatedIterator struct {
+	Event *InboxInboxActivated // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2036,7 +2036,7 @@ type ShastaInboxClientInboxActivatedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientInboxActivatedIterator) Next() bool {
+func (it *InboxInboxActivatedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2045,7 +2045,7 @@ func (it *ShastaInboxClientInboxActivatedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientInboxActivated)
+			it.Event = new(InboxInboxActivated)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2060,7 +2060,7 @@ func (it *ShastaInboxClientInboxActivatedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientInboxActivated)
+		it.Event = new(InboxInboxActivated)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2076,19 +2076,19 @@ func (it *ShastaInboxClientInboxActivatedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientInboxActivatedIterator) Error() error {
+func (it *InboxInboxActivatedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientInboxActivatedIterator) Close() error {
+func (it *InboxInboxActivatedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientInboxActivated represents a InboxActivated event raised by the ShastaInboxClient contract.
-type ShastaInboxClientInboxActivated struct {
+// InboxInboxActivated represents a InboxActivated event raised by the Inbox contract.
+type InboxInboxActivated struct {
 	LastPacayaBlockHash [32]byte
 	Raw                 types.Log // Blockchain specific contextual infos
 }
@@ -2096,21 +2096,21 @@ type ShastaInboxClientInboxActivated struct {
 // FilterInboxActivated is a free log retrieval operation binding the contract event 0xe4356761c97932c05c3ee0859fb1a5e4f91f7a1d7a3752c7d5a72d5cc6ecb2d2.
 //
 // Solidity: event InboxActivated(bytes32 lastPacayaBlockHash)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterInboxActivated(opts *bind.FilterOpts) (*ShastaInboxClientInboxActivatedIterator, error) {
+func (_Inbox *InboxFilterer) FilterInboxActivated(opts *bind.FilterOpts) (*InboxInboxActivatedIterator, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "InboxActivated")
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "InboxActivated")
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientInboxActivatedIterator{contract: _ShastaInboxClient.contract, event: "InboxActivated", logs: logs, sub: sub}, nil
+	return &InboxInboxActivatedIterator{contract: _Inbox.contract, event: "InboxActivated", logs: logs, sub: sub}, nil
 }
 
 // WatchInboxActivated is a free log subscription operation binding the contract event 0xe4356761c97932c05c3ee0859fb1a5e4f91f7a1d7a3752c7d5a72d5cc6ecb2d2.
 //
 // Solidity: event InboxActivated(bytes32 lastPacayaBlockHash)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchInboxActivated(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientInboxActivated) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchInboxActivated(opts *bind.WatchOpts, sink chan<- *InboxInboxActivated) (event.Subscription, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "InboxActivated")
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "InboxActivated")
 	if err != nil {
 		return nil, err
 	}
@@ -2120,8 +2120,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchInboxActivated(opts *b
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientInboxActivated)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "InboxActivated", log); err != nil {
+				event := new(InboxInboxActivated)
+				if err := _Inbox.contract.UnpackLog(event, "InboxActivated", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2145,18 +2145,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchInboxActivated(opts *b
 // ParseInboxActivated is a log parse operation binding the contract event 0xe4356761c97932c05c3ee0859fb1a5e4f91f7a1d7a3752c7d5a72d5cc6ecb2d2.
 //
 // Solidity: event InboxActivated(bytes32 lastPacayaBlockHash)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseInboxActivated(log types.Log) (*ShastaInboxClientInboxActivated, error) {
-	event := new(ShastaInboxClientInboxActivated)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "InboxActivated", log); err != nil {
+func (_Inbox *InboxFilterer) ParseInboxActivated(log types.Log) (*InboxInboxActivated, error) {
+	event := new(InboxInboxActivated)
+	if err := _Inbox.contract.UnpackLog(event, "InboxActivated", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the ShastaInboxClient contract.
-type ShastaInboxClientInitializedIterator struct {
-	Event *ShastaInboxClientInitialized // Event containing the contract specifics and raw log
+// InboxInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Inbox contract.
+type InboxInitializedIterator struct {
+	Event *InboxInitialized // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2170,7 +2170,7 @@ type ShastaInboxClientInitializedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientInitializedIterator) Next() bool {
+func (it *InboxInitializedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2179,7 +2179,7 @@ func (it *ShastaInboxClientInitializedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientInitialized)
+			it.Event = new(InboxInitialized)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2194,7 +2194,7 @@ func (it *ShastaInboxClientInitializedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientInitialized)
+		it.Event = new(InboxInitialized)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2210,19 +2210,19 @@ func (it *ShastaInboxClientInitializedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientInitializedIterator) Error() error {
+func (it *InboxInitializedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientInitializedIterator) Close() error {
+func (it *InboxInitializedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientInitialized represents a Initialized event raised by the ShastaInboxClient contract.
-type ShastaInboxClientInitialized struct {
+// InboxInitialized represents a Initialized event raised by the Inbox contract.
+type InboxInitialized struct {
 	Version uint8
 	Raw     types.Log // Blockchain specific contextual infos
 }
@@ -2230,21 +2230,21 @@ type ShastaInboxClientInitialized struct {
 // FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
 //
 // Solidity: event Initialized(uint8 version)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterInitialized(opts *bind.FilterOpts) (*ShastaInboxClientInitializedIterator, error) {
+func (_Inbox *InboxFilterer) FilterInitialized(opts *bind.FilterOpts) (*InboxInitializedIterator, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Initialized")
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Initialized")
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientInitializedIterator{contract: _ShastaInboxClient.contract, event: "Initialized", logs: logs, sub: sub}, nil
+	return &InboxInitializedIterator{contract: _Inbox.contract, event: "Initialized", logs: logs, sub: sub}, nil
 }
 
 // WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
 //
 // Solidity: event Initialized(uint8 version)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientInitialized) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *InboxInitialized) (event.Subscription, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Initialized")
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Initialized")
 	if err != nil {
 		return nil, err
 	}
@@ -2254,8 +2254,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchInitialized(opts *bind
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientInitialized)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "Initialized", log); err != nil {
+				event := new(InboxInitialized)
+				if err := _Inbox.contract.UnpackLog(event, "Initialized", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2279,18 +2279,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchInitialized(opts *bind
 // ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
 //
 // Solidity: event Initialized(uint8 version)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseInitialized(log types.Log) (*ShastaInboxClientInitialized, error) {
-	event := new(ShastaInboxClientInitialized)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "Initialized", log); err != nil {
+func (_Inbox *InboxFilterer) ParseInitialized(log types.Log) (*InboxInitialized, error) {
+	event := new(InboxInitialized)
+	if err := _Inbox.contract.UnpackLog(event, "Initialized", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientLivenessBondSettledIterator is returned from FilterLivenessBondSettled and is used to iterate over the raw logs and unpacked data for LivenessBondSettled events raised by the ShastaInboxClient contract.
-type ShastaInboxClientLivenessBondSettledIterator struct {
-	Event *ShastaInboxClientLivenessBondSettled // Event containing the contract specifics and raw log
+// InboxLivenessBondSettledIterator is returned from FilterLivenessBondSettled and is used to iterate over the raw logs and unpacked data for LivenessBondSettled events raised by the Inbox contract.
+type InboxLivenessBondSettledIterator struct {
+	Event *InboxLivenessBondSettled // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2304,7 +2304,7 @@ type ShastaInboxClientLivenessBondSettledIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientLivenessBondSettledIterator) Next() bool {
+func (it *InboxLivenessBondSettledIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2313,7 +2313,7 @@ func (it *ShastaInboxClientLivenessBondSettledIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientLivenessBondSettled)
+			it.Event = new(InboxLivenessBondSettled)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2328,7 +2328,7 @@ func (it *ShastaInboxClientLivenessBondSettledIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientLivenessBondSettled)
+		it.Event = new(InboxLivenessBondSettled)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2344,19 +2344,19 @@ func (it *ShastaInboxClientLivenessBondSettledIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientLivenessBondSettledIterator) Error() error {
+func (it *InboxLivenessBondSettledIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientLivenessBondSettledIterator) Close() error {
+func (it *InboxLivenessBondSettledIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientLivenessBondSettled represents a LivenessBondSettled event raised by the ShastaInboxClient contract.
-type ShastaInboxClientLivenessBondSettled struct {
+// InboxLivenessBondSettled represents a LivenessBondSettled event raised by the Inbox contract.
+type InboxLivenessBondSettled struct {
 	Payer        common.Address
 	Payee        common.Address
 	LivenessBond uint64
@@ -2368,7 +2368,7 @@ type ShastaInboxClientLivenessBondSettled struct {
 // FilterLivenessBondSettled is a free log retrieval operation binding the contract event 0xaa22f5157944b5fa6846460e159d57ea9c3878e71fda274af372fa2ccf285aa0.
 //
 // Solidity: event LivenessBondSettled(address indexed payer, address indexed payee, uint64 livenessBond, uint64 credited, uint64 slashed)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterLivenessBondSettled(opts *bind.FilterOpts, payer []common.Address, payee []common.Address) (*ShastaInboxClientLivenessBondSettledIterator, error) {
+func (_Inbox *InboxFilterer) FilterLivenessBondSettled(opts *bind.FilterOpts, payer []common.Address, payee []common.Address) (*InboxLivenessBondSettledIterator, error) {
 
 	var payerRule []interface{}
 	for _, payerItem := range payer {
@@ -2379,17 +2379,17 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterLivenessBondSettled(o
 		payeeRule = append(payeeRule, payeeItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "LivenessBondSettled", payerRule, payeeRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "LivenessBondSettled", payerRule, payeeRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientLivenessBondSettledIterator{contract: _ShastaInboxClient.contract, event: "LivenessBondSettled", logs: logs, sub: sub}, nil
+	return &InboxLivenessBondSettledIterator{contract: _Inbox.contract, event: "LivenessBondSettled", logs: logs, sub: sub}, nil
 }
 
 // WatchLivenessBondSettled is a free log subscription operation binding the contract event 0xaa22f5157944b5fa6846460e159d57ea9c3878e71fda274af372fa2ccf285aa0.
 //
 // Solidity: event LivenessBondSettled(address indexed payer, address indexed payee, uint64 livenessBond, uint64 credited, uint64 slashed)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchLivenessBondSettled(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientLivenessBondSettled, payer []common.Address, payee []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchLivenessBondSettled(opts *bind.WatchOpts, sink chan<- *InboxLivenessBondSettled, payer []common.Address, payee []common.Address) (event.Subscription, error) {
 
 	var payerRule []interface{}
 	for _, payerItem := range payer {
@@ -2400,7 +2400,7 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchLivenessBondSettled(op
 		payeeRule = append(payeeRule, payeeItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "LivenessBondSettled", payerRule, payeeRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "LivenessBondSettled", payerRule, payeeRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2410,8 +2410,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchLivenessBondSettled(op
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientLivenessBondSettled)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "LivenessBondSettled", log); err != nil {
+				event := new(InboxLivenessBondSettled)
+				if err := _Inbox.contract.UnpackLog(event, "LivenessBondSettled", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2435,18 +2435,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchLivenessBondSettled(op
 // ParseLivenessBondSettled is a log parse operation binding the contract event 0xaa22f5157944b5fa6846460e159d57ea9c3878e71fda274af372fa2ccf285aa0.
 //
 // Solidity: event LivenessBondSettled(address indexed payer, address indexed payee, uint64 livenessBond, uint64 credited, uint64 slashed)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseLivenessBondSettled(log types.Log) (*ShastaInboxClientLivenessBondSettled, error) {
-	event := new(ShastaInboxClientLivenessBondSettled)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "LivenessBondSettled", log); err != nil {
+func (_Inbox *InboxFilterer) ParseLivenessBondSettled(log types.Log) (*InboxLivenessBondSettled, error) {
+	event := new(InboxLivenessBondSettled)
+	if err := _Inbox.contract.UnpackLog(event, "LivenessBondSettled", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the ShastaInboxClient contract.
-type ShastaInboxClientOwnershipTransferStartedIterator struct {
-	Event *ShastaInboxClientOwnershipTransferStarted // Event containing the contract specifics and raw log
+// InboxOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the Inbox contract.
+type InboxOwnershipTransferStartedIterator struct {
+	Event *InboxOwnershipTransferStarted // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2460,7 +2460,7 @@ type ShastaInboxClientOwnershipTransferStartedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientOwnershipTransferStartedIterator) Next() bool {
+func (it *InboxOwnershipTransferStartedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2469,7 +2469,7 @@ func (it *ShastaInboxClientOwnershipTransferStartedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientOwnershipTransferStarted)
+			it.Event = new(InboxOwnershipTransferStarted)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2484,7 +2484,7 @@ func (it *ShastaInboxClientOwnershipTransferStartedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientOwnershipTransferStarted)
+		it.Event = new(InboxOwnershipTransferStarted)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2500,19 +2500,19 @@ func (it *ShastaInboxClientOwnershipTransferStartedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientOwnershipTransferStartedIterator) Error() error {
+func (it *InboxOwnershipTransferStartedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientOwnershipTransferStartedIterator) Close() error {
+func (it *InboxOwnershipTransferStartedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the ShastaInboxClient contract.
-type ShastaInboxClientOwnershipTransferStarted struct {
+// InboxOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the Inbox contract.
+type InboxOwnershipTransferStarted struct {
 	PreviousOwner common.Address
 	NewOwner      common.Address
 	Raw           types.Log // Blockchain specific contextual infos
@@ -2521,7 +2521,7 @@ type ShastaInboxClientOwnershipTransferStarted struct {
 // FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ShastaInboxClientOwnershipTransferStartedIterator, error) {
+func (_Inbox *InboxFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*InboxOwnershipTransferStartedIterator, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -2532,17 +2532,17 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterOwnershipTransferStar
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientOwnershipTransferStartedIterator{contract: _ShastaInboxClient.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+	return &InboxOwnershipTransferStartedIterator{contract: _Inbox.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
 }
 
 // WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *InboxOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -2553,7 +2553,7 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferStart
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2563,8 +2563,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferStart
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientOwnershipTransferStarted)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+				event := new(InboxOwnershipTransferStarted)
+				if err := _Inbox.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2588,18 +2588,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferStart
 // ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
 //
 // Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseOwnershipTransferStarted(log types.Log) (*ShastaInboxClientOwnershipTransferStarted, error) {
-	event := new(ShastaInboxClientOwnershipTransferStarted)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+func (_Inbox *InboxFilterer) ParseOwnershipTransferStarted(log types.Log) (*InboxOwnershipTransferStarted, error) {
+	event := new(InboxOwnershipTransferStarted)
+	if err := _Inbox.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the ShastaInboxClient contract.
-type ShastaInboxClientOwnershipTransferredIterator struct {
-	Event *ShastaInboxClientOwnershipTransferred // Event containing the contract specifics and raw log
+// InboxOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Inbox contract.
+type InboxOwnershipTransferredIterator struct {
+	Event *InboxOwnershipTransferred // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2613,7 +2613,7 @@ type ShastaInboxClientOwnershipTransferredIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientOwnershipTransferredIterator) Next() bool {
+func (it *InboxOwnershipTransferredIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2622,7 +2622,7 @@ func (it *ShastaInboxClientOwnershipTransferredIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientOwnershipTransferred)
+			it.Event = new(InboxOwnershipTransferred)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2637,7 +2637,7 @@ func (it *ShastaInboxClientOwnershipTransferredIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientOwnershipTransferred)
+		it.Event = new(InboxOwnershipTransferred)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2653,19 +2653,19 @@ func (it *ShastaInboxClientOwnershipTransferredIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientOwnershipTransferredIterator) Error() error {
+func (it *InboxOwnershipTransferredIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientOwnershipTransferredIterator) Close() error {
+func (it *InboxOwnershipTransferredIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientOwnershipTransferred represents a OwnershipTransferred event raised by the ShastaInboxClient contract.
-type ShastaInboxClientOwnershipTransferred struct {
+// InboxOwnershipTransferred represents a OwnershipTransferred event raised by the Inbox contract.
+type InboxOwnershipTransferred struct {
 	PreviousOwner common.Address
 	NewOwner      common.Address
 	Raw           types.Log // Blockchain specific contextual infos
@@ -2674,7 +2674,7 @@ type ShastaInboxClientOwnershipTransferred struct {
 // FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ShastaInboxClientOwnershipTransferredIterator, error) {
+func (_Inbox *InboxFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*InboxOwnershipTransferredIterator, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -2685,17 +2685,17 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterOwnershipTransferred(
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientOwnershipTransferredIterator{contract: _ShastaInboxClient.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+	return &InboxOwnershipTransferredIterator{contract: _Inbox.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
 }
 
 // WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *InboxOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
 
 	var previousOwnerRule []interface{}
 	for _, previousOwnerItem := range previousOwner {
@@ -2706,7 +2706,7 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferred(o
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
 	if err != nil {
 		return nil, err
 	}
@@ -2716,8 +2716,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferred(o
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientOwnershipTransferred)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+				event := new(InboxOwnershipTransferred)
+				if err := _Inbox.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2741,18 +2741,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchOwnershipTransferred(o
 // ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
 //
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseOwnershipTransferred(log types.Log) (*ShastaInboxClientOwnershipTransferred, error) {
-	event := new(ShastaInboxClientOwnershipTransferred)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+func (_Inbox *InboxFilterer) ParseOwnershipTransferred(log types.Log) (*InboxOwnershipTransferred, error) {
+	event := new(InboxOwnershipTransferred)
+	if err := _Inbox.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the ShastaInboxClient contract.
-type ShastaInboxClientPausedIterator struct {
-	Event *ShastaInboxClientPaused // Event containing the contract specifics and raw log
+// InboxPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the Inbox contract.
+type InboxPausedIterator struct {
+	Event *InboxPaused // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2766,7 +2766,7 @@ type ShastaInboxClientPausedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientPausedIterator) Next() bool {
+func (it *InboxPausedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2775,7 +2775,7 @@ func (it *ShastaInboxClientPausedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientPaused)
+			it.Event = new(InboxPaused)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2790,7 +2790,7 @@ func (it *ShastaInboxClientPausedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientPaused)
+		it.Event = new(InboxPaused)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2806,19 +2806,19 @@ func (it *ShastaInboxClientPausedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientPausedIterator) Error() error {
+func (it *InboxPausedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientPausedIterator) Close() error {
+func (it *InboxPausedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientPaused represents a Paused event raised by the ShastaInboxClient contract.
-type ShastaInboxClientPaused struct {
+// InboxPaused represents a Paused event raised by the Inbox contract.
+type InboxPaused struct {
 	Account common.Address
 	Raw     types.Log // Blockchain specific contextual infos
 }
@@ -2826,21 +2826,21 @@ type ShastaInboxClientPaused struct {
 // FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
 //
 // Solidity: event Paused(address account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterPaused(opts *bind.FilterOpts) (*ShastaInboxClientPausedIterator, error) {
+func (_Inbox *InboxFilterer) FilterPaused(opts *bind.FilterOpts) (*InboxPausedIterator, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Paused")
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Paused")
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientPausedIterator{contract: _ShastaInboxClient.contract, event: "Paused", logs: logs, sub: sub}, nil
+	return &InboxPausedIterator{contract: _Inbox.contract, event: "Paused", logs: logs, sub: sub}, nil
 }
 
 // WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
 //
 // Solidity: event Paused(address account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientPaused) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *InboxPaused) (event.Subscription, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Paused")
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Paused")
 	if err != nil {
 		return nil, err
 	}
@@ -2850,8 +2850,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchPaused(opts *bind.Watc
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientPaused)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "Paused", log); err != nil {
+				event := new(InboxPaused)
+				if err := _Inbox.contract.UnpackLog(event, "Paused", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2875,18 +2875,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchPaused(opts *bind.Watc
 // ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
 //
 // Solidity: event Paused(address account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParsePaused(log types.Log) (*ShastaInboxClientPaused, error) {
-	event := new(ShastaInboxClientPaused)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "Paused", log); err != nil {
+func (_Inbox *InboxFilterer) ParsePaused(log types.Log) (*InboxPaused, error) {
+	event := new(InboxPaused)
+	if err := _Inbox.contract.UnpackLog(event, "Paused", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientProposedIterator is returned from FilterProposed and is used to iterate over the raw logs and unpacked data for Proposed events raised by the ShastaInboxClient contract.
-type ShastaInboxClientProposedIterator struct {
-	Event *ShastaInboxClientProposed // Event containing the contract specifics and raw log
+// InboxProposedIterator is returned from FilterProposed and is used to iterate over the raw logs and unpacked data for Proposed events raised by the Inbox contract.
+type InboxProposedIterator struct {
+	Event *InboxProposed // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -2900,7 +2900,7 @@ type ShastaInboxClientProposedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientProposedIterator) Next() bool {
+func (it *InboxProposedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -2909,7 +2909,7 @@ func (it *ShastaInboxClientProposedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientProposed)
+			it.Event = new(InboxProposed)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -2924,7 +2924,7 @@ func (it *ShastaInboxClientProposedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientProposed)
+		it.Event = new(InboxProposed)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -2940,19 +2940,19 @@ func (it *ShastaInboxClientProposedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientProposedIterator) Error() error {
+func (it *InboxProposedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientProposedIterator) Close() error {
+func (it *InboxProposedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientProposed represents a Proposed event raised by the ShastaInboxClient contract.
-type ShastaInboxClientProposed struct {
+// InboxProposed represents a Proposed event raised by the Inbox contract.
+type InboxProposed struct {
 	Id                             *big.Int
 	Proposer                       common.Address
 	ParentProposalHash             [32]byte
@@ -2965,7 +2965,7 @@ type ShastaInboxClientProposed struct {
 // FilterProposed is a free log retrieval operation binding the contract event 0x7c4c4523e17533e451df15762a093e0693a2cd8b279fe54c6cd3777ed5771213.
 //
 // Solidity: event Proposed(uint48 indexed id, address indexed proposer, bytes32 parentProposalHash, uint48 endOfSubmissionWindowTimestamp, uint8 basefeeSharingPctg, (bool,(bytes32[],uint24,uint48))[] sources)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterProposed(opts *bind.FilterOpts, id []*big.Int, proposer []common.Address) (*ShastaInboxClientProposedIterator, error) {
+func (_Inbox *InboxFilterer) FilterProposed(opts *bind.FilterOpts, id []*big.Int, proposer []common.Address) (*InboxProposedIterator, error) {
 
 	var idRule []interface{}
 	for _, idItem := range id {
@@ -2976,17 +2976,17 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterProposed(opts *bind.F
 		proposerRule = append(proposerRule, proposerItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Proposed", idRule, proposerRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Proposed", idRule, proposerRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientProposedIterator{contract: _ShastaInboxClient.contract, event: "Proposed", logs: logs, sub: sub}, nil
+	return &InboxProposedIterator{contract: _Inbox.contract, event: "Proposed", logs: logs, sub: sub}, nil
 }
 
 // WatchProposed is a free log subscription operation binding the contract event 0x7c4c4523e17533e451df15762a093e0693a2cd8b279fe54c6cd3777ed5771213.
 //
 // Solidity: event Proposed(uint48 indexed id, address indexed proposer, bytes32 parentProposalHash, uint48 endOfSubmissionWindowTimestamp, uint8 basefeeSharingPctg, (bool,(bytes32[],uint24,uint48))[] sources)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProposed(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientProposed, id []*big.Int, proposer []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchProposed(opts *bind.WatchOpts, sink chan<- *InboxProposed, id []*big.Int, proposer []common.Address) (event.Subscription, error) {
 
 	var idRule []interface{}
 	for _, idItem := range id {
@@ -2997,7 +2997,7 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProposed(opts *bind.Wa
 		proposerRule = append(proposerRule, proposerItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Proposed", idRule, proposerRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Proposed", idRule, proposerRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3007,8 +3007,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProposed(opts *bind.Wa
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientProposed)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "Proposed", log); err != nil {
+				event := new(InboxProposed)
+				if err := _Inbox.contract.UnpackLog(event, "Proposed", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3032,18 +3032,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProposed(opts *bind.Wa
 // ParseProposed is a log parse operation binding the contract event 0x7c4c4523e17533e451df15762a093e0693a2cd8b279fe54c6cd3777ed5771213.
 //
 // Solidity: event Proposed(uint48 indexed id, address indexed proposer, bytes32 parentProposalHash, uint48 endOfSubmissionWindowTimestamp, uint8 basefeeSharingPctg, (bool,(bytes32[],uint24,uint48))[] sources)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseProposed(log types.Log) (*ShastaInboxClientProposed, error) {
-	event := new(ShastaInboxClientProposed)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "Proposed", log); err != nil {
+func (_Inbox *InboxFilterer) ParseProposed(log types.Log) (*InboxProposed, error) {
+	event := new(InboxProposed)
+	if err := _Inbox.contract.UnpackLog(event, "Proposed", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientProvedIterator is returned from FilterProved and is used to iterate over the raw logs and unpacked data for Proved events raised by the ShastaInboxClient contract.
-type ShastaInboxClientProvedIterator struct {
-	Event *ShastaInboxClientProved // Event containing the contract specifics and raw log
+// InboxProvedIterator is returned from FilterProved and is used to iterate over the raw logs and unpacked data for Proved events raised by the Inbox contract.
+type InboxProvedIterator struct {
+	Event *InboxProved // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3057,7 +3057,7 @@ type ShastaInboxClientProvedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientProvedIterator) Next() bool {
+func (it *InboxProvedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3066,7 +3066,7 @@ func (it *ShastaInboxClientProvedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientProved)
+			it.Event = new(InboxProved)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3081,7 +3081,7 @@ func (it *ShastaInboxClientProvedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientProved)
+		it.Event = new(InboxProved)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3097,19 +3097,19 @@ func (it *ShastaInboxClientProvedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientProvedIterator) Error() error {
+func (it *InboxProvedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientProvedIterator) Close() error {
+func (it *InboxProvedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientProved represents a Proved event raised by the ShastaInboxClient contract.
-type ShastaInboxClientProved struct {
+// InboxProved represents a Proved event raised by the Inbox contract.
+type InboxProved struct {
 	FirstProposalId    *big.Int
 	FirstNewProposalId *big.Int
 	LastProposalId     *big.Int
@@ -3120,31 +3120,31 @@ type ShastaInboxClientProved struct {
 // FilterProved is a free log retrieval operation binding the contract event 0xa274dcaff3629ec7d69d144038e97732516ff306fcbf8a2bc9423d106779a2f0.
 //
 // Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterProved(opts *bind.FilterOpts, actualProver []common.Address) (*ShastaInboxClientProvedIterator, error) {
+func (_Inbox *InboxFilterer) FilterProved(opts *bind.FilterOpts, actualProver []common.Address) (*InboxProvedIterator, error) {
 
 	var actualProverRule []interface{}
 	for _, actualProverItem := range actualProver {
 		actualProverRule = append(actualProverRule, actualProverItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Proved", actualProverRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Proved", actualProverRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientProvedIterator{contract: _ShastaInboxClient.contract, event: "Proved", logs: logs, sub: sub}, nil
+	return &InboxProvedIterator{contract: _Inbox.contract, event: "Proved", logs: logs, sub: sub}, nil
 }
 
 // WatchProved is a free log subscription operation binding the contract event 0xa274dcaff3629ec7d69d144038e97732516ff306fcbf8a2bc9423d106779a2f0.
 //
 // Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProved(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientProved, actualProver []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchProved(opts *bind.WatchOpts, sink chan<- *InboxProved, actualProver []common.Address) (event.Subscription, error) {
 
 	var actualProverRule []interface{}
 	for _, actualProverItem := range actualProver {
 		actualProverRule = append(actualProverRule, actualProverItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Proved", actualProverRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Proved", actualProverRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3154,8 +3154,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProved(opts *bind.Watc
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientProved)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "Proved", log); err != nil {
+				event := new(InboxProved)
+				if err := _Inbox.contract.UnpackLog(event, "Proved", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3179,18 +3179,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchProved(opts *bind.Watc
 // ParseProved is a log parse operation binding the contract event 0xa274dcaff3629ec7d69d144038e97732516ff306fcbf8a2bc9423d106779a2f0.
 //
 // Solidity: event Proved(uint48 firstProposalId, uint48 firstNewProposalId, uint48 lastProposalId, address indexed actualProver)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseProved(log types.Log) (*ShastaInboxClientProved, error) {
-	event := new(ShastaInboxClientProved)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "Proved", log); err != nil {
+func (_Inbox *InboxFilterer) ParseProved(log types.Log) (*InboxProved, error) {
+	event := new(InboxProved)
+	if err := _Inbox.contract.UnpackLog(event, "Proved", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the ShastaInboxClient contract.
-type ShastaInboxClientUnpausedIterator struct {
-	Event *ShastaInboxClientUnpaused // Event containing the contract specifics and raw log
+// InboxUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the Inbox contract.
+type InboxUnpausedIterator struct {
+	Event *InboxUnpaused // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3204,7 +3204,7 @@ type ShastaInboxClientUnpausedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientUnpausedIterator) Next() bool {
+func (it *InboxUnpausedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3213,7 +3213,7 @@ func (it *ShastaInboxClientUnpausedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientUnpaused)
+			it.Event = new(InboxUnpaused)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3228,7 +3228,7 @@ func (it *ShastaInboxClientUnpausedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientUnpaused)
+		it.Event = new(InboxUnpaused)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3244,19 +3244,19 @@ func (it *ShastaInboxClientUnpausedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientUnpausedIterator) Error() error {
+func (it *InboxUnpausedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientUnpausedIterator) Close() error {
+func (it *InboxUnpausedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientUnpaused represents a Unpaused event raised by the ShastaInboxClient contract.
-type ShastaInboxClientUnpaused struct {
+// InboxUnpaused represents a Unpaused event raised by the Inbox contract.
+type InboxUnpaused struct {
 	Account common.Address
 	Raw     types.Log // Blockchain specific contextual infos
 }
@@ -3264,21 +3264,21 @@ type ShastaInboxClientUnpaused struct {
 // FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
 //
 // Solidity: event Unpaused(address account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterUnpaused(opts *bind.FilterOpts) (*ShastaInboxClientUnpausedIterator, error) {
+func (_Inbox *InboxFilterer) FilterUnpaused(opts *bind.FilterOpts) (*InboxUnpausedIterator, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Unpaused")
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Unpaused")
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientUnpausedIterator{contract: _ShastaInboxClient.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+	return &InboxUnpausedIterator{contract: _Inbox.contract, event: "Unpaused", logs: logs, sub: sub}, nil
 }
 
 // WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
 //
 // Solidity: event Unpaused(address account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientUnpaused) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *InboxUnpaused) (event.Subscription, error) {
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Unpaused")
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Unpaused")
 	if err != nil {
 		return nil, err
 	}
@@ -3288,8 +3288,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchUnpaused(opts *bind.Wa
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientUnpaused)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "Unpaused", log); err != nil {
+				event := new(InboxUnpaused)
+				if err := _Inbox.contract.UnpackLog(event, "Unpaused", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3313,18 +3313,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchUnpaused(opts *bind.Wa
 // ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
 //
 // Solidity: event Unpaused(address account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseUnpaused(log types.Log) (*ShastaInboxClientUnpaused, error) {
-	event := new(ShastaInboxClientUnpaused)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "Unpaused", log); err != nil {
+func (_Inbox *InboxFilterer) ParseUnpaused(log types.Log) (*InboxUnpaused, error) {
+	event := new(InboxUnpaused)
+	if err := _Inbox.contract.UnpackLog(event, "Unpaused", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the ShastaInboxClient contract.
-type ShastaInboxClientUpgradedIterator struct {
-	Event *ShastaInboxClientUpgraded // Event containing the contract specifics and raw log
+// InboxUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the Inbox contract.
+type InboxUpgradedIterator struct {
+	Event *InboxUpgraded // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3338,7 +3338,7 @@ type ShastaInboxClientUpgradedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientUpgradedIterator) Next() bool {
+func (it *InboxUpgradedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3347,7 +3347,7 @@ func (it *ShastaInboxClientUpgradedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientUpgraded)
+			it.Event = new(InboxUpgraded)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3362,7 +3362,7 @@ func (it *ShastaInboxClientUpgradedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientUpgraded)
+		it.Event = new(InboxUpgraded)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3378,19 +3378,19 @@ func (it *ShastaInboxClientUpgradedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientUpgradedIterator) Error() error {
+func (it *InboxUpgradedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientUpgradedIterator) Close() error {
+func (it *InboxUpgradedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientUpgraded represents a Upgraded event raised by the ShastaInboxClient contract.
-type ShastaInboxClientUpgraded struct {
+// InboxUpgraded represents a Upgraded event raised by the Inbox contract.
+type InboxUpgraded struct {
 	Implementation common.Address
 	Raw            types.Log // Blockchain specific contextual infos
 }
@@ -3398,31 +3398,31 @@ type ShastaInboxClientUpgraded struct {
 // FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
 //
 // Solidity: event Upgraded(address indexed implementation)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*ShastaInboxClientUpgradedIterator, error) {
+func (_Inbox *InboxFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*InboxUpgradedIterator, error) {
 
 	var implementationRule []interface{}
 	for _, implementationItem := range implementation {
 		implementationRule = append(implementationRule, implementationItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "Upgraded", implementationRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientUpgradedIterator{contract: _ShastaInboxClient.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+	return &InboxUpgradedIterator{contract: _Inbox.contract, event: "Upgraded", logs: logs, sub: sub}, nil
 }
 
 // WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
 //
 // Solidity: event Upgraded(address indexed implementation)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientUpgraded, implementation []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *InboxUpgraded, implementation []common.Address) (event.Subscription, error) {
 
 	var implementationRule []interface{}
 	for _, implementationItem := range implementation {
 		implementationRule = append(implementationRule, implementationItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "Upgraded", implementationRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3432,8 +3432,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchUpgraded(opts *bind.Wa
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientUpgraded)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "Upgraded", log); err != nil {
+				event := new(InboxUpgraded)
+				if err := _Inbox.contract.UnpackLog(event, "Upgraded", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3457,18 +3457,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchUpgraded(opts *bind.Wa
 // ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
 //
 // Solidity: event Upgraded(address indexed implementation)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseUpgraded(log types.Log) (*ShastaInboxClientUpgraded, error) {
-	event := new(ShastaInboxClientUpgraded)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "Upgraded", log); err != nil {
+func (_Inbox *InboxFilterer) ParseUpgraded(log types.Log) (*InboxUpgraded, error) {
+	event := new(InboxUpgraded)
+	if err := _Inbox.contract.UnpackLog(event, "Upgraded", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientWithdrawalCancelledIterator is returned from FilterWithdrawalCancelled and is used to iterate over the raw logs and unpacked data for WithdrawalCancelled events raised by the ShastaInboxClient contract.
-type ShastaInboxClientWithdrawalCancelledIterator struct {
-	Event *ShastaInboxClientWithdrawalCancelled // Event containing the contract specifics and raw log
+// InboxWithdrawalCancelledIterator is returned from FilterWithdrawalCancelled and is used to iterate over the raw logs and unpacked data for WithdrawalCancelled events raised by the Inbox contract.
+type InboxWithdrawalCancelledIterator struct {
+	Event *InboxWithdrawalCancelled // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3482,7 +3482,7 @@ type ShastaInboxClientWithdrawalCancelledIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientWithdrawalCancelledIterator) Next() bool {
+func (it *InboxWithdrawalCancelledIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3491,7 +3491,7 @@ func (it *ShastaInboxClientWithdrawalCancelledIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientWithdrawalCancelled)
+			it.Event = new(InboxWithdrawalCancelled)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3506,7 +3506,7 @@ func (it *ShastaInboxClientWithdrawalCancelledIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientWithdrawalCancelled)
+		it.Event = new(InboxWithdrawalCancelled)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3522,19 +3522,19 @@ func (it *ShastaInboxClientWithdrawalCancelledIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientWithdrawalCancelledIterator) Error() error {
+func (it *InboxWithdrawalCancelledIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientWithdrawalCancelledIterator) Close() error {
+func (it *InboxWithdrawalCancelledIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientWithdrawalCancelled represents a WithdrawalCancelled event raised by the ShastaInboxClient contract.
-type ShastaInboxClientWithdrawalCancelled struct {
+// InboxWithdrawalCancelled represents a WithdrawalCancelled event raised by the Inbox contract.
+type InboxWithdrawalCancelled struct {
 	Account common.Address
 	Raw     types.Log // Blockchain specific contextual infos
 }
@@ -3542,31 +3542,31 @@ type ShastaInboxClientWithdrawalCancelled struct {
 // FilterWithdrawalCancelled is a free log retrieval operation binding the contract event 0xc51fdb96728de385ec7859819e3997bc618362ef0dbca0ad051d856866cda3db.
 //
 // Solidity: event WithdrawalCancelled(address indexed account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterWithdrawalCancelled(opts *bind.FilterOpts, account []common.Address) (*ShastaInboxClientWithdrawalCancelledIterator, error) {
+func (_Inbox *InboxFilterer) FilterWithdrawalCancelled(opts *bind.FilterOpts, account []common.Address) (*InboxWithdrawalCancelledIterator, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "WithdrawalCancelled", accountRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "WithdrawalCancelled", accountRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientWithdrawalCancelledIterator{contract: _ShastaInboxClient.contract, event: "WithdrawalCancelled", logs: logs, sub: sub}, nil
+	return &InboxWithdrawalCancelledIterator{contract: _Inbox.contract, event: "WithdrawalCancelled", logs: logs, sub: sub}, nil
 }
 
 // WatchWithdrawalCancelled is a free log subscription operation binding the contract event 0xc51fdb96728de385ec7859819e3997bc618362ef0dbca0ad051d856866cda3db.
 //
 // Solidity: event WithdrawalCancelled(address indexed account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchWithdrawalCancelled(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientWithdrawalCancelled, account []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchWithdrawalCancelled(opts *bind.WatchOpts, sink chan<- *InboxWithdrawalCancelled, account []common.Address) (event.Subscription, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "WithdrawalCancelled", accountRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "WithdrawalCancelled", accountRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3576,8 +3576,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchWithdrawalCancelled(op
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientWithdrawalCancelled)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "WithdrawalCancelled", log); err != nil {
+				event := new(InboxWithdrawalCancelled)
+				if err := _Inbox.contract.UnpackLog(event, "WithdrawalCancelled", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3601,18 +3601,18 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchWithdrawalCancelled(op
 // ParseWithdrawalCancelled is a log parse operation binding the contract event 0xc51fdb96728de385ec7859819e3997bc618362ef0dbca0ad051d856866cda3db.
 //
 // Solidity: event WithdrawalCancelled(address indexed account)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseWithdrawalCancelled(log types.Log) (*ShastaInboxClientWithdrawalCancelled, error) {
-	event := new(ShastaInboxClientWithdrawalCancelled)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "WithdrawalCancelled", log); err != nil {
+func (_Inbox *InboxFilterer) ParseWithdrawalCancelled(log types.Log) (*InboxWithdrawalCancelled, error) {
+	event := new(InboxWithdrawalCancelled)
+	if err := _Inbox.contract.UnpackLog(event, "WithdrawalCancelled", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
 	return event, nil
 }
 
-// ShastaInboxClientWithdrawalRequestedIterator is returned from FilterWithdrawalRequested and is used to iterate over the raw logs and unpacked data for WithdrawalRequested events raised by the ShastaInboxClient contract.
-type ShastaInboxClientWithdrawalRequestedIterator struct {
-	Event *ShastaInboxClientWithdrawalRequested // Event containing the contract specifics and raw log
+// InboxWithdrawalRequestedIterator is returned from FilterWithdrawalRequested and is used to iterate over the raw logs and unpacked data for WithdrawalRequested events raised by the Inbox contract.
+type InboxWithdrawalRequestedIterator struct {
+	Event *InboxWithdrawalRequested // Event containing the contract specifics and raw log
 
 	contract *bind.BoundContract // Generic contract to use for unpacking event data
 	event    string              // Event name to use for unpacking event data
@@ -3626,7 +3626,7 @@ type ShastaInboxClientWithdrawalRequestedIterator struct {
 // Next advances the iterator to the subsequent event, returning whether there
 // are any more events found. In case of a retrieval or parsing error, false is
 // returned and Error() can be queried for the exact failure.
-func (it *ShastaInboxClientWithdrawalRequestedIterator) Next() bool {
+func (it *InboxWithdrawalRequestedIterator) Next() bool {
 	// If the iterator failed, stop iterating
 	if it.fail != nil {
 		return false
@@ -3635,7 +3635,7 @@ func (it *ShastaInboxClientWithdrawalRequestedIterator) Next() bool {
 	if it.done {
 		select {
 		case log := <-it.logs:
-			it.Event = new(ShastaInboxClientWithdrawalRequested)
+			it.Event = new(InboxWithdrawalRequested)
 			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 				it.fail = err
 				return false
@@ -3650,7 +3650,7 @@ func (it *ShastaInboxClientWithdrawalRequestedIterator) Next() bool {
 	// Iterator still in progress, wait for either a data or an error event
 	select {
 	case log := <-it.logs:
-		it.Event = new(ShastaInboxClientWithdrawalRequested)
+		it.Event = new(InboxWithdrawalRequested)
 		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
 			it.fail = err
 			return false
@@ -3666,19 +3666,19 @@ func (it *ShastaInboxClientWithdrawalRequestedIterator) Next() bool {
 }
 
 // Error returns any retrieval or parsing error occurred during filtering.
-func (it *ShastaInboxClientWithdrawalRequestedIterator) Error() error {
+func (it *InboxWithdrawalRequestedIterator) Error() error {
 	return it.fail
 }
 
 // Close terminates the iteration process, releasing any pending underlying
 // resources.
-func (it *ShastaInboxClientWithdrawalRequestedIterator) Close() error {
+func (it *InboxWithdrawalRequestedIterator) Close() error {
 	it.sub.Unsubscribe()
 	return nil
 }
 
-// ShastaInboxClientWithdrawalRequested represents a WithdrawalRequested event raised by the ShastaInboxClient contract.
-type ShastaInboxClientWithdrawalRequested struct {
+// InboxWithdrawalRequested represents a WithdrawalRequested event raised by the Inbox contract.
+type InboxWithdrawalRequested struct {
 	Account        common.Address
 	WithdrawableAt *big.Int
 	Raw            types.Log // Blockchain specific contextual infos
@@ -3687,31 +3687,31 @@ type ShastaInboxClientWithdrawalRequested struct {
 // FilterWithdrawalRequested is a free log retrieval operation binding the contract event 0x3bbe41cfdd142e0f9b2224dac18c6efd2a6966e35a9ec23ab57ce63a60b33604.
 //
 // Solidity: event WithdrawalRequested(address indexed account, uint48 withdrawableAt)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) FilterWithdrawalRequested(opts *bind.FilterOpts, account []common.Address) (*ShastaInboxClientWithdrawalRequestedIterator, error) {
+func (_Inbox *InboxFilterer) FilterWithdrawalRequested(opts *bind.FilterOpts, account []common.Address) (*InboxWithdrawalRequestedIterator, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.FilterLogs(opts, "WithdrawalRequested", accountRule)
+	logs, sub, err := _Inbox.contract.FilterLogs(opts, "WithdrawalRequested", accountRule)
 	if err != nil {
 		return nil, err
 	}
-	return &ShastaInboxClientWithdrawalRequestedIterator{contract: _ShastaInboxClient.contract, event: "WithdrawalRequested", logs: logs, sub: sub}, nil
+	return &InboxWithdrawalRequestedIterator{contract: _Inbox.contract, event: "WithdrawalRequested", logs: logs, sub: sub}, nil
 }
 
 // WatchWithdrawalRequested is a free log subscription operation binding the contract event 0x3bbe41cfdd142e0f9b2224dac18c6efd2a6966e35a9ec23ab57ce63a60b33604.
 //
 // Solidity: event WithdrawalRequested(address indexed account, uint48 withdrawableAt)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchWithdrawalRequested(opts *bind.WatchOpts, sink chan<- *ShastaInboxClientWithdrawalRequested, account []common.Address) (event.Subscription, error) {
+func (_Inbox *InboxFilterer) WatchWithdrawalRequested(opts *bind.WatchOpts, sink chan<- *InboxWithdrawalRequested, account []common.Address) (event.Subscription, error) {
 
 	var accountRule []interface{}
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
 
-	logs, sub, err := _ShastaInboxClient.contract.WatchLogs(opts, "WithdrawalRequested", accountRule)
+	logs, sub, err := _Inbox.contract.WatchLogs(opts, "WithdrawalRequested", accountRule)
 	if err != nil {
 		return nil, err
 	}
@@ -3721,8 +3721,8 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchWithdrawalRequested(op
 			select {
 			case log := <-logs:
 				// New log arrived, parse the event and forward to the user
-				event := new(ShastaInboxClientWithdrawalRequested)
-				if err := _ShastaInboxClient.contract.UnpackLog(event, "WithdrawalRequested", log); err != nil {
+				event := new(InboxWithdrawalRequested)
+				if err := _Inbox.contract.UnpackLog(event, "WithdrawalRequested", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -3746,9 +3746,9 @@ func (_ShastaInboxClient *ShastaInboxClientFilterer) WatchWithdrawalRequested(op
 // ParseWithdrawalRequested is a log parse operation binding the contract event 0x3bbe41cfdd142e0f9b2224dac18c6efd2a6966e35a9ec23ab57ce63a60b33604.
 //
 // Solidity: event WithdrawalRequested(address indexed account, uint48 withdrawableAt)
-func (_ShastaInboxClient *ShastaInboxClientFilterer) ParseWithdrawalRequested(log types.Log) (*ShastaInboxClientWithdrawalRequested, error) {
-	event := new(ShastaInboxClientWithdrawalRequested)
-	if err := _ShastaInboxClient.contract.UnpackLog(event, "WithdrawalRequested", log); err != nil {
+func (_Inbox *InboxFilterer) ParseWithdrawalRequested(log types.Log) (*InboxWithdrawalRequested, error) {
+	event := new(InboxWithdrawalRequested)
+	if err := _Inbox.contract.UnpackLog(event, "WithdrawalRequested", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/packages/eventindexer/indexer/get_block_by_timestamp.go
+++ b/packages/eventindexer/indexer/get_block_by_timestamp.go
@@ -1,0 +1,80 @@
+package indexer
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/pkg/errors"
+)
+
+const avgBlockTime = 12 // Ethereum average block time in seconds
+
+// getBlockByTimestamp returns the last block whose timestamp is <= the target timestamp.
+// It uses estimation based on average block time (~12s) followed by binary search
+// for efficient lookup with minimal RPC calls.
+func (i *Indexer) getBlockByTimestamp(ctx context.Context, targetTimestamp uint64) (uint64, error) {
+	// 1. Get latest block header
+	latestHeader, err := i.ethClient.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return 0, errors.Wrap(err, "ethClient.HeaderByNumber(latest)")
+	}
+
+	latestBlock := latestHeader.Number.Uint64()
+	latestTimestamp := latestHeader.Time
+
+	// 2. Boundary checks
+	if targetTimestamp >= latestTimestamp {
+		return latestBlock, nil
+	}
+
+	genesisHeader, err := i.ethClient.HeaderByNumber(ctx, big.NewInt(1))
+	if err != nil {
+		return 0, errors.Wrap(err, "ethClient.HeaderByNumber(block 1)")
+	}
+
+	if targetTimestamp < genesisHeader.Time {
+		return 1, nil
+	}
+
+	// 3. Estimate target block
+	timeDiff := latestTimestamp - targetTimestamp
+	estimatedBlocksBack := timeDiff / avgBlockTime
+
+	// Prevent underflow: if estimation suggests going back further than the chain exists,
+	// clamp to block 1. Binary search will still find the correct block.
+	var estimatedBlock uint64 = 1
+	if estimatedBlocksBack < latestBlock {
+		estimatedBlock = latestBlock - estimatedBlocksBack
+	}
+
+	// 4. Define search range
+	searchMargin := uint64(1000)
+	low := uint64(1)
+
+	if estimatedBlock > searchMargin {
+		low = estimatedBlock - searchMargin
+	}
+
+	high := min(estimatedBlock+searchMargin, latestBlock)
+
+	// 5. Binary search
+	result := low
+
+	for low <= high {
+		mid := low + (high-low)/2
+
+		midHeader, err := i.ethClient.HeaderByNumber(ctx, new(big.Int).SetUint64(mid))
+		if err != nil {
+			return 0, errors.Wrap(err, "ethClient.HeaderByNumber(mid)")
+		}
+
+		if midHeader.Time <= targetTimestamp {
+			result = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+
+	return result, nil
+}

--- a/packages/eventindexer/indexer/set_initial_processing_block_height.go
+++ b/packages/eventindexer/indexer/set_initial_processing_block_height.go
@@ -78,7 +78,6 @@ func (i *Indexer) getGenesisBlockHeight(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, errors.Wrap(err, "shastaInbox.ActivationTimestamp")
 	}
-
 	blockNum, err := i.getBlockByTimestamp(ctx, ts.Uint64())
 	if err != nil {
 		return 0, errors.Wrap(err, "getBlockByTimestamp")

--- a/packages/eventindexer/indexer/set_initial_processing_block_height.go
+++ b/packages/eventindexer/indexer/set_initial_processing_block_height.go
@@ -78,6 +78,7 @@ func (i *Indexer) getGenesisBlockHeight(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, errors.Wrap(err, "shastaInbox.ActivationTimestamp")
 	}
+
 	blockNum, err := i.getBlockByTimestamp(ctx, ts.Uint64())
 	if err != nil {
 		return 0, errors.Wrap(err, "getBlockByTimestamp")


### PR DESCRIPTION
  ## Summary
  - Refactored `setInitialIndexingBlockByMode` to use a cleaner early-return pattern
  - Extracted `getGenesisBlockHeight()` function that tries contract versions in order (v1 → v2 → v3 → v4)
  - Added `getBlockByTimestamp()` binary search function for v4 (Shasta) support
  - Shasta inbox uses `ActivationTimestamp` to determine starting block, eliminating beacon RPC dependency

  ## Changes
  - `indexer/set_initial_processing_block_height.go`: Refactored with extracted helper function
  - `indexer/get_block_by_timestamp.go`: New file with binary search implementation

  ## Related
  - Mirrors relayer changes from #21170