### PR TITLE
fix(protocol): avoid syncing pacaya inbox to the signal service after shasta fork

### DIFF
--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -18,7 +18,7 @@ contract DevnetInbox is TaikoInbox {
         address _bondToken,
         address _signalService
     )
-        TaikoInbox(_wrapper, _verifier, _bondToken, _signalService)
+        TaikoInbox(_wrapper, _verifier, _bondToken, _signalService, type(uint64).max)
     {
         chainId = _chainId;
         cooldownWindow = _cooldownWindow;

--- a/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaInbox.sol
@@ -19,7 +19,7 @@ contract HeklaInbox is TaikoInbox {
         address _bondToken,
         address _signalService
     )
-        TaikoInbox(_wrapper, _verifier, _bondToken, _signalService)
+        TaikoInbox(_wrapper, _verifier, _bondToken, _signalService, type(uint64).max)
     { }
 
     /// @notice Manually write a transition for a batch.

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -15,9 +15,10 @@ contract MainnetInbox is TaikoInbox {
         address _wrapper,
         address _verifier,
         address _bondToken,
-        address _signalService
+        address _signalService,
+        uint64 _shastaForkTimestamp
     )
-        TaikoInbox(_wrapper, _verifier, _bondToken, _signalService)
+        TaikoInbox(_wrapper, _verifier, _bondToken, _signalService, _shastaForkTimestamp)
     { }
 
     function pacayaConfig() public pure override returns (ITaikoInbox.Config memory) {

--- a/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/based/DeployProtocolOnL1.s.sol
@@ -323,7 +323,8 @@ contract DeployProtocolOnL1 is DeployCapability {
                     address(0),
                     proofVerifier,
                     IResolver(_sharedResolver).resolve(uint64(block.chainid), "bond_token", false),
-                    IResolver(_sharedResolver).resolve(uint64(block.chainid), "signal_service", false)
+                    IResolver(_sharedResolver).resolve(uint64(block.chainid), "signal_service", false),
+                    uint64(vm.envOr("SHASTA_FORK_TIMESTAMP", uint256(type(uint64).max)))
                 )
             ),
             data: abi.encodeCall(TaikoInbox.init, (owner, vm.envBytes32("L2_GENESIS_HASH")))

--- a/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
+++ b/packages/protocol/script/layer1/mainnet/DeployMainnetPacayaL1.s.sol
@@ -145,7 +145,15 @@ contract DeployMainnetPacayaL1 is DeployCapability {
 
         // Register taiko
         address newFork =
-            address(new MainnetInbox(taikoWrapper, proofVerifier, taikoToken, signalService));
+            address(
+                new MainnetInbox(
+                    taikoWrapper,
+                    proofVerifier,
+                    taikoToken,
+                    signalService,
+                    uint64(vm.envOr("SHASTA_FORK_TIMESTAMP", uint256(type(uint64).max)))
+                )
+            );
         address forkRouter = address(new PacayaForkRouter(oldFork, newFork));
         console2.log("forkRouter:", forkRouter);
         address newProverSetImpl =

--- a/packages/protocol/script/layer1/mainnet/DeployMainnetPreconf.s.sol
+++ b/packages/protocol/script/layer1/mainnet/DeployMainnetPreconf.s.sol
@@ -55,7 +55,15 @@ contract DeployMainnetPreconf is DeployCapability {
         // be the final step after adding the operators and waiting for at least 2 epochs)
         console2.log("taikoWrapper: ", wrapper);
         address newFork =
-            address(new MainnetInbox(taikoWrapper, proofVerifier, taikoToken, signalService));
+            address(
+                new MainnetInbox(
+                    taikoWrapper,
+                    proofVerifier,
+                    taikoToken,
+                    signalService,
+                    uint64(vm.envOr("SHASTA_FORK_TIMESTAMP", uint256(type(uint64).max)))
+                )
+            );
         address newRouter = address(new PacayaForkRouter(oldFork, newFork));
         // Need to call `upgradeTo`, to address: 0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a(should
         // be the final step after adding the operators and waiting for at least 2 epochs)

--- a/packages/protocol/test/layer1/Layer1Test.sol
+++ b/packages/protocol/test/layer1/Layer1Test.sol
@@ -20,9 +20,10 @@ contract ConfigurableInbox is TaikoInbox {
         address _wrapper,
         address _verifier,
         address _bondToken,
-        address _signalService
+        address _signalService,
+        uint64 _shastaForkTimestamp
     )
-        TaikoInbox(_wrapper, _verifier, _bondToken, _signalService)
+        TaikoInbox(_wrapper, _verifier, _bondToken, _signalService, _shastaForkTimestamp)
     { }
 
     function initWithConfig(
@@ -69,7 +70,15 @@ abstract contract Layer1Test is CommonTest {
         return TaikoInbox(
             deploy({
                 name: "taiko",
-                impl: address(new ConfigurableInbox(_wrapper, _verifier, _bondToken, _signalService)),
+                impl: address(
+                    new ConfigurableInbox(
+                        _wrapper,
+                        _verifier,
+                        _bondToken,
+                        _signalService,
+                        type(uint64).max
+                    )
+                ),
                 data: abi.encodeCall(
                     ConfigurableInbox.initWithConfig, (address(0), _genesisBlockHash, _config)
                 )

--- a/packages/protocol/test/layer1/based/InboxTest_ShastaForkTimestamp.t.sol
+++ b/packages/protocol/test/layer1/based/InboxTest_ShastaForkTimestamp.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "./InboxTestBase.sol";
+import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import "src/shared/based/LibSharedData.sol";
+import "src/shared/libs/LibNetwork.sol";
+import "src/shared/libs/LibStrings.sol";
+import "src/layer1/based/TaikoInbox.sol";
+
+contract InboxTest_ShastaForkTimestamp is InboxTestBase {
+    uint64 private _shastaForkTimestamp;
+
+    function pacayaConfig() internal pure override returns (ITaikoInbox.Config memory) {
+        ITaikoInbox.ForkHeights memory forkHeights;
+
+        return ITaikoInbox.Config({
+            chainId: LibNetwork.TAIKO_MAINNET,
+            maxUnverifiedBatches: 10,
+            batchRingBufferSize: 11,
+            maxBatchesToVerify: 5,
+            blockMaxGasLimit: 240_000_000,
+            livenessBondBase: 125e18, // 125 Taiko token per batch
+            livenessBondPerBlock: 0, // deprecated
+            stateRootSyncInternal: 1,
+            maxAnchorHeightOffset: 64,
+            baseFeeConfig: LibSharedData.BaseFeeConfig({
+                adjustmentQuotient: 8,
+                sharingPctg: 75,
+                gasIssuancePerSecond: 5_000_000,
+                minGasExcess: 1_340_000_000,
+                maxGasIssuancePerBlock: 600_000_000
+            }),
+            provingWindow: 1 hours,
+            cooldownWindow: 1 hours,
+            maxSignalsToReceive: 16,
+            maxBlocksPerBatch: 768,
+            forkHeights: forkHeights
+        });
+    }
+
+    function setUpOnEthereum() internal override {
+        bondToken = deployBondToken();
+        super.setUpOnEthereum();
+
+        _shastaForkTimestamp = uint64(block.timestamp + 1 hours);
+    }
+
+    function test_inbox_verify_batches_skips_signal_service_sync_after_shasta_timestamp() external {
+        vm.deal(Alice, 100 ether);
+        bondToken.transfer(Alice, 10_000 ether);
+
+        vm.startPrank(Alice);
+        bondToken.approve(address(inbox), type(uint256).max);
+        _proposeBatchesWithDefaultParameters(1);
+        _proveBatchesWithCorrectTransitions(range(1, 2));
+        vm.stopPrank();
+
+        ITaikoInbox.Stats2 memory stats2 = inbox.getStats2();
+        assertEq(stats2.lastVerifiedBatchId, 0);
+
+        address verifier = resolver.resolve(block.chainid, "proof_verifier", false);
+        address upgradedImpl = address(
+            new ConfigurableInbox(
+                address(0),
+                verifier,
+                address(bondToken),
+                address(signalService),
+                _shastaForkTimestamp
+            )
+        );
+
+        vm.startPrank(Ownable2StepUpgradeable(address(inbox)).owner());
+        UUPSUpgradeable(address(inbox)).upgradeTo(upgradedImpl);
+        vm.stopPrank();
+
+        vm.prank(signalService.owner());
+        signalService.authorize(address(inbox), false);
+
+        vm.warp(_shastaForkTimestamp + pacayaConfig().cooldownWindow + 1);
+        TaikoInbox(address(inbox)).verifyBatches(1);
+
+        stats2 = inbox.getStats2();
+        assertEq(stats2.lastVerifiedBatchId, 1);
+
+        ITaikoInbox.Stats1 memory stats1 = inbox.getStats1();
+        assertEq(stats1.lastSyncedBatchId, 1);
+
+        assertFalse(
+            signalService.isChainDataSynced(
+                pacayaConfig().chainId, LibStrings.H_STATE_ROOT, 1, correctStateRoot(1)
+            )
+        );
+    }
+}

--- a/packages/protocol/test/layer1/preconf/router/PreconfRouter.t.sol
+++ b/packages/protocol/test/layer1/preconf/router/PreconfRouter.t.sol
@@ -58,7 +58,15 @@ contract PreconfRouterForkTest is ForkTestBase {
         TaikoWrapper wrapperImpl =
             new TaikoWrapper(MAINNET_INBOX, MAINNET_FORCED_INCLUSION, MAINNET_ROUTER);
         address forkImpl =
-            address(new MainnetInbox(MAINNET_WRAPPER, PROOF_VERIFIER, TAIKO_TOKEN, SIGNAL_SERVICE));
+            address(
+                new MainnetInbox(
+                    MAINNET_WRAPPER,
+                    PROOF_VERIFIER,
+                    TAIKO_TOKEN,
+                    SIGNAL_SERVICE,
+                    type(uint64).max
+                )
+            );
         address pacayaRouter = address(new PacayaForkRouter(OLD_FORK, forkImpl));
 
         // Upgrade contracts to optimized implementations

--- a/packages/protocol/test/layer1/preconf/router/PreconfRouterTestBase.sol
+++ b/packages/protocol/test/layer1/preconf/router/PreconfRouterTestBase.sol
@@ -127,7 +127,11 @@ abstract contract PreconfRouterTestBase is Layer1Test {
         UUPSUpgradeable(address(inbox)).upgradeTo(
             address(
                 new ConfigurableInbox(
-                    address(taikoWrapper), verifierAddr, address(bondToken), address(signalService)
+                    address(taikoWrapper),
+                    verifierAddr,
+                    address(bondToken),
+                    address(signalService),
+                    type(uint64).max
                 )
             )
         );


### PR DESCRIPTION
After the shasta fork on Hoodi we realized that we cannot finalize(i.e. verify) the pacaya inbox with the latest transition. This PR avoids the inbox from trying to sync to the signal service after the fork timestamp has occured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches L1 batch verification behavior and deployment wiring; an incorrect timestamp/config could change when cross-chain signals stop being emitted, impacting downstream consumers.
> 
> **Overview**
> Adds a `shastaForkTimestamp` to `TaikoInbox` and gates `signalService.syncChainData` during batch verification so cross-chain state-root signals are **not** written once the Shasta fork timestamp has passed.
> 
> Plumbs the new constructor parameter through `MainnetInbox` and deployment scripts (using `SHASTA_FORK_TIMESTAMP`, defaulting to `uint64.max`), updates devnet/hekla/test inboxes to pass `uint64.max`, and adds a regression test (`InboxTest_ShastaForkTimestamp`) to ensure verification succeeds even when the inbox is deauthorized from the signal service after the fork time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ff058e5efde18ce1316cedb75efe7015adfd3ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->