### PR TITLE
chore(taiko-client-rs): use `taikoAuth` batch lookups and error handling

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-block"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=41fac9fd014a9944439aa2c2fbae56f9f1a627f3#41fac9fd014a9944439aa2c2fbae56f9f1a627f3"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -78,17 +78,19 @@ dependencies = [
  "alloy-evm 0.26.3",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-eth",
+ "flate2",
  "op-alloy-flz",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-ethereum",
- "reth-ethereum-forks 1.10.1",
+ "reth-ethereum-forks 1.10.2",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
  "reth-payload-primitives",
  "reth-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-revm",
  "reth-rpc-eth-api",
  "reth-storage-errors",
@@ -100,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=41fac9fd014a9944439aa2c2fbae56f9f1a627f3#41fac9fd014a9944439aa2c2fbae56f9f1a627f3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -109,10 +111,10 @@ dependencies = [
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "auto_impl",
- "reth-chainspec 1.10.1",
- "reth-ethereum-forks 1.10.1",
+ "reth-chainspec 1.10.2",
+ "reth-ethereum-forks 1.10.2",
  "reth-evm",
- "reth-network-peers 1.10.1",
+ "reth-network-peers 1.10.2",
  "reth-primitives",
  "reth-revm",
  "serde_json",
@@ -121,7 +123,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=41fac9fd014a9944439aa2c2fbae56f9f1a627f3#41fac9fd014a9944439aa2c2fbae56f9f1a627f3"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -129,20 +131,20 @@ dependencies = [
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-sol-types",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus",
  "reth-consensus-common",
  "reth-ethereum",
  "reth-ethereum-consensus",
  "reth-execution-types",
  "reth-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
 ]
 
 [[package]]
 name = "alethia-reth-db"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=41fac9fd014a9944439aa2c2fbae56f9f1a627f3#41fac9fd014a9944439aa2c2fbae56f9f1a627f3"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-primitives",
@@ -158,7 +160,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-evm"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=41fac9fd014a9944439aa2c2fbae56f9f1a627f3#41fac9fd014a9944439aa2c2fbae56f9f1a627f3"
 dependencies = [
  "alloy-evm 0.26.3",
  "alloy-primitives",
@@ -171,7 +173,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=41fac9fd014a9944439aa2c2fbae56f9f1a627f3#41fac9fd014a9944439aa2c2fbae56f9f1a627f3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -179,14 +181,14 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-engine-local",
  "reth-ethereum",
  "reth-ethereum-engine-primitives",
  "reth-node-api",
  "reth-payload-primitives",
  "reth-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "serde",
  "serde_with",
  "sha2 0.10.9",
@@ -196,7 +198,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19#3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=41fac9fd014a9944439aa2c2fbae56f9f1a627f3#41fac9fd014a9944439aa2c2fbae56f9f1a627f3"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -231,7 +233,7 @@ dependencies = [
  "reth-node-core",
  "reth-node-ethereum",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -8101,14 +8103,14 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
  "clap",
  "eyre",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-cli-runner",
  "reth-cli-util",
  "reth-consensus",
@@ -8139,7 +8141,7 @@ dependencies = [
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-tasks",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "reth-transaction-pool",
  "tokio",
  "tracing",
@@ -8147,8 +8149,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8157,11 +8159,11 @@ dependencies = [
  "futures-util",
  "metrics 0.24.3",
  "reth-chain-state",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
@@ -8171,8 +8173,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8182,12 +8184,12 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-api",
  "reth-trie",
  "revm-database 10.0.0",
@@ -8220,8 +8222,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8232,16 +8234,16 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "derive_more",
- "reth-ethereum-forks 1.10.1",
- "reth-network-peers 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-ethereum-forks 1.10.2",
+ "reth-network-peers 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-cli"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8254,8 +8256,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8276,7 +8278,7 @@ dependencies = [
  "metrics 0.24.3",
  "ratatui",
  "reqwest",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-cli",
  "reth-cli-runner",
  "reth-cli-util",
@@ -8287,7 +8289,7 @@ dependencies = [
  "reth-db-api",
  "reth-db-common",
  "reth-discv4",
- "reth-discv5 1.10.1",
+ "reth-discv5 1.10.2",
  "reth-downloaders",
  "reth-ecies",
  "reth-era",
@@ -8301,13 +8303,13 @@ dependencies = [
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers 1.10.1",
+ "reth-network-peers 1.10.2",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune",
  "reth-revm",
@@ -8332,8 +8334,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8342,8 +8344,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8360,8 +8362,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8378,8 +8380,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8388,12 +8390,12 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "eyre",
  "humantime-serde",
- "reth-network-types 1.10.1",
+ "reth-network-types 1.10.2",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
@@ -8404,33 +8406,33 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
 ]
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8445,7 +8447,7 @@ dependencies = [
  "futures",
  "reqwest",
  "reth-node-api",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-tracing",
  "ringbuffer",
  "serde",
@@ -8455,8 +8457,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8466,7 +8468,7 @@ dependencies = [
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
@@ -8479,8 +8481,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8493,7 +8495,7 @@ dependencies = [
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -8504,15 +8506,15 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
  "boyer-moore-magiclen",
  "eyre",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-codecs",
  "reth-config",
  "reth-db-api",
@@ -8520,7 +8522,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-fs-util",
  "reth-node-types",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-stages-types",
  "reth-static-file-types",
@@ -8534,22 +8536,22 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "serde",
 ]
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8558,10 +8560,10 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "rand 0.8.5",
- "reth-ethereum-forks 1.10.1",
- "reth-net-banlist 1.10.1",
+ "reth-ethereum-forks 1.10.2",
+ "reth-net-banlist 1.10.2",
  "reth-net-nat",
- "reth-network-peers 1.10.1",
+ "reth-network-peers 1.10.2",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8597,8 +8599,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8609,10 +8611,10 @@ dependencies = [
  "itertools 0.14.0",
  "metrics 0.24.3",
  "rand 0.9.2",
- "reth-chainspec 1.10.1",
- "reth-ethereum-forks 1.10.1",
- "reth-metrics 1.10.1",
- "reth-network-peers 1.10.1",
+ "reth-chainspec 1.10.2",
+ "reth-ethereum-forks 1.10.2",
+ "reth-metrics 1.10.2",
+ "reth-network-peers 1.10.2",
  "secp256k1 0.30.0",
  "thiserror 2.0.17",
  "tokio",
@@ -8621,8 +8623,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8630,9 +8632,9 @@ dependencies = [
  "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
- "reth-ethereum-forks 1.10.1",
- "reth-network-peers 1.10.1",
- "reth-tokio-util 1.10.1",
+ "reth-ethereum-forks 1.10.2",
+ "reth-network-peers 1.10.2",
+ "reth-tokio-util 1.10.2",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8645,8 +8647,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8661,10 +8663,10 @@ dependencies = [
  "rayon",
  "reth-config",
  "reth-consensus",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-network-p2p",
- "reth-network-peers 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-network-peers 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-api",
  "reth-tasks",
  "thiserror 2.0.17",
@@ -8676,8 +8678,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8692,7 +8694,7 @@ dependencies = [
  "hmac",
  "pin-project",
  "rand 0.8.5",
- "reth-network-peers 1.10.1",
+ "reth-network-peers 1.10.2",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
  "thiserror 2.0.17",
@@ -8704,20 +8706,20 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-api",
  "reth-transaction-pool",
  "tokio",
@@ -8727,8 +8729,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8743,7 +8745,7 @@ dependencies = [
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.17",
@@ -8752,12 +8754,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "futures",
  "pin-project",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus",
  "reth-engine-primitives",
  "reth-engine-tree",
@@ -8775,8 +8777,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8802,11 +8804,11 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune",
  "reth-revm",
@@ -8829,8 +8831,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8838,14 +8840,14 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "pin-project",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-engine-primitives",
  "reth-engine-tree",
  "reth-errors",
  "reth-evm",
  "reth-fs-util",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-revm",
  "reth-storage-api",
  "serde",
@@ -8857,8 +8859,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8872,8 +8874,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8888,8 +8890,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8900,7 +8902,7 @@ dependencies = [
  "reth-era-downloader",
  "reth-etl",
  "reth-fs-util",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-stages-types",
  "reth-storage-api",
@@ -8910,8 +8912,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8921,8 +8923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8934,10 +8936,10 @@ dependencies = [
  "reth-codecs",
  "reth-ecies",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.1",
- "reth-metrics 1.10.1",
- "reth-network-peers 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-ethereum-forks 1.10.2",
+ "reth-metrics 1.10.2",
+ "reth-network-peers 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "serde",
  "snap",
  "thiserror 2.0.17",
@@ -8949,8 +8951,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8960,41 +8962,41 @@ dependencies = [
  "alloy-rlp",
  "bytes",
  "derive_more",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-codecs-derive",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "serde",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus",
  "reth-consensus-common",
  "reth-ethereum-consensus",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-revm",
  "reth-storage-api",
 ]
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "clap",
  "eyre",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
@@ -9011,24 +9013,24 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9037,7 +9039,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-ethereum-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.17",
@@ -9057,8 +9059,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -9070,8 +9072,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9079,7 +9081,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus-common",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -9089,7 +9091,7 @@ dependencies = [
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-payload-validator",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
@@ -9099,8 +9101,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,7 +9112,7 @@ dependencies = [
  "alloy-serde",
  "modular-bitfield",
  "reth-codecs",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-zstd-compressors",
  "serde",
  "serde_with",
@@ -9118,8 +9120,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9128,8 +9130,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9142,8 +9144,8 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-metrics 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
@@ -9152,8 +9154,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9161,20 +9163,20 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
- "reth-chainspec 1.10.1",
- "reth-ethereum-forks 1.10.1",
+ "reth-chainspec 1.10.2",
+ "reth-ethereum-forks 1.10.2",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-errors",
  "revm 34.0.0",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-evm 0.26.3",
  "alloy-primitives",
@@ -9186,8 +9188,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9195,7 +9197,7 @@ dependencies = [
  "alloy-primitives",
  "derive_more",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-trie-common",
  "revm 34.0.0",
  "serde",
@@ -9204,8 +9206,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9216,17 +9218,17 @@ dependencies = [
  "metrics 0.24.3",
  "parking_lot",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-config",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune-types",
  "reth-revm",
@@ -9242,22 +9244,22 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "serde",
  "serde_json",
@@ -9266,8 +9268,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9281,7 @@ dependencies = [
  "pretty_assertions",
  "reth-engine-primitives",
  "reth-evm",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-revm",
  "reth-rpc-api",
@@ -9314,8 +9316,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "bytes",
  "futures",
@@ -9334,8 +9336,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9350,8 +9352,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9368,8 +9370,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "futures",
  "metrics 0.24.3",
@@ -9388,8 +9390,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9397,8 +9399,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -9411,8 +9413,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9431,27 +9433,27 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus",
  "reth-discv4",
- "reth-discv5 1.10.1",
+ "reth-discv5 1.10.2",
  "reth-dns-discovery",
  "reth-ecies",
  "reth-eth-wire",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.1",
+ "reth-ethereum-forks 1.10.2",
  "reth-ethereum-primitives",
  "reth-fs-util",
- "reth-metrics 1.10.1",
- "reth-net-banlist 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-net-banlist 1.10.2",
  "reth-network-api",
  "reth-network-p2p",
- "reth-network-peers 1.10.1",
- "reth-network-types 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-network-peers 1.10.2",
+ "reth-network-types 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-api",
  "reth-tasks",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "reth-transaction-pool",
  "rustc-hash",
  "schnellru",
@@ -9467,8 +9469,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9479,11 +9481,11 @@ dependencies = [
  "enr",
  "futures",
  "reth-eth-wire-types",
- "reth-ethereum-forks 1.10.1",
+ "reth-ethereum-forks 1.10.2",
  "reth-network-p2p",
- "reth-network-peers 1.10.1",
- "reth-network-types 1.10.1",
- "reth-tokio-util 1.10.1",
+ "reth-network-peers 1.10.2",
+ "reth-network-types 1.10.2",
+ "reth-tokio-util 1.10.2",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -9492,8 +9494,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9504,9 +9506,9 @@ dependencies = [
  "reth-consensus",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",
- "reth-network-peers 1.10.1",
- "reth-network-types 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-network-peers 1.10.2",
+ "reth-network-types 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-errors",
  "tokio",
  "tracing",
@@ -9528,8 +9530,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9555,13 +9557,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
- "reth-net-banlist 1.10.1",
- "reth-network-peers 1.10.1",
+ "reth-net-banlist 1.10.2",
+ "reth-network-peers 1.10.2",
  "serde",
  "serde_json",
  "tracing",
@@ -9569,8 +9571,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9586,8 +9588,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9604,14 +9606,14 @@ dependencies = [
  "reth-payload-primitives",
  "reth-provider",
  "reth-tasks",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "reth-transaction-pool",
 ]
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9628,7 +9630,7 @@ dependencies = [
  "rayon",
  "reth-basic-payload-builder",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
@@ -9654,7 +9656,7 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune",
  "reth-rpc",
@@ -9666,7 +9668,7 @@ dependencies = [
  "reth-stages",
  "reth-static-file",
  "reth-tasks",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",
@@ -9679,8 +9681,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9694,22 +9696,22 @@ dependencies = [
  "humantime",
  "ipnet",
  "rand 0.9.2",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-cli-util",
  "reth-config",
  "reth-consensus",
  "reth-db",
  "reth-discv4",
- "reth-discv5 1.10.1",
+ "reth-discv5 1.10.2",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-ethereum-forks 1.10.1",
- "reth-net-banlist 1.10.1",
+ "reth-ethereum-forks 1.10.2",
+ "reth-net-banlist 1.10.2",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
- "reth-network-peers 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-network-peers 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune-types",
  "reth-rpc-convert",
@@ -9735,15 +9737,15 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "eyre",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-consensus",
@@ -9756,7 +9758,7 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -9773,8 +9775,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9784,7 @@ dependencies = [
  "futures-util",
  "reth-chain-state",
  "reth-network-api",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-api",
  "reth-transaction-pool",
  "serde",
@@ -9797,8 +9799,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9810,7 +9812,7 @@ dependencies = [
  "pin-project",
  "reth-engine-primitives",
  "reth-network-api",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-prune-types",
  "reth-stages",
  "reth-static-file-types",
@@ -9821,8 +9823,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "bytes",
  "eyre",
@@ -9835,7 +9837,7 @@ dependencies = [
  "metrics-util 0.20.1",
  "procfs 0.17.0",
  "reqwest",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
@@ -9845,20 +9847,20 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-db-api",
  "reth-engine-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
 ]
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9867,10 +9869,10 @@ dependencies = [
  "metrics 0.24.3",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9878,8 +9880,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9890,8 +9892,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9901,10 +9903,10 @@ dependencies = [
  "either",
  "op-alloy-rpc-types-engine 0.23.1",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-errors",
  "reth-execution-types",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.17",
@@ -9913,24 +9915,24 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "once_cell",
- "reth-ethereum-forks 1.10.1",
+ "reth-ethereum-forks 1.10.2",
  "reth-ethereum-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-static-file-types",
 ]
 
@@ -9957,8 +9959,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9987,8 +9989,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10002,17 +10004,17 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-codecs",
  "reth-db",
  "reth-db-api",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-nippy-jar",
  "reth-node-types",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
@@ -10027,8 +10029,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10040,13 +10042,13 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-exex-types",
- "reth-metrics 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "rustc-hash",
  "thiserror 2.0.17",
  "tokio",
@@ -10055,8 +10057,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10069,8 +10071,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10088,8 +10090,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10101,12 +10103,12 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-node-api",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-ress-protocol",
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "reth-trie",
  "schnellru",
  "tokio",
@@ -10115,11 +10117,11 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
@@ -10128,8 +10130,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10167,7 +10169,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus",
  "reth-consensus-common",
  "reth-engine-primitives",
@@ -10177,12 +10179,12 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-network-api",
- "reth-network-peers 1.10.1",
- "reth-network-types 1.10.1",
+ "reth-network-peers 1.10.2",
+ "reth-network-types 1.10.2",
  "reth-node-api",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-revm",
  "reth-rpc-api",
  "reth-rpc-convert",
@@ -10210,8 +10212,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10232,7 +10234,7 @@ dependencies = [
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
- "reth-network-peers 1.10.1",
+ "reth-network-peers 1.10.2",
  "reth-rpc-eth-api",
  "reth-trie-common",
  "serde_json",
@@ -10240,8 +10242,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10251,15 +10253,15 @@ dependencies = [
  "metrics 0.24.3",
  "pin-project",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-consensus",
  "reth-engine-primitives",
  "reth-evm",
- "reth-ipc 1.10.1",
- "reth-metrics 1.10.1",
+ "reth-ipc 1.10.2",
+ "reth-metrics 1.10.2",
  "reth-network-api",
  "reth-node-core",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-eth-api",
@@ -10268,7 +10270,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "reth-transaction-pool",
  "serde",
  "thiserror 2.0.17",
@@ -10281,8 +10283,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-evm 0.26.3",
@@ -10296,14 +10298,14 @@ dependencies = [
  "jsonrpsee-types",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10312,14 +10314,14 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics 0.24.3",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-engine-primitives",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-rpc-api",
  "reth-storage-api",
  "reth-tasks",
@@ -10332,8 +10334,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10354,12 +10356,12 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-errors",
  "reth-evm",
  "reth-network-api",
  "reth-node-api",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -10376,8 +10378,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10397,13 +10399,13 @@ dependencies = [
  "rand 0.9.2",
  "reqwest",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-metrics 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-server-types",
@@ -10424,8 +10426,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10438,8 +10440,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10454,8 +10456,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10481,7 +10483,7 @@ dependencies = [
  "reth-exex",
  "reth-fs-util",
  "reth-network-p2p",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune",
  "reth-prune-types",
@@ -10499,8 +10501,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10510,15 +10512,15 @@ dependencies = [
  "metrics 0.24.3",
  "reth-consensus",
  "reth-errors",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-network-p2p",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune",
  "reth-stages-types",
  "reth-static-file",
  "reth-static-file-types",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -10526,8 +10528,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10539,28 +10541,28 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
  "rayon",
  "reth-codecs",
  "reth-db-api",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-provider",
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
  "reth-storage-errors",
- "reth-tokio-util 1.10.1",
+ "reth-tokio-util 1.10.2",
  "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10572,20 +10574,20 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-db-api",
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10596,14 +10598,14 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface 9.0.0",
@@ -10613,8 +10615,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10622,7 +10624,7 @@ dependencies = [
  "metrics 0.24.3",
  "pin-project",
  "rayon",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -10641,8 +10643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10651,8 +10653,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "clap",
  "eyre",
@@ -10668,8 +10670,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "clap",
  "eyre",
@@ -10686,8 +10688,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10702,13 +10704,13 @@ dependencies = [
  "pin-project",
  "rand 0.9.2",
  "reth-chain-state",
- "reth-chainspec 1.10.1",
+ "reth-chainspec 1.10.2",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
- "reth-metrics 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-storage-api",
  "reth-tasks",
  "revm-interpreter 32.0.0",
@@ -10726,8 +10728,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10739,8 +10741,8 @@ dependencies = [
  "metrics 0.24.3",
  "parking_lot",
  "reth-execution-errors",
- "reth-metrics 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
@@ -10751,8 +10753,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10767,7 +10769,7 @@ dependencies = [
  "nybbles",
  "rayon",
  "reth-codecs",
- "reth-primitives-traits 1.10.1",
+ "reth-primitives-traits 1.10.2",
  "revm-database 10.0.0",
  "serde",
  "serde_with",
@@ -10775,16 +10777,16 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "metrics 0.24.3",
  "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
@@ -10795,8 +10797,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10807,7 +10809,7 @@ dependencies = [
  "metrics 0.24.3",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
@@ -10820,8 +10822,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10830,8 +10832,8 @@ dependencies = [
  "metrics 0.24.3",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.1",
- "reth-primitives-traits 1.10.1",
+ "reth-metrics 1.10.2",
+ "reth-primitives-traits 1.10.2",
  "reth-trie-common",
  "smallvec",
  "tracing",
@@ -10839,8 +10841,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10848,7 +10850,7 @@ dependencies = [
  "metrics 0.24.3",
  "rayon",
  "reth-execution-errors",
- "reth-metrics 1.10.1",
+ "reth-metrics 1.10.2",
  "reth-trie-common",
  "reth-trie-sparse",
  "smallvec",
@@ -10857,8 +10859,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.1#c9dad4765df6c96a427d513227e09767e8e56f14"
+version = "1.10.2"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.10.2#8e3b5e6a99439561b73c5dd31bd3eced2e994d60"
 dependencies = [
  "zstd",
 ]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -76,12 +76,12 @@ jsonrpsee = { version = "0.26", features = ["server"] }
 k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 
 # taiko
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19" }
-alethia-reth-evm = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-evm", rev = "3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19" }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19", features = [
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "41fac9fd014a9944439aa2c2fbae56f9f1a627f3" }
+alethia-reth-evm = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-evm", rev = "41fac9fd014a9944439aa2c2fbae56f9f1a627f3" }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "41fac9fd014a9944439aa2c2fbae56f9f1a627f3", features = [
   "serde",
 ] }
-alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", rev = "3f2d51d28e57f69d97ea5a2cc090b23fbeb8ce19" }
+alethia-reth-rpc = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc", rev = "41fac9fd014a9944439aa2c2fbae56f9f1a627f3" }
 reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
 
 # types

--- a/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs
@@ -8,22 +8,15 @@ use alloy_provider::Provider;
 
 pub type L1Origin = RpcL1Origin;
 
-use crate::{
-    client::Client,
-    error::{Result, RpcClientError},
-};
+use crate::{auth::handle_ignorable_origin_error, client::Client, error::Result};
 
-/// Engine RPC method names used for L1 origin queries.
+/// Engine RPC method names used for public L1 origin queries.
 #[derive(Debug, Clone, Copy)]
 pub enum TaikoOriginMethod {
     /// `taiko_l1OriginByID`
     L1OriginById,
     /// `taiko_headL1Origin`
     HeadL1Origin,
-    /// `taiko_lastL1OriginByBatchID`
-    LastL1OriginByBatchId,
-    /// `taiko_lastBlockIDByBatchID`
-    LastBlockIdByBatchId,
 }
 
 impl TaikoOriginMethod {
@@ -32,8 +25,6 @@ impl TaikoOriginMethod {
         match self {
             Self::L1OriginById => "taiko_l1OriginByID",
             Self::HeadL1Origin => "taiko_headL1Origin",
-            Self::LastL1OriginByBatchId => "taiko_lastL1OriginByBatchID",
-            Self::LastBlockIdByBatchId => "taiko_lastBlockIDByBatchID",
         }
     }
 }
@@ -54,40 +45,4 @@ impl<P: Provider + Clone> Client<P> {
             .await
             .or_else(handle_ignorable_origin_error)
     }
-
-    /// Fetch the last L1 origin associated with the given batch id via the public engine API.
-    pub async fn last_l1_origin_by_batch_id(&self, proposal_id: U256) -> Result<Option<L1Origin>> {
-        self.l2_provider
-            .raw_request(
-                Cow::Borrowed(TaikoOriginMethod::LastL1OriginByBatchId.as_str()),
-                (proposal_id,),
-            )
-            .await
-            .or_else(handle_ignorable_origin_error)
-    }
-
-    /// Fetch the last block id that corresponds to the provided batch id.
-    pub async fn last_block_id_by_batch_id(&self, proposal_id: U256) -> Result<Option<U256>> {
-        self.l2_provider
-            .raw_request(
-                Cow::Borrowed(TaikoOriginMethod::LastBlockIdByBatchId.as_str()),
-                (proposal_id,),
-            )
-            .await
-            .or_else(handle_ignorable_origin_error)
-    }
-}
-
-/// Checks whether the underlying RPC error message represents a "not found" or ignorable response.
-fn is_ignorable_origin_error(message: &str) -> bool {
-    message.contains("not found") || message.contains("proposal last block uncertain")
-}
-
-/// Converts an RPC error into an optional origin, mapping ignorable errors to `Ok(None)`.
-fn handle_ignorable_origin_error<T, E>(err: E) -> Result<Option<T>>
-where
-    E: Into<RpcClientError> + std::fmt::Display,
-{
-    let message = err.to_string();
-    if is_ignorable_origin_error(&message) { Ok(None) } else { Err(err.into()) }
 }


### PR DESCRIPTION
ref: https://github.com/taikoxyz/alethia-reth/pull/103

  ## Summary

  - Update taiko-client-rs to track the latest alethia-reth main dependency.
  - Consolidate all `taikoAuth` method enums under `TaikoAuthMethod`.
  - Move `taikoAuth` batch lookups and their ignorable-error handling into `crates/rpc/src/auth.rs` to keep authenticated RPC concerns together.

  ## Details

  - Relocated `last_l1_origin_by_batch_id` and `last_block_id_by_batch_id` to auth.rs.
  - Moved `handle_ignorable_origin_error` (and its helper) into `auth.rs`, and had `l1_origin.rs` use it.
  - Kept public L1 origin helpers in `l1_origin.rs` unchanged.
