### PR TITLE
fix(taiko-client-rs): fix tx-list RLP format in whitelist preconfirmation zlib codec

### DIFF
--- a/.github/workflows/taiko-client-rs--docker.yml
+++ b/.github/workflows/taiko-client-rs--docker.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    branches: [main, codec-wl]
+    branches: [main]
     tags:
       - "taiko-alethia-client-rs-v*"
     paths:

--- a/.github/workflows/taiko-client-rs--docker.yml
+++ b/.github/workflows/taiko-client-rs--docker.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [main, codec-wl]
     tags:
       - "taiko-alethia-client-rs-v*"
     paths:


### PR DESCRIPTION

  ## Summary

  This PR aligns taiko-client-rs tx-list wire encoding/decoding with the Go implementation and removes legacy Rust-format fallback decoding.

  ## Changes

  - Updated ZlibTxListCodec in crates/protocol/src/codec.rs:
      - Encode tx-lists as RLP list of byte strings (Go-compatible).
      - Decode tx-lists strictly as RLP list of byte strings.
      - Removed fallback decode path for legacy Rust list-of-u8 encoding.
  - Updated/added codec tests:
      - Confirms Go-style decode works.
      - Confirms Go-style encode output shape.
      - Confirms legacy Rust encoding is now rejected.

  ## Why

  Whitelist preconfirmation payloads gossiped from Go were being dropped by Rust with:
  invalid payload format: invalid RLP bytes for transactions: unexpected string.
  Root cause was format mismatch in tx-list RLP handling.

  ## Compatibility impact

  - Intentional breaking behavior for old Rust-emitted legacy tx-list payloads.
  - Wire format is now strictly Go-aligned.
