### PR TITLE
test(taiko-client-rs): drop `cleanup_provider` and use `l1_source` providers

### DIFF
--- a/packages/taiko-client-rs/crates/test-harness/src/shasta/env.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/shasta/env.rs
@@ -132,8 +132,7 @@ impl ShastaEnv {
         reset_head_l1_origin(&secondary_client).await?;
 
         // Take a fresh snapshot and activate preconf whitelist before tests run.
-        let snapshot_provider = l1_source.to_provider().await?;
-        let snapshot_id = create_snapshot("setup", &snapshot_provider).await?;
+        let snapshot_id = create_snapshot("setup", &l1_source.to_provider().await?).await?;
         ensure_preconf_whitelist_active(&client).await?;
 
         info!(elapsed_ms = started.elapsed().as_millis(), "loaded ShastaEnv");
@@ -156,8 +155,7 @@ impl ShastaEnv {
 
     /// Explicit async teardown to revert the L1 snapshot.
     pub async fn shutdown(self) -> Result<()> {
-        let provider = self.l1_source.to_provider().await?;
-        revert_snapshot(&provider, &self.snapshot_id).await
+        revert_snapshot(&self.l1_source.to_provider().await?, &self.snapshot_id).await
     }
 }
 

--- a/packages/taiko-client-rs/crates/test-harness/src/shasta/helpers.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/shasta/helpers.rs
@@ -59,7 +59,10 @@ pub async fn reset_head_l1_origin(client: &RpcClient) -> Result<()> {
 }
 
 /// Revert the L1 snapshot.
-pub async fn revert_snapshot(provider: &RootProvider, snapshot_id: &str) -> Result<()> {
+pub async fn revert_snapshot<P>(provider: &P, snapshot_id: &str) -> Result<()>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
     let reverted = provider
         .raw_request::<_, bool>(Cow::Borrowed("evm_revert"), (&snapshot_id,))
         .await
@@ -69,7 +72,10 @@ pub async fn revert_snapshot(provider: &RootProvider, snapshot_id: &str) -> Resu
 }
 
 /// Create a new L1 snapshot to reuse across a single test run.
-pub async fn create_snapshot(phase: &'static str, provider: &RootProvider) -> Result<String> {
+pub async fn create_snapshot<P>(phase: &'static str, provider: &P) -> Result<String>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
     provider
         .raw_request::<_, String>(Cow::Borrowed("evm_snapshot"), NoParams::default())
         .await


### PR DESCRIPTION
## Summary

- Remove cleanup_provider from ShastaEnv and build snapshot/revert providers from l1_source.
- Generalize create_snapshot and revert_snapshot to accept any Provider.