### PR TITLE
fix(preconfirmation-p2p): add `consts` to typos ignore list

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -13,6 +13,7 @@ extend-ignore-identifiers-re = [
   "GROTH",
   "TTKOt",
   "J64QPL3oYpZ75230YMfbLfKcUEqlIyWW8",
+  "consts",
 ]
 
 [files]


### PR DESCRIPTION
The Rust standard library module `std::f64::consts` was being flagged as a typo. This is a false positive since it's the valid path for mathematical constants like LN_2, PI, etc.