### PR TITLE
feat(taiko-client-rs): add comprehensive metrics and observability instrumentation for whitelist preconfirmation driver

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -13823,6 +13823,7 @@ dependencies = [
  "hashlink 0.10.0",
  "kona-gossip",
  "libp2p",
+ "metrics 0.24.3",
  "preconfirmation-net",
  "protocol",
  "rpc",

--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -8,7 +8,9 @@ use driver::{DriverConfig, metrics::DriverMetrics};
 use preconfirmation_net::P2pConfig;
 use rpc::{SubscriptionSource, client::ClientConfig};
 use tracing::warn;
-use whitelist_preconfirmation_driver::{RunnerConfig, WhitelistPreconfirmationDriverRunner};
+use whitelist_preconfirmation_driver::{
+    RunnerConfig, WhitelistPreconfirmationDriverMetrics, WhitelistPreconfirmationDriverRunner,
+};
 
 use crate::{
     commands::Subcommand,
@@ -125,6 +127,7 @@ impl Subcommand for WhitelistPreconfirmationDriverSubCommand {
     /// Registers driver metrics with the global registry.
     fn register_metrics(&self) -> Result<()> {
         DriverMetrics::init();
+        WhitelistPreconfirmationDriverMetrics::init();
         Ok(())
     }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3"
 hashlink = "0.10"
 kona-gossip = { git = "https://github.com/op-rs/kona", package = "kona-gossip", tag = "kona-client/v1.2.4", default-features = false }
 libp2p = { version = "0.56.0", features = ["tcp", "gossipsub", "ping", "identify", "noise", "yamux", "macros", "tokio"] }
+metrics = { workspace = true }
 preconfirmation-net = { path = "../../../preconfirmation-p2p/crates/net" }
 protocol = { path = "../protocol" }
 rpc = { path = "../rpc" }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -80,6 +80,11 @@ impl EnvelopeCache {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+
+    /// Returns current number of cached envelopes.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
 }
 
 /// Recently seen validated envelopes used for serving request topic responses.
@@ -130,6 +135,11 @@ impl RecentEnvelopeCache {
         self.entries.iter().rev().find_map(|(_, envelope)| {
             envelope.end_of_sequencing.unwrap_or(false).then(|| envelope.clone())
         })
+    }
+
+    /// Returns current number of recent envelopes.
+    pub fn len(&self) -> usize {
+        self.entries.len()
     }
 }
 
@@ -226,6 +236,7 @@ mod tests {
         assert!(recent.get_recent(&h1).is_none());
         assert!(recent.get_recent(&h2).is_some());
         assert!(recent.get_recent(&h3).is_some());
+        assert_eq!(recent.len(), 2);
     }
 
     #[test]
@@ -289,6 +300,7 @@ mod tests {
 
         let hashes = cache.sorted_hashes_by_block_number();
         assert_eq!(hashes, vec![h2, h3]);
+        assert_eq!(cache.len(), 2);
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -8,6 +8,7 @@ use crate::{
         DecodedUnsafePayload, WhitelistExecutionPayloadEnvelope, block_signing_hash, recover_signer,
     },
     error::{Result, WhitelistPreconfirmationDriverError},
+    metrics::WhitelistPreconfirmationDriverMetrics,
 };
 
 use super::{
@@ -25,18 +26,43 @@ where
         payload: DecodedUnsafePayload,
     ) -> Result<()> {
         let prehash = block_signing_hash(self.chain_id, payload.payload_bytes.as_slice());
-        let signer = recover_signer(prehash, &payload.wire_signature)?;
-        self.ensure_signer_allowed(signer).await?;
+        let signer = match recover_signer(prehash, &payload.wire_signature) {
+            Ok(signer) => signer,
+            Err(err) => {
+                metrics::counter!(
+                    WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+                    "stage" => "payload_signature_recover",
+                )
+                .increment(1);
+                return Err(err);
+            }
+        };
+        if let Err(err) = self.ensure_signer_allowed(signer).await {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+                "stage" => "payload_signer_check",
+            )
+            .increment(1);
+            return Err(err);
+        }
 
         let envelope = normalize_unsafe_payload_envelope(payload.envelope, payload.wire_signature);
-        validate_execution_payload_for_preconf(
+        if let Err(err) = validate_execution_payload_for_preconf(
             &envelope.execution_payload,
             self.chain_id,
             self.anchor_address,
-        )?;
+        ) {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+                "stage" => "payload_validate",
+            )
+            .increment(1);
+            return Err(err);
+        }
         let envelope = Arc::new(envelope);
         self.cache.insert(envelope.clone());
         self.recent_cache.insert_recent(envelope);
+        self.update_cache_gauges();
 
         Ok(())
     }
@@ -47,6 +73,11 @@ where
         envelope: WhitelistExecutionPayloadEnvelope,
     ) -> Result<()> {
         let Some(signature) = envelope.signature else {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+                "stage" => "response_missing_signature",
+            )
+            .increment(1);
             return Err(WhitelistPreconfirmationDriverError::InvalidSignature(
                 "response payload is missing embedded signature".to_string(),
             ));
@@ -54,17 +85,43 @@ where
 
         let prehash =
             block_signing_hash(self.chain_id, envelope.execution_payload.block_hash.as_slice());
-        let signer = recover_signer(prehash, &signature)?;
-        self.ensure_signer_allowed(signer).await?;
+        let signer = match recover_signer(prehash, &signature) {
+            Ok(signer) => signer,
+            Err(err) => {
+                metrics::counter!(
+                    WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+                    "stage" => "response_signature_recover",
+                )
+                .increment(1);
+                return Err(err);
+            }
+        };
+        if let Err(err) = self.ensure_signer_allowed(signer).await {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+                "stage" => "response_signer_check",
+            )
+            .increment(1);
+            return Err(err);
+        }
 
-        validate_execution_payload_for_preconf(
+        if let Err(err) = validate_execution_payload_for_preconf(
             &envelope.execution_payload,
             self.chain_id,
             self.anchor_address,
-        )?;
+        ) {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+                "stage" => "response_validate",
+            )
+            .increment(1);
+            return Err(err);
+        }
+
         let envelope = Arc::new(envelope);
         self.cache.insert(envelope.clone());
         self.recent_cache.insert_recent(envelope);
+        self.update_cache_gauges();
         Ok(())
     }
 
@@ -75,17 +132,28 @@ where
         hash: B256,
     ) -> Result<()> {
         if let Some(envelope) = self.recent_cache.get_recent(&hash) {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::RESPONSE_LOOKUPS_TOTAL,
+                "result" => "cache_hit",
+            )
+            .increment(1);
             tracing::debug!(
                 peer = %from,
                 hash = %hash,
                 "serving whitelist preconfirmation response from recent cache"
             );
             self.recent_cache.insert_recent(envelope.clone());
+            self.update_cache_gauges();
             self.publish_unsafe_response(envelope).await;
             return Ok(());
         }
 
         let Some(envelope) = self.build_response_envelope_from_l2(hash).await? else {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::RESPONSE_LOOKUPS_TOTAL,
+                "result" => "not_found",
+            )
+            .increment(1);
             tracing::debug!(
                 peer = %from,
                 hash = %hash,
@@ -94,6 +162,11 @@ where
             return Ok(());
         };
 
+        metrics::counter!(
+            WhitelistPreconfirmationDriverMetrics::RESPONSE_LOOKUPS_TOTAL,
+            "result" => "l2_hit",
+        )
+        .increment(1);
         tracing::debug!(
             peer = %from,
             hash = %hash,
@@ -101,6 +174,7 @@ where
         );
         let envelope = Arc::new(envelope);
         self.recent_cache.insert_recent(envelope.clone());
+        self.update_cache_gauges();
         self.publish_unsafe_response(envelope).await;
         Ok(())
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -14,6 +14,7 @@ use tracing::{debug, info, warn};
 use crate::{
     cache::{EnvelopeCache, RecentEnvelopeCache, RequestThrottle},
     error::{Result, WhitelistPreconfirmationDriverError},
+    metrics::WhitelistPreconfirmationDriverMetrics,
     network::{NetworkCommand, NetworkEvent},
 };
 
@@ -76,7 +77,7 @@ where
         let whitelist = PreconfWhitelistInstance::new(whitelist_address, rpc.l1_provider.clone());
         let anchor_address = *rpc.shasta.anchor.address();
 
-        Self {
+        let importer = Self {
             event_syncer,
             rpc,
             whitelist,
@@ -87,20 +88,50 @@ where
             network_command_tx,
             sync_ready: false,
             anchor_address,
-        }
+        };
+        importer.update_cache_gauges();
+        importer
     }
 
     /// Handle one network event.
     pub(crate) async fn handle_event(&mut self, event: NetworkEvent) -> Result<()> {
         match event {
             NetworkEvent::UnsafePayload { from, payload } => {
-                if let Err(err) = self.handle_unsafe_payload(payload).await {
-                    warn!(peer = %from, error = %err, "dropping invalid whitelist preconfirmation payload");
+                match self.handle_unsafe_payload(payload).await {
+                    Ok(()) => metrics::counter!(
+                        WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+                        "event_type" => "unsafe_payload",
+                        "result" => "accepted",
+                    )
+                    .increment(1),
+                    Err(err) => {
+                        warn!(peer = %from, error = %err, "dropping invalid whitelist preconfirmation payload");
+                        metrics::counter!(
+                            WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+                            "event_type" => "unsafe_payload",
+                            "result" => "dropped",
+                        )
+                        .increment(1);
+                    }
                 }
             }
             NetworkEvent::UnsafeResponse { from, envelope } => {
-                if let Err(err) = self.handle_unsafe_response(envelope).await {
-                    warn!(peer = %from, error = %err, "dropping invalid whitelist preconfirmation response");
+                match self.handle_unsafe_response(envelope).await {
+                    Ok(()) => metrics::counter!(
+                        WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+                        "event_type" => "unsafe_response",
+                        "result" => "accepted",
+                    )
+                    .increment(1),
+                    Err(err) => {
+                        warn!(peer = %from, error = %err, "dropping invalid whitelist preconfirmation response");
+                        metrics::counter!(
+                            WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+                            "event_type" => "unsafe_response",
+                            "result" => "dropped",
+                        )
+                        .increment(1);
+                    }
                 }
             }
             NetworkEvent::UnsafeRequest { from, hash } => {
@@ -111,6 +142,19 @@ where
                         error = %err,
                         "failed to handle whitelist preconfirmation request"
                     );
+                    metrics::counter!(
+                        WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+                        "event_type" => "unsafe_request",
+                        "result" => "error",
+                    )
+                    .increment(1);
+                } else {
+                    metrics::counter!(
+                        WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+                        "event_type" => "unsafe_request",
+                        "result" => "handled",
+                    )
+                    .increment(1);
                 }
             }
             NetworkEvent::EndOfSequencingRequest { from, epoch } => {
@@ -122,8 +166,20 @@ where
                         "serving end-of-sequencing whitelist preconfirmation response from recent cache"
                     );
                     self.publish_unsafe_response(envelope).await;
+                    metrics::counter!(
+                        WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+                        "event_type" => "end_of_sequencing_request",
+                        "result" => "served",
+                    )
+                    .increment(1);
                 } else {
                     debug!(peer = %from, epoch, "no recent end-of-sequencing envelope to serve");
+                    metrics::counter!(
+                        WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+                        "event_type" => "end_of_sequencing_request",
+                        "result" => "miss",
+                    )
+                    .increment(1);
                 }
             }
         }
@@ -137,7 +193,12 @@ where
             return Ok(());
         }
 
-        self.import_from_cache().await
+        self.import_from_cache().await.inspect_err(|_err| {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::SYNC_READY_IMPORT_FAILURES_TOTAL
+            )
+            .increment(1);
+        })
     }
 
     /// Refresh whether sync is ready.
@@ -145,6 +206,8 @@ where
         let ready = self.head_l1_origin_block_id().await?.is_some();
         let became_ready = sync_ready_transition(self.sync_ready, ready);
         if became_ready {
+            metrics::counter!(WhitelistPreconfirmationDriverMetrics::SYNC_READY_TRANSITIONS_TOTAL)
+                .increment(1);
             info!(
                 "event sync established head l1 origin; enabling whitelist preconfirmation imports"
             );
@@ -166,6 +229,14 @@ where
             .await
             .map(|opt| opt.map(|block| block.hash()))
             .map_err(provider_err)
+    }
+
+    /// Update cache gauges after cache mutations.
+    pub(super) fn update_cache_gauges(&self) {
+        metrics::gauge!(WhitelistPreconfirmationDriverMetrics::CACHE_PENDING_COUNT)
+            .set(self.cache.len() as f64);
+        metrics::gauge!(WhitelistPreconfirmationDriverMetrics::CACHE_RECENT_COUNT)
+            .set(self.recent_cache.len() as f64);
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/response.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/response.rs
@@ -11,6 +11,7 @@ use tracing::warn;
 use crate::{
     codec::WhitelistExecutionPayloadEnvelope,
     error::{Result, WhitelistPreconfirmationDriverError},
+    metrics::WhitelistPreconfirmationDriverMetrics,
     network::NetworkCommand,
 };
 
@@ -119,11 +120,24 @@ where
         if let Err(err) =
             self.network_command_tx.send(NetworkCommand::PublishUnsafeRequest { hash }).await
         {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::NETWORK_OUTBOUND_PUBLISH_TOTAL,
+                "topic" => "request_preconf_blocks",
+                "result" => "queue_failed",
+            )
+            .increment(1);
             warn!(
                 hash = %hash,
                 error = %err,
                 "failed to queue whitelist preconfirmation request publish command"
             );
+        } else {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::NETWORK_OUTBOUND_PUBLISH_TOTAL,
+                "topic" => "request_preconf_blocks",
+                "result" => "queued",
+            )
+            .increment(1);
         }
     }
 
@@ -136,11 +150,24 @@ where
         if let Err(err) =
             self.network_command_tx.send(NetworkCommand::PublishUnsafeResponse { envelope }).await
         {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::NETWORK_OUTBOUND_PUBLISH_TOTAL,
+                "topic" => "response_preconf_blocks",
+                "result" => "queue_failed",
+            )
+            .increment(1);
             warn!(
                 hash = %hash,
                 error = %err,
                 "failed to queue whitelist preconfirmation response publish command"
             );
+        } else {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::NETWORK_OUTBOUND_PUBLISH_TOTAL,
+                "topic" => "response_preconf_blocks",
+                "result" => "queued",
+            )
+            .increment(1);
         }
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/signer.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/signer.rs
@@ -1,7 +1,10 @@
 use alloy_primitives::Address;
 use alloy_provider::Provider;
 
-use crate::error::{Result, WhitelistPreconfirmationDriverError};
+use crate::{
+    error::{Result, WhitelistPreconfirmationDriverError},
+    metrics::WhitelistPreconfirmationDriverMetrics,
+};
 
 use super::WhitelistPreconfirmationImporter;
 
@@ -26,6 +29,10 @@ where
     /// Get the current whitelist sequencer address.
     async fn current_whitelist_sequencer(&self) -> Result<Address> {
         let proposer = self.whitelist.getOperatorForCurrentEpoch().call().await.map_err(|err| {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::WHITELIST_LOOKUP_FAILURES_TOTAL
+            )
+            .increment(1);
             WhitelistPreconfirmationDriverError::WhitelistLookup(format!(
                 "failed to read current whitelist proposer: {err}"
             ))
@@ -33,6 +40,10 @@ where
 
         self.whitelist.operators(proposer).call().await.map(|info| info.sequencerAddress).map_err(
             |err| {
+                metrics::counter!(
+                    WhitelistPreconfirmationDriverMetrics::WHITELIST_LOOKUP_FAILURES_TOTAL
+                )
+                .increment(1);
                 WhitelistPreconfirmationDriverError::WhitelistLookup(format!(
                     "failed to read current whitelist sequencer: {err}"
                 ))
@@ -43,6 +54,10 @@ where
     /// Get the next whitelist sequencer address.
     async fn next_whitelist_sequencer(&self) -> Result<Address> {
         let proposer = self.whitelist.getOperatorForNextEpoch().call().await.map_err(|err| {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::WHITELIST_LOOKUP_FAILURES_TOTAL
+            )
+            .increment(1);
             WhitelistPreconfirmationDriverError::WhitelistLookup(format!(
                 "failed to read next whitelist proposer: {err}"
             ))
@@ -50,6 +65,10 @@ where
 
         self.whitelist.operators(proposer).call().await.map(|info| info.sequencerAddress).map_err(
             |err| {
+                metrics::counter!(
+                    WhitelistPreconfirmationDriverMetrics::WHITELIST_LOOKUP_FAILURES_TOTAL
+                )
+                .increment(1);
                 WhitelistPreconfirmationDriverError::WhitelistLookup(format!(
                     "failed to read next whitelist sequencer: {err}"
                 ))

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/lib.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/lib.rs
@@ -4,9 +4,11 @@ mod cache;
 mod codec;
 mod error;
 mod importer;
+pub mod metrics;
 mod network;
 mod preconf_ingress_sync;
 mod runner;
 
 pub use error::{Result, WhitelistPreconfirmationDriverError};
+pub use metrics::WhitelistPreconfirmationDriverMetrics;
 pub use runner::{RunnerConfig, WhitelistPreconfirmationDriverRunner};

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/metrics.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/metrics.rs
@@ -1,0 +1,244 @@
+//! Metrics exposed by the whitelist preconfirmation driver runtime.
+
+use metrics::Unit;
+
+/// Metric namespace for the whitelist preconfirmation driver.
+pub struct WhitelistPreconfirmationDriverMetrics;
+
+impl WhitelistPreconfirmationDriverMetrics {
+    // Runner lifecycle metrics
+    /// Counter tracking runner starts.
+    pub const RUNNER_START_TOTAL: &'static str = "whitelist_preconf_driver_runner_start_total";
+    /// Counter tracking runner exits by reason.
+    pub const RUNNER_EXIT_TOTAL: &'static str = "whitelist_preconf_driver_runner_exit_total";
+    /// Histogram tracking how long we wait for event-sync ingress readiness.
+    pub const EVENT_SYNC_WAIT_DURATION_SECONDS: &'static str =
+        "whitelist_preconf_driver_event_sync_wait_duration_seconds";
+    /// Counter tracking sync-ready transitions.
+    pub const SYNC_READY_TRANSITIONS_TOTAL: &'static str =
+        "whitelist_preconf_driver_sync_ready_transitions_total";
+    /// Counter tracking sync-ready triggered import failures.
+    pub const SYNC_READY_IMPORT_FAILURES_TOTAL: &'static str =
+        "whitelist_preconf_driver_sync_ready_import_failures_total";
+
+    // Network metrics
+    /// Counter tracking inbound gossip/request messages by topic and decode status.
+    pub const NETWORK_INBOUND_MESSAGES_TOTAL: &'static str =
+        "whitelist_preconf_driver_network_inbound_messages_total";
+    /// Counter tracking decode failures by topic.
+    pub const NETWORK_DECODE_FAILURES_TOTAL: &'static str =
+        "whitelist_preconf_driver_network_decode_failures_total";
+    /// Counter tracking outbound publish commands by topic and result.
+    pub const NETWORK_OUTBOUND_PUBLISH_TOTAL: &'static str =
+        "whitelist_preconf_driver_network_outbound_publish_total";
+    /// Counter tracking dial attempts by source.
+    pub const NETWORK_DIAL_ATTEMPTS_TOTAL: &'static str =
+        "whitelist_preconf_driver_network_dial_attempts_total";
+    /// Counter tracking dial failures by source.
+    pub const NETWORK_DIAL_FAILURES_TOTAL: &'static str =
+        "whitelist_preconf_driver_network_dial_failures_total";
+    /// Counter tracking event-forward failures into importer queue.
+    pub const NETWORK_FORWARD_FAILURES_TOTAL: &'static str =
+        "whitelist_preconf_driver_network_forward_failures_total";
+
+    // Importer metrics
+    /// Counter tracking importer event handling by event type and result.
+    pub const IMPORTER_EVENTS_TOTAL: &'static str =
+        "whitelist_preconf_driver_importer_events_total";
+    /// Counter tracking validation failures by stage.
+    pub const VALIDATION_FAILURES_TOTAL: &'static str =
+        "whitelist_preconf_driver_validation_failures_total";
+    /// Counter tracking whitelist contract lookup failures.
+    pub const WHITELIST_LOOKUP_FAILURES_TOTAL: &'static str =
+        "whitelist_preconf_driver_whitelist_lookup_failures_total";
+    /// Counter tracking request-response lookup outcomes.
+    pub const RESPONSE_LOOKUPS_TOTAL: &'static str =
+        "whitelist_preconf_driver_response_lookups_total";
+    /// Counter tracking cache import attempts.
+    pub const CACHE_IMPORT_ATTEMPTS_TOTAL: &'static str =
+        "whitelist_preconf_driver_cache_import_attempts_total";
+    /// Counter tracking cache import outcomes.
+    pub const CACHE_IMPORT_RESULTS_TOTAL: &'static str =
+        "whitelist_preconf_driver_cache_import_results_total";
+    /// Counter tracking driver submit outcomes.
+    pub const DRIVER_SUBMIT_TOTAL: &'static str = "whitelist_preconf_driver_driver_submit_total";
+    /// Histogram tracking duration of driver submission path.
+    pub const DRIVER_SUBMIT_DURATION_SECONDS: &'static str =
+        "whitelist_preconf_driver_driver_submit_duration_seconds";
+    /// Counter tracking parent request outcomes (issued/throttled).
+    pub const PARENT_REQUESTS_TOTAL: &'static str =
+        "whitelist_preconf_driver_parent_requests_total";
+
+    // Cache gauges
+    /// Gauge tracking pending cache size.
+    pub const CACHE_PENDING_COUNT: &'static str = "whitelist_preconf_driver_cache_pending_count";
+    /// Gauge tracking recent cache size.
+    pub const CACHE_RECENT_COUNT: &'static str = "whitelist_preconf_driver_cache_recent_count";
+
+    /// Register metric descriptors and initialise counters/gauges.
+    pub fn init() {
+        metrics::describe_counter!(Self::RUNNER_START_TOTAL, Unit::Count, "Runner start count");
+        metrics::describe_counter!(
+            Self::RUNNER_EXIT_TOTAL,
+            Unit::Count,
+            "Runner exits grouped by reason"
+        );
+        metrics::describe_histogram!(
+            Self::EVENT_SYNC_WAIT_DURATION_SECONDS,
+            Unit::Seconds,
+            "Time spent waiting for preconfirmation ingress readiness"
+        );
+        metrics::describe_counter!(
+            Self::SYNC_READY_TRANSITIONS_TOTAL,
+            Unit::Count,
+            "Number of sync-ready state transitions"
+        );
+        metrics::describe_counter!(
+            Self::SYNC_READY_IMPORT_FAILURES_TOTAL,
+            Unit::Count,
+            "Sync-ready triggered cache import failures"
+        );
+
+        metrics::describe_counter!(
+            Self::NETWORK_INBOUND_MESSAGES_TOTAL,
+            Unit::Count,
+            "Inbound network messages by topic and decode result"
+        );
+        metrics::describe_counter!(
+            Self::NETWORK_DECODE_FAILURES_TOTAL,
+            Unit::Count,
+            "Network decode failures by topic"
+        );
+        metrics::describe_counter!(
+            Self::NETWORK_OUTBOUND_PUBLISH_TOTAL,
+            Unit::Count,
+            "Outbound publish command outcomes by topic"
+        );
+        metrics::describe_counter!(
+            Self::NETWORK_DIAL_ATTEMPTS_TOTAL,
+            Unit::Count,
+            "Dial attempts by source"
+        );
+        metrics::describe_counter!(
+            Self::NETWORK_DIAL_FAILURES_TOTAL,
+            Unit::Count,
+            "Dial failures by source"
+        );
+        metrics::describe_counter!(
+            Self::NETWORK_FORWARD_FAILURES_TOTAL,
+            Unit::Count,
+            "Failures forwarding network events to importer"
+        );
+
+        metrics::describe_counter!(
+            Self::IMPORTER_EVENTS_TOTAL,
+            Unit::Count,
+            "Importer event handling outcomes"
+        );
+        metrics::describe_counter!(
+            Self::VALIDATION_FAILURES_TOTAL,
+            Unit::Count,
+            "Payload/response validation failures"
+        );
+        metrics::describe_counter!(
+            Self::WHITELIST_LOOKUP_FAILURES_TOTAL,
+            Unit::Count,
+            "Whitelist contract lookup failures"
+        );
+        metrics::describe_counter!(
+            Self::RESPONSE_LOOKUPS_TOTAL,
+            Unit::Count,
+            "Unsafe request lookup outcomes"
+        );
+        metrics::describe_counter!(
+            Self::CACHE_IMPORT_ATTEMPTS_TOTAL,
+            Unit::Count,
+            "Cache import attempts"
+        );
+        metrics::describe_counter!(
+            Self::CACHE_IMPORT_RESULTS_TOTAL,
+            Unit::Count,
+            "Cache import results"
+        );
+        metrics::describe_counter!(
+            Self::DRIVER_SUBMIT_TOTAL,
+            Unit::Count,
+            "Driver submission outcomes"
+        );
+        metrics::describe_histogram!(
+            Self::DRIVER_SUBMIT_DURATION_SECONDS,
+            Unit::Seconds,
+            "Duration for driver submission path"
+        );
+        metrics::describe_counter!(
+            Self::PARENT_REQUESTS_TOTAL,
+            Unit::Count,
+            "Parent request outcomes"
+        );
+
+        metrics::describe_gauge!(Self::CACHE_PENDING_COUNT, Unit::Count, "Pending cache size");
+        metrics::describe_gauge!(Self::CACHE_RECENT_COUNT, Unit::Count, "Recent cache size");
+
+        metrics::counter!(Self::RUNNER_START_TOTAL).absolute(0);
+        metrics::counter!(Self::RUNNER_EXIT_TOTAL).absolute(0);
+        metrics::counter!(Self::SYNC_READY_TRANSITIONS_TOTAL).absolute(0);
+        metrics::counter!(Self::SYNC_READY_IMPORT_FAILURES_TOTAL).absolute(0);
+        metrics::counter!(Self::NETWORK_INBOUND_MESSAGES_TOTAL).absolute(0);
+        metrics::counter!(Self::NETWORK_DECODE_FAILURES_TOTAL).absolute(0);
+        metrics::counter!(Self::NETWORK_OUTBOUND_PUBLISH_TOTAL).absolute(0);
+        metrics::counter!(Self::NETWORK_DIAL_ATTEMPTS_TOTAL).absolute(0);
+        metrics::counter!(Self::NETWORK_DIAL_FAILURES_TOTAL).absolute(0);
+        metrics::counter!(Self::NETWORK_FORWARD_FAILURES_TOTAL).absolute(0);
+        metrics::counter!(Self::IMPORTER_EVENTS_TOTAL).absolute(0);
+        metrics::counter!(Self::VALIDATION_FAILURES_TOTAL).absolute(0);
+        metrics::counter!(Self::WHITELIST_LOOKUP_FAILURES_TOTAL).absolute(0);
+        metrics::counter!(Self::RESPONSE_LOOKUPS_TOTAL).absolute(0);
+        metrics::counter!(Self::CACHE_IMPORT_ATTEMPTS_TOTAL).absolute(0);
+        metrics::counter!(Self::CACHE_IMPORT_RESULTS_TOTAL).absolute(0);
+        metrics::counter!(Self::DRIVER_SUBMIT_TOTAL).absolute(0);
+        metrics::counter!(Self::PARENT_REQUESTS_TOTAL).absolute(0);
+
+        metrics::gauge!(Self::CACHE_PENDING_COUNT).set(0.0);
+        metrics::gauge!(Self::CACHE_RECENT_COUNT).set(0.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WhitelistPreconfirmationDriverMetrics;
+
+    #[test]
+    fn metric_constants_have_expected_prefix() {
+        let names = [
+            WhitelistPreconfirmationDriverMetrics::RUNNER_START_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::RUNNER_EXIT_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::EVENT_SYNC_WAIT_DURATION_SECONDS,
+            WhitelistPreconfirmationDriverMetrics::SYNC_READY_TRANSITIONS_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::SYNC_READY_IMPORT_FAILURES_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::NETWORK_INBOUND_MESSAGES_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::NETWORK_DECODE_FAILURES_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::NETWORK_OUTBOUND_PUBLISH_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::NETWORK_DIAL_ATTEMPTS_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::NETWORK_DIAL_FAILURES_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::NETWORK_FORWARD_FAILURES_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::WHITELIST_LOOKUP_FAILURES_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::RESPONSE_LOOKUPS_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::CACHE_IMPORT_ATTEMPTS_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::CACHE_IMPORT_RESULTS_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::DRIVER_SUBMIT_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::DRIVER_SUBMIT_DURATION_SECONDS,
+            WhitelistPreconfirmationDriverMetrics::PARENT_REQUESTS_TOTAL,
+            WhitelistPreconfirmationDriverMetrics::CACHE_PENDING_COUNT,
+            WhitelistPreconfirmationDriverMetrics::CACHE_RECENT_COUNT,
+        ];
+
+        assert!(names.into_iter().all(|name| name.starts_with("whitelist_preconf_driver_")));
+    }
+
+    #[test]
+    fn init_does_not_panic() {
+        WhitelistPreconfirmationDriverMetrics::init();
+    }
+}


### PR DESCRIPTION

  ## Summary

  Adds comprehensive observability to whitelist-preconfirmation-driver with low-cardinality metrics and structured lifecycle/error logging across runner, network, and importer paths.

  ## What changed

  - Added WhitelistPreconfirmationDriverMetrics in crates/whitelist-preconfirmation-driver/src/metrics.rs.
  - Exported metrics from crates/whitelist-preconfirmation-driver/src/lib.rs.
  - Registered metrics in CLI startup in bin/client/src/commands/whitelist_preconfirmation_driver.rs.
  - Instrumented runner lifecycle in crates/whitelist-preconfirmation-driver/src/runner.rs:
      - runner start/exit counters
      - ingress wait histogram
      - structured startup fields
  - Instrumented network flow in crates/whitelist-preconfirmation-driver/src/network.rs:
      - inbound/decode/publish/dial/forward counters
      - topic/result/source labels with low cardinality
  - Instrumented importer flow in:
      - crates/whitelist-preconfirmation-driver/src/importer/mod.rs
      - crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
      - crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
      - crates/whitelist-preconfirmation-driver/src/importer/response.rs
      - crates/whitelist-preconfirmation-driver/src/importer/signer.rs
  - Added cache length helpers for gauge updates in crates/whitelist-preconfirmation-driver/src/cache.rs.
  - Added metrics API tests in crates/whitelist-preconfirmation-driver/tests/metrics_api.rs.
  - Added metrics dependency in crates/whitelist-preconfirmation-driver/Cargo.toml and lockfile update.

  ## Notes

  - No protocol/consensus behavior changes intended.
  - Labels are intentionally low-cardinality (no peer/hash/block-number metric labels).
