### PR TITLE
fix(eventindexer): check tx.Commit error in CreateMetadata

### DIFF
--- a/packages/eventindexer/pkg/repo/erc20_balance.go
+++ b/packages/eventindexer/pkg/repo/erc20_balance.go
@@ -231,7 +231,9 @@ func (r *ERC20BalanceRepository) CreateMetadata(
 		return 0, err
 	}
 
-	tx.Commit()
+	if err := tx.Commit().Error; err != nil {
+		return 0, err
+	}
 
 	return id, nil
 }


### PR DESCRIPTION
tx.Commit() was silently ignoring errors, so if commit failed the caller would get a success response with an invalid ID. Now we properly return the error. 