### PR TITLE
fix(taiko-client-rs): remove anchor gas subtraction from engine params gas limit

### DIFF
--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -1,8 +1,7 @@
 //! Core proposer implementation for submitting block proposals.
 
-use alethia_reth_consensus::{
-    eip4396::{SHASTA_INITIAL_BASE_FEE, calculate_next_block_eip4396_base_fee},
-    validation::ANCHOR_V3_V4_GAS_LIMIT,
+use alethia_reth_consensus::eip4396::{
+    SHASTA_INITIAL_BASE_FEE, calculate_next_block_eip4396_base_fee,
 };
 use alethia_reth_primitives::{
     decode_shasta_proposal_id,
@@ -58,16 +57,6 @@ pub struct EnginePayloadParams {
     pub timestamp: u64,
     /// The gas limit for the block.
     pub gas_limit: u64,
-}
-
-/// Compute the effective gas limit for the manifest by removing the anchor transaction gas.
-/// Genesis block (parent_block_number == 0) uses the full gas limit since there's no anchor.
-fn effective_gas_limit(parent_block_number: u64, parent_gas_limit: u64) -> u64 {
-    if parent_block_number == 0 {
-        parent_gas_limit
-    } else {
-        parent_gas_limit.saturating_sub(ANCHOR_V3_V4_GAS_LIMIT)
-    }
 }
 
 // Proposer keeps proposing new transactions from L2 execution engine's tx pool at a fixed interval.
@@ -389,7 +378,7 @@ impl Proposer {
         let engine_params = EnginePayloadParams {
             anchor_block_number,
             timestamp,
-            gas_limit: effective_gas_limit(parent.header.number, parent.header.gas_limit),
+            gas_limit: parent.header.gas_limit,
         };
 
         Ok((payload_attributes, engine_params))

--- a/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
@@ -1,5 +1,6 @@
 //! Transaction builder for constructing proposal transactions.
 
+use alethia_reth_consensus::validation::ANCHOR_V3_V4_GAS_LIMIT;
 use alloy::{
     consensus::{BlobTransactionSidecar, SidecarBuilder},
     primitives::{
@@ -48,8 +49,14 @@ impl ShastaProposalTransactionBuilder {
         engine_params: Option<EnginePayloadParams>,
     ) -> Result<TransactionRequest> {
         // Use provided engine params or derive defaults.
+        // For engine mode, subtract anchor gas from the manifest gas limit since the
+        // driver's validation expects gas_limit = parent_gas_limit - anchor_gas.
         let (anchor_block_number, timestamp, gas_limit) = match engine_params {
-            Some(params) => (params.anchor_block_number, params.timestamp, params.gas_limit),
+            Some(params) => (
+                params.anchor_block_number,
+                params.timestamp,
+                params.gas_limit.saturating_sub(ANCHOR_V3_V4_GAS_LIMIT),
+            ),
             None => (
                 self.rpc_provider.l1_provider.get_block_number().await?,
                 current_unix_timestamp(),

--- a/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
@@ -51,6 +51,11 @@ impl ShastaProposalTransactionBuilder {
         // Use provided engine params or derive defaults.
         // For engine mode, subtract anchor gas from the manifest gas limit since the
         // driver's validation expects gas_limit = parent_gas_limit - anchor_gas.
+        //
+        // Note: For the first block after genesis, this subtraction creates a mismatch
+        // with driver validation (which doesn't subtract for genesis parent), causing
+        // a fallback to default manifest. This is acceptable and self-corrects from
+        // the second block onward.
         let (anchor_block_number, timestamp, gas_limit) = match engine_params {
             Some(params) => (
                 params.anchor_block_number,


### PR DESCRIPTION
ref: https://github.com/taikoxyz/alethia-reth/pull/94#discussion_r2713039855

  ## Summary
  - `EnginePayloadParams.gas_limit` now directly inherits the parent block's gas limit
  - `BlockManifest.gas_limit` in proposals subtracts anchor gas to match driver validation

  ## Changes
  - Removed `effective_gas_limit` helper function from `proposer.rs`
  - `EnginePayloadParams.gas_limit` = `parent.header.gas_limit` (direct inheritance)
  - In `transaction_builder.rs`, manifest gas_limit = `engine_params.gas_limit - ANCHOR_V3_V4_GAS_LIMIT`

  ## Rationale
  The driver's `validate_gas_limit` expects the manifest gas_limit to equal `effective_parent_gas_limit`, which is `parent_gas_limit - ANCHOR_V3_V4_GAS_LIMIT` for non-genesis blocks. By having
  `EnginePayloadParams` carry the raw parent gas limit and subtracting anchor gas only when building the manifest, we maintain consistency with driver validation.

  ## Note on First Block Behavior
  In the current integration mode, the first block after genesis will inherit the genesis gas limit (15,000,000). After subtracting anchor gas, the manifest gas_limit becomes ~14,750,000. However, the
  driver's validation uses `effective_parent_gas_limit(0, 15M) = 15M` (no subtraction for genesis parent), causing a bounds mismatch that falls back to the default manifest.

  Starting from the second block, behavior returns to normal because:
  - The parent block already has a proper gas limit in its header
  - Both proposer and driver derive from the same parent header and apply the same anchor gas subtraction

  This edge case on the first block is acceptable for simplicity of implementation.
