### PR TITLE
refactor(taiko-client-rs): centralize `whitelist-preconfirmation-driver` error handling and harden validation paths

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/handlers.rs
@@ -7,10 +7,8 @@ use axum::{
 
 use super::{
     PRECONF_BLOCKS_BODY_LIMIT_BYTES,
-    http_utils::{
-        RequestBodyReadError, error_response, json_response, map_rest_error_status,
-        no_content_response, read_request_body,
-    },
+    http_error::ApiHttpError,
+    http_utils::{error_response, json_response, no_content_response, read_request_body},
     state::AppState,
     websocket::serve_websocket_notifications,
 };
@@ -24,87 +22,47 @@ struct BuildPreconfBlockRestResponse {
     block_header: alloy_rpc_types::Header,
 }
 
-/// Convert an internal REST API error into a serialized HTTP response.
-fn rest_api_error(err: crate::error::WhitelistPreconfirmationDriverError) -> Response {
-    error_response(map_rest_error_status(&err), err.to_string())
-}
-
 /// Health endpoint handler.
 pub(super) async fn handle_root() -> Response {
     no_content_response(http::StatusCode::OK)
 }
 
 /// Status endpoint handler returning importer/runtime health.
-pub(super) async fn handle_status(State(state): State<AppState>) -> Response {
-    match state.api.get_status().await {
-        Ok(status) => {
-            let response = ApiStatus {
-                highest_unsafe_l2_payload_block_id: status.highest_unsafe_l2_payload_block_id,
-                end_of_sequencing_block_hash: status
-                    .end_of_sequencing_block_hash
-                    .unwrap_or_else(|| alloy_primitives::B256::ZERO.to_string()),
-            };
-            json_response(http::StatusCode::OK, &response)
-        }
-        Err(err) => rest_api_error(err),
-    }
+pub(super) async fn handle_status(State(state): State<AppState>) -> Result<Response, ApiHttpError> {
+    let status = state.api.get_status().await?;
+    let response = ApiStatus {
+        highest_unsafe_l2_payload_block_id: status.highest_unsafe_l2_payload_block_id,
+        end_of_sequencing_block_hash: status
+            .end_of_sequencing_block_hash
+            .unwrap_or_else(|| alloy_primitives::B256::ZERO.to_string()),
+    };
+    Ok(json_response(http::StatusCode::OK, &response))
 }
 
 /// `preconfBlocks` REST endpoint handler.
 pub(super) async fn handle_preconf_blocks(
     State(state): State<AppState>,
     request: Request,
-) -> Response {
-    let status = match state.api.get_status().await {
-        Ok(status) => status,
-        Err(err) => return rest_api_error(err),
-    };
+) -> Result<Response, ApiHttpError> {
+    let status = state.api.get_status().await?;
 
     if !status.sync_ready {
-        return error_response(
-            http::StatusCode::BAD_REQUEST,
+        return Err(ApiHttpError::BadRequest(
             "event sync is not ready to serve preconfBlocks".to_string(),
-        );
+        ));
     }
 
-    let body = match read_request_body(request.into_body(), PRECONF_BLOCKS_BODY_LIMIT_BYTES).await {
-        Ok(body) => body,
-        Err(RequestBodyReadError::TooLarge { max_bytes }) => {
-            return error_response(
-                http::StatusCode::PAYLOAD_TOO_LARGE,
-                format!("request body exceeds maximum of {max_bytes} bytes"),
-            );
-        }
-        Err(err) => {
-            return error_response(
-                http::StatusCode::UNPROCESSABLE_ENTITY,
-                format!("failed to read request body: {err}"),
-            );
-        }
-    };
+    let body = read_request_body(request.into_body(), PRECONF_BLOCKS_BODY_LIMIT_BYTES).await?;
 
-    let rest_request: BuildPreconfBlockApiRequest = match serde_json::from_slice(&body) {
-        Ok(value) => value,
-        Err(err) => {
-            return error_response(
-                http::StatusCode::UNPROCESSABLE_ENTITY,
-                format!("failed to parse request body: {err}"),
-            );
-        }
-    };
+    let rest_request: BuildPreconfBlockApiRequest = serde_json::from_slice(&body)?;
 
-    let request = match rest_request.into_rpc_request() {
-        Ok(request) => request,
-        Err(err) => return error_response(http::StatusCode::BAD_REQUEST, err),
-    };
+    let request = rest_request.into_rpc_request().map_err(ApiHttpError::BadRequest)?;
 
-    match state.api.build_preconf_block(request).await {
-        Ok(response) => json_response(
-            http::StatusCode::OK,
-            &BuildPreconfBlockRestResponse { block_header: response.block_header },
-        ),
-        Err(err) => rest_api_error(err),
-    }
+    let response = state.api.build_preconf_block(request).await?;
+    Ok(json_response(
+        http::StatusCode::OK,
+        &BuildPreconfBlockRestResponse { block_header: response.block_header },
+    ))
 }
 
 /// Upgrade a request to a websocket stream for EOS notifications.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http_error.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http_error.rs
@@ -1,0 +1,76 @@
+//! Typed HTTP error boundary for REST handlers.
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use thiserror::Error;
+use tracing::{error, warn};
+
+use super::http_utils::{RequestBodyReadError, error_response, map_rest_error_status};
+use crate::error::WhitelistPreconfirmationDriverError;
+
+/// Error type returned by REST handlers and converted into JSON HTTP responses.
+#[derive(Debug, Error)]
+pub(super) enum ApiHttpError {
+    /// Driver/service-layer failure propagated from the API implementation.
+    #[error(transparent)]
+    Driver(#[from] WhitelistPreconfirmationDriverError),
+    /// Request-body read failure before JSON parsing.
+    #[error("failed to read request body: {0}")]
+    ReadBody(RequestBodyReadError),
+    /// JSON body parse failure.
+    #[error("failed to parse request body: {0}")]
+    ParseBody(#[from] serde_json::Error),
+    /// Explicit client error response with caller-provided message.
+    #[error("{0}")]
+    BadRequest(String),
+}
+
+impl ApiHttpError {
+    /// Resolve the HTTP status code for this API error.
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::Driver(err) => map_rest_error_status(err),
+            Self::ReadBody(RequestBodyReadError::TooLarge { .. }) => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::ReadBody(_) | Self::ParseBody(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+        }
+    }
+
+    /// Resolve the external error message returned in the JSON response body.
+    fn response_message(&self) -> String {
+        match self {
+            Self::Driver(err) => err.to_string(),
+            Self::ReadBody(RequestBodyReadError::TooLarge { max_bytes }) => {
+                format!("request body exceeds maximum of {max_bytes} bytes")
+            }
+            Self::ReadBody(err) => format!("failed to read request body: {err}"),
+            Self::ParseBody(err) => format!("failed to parse request body: {err}"),
+            Self::BadRequest(message) => message.clone(),
+        }
+    }
+}
+
+impl From<RequestBodyReadError> for ApiHttpError {
+    /// Convert a request-body ingestion failure into an API HTTP boundary error.
+    fn from(value: RequestBodyReadError) -> Self {
+        Self::ReadBody(value)
+    }
+}
+
+impl IntoResponse for ApiHttpError {
+    /// Convert the typed API error into a JSON HTTP response and emit one boundary log line.
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        let message = self.response_message();
+
+        if status.is_server_error() {
+            error!(%status, error = %self, "whitelist API request failed");
+        } else {
+            warn!(%status, error = %self, "whitelist API request rejected");
+        }
+
+        error_response(status, message)
+    }
+}

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http_utils.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http_utils.rs
@@ -1,5 +1,7 @@
 //! HTTP response helpers, REST status mapping, and body ingestion utilities.
 
+use std::fmt::Display;
+
 use axum::{
     body::Body,
     http::{StatusCode, header::CONTENT_TYPE},
@@ -61,7 +63,7 @@ pub(super) enum RequestBodyReadError {
     },
 }
 
-impl std::fmt::Display for RequestBodyReadError {
+impl Display for RequestBodyReadError {
     /// Render a human-readable error used in HTTP responses and logs.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 
 mod auth;
 mod handlers;
+mod http_error;
 mod http_utils;
 mod router;
 mod state;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -310,6 +310,37 @@ async fn preconf_blocks_enforces_body_limit() {
         .await
         .expect("request should succeed");
     assert_eq!(response.status(), reqwest::StatusCode::PAYLOAD_TOO_LARGE);
+    let payload: serde_json::Value = response.json().await.expect("json body expected");
+    let error = payload
+        .get("error")
+        .and_then(serde_json::Value::as_str)
+        .expect("error field should be a string");
+    assert!(error.starts_with("request body exceeds maximum of "));
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn preconf_blocks_rejects_invalid_json() {
+    let config = test_config(true, false);
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/preconfBlocks", server.http_url()))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body("{")
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+
+    let payload: serde_json::Value = response.json().await.expect("json body expected");
+    let error = payload
+        .get("error")
+        .and_then(serde_json::Value::as_str)
+        .expect("error field should be a string");
+    assert!(error.starts_with("failed to parse request body: "));
 
     server.stop().await;
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/api_impl.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/api_impl.rs
@@ -13,7 +13,7 @@ where
         command_name: &'static str,
     ) -> Result<()> {
         self.network_command_tx.send(command).await.map_err(|err| {
-            WhitelistPreconfirmationDriverError::P2p(format!(
+            WhitelistPreconfirmationDriverError::p2p(format!(
                 "failed to send {command_name} command: {err}"
             ))
         })
@@ -37,8 +37,12 @@ where
         // positive that taiko-geth emits on genesis chains (currentBlock == highestBlock
         // == 0, txIndexRemainingBlocks = 1).  When current == highest the node is not
         // actually catching up to a remote peer, so we allow the build to proceed.
-        let sync_status =
-            self.rpc.l2_provider.syncing().await.map_err(super::compression::provider_err)?;
+        let sync_status = self
+            .rpc
+            .l2_provider
+            .syncing()
+            .await
+            .map_err(WhitelistPreconfirmationDriverError::provider)?;
         if let SyncStatus::Info(ref info) = sync_status &&
             info.current_block < info.highest_block
         {
@@ -65,7 +69,7 @@ where
             .l2_provider
             .get_block_by_number(BlockNumberOrTag::Number(request.block_number))
             .await
-            .map_err(super::compression::provider_err)?
+            .map_err(WhitelistPreconfirmationDriverError::provider)?
             .ok_or(WhitelistPreconfirmationDriverError::MissingInsertedBlock(
                 request.block_number,
             ))?;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/compression.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/compression.rs
@@ -16,9 +16,10 @@ pub(super) fn decompress_tx_list(bytes: &[u8]) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     let read_cap = MAX_DECOMPRESSED_TX_LIST_BYTES.saturating_add(1) as u64;
     decoder.take(read_cap).read_to_end(&mut out).map_err(|err| {
-        WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-            "failed to decompress tx list from payload: {err}"
-        ))
+        WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+            "failed to decompress tx list from payload",
+            err,
+        )
     })?;
 
     if out.len() > MAX_DECOMPRESSED_TX_LIST_BYTES {
@@ -36,9 +37,4 @@ pub(super) fn decompress_tx_list(bytes: &[u8]) -> Result<Vec<u8>> {
     }
 
     Ok(out)
-}
-
-/// Convert a provider error into a driver error.
-pub(super) fn provider_err(err: impl std::fmt::Display) -> WhitelistPreconfirmationDriverError {
-    WhitelistPreconfirmationDriverError::Rpc(rpc::RpcClientError::Provider(err.to_string()))
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
@@ -78,7 +78,7 @@ where
             .l2_provider
             .get_block_by_hash(parent_hash)
             .await
-            .map_err(super::compression::provider_err)?
+            .map_err(WhitelistPreconfirmationDriverError::provider)?
             .ok_or_else(|| {
                 WhitelistPreconfirmationDriverError::InvalidPayload(format!(
                     "parent block not found for hash {parent_hash}"

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for whitelist preconfirmation driver.
 
-use std::result::Result as StdResult;
+use std::{fmt::Display, result::Result as StdResult};
 
 use thiserror::Error;
 
@@ -86,4 +86,68 @@ pub enum WhitelistPreconfirmationDriverError {
     /// RPC client error.
     #[error(transparent)]
     Rpc(#[from] rpc::RpcClientError),
+}
+
+impl WhitelistPreconfirmationDriverError {
+    /// Build an `InvalidPayload` error from a complete message.
+    pub(crate) fn invalid_payload(message: impl Into<String>) -> Self {
+        Self::InvalidPayload(message.into())
+    }
+
+    /// Build an `InvalidSignature` error from a complete message.
+    pub(crate) fn invalid_signature(message: impl Into<String>) -> Self {
+        Self::InvalidSignature(message.into())
+    }
+
+    /// Map an arbitrary provider failure into an RPC provider error variant.
+    pub(crate) fn provider(err: impl Display) -> Self {
+        Self::Rpc(rpc::RpcClientError::Provider(err.to_string()))
+    }
+
+    /// Map an arbitrary P2P failure into a standardized P2P error variant.
+    pub(crate) fn p2p(err: impl Display) -> Self {
+        Self::P2p(err.to_string())
+    }
+
+    /// Build an `InvalidPayload` error by attaching context to an underlying failure.
+    pub(crate) fn invalid_payload_with_context(context: &str, err: impl Display) -> Self {
+        Self::invalid_payload(format!("{context}: {err}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WhitelistPreconfirmationDriverError;
+
+    #[test]
+    fn provider_helper_wraps_error_message() {
+        let err = WhitelistPreconfirmationDriverError::provider("rpc boom");
+        assert!(matches!(
+            err,
+            WhitelistPreconfirmationDriverError::Rpc(rpc::RpcClientError::Provider(msg))
+                if msg == "rpc boom"
+        ));
+    }
+
+    #[test]
+    fn p2p_helper_wraps_error_message() {
+        let err = WhitelistPreconfirmationDriverError::p2p("channel closed");
+        assert!(matches!(
+            err,
+            WhitelistPreconfirmationDriverError::P2p(msg) if msg == "channel closed"
+        ));
+    }
+
+    #[test]
+    fn invalid_payload_with_context_formats_message() {
+        let err = WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+            "failed to parse payload",
+            "bad bytes",
+        );
+        assert!(matches!(
+            err,
+            WhitelistPreconfirmationDriverError::InvalidPayload(msg)
+                if msg == "failed to parse payload: bad bytes"
+        ));
+    }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -17,6 +17,15 @@ use super::{
     validation::{normalize_unsafe_payload_envelope, validate_execution_payload_for_preconf},
 };
 
+/// Increment validation failure metrics for the given ingest stage.
+fn record_validation_failure(stage: &'static str) {
+    metrics::counter!(
+        WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
+        "stage" => stage,
+    )
+    .increment(1);
+}
+
 impl<P> WhitelistPreconfirmationImporter<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
@@ -27,63 +36,44 @@ where
         payload: DecodedUnsafePayload,
     ) -> Result<()> {
         let prehash = block_signing_hash(self.chain_id, payload.payload_bytes.as_slice());
-        let signer = match recover_signer(prehash, &payload.wire_signature) {
-            Ok(signer) => signer,
-            Err(err) => {
-                metrics::counter!(
-                    WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
-                    "stage" => "payload_signature_recover",
-                )
-                .increment(1);
-                return Err(err);
-            }
-        };
-        if let Err(err) = self.ensure_signer_allowed(signer).await {
-            metrics::counter!(
-                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
-                "stage" => "payload_signer_check",
-            )
-            .increment(1);
-            return Err(err);
-        }
+        let signer = recover_signer(prehash, &payload.wire_signature).inspect_err(|_err| {
+            record_validation_failure("payload_signature_recover");
+        })?;
+        self.ensure_signer_allowed(signer).await.inspect_err(|_err| {
+            record_validation_failure("payload_signer_check");
+        })?;
 
         let envelope = normalize_unsafe_payload_envelope(payload.envelope, payload.wire_signature);
-        if let Err(err) = validate_execution_payload_for_preconf(
+        validate_execution_payload_for_preconf(
             &envelope.execution_payload,
             self.chain_id,
             self.anchor_address,
-        ) {
-            metrics::counter!(
-                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
-                "stage" => "payload_validate",
-            )
-            .increment(1);
-            return Err(err);
-        }
+        )
+        .inspect_err(|_err| {
+            record_validation_failure("payload_validate");
+        })?;
         let envelope = Arc::new(envelope);
         self.cache.insert(envelope.clone());
         self.recent_cache.insert_recent(envelope.clone());
         self.update_cache_gauges();
 
         if envelope.end_of_sequencing.unwrap_or(false) {
-            match self.beacon_client.timestamp_to_epoch(envelope.execution_payload.timestamp) {
-                Ok(epoch) => {
-                    debug!(
-                        epoch,
-                        hash = %envelope.execution_payload.block_hash,
-                        "recording end-of-sequencing envelope for epoch on payload ingress"
-                    );
-                    self.cache_state
-                        .record_end_of_sequencing(epoch, envelope.execution_payload.block_hash)
-                        .await;
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        timestamp = envelope.execution_payload.timestamp,
-                        error = %err,
-                        "failed to derive epoch from payload timestamp for EOS recording"
-                    );
-                }
+            let timestamp = envelope.execution_payload.timestamp;
+            if let Ok(epoch) = self.beacon_client.timestamp_to_epoch(timestamp).inspect_err(|err| {
+                tracing::warn!(
+                    timestamp,
+                    error = %err,
+                    "failed to derive epoch from payload timestamp for EOS recording"
+                );
+            }) {
+                debug!(
+                    epoch,
+                    hash = %envelope.execution_payload.block_hash,
+                    "recording end-of-sequencing envelope for epoch on payload ingress"
+                );
+                self.cache_state
+                    .record_end_of_sequencing(epoch, envelope.execution_payload.block_hash)
+                    .await;
             }
         }
 
@@ -96,50 +86,29 @@ where
         envelope: WhitelistExecutionPayloadEnvelope,
     ) -> Result<()> {
         let Some(signature) = envelope.signature else {
-            metrics::counter!(
-                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
-                "stage" => "response_missing_signature",
-            )
-            .increment(1);
-            return Err(WhitelistPreconfirmationDriverError::InvalidSignature(
-                "response payload is missing embedded signature".to_string(),
+            record_validation_failure("response_missing_signature");
+            return Err(WhitelistPreconfirmationDriverError::invalid_signature(
+                "response payload is missing embedded signature",
             ));
         };
 
         let prehash =
             block_signing_hash(self.chain_id, envelope.execution_payload.block_hash.as_slice());
-        let signer = match recover_signer(prehash, &signature) {
-            Ok(signer) => signer,
-            Err(err) => {
-                metrics::counter!(
-                    WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
-                    "stage" => "response_signature_recover",
-                )
-                .increment(1);
-                return Err(err);
-            }
-        };
-        if let Err(err) = self.ensure_signer_allowed(signer).await {
-            metrics::counter!(
-                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
-                "stage" => "response_signer_check",
-            )
-            .increment(1);
-            return Err(err);
-        }
+        let signer = recover_signer(prehash, &signature).inspect_err(|_err| {
+            record_validation_failure("response_signature_recover");
+        })?;
+        self.ensure_signer_allowed(signer).await.inspect_err(|_err| {
+            record_validation_failure("response_signer_check");
+        })?;
 
-        if let Err(err) = validate_execution_payload_for_preconf(
+        validate_execution_payload_for_preconf(
             &envelope.execution_payload,
             self.chain_id,
             self.anchor_address,
-        ) {
-            metrics::counter!(
-                WhitelistPreconfirmationDriverMetrics::VALIDATION_FAILURES_TOTAL,
-                "stage" => "response_validate",
-            )
-            .increment(1);
-            return Err(err);
-        }
+        )
+        .inspect_err(|_err| {
+            record_validation_failure("response_validate");
+        })?;
 
         let envelope = Arc::new(envelope);
         self.cache.insert(envelope.clone());
@@ -147,24 +116,22 @@ where
         self.update_cache_gauges();
 
         if envelope.end_of_sequencing.unwrap_or(false) {
-            match self.beacon_client.timestamp_to_epoch(envelope.execution_payload.timestamp) {
-                Ok(epoch) => {
-                    debug!(
-                        epoch,
-                        hash = %envelope.execution_payload.block_hash,
-                        "recording end-of-sequencing envelope for epoch on response ingress"
-                    );
-                    self.cache_state
-                        .record_end_of_sequencing(epoch, envelope.execution_payload.block_hash)
-                        .await;
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        timestamp = envelope.execution_payload.timestamp,
-                        error = %err,
-                        "failed to derive epoch from response timestamp for EOS recording"
-                    );
-                }
+            let timestamp = envelope.execution_payload.timestamp;
+            if let Ok(epoch) = self.beacon_client.timestamp_to_epoch(timestamp).inspect_err(|err| {
+                tracing::warn!(
+                    timestamp,
+                    error = %err,
+                    "failed to derive epoch from response timestamp for EOS recording"
+                );
+            }) {
+                debug!(
+                    epoch,
+                    hash = %envelope.execution_payload.block_hash,
+                    "recording end-of-sequencing envelope for epoch on response ingress"
+                );
+                self.cache_state
+                    .record_end_of_sequencing(epoch, envelope.execution_payload.block_hash)
+                    .await;
             }
         }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -305,7 +305,7 @@ where
             .get_block_by_number(alloy_eips::BlockNumberOrTag::Number(block_number))
             .await
             .map(|opt| opt.map(|block| block.hash()))
-            .map_err(provider_err)
+            .map_err(WhitelistPreconfirmationDriverError::provider)
     }
 
     /// Update cache gauges after cache mutations.
@@ -315,11 +315,6 @@ where
         metrics::gauge!(WhitelistPreconfirmationDriverMetrics::CACHE_RECENT_COUNT)
             .set(self.recent_cache.len() as f64);
     }
-}
-
-/// Convert a provider error into a driver error.
-pub(super) fn provider_err(err: impl std::fmt::Display) -> WhitelistPreconfirmationDriverError {
-    WhitelistPreconfirmationDriverError::Rpc(rpc::RpcClientError::Provider(err.to_string()))
 }
 
 /// Returns true only when sync readiness transitions from disabled to enabled.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/payload.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/payload.rs
@@ -30,9 +30,7 @@ where
     ) -> Result<TaikoPayloadAttributes> {
         let execution_payload = &envelope.execution_payload;
         let compressed_tx_list = execution_payload.transactions.first().ok_or_else(|| {
-            WhitelistPreconfirmationDriverError::InvalidPayload(
-                "missing transactions list".to_string(),
-            )
+            WhitelistPreconfirmationDriverError::invalid_payload("missing transactions list")
         })?;
         let tx_list = decompress_tx_list(compressed_tx_list)?;
 
@@ -84,7 +82,7 @@ where
 /// Decompress a zlib-compressed transaction list.
 fn decompress_tx_list(bytes: &[u8]) -> Result<Vec<u8>> {
     if bytes.len() > MAX_COMPRESSED_TX_LIST_BYTES {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(format!(
             "compressed tx list exceeds maximum size: {} > {}",
             bytes.len(),
             MAX_COMPRESSED_TX_LIST_BYTES
@@ -95,13 +93,14 @@ fn decompress_tx_list(bytes: &[u8]) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     let read_cap = MAX_DECOMPRESSED_TX_LIST_BYTES.saturating_add(1) as u64;
     decoder.take(read_cap).read_to_end(&mut out).map_err(|err| {
-        WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-            "failed to decompress tx list from payload: {err}"
-        ))
+        WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+            "failed to decompress tx list from payload",
+            err,
+        )
     })?;
 
     if out.len() > MAX_DECOMPRESSED_TX_LIST_BYTES {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(format!(
             "decompressed tx list exceeds maximum size: {} > {}",
             out.len(),
             MAX_DECOMPRESSED_TX_LIST_BYTES
@@ -109,8 +108,8 @@ fn decompress_tx_list(bytes: &[u8]) -> Result<Vec<u8>> {
     }
 
     if out.is_empty() {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-            "decompressed tx list is empty".to_string(),
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(
+            "decompressed tx list is empty",
         ));
     }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/response.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/response.rs
@@ -17,7 +17,6 @@ use crate::{
 
 use super::{
     MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, WhitelistPreconfirmationImporter,
-    provider_err,
 };
 
 impl<P> WhitelistPreconfirmationImporter<P>
@@ -35,7 +34,7 @@ where
             .get_block_by_hash(hash)
             .full()
             .await
-            .map_err(provider_err)?
+            .map_err(WhitelistPreconfirmationDriverError::provider)?
             .map(|block| block.map_transactions(|tx: RpcTransaction| tx.into()))
         else {
             return Ok(None);
@@ -59,8 +58,8 @@ where
         }
 
         let Some(transactions) = block.transactions.as_transactions() else {
-            return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-                "request-response block missing full transaction bodies".to_string(),
+            return Err(WhitelistPreconfirmationDriverError::invalid_payload(
+                "request-response block missing full transaction bodies",
             ));
         };
 
@@ -74,9 +73,10 @@ where
         )
         .encode(&raw_transactions)
         .map_err(|err| {
-            WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                "failed to encode request-response tx list: {err}"
-            ))
+            WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+                "failed to encode request-response tx list",
+                err,
+            )
         })?;
 
         let end_of_sequencing = self
@@ -85,7 +85,7 @@ where
             .and_then(|envelope| envelope.end_of_sequencing)
             .filter(|enabled| *enabled);
         let base_fee = block.header.base_fee_per_gas.ok_or_else(|| {
-            WhitelistPreconfirmationDriverError::InvalidPayload(format!(
+            WhitelistPreconfirmationDriverError::invalid_payload(format!(
                 "request-response block {} missing base fee",
                 block.header.number
             ))

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/signer.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/signer.rs
@@ -2,11 +2,61 @@ use std::time::Instant;
 
 use alloy_primitives::Address;
 use alloy_provider::Provider;
+use thiserror::Error;
 use tracing::debug;
 
 use crate::error::{Result, WhitelistPreconfirmationDriverError};
 
 use super::WhitelistPreconfirmationImporter;
+
+/// Error states produced while validating a signer against current/next whitelist entries.
+#[derive(Debug, Error)]
+enum SignerCheckError {
+    /// The whitelist snapshot is unusable because both operator slots are empty.
+    #[error("both whitelist sequencer slots are zero")]
+    BothSlotsZero,
+    /// The signer is not equal to either current or next whitelist operator.
+    #[error("signer {signer} is not current ({current}) or next ({next}) whitelist sequencer")]
+    SignerMismatch {
+        /// Address recovered from the payload signature.
+        signer: Address,
+        /// Operator currently assigned for this epoch.
+        current: Address,
+        /// Operator assigned for the next epoch.
+        next: Address,
+    },
+}
+
+impl SignerCheckError {
+    /// Convert a signer-check error into the top-level driver error used by callers.
+    fn into_driver_error(self) -> WhitelistPreconfirmationDriverError {
+        match self {
+            Self::BothSlotsZero => {
+                WhitelistPreconfirmationDriverError::WhitelistLookup(self.to_string())
+            }
+            Self::SignerMismatch { .. } => {
+                WhitelistPreconfirmationDriverError::invalid_signature(self.to_string())
+            }
+        }
+    }
+}
+
+/// Validate that `signer` matches either `current` or `next`, with explicit empty-snapshot guard.
+fn validate_signer_pair(
+    signer: Address,
+    current: Address,
+    next: Address,
+) -> std::result::Result<(), SignerCheckError> {
+    if signer == current || signer == next {
+        return Ok(());
+    }
+
+    if current == Address::ZERO && next == Address::ZERO {
+        return Err(SignerCheckError::BothSlotsZero);
+    }
+
+    Err(SignerCheckError::SignerMismatch { signer, current, next })
+}
 
 impl<P> WhitelistPreconfirmationImporter<P>
 where
@@ -21,25 +71,22 @@ where
         let now = Instant::now();
         let result = self.sequencer_fetcher.cached_whitelist_sequencers(now).await?;
 
-        // Check signer match first — a valid next-operator should be accepted even
-        // when current is zero (legitimate during epoch transitions).
-        if signer == result.current || signer == result.next {
-            return Ok(());
-        }
-
-        // Reject when both slots are zero (contract returned no operators).
-        if result.current == Address::ZERO && result.next == Address::ZERO {
-            return Err(WhitelistPreconfirmationDriverError::WhitelistLookup(
-                "both whitelist sequencer slots are zero".to_string(),
-            ));
+        match validate_signer_pair(signer, result.current, result.next) {
+            Ok(()) => return Ok(()),
+            Err(SignerCheckError::BothSlotsZero) => {
+                return Err(SignerCheckError::BothSlotsZero.into_driver_error());
+            }
+            Err(SignerCheckError::SignerMismatch { .. }) => {}
         }
 
         // If values were freshly fetched already, reject immediately.
         if !result.any_from_cache {
-            return Err(WhitelistPreconfirmationDriverError::InvalidSignature(format!(
-                "signer {signer} is not current ({}) or next ({}) whitelist sequencer",
-                result.current, result.next
-            )));
+            return Err(SignerCheckError::SignerMismatch {
+                signer,
+                current: result.current,
+                next: result.next,
+            }
+            .into_driver_error());
         }
 
         if !self.sequencer_fetcher.sequencer_cache.allow_miss_refresh(now) {
@@ -49,10 +96,12 @@ where
                 cached_next = %result.next,
                 "signer mismatch refresh cooldown active; rejecting without L1 re-fetch"
             );
-            return Err(WhitelistPreconfirmationDriverError::InvalidSignature(format!(
-                "signer {signer} is not current ({}) or next ({}) whitelist sequencer",
-                result.current, result.next
-            )));
+            return Err(SignerCheckError::SignerMismatch {
+                signer,
+                current: result.current,
+                next: result.next,
+            }
+            .into_driver_error());
         }
 
         debug!(
@@ -64,19 +113,7 @@ where
         self.sequencer_fetcher.sequencer_cache.invalidate();
         let fresh = self.sequencer_fetcher.cached_whitelist_sequencers(now).await?;
 
-        if signer == fresh.current || signer == fresh.next {
-            return Ok(());
-        }
-
-        if fresh.current == Address::ZERO && fresh.next == Address::ZERO {
-            return Err(WhitelistPreconfirmationDriverError::WhitelistLookup(
-                "both whitelist sequencer slots are zero".to_string(),
-            ));
-        }
-
-        Err(WhitelistPreconfirmationDriverError::InvalidSignature(format!(
-            "signer {signer} is not current ({}) or next ({}) whitelist sequencer",
-            fresh.current, fresh.next
-        )))
+        validate_signer_pair(signer, fresh.current, fresh.next)
+            .map_err(SignerCheckError::into_driver_error)
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
@@ -7,6 +7,7 @@ use alloy_consensus::{
 use alloy_eips::Decodable2718;
 use alloy_primitives::Address;
 use protocol::codec::{TxListCodecError, ZlibTxListCodec};
+use thiserror::Error;
 
 use crate::{
     codec::WhitelistExecutionPayloadEnvelope,
@@ -15,6 +16,52 @@ use crate::{
 
 use super::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES};
 
+/// Validation failures for the first transaction that must be the Shasta anchor call.
+#[derive(Debug, Error)]
+enum AnchorTransactionValidationError {
+    /// Anchor transaction omitted the recipient field.
+    #[error("invalid anchor transaction recipient: <none> (expected {expected})")]
+    MissingRecipient {
+        /// Required anchor contract address.
+        expected: Address,
+    },
+    /// Anchor transaction targeted the wrong contract.
+    #[error("invalid anchor transaction recipient: {actual} (expected {expected})")]
+    UnexpectedRecipient {
+        /// Actual recipient address found in the transaction.
+        actual: Address,
+        /// Required anchor contract address.
+        expected: Address,
+    },
+    /// Anchor transaction carried an unexpected chain id.
+    #[error("failed to get anchor transaction sender: unexpected chain id {actual:?}")]
+    UnexpectedChainId {
+        /// Chain id observed on the transaction.
+        actual: Option<u64>,
+    },
+    /// Sender recovery from signature failed.
+    #[error("failed to get anchor transaction sender: {reason}")]
+    SenderRecovery {
+        /// Underlying recover-signature failure.
+        reason: String,
+    },
+    /// Sender did not match the golden touch account.
+    #[error("invalid anchor transaction sender: {sender}")]
+    UnexpectedSender {
+        /// Sender recovered from the transaction signature.
+        sender: Address,
+    },
+    /// Anchor calldata is too short to include a 4-byte selector.
+    #[error("failed to get anchor transaction method: missing selector")]
+    MissingSelector,
+    /// Anchor selector bytes did not match `ANCHOR_V4_SELECTOR`.
+    #[error("invalid anchor transaction method: {selector:?}")]
+    UnexpectedMethod {
+        /// Four-byte function selector encoded in the anchor transaction calldata.
+        selector: [u8; 4],
+    },
+}
+
 /// Validate execution payload shape for preconfirmation import compatibility.
 pub(crate) fn validate_execution_payload_for_preconf(
     payload: &alloy_rpc_types_engine::ExecutionPayloadV1,
@@ -22,44 +69,40 @@ pub(crate) fn validate_execution_payload_for_preconf(
     anchor_address: Address,
 ) -> Result<()> {
     if payload.timestamp == 0 {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-            "non-zero timestamp is required".to_string(),
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(
+            "non-zero timestamp is required",
         ));
     }
 
     if payload.fee_recipient == Address::ZERO {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-            "empty L2 fee recipient".to_string(),
-        ));
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload("empty L2 fee recipient"));
     }
 
     if payload.gas_limit == 0 {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-            "non-zero gas limit is required".to_string(),
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(
+            "non-zero gas limit is required",
         ));
     }
 
     if payload.base_fee_per_gas.is_zero() {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-            "non-zero base fee per gas is required".to_string(),
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(
+            "non-zero base fee per gas is required",
         ));
     }
 
     if payload.extra_data.is_empty() {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-            "empty extra data".to_string(),
-        ));
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload("empty extra data"));
     }
 
     if payload.transactions.len() != 1 {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-            "only one transaction list is allowed".to_string(),
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(
+            "only one transaction list is allowed",
         ));
     }
 
     let compressed_tx_list = &payload.transactions[0];
     if compressed_tx_list.len() > MAX_COMPRESSED_TX_LIST_BYTES {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(
             "compressed transactions size exceeds max blob data size".to_string(),
         ));
     }
@@ -71,48 +114,55 @@ pub(crate) fn validate_execution_payload_for_preconf(
     .decode(compressed_tx_list)
     .map_err(|err| match err {
         TxListCodecError::ZlibDecode(reason) => {
-            WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                "invalid zlib bytes for transactions: {reason}"
-            ))
+            WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+                "invalid zlib bytes for transactions",
+                reason,
+            )
         }
-        TxListCodecError::RlpDecode(reason) => WhitelistPreconfirmationDriverError::InvalidPayload(
-            format!("invalid RLP bytes for transactions: {reason}"),
-        ),
+        TxListCodecError::RlpDecode(reason) => {
+            WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+                "invalid RLP bytes for transactions",
+                reason,
+            )
+        }
         TxListCodecError::CompressedTooLarge { .. } => {
-            WhitelistPreconfirmationDriverError::InvalidPayload(
+            WhitelistPreconfirmationDriverError::invalid_payload(
                 "compressed transactions size exceeds max blob data size".to_string(),
             )
         }
         TxListCodecError::DecompressedTooLarge { .. } => {
-            WhitelistPreconfirmationDriverError::InvalidPayload(
+            WhitelistPreconfirmationDriverError::invalid_payload(
                 "decompressed transactions size exceeds max tx list size".to_string(),
             )
         }
         TxListCodecError::ZlibEncode(reason) | TxListCodecError::ZlibFinish(reason) => {
-            WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                "invalid transactions list bytes: {reason}"
-            ))
+            WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+                "invalid transactions list bytes",
+                reason,
+            )
         }
     })?;
 
     if txs.is_empty() {
-        return Err(WhitelistPreconfirmationDriverError::InvalidPayload(
-            "empty transactions list, missing anchor transaction".to_string(),
+        return Err(WhitelistPreconfirmationDriverError::invalid_payload(
+            "empty transactions list, missing anchor transaction",
         ));
     }
 
     let mut first_tx_bytes = txs[0].as_slice();
     let first_tx = TxEnvelope::decode_2718(&mut first_tx_bytes).map_err(|err| {
-        WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-            "invalid RLP bytes for transactions: {err}"
-        ))
+        WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+            "invalid RLP bytes for transactions",
+            err,
+        )
     })?;
 
     validate_anchor_transaction_for_preconf(&first_tx, anchor_address, chain_id).map_err(
         |reason| {
-            WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                "invalid anchor transaction: {reason}"
-            ))
+            WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+                "invalid anchor transaction",
+                reason,
+            )
         },
     )?;
 
@@ -124,45 +174,41 @@ fn validate_anchor_transaction_for_preconf(
     tx: &TxEnvelope,
     anchor_address: Address,
     chain_id: u64,
-) -> std::result::Result<(), String> {
-    let to = tx.to().ok_or_else(|| {
-        format!("invalid anchor transaction recipient: <none> (expected {anchor_address})")
-    })?;
+) -> std::result::Result<(), AnchorTransactionValidationError> {
+    let to = tx
+        .to()
+        .ok_or(AnchorTransactionValidationError::MissingRecipient { expected: anchor_address })?;
 
     if to != anchor_address {
-        return Err(format!(
-            "invalid anchor transaction recipient: {to} (expected {anchor_address})"
-        ));
+        return Err(AnchorTransactionValidationError::UnexpectedRecipient {
+            actual: to,
+            expected: anchor_address,
+        });
     }
 
     let actual_chain_id = tx.chain_id();
     if actual_chain_id != Some(chain_id) {
-        return Err(format!(
-            "failed to get anchor transaction sender: unexpected chain id {actual_chain_id:?}"
-        ));
+        return Err(AnchorTransactionValidationError::UnexpectedChainId { actual: actual_chain_id });
     }
 
-    let sender = tx
-        .recover_signer()
-        .map_err(|err| format!("failed to get anchor transaction sender: {err}"))?;
+    let sender = tx.recover_signer().map_err(|err| {
+        AnchorTransactionValidationError::SenderRecovery { reason: err.to_string() }
+    })?;
 
     let golden_touch_address = Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS);
     if sender != golden_touch_address {
-        return Err(format!("invalid anchor transaction sender: {sender}"));
+        return Err(AnchorTransactionValidationError::UnexpectedSender { sender });
     }
 
     let calldata = tx.input();
     if calldata.len() < ANCHOR_V4_SELECTOR.len() {
-        return Err("failed to get anchor transaction method: missing selector".to_string());
+        return Err(AnchorTransactionValidationError::MissingSelector);
     }
 
     let mut selector = [0u8; 4];
     selector.copy_from_slice(&calldata[..4]);
     if selector != *ANCHOR_V4_SELECTOR {
-        return Err(format!(
-            "invalid anchor transaction method: 0x{:02x}{:02x}{:02x}{:02x}",
-            selector[0], selector[1], selector[2], selector[3]
-        ));
+        return Err(AnchorTransactionValidationError::UnexpectedMethod { selector });
     }
 
     Ok(())

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/event_loop.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/event_loop.rs
@@ -298,13 +298,8 @@ pub(super) async fn forward_event(
         metrics::counter!(WhitelistPreconfirmationDriverMetrics::NETWORK_FORWARD_FAILURES_TOTAL)
             .increment(1);
         warn!(error = %err, "whitelist preconfirmation event channel closed");
-        WhitelistPreconfirmationDriverError::P2p(format!(
+        WhitelistPreconfirmationDriverError::p2p(format!(
             "whitelist preconfirmation event channel closed: {err}"
         ))
     })
-}
-
-/// Convert a p2p error into a driver error.
-pub(super) fn to_p2p_err(err: impl std::fmt::Display) -> WhitelistPreconfirmationDriverError {
-    WhitelistPreconfirmationDriverError::P2p(err.to_string())
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/gossip.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/gossip.rs
@@ -3,8 +3,7 @@
 use libp2p::gossipsub;
 use sha2::{Digest, Sha256};
 
-use super::event_loop::to_p2p_err;
-use crate::error::Result;
+use crate::error::{Result, WhitelistPreconfirmationDriverError};
 
 /// Maximum allowed gossip payload size after decompression.
 const MAX_GOSSIP_SIZE_BYTES: usize = kona_gossip::MAX_GOSSIP_SIZE;
@@ -22,9 +21,10 @@ pub(crate) fn build_gossipsub() -> Result<gossipsub::Behaviour> {
         .message_id_fn(message_id)
         .max_transmit_size(MAX_GOSSIP_SIZE_BYTES)
         .build()
-        .map_err(to_p2p_err)?;
+        .map_err(WhitelistPreconfirmationDriverError::p2p)?;
 
-    gossipsub::Behaviour::new(gossipsub::MessageAuthenticity::Anonymous, config).map_err(to_p2p_err)
+    gossipsub::Behaviour::new(gossipsub::MessageAuthenticity::Anonymous, config)
+        .map_err(WhitelistPreconfirmationDriverError::p2p)
 }
 
 /// Compute gossipsub message IDs.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -12,7 +12,7 @@ use tracing::{debug, warn};
 
 use super::{
     bootnodes::{classify_bootnodes, dial_once, recv_discovered_multiaddr},
-    event_loop::{forward_event, handle_swarm_event, to_p2p_err},
+    event_loop::{forward_event, handle_swarm_event},
     gossip::build_gossipsub,
     inbound::GossipsubInboundState,
     types::{Behaviour, NetworkCommand, NetworkEvent, Topics, WhitelistNetwork},
@@ -23,7 +23,7 @@ use crate::{
         encode_unsafe_payload_message, encode_unsafe_request_message,
         encode_unsafe_response_message,
     },
-    error::Result,
+    error::{Result, WhitelistPreconfirmationDriverError},
     metrics::WhitelistPreconfirmationDriverMetrics,
 };
 
@@ -50,10 +50,18 @@ impl WhitelistNetwork {
 
         let topics = Topics::new(cfg.chain_id);
         let mut gossipsub = build_gossipsub()?;
-        gossipsub.subscribe(&topics.preconf_blocks).map_err(to_p2p_err)?;
-        gossipsub.subscribe(&topics.preconf_request).map_err(to_p2p_err)?;
-        gossipsub.subscribe(&topics.preconf_response).map_err(to_p2p_err)?;
-        gossipsub.subscribe(&topics.eos_request).map_err(to_p2p_err)?;
+        gossipsub
+            .subscribe(&topics.preconf_blocks)
+            .map_err(WhitelistPreconfirmationDriverError::p2p)?;
+        gossipsub
+            .subscribe(&topics.preconf_request)
+            .map_err(WhitelistPreconfirmationDriverError::p2p)?;
+        gossipsub
+            .subscribe(&topics.preconf_response)
+            .map_err(WhitelistPreconfirmationDriverError::p2p)?;
+        gossipsub
+            .subscribe(&topics.eos_request)
+            .map_err(WhitelistPreconfirmationDriverError::p2p)?;
 
         let behaviour = Behaviour {
             gossipsub,
@@ -64,9 +72,11 @@ impl WhitelistNetwork {
             )),
         };
 
-        let noise_config = noise::Config::new(&local_key).map_err(to_p2p_err)?;
+        let noise_config =
+            noise::Config::new(&local_key).map_err(WhitelistPreconfirmationDriverError::p2p)?;
         let base_tcp = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true));
-        let tcp_with_dns = dns::tokio::Transport::system(base_tcp).map_err(to_p2p_err)?;
+        let tcp_with_dns = dns::tokio::Transport::system(base_tcp)
+            .map_err(WhitelistPreconfirmationDriverError::p2p)?;
         let transport = tcp_with_dns
             .upgrade(upgrade::Version::V1Lazy)
             .authenticate(noise_config)
@@ -87,8 +97,8 @@ impl WhitelistNetwork {
                 format!("/ip6/{}/tcp/{}", cfg.listen_addr.ip(), cfg.listen_addr.port())
             }
             .parse::<Multiaddr>()
-            .map_err(to_p2p_err)?;
-            swarm.listen_on(listen_addr).map_err(to_p2p_err)?;
+            .map_err(WhitelistPreconfirmationDriverError::p2p)?;
+            swarm.listen_on(listen_addr).map_err(WhitelistPreconfirmationDriverError::p2p)?;
         }
 
         let bootnodes = classify_bootnodes(cfg.bootnodes);

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/whitelist_fetcher.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/whitelist_fetcher.rs
@@ -266,14 +266,11 @@ where
             return Ok(());
         };
 
-        let latest_block =
-            self.l1_provider.get_block_by_number(BlockNumberOrTag::Latest).await.map_err(
-                |err| {
-                    WhitelistPreconfirmationDriverError::Rpc(rpc::RpcClientError::Provider(
-                        err.to_string(),
-                    ))
-                },
-            )?;
+        let latest_block = self
+            .l1_provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await
+            .map_err(WhitelistPreconfirmationDriverError::provider)?;
 
         let Some(block) = latest_block else {
             return Ok(());


### PR DESCRIPTION
## Summary
This PR improves error handling across the whitelist preconfirmation driver by introducing a typed REST error boundary, standardizing driver error construction, and tightening importer validation/error propagation. It also adds targeted tests for API error responses and new error helpers.

## What Changed
- Added `ApiHttpError` in the API server layer and moved REST handlers to return `Result<Response, ApiHttpError>`.
- Centralized HTTP error-to-status/message mapping for:
  - service/driver failures
  - request body read failures (including body-size overflow)
  - JSON parse failures
  - explicit bad-request cases
- Added boundary logging behavior in `IntoResponse`:
  - 5xx => `error!`
  - 4xx => `warn!`
- Added REST tests for:
  - payload-too-large response body/message
  - invalid JSON request body returning `422`
- Added helper constructors on `WhitelistPreconfirmationDriverError`:
  - `provider(...)`
  - `p2p(...)`
  - `invalid_payload(...)`
  - `invalid_signature(...)`
  - `invalid_payload_with_context(...)`
- Replaced duplicated ad-hoc provider/P2P mapping helpers with the centralized error constructors across API/importer/network/fetcher paths.
- Refactored importer ingress validation flow to use `inspect_err(...)` and a shared `record_validation_failure(stage)` metric helper.
- Refactored signer validation:
  - introduced internal `SignerCheckError`
  - split signer-pair checks into a dedicated validator
  - preserved behavior for cache refresh and zero-slot handling with clearer error typing
- Refactored payload/response/anchor validation error paths for clearer, contextualized invalid-payload messages.

## Invariant Notes
- Preserves sync-readiness gating for `preconfBlocks` (`WLP-INV-002`).
- No behavioral changes to stale-boundary/reorg protections (`WLP-INV-003`, `WLP-INV-004`); this is primarily an error-path and observability hardening change.

## Scope
- 19 files changed
- 496 insertions, 318 deletions

## Testing
- Added/updated unit + API tests in:
  - `src/api/server/tests.rs`
  - `src/error.rs`
