### PR TITLE
feat(taiko-client): gate preconf inserts until post-beacon-sync event sync reset

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -127,12 +127,6 @@ func (s *L2ChainSyncer) Sync() error {
 // and tries to import the pending preconfirmation blocks from the cache, this method should only be
 // called after the L2 execution engine's chain has just finished a beacon sync.
 func (s *L2ChainSyncer) SetUpEventSync(blockIDToSync uint64) error {
-	// Mark the preconfirmation block server as ready to insert blocks.
-	if s.preconfBlockServer != nil {
-		log.Info("Mark preconfirmation block server as ready to insert blocks")
-		s.preconfBlockServer.SetSyncReady(true)
-	}
-
 	var headNumber = new(big.Int).SetUint64(blockIDToSync)
 	if s.progressTracker.OutOfSync() {
 		headNumber = nil
@@ -167,6 +161,8 @@ func (s *L2ChainSyncer) SetUpEventSync(blockIDToSync uint64) error {
 	// If the preconfirmation block server is enabled, we should try to insert the pending
 	// preconfirmation blocks from the cache.
 	if s.preconfBlockServer != nil {
+		log.Info("Mark preconfirmation block server as ready to insert blocks")
+		s.preconfBlockServer.SetSyncReady(true)
 		log.Info(
 			"Try importing pending preconfirmation blocks",
 			"currentL2HeadNumber", l2Head.Number,

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -81,6 +81,11 @@ func (s *L2ChainSyncer) Sync() error {
 	// `P2PSync` flag is set, try triggering a beacon sync in L2 execution engine to catch up the
 	// head.
 	if needNewBeaconSyncTriggered {
+		// Mark the preconfirmation block server as not ready to insert blocks.
+		if s.preconfBlockServer != nil {
+			log.Info("Mark preconfirmation block server as not ready to insert blocks")
+			s.preconfBlockServer.SetSyncReady(false)
+		}
 		if err := s.beaconSyncer.TriggerBeaconSync(blockIDToSync); err != nil {
 			return fmt.Errorf("trigger beacon sync error: %w", err)
 		}
@@ -105,6 +110,12 @@ func (s *L2ChainSyncer) Sync() error {
 		if err := s.SetUpEventSync(blockIDToSync); err != nil {
 			return fmt.Errorf("failed to set up event synchronization: %w", err)
 		}
+	}
+
+	// Mark the preconfirmation block server as ready to insert blocks.
+	if s.preconfBlockServer != nil {
+		log.Info("Mark preconfirmation block server as ready to insert blocks")
+		s.preconfBlockServer.SetSyncReady(true)
 	}
 
 	// Insert the proposed batches one by one.

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -112,7 +112,8 @@ func (s *L2ChainSyncer) Sync() error {
 		}
 	}
 
-	// Mark the preconfirmation block server as ready to insert blocks.
+	// Mark the preconfirmation block server as ready to insert blocks, no matter
+	// whether we have triggered a beacon sync in L2 execution engine.
 	if s.preconfBlockServer != nil {
 		log.Info("Mark preconfirmation block server as ready to insert blocks")
 		s.preconfBlockServer.SetSyncReady(true)
@@ -126,6 +127,12 @@ func (s *L2ChainSyncer) Sync() error {
 // and tries to import the pending preconfirmation blocks from the cache, this method should only be
 // called after the L2 execution engine's chain has just finished a beacon sync.
 func (s *L2ChainSyncer) SetUpEventSync(blockIDToSync uint64) error {
+	// Mark the preconfirmation block server as ready to insert blocks.
+	if s.preconfBlockServer != nil {
+		log.Info("Mark preconfirmation block server as ready to insert blocks")
+		s.preconfBlockServer.SetSyncReady(true)
+	}
+
 	var headNumber = new(big.Int).SetUint64(blockIDToSync)
 	if s.progressTracker.OutOfSync() {
 		headNumber = nil

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -82,6 +82,9 @@ func (s *DriverTestSuite) SetupTest() {
 	}))
 	s.d = d
 	s.cancel = cancel
+	if s.d.preconfBlockServer != nil {
+		s.d.preconfBlockServer.SetSyncReady(true)
+	}
 
 	go func() {
 		if err := s.d.preconfBlockServer.Start(preconfServerPort); err != nil {

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -113,7 +113,11 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 		return s.returnError(c, http.StatusBadRequest, errors.New("l2 execution engine is syncing"))
 	}
 	if !s.syncReady {
-		return s.returnError(c, http.StatusBadRequest, errors.New("l2 execution engine is syncing"))
+		return s.returnError(
+			c,
+			http.StatusBadRequest,
+			errors.New("preconfirmation block server is not ready to insert blocks"),
+		)
 	}
 
 	// Parse the request body.

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -112,6 +112,9 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 	if progress.IsSyncing() {
 		return s.returnError(c, http.StatusBadRequest, errors.New("l2 execution engine is syncing"))
 	}
+	if !s.syncReady {
+		return s.returnError(c, http.StatusBadRequest, errors.New("l2 execution engine is syncing"))
+	}
 
 	// Parse the request body.
 	reqBody := new(BuildPreconfBlockRequestBody)

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -183,6 +183,7 @@ func (s *PreconfBlockAPIServer) SetSyncReady(ready bool) {
 	defer s.mutex.Unlock()
 
 	if s.syncReady == ready {
+		log.Debug("Preconfirmation insert readiness unchanged", "ready", ready)
 		return
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -92,6 +92,9 @@ type PreconfBlockAPIServer struct {
 	latestSeenProposalCh chan *encoding.LastSeenProposal
 	latestSeenProposal   *encoding.LastSeenProposal
 
+	// Sync readiness gate for preconfirmation inserts.
+	syncReady bool
+
 	// Mutex for P2P message handlers
 	mutex sync.Mutex
 }
@@ -151,6 +154,7 @@ func New(
 		latestSeenProposalCh:          latestSeenProposalCh,
 		responseSeenCache:             responseSeenCache,
 		highestUnsafeL2PayloadBlockID: head.NumberU64(),
+		syncReady:                     false,
 	}
 
 	server.echo.HideBanner = true
@@ -171,6 +175,19 @@ func (s *PreconfBlockAPIServer) SetP2PNode(p2pNode *p2p.NodeP2P) {
 // SetP2PSigner sets the P2P signer for the preconfirmation block server.
 func (s *PreconfBlockAPIServer) SetP2PSigner(p2pSigner p2p.Signer) {
 	s.p2pSigner = p2pSigner
+}
+
+// SetSyncReady toggles readiness for preconfirmation inserts.
+func (s *PreconfBlockAPIServer) SetSyncReady(ready bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.syncReady == ready {
+		return
+	}
+
+	s.syncReady = ready
+	log.Info("Preconfirmation insert readiness updated", "ready", ready)
 }
 
 // LogSkipper implements the `middleware.Skipper` interface,
@@ -287,6 +304,19 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 		return nil
 	}
 
+	// Check if we are ready to insert preconfirmation blocks.
+	if !s.syncReady {
+		log.Info(
+			"Preconfirmation block server not ready to insert blocks, caching the payload",
+			"peer", from,
+			"blockID", uint64(msg.ExecutionPayload.BlockNumber),
+			"hash", msg.ExecutionPayload.BlockHash.Hex(),
+			"parentHash", msg.ExecutionPayload.ParentHash.Hex(),
+		)
+		s.tryPutEnvelopeIntoCache(msg, from)
+		return nil
+	}
+
 	// Check if the L2 execution engine is syncing from L1.
 	progress, err := s.rpc.L2ExecutionEngineSyncProgress(ctx)
 	if err != nil {
@@ -375,6 +405,19 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 			"error", err,
 		)
 		metrics.DriverPreconfInvalidEnvelopeCounter.Inc()
+		return nil
+	}
+
+	// Check if we are ready to insert preconfirmation blocks.
+	if !s.syncReady {
+		log.Info(
+			"Preconfirmation block server not ready to insert blocks, caching the payload",
+			"peer", from,
+			"blockID", uint64(msg.ExecutionPayload.BlockNumber),
+			"hash", msg.ExecutionPayload.BlockHash.Hex(),
+			"parentHash", msg.ExecutionPayload.ParentHash.Hex(),
+		)
+		s.tryPutEnvelopeIntoCache(msg, from)
 		return nil
 	}
 


### PR DESCRIPTION
  ## What

  - Add a sync-ready gate to preconfirmation inserts.
  - Disable preconf inserts when beacon sync is triggered; re-enable after SetUpEventSync resets L1 cursor.
  - While gated: cache P2P preconf envelopes; /preconfBlocks returns 400 with existing message l2 execution engine is syncing.

 ## Why

  - Prevent preconf blocks from being inserted between beacon sync completion and event sync reset, which can cause preconf blocks to land before the L1 cursor is reset.

 ## How

  - driver/preconf_blocks/server.go: add syncReady state + SetSyncReady, and gate OnUnsafeL2Payload/OnUnsafeL2Response.
  - driver/preconf_blocks/api.go: gate BuildPreconfBlock with same error message.
  - driver/chain_syncer/chain_syncer.go: toggle readiness around beacon sync and SetUpEventSync.
