### PR TITLE
chore(taiko-client): move `--preconfirmation.whitelist` into common flags

### DIFF
--- a/packages/taiko-client/cmd/flags/common.go
+++ b/packages/taiko-client/cmd/flags/common.go
@@ -162,6 +162,13 @@ var (
 		Category: commonCategory,
 		EnvVars:  []string{"PROVER_SET"},
 	}
+	PreconfWhitelistAddress = &cli.StringFlag{
+		Name:     "preconfirmation.whitelist",
+		Usage:    "PreconfWhitelist contract L1 `address`",
+		Required: false,
+		Category: commonCategory,
+		EnvVars:  []string{"PRECONFIRMATION_WHITELIST"},
+	}
 	ShastaForkTime = &cli.Uint64Flag{
 		Name:     "shasta.time",
 		Usage:    "Shasta hardfork activation timestamp (unix seconds)",
@@ -179,6 +186,7 @@ var CommonFlags = []cli.Flag{
 	TaikoAnchorAddress,
 	// Optional
 	ProverSetAddress,
+	PreconfWhitelistAddress,
 	ShastaForkTime,
 	Verbosity,
 	LogJSON,

--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -58,13 +58,6 @@ var (
 		Value:    "*",
 		EnvVars:  []string{"PRECONFIRMATION_SERVER_CORS_ORIGINS"},
 	}
-	PreconfWhitelistAddress = &cli.StringFlag{
-		Name:     "preconfirmation.whitelist",
-		Usage:    "PreconfWhitelist contract L1 `address`",
-		Required: false,
-		Category: driverCategory,
-		EnvVars:  []string{"PRECONFIRMATION_WHITELIST"},
-	}
 	DriverTaikoWrapperAddress = &cli.StringFlag{
 		Name:     "taikoWrapper",
 		Usage:    "TaikoWrapper contract `address`",
@@ -87,6 +80,5 @@ var DriverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	PreconfBlockServerPort,
 	PreconfBlockServerJWTSecret,
 	PreconfBlockServerCORSOrigins,
-	PreconfWhitelistAddress,
 	DriverTaikoWrapperAddress,
 }, p2pFlags.P2PFlags("PRECONFIRMATION"))


### PR DESCRIPTION
## Summary
- Moved `PreconfWhitelistAddress` (`preconfirmation.whitelist`) from `cmd/flags/driver.go` to `cmd/flags/common.go`.
- Added `PreconfWhitelistAddress` to `CommonFlags`.
- Removed the driver-local definition and driver-local inclusion to avoid duplication.

## Why
- `preconfirmation.whitelist` is shared configuration and fits better in the common flag set.
- Centralizing this flag keeps flag ownership clearer and prevents command-specific duplication.

## Behavior impact
- Flag name is unchanged: `preconfirmation.whitelist`.
- Env var is unchanged: `PRECONFIRMATION_WHITELIST`.
- The flag now appears under the `COMMON` category instead of `DRIVER`.

## Verification
- Ran `gofmt -w cmd/flags/common.go cmd/flags/driver.go`.
- Ran `go test ./cmd/flags` (package builds cleanly; no test files in this package).
