### PR TITLE
chore(eventindexer): correct error wrapping messages

### DIFF
--- a/packages/eventindexer/indexer/save_batches_proved_event.go
+++ b/packages/eventindexer/indexer/save_batches_proved_event.go
@@ -33,7 +33,7 @@ func (i *Indexer) saveBatchesProvedEvents(
 			if err := i.saveBatchesProvedEvent(ctx, chainID, event); err != nil {
 				eventindexer.BatchesProvenEventsProcessedError.Inc()
 
-				return errors.Wrap(err, "i.saveBlockProvenEvent")
+				return errors.Wrap(err, "i.saveBatchesProvedEvent")
 			}
 
 			return nil

--- a/packages/eventindexer/indexer/save_transition_contested_event.go
+++ b/packages/eventindexer/indexer/save_transition_contested_event.go
@@ -29,7 +29,7 @@ func (i *Indexer) saveTransitionContestedEvents(
 		if err := i.saveTransitionContestedEvent(ctx, chainID, event); err != nil {
 			eventindexer.TransitionContestedEventsProcessedError.Inc()
 
-			return errors.Wrap(err, "i.saveBlockProvenEvent")
+			return errors.Wrap(err, "i.saveTransitionContestedEvent")
 		}
 
 		if !events.Next() {
@@ -98,7 +98,7 @@ func (i *Indexer) saveTransitionContestedEventsV2(
 		if err := i.saveTransitionContestedEventV2(ctx, chainID, event); err != nil {
 			eventindexer.TransitionContestedEventsProcessedError.Inc()
 
-			return errors.Wrap(err, "i.saveBlockProvenEvent")
+			return errors.Wrap(err, "i.saveTransitionContestedEvent")
 		}
 
 		if !events.Next() {


### PR DESCRIPTION
Fixed copy-pasted error messages that incorrectly referenced saveBlockProvenEvent, ensuring error traces point to the actual function names for accurate debugging.