### PR TITLE
 repo: replace placeholder vault names with actual contract names

### DIFF
--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-architecture/bridging.md
@@ -115,7 +115,7 @@ Token bridging requires a **BridgedERC contract** on the destination chain.
 1. The sender calls `sendToken` on the `BridgedERC` contract (destination chain).
 2. The contract **burns** the token and generates a **Merkle proof**.
 3. The recipient submits the **proof** on the canonical chain.
-4. The canonical **TokenVault contract** releases the original token.
+4. The canonical **ERC20Vault**, **ERC721Vault**, or **ERC1155Vault** contract releases the original token.
 
 ## Summary
 

--- a/packages/protocol/docs/actors_privileges_deployments.md
+++ b/packages/protocol/docs/actors_privileges_deployments.md
@@ -24,7 +24,7 @@ In the context of the smart contract system, various actors play distinct roles.
   - The right to trigger transferring/minting the tokens (on destination chain) (be it ERC20, ERC721, ERC1155) from the vault contracts
   - The right to trigger releasing the custodied assets on the source chain (if bridging is not successful)
 
-### 1.3 ERCXXX_Vault
+### 1.3 ERC20Vault / ERC721Vault / ERC1155Vault
 
 - **Role**: This role is given to respective token vault contracts (ERC20, ERC721, ERC1155)
 - **Privileges**:


### PR DESCRIPTION
 Two docs referenced vault contracts with placeholder names (`ERCXXX_Vault`, `TokenVault contract`) instead of the real implementations.

  The actual contracts — `ERC20Vault`, `ERC721Vault`, and `ERC1155Vault` — exist in `packages/protocol/contracts/shared/vault/`. Using placeholder names in docs is misleading and makes it harder for developers to locate the right contracts.

  This replaces both occurrences with the correct contract names.