### PR TITLE
ci(repo): move test workflows to arc runners

### DIFF
--- a/.github/workflows/preconfirmation-p2p.yml
+++ b/.github/workflows/preconfirmation-p2p.yml
@@ -23,7 +23,7 @@ jobs:
   lint:
     if: ${{ github.event.pull_request.draft == false && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
     name: Lint
-    runs-on: [ubuntu-latest]
+    runs-on: [arc-runner-set]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -61,7 +61,7 @@ jobs:
   test:
     if: ${{ github.event.pull_request.draft == false && !startsWith(github.head_ref, 'release-please') }}
     name: Tests
-    runs-on: [ubuntu-latest]
+    runs-on: [arc-runner-set]
     timeout-minutes: 15
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -23,7 +23,7 @@ jobs:
   lint:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
     name: Lint
-    runs-on: [ubuntu-latest]
+    runs-on: [arc-runner-set]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -41,7 +41,7 @@ jobs:
   integration_tests:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     name: Integration tests
-    runs-on: [ubuntu-latest]
+    runs-on: [arc-runner-set]
     timeout-minutes: 30
     env:
       OLD_FORK_TAIKO_MONO_DIR: old-fork-taiko-mono

--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -23,7 +23,7 @@ jobs:
   lint:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
     name: Lint
-    runs-on: [ubuntu-latest]
+    runs-on: [arc-runner-set]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -61,7 +61,7 @@ jobs:
   test:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     name: Tests
-    runs-on: [ubuntu-latest]
+    runs-on: [arc-runner-set]
     timeout-minutes: 15
     env:
       PROTOCOL_FORK_DIR: protocol-taiko-mono


### PR DESCRIPTION
## Summary
- migrate test workflow jobs from `runs-on: [ubuntu-latest]` to `runs-on: [arc-runner-set]`
- update:
  - `.github/workflows/preconfirmation-p2p.yml`
  - `.github/workflows/taiko-client--test.yml`
  - `.github/workflows/taiko-client-rs--test.yml`