### PR TITLE
feat(taiko-client): bump `taiko-geth` to sync RPC namespace changes

### DIFF
--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -51,7 +51,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        execution_node: [l2_geth, l2_nmc]
+        execution_node: [l2_geth]
+        # execution_node: [l2_geth, l2_nmc]
 
     # Allow l2_nmc tests to fail without blocking PR merges
     continue-on-error: ${{ matrix.execution_node == 'l2_nmc' }}

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -51,8 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        execution_node: [l2_geth]
-        # execution_node: [l2_geth, l2_nmc]
+        execution_node: [l2_geth, l2_nmc]
 
     # Allow l2_nmc tests to fail without blocking PR merges
     continue-on-error: ${{ matrix.execution_node == 'l2_nmc' }}

--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260127025607-9680af1dc948
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260129032212-a6027c7ecce1
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f
 

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082 h1:ymZR+Y88LOnA8i3Ke
 github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082/go.mod h1:RHnIu3EFehrWX3JhFAMQSXD5uz7l0xaNroTzXrap7EQ=
 github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f h1:7lZFtV7wip0wmcTquvmtSH5LRp1djzSiDkOeGpIuEN4=
 github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260127025607-9680af1dc948 h1:8K8yGsi5TxRpta9omhKElg5uY/wq4qRK6mzgrQYIbP4=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260127025607-9680af1dc948/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260129032212-a6027c7ecce1 h1:TzrxLKMnVTl/BhJzSD3/NGXLWsf1W9Mz1NS7n1tInPw=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260129032212-a6027c7ecce1/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -127,6 +127,8 @@ var (
 var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	L2WSEndpoint,
 	L2HTTPEndpoint,
+	L2AuthEndpoint,
+	JWTSecret,
 	RaikoHostEndpoint,
 	RaikoApiKeyPath,
 	L1ProverPrivKey,

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -177,7 +177,6 @@ func (s *L2ChainSyncer) SetUpEventSync(blockIDToSync uint64) error {
 			)
 		}
 	}
-
 	return nil
 }
 

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
@@ -92,7 +92,7 @@ func (i *Shasta) InsertBlocksWithManifest(
 		return nil, fmt.Errorf("failed to fetch Shasta core state: %w", err)
 	}
 	if coreState.LastFinalizedProposalId.Cmp(meta.GetEventData().Id) >= 0 {
-		blockID, err := i.rpc.L2.LastBlockIDByBatchID(ctx, coreState.LastFinalizedProposalId)
+		blockID, err := i.rpc.L2Engine.LastBlockIDByBatchID(ctx, coreState.LastFinalizedProposalId)
 		if err == nil {
 			if lastFinalizedHeader, err = i.rpc.L2.HeaderByNumber(ctx, blockID.ToInt()); err != nil {
 				return nil, fmt.Errorf("failed to fetch last finalized block header (%d): %w", blockID.ToInt(), err)

--- a/packages/taiko-client/driver/chain_syncer/event/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer.go
@@ -273,7 +273,7 @@ func (s *Syncer) processShastaProposal(
 		}
 	} else {
 		// For other proposals, fetch the parent block by getting the last block in the previous proposal.
-		blockID, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(meta.GetEventData().Id, common.Big1))
+		blockID, err := s.rpc.L2Engine.LastBlockIDByBatchID(ctx, new(big.Int).Sub(meta.GetEventData().Id, common.Big1))
 		if err != nil {
 			return fmt.Errorf("failed to fetch last L1 origin by batch ID: %w", err)
 		}
@@ -602,7 +602,7 @@ func (s *Syncer) checkLastVerifiedBlockMismatchShasta(ctx context.Context) (*rpc
 		return reorgCheckResult, nil
 	}
 
-	lastBlockInBatch, err := s.rpc.L2.LastL1OriginByBatchID(ctx, coreState.LastFinalizedProposalId)
+	lastBlockInBatch, err := s.rpc.L2Engine.LastL1OriginByBatchID(ctx, coreState.LastFinalizedProposalId)
 	if err != nil &&
 		err.Error() != ethereum.NotFound.Error() &&
 		err.Error() != eth.ErrProposalLastBlockUncertain.Error() {

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -167,7 +167,7 @@ func (s *DriverTestSuite) TestCheckL1ReorgToHigherFork() {
 	s.Greater(l2Head2.Number.Uint64(), l2Head1.Number.Uint64())
 	s.Greater(l1Head2.Number.Uint64(), l1Head1.Number.Uint64())
 
-	headL1Origin, err := s.RPCClient.L2.LastL1OriginByBatchID(context.Background(), m.Shasta().GetEventData().Id)
+	headL1Origin, err := s.RPCClient.L2Engine.LastL1OriginByBatchID(context.Background(), m.Shasta().GetEventData().Id)
 	s.Nil(err)
 	s.Equal(l2Head2.Hash(), headL1Origin.L2BlockHash)
 
@@ -227,7 +227,7 @@ func (s *DriverTestSuite) TestCheckL1ReorgToLowerFork() {
 	s.Greater(l2Head2.Number.Uint64(), l2Head1.Number.Uint64())
 	s.Greater(l1Head2.Number.Uint64(), l1Head1.Number.Uint64())
 
-	headL1Origin, err := s.RPCClient.L2.LastL1OriginByBatchID(context.Background(), m.Shasta().GetEventData().Id)
+	headL1Origin, err := s.RPCClient.L2Engine.LastL1OriginByBatchID(context.Background(), m.Shasta().GetEventData().Id)
 	s.Nil(err)
 	s.Equal(l2Head2.Hash(), headL1Origin.L2BlockHash)
 
@@ -291,7 +291,7 @@ func (s *DriverTestSuite) TestCheckL1ReorgShastaToPacaya() {
 	s.Nil(err)
 	s.Greater(l2Head3.Time, s.RPCClient.ShastaClients.ForkTime)
 
-	headL1Origin, err := s.RPCClient.L2.LastL1OriginByBatchID(context.Background(), m.Shasta().GetEventData().Id)
+	headL1Origin, err := s.RPCClient.L2Engine.LastL1OriginByBatchID(context.Background(), m.Shasta().GetEventData().Id)
 	s.Nil(err)
 	s.Equal(l2Head3.Hash(), headL1Origin.L2BlockHash)
 
@@ -360,7 +360,7 @@ func (s *DriverTestSuite) TestCheckL1ReorgToSameHeightFork() {
 	s.Greater(l2Head2.Number.Uint64(), l2Head1.Number.Uint64())
 	s.Greater(l1Head2.Number.Uint64(), l1Head1.Number.Uint64())
 
-	headL1Origin, err := s.RPCClient.L2.LastL1OriginByBatchID(context.Background(), m.Shasta().GetEventData().Id)
+	headL1Origin, err := s.RPCClient.L2Engine.LastL1OriginByBatchID(context.Background(), m.Shasta().GetEventData().Id)
 	s.Nil(err)
 	s.Equal(l2Head2.Hash(), headL1Origin.L2BlockHash)
 

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1195,7 +1195,7 @@ func (s *PreconfBlockAPIServer) handleShastaProposalReorg(ctx context.Context, l
 		return
 	}
 
-	blockID, err := s.rpc.L2.LastBlockIDByBatchID(ctx, recordedProposal.Id)
+	blockID, err := s.rpc.L2Engine.LastBlockIDByBatchID(ctx, recordedProposal.Id)
 	if err != nil {
 		log.Error(
 			"Failed to get last block in batch for shasta proposal",

--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -78,7 +78,7 @@ func (s *State) ResetL1Current(ctx context.Context, blockID *big.Int) error {
 				return fmt.Errorf("failed to get Shasta activation block number: %w", err)
 			}
 		} else {
-			blockIDFromLastProposal, err := s.rpc.L2.LastBlockIDByBatchID(ctx, new(big.Int).Sub(proposalID, common.Big1))
+			blockIDFromLastProposal, err := s.rpc.L2Engine.LastBlockIDByBatchID(ctx, new(big.Int).Sub(proposalID, common.Big1))
 			if err != nil {
 				return fmt.Errorf("failed to get last block ID by batch ID (%d): %w", proposalID, err)
 			}

--- a/packages/taiko-client/pkg/rpc/engine.go
+++ b/packages/taiko-client/pkg/rpc/engine.go
@@ -24,7 +24,14 @@ type EngineClient struct {
 }
 
 // CallContext wraps the underlying RPC client's CallContext with metrics tracking.
+// If the context does not have a deadline, a default timeout is applied.
 func (c *EngineClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, DefaultRpcTimeout)
+		defer cancel()
+	}
+
 	start := time.Now()
 	err := c.Client.CallContext(ctx, result, method, args...)
 	recordRPCMetrics(method, c.rpcURL, start, err)
@@ -54,11 +61,8 @@ func (c *EngineClient) ForkchoiceUpdate(
 	fc *engine.ForkchoiceStateV1,
 	attributes *engine.PayloadAttributes,
 ) (*engine.ForkChoiceResponse, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, DefaultRpcTimeout)
-	defer cancel()
-
 	var result *engine.ForkChoiceResponse
-	if err := c.CallContext(timeoutCtx, &result, "engine_forkchoiceUpdatedV2", fc, attributes); err != nil {
+	if err := c.CallContext(ctx, &result, "engine_forkchoiceUpdatedV2", fc, attributes); err != nil {
 		return nil, err
 	}
 
@@ -70,11 +74,8 @@ func (c *EngineClient) NewPayload(
 	ctx context.Context,
 	payload *engine.ExecutableData,
 ) (*engine.PayloadStatusV1, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, DefaultRpcTimeout)
-	defer cancel()
-
 	var result *engine.PayloadStatusV1
-	if err := c.CallContext(timeoutCtx, &result, "engine_newPayloadV2", payload); err != nil {
+	if err := c.CallContext(ctx, &result, "engine_newPayloadV2", payload); err != nil {
 		return nil, err
 	}
 
@@ -86,11 +87,8 @@ func (c *EngineClient) GetPayload(
 	ctx context.Context,
 	payloadID *engine.PayloadID,
 ) (*engine.ExecutableData, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, DefaultRpcTimeout)
-	defer cancel()
-
 	var result *engine.ExecutionPayloadEnvelope
-	if err := c.CallContext(timeoutCtx, &result, "engine_getPayloadV2", payloadID); err != nil {
+	if err := c.CallContext(ctx, &result, "engine_getPayloadV2", payloadID); err != nil {
 		return nil, err
 	}
 
@@ -102,11 +100,8 @@ func (c *EngineClient) ExchangeTransitionConfiguration(
 	ctx context.Context,
 	cfg *engine.TransitionConfigurationV1,
 ) (*engine.TransitionConfigurationV1, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, DefaultRpcTimeout)
-	defer cancel()
-
 	var result *engine.TransitionConfigurationV1
-	if err := c.CallContext(timeoutCtx, &result, "engine_exchangeTransitionConfigurationV1", cfg); err != nil {
+	if err := c.CallContext(ctx, &result, "engine_exchangeTransitionConfigurationV1", cfg); err != nil {
 		return nil, err
 	}
 
@@ -124,12 +119,9 @@ func (c *EngineClient) TxPoolContentWithMinTip(
 	maxTransactionsLists uint64,
 	minTip uint64,
 ) ([]*miner.PreBuiltTxList, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, DefaultRpcTimeout)
-	defer cancel()
 	var result []*miner.PreBuiltTxList
-
 	if err := c.CallContext(
-		timeoutCtx,
+		ctx,
 		&result,
 		"taikoAuth_txPoolContentWithMinTip",
 		beneficiary,
@@ -196,7 +188,6 @@ func (c *EngineClient) SetBatchToLastBlock(ctx context.Context, batchID *big.Int
 // LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
 func (c *EngineClient) LastL1OriginByBatchID(ctx context.Context, batchID *big.Int) (*rawdb.L1Origin, error) {
 	var res *rawdb.L1Origin
-
 	if err := c.CallContext(ctx, &res, "taikoAuth_lastL1OriginByBatchID", hexutil.EncodeBig(batchID)); err != nil {
 		return nil, err
 	}
@@ -207,7 +198,6 @@ func (c *EngineClient) LastL1OriginByBatchID(ctx context.Context, batchID *big.I
 // LastBlockIDByBatchID returns the ID of the last block for the given batch.
 func (c *EngineClient) LastBlockIDByBatchID(ctx context.Context, batchID *big.Int) (*hexutil.Big, error) {
 	var res *hexutil.Big
-
 	if err := c.CallContext(ctx, &res, "taikoAuth_lastBlockIDByBatchID", hexutil.EncodeBig(batchID)); err != nil {
 		return nil, err
 	}

--- a/packages/taiko-client/pkg/rpc/engine.go
+++ b/packages/taiko-client/pkg/rpc/engine.go
@@ -192,3 +192,25 @@ func (c *EngineClient) SetBatchToLastBlock(ctx context.Context, batchID *big.Int
 
 	return (*big.Int)(&res), nil
 }
+
+// LastL1OriginByBatchID returns the L1 origin of the last block for the given batch.
+func (c *EngineClient) LastL1OriginByBatchID(ctx context.Context, batchID *big.Int) (*rawdb.L1Origin, error) {
+	var res *rawdb.L1Origin
+
+	if err := c.CallContext(ctx, &res, "taikoAuth_lastL1OriginByBatchID", hexutil.EncodeBig(batchID)); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// LastBlockIDByBatchID returns the ID of the last block for the given batch.
+func (c *EngineClient) LastBlockIDByBatchID(ctx context.Context, batchID *big.Int) (*hexutil.Big, error) {
+	var res *hexutil.Big
+
+	if err := c.CallContext(ctx, &res, "taikoAuth_lastBlockIDByBatchID", hexutil.EncodeBig(batchID)); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -454,7 +454,7 @@ func (c *Client) WaitShastaHeader(ctx context.Context, batchID *big.Int) (*types
 			return nil, ctxWithTimeout.Err()
 		}
 
-		l1Origin, err := c.L2.LastL1OriginByBatchID(ctxWithTimeout, batchID)
+		l1Origin, err := c.L2Engine.LastL1OriginByBatchID(ctxWithTimeout, batchID)
 		if err != nil {
 			if err.Error() == eth.ErrProposalLastBlockUncertain.Error() {
 				log.Warn(
@@ -597,7 +597,7 @@ func (c *Client) L2ExecutionEngineSyncProgress(ctx context.Context) (*L2SyncProg
 
 		// If the next proposal ID is 1, it means there is no Shasta proposal has been made on L2 yet.
 		if coreState.NextProposalId.Cmp(common.Big1) > 0 {
-			l1Origin, err := c.L2.LastL1OriginByBatchID(
+			l1Origin, err := c.L2Engine.LastL1OriginByBatchID(
 				ctx,
 				new(big.Int).Sub(coreState.NextProposalId, common.Big1),
 			)
@@ -785,7 +785,7 @@ func (c *Client) CheckL1Reorg(ctx context.Context, batchID *big.Int, isShastaBat
 		// 1. Check whether the last L2 block's corresponding L1 block which in L1Origin has been reorged.
 		var l1Origin *rawdb.L1Origin
 		if isShastaBatch {
-			if l1Origin, err = c.L2.LastL1OriginByBatchID(ctxWithTimeout, batchID); err != nil {
+			if l1Origin, err = c.L2Engine.LastL1OriginByBatchID(ctxWithTimeout, batchID); err != nil {
 				// If the L2 EE is just synced through P2P, so there is no L1Origin information recorded in
 				// its local database, we skip this check.
 				if err.Error() == ethereum.NotFound.Error() || err.Error() == eth.ErrProposalLastBlockUncertain.Error() {
@@ -943,7 +943,7 @@ func (c *Client) LastL1OriginInBatchShasta(ctx context.Context, batchID *big.Int
 		return l1Origin, nil
 	}
 
-	l1Origin, err := c.L2.LastL1OriginByBatchID(ctxWithTimeout, batchID)
+	l1Origin, err := c.L2Engine.LastL1OriginByBatchID(ctxWithTimeout, batchID)
 	if err != nil {
 		return nil, fmt.Errorf("L1Origin not found for batch ID %d: %w", batchID, err)
 	}
@@ -1525,7 +1525,7 @@ func (c *Client) GetProposalByIDShasta(
 	ctxWithTimeout, cancel := CtxWithTimeoutOrDefault(ctx, DefaultRpcTimeout)
 	defer cancel()
 
-	blockID, err := c.L2.LastBlockIDByBatchID(ctxWithTimeout, proposalID)
+	blockID, err := c.L2Engine.LastBlockIDByBatchID(ctxWithTimeout, proposalID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get last block ID by batch ID %d: %w", proposalID, err)
 	}

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/cmd/flags"
 	pkgFlags "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/flags"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/jwt"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/utils"
 )
 
@@ -24,6 +25,8 @@ type Config struct {
 	L1WsEndpoint              string
 	L2WsEndpoint              string
 	L2HttpEndpoint            string
+	L2EngineEndpoint          string
+	JwtSecret                 string
 	PacayaInboxAddress        common.Address
 	ShastaInboxAddress        common.Address
 	TaikoAnchorAddress        common.Address
@@ -63,6 +66,11 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		return nil, fmt.Errorf("invalid L1 prover private key: %w", err)
 	}
 
+	jwtSecret, err := jwt.ParseSecretFromFile(c.String(flags.JWTSecret.Name))
+	if err != nil {
+		return nil, fmt.Errorf("invalid JWT secret file: %w", err)
+	}
+
 	var startingBatchID *big.Int
 	if c.IsSet(flags.StartingBatchID.Name) {
 		startingBatchID = new(big.Int).SetUint64(c.Uint64(flags.StartingBatchID.Name))
@@ -100,6 +108,8 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		L1WsEndpoint:           c.String(flags.L1WSEndpoint.Name),
 		L2WsEndpoint:           c.String(flags.L2WSEndpoint.Name),
 		L2HttpEndpoint:         c.String(flags.L2HTTPEndpoint.Name),
+		L2EngineEndpoint:       c.String(flags.L2AuthEndpoint.Name),
+		JwtSecret:              string(jwtSecret),
 		PacayaInboxAddress:     common.HexToAddress(c.String(flags.PacayaInboxAddress.Name)),
 		ShastaInboxAddress:     common.HexToAddress(c.String(flags.ShastaInboxAddress.Name)),
 		TaikoAnchorAddress:     common.HexToAddress(c.String(flags.TaikoAnchorAddress.Name)),

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -104,6 +104,8 @@ func InitFromConfig(
 	if p.rpc, err = rpc.NewClient(p.ctx, &rpc.ClientConfig{
 		L1Endpoint:         cfg.L1WsEndpoint,
 		L2Endpoint:         cfg.L2WsEndpoint,
+		L2EngineEndpoint:   cfg.L2EngineEndpoint,
+		JwtSecret:          cfg.JwtSecret,
 		PacayaInboxAddress: cfg.PacayaInboxAddress,
 		ShastaInboxAddress: cfg.ShastaInboxAddress,
 		TaikoAnchorAddress: cfg.TaikoAnchorAddress,

--- a/packages/taiko-client/prover/prover_test.go
+++ b/packages/taiko-client/prover/prover_test.go
@@ -723,11 +723,17 @@ func (s *ProverTestSuite) initProver(ctx context.Context, key *ecdsa.PrivateKey)
 	s.Nil(err)
 	s.NotNil(proposerKey)
 
+	jwtSecret, err := jwt.ParseSecretFromFile(os.Getenv("JWT_SECRET"))
+	s.Nil(err)
+	s.NotEmpty(jwtSecret)
+
 	p := new(Prover)
 	s.Nil(InitFromConfig(ctx, p, &Config{
 		L1WsEndpoint:           os.Getenv("L1_WS"),
 		L2WsEndpoint:           os.Getenv("L2_WS"),
 		L2HttpEndpoint:         os.Getenv("L2_HTTP"),
+		L2EngineEndpoint:       os.Getenv("L2_AUTH"),
+		JwtSecret:              string(jwtSecret),
 		PacayaInboxAddress:     common.HexToAddress(os.Getenv("PACAYA_INBOX")),
 		ShastaInboxAddress:     common.HexToAddress(os.Getenv("SHASTA_INBOX")),
 		TaikoAnchorAddress:     common.HexToAddress(os.Getenv("TAIKO_ANCHOR")),

--- a/packages/taiko-client/prover/prover_test.go
+++ b/packages/taiko-client/prover/prover_test.go
@@ -368,11 +368,16 @@ func (s *ProverTestSuite) TestAggregateProofsAlreadyProved() {
 	)
 	decimal, err := s.RPCClient.PacayaClients.TaikoToken.Decimals(nil)
 	s.Nil(err)
+	jwtSecret, err := jwt.ParseSecretFromFile(os.Getenv("JWT_SECRET"))
+	s.Nil(err)
+	s.NotEmpty(jwtSecret)
 	batchProver := new(Prover)
 	s.Nil(InitFromConfig(context.Background(), batchProver, &Config{
 		L1WsEndpoint:          os.Getenv("L1_WS"),
 		L2WsEndpoint:          os.Getenv("L2_WS"),
 		L2HttpEndpoint:        os.Getenv("L2_HTTP"),
+		L2EngineEndpoint:      os.Getenv("L2_AUTH"),
+		JwtSecret:             string(jwtSecret),
 		PacayaInboxAddress:    common.HexToAddress(os.Getenv("PACAYA_INBOX")),
 		ShastaInboxAddress:    common.HexToAddress(os.Getenv("SHASTA_INBOX")),
 		TaikoAnchorAddress:    common.HexToAddress(os.Getenv("TAIKO_ANCHOR")),
@@ -426,11 +431,16 @@ func (s *ProverTestSuite) TestAggregateProofs() {
 	)
 	decimal, err := s.RPCClient.PacayaClients.TaikoToken.Decimals(nil)
 	s.Nil(err)
+	jwtSecret, err := jwt.ParseSecretFromFile(os.Getenv("JWT_SECRET"))
+	s.Nil(err)
+	s.NotEmpty(jwtSecret)
 	batchProver := new(Prover)
 	s.Nil(InitFromConfig(context.Background(), batchProver, &Config{
 		L1WsEndpoint:          os.Getenv("L1_WS"),
 		L2WsEndpoint:          os.Getenv("L2_WS"),
 		L2HttpEndpoint:        os.Getenv("L2_HTTP"),
+		L2EngineEndpoint:      os.Getenv("L2_AUTH"),
+		JwtSecret:             string(jwtSecret),
 		PacayaInboxAddress:    common.HexToAddress(os.Getenv("PACAYA_INBOX")),
 		ShastaInboxAddress:    common.HexToAddress(os.Getenv("SHASTA_INBOX")),
 		TaikoAnchorAddress:    common.HexToAddress(os.Getenv("TAIKO_ANCHOR")),
@@ -659,11 +669,16 @@ func (s *ProverTestSuite) TestForceAggregate() {
 	decimal, err := s.RPCClient.PacayaClients.TaikoToken.Decimals(nil)
 	s.Nil(err)
 	s.NotZero(decimal)
+	jwtSecret, err := jwt.ParseSecretFromFile(os.Getenv("JWT_SECRET"))
+	s.Nil(err)
+	s.NotEmpty(jwtSecret)
 	batchProver := new(Prover)
 	s.Nil(InitFromConfig(context.Background(), batchProver, &Config{
 		L1WsEndpoint:          os.Getenv("L1_WS"),
 		L2WsEndpoint:          os.Getenv("L2_WS"),
 		L2HttpEndpoint:        os.Getenv("L2_HTTP"),
+		L2EngineEndpoint:      os.Getenv("L2_AUTH"),
+		JwtSecret:             string(jwtSecret),
 		PacayaInboxAddress:    common.HexToAddress(os.Getenv("PACAYA_INBOX")),
 		ShastaInboxAddress:    common.HexToAddress(os.Getenv("SHASTA_INBOX")),
 		TaikoAnchorAddress:    common.HexToAddress(os.Getenv("TAIKO_ANCHOR")),


### PR DESCRIPTION
ref: https://github.com/taikoxyz/taiko-geth/pull/510

  ## Summary
  - Bump taiko-geth to `a6027c7ecce1` to sync RPC namespace changes
  - `LastL1OriginByBatchID` and `LastBlockIDByBatchID` moved from `taiko_` to `taikoAuth_` namespace
  - No code changes required - ethclient API remains unchanged
