### PR TITLE
fix(taiko-client-rs): add TTL cache for whitelist sequencer lookups

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use hashlink::LinkedHashMap;
 
 use crate::codec::WhitelistExecutionPayloadEnvelope;
@@ -17,6 +17,10 @@ const DEFAULT_RECENT_ENVELOPE_CAPACITY: usize = 1024;
 const DEFAULT_PENDING_ENVELOPE_CAPACITY: usize = 768;
 /// Default cooldown, in seconds, between duplicate parent-hash requests.
 const DEFAULT_REQUEST_COOLDOWN_SECS: u64 = 10;
+/// Default TTL for cached whitelist sequencer addresses (one L1 slot).
+const DEFAULT_SEQUENCER_CACHE_TTL_SECS: u64 = 12;
+/// Minimum interval between forced signer-miss refreshes from L1.
+const DEFAULT_SEQUENCER_MISS_REFRESH_COOLDOWN_SECS: u64 = 2;
 
 /// Simple in-memory cache keyed by block hash with bounded capacity.
 pub(crate) struct EnvelopeCache {
@@ -176,6 +180,83 @@ impl RequestThrottle {
     }
 }
 
+/// Cached pair of current/next whitelist sequencer addresses with a TTL.
+#[derive(Debug)]
+pub(crate) struct WhitelistSequencerCache {
+    /// TTL for cached entries.
+    ttl: Duration,
+    /// Minimum interval between L1 refreshes triggered by signer mismatches.
+    miss_refresh_cooldown: Duration,
+    /// Last time a signer mismatch forced invalidation + refresh.
+    last_miss_refresh_at: Option<Instant>,
+    /// Cached current-epoch sequencer address and fetch time.
+    current: Option<(Address, Instant)>,
+    /// Cached next-epoch sequencer address and fetch time.
+    next: Option<(Address, Instant)>,
+}
+
+impl Default for WhitelistSequencerCache {
+    fn default() -> Self {
+        Self::new(Duration::from_secs(DEFAULT_SEQUENCER_CACHE_TTL_SECS))
+    }
+}
+
+impl WhitelistSequencerCache {
+    /// Create a sequencer cache with a custom TTL.
+    pub fn new(ttl: Duration) -> Self {
+        Self::with_cooldowns(ttl, Duration::from_secs(DEFAULT_SEQUENCER_MISS_REFRESH_COOLDOWN_SECS))
+    }
+
+    /// Create a sequencer cache with custom TTL and signer-miss refresh cooldown.
+    ///
+    /// `miss_refresh_cooldown` only gates forced refreshes triggered by signer mismatches.
+    /// Normal TTL expiry refreshes are still allowed even when `miss_refresh_cooldown > ttl`.
+    pub fn with_cooldowns(ttl: Duration, miss_refresh_cooldown: Duration) -> Self {
+        Self { ttl, miss_refresh_cooldown, last_miss_refresh_at: None, current: None, next: None }
+    }
+
+    /// Return the cached current-epoch sequencer if still fresh.
+    pub fn get_current(&self, now: Instant) -> Option<Address> {
+        self.current
+            .filter(|(_, fetched_at)| now.saturating_duration_since(*fetched_at) < self.ttl)
+            .map(|(addr, _)| addr)
+    }
+
+    /// Return the cached next-epoch sequencer if still fresh.
+    pub fn get_next(&self, now: Instant) -> Option<Address> {
+        self.next
+            .filter(|(_, fetched_at)| now.saturating_duration_since(*fetched_at) < self.ttl)
+            .map(|(addr, _)| addr)
+    }
+
+    /// Return true when signer-mismatch handling may force a fresh L1 read.
+    pub fn allow_miss_refresh(&mut self, now: Instant) -> bool {
+        if let Some(last) = self.last_miss_refresh_at
+            && now.saturating_duration_since(last) < self.miss_refresh_cooldown
+        {
+            return false;
+        }
+        self.last_miss_refresh_at = Some(now);
+        true
+    }
+
+    /// Clear both cached entries, forcing the next lookup to re-fetch from L1.
+    pub fn invalidate(&mut self) {
+        self.current = None;
+        self.next = None;
+    }
+
+    /// Store the current-epoch sequencer address.
+    pub fn set_current(&mut self, addr: Address, now: Instant) {
+        self.current = Some((addr, now));
+    }
+
+    /// Store the next-epoch sequencer address.
+    pub fn set_next(&mut self, addr: Address, now: Instant) {
+        self.next = Some((addr, now));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -321,6 +402,83 @@ mod tests {
         cache.insert(Arc::new(sample_envelope(h3, 8)));
 
         assert_eq!(cache.sorted_hashes_by_block_number(), vec![h1, h2, h3]);
+    }
+
+    #[test]
+    fn sequencer_cache_returns_none_when_empty() {
+        let cache = WhitelistSequencerCache::new(Duration::from_secs(10));
+        let now = Instant::now();
+        assert!(cache.get_current(now).is_none());
+        assert!(cache.get_next(now).is_none());
+    }
+
+    #[test]
+    fn sequencer_cache_returns_cached_value_within_ttl() {
+        let mut cache = WhitelistSequencerCache::new(Duration::from_secs(10));
+        let now = Instant::now();
+        let addr = Address::from([0xaau8; 20]);
+
+        cache.set_current(addr, now);
+        cache.set_next(addr, now);
+
+        assert_eq!(cache.get_current(now + Duration::from_secs(5)), Some(addr));
+        assert_eq!(cache.get_next(now + Duration::from_secs(5)), Some(addr));
+    }
+
+    #[test]
+    fn sequencer_cache_expires_after_ttl() {
+        let mut cache = WhitelistSequencerCache::new(Duration::from_secs(10));
+        let now = Instant::now();
+        let addr = Address::from([0xbbu8; 20]);
+
+        cache.set_current(addr, now);
+        cache.set_next(addr, now);
+
+        assert!(cache.get_current(now + Duration::from_secs(11)).is_none());
+        assert!(cache.get_next(now + Duration::from_secs(11)).is_none());
+    }
+
+    #[test]
+    fn sequencer_cache_invalidate_clears_both_entries() {
+        let mut cache = WhitelistSequencerCache::new(Duration::from_secs(10));
+        let now = Instant::now();
+        let addr = Address::from([0xccu8; 20]);
+
+        cache.set_current(addr, now);
+        cache.set_next(addr, now);
+        assert!(cache.get_current(now).is_some());
+        assert!(cache.get_next(now).is_some());
+
+        cache.invalidate();
+        assert!(cache.get_current(now).is_none());
+        assert!(cache.get_next(now).is_none());
+    }
+
+    #[test]
+    fn sequencer_cache_set_replaces_previous_entry() {
+        let mut cache = WhitelistSequencerCache::new(Duration::from_secs(10));
+        let now = Instant::now();
+        let addr1 = Address::from([0x11u8; 20]);
+        let addr2 = Address::from([0x22u8; 20]);
+
+        cache.set_current(addr1, now);
+        assert_eq!(cache.get_current(now), Some(addr1));
+
+        cache.set_current(addr2, now + Duration::from_secs(1));
+        assert_eq!(cache.get_current(now + Duration::from_secs(1)), Some(addr2));
+    }
+
+    #[test]
+    fn sequencer_cache_miss_refresh_is_rate_limited() {
+        let mut cache = WhitelistSequencerCache::with_cooldowns(
+            Duration::from_secs(10),
+            Duration::from_secs(2),
+        );
+        let now = Instant::now();
+
+        assert!(cache.allow_miss_refresh(now));
+        assert!(!cache.allow_miss_refresh(now + Duration::from_secs(1)));
+        assert!(cache.allow_miss_refresh(now + Duration::from_secs(3)));
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -17,8 +17,8 @@ const DEFAULT_RECENT_ENVELOPE_CAPACITY: usize = 1024;
 const DEFAULT_PENDING_ENVELOPE_CAPACITY: usize = 768;
 /// Default cooldown, in seconds, between duplicate parent-hash requests.
 const DEFAULT_REQUEST_COOLDOWN_SECS: u64 = 10;
-/// Default TTL for cached whitelist sequencer addresses (one L1 slot).
-const DEFAULT_SEQUENCER_CACHE_TTL_SECS: u64 = 12;
+/// Default TTL for cached whitelist sequencer addresses (one L1 epoch = 32 slots).
+const DEFAULT_SEQUENCER_CACHE_TTL_SECS: u64 = 12 * 32;
 /// Minimum interval between forced signer-miss refreshes from L1.
 const DEFAULT_SEQUENCER_MISS_REFRESH_COOLDOWN_SECS: u64 = 2;
 
@@ -231,8 +231,8 @@ impl WhitelistSequencerCache {
 
     /// Return true when signer-mismatch handling may force a fresh L1 read.
     pub fn allow_miss_refresh(&mut self, now: Instant) -> bool {
-        if let Some(last) = self.last_miss_refresh_at
-            && now.saturating_duration_since(last) < self.miss_refresh_cooldown
+        if let Some(last) = self.last_miss_refresh_at &&
+            now.saturating_duration_since(last) < self.miss_refresh_cooldown
         {
             return false;
         }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/signer.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/signer.rs
@@ -1,30 +1,116 @@
+use std::time::Instant;
+
 use alloy_primitives::Address;
 use alloy_provider::Provider;
+use tracing::debug;
 
 use crate::error::{Result, WhitelistPreconfirmationDriverError};
 
 use super::WhitelistPreconfirmationImporter;
+
+/// Result of a cached sequencer lookup, including whether values came from cache.
+struct CachedSequencers {
+    current: Address,
+    next: Address,
+    /// True when at least one value was served from the TTL cache rather than freshly fetched.
+    any_from_cache: bool,
+}
 
 impl<P> WhitelistPreconfirmationImporter<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
     /// Ensure the signer is allowed in the whitelist.
-    pub(super) async fn ensure_signer_allowed(&self, signer: Address) -> Result<()> {
-        let (current, next) =
-            tokio::try_join!(self.current_whitelist_sequencer(), self.next_whitelist_sequencer())?;
+    ///
+    /// First checks the TTL cache. On a cache miss (signer not in cached set), only re-fetches
+    /// from L1 if the cached values were served from cache (could be stale due to epoch rotation).
+    /// When the values were freshly fetched, rejects immediately to prevent spam from bypassing
+    /// the cache.
+    pub(super) async fn ensure_signer_allowed(&mut self, signer: Address) -> Result<()> {
+        let now = Instant::now();
+        let result = self.cached_whitelist_sequencers(now).await?;
 
-        if signer == current || signer == next {
+        if signer == result.current || signer == result.next {
+            return Ok(());
+        }
+
+        // Only re-fetch if at least one value was served from cache (could be stale).
+        // If both were freshly fetched from L1, reject immediately — re-fetching would
+        // return the same result and lets spam bypass the cache.
+        if !result.any_from_cache {
+            return Err(WhitelistPreconfirmationDriverError::InvalidSignature(format!(
+                "signer {signer} is not current ({}) or next ({}) whitelist sequencer",
+                result.current, result.next
+            )));
+        }
+
+        if !self.sequencer_cache.allow_miss_refresh(now) {
+            debug!(
+                %signer,
+                cached_current = %result.current,
+                cached_next = %result.next,
+                "signer mismatch refresh cooldown active; rejecting without L1 re-fetch"
+            );
+            return Err(WhitelistPreconfirmationDriverError::InvalidSignature(format!(
+                "signer {signer} is not current ({}) or next ({}) whitelist sequencer",
+                result.current, result.next
+            )));
+        }
+
+        debug!(
+            %signer,
+            cached_current = %result.current,
+            cached_next = %result.next,
+            "signer not in cached whitelist; re-fetching from L1"
+        );
+        self.sequencer_cache.invalidate();
+        let fresh = self.cached_whitelist_sequencers(now).await?;
+
+        if signer == fresh.current || signer == fresh.next {
             return Ok(());
         }
 
         Err(WhitelistPreconfirmationDriverError::InvalidSignature(format!(
-            "signer {signer} is not current ({current}) or next ({next}) whitelist sequencer"
+            "signer {signer} is not current ({}) or next ({}) whitelist sequencer",
+            fresh.current, fresh.next
         )))
     }
 
-    /// Get the current whitelist sequencer address.
-    async fn current_whitelist_sequencer(&self) -> Result<Address> {
+    /// Return (current, next) sequencer addresses, using the TTL cache when fresh.
+    async fn cached_whitelist_sequencers(&mut self, now: Instant) -> Result<CachedSequencers> {
+        // Access here is serialized by `&mut self` on the importer's event loop,
+        // so a single importer instance cannot stampede concurrent L1 lookups.
+        let mut any_from_cache = false;
+
+        let current = match self.sequencer_cache.get_current(now) {
+            Some(addr) => {
+                any_from_cache = true;
+                addr
+            }
+            None => {
+                let addr = self.fetch_current_whitelist_sequencer().await?;
+                self.sequencer_cache.set_current(addr, now);
+                addr
+            }
+        };
+
+        let next = match self.sequencer_cache.get_next(now) {
+            Some(addr) => {
+                any_from_cache = true;
+                addr
+            }
+            None => {
+                let addr = self.fetch_next_whitelist_sequencer().await?;
+                self.sequencer_cache.set_next(addr, now);
+                addr
+            }
+        };
+
+        Ok(CachedSequencers { current, next, any_from_cache })
+    }
+
+    /// Fetch the current whitelist sequencer address from L1.
+    async fn fetch_current_whitelist_sequencer(&self) -> Result<Address> {
         let proposer = self.whitelist.getOperatorForCurrentEpoch().call().await.map_err(|err| {
             WhitelistPreconfirmationDriverError::WhitelistLookup(format!(
                 "failed to read current whitelist proposer: {err}"
@@ -40,8 +126,8 @@ where
         )
     }
 
-    /// Get the next whitelist sequencer address.
-    async fn next_whitelist_sequencer(&self) -> Result<Address> {
+    /// Fetch the next whitelist sequencer address from L1.
+    async fn fetch_next_whitelist_sequencer(&self) -> Result<Address> {
         let proposer = self.whitelist.getOperatorForNextEpoch().call().await.map_err(|err| {
             WhitelistPreconfirmationDriverError::WhitelistLookup(format!(
                 "failed to read next whitelist proposer: {err}"


### PR DESCRIPTION
…quencer lookups

Cache current/next whitelist sequencer addresses with a 12-second TTL (one L1 slot) to avoid 4 on-chain RPC calls per incoming gossip message.

On signer mismatch, only invalidate and re-fetch from L1 when cached values were served from cache (could be stale due to epoch rotation). When values were freshly fetched, reject immediately to prevent spam from bypassing the cache and saturating the L1 RPC.

Fixes https://github.com/taikoxyz/taiko-mono/issues/21293