### PR TITLE
fix(eventindexer): correct V2 error messages in event handlers

### DIFF
--- a/packages/eventindexer/indexer/save_block_proposed_event.go
+++ b/packages/eventindexer/indexer/save_block_proposed_event.go
@@ -133,7 +133,7 @@ func (i *Indexer) saveBlockProposedEventsV2(
 			if err := i.saveBlockProposedEventV2(ctx, chainID, event, sender); err != nil {
 				eventindexer.BlockProposedEventsProcessedError.Inc()
 
-				return errors.Wrap(err, "i.saveBlockProposedEvent")
+				return errors.Wrap(err, "i.saveBlockProposedEventV2")
 			}
 
 			return nil

--- a/packages/eventindexer/indexer/save_block_verified_event.go
+++ b/packages/eventindexer/indexer/save_block_verified_event.go
@@ -108,7 +108,7 @@ func (i *Indexer) saveBlockVerifiedEventsV2(
 			if err := i.saveBlockVerifiedEventV2(ctx, chainID, event); err != nil {
 				eventindexer.BlockVerifiedEventsProcessedError.Inc()
 
-				return errors.Wrap(err, "i.saveBlockVerifiedEvent")
+				return errors.Wrap(err, "i.saveBlockVerifiedEventV2")
 			}
 
 			return nil

--- a/packages/eventindexer/indexer/save_transition_contested_event.go
+++ b/packages/eventindexer/indexer/save_transition_contested_event.go
@@ -98,7 +98,7 @@ func (i *Indexer) saveTransitionContestedEventsV2(
 		if err := i.saveTransitionContestedEventV2(ctx, chainID, event); err != nil {
 			eventindexer.TransitionContestedEventsProcessedError.Inc()
 
-			return errors.Wrap(err, "i.saveTransitionContestedEvent")
+			return errors.Wrap(err, "i.saveTransitionContestedEventV2")
 		}
 
 		if !events.Next() {


### PR DESCRIPTION
Fixed error messages in V2 event handlers that were missing the V2 suffix, making it clear which version failed during debugging.