### PR TITLE
chore(taiko-client): double-check `sourcePayload.Default` in `InsertBlocksWithManifest`

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
@@ -130,7 +130,7 @@ func (i *Shasta) InsertBlocksWithManifest(
 		// If this is the first block in the batch, we check if the whole batch has been inserted by
 		// trying to fetch the last block header from L2 EE. If it is known in canonical,
 		// we can skip the rest of the blocks, and only update the L1Origin in L2 EE for each block.
-		if j == 0 {
+		if j == 0 && !sourcePayload.Default {
 			log.Debug(
 				"Checking if batch is in canonical chain",
 				"batchID", meta.GetEventData().Id,


### PR DESCRIPTION
Add a double-check of `sourcePayload.Default` in `InsertBlocksWithManifest` for safety, if this is a default manifest, we can just skip the `isKnownInCanonical` check.