### PR TITLE
feat(taiko-client-rs): prevent preconfirmation reorgs of event-synced L2 history

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/lib.rs
+++ b/packages/taiko-client-rs/crates/driver/src/lib.rs
@@ -17,7 +17,7 @@ pub use config::DriverConfig;
 pub use driver::Driver;
 pub use error::DriverError;
 pub use production::PreconfPayload;
-pub use sync::{SyncPipeline, SyncStage, event::EventSyncer};
+pub use sync::{CanonicalTipState, SyncPipeline, SyncStage, event::EventSyncer};
 
 // Re-export signer from protocol crate for backward compatibility
 pub use protocol::signer;

--- a/packages/taiko-client-rs/crates/driver/src/metrics.rs
+++ b/packages/taiko-client-rs/crates/driver/src/metrics.rs
@@ -53,6 +53,9 @@ impl DriverMetrics {
     /// Gauge tracking the last canonical proposal id from L1 events.
     pub const EVENT_LAST_CANONICAL_PROPOSAL_ID: &'static str =
         "driver_event_last_canonical_proposal_id";
+    /// Gauge tracking the last canonical L2 block number produced from L1 events.
+    pub const EVENT_LAST_CANONICAL_BLOCK_NUMBER: &'static str =
+        "driver_event_last_canonical_block_number";
 
     // Preconf queue metrics
     /// Counter for preconfirmation enqueue timeouts.
@@ -67,6 +70,8 @@ impl DriverMetrics {
     /// Counter for preconfirmation responses dropped (channel closed).
     pub const PRECONF_RESPONSE_DROPPED_TOTAL: &'static str =
         "driver_preconf_response_dropped_total";
+    /// Counter for stale preconfirmation payloads dropped before processing.
+    pub const PRECONF_STALE_DROPPED_TOTAL: &'static str = "driver_preconf_stale_dropped_total";
 
     // Production path metrics
     /// Histogram for parent hash lookup duration.
@@ -170,6 +175,11 @@ impl DriverMetrics {
             Unit::Count,
             "Last canonical proposal id processed from L1 events"
         );
+        metrics::describe_gauge!(
+            Self::EVENT_LAST_CANONICAL_BLOCK_NUMBER,
+            Unit::Count,
+            "Last canonical L2 block number produced from L1 events"
+        );
 
         // Preconf queue metrics
         metrics::describe_counter!(
@@ -191,6 +201,11 @@ impl DriverMetrics {
             Self::PRECONF_RESPONSE_DROPPED_TOTAL,
             Unit::Count,
             "Preconfirmation responses dropped due to channel closure"
+        );
+        metrics::describe_counter!(
+            Self::PRECONF_STALE_DROPPED_TOTAL,
+            Unit::Count,
+            "Stale preconfirmation payloads dropped because canonical tip already passed the block"
         );
 
         // Production path metrics
@@ -223,11 +238,13 @@ impl DriverMetrics {
         metrics::counter!(Self::PRECONF_RESPONSE_TIMEOUTS_TOTAL).absolute(0);
         metrics::counter!(Self::PRECONF_ENQUEUE_FAILURES_TOTAL).absolute(0);
         metrics::counter!(Self::PRECONF_RESPONSE_DROPPED_TOTAL).absolute(0);
+        metrics::counter!(Self::PRECONF_STALE_DROPPED_TOTAL).absolute(0);
 
         // Reset production path counters
         metrics::counter!(Self::PRECONF_PARENT_HASH_LOOKUP_FAILURES_TOTAL).absolute(0);
 
         // Reset event syncer gauge
         metrics::gauge!(Self::EVENT_LAST_CANONICAL_PROPOSAL_ID).set(0.0);
+        metrics::gauge!(Self::EVENT_LAST_CANONICAL_BLOCK_NUMBER).set(0.0);
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/production/path.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/path.rs
@@ -8,7 +8,10 @@ use crate::{
     derivation::DerivationPipeline,
     error::DriverError,
     metrics::DriverMetrics,
-    sync::{AtomicCanonicalTip, CanonicalTipState, engine::PayloadApplier, error::SyncError},
+    sync::{
+        AtomicCanonicalTip, CanonicalTipState, engine::PayloadApplier, error::SyncError,
+        is_stale_preconf,
+    },
 };
 use alloy::{eips::BlockNumberOrTag, primitives::B256, providers::Provider};
 use async_trait::async_trait;
@@ -113,7 +116,7 @@ where
                         return Err(DriverError::PreconfIngressNotReady);
                     }
                     CanonicalTipState::Known(canonical_block_tip) => {
-                        if block_number <= canonical_block_tip {
+                        if is_stale_preconf(block_number, canonical_block_tip) {
                             counter!(DriverMetrics::PRECONF_STALE_DROPPED_TOTAL).increment(1);
                             counter!(DriverMetrics::PRECONF_STALE_DROPPED_PRODUCTION_TOTAL)
                                 .increment(1);

--- a/packages/taiko-client-rs/crates/driver/src/production/path.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/path.rs
@@ -77,11 +77,6 @@ impl<A> PreconfirmationPath<A>
 where
     A: PayloadApplier + BlockHashReader,
 {
-    /// Construct a preconfirmation path backed by the given payload applier.
-    pub fn new(applier: A) -> Self {
-        Self { applier, canonical_block_tip: None }
-    }
-
     /// Construct a preconfirmation path with a canonical block tip boundary.
     ///
     /// Blocks at or below this tip are considered event-synced canonical history and must never be
@@ -416,7 +411,8 @@ mod tests {
     fn preconfirmation_path_delegates_to_applier() {
         let parent_hash = B256::from([1u8; 32]);
         let applier = MockApplier::new(0, parent_hash);
-        let path = PreconfirmationPath::new(applier.clone());
+        let canonical_tip = Arc::new(AtomicU64::new(0));
+        let path = PreconfirmationPath::new_with_canonical_tip(applier.clone(), canonical_tip);
         let payload = Arc::new(PreconfPayload::new(sample_payload(1)));
 
         let rt = Runtime::new().unwrap();

--- a/packages/taiko-client-rs/crates/driver/src/production/path.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/path.rs
@@ -111,6 +111,8 @@ where
                     let canonical_block_tip = canonical_tip.load(Ordering::Relaxed);
                     if block_number <= canonical_block_tip {
                         counter!(DriverMetrics::PRECONF_STALE_DROPPED_TOTAL).increment(1);
+                        counter!(DriverMetrics::PRECONF_STALE_DROPPED_PRODUCTION_TOTAL)
+                            .increment(1);
                         warn!(
                             block_number,
                             canonical_block_tip,

--- a/packages/taiko-client-rs/crates/driver/src/sync/canonical_tip.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/canonical_tip.rs
@@ -86,9 +86,15 @@ impl AtomicCanonicalTip {
     }
 }
 
+/// Return true when a preconfirmation target block is stale against the canonical tip boundary.
+#[inline]
+pub(crate) fn is_stale_preconf(block_number: u64, canonical_block_tip: u64) -> bool {
+    block_number <= canonical_block_tip
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{AtomicCanonicalTip, CanonicalTipState};
+    use super::{AtomicCanonicalTip, CanonicalTipState, is_stale_preconf};
     use std::sync::atomic::Ordering;
 
     #[test]
@@ -110,5 +116,12 @@ mod tests {
 
         assert_eq!(previous, CanonicalTipState::Known(100));
         assert_eq!(state.load(Ordering::Relaxed), CanonicalTipState::Known(95));
+    }
+
+    #[test]
+    fn stale_preconf_comparison_matches_canonical_boundary() {
+        assert!(is_stale_preconf(10, 10));
+        assert!(is_stale_preconf(9, 10));
+        assert!(!is_stale_preconf(11, 10));
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/canonical_tip.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/canonical_tip.rs
@@ -1,0 +1,114 @@
+//! Canonical L2 tip state shared by event sync and preconfirmation flows.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Explicit canonical tip state produced by event sync.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CanonicalTipState {
+    /// Event sync has not established a canonical tip yet.
+    #[default]
+    Unknown,
+    /// Event sync has established a canonical tip at the given L2 block number.
+    Known(u64),
+}
+
+/// Atomic wrapper for canonical tip state.
+#[derive(Debug)]
+pub struct AtomicCanonicalTip(AtomicU64);
+
+impl Default for AtomicCanonicalTip {
+    fn default() -> Self {
+        Self::new(CanonicalTipState::Unknown)
+    }
+}
+
+impl AtomicCanonicalTip {
+    const UNKNOWN_SENTINEL: u64 = u64::MAX;
+
+    /// Construct a new atomic canonical tip with the provided initial state.
+    pub fn new(initial: CanonicalTipState) -> Self {
+        let raw = match initial {
+            CanonicalTipState::Unknown => Self::UNKNOWN_SENTINEL,
+            CanonicalTipState::Known(block_number) => {
+                assert!(
+                    block_number != Self::UNKNOWN_SENTINEL,
+                    "u64::MAX is reserved for CanonicalTipState::Unknown"
+                );
+                block_number
+            }
+        };
+        Self(AtomicU64::new(raw))
+    }
+
+    /// Load the canonical tip state using the given memory ordering.
+    pub fn load(&self, ordering: Ordering) -> CanonicalTipState {
+        let raw = self.0.load(ordering);
+        if raw == Self::UNKNOWN_SENTINEL {
+            CanonicalTipState::Unknown
+        } else {
+            CanonicalTipState::Known(raw)
+        }
+    }
+
+    /// Store the canonical tip state using the given memory ordering.
+    pub fn store(&self, state: CanonicalTipState, ordering: Ordering) {
+        let raw = match state {
+            CanonicalTipState::Unknown => Self::UNKNOWN_SENTINEL,
+            CanonicalTipState::Known(block_number) => {
+                assert!(
+                    block_number != Self::UNKNOWN_SENTINEL,
+                    "u64::MAX is reserved for CanonicalTipState::Unknown"
+                );
+                block_number
+            }
+        };
+        self.0.store(raw, ordering);
+    }
+
+    /// Swap the canonical tip state, returning the previous state.
+    pub fn swap(&self, state: CanonicalTipState, ordering: Ordering) -> CanonicalTipState {
+        let next_raw = match state {
+            CanonicalTipState::Unknown => Self::UNKNOWN_SENTINEL,
+            CanonicalTipState::Known(block_number) => {
+                assert!(
+                    block_number != Self::UNKNOWN_SENTINEL,
+                    "u64::MAX is reserved for CanonicalTipState::Unknown"
+                );
+                block_number
+            }
+        };
+        let previous_raw = self.0.swap(next_raw, ordering);
+        if previous_raw == Self::UNKNOWN_SENTINEL {
+            CanonicalTipState::Unknown
+        } else {
+            CanonicalTipState::Known(previous_raw)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AtomicCanonicalTip, CanonicalTipState};
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn canonical_tip_state_roundtrip_unknown() {
+        let state = AtomicCanonicalTip::new(CanonicalTipState::Unknown);
+        assert_eq!(state.load(Ordering::Relaxed), CanonicalTipState::Unknown);
+    }
+
+    #[test]
+    fn canonical_tip_state_roundtrip_known_zero() {
+        let state = AtomicCanonicalTip::new(CanonicalTipState::Known(0));
+        assert_eq!(state.load(Ordering::Relaxed), CanonicalTipState::Known(0));
+    }
+
+    #[test]
+    fn canonical_tip_state_tracks_decreasing_values() {
+        let state = AtomicCanonicalTip::new(CanonicalTipState::Known(100));
+        let previous = state.swap(CanonicalTipState::Known(95), Ordering::Relaxed);
+
+        assert_eq!(previous, CanonicalTipState::Known(100));
+        assert_eq!(state.load(Ordering::Relaxed), CanonicalTipState::Known(95));
+    }
+}

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -228,6 +228,7 @@ where
                 let canonical_block_tip = last_canonical_block_number.load(Ordering::Relaxed);
                 if block_number <= canonical_block_tip {
                     counter!(DriverMetrics::PRECONF_STALE_DROPPED_TOTAL).increment(1);
+                    counter!(DriverMetrics::PRECONF_STALE_DROPPED_INGRESS_TOTAL).increment(1);
                     warn!(
                         block_number,
                         canonical_block_tip,
@@ -490,6 +491,7 @@ where
         })?;
         if block_number <= canonical_block_tip {
             counter!(DriverMetrics::PRECONF_STALE_DROPPED_TOTAL).increment(1);
+            counter!(DriverMetrics::PRECONF_STALE_DROPPED_BEFORE_ENQUEUE_TOTAL).increment(1);
             warn!(
                 block_number,
                 canonical_block_tip, "dropping stale preconfirmation payload before enqueue"

--- a/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
@@ -19,6 +19,7 @@ pub mod engine;
 pub mod error;
 pub mod event;
 
+pub(crate) use canonical_tip::is_stale_preconf;
 pub use canonical_tip::{AtomicCanonicalTip, CanonicalTipState};
 pub use error::SyncError;
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
@@ -14,10 +14,12 @@ use crate::{
 };
 
 pub mod beacon;
+pub mod canonical_tip;
 pub mod engine;
 pub mod error;
 pub mod event;
 
+pub use canonical_tip::{AtomicCanonicalTip, CanonicalTipState};
 pub use error::SyncError;
 
 /// High level trait to represent a driver sync stage.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -75,7 +75,7 @@ pub trait PreconfirmationIngress: Send + Sync {
     /// Subscribe to canonical proposal id updates.
     fn subscribe_proposal_id(&self) -> tokio::sync::watch::Receiver<u64>;
 
-    /// Return the highest canonical L2 block produced from event sync.
+    /// Return the latest canonical L2 block produced from event sync.
     fn last_canonical_block_number(&self) -> u64;
 }
 
@@ -97,7 +97,7 @@ where
         self.subscribe_proposal_id()
     }
 
-    /// Return the highest canonical L2 block produced from event sync.
+    /// Return the latest canonical L2 block produced from event sync.
     fn last_canonical_block_number(&self) -> u64 {
         self.last_canonical_block_number()
     }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
@@ -32,7 +32,7 @@ pub trait DriverClient: Send + Sync {
     async fn submit_preconfirmation(&self, input: PreconfirmationInput) -> Result<()>;
     /// Await the driver event sync completion signal.
     async fn wait_event_sync(&self) -> Result<()>;
-    /// Return the latest event sync tip block number.
+    /// Return the latest event-synced canonical L2 block number.
     async fn event_sync_tip(&self) -> Result<U256>;
     /// Return the latest preconfirmation tip block number.
     async fn preconf_tip(&self) -> Result<U256>;

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/error.rs
@@ -63,6 +63,9 @@ pub enum DriverApiError {
     /// Latest block not found on the L2 provider.
     #[error("missing latest block")]
     MissingLatestBlock,
+    /// Event sync tip is unknown because canonical tip has not been established yet.
+    #[error("event sync tip is unknown")]
+    EventSyncTipUnknown,
     /// Missing transactions in the preconfirmation input.
     #[error("missing transactions for execution payload")]
     MissingTransactions,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rpc/server.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rpc/server.rs
@@ -213,11 +213,8 @@ async fn status_handler(State(state): State<RestWsState>) -> Response {
         Ok(status) => {
             let response = RestStatus {
                 lookahead: status.lookahead,
-                total_cached: status.total_cached.unwrap_or_default(),
-                highest_unsafe_l2_payload_block_id: status
-                    .highest_unsafe_l2_payload_block_id
-                    .or(status.highest_unsafe_block_number)
-                    .unwrap_or_default(),
+                total_cached: status.total_cached,
+                highest_unsafe_l2_payload_block_id: status.highest_unsafe_l2_payload_block_id,
                 end_of_sequencing_block_hash: status
                     .end_of_sequencing_block_hash
                     .unwrap_or_else(|| alloy_primitives::B256::ZERO.to_string()),
@@ -421,12 +418,12 @@ mod tests {
         async fn get_status(&self) -> Result<WhitelistStatus> {
             Ok(WhitelistStatus {
                 head_l1_origin_block_id: Some(42),
-                highest_unsafe_block_number: Some(100),
+                highest_unsafe_block_number: 100,
                 peer_id: "test-peer".to_string(),
                 sync_ready: true,
                 lookahead: None,
-                total_cached: Some(0),
-                highest_unsafe_l2_payload_block_id: Some(100),
+                total_cached: 0,
+                highest_unsafe_l2_payload_block_id: 100,
                 end_of_sequencing_block_hash: Some(B256::ZERO.to_string()),
             })
         }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rpc/types.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rpc/types.rs
@@ -156,7 +156,7 @@ pub struct WhitelistStatus {
     /// Head L1 origin block ID, if available.
     pub head_l1_origin_block_id: Option<u64>,
     /// Highest unsafe block number on L2.
-    pub highest_unsafe_block_number: Option<u64>,
+    pub highest_unsafe_block_number: u64,
     /// Local libp2p peer ID.
     pub peer_id: String,
     /// Whether event sync has established a head L1 origin.
@@ -165,11 +165,9 @@ pub struct WhitelistStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lookahead: Option<LookaheadStatus>,
     /// Total cached envelopes (best-effort).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_cached: Option<u64>,
+    pub total_cached: u64,
     /// Highest unsafe payload block ID tracked by this node.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub highest_unsafe_l2_payload_block_id: Option<u64>,
+    pub highest_unsafe_l2_payload_block_id: u64,
     /// End-of-sequencing block hash for current epoch.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_of_sequencing_block_hash: Option<String>,
@@ -207,12 +205,12 @@ mod tests {
     fn whitelist_status_camel_case() {
         let status = WhitelistStatus {
             head_l1_origin_block_id: Some(42),
-            highest_unsafe_block_number: Some(100),
+            highest_unsafe_block_number: 100,
             peer_id: "test-peer".to_string(),
             sync_ready: true,
             lookahead: None,
-            total_cached: Some(0),
-            highest_unsafe_l2_payload_block_id: Some(100),
+            total_cached: 0,
+            highest_unsafe_l2_payload_block_id: 100,
             end_of_sequencing_block_hash: Some(B256::ZERO.to_string()),
         };
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rpc_handler.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rpc_handler.rs
@@ -499,12 +499,12 @@ where
 
         Ok(WhitelistStatus {
             head_l1_origin_block_id,
-            highest_unsafe_block_number: Some(highest_unsafe),
+            highest_unsafe_block_number: highest_unsafe,
             peer_id: self.local_peer_id.clone(),
             sync_ready,
             lookahead: self.current_lookahead_status().await,
-            total_cached: Some(0),
-            highest_unsafe_l2_payload_block_id: Some(highest_unsafe),
+            total_cached: 0,
+            highest_unsafe_l2_payload_block_id: highest_unsafe,
             end_of_sequencing_block_hash,
         })
     }


### PR DESCRIPTION

  ## Summary
  - Track canonical L2 block tip in `EventSyncer` and expose it to preconfirmation ingress/clients.
  - Gate preconfirmation ingress until event scanner is live and event sync establishes the canonical boundary (with an empty-inbox fast path).
  - Drop stale preconfirmation payloads (`block_number <= canonical_tip`) before enqueue, inside ingress, and in production path.
  - Add/emit new metrics:
    - `driver_event_last_canonical_block_number`
    - `driver_preconf_stale_dropped_total`
  - Update preconfirmation-driver interfaces/channels so `event_sync_tip` reports event-synced canonical L2 block number (not provider safe tip).
  - Update tests and harness helpers to match behavior, including txlist encoding via `ZlibTxListCodec` and empty txlists for catch-up chains.

  ## Why
  Preconfirmations should not rewrite canonical history already derived from L1 events. This enforces that boundary while preserving reorg handling above the canonical tip and improves observability.
