### PR TITLE
feat(taiko-client-rs): get_preconf_slot_info API for the taiko-client-rs

### DIFF
--- a/packages/ejector/Cargo.lock
+++ b/packages/ejector/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "ejector"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "alloy",
  "alloy-serde 0.11.1",

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/node.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/node.rs
@@ -154,6 +154,7 @@ impl<I: InboxReader + 'static> PreconfirmationDriverNode<I> {
             preconf_tip_rx: self.preconf_tip_rx.clone(),
             local_peer_id: self.p2p_client.p2p_handle().local_peer_id().to_string(),
             inbox_reader: self.driver_client.inbox_reader().clone(),
+            lookahead_resolver: self.p2p_client.lookahead_resolver().clone(),
         });
 
         let server = PreconfRpcServer::start(rpc_config.clone(), api).await?;

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/api.rs
@@ -4,8 +4,8 @@ use alloy_primitives::U256;
 use async_trait::async_trait;
 
 use super::types::{
-    NodeStatus, PublishCommitmentRequest, PublishCommitmentResponse, PublishTxListRequest,
-    PublishTxListResponse,
+    NodeStatus, PreconfSlotInfo, PublishCommitmentRequest, PublishCommitmentResponse,
+    PublishTxListRequest, PublishTxListResponse,
 };
 use crate::Result;
 
@@ -33,12 +33,15 @@ pub trait PreconfRpcApi: Send + Sync {
 
     /// Get the last canonical proposal ID from L1 events.
     async fn canonical_proposal_id(&self) -> Result<u64>;
+
+    /// Get the preconfirmation slot info (signer and submission window end) for a given L2 block timestamp.
+    async fn get_preconf_slot_info(&self, timestamp: U256) -> Result<PreconfSlotInfo>;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
+    use alloy_primitives::{Address, B256};
 
     struct MockApi;
 
@@ -74,6 +77,13 @@ mod tests {
 
         async fn canonical_proposal_id(&self) -> Result<u64> {
             Ok(42)
+        }
+
+        async fn get_preconf_slot_info(&self, _timestamp: U256) -> Result<PreconfSlotInfo> {
+            Ok(PreconfSlotInfo {
+                signer: Address::ZERO,
+                submission_window_end: U256::ZERO,
+            })
         }
     }
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/api.rs
@@ -81,8 +81,8 @@ mod tests {
 
         async fn get_preconf_slot_info(&self, _timestamp: U256) -> Result<PreconfSlotInfo> {
             Ok(PreconfSlotInfo {
-                signer: Address::ZERO,
-                submission_window_end: U256::ZERO,
+                signer: Address::repeat_byte(0x11),
+                submission_window_end: U256::from(2000),
             })
         }
     }
@@ -96,5 +96,9 @@ mod tests {
         assert_eq!(status.preconf_tip, U256::from(100));
         assert_eq!(api.preconf_tip().await.unwrap(), U256::from(100));
         assert_eq!(api.canonical_proposal_id().await.unwrap(), 42);
+
+        let slot_info = api.get_preconf_slot_info(U256::from(123)).await.unwrap();
+        assert_eq!(slot_info.signer, Address::repeat_byte(0x11));
+        assert_eq!(slot_info.submission_window_end, U256::from(2000));
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/api.rs
@@ -34,7 +34,8 @@ pub trait PreconfRpcApi: Send + Sync {
     /// Get the last canonical proposal ID from L1 events.
     async fn canonical_proposal_id(&self) -> Result<u64>;
 
-    /// Get the preconfirmation slot info (signer and submission window end) for a given L2 block timestamp.
+    /// Get the preconfirmation slot info (signer and submission window end) for a given L2 block
+    /// timestamp.
     async fn get_preconf_slot_info(&self, timestamp: U256) -> Result<PreconfSlotInfo>;
 }
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/mod.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/mod.rs
@@ -34,6 +34,6 @@ pub mod types;
 pub use api::PreconfRpcApi;
 pub use server::{PreconfRpcServer, PreconfRpcServerConfig};
 pub use types::{
-    NodeStatus, PreconfRpcErrorCode, PublishCommitmentRequest, PublishCommitmentResponse,
-    PublishTxListRequest, PublishTxListResponse,
+    NodeStatus, PreconfRpcErrorCode, PreconfSlotInfo, PublishCommitmentRequest,
+    PublishCommitmentResponse, PublishTxListRequest, PublishTxListResponse,
 };

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/node_api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/node_api.rs
@@ -31,7 +31,8 @@ pub(crate) struct NodeRpcApiImpl<I: InboxReader> {
     /// Inbox reader for checking L1 sync state.
     pub(crate) inbox_reader: I,
     /// Lookahead resolver for slot info by timestamp.
-    pub(crate) lookahead_resolver: Arc<dyn protocol::preconfirmation::PreconfSignerResolver + Send + Sync>,
+    pub(crate) lookahead_resolver:
+        Arc<dyn protocol::preconfirmation::PreconfSignerResolver + Send + Sync>,
 }
 
 #[async_trait::async_trait]
@@ -84,7 +85,8 @@ impl<I: InboxReader + 'static> PreconfRpcApi for NodeRpcApiImpl<I> {
         Ok(*self.canonical_proposal_id_rx.borrow())
     }
 
-    /// Returns the preconfirmation slot info (signer and submission window end) for the given L2 block timestamp.
+    /// Returns the preconfirmation slot info (signer and submission window end) for the given L2
+    /// block timestamp.
     async fn get_preconf_slot_info(&self, timestamp: U256) -> Result<PreconfSlotInfo> {
         let info = self.lookahead_resolver.slot_info_for_timestamp(timestamp).await?;
         Ok(PreconfSlotInfo {
@@ -310,9 +312,7 @@ mod tests {
             lookahead_resolver: Arc::new(MockLookaheadResolver),
         };
 
-        tokio::spawn(async move {
-            while command_rx.recv().await.is_some() {}
-        });
+        tokio::spawn(async move { while command_rx.recv().await.is_some() {} });
 
         let timestamp = U256::from(500);
         let slot_info = api.get_preconf_slot_info(timestamp).await.unwrap();

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/runner_api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/runner_api.rs
@@ -49,14 +49,7 @@ impl<I: InboxReader> RunnerRpcApiImpl<I> {
         inbox_reader: I,
         lookahead_resolver: Arc<dyn protocol::preconfirmation::PreconfSignerResolver + Send + Sync>,
     ) -> Self {
-        Self {
-            command_tx,
-            canonical_id,
-            driver,
-            local_peer_id,
-            inbox_reader,
-            lookahead_resolver,
-        }
+        Self { command_tx, canonical_id, driver, local_peer_id, inbox_reader, lookahead_resolver }
     }
 }
 
@@ -103,9 +96,11 @@ impl<I: InboxReader + 'static> PreconfRpcApi for RunnerRpcApiImpl<I> {
         Ok(self.canonical_id.canonical_proposal_id())
     }
 
-    /// Return the preconfirmation slot info (signer and submission window end) for the given L2 block timestamp.
+    /// Return the preconfirmation slot info (signer and submission window end) for the given L2
+    /// block timestamp.
     async fn get_preconf_slot_info(&self, timestamp: U256) -> Result<PreconfSlotInfo> {
-        let info: protocol::preconfirmation::PreconfSlotInfo = self.lookahead_resolver.slot_info_for_timestamp(timestamp).await?;
+        let info: protocol::preconfirmation::PreconfSlotInfo =
+            self.lookahead_resolver.slot_info_for_timestamp(timestamp).await?;
         Ok(PreconfSlotInfo {
             signer: info.signer,
             submission_window_end: info.submission_window_end,
@@ -168,15 +163,15 @@ mod tests {
             &self,
             _: U256,
         ) -> protocol::preconfirmation::Result<alloy_primitives::Address> {
-            Ok(alloy_primitives::Address::ZERO)
+            Ok(alloy_primitives::Address::repeat_byte(0x11))
         }
         async fn slot_info_for_timestamp(
             &self,
             _: U256,
         ) -> protocol::preconfirmation::Result<protocol::preconfirmation::PreconfSlotInfo> {
             Ok(protocol::preconfirmation::PreconfSlotInfo {
-                signer: alloy_primitives::Address::ZERO,
-                submission_window_end: U256::ZERO,
+                signer: alloy_primitives::Address::repeat_byte(0x11),
+                submission_window_end: U256::from(2000),
             })
         }
     }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/runner_api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/runner_api.rs
@@ -99,11 +99,7 @@ impl<I: InboxReader + 'static> PreconfRpcApi for RunnerRpcApiImpl<I> {
     /// Return the preconfirmation slot info (signer and submission window end) for the given L2
     /// block timestamp.
     async fn get_preconf_slot_info(&self, timestamp: U256) -> Result<PreconfSlotInfo> {
-        let info = self.lookahead_resolver.slot_info_for_timestamp(timestamp).await?;
-        Ok(PreconfSlotInfo {
-            signer: info.signer,
-            submission_window_end: info.submission_window_end,
-        })
+        Ok(self.lookahead_resolver.slot_info_for_timestamp(timestamp).await?.into())
     }
 }
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/runner_api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/runner_api.rs
@@ -105,7 +105,7 @@ impl<I: InboxReader + 'static> PreconfRpcApi for RunnerRpcApiImpl<I> {
 
     /// Return the preconfirmation slot info (signer and submission window end) for the given L2 block timestamp.
     async fn get_preconf_slot_info(&self, timestamp: U256) -> Result<PreconfSlotInfo> {
-        let info: protocol::preconfirmation::PreconfSlotInfo = self.lookahead_resolver.slot_info_for_timestamp(timestamp).await?;
+        let info = self.lookahead_resolver.slot_info_for_timestamp(timestamp).await?;
         Ok(PreconfSlotInfo {
             signer: info.signer,
             submission_window_end: info.submission_window_end,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/server.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/server.rs
@@ -200,8 +200,8 @@ fn api_error_to_rpc(err: PreconfirmationClientError) -> ErrorObjectOwned {
 mod tests {
     use super::*;
     use crate::rpc::types::{
-    NodeStatus, PreconfSlotInfo, PublishCommitmentResponse, PublishTxListResponse,
-};
+        NodeStatus, PreconfSlotInfo, PublishCommitmentResponse, PublishTxListResponse,
+    };
     use alloy_primitives::{B256, U256};
     use async_trait::async_trait;
 
@@ -244,8 +244,8 @@ mod tests {
 
         async fn get_preconf_slot_info(&self, _timestamp: U256) -> Result<PreconfSlotInfo> {
             Ok(PreconfSlotInfo {
-                signer: alloy_primitives::Address::ZERO,
-                submission_window_end: U256::ZERO,
+                signer: alloy_primitives::Address::repeat_byte(0x11),
+                submission_window_end: U256::from(2000),
             })
         }
     }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
@@ -1,6 +1,6 @@
 //! Preconfirmation sidecar JSON-RPC API types for the preconfirmation driver node.
 
-use alloy_primitives::{B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use serde::{Deserialize, Serialize};
 
 /// Request to publish a signed preconfirmation commitment.
@@ -37,6 +37,16 @@ pub struct PublishCommitmentResponse {
 pub struct PublishTxListResponse {
     /// The keccak256 hash of the published transaction list.
     pub tx_list_hash: B256,
+}
+
+/// Resolved signer and submission window end for a preconfirmation slot (RPC response).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreconfSlotInfo {
+    /// Address allowed to sign the commitment for the slot.
+    pub signer: Address,
+    /// Canonical end of the submission window for the slot.
+    pub submission_window_end: U256,
 }
 
 /// Current status of the preconfirmation driver node.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
@@ -117,6 +117,18 @@ mod tests {
     }
 
     #[test]
+    fn test_preconf_slot_info_camel_case() {
+        let slot_info = PreconfSlotInfo {
+            signer: Address::repeat_byte(0x22),
+            submission_window_end: U256::from(2000),
+        };
+
+        let json = serde_json::to_string(&slot_info).unwrap();
+        assert!(json.contains("signer"));
+        assert!(json.contains("submissionWindowEnd"));
+    }
+
+    #[test]
     fn test_node_status_camel_case() {
         let status = NodeStatus {
             is_synced_with_inbox: true,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
@@ -49,6 +49,12 @@ pub struct PreconfSlotInfo {
     pub submission_window_end: U256,
 }
 
+impl From<protocol::preconfirmation::PreconfSlotInfo> for PreconfSlotInfo {
+    fn from(info: protocol::preconfirmation::PreconfSlotInfo) -> Self {
+        Self { signer: info.signer, submission_window_end: info.submission_window_end }
+    }
+}
+
 /// Current status of the preconfirmation driver node.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/runner/mod.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/runner/mod.rs
@@ -150,6 +150,7 @@ impl PreconfirmationDriverRunner {
         let preconf_client = PreconfirmationClient::new(client_config, driver_client)?;
         let command_tx = preconf_client.command_tx();
         let local_peer_id = preconf_client.p2p_handle().local_peer_id().to_string();
+        let lookahead_resolver = preconf_client.lookahead_resolver().clone();
 
         let mut rpc_server = None;
         if let Some(rpc_config) = &self.config.rpc_config {
@@ -165,6 +166,7 @@ impl PreconfirmationDriverRunner {
                 rpc_driver,
                 local_peer_id,
                 inbox_reader,
+                lookahead_resolver,
             ));
             let server = PreconfRpcServer::start(rpc_config.clone(), api).await?;
             info!(url = %server.http_url(), "preconfirmation RPC server started");


### PR DESCRIPTION
New API for accessing lookahead resolver slot info.