### PR TITLE
chore(taiko-client): rename Shasta fork config accessor

### DIFF
--- a/packages/taiko-client/pkg/config/protocol_config.go
+++ b/packages/taiko-client/pkg/config/protocol_config.go
@@ -16,7 +16,7 @@ type ProtocolConfigs interface {
 	BlockMaxGasLimit() uint32
 	ForkHeightsOntake() uint64
 	ForkHeightsPacaya() uint64
-	ForkHeightsShasta() uint64
+	ForkTimeShasta() uint64
 	LivenessBond() *big.Int
 	LivenessBondPerBlock() *big.Int
 	MaxProposals() uint64
@@ -33,7 +33,7 @@ func ReportProtocolConfigs(configs ProtocolConfigs) {
 		"BlockMaxGasLimit", configs.BlockMaxGasLimit(),
 		"ForkHeightsOntake", configs.ForkHeightsOntake(),
 		"ForkHeightsPacaya", configs.ForkHeightsPacaya(),
-		"ForkHeightsShasta", configs.ForkHeightsShasta(),
+		"ForkTimeShasta", configs.ForkTimeShasta(),
 		"LivenessBond", utils.WeiToEther(configs.LivenessBond()),
 		"LivenessBondPerBlock", utils.WeiToEther(configs.LivenessBondPerBlock()),
 		"MaxProposals", configs.MaxProposals(),
@@ -71,8 +71,8 @@ func (c *PacayaProtocolConfigs) ForkHeightsPacaya() uint64 {
 	return c.configs.ForkHeights.Pacaya
 }
 
-// ForkHeightsShasta implements the ProtocolConfigs interface.
-func (c *PacayaProtocolConfigs) ForkHeightsShasta() uint64 {
+// ForkTimeShasta implements the ProtocolConfigs interface.
+func (c *PacayaProtocolConfigs) ForkTimeShasta() uint64 {
 	return c.configs.ForkHeights.Shasta
 }
 

--- a/packages/taiko-client/pkg/config/protocol_config.go
+++ b/packages/taiko-client/pkg/config/protocol_config.go
@@ -43,12 +43,16 @@ func ReportProtocolConfigs(configs ProtocolConfigs) {
 
 // PacayaProtocolConfigs is the configuration for the Pacaya fork protocol.
 type PacayaProtocolConfigs struct {
-	configs *pacayaBindings.ITaikoInboxConfig
+	configs        *pacayaBindings.ITaikoInboxConfig
+	shastaForkTime uint64
 }
 
 // NewPacayaProtocolConfigs creates a new PacayaProtocolConfigs instance.
-func NewPacayaProtocolConfigs(configs *pacayaBindings.ITaikoInboxConfig) *PacayaProtocolConfigs {
-	return &PacayaProtocolConfigs{configs: configs}
+func NewPacayaProtocolConfigs(
+	configs *pacayaBindings.ITaikoInboxConfig,
+	shastaForkTime uint64,
+) *PacayaProtocolConfigs {
+	return &PacayaProtocolConfigs{configs: configs, shastaForkTime: shastaForkTime}
 }
 
 // BaseFeeConfig implements the ProtocolConfigs interface.
@@ -73,7 +77,7 @@ func (c *PacayaProtocolConfigs) ForkHeightsPacaya() uint64 {
 
 // ForkTimeShasta implements the ProtocolConfigs interface.
 func (c *PacayaProtocolConfigs) ForkTimeShasta() uint64 {
-	return c.configs.ForkHeights.Shasta
+	return c.shastaForkTime
 }
 
 // MaxProposals implements the ProtocolConfigs interface.

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -54,7 +54,12 @@ func (c *Client) GetProtocolConfigs(opts *bind.CallOpts) (config.ProtocolConfigs
 		return nil, err
 	}
 
-	return config.NewPacayaProtocolConfigs(&configs), nil
+	var shastaForkTime uint64
+	if c.ShastaClients != nil {
+		shastaForkTime = c.ShastaClients.ForkTime
+	}
+
+	return config.NewPacayaProtocolConfigs(&configs, shastaForkTime), nil
 }
 
 // GetProtocolConfigsShasta gets the protocol configs from Shasta Inbox contract.


### PR DESCRIPTION
## Summary
- Update protocol config logging key from `ForkHeightsShasta` to `ForkTimeShasta`.

## Scope
- No behavior change, naming/readability only.
