### PR TITLE
fix(eventindexer): add defer Close() to event iterators

### DIFF
--- a/packages/eventindexer/indexer/save_batch_proposed_event.go
+++ b/packages/eventindexer/indexer/save_batch_proposed_event.go
@@ -24,6 +24,7 @@ func (i *Indexer) saveBatchProposedEvents(
 		slog.Info("no batchProposed events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 

--- a/packages/eventindexer/indexer/save_batches_proved_event.go
+++ b/packages/eventindexer/indexer/save_batches_proved_event.go
@@ -23,6 +23,7 @@ func (i *Indexer) saveBatchesProvedEvents(
 		slog.Info("no batchesProved events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 

--- a/packages/eventindexer/indexer/save_batches_verified_event.go
+++ b/packages/eventindexer/indexer/save_batches_verified_event.go
@@ -23,6 +23,7 @@ func (i *Indexer) saveBatchesVerifiedEvents(
 		slog.Info("no BatchesVerified events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 

--- a/packages/eventindexer/indexer/save_block_proposed_event.go
+++ b/packages/eventindexer/indexer/save_block_proposed_event.go
@@ -24,6 +24,7 @@ func (i *Indexer) saveBlockProposedEvents(
 		slog.Info("no blockProposed events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 
@@ -113,6 +114,7 @@ func (i *Indexer) saveBlockProposedEventsV2(
 		slog.Info("no blockProposedV2 events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 

--- a/packages/eventindexer/indexer/save_block_verified_event.go
+++ b/packages/eventindexer/indexer/save_block_verified_event.go
@@ -23,6 +23,7 @@ func (i *Indexer) saveBlockVerifiedEvents(
 		slog.Info("no BlockVerified events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 
@@ -98,6 +99,7 @@ func (i *Indexer) saveBlockVerifiedEventsV2(
 		slog.Info("no BlockVerified events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 

--- a/packages/eventindexer/indexer/save_message_sent_event.go
+++ b/packages/eventindexer/indexer/save_message_sent_event.go
@@ -24,6 +24,7 @@ func (i *Indexer) saveMessageSentEvents(
 
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 

--- a/packages/eventindexer/indexer/save_proposed_event.go
+++ b/packages/eventindexer/indexer/save_proposed_event.go
@@ -23,6 +23,7 @@ func (i *Indexer) saveProposedEvents(
 		slog.Info("no Proposed events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 

--- a/packages/eventindexer/indexer/save_proved_event.go
+++ b/packages/eventindexer/indexer/save_proved_event.go
@@ -23,6 +23,7 @@ func (i *Indexer) saveProvedEvents(
 		slog.Info("no Proved events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 

--- a/packages/eventindexer/indexer/save_transition_contested_event.go
+++ b/packages/eventindexer/indexer/save_transition_contested_event.go
@@ -22,6 +22,7 @@ func (i *Indexer) saveTransitionContestedEvents(
 		slog.Info("no transitionContested events")
 		return nil
 	}
+	defer events.Close()
 
 	for {
 		event := events.Event
@@ -91,6 +92,7 @@ func (i *Indexer) saveTransitionContestedEventsV2(
 		slog.Info("no transitionContested events")
 		return nil
 	}
+	defer events.Close()
 
 	for {
 		event := events.Event

--- a/packages/eventindexer/indexer/save_transition_proved_event.go
+++ b/packages/eventindexer/indexer/save_transition_proved_event.go
@@ -23,6 +23,7 @@ func (i *Indexer) saveTransitionProvedEvents(
 		slog.Info("no transitionProved events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 
@@ -101,6 +102,7 @@ func (i *Indexer) saveTransitionProvedEventsV2(
 		slog.Info("no transitionProved events")
 		return nil
 	}
+	defer events.Close()
 
 	wg, ctx := errgroup.WithContext(ctx)
 


### PR DESCRIPTION
Event iterators returned from Filter* functions contain an internal subscription that must be released via Close(). Without calling Close(), the subscription's resources (channels, goroutines) are never freed, causing a memory leak.

This commit adds [defer events.Close()]https://github.com/taikoxyz/taiko-mono/blob/087a04c1c83504dbbb01ee30e5e5b4358e3f8b29/packages/eventindexer/contracts/shasta/inbox/Inbox.go#L3104-L3109 after the initial Next() check in all save*Events functions across the eventindexer package.