### PR TITLE
feat(taiko-client): derive L1 current from last Shasta proposal anchor

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main, improve-ResetL1Current-2]
+    branches: [main]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main]
+    branches: [main, improve-ResetL1Current-2]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -275,14 +275,14 @@ func (s *Syncer) processShastaProposal(
 		// Fetch the parent block, here we try to find the L1 origin of the previous proposal at first,
 		// if not found, which means either the previous proposal is genesis or the L2 EE just finishes the
 		// P2P sync, then we just use the latest block as parent block in this case.
-		l1Origin, err := s.rpc.L2.LastL1OriginByBatchID(ctx, new(big.Int).Sub(meta.GetEventData().Id, common.Big1))
+		blockID, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(meta.GetEventData().Id, common.Big1))
 		if err != nil &&
 			err.Error() != ethereum.NotFound.Error() &&
 			err.Error() != eth.ErrProposalLastBlockUncertain.Error() {
 			return fmt.Errorf("failed to fetch last L1 origin by batch ID: %w", err)
 		}
-		if l1Origin != nil {
-			if parent, err = s.rpc.L2.BlockByNumber(ctx, l1Origin.BlockID); err != nil {
+		if blockID != nil {
+			if parent, err = s.rpc.L2.BlockByNumber(ctx, blockID.ToInt()); err != nil {
 				return err
 			}
 		} else {

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -272,29 +272,20 @@ func (s *Syncer) processShastaProposal(
 			return fmt.Errorf("failed to fetch the last Pacaya block: %w", err)
 		}
 	} else {
-		// Fetch the parent block, here we try to find the L1 origin of the previous proposal at first,
-		// if not found, which means either the previous proposal is genesis or the L2 EE just finishes the
-		// P2P sync, then we just use the latest block as parent block in this case.
+		// For other proposals, fetch the parent block by getting the last block in the previous proposal.
 		blockID, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(meta.GetEventData().Id, common.Big1))
-		if err != nil &&
-			err.Error() != ethereum.NotFound.Error() &&
-			err.Error() != eth.ErrProposalLastBlockUncertain.Error() {
+		if err != nil {
 			return fmt.Errorf("failed to fetch last L1 origin by batch ID: %w", err)
 		}
-		if blockID != nil {
-			if parent, err = s.rpc.L2.BlockByNumber(ctx, blockID.ToInt()); err != nil {
-				return err
-			}
-		} else {
-			if parent, err = s.rpc.L2.BlockByNumber(ctx, nil); err != nil {
-				return err
-			}
-			log.Info(
-				"No L1 origin found for the previous proposal, using the latest block as parent",
-				"proposalID", meta.GetEventData().Id,
-				"proposer", meta.GetEventData().Proposer,
-				"parentBlockID", parent.Number(),
+		if blockID == nil {
+			return fmt.Errorf(
+				"no last L1 origin found for batch ID %s",
+				new(big.Int).Sub(meta.GetEventData().Id, common.Big1),
 			)
+		}
+
+		if parent, err = s.rpc.L2.BlockByNumber(ctx, blockID.ToInt()); err != nil {
+			return err
 		}
 	}
 

--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -67,12 +68,32 @@ func (s *State) ResetL1Current(ctx context.Context, blockID *big.Int) error {
 		if block.Transactions().Len() == 0 {
 			return fmt.Errorf("no transactions found in block %d", blockID)
 		}
-		// Fetch the anchor block number from the anchorV4 transaction for Shasta blocks.
-		_, anchorBlockNumber, _, err := s.rpc.GetSyncedL1SnippetFromAnchor(block.Transactions()[0])
+		// For Shasta blocks, we need to get the last block ID from the last seen proposal ID - 1.
+		proposalID, err := core.DecodeShastaProposalID(block.Extra())
 		if err != nil {
-			return fmt.Errorf("failed to decode anchorV4 block params: %w", err)
+			return fmt.Errorf("failed to decode Shasta proposal ID from block %d: %w", blockID, err)
 		}
-		proposedIn = new(big.Int).SetUint64(anchorBlockNumber)
+		blockID, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(proposalID, common.Big1))
+		if err != nil {
+			return fmt.Errorf("failed to get last block ID by batch ID (%d): %w", proposalID, err)
+		}
+		if blockID.ToInt().Cmp(common.Big0) == 0 {
+			if proposedIn, err = s.rpc.GetShastaActivationBlockNumber(ctx); err != nil {
+				return fmt.Errorf("failed to get Shasta activation block number: %w", err)
+			}
+		} else {
+			blockFromLastProposal, err := s.rpc.L2.BlockByNumber(ctx, blockID.ToInt())
+			if err != nil {
+				return fmt.Errorf("failed to get L2 block by number (%d): %w", blockID, err)
+			}
+
+			// Fetch the anchor block number from the anchorV4 transaction for Shasta blocks.
+			_, anchorBlockNumber, _, err := s.rpc.GetSyncedL1SnippetFromAnchor(blockFromLastProposal.Transactions()[0])
+			if err != nil {
+				return fmt.Errorf("failed to decode anchorV4 block params: %w", err)
+			}
+			proposedIn = new(big.Int).SetUint64(anchorBlockNumber)
+		}
 	}
 
 	l1Current, err := s.rpc.L1.HeaderByNumber(ctx, proposedIn)

--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -73,15 +73,16 @@ func (s *State) ResetL1Current(ctx context.Context, blockID *big.Int) error {
 		if err != nil {
 			return fmt.Errorf("failed to decode Shasta proposal ID from block %d: %w", blockID, err)
 		}
-		blockID, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(proposalID, common.Big1))
-		if err != nil {
-			return fmt.Errorf("failed to get last block ID by batch ID (%d): %w", proposalID, err)
-		}
-		if blockID.ToInt().Cmp(common.Big0) == 0 {
+		if proposalID.Cmp(common.Big1) <= 0 {
 			if proposedIn, err = s.rpc.GetShastaActivationBlockNumber(ctx); err != nil {
 				return fmt.Errorf("failed to get Shasta activation block number: %w", err)
 			}
 		} else {
+			blockID, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(proposalID, common.Big1))
+			if err != nil {
+				return fmt.Errorf("failed to get last block ID by batch ID (%d): %w", proposalID, err)
+			}
+
 			blockFromLastProposal, err := s.rpc.L2.BlockByNumber(ctx, blockID.ToInt())
 			if err != nil {
 				return fmt.Errorf("failed to get L2 block by number (%d): %w", blockID.ToInt(), err)

--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -90,7 +90,9 @@ func (s *State) ResetL1Current(ctx context.Context, blockID *big.Int) error {
 			if err != nil {
 				return fmt.Errorf("failed to get L2 block by number (%d): %w", blockIDFromLastProposal.ToInt(), err)
 			}
-
+			if blockFromLastProposal.Transactions().Len() == 0 {
+				return fmt.Errorf("no transactions found in block %d", blockIDFromLastProposal)
+			}
 			// Fetch the anchor block number from the anchorV4 transaction for Shasta blocks.
 			_, anchorBlockNumber, _, err := s.rpc.GetSyncedL1SnippetFromAnchor(blockFromLastProposal.Transactions()[0])
 			if err != nil {

--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -91,7 +91,7 @@ func (s *State) ResetL1Current(ctx context.Context, blockID *big.Int) error {
 				return fmt.Errorf("failed to get L2 block by number (%d): %w", blockIDFromLastProposal.ToInt(), err)
 			}
 			if blockFromLastProposal.Transactions().Len() == 0 {
-				return fmt.Errorf("no transactions found in block %d", blockIDFromLastProposal)
+				return fmt.Errorf("no transactions found in block %d", blockIDFromLastProposal.ToInt())
 			}
 			// Fetch the anchor block number from the anchorV4 transaction for Shasta blocks.
 			_, anchorBlockNumber, _, err := s.rpc.GetSyncedL1SnippetFromAnchor(blockFromLastProposal.Transactions()[0])

--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -82,6 +82,9 @@ func (s *State) ResetL1Current(ctx context.Context, blockID *big.Int) error {
 			if err != nil {
 				return fmt.Errorf("failed to get last block ID by batch ID (%d): %w", proposalID, err)
 			}
+			if blockIDFromLastProposal == nil {
+				return fmt.Errorf("no last block ID found for batch ID %d", new(big.Int).Sub(proposalID, common.Big1))
+			}
 
 			blockFromLastProposal, err := s.rpc.L2.BlockByNumber(ctx, blockIDFromLastProposal.ToInt())
 			if err != nil {

--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -78,14 +78,14 @@ func (s *State) ResetL1Current(ctx context.Context, blockID *big.Int) error {
 				return fmt.Errorf("failed to get Shasta activation block number: %w", err)
 			}
 		} else {
-			blockID, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(proposalID, common.Big1))
+			blockIDFromLastProposal, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(proposalID, common.Big1))
 			if err != nil {
 				return fmt.Errorf("failed to get last block ID by batch ID (%d): %w", proposalID, err)
 			}
 
-			blockFromLastProposal, err := s.rpc.L2.BlockByNumber(ctx, blockID.ToInt())
+			blockFromLastProposal, err := s.rpc.L2.BlockByNumber(ctx, blockIDFromLastProposal.ToInt())
 			if err != nil {
-				return fmt.Errorf("failed to get L2 block by number (%d): %w", blockID.ToInt(), err)
+				return fmt.Errorf("failed to get L2 block by number (%d): %w", blockIDFromLastProposal.ToInt(), err)
 			}
 
 			// Fetch the anchor block number from the anchorV4 transaction for Shasta blocks.

--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -84,7 +84,7 @@ func (s *State) ResetL1Current(ctx context.Context, blockID *big.Int) error {
 		} else {
 			blockFromLastProposal, err := s.rpc.L2.BlockByNumber(ctx, blockID.ToInt())
 			if err != nil {
-				return fmt.Errorf("failed to get L2 block by number (%d): %w", blockID, err)
+				return fmt.Errorf("failed to get L2 block by number (%d): %w", blockID.ToInt(), err)
 			}
 
 			// Fetch the anchor block number from the anchorV4 transaction for Shasta blocks.

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -1121,14 +1121,14 @@ func (c *Client) CalculateBaseFeePacaya(
 func (c *Client) getGenesisHeight(ctx context.Context) (*big.Int, error) {
 	stateVars, err := c.GetProtocolStateVariablesPacaya(&bind.CallOpts{Context: ctx})
 	if err != nil {
-		return c.getShastaActivationBlockNumber(ctx)
+		return c.GetShastaActivationBlockNumber(ctx)
 	}
 
 	return new(big.Int).SetUint64(stateVars.Stats1.GenesisHeight), nil
 }
 
-// getShastaActivationBlockNumber resolves the L1 block number when the Shasta inbox was activated.
-func (c *Client) getShastaActivationBlockNumber(ctx context.Context) (*big.Int, error) {
+// GetShastaActivationBlockNumber resolves the L1 block number when the Shasta inbox was activated.
+func (c *Client) GetShastaActivationBlockNumber(ctx context.Context) (*big.Int, error) {
 	ctxWithTimeout, cancel := CtxWithTimeoutOrDefault(ctx, DefaultRpcTimeout)
 	defer cancel()
 


### PR DESCRIPTION
  ## Summary
  - Derive `proposedIn` for Shasta resets from the last proposal’s L2 block anchor instead of the current block’s first tx.
  - Fall back to the Shasta activation block when there is no previous proposal (`proposalID - 1` yields block ID 0).
  - Export `GetShastaActivationBlockNumber` for reuse.

  ## Changes
  - Decode Shasta proposal ID from block extra data and look up `LastBlockIDByBatchID`.
  - Fetch the last proposal’s L2 block and parse anchorV4 params for the L1 anchor.
  - Export Shasta activation block lookup and update genesis-height fallback to use it.