### PR TITLE
fix(taiko-client): close event filter iterators

### DIFF
--- a/packages/taiko-client/driver/txlist_fetcher/calldata.go
+++ b/packages/taiko-client/driver/txlist_fetcher/calldata.go
@@ -35,6 +35,7 @@ func (d *CalldataFetcher) FetchPacaya(ctx context.Context, meta metadata.TaikoBa
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batch proposed filter: %w", err)
 	}
+	defer iter.Close()
 	for iter.Next() {
 		if iter.Event.Meta.BatchId != meta.GetBatchID().Uint64() {
 			continue

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -121,6 +121,7 @@ func (c *Client) ensureGenesisMatched(
 		if err != nil {
 			return err
 		}
+		defer iter.Close()
 		if iter.Next() {
 			l2GenesisHash = iter.Event.BlockHash
 		}
@@ -175,6 +176,7 @@ func (c *Client) filterGenesisBlockVerifiedV2(
 	if err != nil {
 		return common.Hash{}, err
 	}
+	defer iter.Close()
 	if iter.Next() {
 		return iter.Event.BlockHash, nil
 	}
@@ -202,6 +204,7 @@ func (c *Client) filterGenesisBlockVerified(
 	if err != nil {
 		return common.Hash{}, err
 	}
+	defer iter.Close()
 	if iter.Next() {
 		return iter.Event.BlockHash, nil
 	}
@@ -1554,6 +1557,7 @@ func (c *Client) GetProposalByIDShasta(
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to filter proposed events from Shasta Inbox: %w", err)
 	}
+	defer iter.Close()
 
 	var (
 		event *shastaBindings.ShastaInboxClientProposed


### PR DESCRIPTION
 ## Description

  Add `defer iter.Close()` calls to event filter iterators in taiko-client, preventing resource leaks from unclosed subscriptions.

  ## Changes

  This PR fixes resource leaks in 5 locations where event filter iterators were not properly closed:

  **packages/taiko-client/pkg/rpc/methods.go:**
  - Line 124: `FilterBatchesVerified` iterator
  - Line 179: `FilterBlockVerifiedV2` iterator
  - Line 207: `FilterBlockVerified` iterator
  - Line 1560: `FilterProposed` iterator (Shasta)

  **packages/taiko-client/driver/txlist_fetcher/calldata.go:**
  - Line 38: `FilterBatchProposed` iterator

  Each fix adds `defer iter.Close()` immediately after the error check, ensuring the underlying `ethereum.Subscription` is properly unsubscribed and resources (goroutines, channels) are released.

  ## Why

  Event filter iterators hold `ethereum.Subscription` objects that must be explicitly closed via `Unsubscribe()` to prevent:
  - Goroutine leaks (subscription background workers)
  - Channel leaks (logs and error channels)
  - Memory leaks (event buffers)

  Since taiko-client services (driver, proposer, prover) are long-running processes that repeatedly call these filter methods, unclosed iterators accumulate over time and can lead to OOM.