### PR TITLE
feat(protocol): introduce `end-of-proposal` flag in `extradata`

### DIFF
--- a/packages/protocol/docs/Derivation.md
+++ b/packages/protocol/docs/Derivation.md
@@ -301,6 +301,7 @@ Metadata encoding into L2 block header fields facilitates efficient peer validat
 | `gasLimit`           | uint256 | `gasLimit`                |
 | `basefeeSharingPctg` | uint8   | First byte in `extraData` |
 | `proposalId`         | uint48  | Bytes 1..6 in `extraData` |
+| `endOfProposalFlag`  | bool    | Byte 7 in `extraData`     |
 
 #### Additional Pre-Execution Block Header Fields
 


### PR DESCRIPTION
## Summary
  - Add `endOfProposalFlag` to the Pre-Execution Block Header metadata table
  - Document placement in `extraData` as byte 7 (immediately after proposalId)
