### PR TITLE
chore(taiko-client-rs): bump Docker build Rust toolchain

### DIFF
--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 [workspace.package]
 version = "2.0.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.91"
 authors = ["Taiko Labs"]
 license = "MIT"
 repository = "https://github.com/taikoxyz/taiko-mono"

--- a/packages/taiko-client-rs/Dockerfile
+++ b/packages/taiko-client-rs/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app/packages/taiko-client-rs
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/packages/taiko-client-rs/target \
-    cargo build --release && \
+    cargo build --release --locked && \
     cp /app/packages/taiko-client-rs/target/release/taiko-client /tmp/taiko-client
 
 FROM ubuntu:22.04

--- a/packages/taiko-client-rs/Dockerfile
+++ b/packages/taiko-client-rs/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88 AS build
+FROM rust:1.91 AS build
 
 WORKDIR /app
 

--- a/packages/taiko-client-rs/clippy.toml
+++ b/packages/taiko-client-rs/clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.88"
+msrv = "1.91"
 too-large-for-stack = 128
 doc-valid-idents = [
   "P2P",


### PR DESCRIPTION
To fix: https://github.com/taikoxyz/taiko-mono/actions/runs/22510701319/job/65219152934

## Summary
- Update the taiko-client-rs Docker builder image from `rust:1.88` to `rust:1.91` in [Dockerfile](/Users/davidcai/taiko/taiko-mono/packages/taiko-client-rs/Dockerfile).
- No application code or dependency lockfile changes.

## Why
- CI failed because the current lockfile resolves `alloy` crates at `1.4.3"`, which require `rustc 1.91`.
- The previous Docker build stage used Rust 1.88, causing `cargo build --release` to fail with MSRV mismatch errors.

## Validation
- `cargo +1.91.0 build --release --locked -p taiko-client` passes locally.