### PR TITLE
fix(bridge-ui): empty gas values explicitely

### DIFF
--- a/packages/bridge-ui/__mocks__/@wagmi/core.ts
+++ b/packages/bridge-ui/__mocks__/@wagmi/core.ts
@@ -14,6 +14,8 @@ export const getToken = vi.fn();
 
 export const readContract = vi.fn();
 
+export const writeContract = vi.fn();
+
 const mockChains = [
   {
     id: 0,

--- a/packages/bridge-ui/src/libs/bridge/Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/Bridge.ts
@@ -1,4 +1,4 @@
-import { getPublicClient, readContract, simulateContract, writeContract } from '@wagmi/core';
+import { getPublicClient, readContract, simulateContract } from '@wagmi/core';
 import { getAddress, getContract, type Hash, UserRejectedRequestError, type WalletClient } from 'viem';
 
 import { bridgeAbi } from '$abi';
@@ -8,6 +8,7 @@ import type { BridgeProver } from '$libs/proof';
 import { getConnectedWallet } from '$libs/util/getConnectedWallet';
 import { isSmartContract } from '$libs/util/isSmartContract';
 import { getLogger } from '$libs/util/logger';
+import { safeWriteContract } from '$libs/util/safeWriteContract';
 import { config } from '$libs/wagmi';
 
 import {
@@ -269,7 +270,7 @@ export abstract class Bridge {
       estimatedGas = (estimatedGas * 105n) / 100n;
     }
     if (force) {
-      return await writeContract(config, {
+      return await safeWriteContract({
         address: bridgeContract.address,
         abi: bridgeContract.abi,
         functionName: 'processMessage',
@@ -286,7 +287,7 @@ export abstract class Bridge {
       });
       log('Simulate contract for processMessage', request);
 
-      return await writeContract(config, request);
+      return await safeWriteContract(request);
     }
   }
 
@@ -317,7 +318,7 @@ export abstract class Bridge {
     });
     log('Simulate contract for retryMessage', request);
 
-    return await writeContract(config, request);
+    return await safeWriteContract(request);
   }
 
   private async release(args: ReleaseArgs) {
@@ -346,6 +347,6 @@ export abstract class Bridge {
     });
     log('Simulate contract for recallMessage', request);
 
-    return await writeContract(config, request);
+    return await safeWriteContract(request);
   }
 }

--- a/packages/bridge-ui/src/libs/bridge/ERC1155Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC1155Bridge.ts
@@ -1,4 +1,4 @@
-import { getPublicClient, simulateContract, writeContract } from '@wagmi/core';
+import { getPublicClient, simulateContract } from '@wagmi/core';
 import { get } from 'svelte/store';
 import { getContract, UserRejectedRequestError } from 'viem';
 
@@ -17,6 +17,7 @@ import type { BridgeProver } from '$libs/proof';
 import { TokenType } from '$libs/token';
 import { getCanonicalInfoForAddress } from '$libs/token/getCanonicalInfoForToken';
 import { getLogger } from '$libs/util/logger';
+import { safeWriteContract } from '$libs/util/safeWriteContract';
 import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
@@ -110,7 +111,7 @@ export class ERC1155Bridge extends Bridge {
       });
       log('Simulate contract', request);
 
-      const tx = await writeContract(config, request);
+      const tx = await safeWriteContract(request);
 
       log('ERC1155 sent', tx);
 
@@ -157,7 +158,7 @@ export class ERC1155Bridge extends Bridge {
       });
       log('Simulate contract', request);
 
-      const txHash = await writeContract(config, request);
+      const txHash = await safeWriteContract(request);
 
       log('Transaction hash for approve call', txHash);
 

--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -1,4 +1,4 @@
-import { getPublicClient, readContract, simulateContract, writeContract } from '@wagmi/core';
+import { getPublicClient, readContract, simulateContract } from '@wagmi/core';
 import { get } from 'svelte/store';
 import { getContract, UserRejectedRequestError } from 'viem';
 
@@ -17,6 +17,7 @@ import type { BridgeProver } from '$libs/proof';
 import { isBridgePaused } from '$libs/util/checkForPausedContracts';
 import { getConnectedWallet } from '$libs/util/getConnectedWallet';
 import { getLogger } from '$libs/util/logger';
+import { safeWriteContract } from '$libs/util/safeWriteContract';
 import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
@@ -192,7 +193,7 @@ export class ERC20Bridge extends Bridge {
 
       if (!wallet || !wallet.account || !wallet.chain) throw new Error('Wallet is not connected');
 
-      const txHash = await writeContract(config, request);
+      const txHash = await safeWriteContract(request);
 
       log('Transaction hash for approve call', txHash);
 
@@ -237,7 +238,7 @@ export class ERC20Bridge extends Bridge {
       });
       log('Simulate contract', request);
 
-      const txHash = await writeContract(config, request);
+      const txHash = await safeWriteContract(request);
 
       log('Transaction hash for sendERC20 call', txHash);
 

--- a/packages/bridge-ui/src/libs/bridge/ERC721Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC721Bridge.ts
@@ -1,4 +1,4 @@
-import { getPublicClient, getWalletClient, readContract, simulateContract, writeContract } from '@wagmi/core';
+import { getPublicClient, getWalletClient, readContract, simulateContract } from '@wagmi/core';
 import { get } from 'svelte/store';
 import { getContract, UserRejectedRequestError } from 'viem';
 
@@ -19,6 +19,7 @@ import { TokenType } from '$libs/token';
 import { getCanonicalInfoForAddress } from '$libs/token/getCanonicalInfoForToken';
 import { isBridgePaused } from '$libs/util/checkForPausedContracts';
 import { getLogger } from '$libs/util/logger';
+import { safeWriteContract } from '$libs/util/safeWriteContract';
 import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
@@ -122,7 +123,7 @@ export class ERC721Bridge extends Bridge {
       });
       log('Simulate contract', request);
 
-      const txHash = await writeContract(config, request);
+      const txHash = await safeWriteContract(request);
 
       log('Transaction hash for sendERC20 call', txHash);
 
@@ -168,7 +169,7 @@ export class ERC721Bridge extends Bridge {
       });
       log('Simulate contract', request);
 
-      const txHash = await writeContract(config, request);
+      const txHash = await safeWriteContract(request);
 
       log('Transaction hash for approve call', txHash);
 

--- a/packages/bridge-ui/src/libs/bridge/ETHBridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ETHBridge.ts
@@ -1,4 +1,4 @@
-import { getWalletClient, simulateContract, writeContract } from '@wagmi/core';
+import { getWalletClient, simulateContract } from '@wagmi/core';
 import { get } from 'svelte/store';
 import { getContract, UserRejectedRequestError } from 'viem';
 
@@ -8,6 +8,7 @@ import { BridgePausedError, SendMessageError } from '$libs/error';
 import type { BridgeProver } from '$libs/proof';
 import { isBridgePaused } from '$libs/util/checkForPausedContracts';
 import { getLogger } from '$libs/util/logger';
+import { safeWriteContract } from '$libs/util/safeWriteContract';
 import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
@@ -117,7 +118,7 @@ export class ETHBridge extends Bridge {
       });
       log('Simulate contract', request);
 
-      const txHash = await writeContract(config, request);
+      const txHash = await safeWriteContract(request);
       log('Transaction hash for sendMessage call', txHash);
 
       return txHash;

--- a/packages/bridge-ui/src/libs/util/safeWriteContract.test.ts
+++ b/packages/bridge-ui/src/libs/util/safeWriteContract.test.ts
@@ -1,0 +1,44 @@
+import { writeContract,type WriteContractParameters } from '@wagmi/core';
+import { zeroAddress } from 'viem';
+
+import { config } from '$libs/wagmi';
+
+import { safeWriteContract } from './safeWriteContract';
+
+vi.mock('@wagmi/core');
+
+describe('safeWriteContract', () => {
+  it('removes fee fields before submitting tx request', async () => {
+    vi.mocked(writeContract).mockResolvedValue('0x1234' as `0x${string}`);
+
+    const params = {
+      address: zeroAddress,
+      abi: [],
+      functionName: 'test',
+      maxFeePerGas: 1n,
+      maxPriorityFeePerGas: 1n,
+      gasPrice: 1n,
+      type: 'eip1559',
+      gas: 21000n,
+    } as unknown as WriteContractParameters;
+
+    await safeWriteContract(params);
+
+    expect(writeContract).toHaveBeenCalledTimes(1);
+    expect(writeContract).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        address: zeroAddress,
+        abi: [],
+        functionName: 'test',
+        gas: 21000n,
+      }),
+    );
+
+    const submitted = vi.mocked(writeContract).mock.calls[0][1] as Record<string, unknown>;
+    expect(submitted.maxFeePerGas).toBeUndefined();
+    expect(submitted.maxPriorityFeePerGas).toBeUndefined();
+    expect(submitted.gasPrice).toBeUndefined();
+    expect(submitted.type).toBeUndefined();
+  });
+});

--- a/packages/bridge-ui/src/libs/util/safeWriteContract.test.ts
+++ b/packages/bridge-ui/src/libs/util/safeWriteContract.test.ts
@@ -1,4 +1,4 @@
-import { writeContract,type WriteContractParameters } from '@wagmi/core';
+import { writeContract, type WriteContractParameters } from '@wagmi/core';
 import { zeroAddress } from 'viem';
 
 import { config } from '$libs/wagmi';

--- a/packages/bridge-ui/src/libs/util/safeWriteContract.ts
+++ b/packages/bridge-ui/src/libs/util/safeWriteContract.ts
@@ -1,0 +1,16 @@
+import { writeContract,type WriteContractParameters } from '@wagmi/core';
+
+import { config } from '$libs/wagmi';
+
+// Wallets are better positioned to set current fee fields at signing time.
+// We remove simulated fee fields to avoid submitting stale underpriced txs.
+const feeKeys = ['maxFeePerGas', 'maxPriorityFeePerGas', 'gasPrice', 'type'] as const;
+
+export async function safeWriteContract(params: WriteContractParameters) {
+  const next = { ...params } as Record<string, unknown>;
+  for (const key of feeKeys) {
+    if (key in next) delete next[key];
+  }
+
+  return await writeContract(config, next as unknown as WriteContractParameters);
+}

--- a/packages/bridge-ui/src/libs/util/safeWriteContract.ts
+++ b/packages/bridge-ui/src/libs/util/safeWriteContract.ts
@@ -1,4 +1,4 @@
-import { writeContract,type WriteContractParameters } from '@wagmi/core';
+import { writeContract, type WriteContractParameters } from '@wagmi/core';
 
 import { config } from '$libs/wagmi';
 


### PR DESCRIPTION
another approach to solving the hoodi L2->L1 issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the transaction submission path for all bridge operations; while behavior is a narrow parameter sanitization, it impacts every write and could affect wallets/networks that rely on explicit fee fields.
> 
> **Overview**
> Updates the bridge UI to submit all on-chain writes (ETH, ERC20, ERC721, ERC1155, and message `process/retry/recall`) via a new `safeWriteContract` wrapper instead of calling `@wagmi/core` `writeContract` directly.
> 
> `safeWriteContract` removes fee-related fields (`maxFeePerGas`, `maxPriorityFeePerGas`, `gasPrice`, `type`) from simulated requests before sending, aiming to avoid stale/underpriced transactions; includes a unit test for the stripping behavior and updates the wagmi mock to export `writeContract`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 089911079dc0673b076ad651e9a90998711b9a91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->