### PR TITLE
feat(bridge-ui): separate deploy tags for hoodi and mainnet

### DIFF
--- a/.github/workflows/bridge-ui.yml
+++ b/.github/workflows/bridge-ui.yml
@@ -8,7 +8,8 @@ on:
       - dependabot/**
       - release-please--branches--**
     tags:
-      - "bridge-ui-v*"
+      - "bridge-ui-hoodi-v*"
+      - "bridge-ui-mainnet-v*"
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -53,7 +54,7 @@ jobs:
       vercel_token: ${{ secrets.VERCEL_TOKEN }}
 
   deploy_bridge-ui_hoodi_production:
-    if: ${{ startsWith(github.ref, 'refs/tags/bridge-ui-v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/bridge-ui-hoodi-v') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:
@@ -78,7 +79,7 @@ jobs:
       vercel_token: ${{ secrets.VERCEL_TOKEN }}
 
   deploy_bridge-ui_mainnet_production:
-    if: ${{ startsWith(github.ref, 'refs/tags/bridge-ui-v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/bridge-ui-mainnet-v') }}
     needs: build-and-test
     uses: ./.github/workflows/repo--vercel-deploy.yml
     with:


### PR DESCRIPTION
Use different tag patterns to allow independent production deployments:
- bridge-ui-hoodi-v* triggers hoodi production only
- bridge-ui-mainnet-v* triggers mainnet production only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts deployment trigger conditions; main risk is accidental missed or unintended deploys if tags are misnamed.
> 
> **Overview**
> Bridge UI CI/CD now uses **network-specific git tags** to trigger production deploys, replacing the shared `bridge-ui-v*` tag pattern.
> 
> The workflow only runs on pushes to `bridge-ui-hoodi-v*` / `bridge-ui-mainnet-v*` tags, and each production deploy job (`deploy_bridge-ui_hoodi_production`, `deploy_bridge-ui_mainnet_production`) is gated by its corresponding tag prefix so the two environments can be released independently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6217cba91456a93b10573f1757645e846ced7074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->