### PR TITLE
feat(taiko-client-rs): add function to decode a single blob

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/shasta/blob_coder.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/blob_coder.rs
@@ -392,4 +392,15 @@ mod tests {
         individual_decoded.extend_from_slice(&blob2_decoded);
         assert_eq!(individual_decoded, payload);
     }
+
+    #[test]
+    fn decode_single_blob_convenience_method() {
+        let payload = vec![0xAB; 100];
+        let builder = SidecarBuilder::<BlobCoder>::from_slice(&payload);
+        let blobs = builder.take();
+
+        // Test the new convenience method
+        let decoded = BlobCoder::decode_blob(&blobs[0]).unwrap();
+        assert_eq!(decoded, payload);
+    }
 }

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/blob_coder.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/blob_coder.rs
@@ -142,6 +142,12 @@ impl BlobCoder {
     pub fn decode_blobs(blobs: &[Blob]) -> Option<Vec<Vec<u8>>> {
         Self.decode_all(blobs)
     }
+
+    /// Decode a single blob using the Kona-compatible scheme, returning the raw payload bytes
+    /// if the encoding is valid.
+    pub fn decode_blob(blob: &Blob) -> Option<Vec<u8>> {
+        decode_blob(blob)
+    }
 }
 
 impl SidecarCoder for BlobCoder {


### PR DESCRIPTION
This PR adds a new `decode_blob` function to `BlobCoder` to simplify decoding of a single blob.
Previously, decoding a single blob required calling decode_blobs and manually extracting the first element:
```Rust
let payloads = BlobCoder::decode_blobs(&[blob])?;
let payload = payloads.into_iter().next()?;
```
This approach works but is unnecessarily verbose and requires additional handling to extract the result.
The new decode_blob function provides a clearer and more ergonomic API for single-blob decoding:
```Rust
let payload = BlobCoder::decode_blob(&blob)?;
```