### PR TITLE
fix(taiko-client): fix `NotFound` handling for RPC by using error string matching

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -232,7 +232,7 @@ func isKnownCanonicalBatchPacaya(
 		g.Go(func() error {
 			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
 			if err != nil {
-				if errors.Is(err, ethereum.NotFound) {
+				if err.Error() == ethereum.NotFound.Error() {
 					return errBatchNotKnown
 				}
 				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
@@ -310,7 +310,7 @@ func isKnownCanonicalBatchShasta(
 		g.Go(func() error {
 			parentHeader, err := rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(parent.Number.Uint64()+uint64(i)))
 			if err != nil {
-				if errors.Is(err, ethereum.NotFound) {
+				if err.Error() == ethereum.NotFound.Error() {
 					return errBatchNotKnown
 				}
 				return fmt.Errorf("failed to get parent block by number %d: %w", parent.Number.Uint64()+uint64(i), err)
@@ -375,7 +375,7 @@ func isKnownCanonicalBlock(
 ) (*types.Header, bool, error) {
 	var blockID = new(big.Int).Add(meta.Parent.Number, common.Big1)
 	block, err := rpc.L2.BlockByNumber(ctx, blockID)
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
+	if err != nil && err.Error() != ethereum.NotFound.Error() {
 		return nil, false, fmt.Errorf("failed to get block by number %d: %w", blockID, err)
 	}
 
@@ -416,7 +416,7 @@ func isKnownCanonicalBlock(
 	)
 
 	l1Origin, err := rpc.L2.L1OriginByID(ctx, blockID)
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
+	if err != nil && err.Error() != ethereum.NotFound.Error() {
 		return nil, false, fmt.Errorf("failed to get L1Origin by ID %d: %w", blockID, err)
 	}
 	// If L1Origin is not found, it means this block is synced from beacon sync.
@@ -756,7 +756,7 @@ func updateL1OriginForBlocks(
 
 			// Fetch the original L1Origin to get the BuildPayloadArgsID.
 			originalL1Origin, err := rpc.L2.L1OriginByID(ctx, blockID)
-			if err != nil && !errors.Is(err, ethereum.NotFound) {
+			if err != nil && err.Error() != ethereum.NotFound.Error() {
 				return fmt.Errorf("failed to get L1Origin by ID %d: %w", blockID, err)
 			}
 			// If L1Origin is not found, it means this block is synced from beacon sync,
@@ -995,7 +995,7 @@ func IsBasedOnCanonicalChain(
 	headL1Origin *rawdb.L1Origin,
 ) (bool, error) {
 	canonicalParent, err := cli.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(uint64(envelope.Payload.BlockNumber-1)))
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
+	if err != nil && err.Error() != ethereum.NotFound.Error() {
 		return false, fmt.Errorf("failed to fetch canonical parent block: %w", err)
 	}
 	// If the parent hash of the executable data matches the canonical parent block hash, it is in the canonical chain.

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -380,7 +380,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 
 	// Ignore the message if it has been inserted already.
 	head, err := s.rpc.L2.HeaderByHash(ctx, msg.ExecutionPayload.BlockHash)
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
+	if err != nil && err.Error() != ethereum.NotFound.Error() {
 		return fmt.Errorf("failed to fetch header by hash: %w", err)
 	}
 	if head != nil {
@@ -775,7 +775,7 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 		// Check if the found parent payload is in the canonical chain,
 		// if it is not, continue to find the parent payload.
 		parentHeader, err := s.rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(uint64(parentPayload.Payload.BlockNumber)))
-		if err != nil && !errors.Is(err, ethereum.NotFound) {
+		if err != nil && err.Error() != ethereum.NotFound.Error() {
 			return fmt.Errorf("failed to fetch parent header: %w", err)
 		}
 
@@ -1262,7 +1262,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 		ctx,
 		new(big.Int).SetUint64(uint64(msg.ExecutionPayload.BlockNumber-1)),
 	)
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
+	if err != nil && err.Error() != ethereum.NotFound.Error() {
 		return false, fmt.Errorf("failed to fetch parent header by number: %w", err)
 	}
 	cachedParent := s.envelopesCache.get(
@@ -1375,7 +1375,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 
 	// Check if the block already exists in the canonical chain, if it does, we ignore the message.
 	header, err := s.rpc.L2.HeaderByNumber(ctx, new(big.Int).SetUint64(uint64(msg.ExecutionPayload.BlockNumber)))
-	if err != nil && !errors.Is(err, ethereum.NotFound) {
+	if err != nil && err.Error() != ethereum.NotFound.Error() {
 		return false, fmt.Errorf("failed to fetch header by hash: %w", err)
 	}
 


### PR DESCRIPTION

  ## Summary

  - Replace errors.Is(err, ethereum.NotFound) checks with err.Error() == ethereum.NotFound.Error() across taiko-client.
  - Ensure “not found” errors returned via JSON-RPC (e.g., taiko_l1OriginByID) are treated as NotFound instead of surfacing as hard errors.

  ## Rationale

  Custom RPC methods return JSON-RPC errors with message "not found" but without wrapping `ethereum.NotFound`, so errors.Is fails to match. String comparison aligns behavior with existing code paths and prevents unnecessary retries/log spam.
