### PR TITLE
chore(repo): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,10 @@
 .github/CODEOWNERS              @dantaik @ggonzalez94 @davidtaikocha
 .github/workflows/*             @ggonzalez94 @YoGhurt111 @davidtaikocha @RogerLamTd
 
-# Protocol (core smart contracts - highest activity)
-/packages/protocol/**           @dantaik @ggonzalez94 @davidtaikocha @smtmfft
-/packages/protocol/contracts/**/*Verifier*.sol @dantaik @ggonzalez94 @smtmfft
-/packages/protocol/contracts/layer1/preconf/** @dantaik @ggonzalez94 @AnshuJalan
+# Protocol
+/packages/protocol/**           @ggonzalez94 @davidtaikocha
+/packages/protocol/contracts/**/*Verifier*.sol @smtmfft @ggonzalez94 @davidtaikocha
+/packages/protocol/contracts/layer1/preconf/** @AnshuJalan @ggonzalez94 @davidtaikocha
 
 # Client services
 /packages/taiko-client/**       @YoGhurt111 @davidtaikocha @MatusKysel
@@ -14,11 +14,11 @@
 /packages/relayer/**            @YoGhurt111 @davidtaikocha @MatusKysel
 
 # Frontend applications
-/packages/docs-site/**          @ggonzalez94 @RogerLamTd
-/packages/bridge-ui/**          @KorbinianK @myronrotter @bearni95
+/packages/docs-site/**          @RogerLamTd @ggonzalez94
+/packages/bridge-ui/**          @RogerLamTd @ggonzalez94
 
 # Infrastructure and tools
-/packages/balance-monitor/**    @YoGhurt111 @davidtaikocha
-/packages/ejector/**            @YoGhurt111 @davidtaikocha @MatusKysel
+/packages/balance-monitor/**    @YoGhurt111 @davidtaikocha @RogerLamTd
+/packages/ejector/**            @YoGhurt111 @davidtaikocha @MatusKysel @RogerLamTd
 /packages/fork-diff/**          @YoGhurt111 @davidtaikocha @RogerLamTd
 /packages/geth-rpc-gateway/**   @YoGhurt111 @davidtaikocha


### PR DESCRIPTION
@dantaik let me know if you still wanna be codeowner on some of these files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Administrative ownership changes only; no runtime or behavior changes.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to **reassign ownership** across several areas.
> 
> Protocol ownership is streamlined (removing `@dantaik` from the general `/packages/protocol/**` path while keeping specialized owners for verifier/preconf contracts), frontend app ownership is shifted to `@RogerLamTd`/`@ggonzalez94`, and infrastructure tools (`balance-monitor`, `ejector`) add `@RogerLamTd` as a codeowner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20dbe00fa63ddaca1b49eba92c073202154c6d4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->