### PR TITLE
chore(balance-monitor): close eth clients on monitor shutdown

### DIFF
--- a/packages/balance-monitor/balance-monitor/balance_monitor.go
+++ b/packages/balance-monitor/balance-monitor/balance_monitor.go
@@ -64,6 +64,12 @@ func (b *BalanceMonitor) Name() string {
 }
 
 func (b *BalanceMonitor) Close(ctx context.Context) {
+	if b.l1EthClient != nil {
+		b.l1EthClient.Close()
+	}
+	if b.l2EthClient != nil {
+		b.l2EthClient.Close()
+	}
 }
 
 func (b *BalanceMonitor) Start() error {


### PR DESCRIPTION
Close L1 and L2 eth clients on shutdown to avoid leaking RPC connections and goroutines.
