### PR TITLE
feat(taiko-client): introduce `blockIDToSync` in `SetUpEventSync`

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main]
+    branches: [main, update-chain-syncer-id]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main, update-chain-syncer-id]
+    branches: [main]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -115,7 +115,17 @@ func (s *L2ChainSyncer) Sync() error {
 // and tries to import the pending preconfirmation blocks from the cache, this method should only be
 // called after the L2 execution engine's chain has just finished a beacon sync.
 func (s *L2ChainSyncer) SetUpEventSync(blockIDToSync uint64) error {
-	l2Head, err := s.rpc.L2.HeaderByNumber(s.ctx, new(big.Int).SetUint64(blockIDToSync))
+	var headNumber = new(big.Int).SetUint64(blockIDToSync)
+	if s.progressTracker.OutOfSync() {
+		headNumber = nil
+	}
+	log.Info(
+		"Setting up event synchronization",
+		"blockIDToSync", blockIDToSync,
+		"outOfSync", s.progressTracker.OutOfSync(),
+		"headNumber", headNumber,
+	)
+	l2Head, err := s.rpc.L2.HeaderByNumber(s.ctx, headNumber)
 	if err != nil {
 		return fmt.Errorf("failed to get L2 chain head: %w", err)
 	}

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -3,6 +3,7 @@ package chainsyncer
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"net/url"
 	"time"
 
@@ -101,7 +102,7 @@ func (s *L2ChainSyncer) Sync() error {
 			"p2pOutOfSync", s.progressTracker.OutOfSync(),
 		)
 
-		if err := s.SetUpEventSync(); err != nil {
+		if err := s.SetUpEventSync(blockIDToSync); err != nil {
 			return fmt.Errorf("failed to set up event synchronization: %w", err)
 		}
 	}
@@ -113,9 +114,9 @@ func (s *L2ChainSyncer) Sync() error {
 // SetUpEventSync resets the L1Current cursor to the latest L2 execution engine's chain head,
 // and tries to import the pending preconfirmation blocks from the cache, this method should only be
 // called after the L2 execution engine's chain has just finished a beacon sync.
-func (s *L2ChainSyncer) SetUpEventSync() error {
+func (s *L2ChainSyncer) SetUpEventSync(blockIDToSync uint64) error {
 	// Get the execution engine's chain head.
-	l2Head, err := s.rpc.L2.HeaderByNumber(s.ctx, nil)
+	l2Head, err := s.rpc.L2.HeaderByNumber(s.ctx, new(big.Int).SetUint64(blockIDToSync))
 	if err != nil {
 		return fmt.Errorf("failed to get L2 chain head: %w", err)
 	}

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -115,7 +115,6 @@ func (s *L2ChainSyncer) Sync() error {
 // and tries to import the pending preconfirmation blocks from the cache, this method should only be
 // called after the L2 execution engine's chain has just finished a beacon sync.
 func (s *L2ChainSyncer) SetUpEventSync(blockIDToSync uint64) error {
-	// Get the execution engine's chain head.
 	l2Head, err := s.rpc.L2.HeaderByNumber(s.ctx, new(big.Int).SetUint64(blockIDToSync))
 	if err != nil {
 		return fmt.Errorf("failed to get L2 chain head: %w", err)

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -1194,7 +1194,7 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 	s.Nil(err)
 	s.Equal(l2Head1.Number().Uint64(), headL1Origin.BlockID.Uint64())
 
-	s.Nil(s.d.ChainSyncer().SetUpEventSync())
+	s.Nil(s.d.ChainSyncer().SetUpEventSync(headL1Origin.BlockID.Uint64()))
 
 	l2Head3, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)


### PR DESCRIPTION
## Summary
After beacon sync completes, align event sync to `blockIDToSync` instead of the latest head

## Changes
Pass `blockIDToSync` into `SetUpEventSync and fetch the L2 header at that height via `HeaderByNumber`

## Rationale
Prevent a race where a preconf block lands between beacon sync completion and `SetUpEventSync`, making a “latest beacon synced head” lookup inconsistent for the intended sync point