### PR TITLE
fix(protocol): add nonReentrant guard to Inbox.prove()

### DIFF
--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -263,7 +263,7 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, IBondManager, Essential
     ///
     /// @param _data Encoded ProveInput struct
     /// @param _proof Validity proof for the batch of proposals
-    function prove(bytes calldata _data, bytes calldata _proof) external {
+    function prove(bytes calldata _data, bytes calldata _proof) external nonReentrant {
         unchecked {
 
             CoreState memory state = _coreState;


### PR DESCRIPTION
## Summary
Adds a `nonReentrant` guard to `Inbox.prove()` as a defense-in-depth measure.

## Issue
`Inbox.prove()` performs external calls to:
- `_signalService.saveCheckpoint()`
- `_proofVerifier.verifyProof()`

without reentrancy protection.

## Risk
`_proofVerifier.verifyProof()` may call into third-party ZK proof verification contracts (e.g., RISC Zero risc0, Succinct SP1 verifiers). These contracts are external / untrusted from the protocol’s perspective. If compromised or implemented with callbacks, they could reenter `Inbox` during `prove()` and potentially cause state corruption.

## Fix
Apply the existing `nonReentrant` modifier (from `EssentialContract`) to `prove()` to prevent reentrant execution across the external calls.

---

> **Discovery:** This issue was identified during an [EVMBench](https://github.com/paradigmxyz/evmbench)-assisted security review of the Shasta 3.0.0 contracts (`taiko-alethia-protocol-v3.0.0` branch).