### PR TITLE
fix(taiko-client-rs): improve l1 origin bootstrap

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -75,10 +75,8 @@ where
             return Ok(None);
         };
 
-        let response: Option<L1Origin> = match provider
-            .raw_request(Cow::Borrowed("taiko_headL1Origin"), ())
-            .await
-        {
+        let response: Option<L1Origin> =
+            match provider.raw_request(Cow::Borrowed("taiko_headL1Origin"), ()).await {
             Ok(response) => response,
             Err(err) => {
                 let error = RpcClientError::from(err);
@@ -170,10 +168,8 @@ where
             return Ok(());
         }
 
-        let Some(mut checkpoint_head) = self
-            .checkpoint_head()
-            .await
-            .map_err(SyncError::CheckpointQuery)?
+        let Some(mut checkpoint_head) =
+            self.checkpoint_head().await.map_err(SyncError::CheckpointQuery)?
         else {
             error!("checkpoint node reports no head origin; cannot run beacon sync in checkpoint mode");
             return Err(SyncError::CheckpointNoOrigin);
@@ -208,10 +204,8 @@ where
                     }
                 };
 
-            let Some(next_checkpoint_head) = self
-                .checkpoint_head()
-                .await
-                .map_err(SyncError::CheckpointQuery)?
+            let Some(next_checkpoint_head) =
+                self.checkpoint_head().await.map_err(SyncError::CheckpointQuery)?
             else {
                 error!(
                     "checkpoint node stopped returning head origin; stopping beacon sync to avoid unsafe resume"

--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -75,14 +75,10 @@ where
             return Ok(None);
         };
 
-        let response: Option<L1Origin> =
-            match provider.raw_request(Cow::Borrowed("taiko_headL1Origin"), ()).await {
-            Ok(response) => response,
-            Err(err) => {
-                let error = RpcClientError::from(err);
-                return Err(error);
-            }
-        };
+        let response: Option<L1Origin> = provider
+            .raw_request(Cow::Borrowed("taiko_headL1Origin"), ())
+            .await
+            .map_err(RpcClientError::from)?;
 
         let head = response.map(|origin| origin.block_id.to::<u64>());
         debug!(?head, "queried checkpoint head");

--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -19,7 +19,7 @@ use rpc::{
     l1_origin::L1Origin,
 };
 use tokio::time::{MissedTickBehavior, interval};
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 use super::{SyncError, SyncStage, checkpoint_resume_head::CheckpointResumeHead};
 use crate::{config::DriverConfig, error::DriverError, metrics::DriverMetrics};
@@ -75,10 +75,16 @@ where
             return Ok(None);
         };
 
-        let response: Option<L1Origin> = provider
+        let response: Option<L1Origin> = match provider
             .raw_request(Cow::Borrowed("taiko_headL1Origin"), ())
             .await
-            .map_err(RpcClientError::from)?;
+        {
+            Ok(response) => response,
+            Err(err) => {
+                let error = RpcClientError::from(err);
+                return Err(error);
+            }
+        };
 
         let head = response.map(|origin| origin.block_id.to::<u64>());
         debug!(?head, "queried checkpoint head");
@@ -164,9 +170,12 @@ where
             return Ok(());
         }
 
-        let Some(mut checkpoint_head) =
-            self.checkpoint_head().await.map_err(SyncError::CheckpointQuery)?
+        let Some(mut checkpoint_head) = self
+            .checkpoint_head()
+            .await
+            .map_err(SyncError::CheckpointQuery)?
         else {
+            error!("checkpoint node reports no head origin; cannot run beacon sync in checkpoint mode");
             return Err(SyncError::CheckpointNoOrigin);
         };
 
@@ -199,11 +208,17 @@ where
                     }
                 };
 
-            checkpoint_head = self
+            let Some(next_checkpoint_head) = self
                 .checkpoint_head()
                 .await
                 .map_err(SyncError::CheckpointQuery)?
-                .ok_or(SyncError::CheckpointNoOrigin)?;
+            else {
+                error!(
+                    "checkpoint node stopped returning head origin; stopping beacon sync to avoid unsafe resume"
+                );
+                return Err(SyncError::CheckpointNoOrigin);
+            };
+            checkpoint_head = next_checkpoint_head;
             gauge!(DriverMetrics::BEACON_SYNC_CHECKPOINT_HEAD_BLOCK).set(checkpoint_head as f64);
             gauge!(DriverMetrics::BEACON_SYNC_HEAD_LAG_BLOCKS)
                 .set(checkpoint_head.saturating_sub(local_head) as f64);

--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -167,7 +167,9 @@ where
         let Some(mut checkpoint_head) =
             self.checkpoint_head().await.map_err(SyncError::CheckpointQuery)?
         else {
-            error!("checkpoint node reports no head origin; cannot run beacon sync in checkpoint mode");
+            error!(
+                "checkpoint node reports no head origin; cannot run beacon sync in checkpoint mode"
+            );
             return Err(SyncError::CheckpointNoOrigin);
         };
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -1,5 +1,6 @@
 //! Event sync logic.
 
+use alethia_reth_primitives::payload::attributes::RpcL1Origin;
 use std::{
     sync::{
         Arc,
@@ -117,6 +118,9 @@ fn resolve_resume_head_block_number(
     if checkpoint_configured {
         checkpoint_synced_head.ok_or(SyncError::MissingCheckpointResumeHead)
     } else {
+        // In production this function is called only after
+        // `ensure_head_l1_origin()` in non-checkpoint mode, so this fallback should
+        // only be used by explicit callers/tests that bypass that path.
         head_l1_origin_block_id.ok_or(SyncError::MissingHeadL1OriginResume)
     }
 }
@@ -600,12 +604,11 @@ where
 
     /// Resolve the L2 execution block used as event-sync resume source.
     ///
-    /// Important safety behavior:
-    /// - If checkpoint mode is enabled, we require the exact checkpoint head that beacon sync
-    ///   finished at. This avoids trusting stale local origin pointers.
-    /// - Without checkpoint mode, we require local `head_l1_origin` and fail fast when missing.
-    ///   This avoids deriving proposal IDs from `Latest`, which may include local preconf-only
-    ///   blocks that were never event-confirmed.
+    /// - Checkpoint mode: use the checkpoint-synced resume head only.
+    /// - Non-checkpoint mode: ensure local `head_l1_origin` exists and use it.
+    ///
+    /// Fail-closed behavior intentionally remains strict in checkpoint mode; local state is never
+    /// used when a checkpoint sync head was not produced.
     #[instrument(skip(self), level = "debug")]
     async fn resume_head_block_number(&self) -> Result<u64, SyncError> {
         let checkpoint_configured = self.cfg.l2_checkpoint_url.is_some();
@@ -613,7 +616,7 @@ where
         let head_l1_origin_block_id = if checkpoint_configured {
             None
         } else {
-            self.rpc.head_l1_origin().await?.map(|origin| origin.block_id.to::<u64>())
+            Some(self.ensure_head_l1_origin().await?)
         };
 
         let resume_head_block_number = resolve_resume_head_block_number(
@@ -629,6 +632,95 @@ where
         }
 
         Ok(resume_head_block_number)
+    }
+
+    /// Recovery scan stride in blocks when searching existing `l1_origin` rows on startup.
+    /// This keeps startup bounded per chunk, though rows are still discovered with
+    /// per-block RPC lookups in the worst case.
+    const HEAD_L1_ORIGIN_SCAN_STEP: u64 = 1024;
+
+    /// Ensure `head_l1_origin` is available before event sync starts and return the resolved block id.
+    ///
+    /// On fresh local chains where auth tables are uninitialized, this:
+    /// - Reuses the latest known L1 origin row if present.
+    /// - Otherwise seeds genesis origin metadata and points head_l1_origin to block 0.
+    #[instrument(skip(self), level = "debug")]
+    async fn ensure_head_l1_origin(&self) -> Result<u64, SyncError> {
+        if let Some(origin) = self.rpc.head_l1_origin().await? {
+            return Ok(origin.block_id.to::<u64>());
+        }
+
+        warn!("head_l1_origin is missing; attempting to recover from persisted origin rows");
+
+        let latest = self
+            .rpc
+            .l2_provider
+            .get_block_number()
+            .await
+            .map_err(RpcClientError::from)?;
+
+        let mut scan_end = latest;
+        loop {
+            let scan_start = scan_end.saturating_sub(Self::HEAD_L1_ORIGIN_SCAN_STEP - 1);
+            if let Some(block_id) = self.scan_head_l1_origin_in_range(scan_end, scan_start).await? {
+                return Ok(block_id);
+            }
+
+            if scan_start == 0 {
+                break;
+            }
+
+            scan_end = scan_start.saturating_sub(1);
+        }
+
+        warn!(latest, "no persisted L1 origin rows found; seeding genesis origin");
+        let genesis = self
+            .rpc
+            .l2_provider
+            .get_block_by_number(BlockNumberOrTag::Number(0))
+            .full()
+            .await
+            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
+            .ok_or(SyncError::MissingExecutionBlock { number: 0 })?;
+
+        let genesis_origin = RpcL1Origin {
+            block_id: U256::ZERO,
+            l2_block_hash: genesis.hash(),
+            l1_block_height: Some(U256::ZERO),
+            l1_block_hash: None,
+            build_payload_args_id: [0u8; 8],
+            is_forced_inclusion: false,
+            signature: [0u8; 65],
+        };
+        self.rpc.update_l1_origin(&genesis_origin).await?;
+        self.rpc.set_head_l1_origin(U256::ZERO).await?;
+
+        info!("seeded head_l1_origin at block 0");
+        Ok(0)
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn scan_head_l1_origin_in_range(
+        &self,
+        start_block_id: u64,
+        end_block_id: u64,
+    ) -> Result<Option<u64>, SyncError> {
+        if end_block_id > start_block_id {
+            return Ok(None);
+        }
+
+        for block_id in (end_block_id..=start_block_id).rev() {
+            if let Some(origin) = self.rpc.l1_origin_by_id(U256::from(block_id)).await? {
+                self.rpc.set_head_l1_origin(origin.block_id).await?;
+                info!(
+                    block_id = origin.block_id.to::<u64>(),
+                    "recovered head_l1_origin from existing origin row"
+                );
+                return Ok(Some(origin.block_id.to::<u64>()));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Resolve finalized L1 block metadata and finalized-safe proposal ID.

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -613,11 +613,8 @@ where
     async fn resume_head_block_number(&self) -> Result<u64, SyncError> {
         let checkpoint_configured = self.cfg.l2_checkpoint_url.is_some();
 
-        let head_l1_origin_block_id = if checkpoint_configured {
-            None
-        } else {
-            Some(self.ensure_head_l1_origin().await?)
-        };
+        let head_l1_origin_block_id =
+            if checkpoint_configured { None } else { Some(self.ensure_head_l1_origin().await?) };
 
         let resume_head_block_number = resolve_resume_head_block_number(
             checkpoint_configured,
@@ -639,7 +636,8 @@ where
     /// per-block RPC lookups in the worst case.
     const HEAD_L1_ORIGIN_SCAN_STEP: u64 = 1024;
 
-    /// Ensure `head_l1_origin` is available before event sync starts and return the resolved block id.
+    /// Ensure `head_l1_origin` is available before event sync starts and return the resolved block
+    /// id.
     ///
     /// On fresh local chains where auth tables are uninitialized, this:
     /// - Reuses the latest known L1 origin row if present.
@@ -652,12 +650,7 @@ where
 
         warn!("head_l1_origin is missing; attempting to recover from persisted origin rows");
 
-        let latest = self
-            .rpc
-            .l2_provider
-            .get_block_number()
-            .await
-            .map_err(RpcClientError::from)?;
+        let latest = self.rpc.l2_provider.get_block_number().await.map_err(RpcClientError::from)?;
 
         let mut scan_end = latest;
         loop {

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -635,6 +635,9 @@ where
     /// This keeps startup bounded per chunk, though rows are still discovered with
     /// per-block RPC lookups in the worst case.
     const HEAD_L1_ORIGIN_SCAN_STEP: u64 = 1024;
+    /// Maximum number of blocks scanned during `head_l1_origin` recovery before seeding
+    /// genesis to keep startup bounded on fresh chains or corrupted local tables.
+    const HEAD_L1_ORIGIN_SCAN_WINDOW_BLOCKS: u64 = Self::HEAD_L1_ORIGIN_SCAN_STEP * 16;
 
     /// Ensure `head_l1_origin` is available before event sync starts and return the resolved block
     /// id.
@@ -651,22 +654,34 @@ where
         warn!("head_l1_origin is missing; attempting to recover from persisted origin rows");
 
         let latest = self.rpc.l2_provider.get_block_number().await.map_err(RpcClientError::from)?;
+        let mut scan_budget_blocks = Self::HEAD_L1_ORIGIN_SCAN_WINDOW_BLOCKS;
 
         let mut scan_end = latest;
         loop {
-            let scan_start = scan_end.saturating_sub(Self::HEAD_L1_ORIGIN_SCAN_STEP - 1);
+            let scan_width =
+                Self::HEAD_L1_ORIGIN_SCAN_STEP.min(scan_budget_blocks);
+            let scan_start = scan_end.saturating_sub(scan_width - 1);
             if let Some(block_id) = self.scan_head_l1_origin_in_range(scan_end, scan_start).await? {
                 return Ok(block_id);
             }
 
+            scan_budget_blocks = scan_budget_blocks.saturating_sub(scan_width);
+
             if scan_start == 0 {
+                break;
+            }
+            if scan_budget_blocks == 0 {
                 break;
             }
 
             scan_end = scan_start.saturating_sub(1);
         }
 
-        warn!(latest, "no persisted L1 origin rows found; seeding genesis origin");
+        warn!(
+            latest,
+            scan_window = Self::HEAD_L1_ORIGIN_SCAN_WINDOW_BLOCKS,
+            "no persisted confirmed L1 origin rows found within the recovery window; seeding genesis origin"
+        );
         let genesis = self
             .rpc
             .l2_provider

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -694,10 +694,10 @@ where
         Ok(0)
     }
 
-    /// Scan `l1_origin_by_id` for the latest known row in an inclusive block range.
+    /// Scan `l1_origin_by_id` for the latest candidate row in an inclusive block range.
     ///
-    /// The range is processed from high to low block id and returns the first matching
-    /// `block_id` if any row is found.
+    /// The range is processed from high to low block id and returns the first confirmed
+    /// candidate block id, prioritising the latest possible recovery point.
     #[instrument(skip(self), level = "debug")]
     async fn scan_head_l1_origin_in_range(
         &self,
@@ -709,17 +709,59 @@ where
         }
 
         for block_id in (scan_low_block_id..=scan_high_block_id).rev() {
-            if let Some(origin) = self.rpc.l1_origin_by_id(U256::from(block_id)).await? {
-                self.rpc.set_head_l1_origin(origin.block_id).await?;
+            if self.rpc.l1_origin_by_id(U256::from(block_id)).await?.is_none() {
+                continue;
+            }
+
+            if self.is_confirmed_origin_block(block_id).await? {
+                self.rpc.set_head_l1_origin(U256::from(block_id)).await?;
                 info!(
-                    block_id = origin.block_id.to::<u64>(),
-                    "recovered head_l1_origin from existing origin row"
+                    block_id,
+                    "recovered head_l1_origin from confirmed origin row"
                 );
-                return Ok(Some(origin.block_id.to::<u64>()));
+                return Ok(Some(block_id));
             }
         }
 
         Ok(None)
+    }
+
+    /// Return whether a candidate `l1_origin` row belongs to a confirmed proposal tail block.
+    #[instrument(skip(self), level = "debug")]
+    async fn is_confirmed_origin_block(&self, block_id: u64) -> Result<bool, SyncError> {
+        if block_id == 0 {
+            return Ok(true);
+        }
+
+        let Some(block) = self
+            .rpc
+            .l2_provider
+            .get_block_by_number(BlockNumberOrTag::Number(block_id))
+            .full()
+            .await
+            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
+        else {
+            return Ok(false);
+        };
+        let block = block.map_transactions(|tx: RpcTransaction| tx.into());
+
+        let proposal_id = match decode_anchor_proposal_id(&block) {
+            Ok(proposal_id) => proposal_id,
+            Err(err) => {
+                warn!(block_id, ?err, "unable to parse proposal id for origin recovery candidate");
+                return Ok(false);
+            }
+        };
+
+        let Some(last_block_id) = self
+            .rpc
+            .last_block_id_by_batch_id(U256::from(proposal_id))
+            .await?
+        else {
+            return Ok(false);
+        };
+
+        Ok(last_block_id.to::<u64>() == block_id)
     }
 
     /// Resolve finalized L1 block metadata and finalized-safe proposal ID.

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -655,9 +655,7 @@ where
         let mut scan_end = latest;
         loop {
             let scan_start = scan_end.saturating_sub(Self::HEAD_L1_ORIGIN_SCAN_STEP - 1);
-            if let Some(block_id) =
-                self.scan_head_l1_origin_in_range(scan_end, scan_start).await?
-            {
+            if let Some(block_id) = self.scan_head_l1_origin_in_range(scan_end, scan_start).await? {
                 return Ok(block_id);
             }
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -804,7 +804,21 @@ where
     #[instrument(skip(self), level = "debug")]
     async fn event_stream_start_block(&self) -> Result<EventStreamStartPoint, SyncError> {
         let resume_head_block_number = self.resume_head_block_number().await?;
-        let finalized_snapshot = self.finalized_l1_snapshot().await?;
+        let finalized_snapshot = match self.finalized_l1_snapshot().await {
+            Ok(snapshot) => snapshot,
+            Err(SyncError::MissingFinalizedL1Block) => {
+                warn!(
+                    resume_head_block_number,
+                    "missing L1 finalized block; using synthetic finalized snapshot for startup"
+                );
+                FinalizedL1Snapshot {
+                    block_number: 0,
+                    block_hash: B256::ZERO,
+                    finalized_safe_proposal_id: 0,
+                }
+            }
+            Err(err) => return Err(err),
+        };
         let resume_head_block = self
             .rpc
             .l2_provider

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -655,7 +655,9 @@ where
         let mut scan_end = latest;
         loop {
             let scan_start = scan_end.saturating_sub(Self::HEAD_L1_ORIGIN_SCAN_STEP - 1);
-            if let Some(block_id) = self.scan_head_l1_origin_in_range(scan_end, scan_start).await? {
+            if let Some(block_id) =
+                self.scan_head_l1_origin_in_range(scan_end, scan_start).await?
+            {
                 return Ok(block_id);
             }
 
@@ -676,6 +678,8 @@ where
             .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
             .ok_or(SyncError::MissingExecutionBlock { number: 0 })?;
 
+        // Genesis L1 origin uses sentinel zero values. This row is synthetic and only used to
+        // bootstrap local event sync when no persisted origin rows are available.
         let genesis_origin = RpcL1Origin {
             block_id: U256::ZERO,
             l2_block_hash: genesis.hash(),
@@ -699,14 +703,14 @@ where
     #[instrument(skip(self), level = "debug")]
     async fn scan_head_l1_origin_in_range(
         &self,
-        start_block_id: u64,
-        end_block_id: u64,
+        scan_high_block_id: u64,
+        scan_low_block_id: u64,
     ) -> Result<Option<u64>, SyncError> {
-        if end_block_id > start_block_id {
+        if scan_low_block_id > scan_high_block_id {
             return Ok(None);
         }
 
-        for block_id in (end_block_id..=start_block_id).rev() {
+        for block_id in (scan_low_block_id..=scan_high_block_id).rev() {
             if let Some(origin) = self.rpc.l1_origin_by_id(U256::from(block_id)).await? {
                 self.rpc.set_head_l1_origin(origin.block_id).await?;
                 info!(

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -658,8 +658,7 @@ where
 
         let mut scan_end = latest;
         loop {
-            let scan_width =
-                Self::HEAD_L1_ORIGIN_SCAN_STEP.min(scan_budget_blocks);
+            let scan_width = Self::HEAD_L1_ORIGIN_SCAN_STEP.min(scan_budget_blocks);
             let scan_start = scan_end.saturating_sub(scan_width - 1);
             if let Some(block_id) = self.scan_head_l1_origin_in_range(scan_end, scan_start).await? {
                 return Ok(block_id);
@@ -730,10 +729,7 @@ where
 
             if self.is_confirmed_origin_block(block_id).await? {
                 self.rpc.set_head_l1_origin(U256::from(block_id)).await?;
-                info!(
-                    block_id,
-                    "recovered head_l1_origin from confirmed origin row"
-                );
+                info!(block_id, "recovered head_l1_origin from confirmed origin row");
                 return Ok(Some(block_id));
             }
         }
@@ -768,10 +764,8 @@ where
             }
         };
 
-        let Some(last_block_id) = self
-            .rpc
-            .last_block_id_by_batch_id(U256::from(proposal_id))
-            .await?
+        let Some(last_block_id) =
+            self.rpc.last_block_id_by_batch_id(U256::from(proposal_id)).await?
         else {
             return Ok(false);
         };

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -699,6 +699,10 @@ where
         Ok(0)
     }
 
+    /// Scan `l1_origin_by_id` for the latest known row in an inclusive block range.
+    ///
+    /// The range is processed from high to low block id and returns the first matching
+    /// `block_id` if any row is found.
     #[instrument(skip(self), level = "debug")]
     async fn scan_head_l1_origin_in_range(
         &self,

--- a/packages/taiko-client-rs/crates/protocol/src/codec.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/codec.rs
@@ -169,7 +169,8 @@ mod tests {
             0x80, 0x80,
         ];
         let mut rlp_encoded = Vec::new();
-        alloy_rlp::encode_list::<_, RlpBytes>(&[RlpBytes::from(tx.clone())], &mut rlp_encoded);
+        let tx_ref = RlpBytes::copy_from_slice(&tx);
+        alloy_rlp::encode_list::<_, RlpBytes>(std::slice::from_ref(&tx_ref), &mut rlp_encoded);
         let compressed = compress_payload(&rlp_encoded);
 
         let codec = ZlibTxListCodec::new(1024);
@@ -187,7 +188,7 @@ mod tests {
             0x80, 0x80,
         ];
         let mut rlp_encoded = Vec::new();
-        alloy_rlp::encode_list::<_, Vec<u8>>(&[tx.clone()], &mut rlp_encoded);
+        alloy_rlp::encode_list::<_, Vec<u8>>(std::slice::from_ref(&tx), &mut rlp_encoded);
         let compressed = compress_payload(&rlp_encoded);
 
         let codec = ZlibTxListCodec::new(1024);
@@ -206,7 +207,7 @@ mod tests {
         ];
         let codec = ZlibTxListCodec::new(1024);
 
-        let compressed = codec.encode(&[tx.clone()]).expect("encode tx-list");
+        let compressed = codec.encode(std::slice::from_ref(&tx)).expect("encode tx-list");
         let decoded = decompress_payload(&compressed);
 
         let mut expected_rlp = Vec::new();

--- a/packages/taiko-client-rs/crates/protocol/src/preconfirmation/lookahead/resolver/types.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/preconfirmation/lookahead/resolver/types.rs
@@ -129,14 +129,15 @@ mod tests {
             validatorLeafIndex: U256::ZERO,
         };
 
-        let picked = pick_slot_origin(210, &current, Some(&[next_first.clone()])).expect("slot");
+        let picked =
+            pick_slot_origin(210, &current, Some(std::slice::from_ref(&next_first))).expect("slot");
         assert_eq!(picked, SlotOrigin::Current(1));
 
-        let picked_next =
-            pick_slot_origin(300, &current, Some(&[next_first.clone()])).expect("next slot");
+        let picked_next = pick_slot_origin(300, &current, Some(std::slice::from_ref(&next_first)))
+            .expect("next slot");
         assert_eq!(picked_next, SlotOrigin::Next(0));
 
-        let none = pick_slot_origin(500, &current, Some(&[next_first.clone()]));
+        let none = pick_slot_origin(500, &current, Some(std::slice::from_ref(&next_first)));
         assert!(none.is_none());
     }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest/types.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest/types.rs
@@ -160,6 +160,7 @@ pub struct WhitelistStatus {
     /// Local libp2p peer ID.
     pub peer_id: String,
     /// Whether event sync has established a head L1 origin.
+    /// head L1 origin is available and engine is not syncing.
     pub sync_ready: bool,
     /// Sequencing lookahead information.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
@@ -516,6 +516,7 @@ where
             SyncStatus::Info(_)
         );
         let highest_unsafe = *self.highest_unsafe_l2_payload_block_id.lock().await;
+        let sync_ready = head_l1_origin_block_id.is_some() && !is_syncing;
         let current_epoch = self.beacon_client.current_epoch();
         let end_of_sequencing_block_hash = self
             .end_of_sequencing_by_epoch
@@ -524,7 +525,6 @@ where
             .get(&current_epoch)
             .copied()
             .map(|hash| hash.to_string());
-        let sync_ready = head_l1_origin_block_id.is_some() && !is_syncing;
 
         Ok(WhitelistStatus {
             head_l1_origin_block_id,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
@@ -511,6 +511,10 @@ where
     async fn get_status(&self) -> Result<WhitelistStatus> {
         let head_l1_origin_block_id =
             self.rpc.head_l1_origin().await?.map(|h| h.block_id.to::<u64>());
+        let is_syncing = matches!(
+            self.rpc.l2_provider.syncing().await.map_err(provider_err)?,
+            SyncStatus::Info(_)
+        );
         let highest_unsafe = *self.highest_unsafe_l2_payload_block_id.lock().await;
         let current_epoch = self.beacon_client.current_epoch();
         let end_of_sequencing_block_hash = self
@@ -520,7 +524,7 @@ where
             .get(&current_epoch)
             .copied()
             .map(|hash| hash.to_string());
-        let sync_ready = head_l1_origin_block_id.is_some();
+        let sync_ready = head_l1_origin_block_id.is_some() && !is_syncing;
 
         Ok(WhitelistStatus {
             head_l1_origin_block_id,


### PR DESCRIPTION
This PR fixes checkpoint-mode safety regressions and improves event-sync startup recovery when head_l1_origin is missing on taiko-client-rs.