### PR TITLE
feat(taiko-client): align `setL1OriginSignature` RPC encoding with taiko-geth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260129032212-a6027c7ecce1
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260224093452-3c2eee10ddf0
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f
 

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082 h1:ymZR+Y88LOnA8i3Ke
 github.com/taikoxyz/hive v0.0.0-20240827015317-405b241dd082/go.mod h1:RHnIu3EFehrWX3JhFAMQSXD5uz7l0xaNroTzXrap7EQ=
 github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f h1:7lZFtV7wip0wmcTquvmtSH5LRp1djzSiDkOeGpIuEN4=
 github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260129032212-a6027c7ecce1 h1:TzrxLKMnVTl/BhJzSD3/NGXLWsf1W9Mz1NS7n1tInPw=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260129032212-a6027c7ecce1/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260224093452-3c2eee10ddf0 h1:K4xxtw+4qJSniFjFpArpiY6dYu4IAH+GGf3ZNHv1jxc=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260224093452-3c2eee10ddf0/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/packages/taiko-client/pkg/rpc/engine.go
+++ b/packages/taiko-client/pkg/rpc/engine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethMath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/node"
@@ -156,7 +157,13 @@ func (c *EngineClient) SetL1OriginSignature(
 ) (*rawdb.L1Origin, error) {
 	var res *rawdb.L1Origin
 
-	if err := c.CallContext(ctx, &res, "taikoAuth_setL1OriginSignature", blockID, signature); err != nil {
+	if err := c.CallContext(
+		ctx,
+		&res,
+		"taikoAuth_setL1OriginSignature",
+		(*ethMath.HexOrDecimal256)(blockID),
+		hexutil.Bytes(signature[:]),
+	); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
ref: https://github.com/taikoxyz/taiko-geth/pull/531

### Summary
This updates `taiko-client` to match the RPC contract changes introduced in taiko-geth commit `3c2eee10ddf0` for `taikoAuth_setL1OriginSignature`.

### Changes
- Updated `packages/taiko-client/pkg/rpc/engine.go`:
  - Send `blockID` as `*math.HexOrDecimal256`
  - Send `signature` as `hexutil.Bytes` (`0x...` hex encoding) instead of `[65]byte` JSON array

### Why
taiko-geth `3c2eee10d` changed `SetL1OriginSignature` to accept:
- `blockID *math.HexOrDecimal256`
- `signature hexutil.Bytes`

Without this client-side encoding update, signature payloads can be serialized in an incompatible format.
