### PR TITLE
feat(taiko-client-rs): gate net dependencies for zkvm

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/Cargo.toml
+++ b/packages/taiko-client-rs/crates/protocol/Cargo.toml
@@ -8,9 +8,9 @@ license.workspace = true
 [dependencies]
 # async
 async-trait = { workspace = true }
-tokio = { workspace = true }
-tokio-retry = { workspace = true }
-tokio-stream = { workspace = true }
+tokio = { workspace = true, optional = true }
+tokio-retry = { workspace = true, optional = true }
+tokio-stream = { workspace = true, optional = true }
 
 # observability
 tracing = { workspace = true }
@@ -22,12 +22,12 @@ alloy-contract = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-hardforks = { workspace = true }
 alloy-primitives = { workspace = true, default-features = false }
-alloy-provider = { workspace = true }
+alloy-provider = { workspace = true, optional = true }
 alloy-rlp = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-rpc-types-engine = { workspace = true }
 alloy-sol-types = { workspace = true }
-event-scanner = { workspace = true }
+event-scanner = { workspace = true, optional = true }
 
 # crypto
 k256 = { workspace = true }
@@ -49,4 +49,13 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["std", "std_rng"] }
-tokio = { workspace = true }
+
+[features]
+default = ["net"]
+net = [
+  "tokio",
+  "tokio-retry",
+  "tokio-stream",
+  "alloy-provider",
+  "event-scanner",
+]

--- a/packages/taiko-client-rs/crates/protocol/src/lib.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/lib.rs
@@ -1,8 +1,10 @@
 //! Taiko protocol constants and types.
 
+#[cfg(feature = "net")]
 pub mod preconfirmation;
 pub mod shasta;
 pub mod signer;
+#[cfg(feature = "net")]
 pub mod subscription_source;
 
 pub use signer::{FixedKSigner, FixedKSignerError};

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
@@ -1,5 +1,6 @@
 //! Shasta protocol implementation.
 
+#[cfg(feature = "net")]
 pub mod anchor;
 pub mod blob_coder;
 pub mod constants;
@@ -8,6 +9,7 @@ pub mod manifest;
 pub mod payload_helpers;
 pub mod rpc_methods;
 
+#[cfg(feature = "net")]
 pub use anchor::{AnchorTxConstructor, AnchorTxConstructorError, AnchorV4Input};
 pub use blob_coder::BlobCoder;
 pub use error::{ForkConfigResult, ProtocolError, Result, ShastaForkConfigError};

--- a/packages/taiko-client-rs/crates/protocol/src/signer.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/signer.rs
@@ -200,7 +200,7 @@ impl SignerSync for FixedKSigner {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "net"))]
 mod tests {
     use super::*;
     use k256::Scalar;


### PR DESCRIPTION
## Summary
- gate net-only modules behind the net feature
- make tokio/alloy-provider/event-scanner optional and enabled via net
- keep net as the default feature

## Testing
- cargo check -p protocol --no-default-features
- cargo check -p protocol --features net