### PR TITLE
fix(taiko-client-rs): make Shasta event sync resilient on genesis and pre-finality startup

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
@@ -275,7 +275,12 @@ fn envelope_into_submission(
 ) -> (ExecutionPayloadInputV2, B256, u64) {
     match envelope.execution_payload {
         ExecutionPayloadFieldV2::V1(payload) => (
-            ExecutionPayloadInputV2 { execution_payload: payload.clone(), withdrawals: None },
+            // Taiko chains are always post-Shanghai so withdrawals must be non-nil even
+            // when the engine returns a V1 envelope (which omits the withdrawals field).
+            ExecutionPayloadInputV2 {
+                execution_payload: payload.clone(),
+                withdrawals: Some(Vec::new()),
+            },
             payload.block_hash,
             payload.block_number,
         ),

--- a/packages/taiko-client-rs/crates/driver/src/sync/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/error.rs
@@ -56,9 +56,14 @@ pub enum SyncError {
         number: u64,
     },
 
-    /// Event sync: finalized L1 block is unavailable; resume must fail closed.
-    #[error("finalized l1 block is unavailable")]
-    MissingFinalizedL1Block,
+    /// Event sync: finalized L1 block is unavailable on a mature chain; resume must fail closed.
+    #[error("finalized l1 block is unavailable (l1_head={l1_head_block_number}, resume_proposal_id={resume_proposal_id})")]
+    MissingFinalizedL1Block {
+        /// Current L1 head block number.
+        l1_head_block_number: u64,
+        /// Resume proposal id that triggered the check.
+        resume_proposal_id: u64,
+    },
 
     /// Event sync: execution engine missing batch-to-block mapping.
     #[error("no execution block found for batch {proposal_id}")]

--- a/packages/taiko-client-rs/crates/driver/src/sync/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/error.rs
@@ -56,15 +56,6 @@ pub enum SyncError {
         number: u64,
     },
 
-    /// Event sync: finalized L1 block is unavailable on a mature chain; resume must fail closed.
-    #[error("finalized l1 block is unavailable (l1_head={l1_head_block_number}, resume_proposal_id={resume_proposal_id})")]
-    MissingFinalizedL1Block {
-        /// Current L1 head block number.
-        l1_head_block_number: u64,
-        /// Resume proposal id that triggered the check.
-        resume_proposal_id: u64,
-    },
-
     /// Event sync: execution engine missing batch-to-block mapping.
     #[error("no execution block found for batch {proposal_id}")]
     MissingExecutionBlockForBatch {

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -145,8 +145,8 @@ fn resolve_zero_target_start_block(
 ///
 /// - When finalization is available, target is bounded by `min(resume, finalized_safe)`.
 /// - When finalization is unavailable and `resume_proposal_id == 0` (genesis), target is 0.
-/// - When finalization is unavailable and `resume_proposal_id > 0`, finalization is required
-///   and a `MissingFinalizedL1Block` error is returned.
+/// - When finalization is unavailable and `resume_proposal_id > 0`, finalization is required and a
+///   `MissingFinalizedL1Block` error is returned.
 fn resolve_target_with_optional_finalization(
     resume_proposal_id: u64,
     finalized_safe_proposal_id: Option<u64>,
@@ -666,9 +666,7 @@ where
     ///
     /// Returns `None` when the L1 chain has not yet finalized (e.g. fresh devnets).
     #[instrument(skip(self), level = "debug")]
-    async fn try_finalized_l1_snapshot(
-        &self,
-    ) -> Result<Option<FinalizedL1Snapshot>, SyncError> {
+    async fn try_finalized_l1_snapshot(&self) -> Result<Option<FinalizedL1Snapshot>, SyncError> {
         let finalized_block = self
             .rpc
             .l1_provider
@@ -723,22 +721,21 @@ where
                 finalized_snapshot.as_ref().map(|s| s.finalized_safe_proposal_id),
             )?;
         let start_block = if target_proposal_id == 0 {
-            finalized_snapshot
-                .as_ref()
-                .map_or(0, |snapshot| {
-                    resolve_zero_target_start_block(
-                        snapshot.finalized_safe_proposal_id,
-                        snapshot.block_number,
-                    )
-                })
+            finalized_snapshot.as_ref().map_or(0, |snapshot| {
+                resolve_zero_target_start_block(
+                    snapshot.finalized_safe_proposal_id,
+                    snapshot.block_number,
+                )
+            })
         } else {
             0
         };
-        let (finalized_block_number, finalized_block_hash) = if let Some(snapshot) = finalized_snapshot {
-            (Some(snapshot.block_number), Some(snapshot.block_hash))
-        } else {
-            (None, None)
-        };
+        let (finalized_block_number, finalized_block_hash) =
+            if let Some(snapshot) = finalized_snapshot {
+                (Some(snapshot.block_number), Some(snapshot.block_hash))
+            } else {
+                (None, None)
+            };
 
         info!(
             resume_proposal_id,
@@ -1258,5 +1255,4 @@ mod tests {
         assert_eq!(target, 50);
         assert_eq!(safe, 120);
     }
-
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -715,16 +715,6 @@ where
                 resume_proposal_id,
                 finalized_snapshot.as_ref().map(|s| s.finalized_safe_proposal_id),
             );
-        let start_block = if target_proposal_id == 0 {
-            finalized_snapshot.as_ref().map_or(0, |snapshot| {
-                resolve_zero_target_start_block(
-                    snapshot.finalized_safe_proposal_id,
-                    snapshot.block_number,
-                )
-            })
-        } else {
-            0
-        };
         let (finalized_block_number, finalized_block_hash) =
             if let Some(snapshot) = finalized_snapshot {
                 (Some(snapshot.block_number), Some(snapshot.block_hash))
@@ -743,9 +733,14 @@ where
             "selected finalized-bounded proposal id from resume-source anchor metadata",
         );
         if target_proposal_id == 0 {
+            let start_block = finalized_snapshot.as_ref().map_or(0, |snapshot| {
+                resolve_zero_target_start_block(
+                    snapshot.finalized_safe_proposal_id,
+                    snapshot.block_number,
+                )
+            });
             info!(
                 start_block,
-                target_proposal_id,
                 finalized_safe_proposal_id,
                 finalized_block_number,
                 "resolved zero-target scanner start block",

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -623,18 +623,9 @@ where
             Some(
                 self.rpc
                     .l2_provider
-                    .get_block_by_number(BlockNumberOrTag::Latest)
+                    .get_block_number()
                     .await
-                    .map_err(|err| {
-                        SyncError::Rpc(RpcClientError::Provider(err.to_string()))
-                    })?
-                    .full()
-                    .await
-                    .map_err(|err| {
-                        SyncError::Rpc(RpcClientError::Provider(err.to_string()))
-                    })?
-                    .map(|block| block.number())
-                    .ok_or(SyncError::MissingExecutionBlock { number: 0 })?,
+                    .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?,
             )
         };
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -24,7 +24,7 @@ use metrics::{counter, gauge, histogram};
 use tokio::{
     spawn,
     sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot},
-    time::{sleep, timeout},
+    time::timeout,
 };
 use tokio_retry::{Retry, strategy::ExponentialBackoff};
 use tokio_stream::StreamExt;
@@ -53,9 +53,6 @@ use rpc::{RpcClientError, blob::BlobDataSource, client::Client};
 ///
 /// Covers both the enqueue operation and awaiting the processing response.
 const PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT: Duration = Duration::from_secs(12);
-/// Poll interval used to retry waiting for finalized L1 snapshots.
-const FINALITY_POLL_INTERVAL: Duration = Duration::from_secs(12);
-
 /// Finalized L1 snapshot used to derive a fail-closed, non-reorgable resume target.
 #[derive(Debug, Clone, Copy)]
 struct FinalizedL1Snapshot {
@@ -140,21 +137,33 @@ fn resolve_zero_target_start_block(
     if finalized_safe_proposal_id == 0 { finalized_block_number } else { 0 }
 }
 
+/// Maximum L1 head height at which missing finalization is expected (2 beacon epochs).
+///
+/// Below this threshold the chain is too young to have finalized and a genesis-replay
+/// fallback is safe (at most ~64 L1 blocks to scan).
+const FINALIZATION_EXPECTATION_THRESHOLD: u64 = 64;
+
 /// Resolve the target proposal id and finalized-safe proposal id, accounting for the
 /// finalized snapshot being unavailable on fresh chains.
 ///
 /// - When finalization is available, target is bounded by `min(resume, finalized_safe)`.
-/// - When finalization is unavailable and `resume_proposal_id == 0` (genesis), target is 0.
-/// - When finalization is unavailable and `resume_proposal_id > 0`, finalization is required and a
-///   `MissingFinalizedL1Block` error is returned.
+/// - When finalization is unavailable and the L1 chain is young (head < 2 epochs), both
+///   values reset to 0. This triggers a full scan from genesis which is trivially cheap.
+/// - When finalization is unavailable but the L1 chain is mature (head >= 2 epochs), a
+///   `MissingFinalizedL1Block` error is returned to fail fast instead of silently replaying
+///   from an untrusted genesis path.
 fn resolve_target_with_optional_finalization(
     resume_proposal_id: u64,
     finalized_safe_proposal_id: Option<u64>,
+    l1_head_block_number: u64,
 ) -> Result<(u64, u64), SyncError> {
     match finalized_safe_proposal_id {
         Some(safe_id) => Ok((resume_proposal_id.min(safe_id), safe_id)),
-        None if resume_proposal_id == 0 => Ok((0, 0)),
-        None => Err(SyncError::MissingFinalizedL1Block),
+        None if l1_head_block_number < FINALIZATION_EXPECTATION_THRESHOLD => Ok((0, 0)),
+        None => Err(SyncError::MissingFinalizedL1Block {
+            l1_head_block_number,
+            resume_proposal_id,
+        }),
     }
 }
 
@@ -711,14 +720,21 @@ where
         let anchor_address = *self.rpc.shasta.anchor.address();
         let resume_proposal_id = decode_anchor_proposal_id(&resume_head_block)?;
 
-        // Try to get finalized snapshot. When unavailable and resume is at genesis,
-        // proceed without waiting so fresh devnets can start immediately.
+        // Try to get finalized snapshot. When unavailable on a young L1 (< 2 epochs),
+        // fall back to genesis replay. On mature chains, fail fast.
         let finalized_snapshot = self.try_finalized_l1_snapshot().await?;
+        let l1_head_block_number = self
+            .rpc
+            .l1_provider
+            .get_block_number()
+            .await
+            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
 
         let (target_proposal_id, finalized_safe_proposal_id) =
             resolve_target_with_optional_finalization(
                 resume_proposal_id,
                 finalized_snapshot.as_ref().map(|s| s.finalized_safe_proposal_id),
+                l1_head_block_number,
             )?;
         let start_block = if target_proposal_id == 0 {
             finalized_snapshot.as_ref().map_or(0, |snapshot| {
@@ -901,18 +917,7 @@ where
     /// Start the event syncer.
     #[instrument(skip(self), name = "event_syncer_run")]
     async fn run(&self) -> Result<(), SyncError> {
-        let start_point = loop {
-            match self.event_stream_start_block().await {
-                Ok(start_point) => break start_point,
-                Err(SyncError::MissingFinalizedL1Block) => {
-                    warn!(
-                        "finalized block not available yet; waiting before starting event sync bootstrap"
-                    );
-                    sleep(FINALITY_POLL_INTERVAL).await;
-                }
-                Err(err) => return Err(err),
-            }
-        };
+        let start_point = self.event_stream_start_block().await?;
         let anchor_block_number = start_point.anchor_block_number;
         let initial_proposal_id = start_point.initial_proposal_id;
         let start_tag = BlockNumberOrTag::Number(anchor_block_number);
@@ -1172,7 +1177,7 @@ mod tests {
 
     #[test]
     fn confirmed_sync_probe_error_keeps_ingress_closed() {
-        let ready = resolve_confirmed_sync_probe(Err(SyncError::MissingFinalizedL1Block));
+        let ready = resolve_confirmed_sync_probe(Err(SyncError::MissingCheckpointResumeHead));
         assert!(!ready, "probe errors must keep ingress closed until a later successful probe",);
     }
 
@@ -1226,32 +1231,38 @@ mod tests {
     // -- resolve_target_with_optional_finalization tests --
 
     #[test]
-    fn genesis_resume_without_finalization_returns_zero_target() {
-        let (target, safe) = resolve_target_with_optional_finalization(0, None)
-            .expect("genesis resume without finalization should succeed");
+    fn young_chain_without_finalization_resets_to_zero_target() {
+        let (target, safe) =
+            resolve_target_with_optional_finalization(0, None, 30).expect("young chain ok");
+        assert_eq!(target, 0);
+        assert_eq!(safe, 0);
+
+        // Even with a non-zero resume, young L1 (< 64) resets both to 0.
+        let (target, safe) =
+            resolve_target_with_optional_finalization(5, None, 30).expect("young chain ok");
         assert_eq!(target, 0);
         assert_eq!(safe, 0);
     }
 
     #[test]
-    fn nonzero_resume_without_finalization_requires_finalized_block() {
-        let err = resolve_target_with_optional_finalization(5, None)
-            .expect_err("non-genesis resume without finalization must fail");
-        assert!(matches!(err, SyncError::MissingFinalizedL1Block));
+    fn mature_chain_without_finalization_errors() {
+        let err = resolve_target_with_optional_finalization(5, None, 200)
+            .expect_err("mature chain without finalization must fail");
+        assert!(matches!(err, SyncError::MissingFinalizedL1Block { .. }));
     }
 
     #[test]
     fn with_finalization_target_is_bounded_by_finalized_safe() {
-        let (target, safe) = resolve_target_with_optional_finalization(120, Some(90))
-            .expect("with finalization should succeed");
+        let (target, safe) =
+            resolve_target_with_optional_finalization(120, Some(90), 500).expect("finalized ok");
         assert_eq!(target, 90);
         assert_eq!(safe, 90);
     }
 
     #[test]
     fn with_finalization_target_keeps_resume_when_behind() {
-        let (target, safe) = resolve_target_with_optional_finalization(50, Some(120))
-            .expect("with finalization should succeed");
+        let (target, safe) =
+            resolve_target_with_optional_finalization(50, Some(120), 500).expect("finalized ok");
         assert_eq!(target, 50);
         assert_eq!(safe, 120);
     }

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -137,33 +137,19 @@ fn resolve_zero_target_start_block(
     if finalized_safe_proposal_id == 0 { finalized_block_number } else { 0 }
 }
 
-/// Maximum L1 head height at which missing finalization is expected (2 beacon epochs).
-///
-/// Below this threshold the chain is too young to have finalized and a genesis-replay
-/// fallback is safe (at most ~64 L1 blocks to scan).
-const FINALIZATION_EXPECTATION_THRESHOLD: u64 = 64;
-
 /// Resolve the target proposal id and finalized-safe proposal id, accounting for the
 /// finalized snapshot being unavailable on fresh chains.
 ///
 /// - When finalization is available, target is bounded by `min(resume, finalized_safe)`.
-/// - When finalization is unavailable and the L1 chain is young (head < 2 epochs), both
-///   values reset to 0. This triggers a full scan from genesis which is trivially cheap.
-/// - When finalization is unavailable but the L1 chain is mature (head >= 2 epochs), a
-///   `MissingFinalizedL1Block` error is returned to fail fast instead of silently replaying
-///   from an untrusted genesis path.
+/// - When finalization is unavailable, both values reset to 0 triggering a full genesis replay.
+///   This is safe because derivation is idempotent (the engine skips already-known blocks).
 fn resolve_target_with_optional_finalization(
     resume_proposal_id: u64,
     finalized_safe_proposal_id: Option<u64>,
-    l1_head_block_number: u64,
-) -> Result<(u64, u64), SyncError> {
+) -> (u64, u64) {
     match finalized_safe_proposal_id {
-        Some(safe_id) => Ok((resume_proposal_id.min(safe_id), safe_id)),
-        None if l1_head_block_number < FINALIZATION_EXPECTATION_THRESHOLD => Ok((0, 0)),
-        None => Err(SyncError::MissingFinalizedL1Block {
-            l1_head_block_number,
-            resume_proposal_id,
-        }),
+        Some(safe_id) => (resume_proposal_id.min(safe_id), safe_id),
+        None => (0, 0),
     }
 }
 
@@ -720,22 +706,15 @@ where
         let anchor_address = *self.rpc.shasta.anchor.address();
         let resume_proposal_id = decode_anchor_proposal_id(&resume_head_block)?;
 
-        // Try to get finalized snapshot. When unavailable on a young L1 (< 2 epochs),
-        // fall back to genesis replay. On mature chains, fail fast.
+        // Try to get finalized snapshot. When unavailable, fall back to genesis replay
+        // which is safe because derivation is idempotent.
         let finalized_snapshot = self.try_finalized_l1_snapshot().await?;
-        let l1_head_block_number = self
-            .rpc
-            .l1_provider
-            .get_block_number()
-            .await
-            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
 
         let (target_proposal_id, finalized_safe_proposal_id) =
             resolve_target_with_optional_finalization(
                 resume_proposal_id,
                 finalized_snapshot.as_ref().map(|s| s.finalized_safe_proposal_id),
-                l1_head_block_number,
-            )?;
+            );
         let start_block = if target_proposal_id == 0 {
             finalized_snapshot.as_ref().map_or(0, |snapshot| {
                 resolve_zero_target_start_block(
@@ -1231,38 +1210,27 @@ mod tests {
     // -- resolve_target_with_optional_finalization tests --
 
     #[test]
-    fn young_chain_without_finalization_resets_to_zero_target() {
-        let (target, safe) =
-            resolve_target_with_optional_finalization(0, None, 30).expect("young chain ok");
+    fn without_finalization_resets_to_zero_target() {
+        let (target, safe) = resolve_target_with_optional_finalization(0, None);
         assert_eq!(target, 0);
         assert_eq!(safe, 0);
 
-        // Even with a non-zero resume, young L1 (< 64) resets both to 0.
-        let (target, safe) =
-            resolve_target_with_optional_finalization(5, None, 30).expect("young chain ok");
+        // Even with a non-zero resume, no finalization resets both to 0.
+        let (target, safe) = resolve_target_with_optional_finalization(5, None);
         assert_eq!(target, 0);
         assert_eq!(safe, 0);
-    }
-
-    #[test]
-    fn mature_chain_without_finalization_errors() {
-        let err = resolve_target_with_optional_finalization(5, None, 200)
-            .expect_err("mature chain without finalization must fail");
-        assert!(matches!(err, SyncError::MissingFinalizedL1Block { .. }));
     }
 
     #[test]
     fn with_finalization_target_is_bounded_by_finalized_safe() {
-        let (target, safe) =
-            resolve_target_with_optional_finalization(120, Some(90), 500).expect("finalized ok");
+        let (target, safe) = resolve_target_with_optional_finalization(120, Some(90));
         assert_eq!(target, 90);
         assert_eq!(safe, 90);
     }
 
     #[test]
     fn with_finalization_target_keeps_resume_when_behind() {
-        let (target, safe) =
-            resolve_target_with_optional_finalization(50, Some(120), 500).expect("finalized ok");
+        let (target, safe) = resolve_target_with_optional_finalization(50, Some(120));
         assert_eq!(target, 50);
         assert_eq!(safe, 120);
     }

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -53,10 +53,8 @@ use rpc::{RpcClientError, blob::BlobDataSource, client::Client};
 ///
 /// Covers both the enqueue operation and awaiting the processing response.
 const PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT: Duration = Duration::from_secs(12);
-/// Poll interval in seconds used to retry waiting for finalized L1 snapshots.
-const FINALITY_POLL_INTERVAL_SECS: u64 = 12;
 /// Poll interval used to retry waiting for finalized L1 snapshots.
-const FINALITY_POLL_INTERVAL: Duration = Duration::from_secs(FINALITY_POLL_INTERVAL_SECS);
+const FINALITY_POLL_INTERVAL: Duration = Duration::from_secs(12);
 
 /// Finalized L1 snapshot used to derive a fail-closed, non-reorgable resume target.
 #[derive(Debug, Clone, Copy)]
@@ -131,11 +129,6 @@ fn resolve_resume_head_block_number(
     }
 }
 
-/// Return the smaller of the local resume proposal and finalized-safe proposal.
-fn resolve_target_proposal_id(resume_proposal_id: u64, finalized_safe_proposal_id: u64) -> u64 {
-    resume_proposal_id.min(finalized_safe_proposal_id)
-}
-
 /// Select scanner start block when the resolved target proposal id is zero.
 ///
 /// - If finalized-safe proposal id is zero, scanner can safely start from finalized L1 block.
@@ -147,10 +140,22 @@ fn resolve_zero_target_start_block(
     if finalized_safe_proposal_id == 0 { finalized_block_number } else { 0 }
 }
 
-/// Convert missing finalized block responses into an explicit fail-closed sync error.
-#[cfg(test)]
-fn require_finalized_block<T>(value: Option<T>) -> Result<T, SyncError> {
-    value.ok_or(SyncError::MissingFinalizedL1Block)
+/// Resolve the target proposal id and finalized-safe proposal id, accounting for the
+/// finalized snapshot being unavailable on fresh chains.
+///
+/// - When finalization is available, target is bounded by `min(resume, finalized_safe)`.
+/// - When finalization is unavailable and `resume_proposal_id == 0` (genesis), target is 0.
+/// - When finalization is unavailable and `resume_proposal_id > 0`, finalization is required
+///   and a `MissingFinalizedL1Block` error is returned.
+fn resolve_target_with_optional_finalization(
+    resume_proposal_id: u64,
+    finalized_safe_proposal_id: Option<u64>,
+) -> Result<(u64, u64), SyncError> {
+    match finalized_safe_proposal_id {
+        Some(safe_id) => Ok((resume_proposal_id.min(safe_id), safe_id)),
+        None if resume_proposal_id == 0 => Ok((0, 0)),
+        None => Err(SyncError::MissingFinalizedL1Block),
+    }
 }
 
 /// Return true when a preconfirmation target block is stale against the confirmed tip boundary.
@@ -657,30 +662,22 @@ where
         Ok(resume_head_block_number)
     }
 
-    /// Resolve finalized L1 block metadata and finalized-safe proposal ID.
+    /// Try to resolve finalized L1 block metadata and finalized-safe proposal ID.
     ///
-    /// Polls L1 every 12 seconds until a finalized block becomes available, which avoids
-    /// crash-looping on fresh devnets that have not yet reached finalization.
+    /// Returns `None` when the L1 chain has not yet finalized (e.g. fresh devnets).
     #[instrument(skip(self), level = "debug")]
-    async fn finalized_l1_snapshot(&self) -> Result<FinalizedL1Snapshot, SyncError> {
-        let finalized_block = loop {
-            let block = self
-                .rpc
-                .l1_provider
-                .get_block_by_number(BlockNumberOrTag::Finalized)
-                .await
-                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
+    async fn try_finalized_l1_snapshot(
+        &self,
+    ) -> Result<Option<FinalizedL1Snapshot>, SyncError> {
+        let finalized_block = self
+            .rpc
+            .l1_provider
+            .get_block_by_number(BlockNumberOrTag::Finalized)
+            .await
+            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
 
-            match block {
-                Some(b) => break b,
-                None => {
-                    info!(
-                        poll_interval_secs = FINALITY_POLL_INTERVAL_SECS,
-                        "L1 finalized block not yet available; retrying"
-                    );
-                    tokio::time::sleep(FINALITY_POLL_INTERVAL).await;
-                }
-            }
+        let Some(finalized_block) = finalized_block else {
+            return Ok(None);
         };
 
         let block_hash = finalized_block.header.hash;
@@ -696,14 +693,13 @@ where
             .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
         let finalized_safe_proposal_id = core_state.nextProposalId.to::<u64>().saturating_sub(1);
 
-        Ok(FinalizedL1Snapshot { block_number, block_hash, finalized_safe_proposal_id })
+        Ok(Some(FinalizedL1Snapshot { block_number, block_hash, finalized_safe_proposal_id }))
     }
 
     /// Determine the L1 block height used to resume event consumption after beacon sync.
     #[instrument(skip(self), level = "debug")]
     async fn event_stream_start_block(&self) -> Result<EventStreamStartPoint, SyncError> {
         let resume_head_block_number = self.resume_head_block_number().await?;
-        let finalized_snapshot = self.finalized_l1_snapshot().await?;
         let resume_head_block = self
             .rpc
             .l2_provider
@@ -716,30 +712,50 @@ where
 
         let anchor_address = *self.rpc.shasta.anchor.address();
         let resume_proposal_id = decode_anchor_proposal_id(&resume_head_block)?;
-        let target_proposal_id = resolve_target_proposal_id(
-            resume_proposal_id,
-            finalized_snapshot.finalized_safe_proposal_id,
-        );
+
+        // Try to get finalized snapshot. When unavailable and resume is at genesis,
+        // proceed without waiting so fresh devnets can start immediately.
+        let finalized_snapshot = self.try_finalized_l1_snapshot().await?;
+
+        let (target_proposal_id, finalized_safe_proposal_id) =
+            resolve_target_with_optional_finalization(
+                resume_proposal_id,
+                finalized_snapshot.as_ref().map(|s| s.finalized_safe_proposal_id),
+            )?;
+        let start_block = if target_proposal_id == 0 {
+            finalized_snapshot
+                .as_ref()
+                .map_or(0, |snapshot| {
+                    resolve_zero_target_start_block(
+                        snapshot.finalized_safe_proposal_id,
+                        snapshot.block_number,
+                    )
+                })
+        } else {
+            0
+        };
+        let (finalized_block_number, finalized_block_hash) = if let Some(snapshot) = finalized_snapshot {
+            (Some(snapshot.block_number), Some(snapshot.block_hash))
+        } else {
+            (None, None)
+        };
+
         info!(
             resume_proposal_id,
-            finalized_safe_proposal_id = finalized_snapshot.finalized_safe_proposal_id,
-            finalized_block_number = finalized_snapshot.block_number,
-            finalized_block_hash = ?finalized_snapshot.block_hash,
+            finalized_safe_proposal_id,
+            finalized_block_number,
+            finalized_block_hash = ?finalized_block_hash,
             target_proposal_id,
             resume_hash = ?resume_head_block.hash(),
             resume_number = resume_head_block.number(),
             "selected finalized-bounded proposal id from resume-source anchor metadata",
         );
         if target_proposal_id == 0 {
-            let start_block = resolve_zero_target_start_block(
-                finalized_snapshot.finalized_safe_proposal_id,
-                finalized_snapshot.block_number,
-            );
             info!(
                 start_block,
                 target_proposal_id,
-                finalized_safe_proposal_id = finalized_snapshot.finalized_safe_proposal_id,
-                finalized_block_number = finalized_snapshot.block_number,
+                finalized_safe_proposal_id,
+                finalized_block_number,
                 "resolved zero-target scanner start block",
             );
             return Ok(EventStreamStartPoint {
@@ -1199,18 +1215,6 @@ mod tests {
     }
 
     #[test]
-    fn target_proposal_id_is_bounded_by_finalized_safe_id_when_resume_is_ahead() {
-        let target = resolve_target_proposal_id(120, 90);
-        assert_eq!(target, 90);
-    }
-
-    #[test]
-    fn target_proposal_id_keeps_resume_id_when_resume_is_behind_finalized_safe() {
-        let target = resolve_target_proposal_id(90, 120);
-        assert_eq!(target, 90);
-    }
-
-    #[test]
     fn zero_target_uses_finalized_block_when_finalized_safe_is_zero() {
         let start_block = resolve_zero_target_start_block(0, 4_096);
         assert_eq!(start_block, 4_096);
@@ -1222,10 +1226,37 @@ mod tests {
         assert_eq!(start_block, 0);
     }
 
+    // -- resolve_target_with_optional_finalization tests --
+
     #[test]
-    fn missing_finalized_block_is_fail_closed() {
-        let err = require_finalized_block::<u64>(None)
-            .expect_err("missing finalized block must fail closed with explicit sync error");
+    fn genesis_resume_without_finalization_returns_zero_target() {
+        let (target, safe) = resolve_target_with_optional_finalization(0, None)
+            .expect("genesis resume without finalization should succeed");
+        assert_eq!(target, 0);
+        assert_eq!(safe, 0);
+    }
+
+    #[test]
+    fn nonzero_resume_without_finalization_requires_finalized_block() {
+        let err = resolve_target_with_optional_finalization(5, None)
+            .expect_err("non-genesis resume without finalization must fail");
         assert!(matches!(err, SyncError::MissingFinalizedL1Block));
     }
+
+    #[test]
+    fn with_finalization_target_is_bounded_by_finalized_safe() {
+        let (target, safe) = resolve_target_with_optional_finalization(120, Some(90))
+            .expect("with finalization should succeed");
+        assert_eq!(target, 90);
+        assert_eq!(safe, 90);
+    }
+
+    #[test]
+    fn with_finalization_target_keeps_resume_when_behind() {
+        let (target, safe) = resolve_target_with_optional_finalization(50, Some(120))
+            .expect("with finalization should succeed");
+        assert_eq!(target, 50);
+        assert_eq!(safe, 120);
+    }
+
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -24,7 +24,7 @@ use metrics::{counter, gauge, histogram};
 use tokio::{
     spawn,
     sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot},
-    time::timeout,
+    time::{sleep, timeout},
 };
 use tokio_retry::{Retry, strategy::ExponentialBackoff};
 use tokio_stream::StreamExt;
@@ -662,15 +662,27 @@ where
     }
 
     /// Resolve finalized L1 block metadata and finalized-safe proposal ID.
+    ///
+    /// Polls L1 every 12 seconds until a finalized block becomes available, which avoids
+    /// crash-looping on fresh devnets that have not yet reached finalization.
     #[instrument(skip(self), level = "debug")]
     async fn finalized_l1_snapshot(&self) -> Result<FinalizedL1Snapshot, SyncError> {
-        let finalized_block = require_finalized_block(
-            self.rpc
+        let finalized_block = loop {
+            let block = self
+                .rpc
                 .l1_provider
                 .get_block_by_number(BlockNumberOrTag::Finalized)
                 .await
-                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?,
-        )?;
+                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
+
+            match block {
+                Some(b) => break b,
+                None => {
+                    info!("L1 finalized block not yet available; retrying in 12s");
+                    tokio::time::sleep(Duration::from_secs(12)).await;
+                }
+            }
+        };
 
         let block_hash = finalized_block.header.hash;
         let block_number = finalized_block.header.number;
@@ -877,7 +889,18 @@ where
     /// Start the event syncer.
     #[instrument(skip(self), name = "event_syncer_run")]
     async fn run(&self) -> Result<(), SyncError> {
-        let start_point = self.event_stream_start_block().await?;
+        let start_point = loop {
+            match self.event_stream_start_block().await {
+                Ok(start_point) => break start_point,
+                Err(SyncError::MissingFinalizedL1Block) => {
+                    warn!(
+                        "finalized block not available yet; waiting before starting event sync bootstrap"
+                    );
+                    sleep(Duration::from_secs(12)).await;
+                }
+                Err(err) => return Err(err),
+            }
+        };
         let anchor_block_number = start_point.anchor_block_number;
         let initial_proposal_id = start_point.initial_proposal_id;
         let start_tag = BlockNumberOrTag::Number(anchor_block_number);

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -53,6 +53,8 @@ use rpc::{RpcClientError, blob::BlobDataSource, client::Client};
 ///
 /// Covers both the enqueue operation and awaiting the processing response.
 const PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT: Duration = Duration::from_secs(12);
+const FINALITY_POLL_INTERVAL_SECS: u64 = 12;
+const FINALITY_POLL_INTERVAL: Duration = Duration::from_secs(FINALITY_POLL_INTERVAL_SECS);
 
 /// Finalized L1 snapshot used to derive a fail-closed, non-reorgable resume target.
 #[derive(Debug, Clone, Copy)]
@@ -114,14 +116,14 @@ fn resolve_resume_head_block_number(
     checkpoint_configured: bool,
     checkpoint_synced_head: Option<u64>,
     head_l1_origin_block_id: Option<u64>,
-    local_head_block_id: Option<u64>,
+    local_head_is_genesis: bool,
 ) -> Result<u64, SyncError> {
     if checkpoint_configured {
         checkpoint_synced_head.ok_or(SyncError::MissingCheckpointResumeHead)
     } else {
         match head_l1_origin_block_id {
             Some(block_id) => Ok(block_id),
-            None if local_head_block_id == Some(0) => Ok(0),
+            None if local_head_is_genesis => Ok(0),
             None => Err(SyncError::MissingHeadL1OriginResume),
         }
     }
@@ -617,29 +619,27 @@ where
     async fn resume_head_block_number(&self) -> Result<u64, SyncError> {
         let checkpoint_configured = self.cfg.l2_checkpoint_url.is_some();
 
-        let local_head_block_id = if checkpoint_configured {
-            None
-        } else {
-            Some(
-                self.rpc
-                    .l2_provider
-                    .get_block_number()
-                    .await
-                    .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?,
-            )
-        };
-
         let head_l1_origin_block_id = if checkpoint_configured {
             None
         } else {
             self.rpc.head_l1_origin().await?.map(|origin| origin.block_id.to::<u64>())
+        };
+        let local_head_is_genesis = if checkpoint_configured || head_l1_origin_block_id.is_some() {
+            false
+        } else {
+            self.rpc
+                .l2_provider
+                .get_block_number()
+                .await
+                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
+                == 0
         };
 
         let resume_head_block_number = resolve_resume_head_block_number(
             checkpoint_configured,
             self.checkpoint_resume_head.get(),
             head_l1_origin_block_id,
-            local_head_block_id,
+            local_head_is_genesis,
         )?;
 
         if checkpoint_configured {
@@ -678,8 +678,11 @@ where
             match block {
                 Some(b) => break b,
                 None => {
-                    info!("L1 finalized block not yet available; retrying in 12s");
-                    tokio::time::sleep(Duration::from_secs(12)).await;
+                    info!(
+                        poll_interval_secs = FINALITY_POLL_INTERVAL_SECS,
+                        "L1 finalized block not yet available; retrying"
+                    );
+                    tokio::time::sleep(FINALITY_POLL_INTERVAL).await;
                 }
             }
         };
@@ -896,7 +899,7 @@ where
                     warn!(
                         "finalized block not available yet; waiting before starting event sync bootstrap"
                     );
-                    sleep(Duration::from_secs(12)).await;
+                    sleep(FINALITY_POLL_INTERVAL).await;
                 }
                 Err(err) => return Err(err),
             }
@@ -1166,27 +1169,27 @@ mod tests {
 
     #[test]
     fn resume_head_resolution_requires_checkpoint_state_in_checkpoint_mode() {
-        let err = resolve_resume_head_block_number(true, None, Some(100), Some(64))
+        let err = resolve_resume_head_block_number(true, None, Some(100), false)
             .expect_err("checkpoint mode should require checkpoint resume state");
         assert!(matches!(err, SyncError::MissingCheckpointResumeHead));
 
-        let resolved = resolve_resume_head_block_number(true, Some(420), None, Some(64))
+        let resolved = resolve_resume_head_block_number(true, Some(420), None, false)
             .expect("checkpoint resume head should be used when present");
         assert_eq!(resolved, 420);
     }
 
     #[test]
     fn resume_head_resolution_requires_head_l1_origin_without_checkpoint() {
-        let err = resolve_resume_head_block_number(false, Some(999), None, Some(64))
+        let err = resolve_resume_head_block_number(false, Some(999), None, false)
             .expect_err("non-checkpoint mode should require head_l1_origin");
         assert!(matches!(err, SyncError::MissingHeadL1OriginResume));
 
-        let resolved = resolve_resume_head_block_number(false, Some(999), Some(64), Some(64))
+        let resolved = resolve_resume_head_block_number(false, Some(999), Some(64), false)
             .expect("head_l1_origin should drive resume without checkpoint");
         assert_eq!(resolved, 64);
 
         let resolved =
-            resolve_resume_head_block_number(false, None, None, Some(0)).expect("genesis fallback");
+            resolve_resume_head_block_number(false, None, None, true).expect("genesis fallback");
         assert_eq!(resolved, 0);
     }
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -53,7 +53,9 @@ use rpc::{RpcClientError, blob::BlobDataSource, client::Client};
 ///
 /// Covers both the enqueue operation and awaiting the processing response.
 const PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT: Duration = Duration::from_secs(12);
+/// Poll interval in seconds used to retry waiting for finalized L1 snapshots.
 const FINALITY_POLL_INTERVAL_SECS: u64 = 12;
+/// Poll interval used to retry waiting for finalized L1 snapshots.
 const FINALITY_POLL_INTERVAL: Duration = Duration::from_secs(FINALITY_POLL_INTERVAL_SECS);
 
 /// Finalized L1 snapshot used to derive a fail-closed, non-reorgable resume target.
@@ -146,6 +148,7 @@ fn resolve_zero_target_start_block(
 }
 
 /// Convert missing finalized block responses into an explicit fail-closed sync error.
+#[cfg(test)]
 fn require_finalized_block<T>(value: Option<T>) -> Result<T, SyncError> {
     value.ok_or(SyncError::MissingFinalizedL1Block)
 }
@@ -612,9 +615,9 @@ where
     /// - If checkpoint mode is enabled, we require the exact checkpoint head that beacon sync
     ///   finished at. This avoids trusting stale local origin pointers.
     /// - Without checkpoint mode, we prefer local `head_l1_origin`. If missing on fresh genesis
-    ///   chains (where local head is block 0), we fallback to resume from block 0.
-    ///   Otherwise we fail fast instead of deriving proposal IDs from `Latest`, which may include
-    ///   local preconfirmation-only blocks that were never event-confirmed.
+    ///   chains (where local head is block 0), we fallback to resume from block 0. Otherwise we
+    ///   fail fast instead of deriving proposal IDs from `Latest`, which may include local
+    ///   preconfirmation-only blocks that were never event-confirmed.
     #[instrument(skip(self), level = "debug")]
     async fn resume_head_block_number(&self) -> Result<u64, SyncError> {
         let checkpoint_configured = self.cfg.l2_checkpoint_url.is_some();
@@ -631,8 +634,8 @@ where
                 .l2_provider
                 .get_block_number()
                 .await
-                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
-                == 0
+                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))? ==
+                0
         };
 
         let resume_head_block_number = resolve_resume_head_block_number(
@@ -644,18 +647,13 @@ where
 
         if checkpoint_configured {
             info!(resume_head_block_number, "using checkpoint-synced head as event resume source");
+        } else if head_l1_origin_block_id.is_some() {
+            info!(resume_head_block_number, "using local head_l1_origin as event resume source");
         } else {
-            if head_l1_origin_block_id.is_some() {
-                info!(
-                    resume_head_block_number,
-                    "using local head_l1_origin as event resume source"
-                );
-            } else {
-                info!(
-                    resume_head_block_number,
-                    "using genesis fallback as event resume source (head_l1_origin unavailable)"
-                );
-            }
+            info!(
+                resume_head_block_number,
+                "using genesis fallback as event resume source (head_l1_origin unavailable)"
+            );
         }
 
         Ok(resume_head_block_number)

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -105,7 +105,8 @@ fn resolve_confirmed_sync_probe(
 /// Resolve the L2 block number that event sync should use as its resume source.
 ///
 /// - Checkpoint mode: must use the checkpoint head that beacon sync actually caught up to.
-/// - Non-checkpoint mode: must use local `head_l1_origin`.
+/// - Non-checkpoint mode: prefer local `head_l1_origin`, otherwise allow genesis fallback (block 0)
+///   for brand-new chains bootstrapped from genesis.
 ///
 /// Any missing source is treated as a hard error to avoid silently falling back to an unsafe
 /// resume point such as `Latest`, which can include local preconfirmation-only blocks.
@@ -113,11 +114,16 @@ fn resolve_resume_head_block_number(
     checkpoint_configured: bool,
     checkpoint_synced_head: Option<u64>,
     head_l1_origin_block_id: Option<u64>,
+    local_head_block_id: Option<u64>,
 ) -> Result<u64, SyncError> {
     if checkpoint_configured {
         checkpoint_synced_head.ok_or(SyncError::MissingCheckpointResumeHead)
     } else {
-        head_l1_origin_block_id.ok_or(SyncError::MissingHeadL1OriginResume)
+        match head_l1_origin_block_id {
+            Some(block_id) => Ok(block_id),
+            None if local_head_block_id == Some(0) => Ok(0),
+            None => Err(SyncError::MissingHeadL1OriginResume),
+        }
     }
 }
 
@@ -603,12 +609,34 @@ where
     /// Important safety behavior:
     /// - If checkpoint mode is enabled, we require the exact checkpoint head that beacon sync
     ///   finished at. This avoids trusting stale local origin pointers.
-    /// - Without checkpoint mode, we require local `head_l1_origin` and fail fast when missing.
-    ///   This avoids deriving proposal IDs from `Latest`, which may include local preconf-only
-    ///   blocks that were never event-confirmed.
+    /// - Without checkpoint mode, we prefer local `head_l1_origin`. If missing on fresh genesis
+    ///   chains (where local head is block 0), we fallback to resume from block 0.
+    ///   Otherwise we fail fast instead of deriving proposal IDs from `Latest`, which may include
+    ///   local preconfirmation-only blocks that were never event-confirmed.
     #[instrument(skip(self), level = "debug")]
     async fn resume_head_block_number(&self) -> Result<u64, SyncError> {
         let checkpoint_configured = self.cfg.l2_checkpoint_url.is_some();
+
+        let local_head_block_id = if checkpoint_configured {
+            None
+        } else {
+            Some(
+                self.rpc
+                    .l2_provider
+                    .get_block_by_number(BlockNumberOrTag::Latest)
+                    .await
+                    .map_err(|err| {
+                        SyncError::Rpc(RpcClientError::Provider(err.to_string()))
+                    })?
+                    .full()
+                    .await
+                    .map_err(|err| {
+                        SyncError::Rpc(RpcClientError::Provider(err.to_string()))
+                    })?
+                    .map(|block| block.number())
+                    .ok_or(SyncError::MissingExecutionBlock { number: 0 })?,
+            )
+        };
 
         let head_l1_origin_block_id = if checkpoint_configured {
             None
@@ -620,12 +648,23 @@ where
             checkpoint_configured,
             self.checkpoint_resume_head.get(),
             head_l1_origin_block_id,
+            local_head_block_id,
         )?;
 
         if checkpoint_configured {
             info!(resume_head_block_number, "using checkpoint-synced head as event resume source");
         } else {
-            info!(resume_head_block_number, "using local head_l1_origin as event resume source");
+            if head_l1_origin_block_id.is_some() {
+                info!(
+                    resume_head_block_number,
+                    "using local head_l1_origin as event resume source"
+                );
+            } else {
+                info!(
+                    resume_head_block_number,
+                    "using genesis fallback as event resume source (head_l1_origin unavailable)"
+                );
+            }
         }
 
         Ok(resume_head_block_number)
@@ -1113,24 +1152,28 @@ mod tests {
 
     #[test]
     fn resume_head_resolution_requires_checkpoint_state_in_checkpoint_mode() {
-        let err = resolve_resume_head_block_number(true, None, Some(100))
+        let err = resolve_resume_head_block_number(true, None, Some(100), Some(64))
             .expect_err("checkpoint mode should require checkpoint resume state");
         assert!(matches!(err, SyncError::MissingCheckpointResumeHead));
 
-        let resolved = resolve_resume_head_block_number(true, Some(420), None)
+        let resolved = resolve_resume_head_block_number(true, Some(420), None, Some(64))
             .expect("checkpoint resume head should be used when present");
         assert_eq!(resolved, 420);
     }
 
     #[test]
     fn resume_head_resolution_requires_head_l1_origin_without_checkpoint() {
-        let err = resolve_resume_head_block_number(false, Some(999), None)
+        let err = resolve_resume_head_block_number(false, Some(999), None, Some(64))
             .expect_err("non-checkpoint mode should require head_l1_origin");
         assert!(matches!(err, SyncError::MissingHeadL1OriginResume));
 
-        let resolved = resolve_resume_head_block_number(false, None, Some(64))
+        let resolved = resolve_resume_head_block_number(false, Some(999), Some(64), Some(64))
             .expect("head_l1_origin should drive resume without checkpoint");
         assert_eq!(resolved, 64);
+
+        let resolved =
+            resolve_resume_head_block_number(false, None, None, Some(0)).expect("genesis fallback");
+        assert_eq!(resolved, 0);
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -260,17 +260,12 @@ where
                 let router_guard = router.lock().await;
                 // Re-check after acquiring router lock so event-sync updates cannot race this
                 // preconfirmation submission.
+                // On genesis chains head_l1_origin is not yet written; default to 0 so
+                // the staleness check passes for any block_number >= 1.  This matches the
+                // Go driver's `checkMessageBlockNumber` which skips the check when nil.
                 let head_l1_origin_block_id = match rpc.head_l1_origin().await {
                     Ok(Some(origin)) => origin.block_id.to::<u64>(),
-                    Ok(None) => {
-                        warn!(
-                            block_number,
-                            "rejecting preconfirmation payload in ingress loop: head_l1_origin missing"
-                        );
-                        let _ = job.respond_to.send(Err(DriverError::PreconfIngressNotReady));
-                        gauge!(DriverMetrics::PRECONF_QUEUE_DEPTH).set(rx.len() as f64);
-                        continue;
-                    }
+                    Ok(None) => 0,
                     Err(err) => {
                         error!(?err, block_number, "failed to read head_l1_origin in ingress loop");
                         let _ = job.respond_to.send(Err(DriverError::Rpc(err)));
@@ -502,6 +497,13 @@ where
         }
     }
 
+    /// Returns whether preconfirmation ingress is currently ready.
+    ///
+    /// This mirrors the internal readiness signal used by the strict ingress gate.
+    pub fn is_preconf_ingress_ready(&self) -> bool {
+        self.preconf_ingress_ready.load(Ordering::Acquire)
+    }
+
     /// Submit a preconfirmation payload and await the processing result.
     pub async fn submit_preconfirmation_payload(
         &self,
@@ -528,15 +530,11 @@ where
         }
 
         let block_number = payload.block_number();
+        // On genesis chains head_l1_origin is not yet written; default to 0 so
+        // the staleness check passes for any block_number >= 1.
         let head_l1_origin_block_id = match self.rpc.head_l1_origin().await? {
             Some(origin) => origin.block_id.to::<u64>(),
-            None => {
-                warn!(
-                    block_number,
-                    "rejecting preconfirmation payload before enqueue: head_l1_origin missing"
-                );
-                return Err(DriverError::PreconfIngressNotReady);
-            }
+            None => 0,
         };
         if is_stale_preconf(block_number, head_l1_origin_block_id) {
             counter!(DriverMetrics::PRECONF_STALE_DROPPED_TOTAL).increment(1);

--- a/packages/taiko-client-rs/crates/rpc/src/auth.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/auth.rs
@@ -224,7 +224,7 @@ impl<P: Provider + Clone> Client<P> {
         forkchoice_state: ForkchoiceState,
         payload_attributes: Option<TaikoPayloadAttributes>,
     ) -> Result<ForkchoiceUpdated> {
-        let forkchoice_state = serde_json::to_value(&forkchoice_state)
+        let forkchoice_state = serde_json::to_value(forkchoice_state)
             .map_err(|err| RpcClientError::Other(anyhow!(err)))?;
 
         let payload_attributes = match payload_attributes {

--- a/packages/taiko-client-rs/crates/rpc/src/auth.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/auth.rs
@@ -224,10 +224,23 @@ impl<P: Provider + Clone> Client<P> {
         forkchoice_state: ForkchoiceState,
         payload_attributes: Option<TaikoPayloadAttributes>,
     ) -> Result<ForkchoiceUpdated> {
+        let forkchoice_state = serde_json::to_value(&forkchoice_state)
+            .map_err(|err| RpcClientError::Other(anyhow!(err)))?;
+
+        let payload_attributes = match payload_attributes {
+            Some(payload_attributes) => {
+                let mut payload_attributes = serde_json::to_value(&payload_attributes)
+                    .map_err(|err| RpcClientError::Other(anyhow!(err)))?;
+                normalize_double_quoted_json_strings(&mut payload_attributes);
+                payload_attributes
+            }
+            None => Value::Null,
+        };
+
         self.l2_auth_provider
             .raw_request(
                 Cow::Borrowed(TaikoEngineMethod::ForkchoiceUpdatedV2.as_str()),
-                (forkchoice_state, payload_attributes),
+                (forkchoice_state, Some(payload_attributes)),
             )
             .await
             .map_err(Into::into)
@@ -257,4 +270,36 @@ where
 {
     let message = err.to_string();
     if is_ignorable_origin_error(&message) { Ok(None) } else { Err(err.into()) }
+}
+
+fn normalize_double_quoted_json_strings(value: &mut Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                normalize_double_quoted_json_strings(value);
+            }
+        }
+        Value::Object(map) => {
+            for value in map.values_mut() {
+                normalize_double_quoted_json_strings(value);
+            }
+        }
+        Value::String(value) if is_wrapped_json_string(value) => {
+            let unwrapped = value
+                .strip_prefix('"')
+                .and_then(|value| value.strip_suffix('"'))
+                .unwrap_or(value)
+                .to_string();
+            *value = unwrapped;
+        }
+        _ => {}
+    }
+}
+
+fn is_wrapped_json_string(value: &str) -> bool {
+    value.len() > 1
+        && value.starts_with('"')
+        && value.ends_with('"')
+        && (value[1..value.len() - 1].starts_with("0x")
+            || value[1..value.len() - 1].chars().all(|ch| ch.is_ascii_digit()))
 }

--- a/packages/taiko-client-rs/crates/rpc/src/auth.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/auth.rs
@@ -228,19 +228,17 @@ impl<P: Provider + Clone> Client<P> {
             .map_err(|err| RpcClientError::Other(anyhow!(err)))?;
 
         let payload_attributes = match payload_attributes {
-            Some(payload_attributes) => {
-                let mut payload_attributes = serde_json::to_value(&payload_attributes)
-                    .map_err(|err| RpcClientError::Other(anyhow!(err)))?;
-                normalize_double_quoted_json_strings(&mut payload_attributes);
-                payload_attributes
-            }
-            None => Value::Null,
+            Some(payload_attributes) => Some(
+                serde_json::to_value(&payload_attributes)
+                    .map_err(|err| RpcClientError::Other(anyhow!(err)))?,
+            ),
+            None => None,
         };
 
         self.l2_auth_provider
             .raw_request(
                 Cow::Borrowed(TaikoEngineMethod::ForkchoiceUpdatedV2.as_str()),
-                (forkchoice_state, Some(payload_attributes)),
+                (forkchoice_state, payload_attributes),
             )
             .await
             .map_err(Into::into)
@@ -270,36 +268,4 @@ where
 {
     let message = err.to_string();
     if is_ignorable_origin_error(&message) { Ok(None) } else { Err(err.into()) }
-}
-
-fn normalize_double_quoted_json_strings(value: &mut Value) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_double_quoted_json_strings(value);
-            }
-        }
-        Value::Object(map) => {
-            for value in map.values_mut() {
-                normalize_double_quoted_json_strings(value);
-            }
-        }
-        Value::String(value) if is_wrapped_json_string(value) => {
-            let unwrapped = value
-                .strip_prefix('"')
-                .and_then(|value| value.strip_suffix('"'))
-                .unwrap_or(value)
-                .to_string();
-            *value = unwrapped;
-        }
-        _ => {}
-    }
-}
-
-fn is_wrapped_json_string(value: &str) -> bool {
-    value.len() > 1
-        && value.starts_with('"')
-        && value.ends_with('"')
-        && (value[1..value.len() - 1].starts_with("0x")
-            || value[1..value.len() - 1].chars().all(|ch| ch.is_ascii_digit()))
 }

--- a/packages/taiko-client-rs/crates/rpc/src/auth.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/auth.rs
@@ -201,6 +201,15 @@ impl<P: Provider + Clone> Client<P> {
         let mut payload_value = serde_json::to_value(&payload.execution_payload)
             .map_err(|err| RpcClientError::Other(anyhow!(err)))?;
         if let serde_json::Value::Object(ref mut obj) = payload_value {
+            // Include the withdrawals list so taiko-geth can reconstruct the full block.
+            // The Go driver sends the full ExecutableData (with withdrawals); omitting
+            // this field causes a blockhash mismatch because geth cannot recompute the
+            // withdrawals root from the hash alone.
+            if let Some(ref withdrawals) = payload.withdrawals {
+                let withdrawals_value = serde_json::to_value(withdrawals)
+                    .map_err(|err| RpcClientError::Other(anyhow!(err)))?;
+                obj.insert("withdrawals".to_string(), withdrawals_value);
+            }
             obj.insert(
                 "txHash".to_string(),
                 serde_json::Value::String(format!("{:#066x}", sidecar.tx_hash)),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -213,6 +213,11 @@ where
             "inserted whitelist preconfirmation block"
         );
 
+        if let Some(ref highest) = self.highest_unsafe_l2_payload_block_id {
+            let mut guard = highest.lock().await;
+            *guard = block_number.max(*guard);
+        }
+
         Ok(true)
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -3,13 +3,12 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumberOrTag;
-use tokio::sync::Mutex;
 use alloy_primitives::{Address, B256};
 use alloy_provider::Provider;
 use bindings::preconf_whitelist::PreconfWhitelist::PreconfWhitelistInstance;
 use driver::sync::event::EventSyncer;
 use rpc::client::Client;
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc};
 use tracing::{debug, info, warn};
 
 use crate::{

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumberOrTag;
+use tokio::sync::Mutex;
 use alloy_primitives::{Address, B256};
 use alloy_provider::Provider;
 use bindings::preconf_whitelist::PreconfWhitelist::PreconfWhitelistInstance;
@@ -68,6 +69,8 @@ where
     sequencer_cache: WhitelistSequencerCache,
     /// Command channel used to publish P2P requests/responses.
     network_command_tx: mpsc::Sender<NetworkCommand>,
+    /// Shared highest unsafe L2 payload block ID (updated on P2P import when REST server enabled).
+    highest_unsafe_l2_payload_block_id: Option<Arc<Mutex<u64>>>,
     /// Latched flag indicating event sync has exposed a head L1 origin.
     sync_ready: bool,
     /// Shasta anchor contract address used to validate the first transaction.
@@ -85,6 +88,7 @@ where
         whitelist_address: Address,
         chain_id: u64,
         network_command_tx: mpsc::Sender<NetworkCommand>,
+        highest_unsafe_l2_payload_block_id: Option<Arc<Mutex<u64>>>,
     ) -> Self {
         let whitelist = PreconfWhitelistInstance::new(whitelist_address, rpc.l1_provider.clone());
         let anchor_address = *rpc.shasta.anchor.address();
@@ -99,6 +103,7 @@ where
             request_throttle: RequestThrottle::default(),
             sequencer_cache: WhitelistSequencerCache::default(),
             network_command_tx,
+            highest_unsafe_l2_payload_block_id,
             sync_ready: false,
             anchor_address,
         };

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest/types.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest/types.rs
@@ -159,7 +159,7 @@ pub struct WhitelistStatus {
     pub highest_unsafe_block_number: u64,
     /// Local libp2p peer ID.
     pub peer_id: String,
-    /// Whether event sync has established a head L1 origin.
+    /// Whether preconfirmation ingress is ready.
     pub sync_ready: bool,
     /// Sequencing lookahead information.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
@@ -520,7 +520,9 @@ where
             .get(&current_epoch)
             .copied()
             .map(|hash| hash.to_string());
-        let sync_ready = head_l1_origin_block_id.is_some();
+        // sync_ready reflects ingress readiness, which already includes the confirmed-sync
+        // and scanner-live checks required by the event syncer.
+        let sync_ready = self.event_syncer.is_preconf_ingress_ready();
 
         Ok(WhitelistStatus {
             head_l1_origin_block_id,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
@@ -375,11 +375,17 @@ where
         let started_at = Instant::now();
         let _build_guard = self.build_preconf_lock.lock().await;
 
+        // Guard against building on a genuinely syncing node, but tolerate the false-
+        // positive that taiko-geth emits on genesis chains (currentBlock == highestBlock
+        // == 0, txIndexRemainingBlocks = 1).  When current == highest the node is not
+        // actually catching up to a remote peer, so we allow the build to proceed.
         let sync_status = self.rpc.l2_provider.syncing().await.map_err(provider_err)?;
-        if matches!(sync_status, SyncStatus::Info(_)) {
-            return Err(WhitelistPreconfirmationDriverError::Driver(
-                driver::DriverError::EngineSyncing(request.block_number),
-            ));
+        if let SyncStatus::Info(ref info) = sync_status
+            && info.current_block < info.highest_block
+        {
+                return Err(WhitelistPreconfirmationDriverError::Driver(
+                    driver::DriverError::EngineSyncing(request.block_number),
+                ));
         }
 
         self.ensure_fee_recipient_allowed(request.fee_recipient).await?;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
@@ -73,8 +73,8 @@ where
     build_preconf_lock: Mutex<()>,
     /// Preconf whitelist contract used for operator checks.
     whitelist: PreconfWhitelistInstance<P>,
-    /// Highest unsafe payload block ID tracked by this node.
-    highest_unsafe_l2_payload_block_id: Mutex<u64>,
+    /// Highest unsafe payload block ID tracked by this node (shared with importer).
+    highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
     /// End-of-sequencing hash cache keyed by epoch.
     end_of_sequencing_by_epoch: Mutex<HashMap<u64, B256>>,
     /// Broadcast channel for REST `/ws` end-of-sequencing notifications.
@@ -98,8 +98,8 @@ where
     pub beacon_client: Arc<BeaconClient>,
     /// Whitelist contract address used for operator checks.
     pub whitelist_address: Address,
-    /// Highest unsafe payload block ID tracked by this node at startup.
-    pub initial_highest_unsafe_l2_payload_block_id: u64,
+    /// Shared highest unsafe payload block ID (also updated by importer on P2P import).
+    pub highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
     /// Channel used to publish messages to the P2P network.
     pub network_command_tx: mpsc::Sender<NetworkCommand>,
     /// Local peer ID string.
@@ -119,7 +119,7 @@ where
             signer,
             beacon_client,
             whitelist_address,
-            initial_highest_unsafe_l2_payload_block_id,
+            highest_unsafe_l2_payload_block_id,
             network_command_tx,
             local_peer_id,
         } = params;
@@ -132,9 +132,7 @@ where
             signer,
             beacon_client,
             whitelist,
-            highest_unsafe_l2_payload_block_id: Mutex::new(
-                initial_highest_unsafe_l2_payload_block_id,
-            ),
+            highest_unsafe_l2_payload_block_id,
             end_of_sequencing_by_epoch: Mutex::new(HashMap::new()),
             eos_notification_tx,
             network_command_tx,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/rest_handler.rs
@@ -380,12 +380,12 @@ where
         // == 0, txIndexRemainingBlocks = 1).  When current == highest the node is not
         // actually catching up to a remote peer, so we allow the build to proceed.
         let sync_status = self.rpc.l2_provider.syncing().await.map_err(provider_err)?;
-        if let SyncStatus::Info(ref info) = sync_status
-            && info.current_block < info.highest_block
+        if let SyncStatus::Info(ref info) = sync_status &&
+            info.current_block < info.highest_block
         {
-                return Err(WhitelistPreconfirmationDriverError::Driver(
-                    driver::DriverError::EngineSyncing(request.block_number),
-                ));
+            return Err(WhitelistPreconfirmationDriverError::Driver(
+                driver::DriverError::EngineSyncing(request.block_number),
+            ));
         }
 
         self.ensure_fee_recipient_allowed(request.fee_recipient).await?;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -14,8 +14,7 @@ use driver::{DriverConfig, map_driver_error};
 use preconfirmation_net::P2pConfig;
 use protocol::signer::FixedKSigner;
 use rpc::beacon::BeaconClient;
-use tokio::sync::Mutex;
-use tokio::time;
+use tokio::{sync::Mutex, time};
 use tracing::{info, warn};
 
 use crate::{
@@ -238,8 +237,8 @@ impl WhitelistPreconfirmationDriverRunner {
                     BeaconClient::new(self.config.driver_config.l1_beacon_endpoint.clone())
                         .await
                         .map_err(|err| WhitelistPreconfirmationDriverError::RestWsServerBeaconInit {
-                            reason: err.to_string(),
-                        })?,
+                        reason: err.to_string(),
+                    })?,
                 );
 
                 let signer = FixedKSigner::new(signer_key).map_err(|e| {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -14,6 +14,7 @@ use driver::{DriverConfig, map_driver_error};
 use preconfirmation_net::P2pConfig;
 use protocol::signer::FixedKSigner;
 use rpc::beacon::BeaconClient;
+use tokio::sync::Mutex;
 use tokio::time;
 use tracing::{info, warn};
 
@@ -227,55 +228,59 @@ impl WhitelistPreconfirmationDriverRunner {
         );
 
         // Optionally start the REST/WS server when both rpc_listen_addr and p2p_signer_key
-        // are configured.
-        let mut rest_ws_server = if let (Some(listen_addr), Some(signer_key)) =
-            (self.config.rpc_listen_addr, &self.config.p2p_signer_key)
-        {
-            let beacon_client = Arc::new(
-                BeaconClient::new(self.config.driver_config.l1_beacon_endpoint.clone())
-                    .await
-                    .map_err(|err| WhitelistPreconfirmationDriverError::RestWsServerBeaconInit {
-                        reason: err.to_string(),
-                    })?,
-            );
+        // are configured. When enabled, create shared state for highestUnsafeL2PayloadBlockID
+        // so the importer can update it on P2P imports.
+        let (mut rest_ws_server, shared_highest_unsafe) =
+            if let (Some(listen_addr), Some(signer_key)) =
+                (self.config.rpc_listen_addr, &self.config.p2p_signer_key)
+            {
+                let beacon_client = Arc::new(
+                    BeaconClient::new(self.config.driver_config.l1_beacon_endpoint.clone())
+                        .await
+                        .map_err(|err| WhitelistPreconfirmationDriverError::RestWsServerBeaconInit {
+                            reason: err.to_string(),
+                        })?,
+                );
 
-            let signer = FixedKSigner::new(signer_key).map_err(|e| {
-                WhitelistPreconfirmationDriverError::Signing(format!(
-                    "failed to create P2P signer: {e}"
-                ))
-            })?;
-            let initial_highest_unsafe_l2_payload_block_id =
-                initial_highest_unsafe_l2_payload_block_id(&preconf_ingress_sync).await;
+                let signer = FixedKSigner::new(signer_key).map_err(|e| {
+                    WhitelistPreconfirmationDriverError::Signing(format!(
+                        "failed to create P2P signer: {e}"
+                    ))
+                })?;
+                let initial_highest_unsafe_l2_payload_block_id =
+                    initial_highest_unsafe_l2_payload_block_id(&preconf_ingress_sync).await;
+                let shared_highest =
+                    Arc::new(Mutex::new(initial_highest_unsafe_l2_payload_block_id));
 
-            let handler = WhitelistRestHandler::new(WhitelistRestHandlerParams {
-                event_syncer: preconf_ingress_sync.event_syncer(),
-                rpc: preconf_ingress_sync.client().clone(),
-                chain_id: self.config.p2p_config.chain_id,
-                signer,
-                beacon_client,
-                whitelist_address: self.config.whitelist_address,
-                initial_highest_unsafe_l2_payload_block_id,
-                network_command_tx: network.command_tx.clone(),
-                local_peer_id: network.local_peer_id.to_string(),
-            });
+                let handler = WhitelistRestHandler::new(WhitelistRestHandlerParams {
+                    event_syncer: preconf_ingress_sync.event_syncer(),
+                    rpc: preconf_ingress_sync.client().clone(),
+                    chain_id: self.config.p2p_config.chain_id,
+                    signer,
+                    beacon_client,
+                    whitelist_address: self.config.whitelist_address,
+                    highest_unsafe_l2_payload_block_id: shared_highest.clone(),
+                    network_command_tx: network.command_tx.clone(),
+                    local_peer_id: network.local_peer_id.to_string(),
+                });
 
-            let server_config = WhitelistRestWsServerConfig {
-                listen_addr,
-                jwt_secret: self.config.rpc_jwt_secret.clone(),
-                cors_origins: self.config.rpc_cors_origins.clone(),
-                ..Default::default()
+                let server_config = WhitelistRestWsServerConfig {
+                    listen_addr,
+                    jwt_secret: self.config.rpc_jwt_secret.clone(),
+                    cors_origins: self.config.rpc_cors_origins.clone(),
+                    ..Default::default()
+                };
+                let server = WhitelistRestWsServer::start(server_config, Arc::new(handler)).await?;
+                info!(
+                    addr = %server.local_addr(),
+                    http_url = %server.http_url(),
+                    ws_url = %server.ws_url(),
+                    "whitelist preconfirmation REST server started"
+                );
+                (Some(server), Some(shared_highest))
+            } else {
+                (None, None)
             };
-            let server = WhitelistRestWsServer::start(server_config, Arc::new(handler)).await?;
-            info!(
-                addr = %server.local_addr(),
-                http_url = %server.http_url(),
-                ws_url = %server.ws_url(),
-                "whitelist preconfirmation REST server started"
-            );
-            Some(server)
-        } else {
-            None
-        };
 
         let mut importer = WhitelistPreconfirmationImporter::new(
             preconf_ingress_sync.event_syncer(),
@@ -283,6 +288,7 @@ impl WhitelistPreconfirmationDriverRunner {
             self.config.whitelist_address,
             self.config.p2p_config.chain_id,
             network.command_tx.clone(),
+            shared_highest_unsafe,
         );
         let mut epoch_tick = time::interval(Duration::from_secs(L1_EPOCH_DURATION_SECS));
 


### PR DESCRIPTION
 ## Summary

  Fixes current Shasta driver startup behavior for two real-world bootstrap cases:

  1) Forkchoice payload handling in whitelist driver now uses explicit JSON pre-serialization in FCU calls, matching existing engine new payload behavior.
  2) Event sync bootstrap no longer fails fatally when finality is not yet available; it waits and retries instead of exiting.