### PR TITLE
fix(taiko-client-rs): add DNS support to libp2p transport configuration

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
@@ -30,7 +30,7 @@ http-body-util = { workspace = true }
 lru = "0.12"
 jsonwebtoken = "9"
 kona-gossip = { git = "https://github.com/op-rs/kona", package = "kona-gossip", tag = "kona-client/v1.2.4", default-features = false }
-libp2p = { version = "0.56.0", features = ["tcp", "gossipsub", "ping", "identify", "noise", "yamux", "macros", "tokio"] }
+libp2p = { version = "0.56.0", features = ["tcp", "dns", "gossipsub", "ping", "identify", "noise", "yamux", "macros", "tokio"] }
 metrics = { workspace = true }
 preconfirmation-net = { path = "../../../preconfirmation-p2p/crates/net" }
 protocol = { path = "../protocol" }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
@@ -27,10 +27,10 @@ hashlink = "0.10"
 http = "1"
 http-body = "1"
 http-body-util = { workspace = true }
-lru = "0.12"
 jsonwebtoken = "9"
 kona-gossip = { git = "https://github.com/op-rs/kona", package = "kona-gossip", tag = "kona-client/v1.2.4", default-features = false }
 libp2p = { version = "0.56.0", features = ["tcp", "dns", "gossipsub", "ping", "identify", "noise", "yamux", "macros", "tokio"] }
+lru = "0.12"
 metrics = { workspace = true }
 preconfirmation-net = { path = "../../../preconfirmation-p2p/crates/net" }
 protocol = { path = "../protocol" }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, sync::Arc, time::Instant};
 use alloy_primitives::B256;
 use futures::StreamExt;
 use libp2p::{
-    dns, Multiaddr, PeerId, Swarm, Transport, core::upgrade, gossipsub, identify, identity, noise,
+    Multiaddr, PeerId, Swarm, Transport, core::upgrade, dns, gossipsub, identify, identity, noise,
     ping, swarm::NetworkBehaviour, tcp, yamux,
 };
 use preconfirmation_net::{P2pConfig, spawn_discovery};
@@ -225,8 +225,7 @@ impl WhitelistNetwork {
 
         let noise_config = noise::Config::new(&local_key).map_err(to_p2p_err)?;
         let base_tcp = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true));
-        let tcp_with_dns =
-            dns::tokio::Transport::system(base_tcp).map_err(to_p2p_err)?;
+        let tcp_with_dns = dns::tokio::Transport::system(base_tcp).map_err(to_p2p_err)?;
         let transport = tcp_with_dns
             .upgrade(upgrade::Version::V1Lazy)
             .authenticate(noise_config)

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network.rs
@@ -4,8 +4,8 @@ use std::{collections::HashSet, sync::Arc, time::Instant};
 use alloy_primitives::B256;
 use futures::StreamExt;
 use libp2p::{
-    Multiaddr, PeerId, Swarm, Transport, core::upgrade, gossipsub, identify, identity, noise, ping,
-    swarm::NetworkBehaviour, tcp, yamux,
+    dns, Multiaddr, PeerId, Swarm, Transport, core::upgrade, gossipsub, identify, identity, noise,
+    ping, swarm::NetworkBehaviour, tcp, yamux,
 };
 use preconfirmation_net::{P2pConfig, spawn_discovery};
 use sha2::{Digest, Sha256};
@@ -224,7 +224,10 @@ impl WhitelistNetwork {
         };
 
         let noise_config = noise::Config::new(&local_key).map_err(to_p2p_err)?;
-        let transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true))
+        let base_tcp = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true));
+        let tcp_with_dns =
+            dns::tokio::Transport::system(base_tcp).map_err(to_p2p_err)?;
+        let transport = tcp_with_dns
             .upgrade(upgrade::Version::V1Lazy)
             .authenticate(noise_config)
             .multiplex(yamux::Config::default())


### PR DESCRIPTION
This enables using static peers in docker compose like this:
`--p2p.static-peers=/dns4/taiko-driver-2/tcp/9000`