### PR TITLE
docs(docs-site): add GetBlock RPC provider to developer tools

### DIFF
--- a/packages/docs-site/src/content/docs/resources/developer-tools.mdx
+++ b/packages/docs-site/src/content/docs/resources/developer-tools.mdx
@@ -93,6 +93,11 @@ import { LinkCard, CardGrid } from "@astrojs/starlight/components";
     description="Thirdweb is a Web3 development platform that lets you easily build, deploy, and scale blockchain apps with prebuilt smart contracts, wallet infrastructure, and developer tools."
     href="https://thirdweb.com/chainlist?service=rpc-edge&query=taiko"
   />
+  <LinkCard
+    title="GetBlock"
+    description="GetBlock is a premium provider of RPC nodes and Web3 infrastructure, offering private connection to full and archive nodes of 100+ mainnet and testnet blockchains with fast and reliable service."
+    href="https://getblock.io/nodes/taiko/"
+  />
 </CardGrid>
 
 ## Indexers


### PR DESCRIPTION
Add GetBlock as a Node and RPC provider option for Taiko developers. GetBlock offers premium RPC nodes with support for 100+ blockchains including Taiko mainnet and testnet. 