### PR TITLE
chore(taiko-client-rs): preserve lookahead error semantics for slot info RPC

### DIFF
--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
@@ -87,6 +87,8 @@ pub enum PreconfRpcErrorCode {
     SubmissionWindowExpired = -32004,
     /// The signer is not the expected preconfirmer for this slot.
     InvalidSigner = -32005,
+    /// Lookahead data/state could not be resolved by the node.
+    LookaheadUnavailable = -32006,
 }
 
 impl PreconfRpcErrorCode {
@@ -104,6 +106,7 @@ impl PreconfRpcErrorCode {
             Self::NotSynced => "Node is not synced",
             Self::SubmissionWindowExpired => "Submission window has expired",
             Self::InvalidSigner => "Signer is not the expected preconfirmer",
+            Self::LookaheadUnavailable => "Lookahead data is unavailable",
         }
     }
 }
@@ -155,5 +158,6 @@ mod tests {
         assert_eq!(PreconfRpcErrorCode::InvalidCommitment.code(), -32001);
         assert_eq!(PreconfRpcErrorCode::NotSynced.code(), -32003);
         assert_eq!(PreconfRpcErrorCode::InternalError.code(), -32000);
+        assert_eq!(PreconfRpcErrorCode::LookaheadUnavailable.code(), -32006);
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes error semantics for `preconf_getPreconfSlotInfo` so clients can distinguish invalid timestamp input from signer-related failures.

### Changes
- Keep structured lookahead errors in `PreconfirmationClientError`:
  - `Lookahead(String)` -> `Lookahead(LookaheadError)`
- Refine RPC error mapping in `api_error_to_rpc`:
  - `BeforeGenesis`, `TooOld`, `TooNew` -> JSON-RPC `InvalidParams` (`-32602`)
  - Other lookahead errors remain mapped to `InvalidSigner` (`-32005`)
- Add regression tests for both mapping paths:
  - timestamp-bound lookahead errors map to `InvalidParams`
  - non-timestamp lookahead errors still map to `InvalidSigner`

## Why
Previously, all lookahead resolver failures were collapsed into `InvalidSigner`, which hid invalid timestamp/range errors and made client retry/handling behavior inaccurate.
