### PR TITLE
balance-monitor: remove ineffective `os.Kill` from signal handler

### DIFF
--- a/packages/balance-monitor/cmd/utils/subcommand.go
+++ b/packages/balance-monitor/cmd/utils/subcommand.go
@@ -52,7 +52,6 @@ func SubcommandAction(app SubcommandApplication) cli.ActionFunc {
 		quitCh := make(chan os.Signal, 1)
 		signal.Notify(quitCh, []os.Signal{
 			os.Interrupt,
-			os.Kill,
 			syscall.SIGTERM,
 			syscall.SIGQUIT,
 		}...)


### PR DESCRIPTION

Removes `os.Kill` (SIGKILL) from the signal notification list in `SubcommandAction`, as it cannot be caught or handled by `signal.Notify`.

`os.Kill` is a non-catchable signal that cannot be intercepted by user-space handlers. Including it in `signal.Notify` has no effect and may mislead readers into thinking the application handles SIGKILL gracefully.

