### PR TITLE
chore(taiko-client-rs): bump `alethia-reth` and tolerate Shasta origin lookup uncertainty

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,36 +68,39 @@ dependencies = [
 [[package]]
 name = "alethia-reth-block"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=5137cd8aa1a5c1602bd61b0851211dfdf5913c3b#5137cd8aa1a5c1602bd61b0851211dfdf5913c3b"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
  "alethia-reth-primitives",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "reth-chainspec 1.10.0",
+ "op-alloy-flz",
+ "reth-chainspec 1.10.1",
  "reth-ethereum",
- "reth-ethereum-forks 1.10.0",
+ "reth-ethereum-forks 1.10.1",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-payload-primitives",
  "reth-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-revm",
  "reth-rpc-eth-api",
  "reth-storage-errors",
- "revm-database-interface",
+ "reth-transaction-pool",
+ "revm-database-interface 9.0.0",
+ "tracing",
 ]
 
 [[package]]
 name = "alethia-reth-chainspec"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=5137cd8aa1a5c1602bd61b0851211dfdf5913c3b#5137cd8aa1a5c1602bd61b0851211dfdf5913c3b"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -106,10 +109,10 @@ dependencies = [
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "auto_impl",
- "reth-chainspec 1.10.0",
- "reth-ethereum-forks 1.10.0",
+ "reth-chainspec 1.10.1",
+ "reth-ethereum-forks 1.10.1",
  "reth-evm",
- "reth-network-peers 1.10.0",
+ "reth-network-peers 1.10.1",
  "reth-primitives",
  "reth-revm",
  "serde_json",
@@ -118,7 +121,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=5137cd8aa1a5c1602bd61b0851211dfdf5913c3b#5137cd8aa1a5c1602bd61b0851211dfdf5913c3b"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -126,20 +129,20 @@ dependencies = [
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-sol-types",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus",
  "reth-consensus-common",
  "reth-ethereum",
  "reth-ethereum-consensus",
  "reth-execution-types",
  "reth-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
 ]
 
 [[package]]
 name = "alethia-reth-db"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=5137cd8aa1a5c1602bd61b0851211dfdf5913c3b#5137cd8aa1a5c1602bd61b0851211dfdf5913c3b"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-primitives",
@@ -155,20 +158,20 @@ dependencies = [
 [[package]]
 name = "alethia-reth-evm"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=5137cd8aa1a5c1602bd61b0851211dfdf5913c3b#5137cd8aa1a5c1602bd61b0851211dfdf5913c3b"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
 dependencies = [
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "reth-evm",
  "reth-revm",
- "revm-database-interface",
+ "revm-database-interface 9.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "alethia-reth-primitives"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=5137cd8aa1a5c1602bd61b0851211dfdf5913c3b#5137cd8aa1a5c1602bd61b0851211dfdf5913c3b"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -176,14 +179,14 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-engine-local",
  "reth-ethereum",
  "reth-ethereum-engine-primitives",
  "reth-node-api",
  "reth-payload-primitives",
  "reth-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "serde",
  "serde_with",
  "sha2 0.10.9",
@@ -193,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=5137cd8aa1a5c1602bd61b0851211dfdf5913c3b#5137cd8aa1a5c1602bd61b0851211dfdf5913c3b"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -228,7 +231,7 @@ dependencies = [
  "reth-node-core",
  "reth-node-ethereum",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -447,12 +450,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.1.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926b2c0d34e641cf8b17bf54ce50fda16715b9f68ad878fa6128bae410c6f890"
+checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
@@ -500,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.25.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ccc4c702c840148af1ce784cc5c6ed9274a020ef32417c5b1dbeab8c317673"
+checksum = "a96827207397445a919a8adc49289b53cc74e48e460411740bba31cec2fc307d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -514,8 +518,8 @@ dependencies = [
  "auto_impl",
  "derive_more",
  "op-alloy",
- "op-revm",
- "revm 33.1.0",
+ "op-revm 15.0.0",
+ "revm 34.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -1787,12 +1791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "az"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,13 +2304,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2320,12 +2328,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.2",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -3052,7 +3060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3380,7 +3388,7 @@ dependencies = [
  "proposer",
  "protocol",
  "rand 0.8.5",
- "reth-ipc",
+ "reth-ipc 1.10.0",
  "rpc",
  "secp256k1 0.30.0",
  "serde",
@@ -4226,16 +4234,6 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5317,7 +5315,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "derive_more",
- "op-revm",
+ "op-revm 14.1.0",
  "serde",
  "serde_repr",
  "thiserror 2.0.17",
@@ -6856,6 +6854,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-revm"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
+dependencies = [
+ "auto_impl",
+ "revm 34.0.0",
+ "serde",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8092,14 +8101,14 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
  "clap",
  "eyre",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-cli-runner",
  "reth-cli-util",
  "reth-consensus",
@@ -8130,7 +8139,7 @@ dependencies = [
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-tasks",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "reth-transaction-pool",
  "tokio",
  "tracing",
@@ -8138,8 +8147,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8148,11 +8157,11 @@ dependencies = [
  "futures-util",
  "metrics 0.24.3",
  "reth-chain-state",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
@@ -8162,8 +8171,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8173,16 +8182,16 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-api",
  "reth-trie",
- "revm-database",
- "revm-state",
+ "revm-database 10.0.0",
+ "revm-state 9.0.0",
  "serde",
  "tokio",
  "tokio-stream",
@@ -8211,28 +8220,28 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
  "auto_impl",
  "derive_more",
- "reth-ethereum-forks 1.10.0",
- "reth-network-peers 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-ethereum-forks 1.10.1",
+ "reth-network-peers 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-cli"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8245,8 +8254,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8267,7 +8276,7 @@ dependencies = [
  "metrics 0.24.3",
  "ratatui",
  "reqwest",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-cli",
  "reth-cli-runner",
  "reth-cli-util",
@@ -8278,7 +8287,7 @@ dependencies = [
  "reth-db-api",
  "reth-db-common",
  "reth-discv4",
- "reth-discv5 1.10.0",
+ "reth-discv5 1.10.1",
  "reth-downloaders",
  "reth-ecies",
  "reth-era",
@@ -8292,13 +8301,13 @@ dependencies = [
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers 1.10.0",
+ "reth-network-peers 1.10.1",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune",
  "reth-revm",
@@ -8323,8 +8332,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8333,8 +8342,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8351,8 +8360,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8369,8 +8378,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8379,12 +8388,12 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "eyre",
  "humantime-serde",
- "reth-network-types 1.10.0",
+ "reth-network-types 1.10.1",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
@@ -8395,33 +8404,33 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
 ]
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8436,7 +8445,7 @@ dependencies = [
  "futures",
  "reqwest",
  "reth-node-api",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-tracing",
  "ringbuffer",
  "serde",
@@ -8446,8 +8455,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8457,7 +8466,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -8470,8 +8479,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8484,7 +8493,7 @@ dependencies = [
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -8495,15 +8504,15 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
  "boyer-moore-magiclen",
  "eyre",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-codecs",
  "reth-config",
  "reth-db-api",
@@ -8511,7 +8520,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-fs-util",
  "reth-node-types",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-stages-types",
  "reth-static-file-types",
@@ -8525,22 +8534,22 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "serde",
 ]
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8549,10 +8558,10 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "rand 0.8.5",
- "reth-ethereum-forks 1.10.0",
- "reth-net-banlist 1.10.0",
+ "reth-ethereum-forks 1.10.1",
+ "reth-net-banlist 1.10.1",
  "reth-net-nat",
- "reth-network-peers 1.10.0",
+ "reth-network-peers 1.10.1",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8588,8 +8597,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8600,10 +8609,10 @@ dependencies = [
  "itertools 0.14.0",
  "metrics 0.24.3",
  "rand 0.9.2",
- "reth-chainspec 1.10.0",
- "reth-ethereum-forks 1.10.0",
- "reth-metrics 1.10.0",
- "reth-network-peers 1.10.0",
+ "reth-chainspec 1.10.1",
+ "reth-ethereum-forks 1.10.1",
+ "reth-metrics 1.10.1",
+ "reth-network-peers 1.10.1",
  "secp256k1 0.30.0",
  "thiserror 2.0.17",
  "tokio",
@@ -8612,8 +8621,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8621,9 +8630,9 @@ dependencies = [
  "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
- "reth-ethereum-forks 1.10.0",
- "reth-network-peers 1.10.0",
- "reth-tokio-util 1.10.0",
+ "reth-ethereum-forks 1.10.1",
+ "reth-network-peers 1.10.1",
+ "reth-tokio-util 1.10.1",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8636,8 +8645,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8652,10 +8661,10 @@ dependencies = [
  "rayon",
  "reth-config",
  "reth-consensus",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-network-p2p",
- "reth-network-peers 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-network-peers 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-api",
  "reth-tasks",
  "thiserror 2.0.17",
@@ -8667,8 +8676,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8683,7 +8692,7 @@ dependencies = [
  "hmac",
  "pin-project",
  "rand 0.8.5",
- "reth-network-peers 1.10.0",
+ "reth-network-peers 1.10.1",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
  "thiserror 2.0.17",
@@ -8695,20 +8704,20 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-api",
  "reth-transaction-pool",
  "tokio",
@@ -8718,8 +8727,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8734,7 +8743,7 @@ dependencies = [
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.17",
@@ -8743,12 +8752,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "futures",
  "pin-project",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus",
  "reth-engine-primitives",
  "reth-engine-tree",
@@ -8761,17 +8770,18 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
+ "reth-trie-db",
 ]
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8792,22 +8802,24 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune",
  "reth-revm",
  "reth-stages-api",
  "reth-tasks",
  "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "reth-trie-sparse-parallel",
- "revm 33.1.0",
- "revm-primitives",
+ "revm 34.0.0",
+ "revm-primitives 22.0.0",
  "schnellru",
  "smallvec",
  "thiserror 2.0.17",
@@ -8817,8 +8829,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8826,14 +8838,14 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "pin-project",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-engine-primitives",
  "reth-engine-tree",
  "reth-errors",
  "reth-evm",
  "reth-fs-util",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-revm",
  "reth-storage-api",
  "serde",
@@ -8845,8 +8857,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8860,8 +8872,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8876,8 +8888,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8888,7 +8900,7 @@ dependencies = [
  "reth-era-downloader",
  "reth-etl",
  "reth-fs-util",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-stages-types",
  "reth-storage-api",
@@ -8898,8 +8910,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8909,8 +8921,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8922,10 +8934,10 @@ dependencies = [
  "reth-codecs",
  "reth-ecies",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.0",
- "reth-metrics 1.10.0",
- "reth-network-peers 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-ethereum-forks 1.10.1",
+ "reth-metrics 1.10.1",
+ "reth-network-peers 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "serde",
  "snap",
  "thiserror 2.0.17",
@@ -8937,8 +8949,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8948,41 +8960,41 @@ dependencies = [
  "alloy-rlp",
  "bytes",
  "derive_more",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-codecs-derive",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "serde",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus",
  "reth-consensus-common",
  "reth-ethereum-consensus",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-revm",
  "reth-storage-api",
 ]
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "clap",
  "eyre",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
@@ -8999,24 +9011,24 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9025,7 +9037,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-ethereum-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.17",
@@ -9045,8 +9057,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -9058,8 +9070,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9067,7 +9079,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus-common",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -9077,18 +9089,18 @@ dependencies = [
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-payload-validator",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
- "revm 33.1.0",
+ "revm 34.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9098,7 +9110,7 @@ dependencies = [
  "alloy-serde",
  "modular-bitfield",
  "reth-codecs",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-zstd-compressors",
  "serde",
  "serde_with",
@@ -9106,8 +9118,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9116,12 +9128,12 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9130,41 +9142,41 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm 33.1.0",
+ "revm 34.0.0",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
- "reth-chainspec 1.10.0",
- "reth-ethereum-forks 1.10.0",
+ "reth-chainspec 1.10.1",
+ "reth-ethereum-forks 1.10.1",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-errors",
- "revm 33.1.0",
+ "revm 34.0.0",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -9174,26 +9186,26 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "derive_more",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-trie-common",
- "revm 33.1.0",
+ "revm 34.0.0",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-exex"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9204,17 +9216,17 @@ dependencies = [
  "metrics 0.24.3",
  "parking_lot",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-config",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune-types",
  "reth-revm",
@@ -9230,22 +9242,22 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "serde",
  "serde_json",
@@ -9254,8 +9266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9267,15 +9279,15 @@ dependencies = [
  "pretty_assertions",
  "reth-engine-primitives",
  "reth-evm",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-revm",
  "reth-rpc-api",
  "reth-tracing",
  "reth-trie",
- "revm 33.1.0",
- "revm-bytecode",
- "revm-database",
+ "revm 34.0.0",
+ "revm-bytecode 8.0.0",
+ "revm-database 10.0.0",
  "serde",
  "serde_json",
 ]
@@ -9301,9 +9313,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-ipc"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+dependencies = [
+ "bytes",
+ "futures",
+ "futures-util",
+ "interprocess",
+ "jsonrpsee",
+ "pin-project",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "reth-libmdbx"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9318,8 +9350,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9336,8 +9368,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "futures",
  "metrics 0.24.3",
@@ -9356,8 +9388,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9365,8 +9397,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -9379,8 +9411,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9399,27 +9431,27 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus",
  "reth-discv4",
- "reth-discv5 1.10.0",
+ "reth-discv5 1.10.1",
  "reth-dns-discovery",
  "reth-ecies",
  "reth-eth-wire",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.0",
+ "reth-ethereum-forks 1.10.1",
  "reth-ethereum-primitives",
  "reth-fs-util",
- "reth-metrics 1.10.0",
- "reth-net-banlist 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-net-banlist 1.10.1",
  "reth-network-api",
  "reth-network-p2p",
- "reth-network-peers 1.10.0",
- "reth-network-types 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-network-peers 1.10.1",
+ "reth-network-types 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-api",
  "reth-tasks",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "reth-transaction-pool",
  "rustc-hash",
  "schnellru",
@@ -9435,8 +9467,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9447,11 +9479,11 @@ dependencies = [
  "enr",
  "futures",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.0",
+ "reth-ethereum-forks 1.10.1",
  "reth-network-p2p",
- "reth-network-peers 1.10.0",
- "reth-network-types 1.10.0",
- "reth-tokio-util 1.10.0",
+ "reth-network-peers 1.10.1",
+ "reth-network-types 1.10.1",
+ "reth-tokio-util 1.10.1",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -9460,8 +9492,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9472,9 +9504,9 @@ dependencies = [
  "reth-consensus",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",
- "reth-network-peers 1.10.0",
- "reth-network-types 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-network-peers 1.10.1",
+ "reth-network-types 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-errors",
  "tokio",
  "tracing",
@@ -9496,8 +9528,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9523,13 +9555,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
- "reth-net-banlist 1.10.0",
- "reth-network-peers 1.10.0",
+ "reth-net-banlist 1.10.1",
+ "reth-network-peers 1.10.1",
  "serde",
  "serde_json",
  "tracing",
@@ -9537,8 +9569,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9554,8 +9586,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9572,14 +9604,14 @@ dependencies = [
  "reth-payload-primitives",
  "reth-provider",
  "reth-tasks",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "reth-transaction-pool",
 ]
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9596,7 +9628,7 @@ dependencies = [
  "rayon",
  "reth-basic-payload-builder",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
@@ -9622,7 +9654,7 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune",
  "reth-rpc",
@@ -9634,9 +9666,10 @@ dependencies = [
  "reth-stages",
  "reth-static-file",
  "reth-tasks",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9646,8 +9679,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9661,22 +9694,22 @@ dependencies = [
  "humantime",
  "ipnet",
  "rand 0.9.2",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-cli-util",
  "reth-config",
  "reth-consensus",
  "reth-db",
  "reth-discv4",
- "reth-discv5 1.10.0",
+ "reth-discv5 1.10.1",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-ethereum-forks 1.10.0",
- "reth-net-banlist 1.10.0",
+ "reth-ethereum-forks 1.10.1",
+ "reth-net-banlist 1.10.1",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-network-peers 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune-types",
  "reth-rpc-convert",
@@ -9702,15 +9735,15 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "eyre",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-consensus",
@@ -9723,7 +9756,7 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -9734,14 +9767,14 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tracing",
  "reth-transaction-pool",
- "revm 33.1.0",
+ "revm 34.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9749,7 +9782,7 @@ dependencies = [
  "futures-util",
  "reth-chain-state",
  "reth-network-api",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-api",
  "reth-transaction-pool",
  "serde",
@@ -9764,8 +9797,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9777,7 +9810,7 @@ dependencies = [
  "pin-project",
  "reth-engine-primitives",
  "reth-network-api",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-prune-types",
  "reth-stages",
  "reth-static-file-types",
@@ -9788,8 +9821,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "bytes",
  "eyre",
@@ -9802,7 +9835,7 @@ dependencies = [
  "metrics-util 0.20.1",
  "procfs 0.17.0",
  "reqwest",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9812,20 +9845,20 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-db-api",
  "reth-engine-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
 ]
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9834,10 +9867,10 @@ dependencies = [
  "metrics 0.24.3",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9845,8 +9878,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9857,8 +9890,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9868,10 +9901,10 @@ dependencies = [
  "either",
  "op-alloy-rpc-types-engine 0.23.1",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-errors",
  "reth-execution-types",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.17",
@@ -9880,24 +9913,24 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "once_cell",
- "reth-ethereum-forks 1.10.0",
+ "reth-ethereum-forks 1.10.1",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-static-file-types",
 ]
 
@@ -9916,16 +9949,16 @@ dependencies = [
  "bytes",
  "derive_more",
  "once_cell",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 7.1.1",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9943,9 +9976,9 @@ dependencies = [
  "op-alloy-consensus 0.23.1",
  "rayon",
  "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
@@ -9954,8 +9987,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9969,17 +10002,17 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-codecs",
  "reth-db",
  "reth-db-api",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-nippy-jar",
  "reth-node-types",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
@@ -9987,15 +10020,15 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
- "revm-database",
+ "revm-database 10.0.0",
  "strum 0.27.2",
  "tracing",
 ]
 
 [[package]]
 name = "reth-prune"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10007,13 +10040,13 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "rustc-hash",
  "thiserror 2.0.17",
  "tokio",
@@ -10022,8 +10055,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10036,8 +10069,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10055,8 +10088,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10068,12 +10101,12 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-node-api",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-ress-protocol",
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "reth-trie",
  "schnellru",
  "tokio",
@@ -10082,27 +10115,27 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm 33.1.0",
+ "revm 34.0.0",
 ]
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -10134,7 +10167,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus",
  "reth-consensus-common",
  "reth-engine-primitives",
@@ -10144,12 +10177,12 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-network-api",
- "reth-network-peers 1.10.0",
- "reth-network-types 1.10.0",
+ "reth-network-peers 1.10.1",
+ "reth-network-types 1.10.1",
  "reth-node-api",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-revm",
  "reth-rpc-api",
  "reth-rpc-convert",
@@ -10161,9 +10194,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm 33.1.0",
+ "revm 34.0.0",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -10177,8 +10210,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10199,17 +10232,16 @@ dependencies = [
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
- "reth-network-peers 1.10.0",
+ "reth-network-peers 1.10.1",
  "reth-rpc-eth-api",
  "reth-trie-common",
- "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10219,15 +10251,15 @@ dependencies = [
  "metrics 0.24.3",
  "pin-project",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-consensus",
  "reth-engine-primitives",
  "reth-evm",
- "reth-ipc",
- "reth-metrics 1.10.0",
+ "reth-ipc 1.10.1",
+ "reth-metrics 1.10.1",
  "reth-network-api",
  "reth-node-core",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-eth-api",
@@ -10236,7 +10268,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "reth-transaction-pool",
  "serde",
  "thiserror 2.0.17",
@@ -10249,11 +10281,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10264,14 +10296,14 @@ dependencies = [
  "jsonrpsee-types",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10280,14 +10312,14 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics 0.24.3",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-engine-primitives",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-rpc-api",
  "reth-storage-api",
  "reth-tasks",
@@ -10300,13 +10332,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10322,12 +10354,12 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-errors",
  "reth-evm",
  "reth-network-api",
  "reth-node-api",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -10336,7 +10368,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm 33.1.0",
+ "revm 34.0.0",
  "revm-inspectors",
  "tokio",
  "tracing",
@@ -10344,12 +10376,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm 0.26.3",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
@@ -10365,13 +10397,13 @@ dependencies = [
  "rand 0.9.2",
  "reqwest",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-server-types",
@@ -10379,7 +10411,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm 33.1.0",
+ "revm 34.0.0",
  "revm-inspectors",
  "schnellru",
  "serde",
@@ -10392,8 +10424,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10406,8 +10438,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10422,8 +10454,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10449,7 +10481,7 @@ dependencies = [
  "reth-exex",
  "reth-fs-util",
  "reth-network-p2p",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune",
  "reth-prune-types",
@@ -10467,8 +10499,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10478,15 +10510,15 @@ dependencies = [
  "metrics 0.24.3",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-network-p2p",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune",
  "reth-stages-types",
  "reth-static-file",
  "reth-static-file-types",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -10494,8 +10526,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10507,28 +10539,28 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
  "rayon",
  "reth-codecs",
  "reth-db-api",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-provider",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
  "reth-storage-errors",
- "reth-tokio-util 1.10.0",
+ "reth-tokio-util 1.10.1",
  "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10540,48 +10572,49 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-db-api",
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm-database",
+ "revm-database 10.0.0",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-primitives-traits 1.10.0",
+ "reth-primitives-traits 1.10.1",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
+ "revm-database-interface 9.0.0",
+ "revm-state 9.0.0",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10589,7 +10622,7 @@ dependencies = [
  "metrics 0.24.3",
  "pin-project",
  "rayon",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -10608,8 +10641,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10618,8 +10651,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "clap",
  "eyre",
@@ -10635,8 +10668,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "clap",
  "eyre",
@@ -10653,8 +10686,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10669,17 +10702,17 @@ dependencies = [
  "pin-project",
  "rand 0.9.2",
  "reth-chain-state",
- "reth-chainspec 1.10.0",
+ "reth-chainspec 1.10.1",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-storage-api",
  "reth-tasks",
- "revm-interpreter 31.1.0",
- "revm-primitives",
+ "revm-interpreter 32.0.0",
+ "revm-primitives 22.0.0",
  "rustc-hash",
  "schnellru",
  "serde",
@@ -10693,8 +10726,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10706,20 +10739,20 @@ dependencies = [
  "metrics 0.24.3",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database",
+ "revm-database 10.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10734,31 +10767,36 @@ dependencies = [
  "nybbles",
  "rayon",
  "reth-codecs",
- "reth-primitives-traits 1.10.0",
- "revm-database",
+ "reth-primitives-traits 1.10.1",
+ "revm-database 10.0.0",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
+ "metrics 0.24.3",
+ "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-primitives-traits 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-primitives-traits 1.10.1",
+ "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-common",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10769,7 +10807,7 @@ dependencies = [
  "metrics 0.24.3",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
@@ -10782,8 +10820,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10792,8 +10830,8 @@ dependencies = [
  "metrics 0.24.3",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.0",
- "reth-primitives-traits 1.10.0",
+ "reth-metrics 1.10.1",
+ "reth-primitives-traits 1.10.1",
  "reth-trie-common",
  "smallvec",
  "tracing",
@@ -10801,8 +10839,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10810,7 +10848,7 @@ dependencies = [
  "metrics 0.24.3",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.0",
+ "reth-metrics 1.10.1",
  "reth-trie-common",
  "reth-trie-sparse",
  "smallvec",
@@ -10819,8 +10857,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.0#b25f32a977b489f9b84254c7811a2a5a25a81369"
+version = "1.10.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
 dependencies = [
  "zstd",
 ]
@@ -10831,17 +10869,17 @@ version = "31.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb67a5223602113cae59a305acde2d9936bc18f2478dda879a6124b267cebfb6"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 7.1.1",
  "revm-context 11.0.2",
  "revm-context-interface 12.0.1",
- "revm-database",
- "revm-database-interface",
+ "revm-database 9.0.6",
+ "revm-database-interface 8.0.5",
  "revm-handler 12.0.2",
  "revm-inspector 12.0.2",
  "revm-interpreter 29.0.1",
  "revm-precompile 29.0.1",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
 ]
 
 [[package]]
@@ -10850,17 +10888,36 @@ version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 7.1.1",
  "revm-context 12.1.0",
  "revm-context-interface 13.1.0",
- "revm-database",
- "revm-database-interface",
+ "revm-database 9.0.6",
+ "revm-database-interface 8.0.5",
  "revm-handler 14.1.0",
  "revm-inspector 14.1.0",
  "revm-interpreter 31.1.0",
  "revm-precompile 31.0.0",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+]
+
+[[package]]
+name = "revm"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+dependencies = [
+ "revm-bytecode 8.0.0",
+ "revm-context 13.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-database 10.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-handler 15.0.0",
+ "revm-inspector 15.0.0",
+ "revm-interpreter 32.0.0",
+ "revm-precompile 32.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
 ]
 
 [[package]]
@@ -10871,7 +10928,19 @@ checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
 dependencies = [
  "bitvec",
  "phf",
- "revm-primitives",
+ "revm-primitives 21.0.2",
+ "serde",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
@@ -10884,11 +10953,11 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 7.1.1",
  "revm-context-interface 12.0.1",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
 ]
 
 [[package]]
@@ -10900,11 +10969,28 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 7.1.1",
  "revm-context-interface 13.1.0",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 8.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10918,9 +11004,9 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
 ]
 
 [[package]]
@@ -10933,9 +11019,25 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10946,10 +11048,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
 dependencies = [
  "alloy-eips",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 7.1.1",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+dependencies = [
+ "alloy-eips",
+ "revm-bytecode 8.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10961,9 +11077,23 @@ checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
+ "serde",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -10974,14 +11104,14 @@ checksum = "b45418ed95cfdf0cb19effdbb7633cf2144cab7fb0e6ffd6b0eb9117a50adff6"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 7.1.1",
  "revm-context 11.0.2",
  "revm-context-interface 12.0.1",
- "revm-database-interface",
+ "revm-database-interface 8.0.5",
  "revm-interpreter 29.0.1",
  "revm-precompile 29.0.1",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
 ]
 
 [[package]]
@@ -10992,14 +11122,33 @@ checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 7.1.1",
  "revm-context 12.1.0",
  "revm-context-interface 13.1.0",
- "revm-database-interface",
+ "revm-database-interface 8.0.5",
  "revm-interpreter 31.1.0",
  "revm-precompile 31.0.0",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 8.0.0",
+ "revm-context 13.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-interpreter 32.0.0",
+ "revm-precompile 32.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -11012,11 +11161,11 @@ dependencies = [
  "auto_impl",
  "either",
  "revm-context 11.0.2",
- "revm-database-interface",
+ "revm-database-interface 8.0.5",
  "revm-handler 12.0.2",
  "revm-interpreter 29.0.1",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
 ]
 
 [[package]]
@@ -11028,20 +11177,37 @@ dependencies = [
  "auto_impl",
  "either",
  "revm-context 12.1.0",
- "revm-database-interface",
+ "revm-database-interface 8.0.5",
  "revm-handler 14.1.0",
  "revm-interpreter 31.1.0",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 13.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-handler 15.0.0",
+ "revm-interpreter 32.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-inspectors"
-version = "0.33.2"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01def7351cd9af844150b8e88980bcd11304f33ce23c3d7c25f2a8dab87c1345"
+checksum = "a24ca988ae1f7a0bb5688630579c00e867cd9f1df0a2f040623887f63d3b414c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11051,7 +11217,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm 33.1.0",
+ "revm 34.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -11063,10 +11229,10 @@ version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22789ce92c5808c70185e3bc49732f987dc6fd907f77828c8d3470b2299c9c65"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 7.1.1",
  "revm-context-interface 12.0.1",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
 ]
 
 [[package]]
@@ -11075,10 +11241,23 @@ version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 7.1.1",
  "revm-context-interface 13.1.0",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+dependencies = [
+ "revm-bytecode 8.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -11098,7 +11277,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-primitives",
+ "revm-primitives 21.0.2",
  "ripemd",
  "sha2 0.10.9",
 ]
@@ -11116,14 +11295,34 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-primitives 21.0.2",
+ "ripemd",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
  "p256",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "ripemd",
- "rug",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
@@ -11141,14 +11340,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-primitives"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "revm-state"
 version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
 dependencies = [
  "bitflags 2.10.0",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 7.1.1",
+ "revm-primitives 21.0.2",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.10.0",
+ "revm-bytecode 8.0.0",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
@@ -11324,18 +11548,6 @@ dependencies = [
  "nix",
  "thiserror 1.0.69",
  "tokio",
-]
-
-[[package]]
-name = "rug"
-version = "1.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
 ]
 
 [[package]]
@@ -13364,12 +13576,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",
@@ -13379,9 +13591,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "1.0.7"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -13394,9 +13606,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "0.1.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -76,12 +76,12 @@ jsonrpsee = { version = "0.26", features = ["server"] }
 k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 
 # taiko
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "5137cd8aa1a5c1602bd61b0851211dfdf5913c3b" }
-alethia-reth-evm = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-evm", rev = "5137cd8aa1a5c1602bd61b0851211dfdf5913c3b" }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "5137cd8aa1a5c1602bd61b0851211dfdf5913c3b", features = [
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19" }
+alethia-reth-evm = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-evm", rev = "3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19" }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19", features = [
   "serde",
 ] }
-alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", rev = "5137cd8aa1a5c1602bd61b0851211dfdf5913c3b" }
+alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", rev = "3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19" }
 reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
 
 # types

--- a/packages/taiko-client-rs/crates/protocol/Cargo.toml
+++ b/packages/taiko-client-rs/crates/protocol/Cargo.toml
@@ -5,6 +5,16 @@ edition.workspace = true
 publish = false
 license.workspace = true
 
+[features]
+default = ["net"]
+net = [
+    "tokio",
+    "tokio-retry",
+    "tokio-stream",
+    "alloy-provider",
+    "event-scanner",
+]
+
 [dependencies]
 # async
 async-trait = { workspace = true }
@@ -49,13 +59,3 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["std", "std_rng"] }
-
-[features]
-default = ["net"]
-net = [
-  "tokio",
-  "tokio-retry",
-  "tokio-stream",
-  "alloy-provider",
-  "event-scanner",
-]


### PR DESCRIPTION
ref: 
- https://github.com/taikoxyz/taiko-mono/pull/21225
- https://github.com/taikoxyz/alethia-reth/pull/100

  ## Summary

  - Align Shasta L1 origin lookups with Go client by treating “proposal last block uncertain” as ignorable (returns `None`), and rename helper functions for clarity
  - Update `alethia-reth` dependencies to latest main and refresh `Cargo.lock`
