### PR TITLE
chore(protocol): update `forcedInclusionDelay` in `DevnetInbox`

### DIFF
--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -43,7 +43,7 @@ contract DevnetInbox is Inbox {
                 maxProofSubmissionDelay: 3 minutes,
                 ringBufferSize: _RING_BUFFER_SIZE,
                 basefeeSharingPctg: 75,
-                forcedInclusionDelay: 0 seconds, // Devnet: immediate forced inclusion for faster testing
+                forcedInclusionDelay: 576 seconds,
                 forcedInclusionFeeInGwei: 1_000_000,
                 forcedInclusionFeeDoubleThreshold: 50,
                 permissionlessInclusionMultiplier: 160


### PR DESCRIPTION
update `forcedInclusionDelay` in `DevnetInbox` to avoid preconfirmation reorgs