### PR TITLE
docs(docs-site): update zk coverage and rpc explorer entries

### DIFF
--- a/packages/docs-site/src/content/docs/network-reference/network-configuration.mdx
+++ b/packages/docs-site/src/content/docs/network-reference/network-configuration.mdx
@@ -24,4 +24,4 @@ If the function of the bonds is not clear to you, please find out more [here](/r
 
 ## Current ZK Proof Coverage
 
-Currently, the ZK coverage of our prover is set to 40%. You can keep track of the actual overall coverage over the past seven days with [this Dune query](https://dune.com/queries/4809870) visible on our dashboard.
+Currently, the ZK coverage of our prover is set to 100%. You can keep track of the proof coverage on [proofs.taiko.xyz](https://proofs.taiko.xyz/).

--- a/packages/docs-site/src/content/docs/network-reference/rpc-configuration.mdx
+++ b/packages/docs-site/src/content/docs/network-reference/rpc-configuration.mdx
@@ -29,7 +29,7 @@ Below are the RPCs maintained by Taiko Labs. You can find additional RPCs at [ch
 | Chain ID        | 167013                                                                                                                                                                                 |
 | RPC             | https://rpc.hoodi.taiko.xyz                                                                                                                                                            |
 | Symbol          | ETH                                                                                                                                                                                    |
-| Block Explorers | - Taikoscan (by Etherscan): https://hoodi.taikoscan.io/ <br />- Taikoexplorer (by Routescan): https://hoodi.taikoexplorer.com/ <br />- Blockscout: https://blockscout.hoodi.taiko.xyz/ |
+| Block Explorers | - Taikoscan (by Etherscan): https://hoodi.taikoscan.io/ <br />- Blockscout: https://blockscout.hoodi.taiko.xyz/ |
 
 ## Taiko Alethia
 
@@ -38,4 +38,4 @@ Below are the RPCs maintained by Taiko Labs. You can find additional RPCs at [ch
 | Chain ID        | 167000                                                                                                                                                                      |
 | RPC             | https://rpc.mainnet.taiko.xyz                                                                                                                                               |
 | Symbol          | ETH                                                                                                                                                                         |
-| Block Explorers | - Taikoscan (by Etherscan): https://taikoscan.io <br />- Taikoexplorer (by Routescan): https://taikoexplorer.com/ <br />- Blockscout: https://blockscout.mainnet.taiko.xyz/ |
+| Block Explorers | - Taikoscan (by Etherscan): https://taikoscan.io <br />- Blockscout: https://blockscout.mainnet.taiko.xyz/ |


### PR DESCRIPTION
## Summary
- update network configuration docs to reflect 100% zk proof coverage
- replace the old dune link with https://proofs.taiko.xyz/
- remove Taikoexplorer (by Routescan) entries from Taiko Hoodi and Taiko Alethia RPC configuration tables

## Testing
- not run (docs-only changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates that adjust displayed network metrics/links and prune outdated explorer references; no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates network reference docs to reflect **100% ZK proof coverage**, replacing the prior 40% statement and swapping the tracking link from a Dune query to `https://proofs.taiko.xyz/`.
> 
> Cleans up RPC configuration tables for Taiko Hoodi and Taiko Alethia by removing the Routescan *Taikoexplorer* block explorer entries, leaving Taikoscan and Blockscout as the listed explorers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45649aee49075b6e39164b010d1f7ca12174b073. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->