### PR TITLE
fix(relayer): remove duplicate BlockByNumber call in getBaseFee

### DIFF
--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -729,12 +729,7 @@ func (p *Processor) getBaseFee(ctx context.Context) (*big.Int, error) {
 	var baseFee *big.Int
 
 	if p.taikoL2 != nil {
-		latestL2Block, err := p.destEthClient.BlockByNumber(ctx, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		bf, err := p.taikoL2.GetBasefee(&bind.CallOpts{Context: ctx}, blk.NumberU64(), uint32(latestL2Block.GasUsed()))
+		bf, err := p.taikoL2.GetBasefee(&bind.CallOpts{Context: ctx}, blk.NumberU64(), uint32(blk.GasUsed()))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Removes duplicate RPC call in getBaseFee function. The function was calling BlockByNumber twice to get the same block, which is unnecessary and could cause inconsistency if a new block is produced between calls. 