### PR TITLE
feat(taiko-client): tolerate `ErrProposalLastBlockUncertain`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,6 +143,7 @@ require (
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/herumi/bls-eth-go-binary v1.31.0 // indirect
+	github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect
@@ -263,6 +264,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/status-im/keycard-go v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/supranational/blst v0.3.14 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -457,7 +457,10 @@ func (c *Client) WaitShastaHeader(ctx context.Context, batchID *big.Int) (*types
 		l1Origin, err := c.L2.LastL1OriginByBatchID(ctxWithTimeout, batchID)
 		if err != nil {
 			if err.Error() == eth.ErrProposalLastBlockUncertain.Error() {
-				log.Warn("Proposal last block uncertain, keep retrying", "batchID", batchID)
+				log.Warn(
+					"Proposal last block uncertain, keep retrying",
+					"batchID", batchID,
+				)
 			} else {
 				log.Debug(
 					"Fetch Shasta block header from L2 execution engine not found, keep retrying",

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/params"
@@ -455,11 +456,15 @@ func (c *Client) WaitShastaHeader(ctx context.Context, batchID *big.Int) (*types
 
 		l1Origin, err := c.L2.LastL1OriginByBatchID(ctxWithTimeout, batchID)
 		if err != nil {
-			log.Debug(
-				"Fetch Shasta block header from L2 execution engine not found, keep retrying",
-				"batchID", batchID,
-				"error", err,
-			)
+			if errors.Is(err, eth.ErrProposalLastBlockUncertain) {
+				log.Warn("Proposal last block uncertain, keep retrying", "batchID", batchID)
+			} else {
+				log.Debug(
+					"Fetch Shasta block header from L2 execution engine not found, keep retrying",
+					"batchID", batchID,
+					"error", err,
+				)
+			}
 			continue
 		}
 
@@ -593,7 +598,9 @@ func (c *Client) L2ExecutionEngineSyncProgress(ctx context.Context) (*L2SyncProg
 				ctx,
 				new(big.Int).Sub(coreState.NextProposalId, common.Big1),
 			)
-			if err != nil && err.Error() != ethereum.NotFound.Error() {
+			if err != nil &&
+				err.Error() != ethereum.NotFound.Error() &&
+				err.Error() != eth.ErrProposalLastBlockUncertain.Error() {
 				return err
 			}
 			// If the L1Origin is not found, it means the L2 execution engine has not synced yet,
@@ -778,7 +785,7 @@ func (c *Client) CheckL1Reorg(ctx context.Context, batchID *big.Int, isShastaBat
 			if l1Origin, err = c.L2.LastL1OriginByBatchID(ctxWithTimeout, batchID); err != nil {
 				// If the L2 EE is just synced through P2P, so there is no L1Origin information recorded in
 				// its local database, we skip this check.
-				if err.Error() == ethereum.NotFound.Error() {
+				if err.Error() == ethereum.NotFound.Error() || err.Error() == eth.ErrProposalLastBlockUncertain.Error() {
 					log.Info("L1Origin not found, the L2 execution engine has just synced from P2P network", "batchID", batchID)
 					return result, nil
 				}

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -456,7 +456,7 @@ func (c *Client) WaitShastaHeader(ctx context.Context, batchID *big.Int) (*types
 
 		l1Origin, err := c.L2.LastL1OriginByBatchID(ctxWithTimeout, batchID)
 		if err != nil {
-			if errors.Is(err, eth.ErrProposalLastBlockUncertain) {
+			if err.Error() == eth.ErrProposalLastBlockUncertain.Error() {
 				log.Warn("Proposal last block uncertain, keep retrying", "batchID", batchID)
 			} else {
 				log.Debug(


### PR DESCRIPTION
Ref: https://github.com/taikoxyz/taiko-geth/pull/504
  ## Summary
- Make Shasta sync paths resilient to ErrProposalLastBlockUncertain from the L2 execution engine by retrying or skipping reorg checks instead of failing.
 ## Changes
- Treat eth.ErrProposalLastBlockUncertain as non-fatal in Shasta proposal processing, reorg checks, sync progress, and header waiting.
- Add indirect deps in go.mod (github.com/holiman/billy, github.com/status-im/keycard-go).