### PR TITLE
 refactor(taiko-client): remove unused preconfRouterAddress from Buil…

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -160,7 +160,6 @@ func (s *ChainSyncerTestSuite) TestShastaInvalidBlobs() {
 	txCandidate, err := s.shastaProposalBuilder.BuildShasta(
 		context.Background(),
 		[]types.Transactions{{}},
-		common.Address{},
 	)
 	s.Nil(err)
 	b, err := builder.SplitToBlobs([]byte{0x1})
@@ -207,7 +206,6 @@ func (s *ChainSyncerTestSuite) TestShastaDerivationFetchDoesNotBlockPreconf() {
 	txCandidate, err := s.shastaProposalBuilder.BuildShasta(
 		ctx,
 		[]types.Transactions{{}},
-		common.Address{},
 	)
 	s.Nil(err)
 	s.Nil(s.p.SendTx(ctx, txCandidate))
@@ -290,7 +288,6 @@ func (s *ChainSyncerTestSuite) TestShastaValidBlobs() {
 	txCandidate, err := s.shastaProposalBuilder.BuildShasta(
 		context.Background(),
 		[]types.Transactions{{}},
-		common.Address{},
 	)
 	s.Nil(err)
 	s.Nil(s.p.SendTx(context.Background(), txCandidate))
@@ -346,7 +343,6 @@ func (s *ChainSyncerTestSuite) TestShastaProposalWithMultipleBlocks() {
 	txCandidate, err := s.shastaProposalBuilder.BuildShasta(
 		context.Background(),
 		[]types.Transactions{{testTx1}, {testTx2}},
-		common.Address{},
 	)
 	s.Nil(err)
 	s.Nil(s.p.SendTx(context.Background(), txCandidate))
@@ -395,7 +391,6 @@ func (s *ChainSyncerTestSuite) TestShastaProposalWithOneBlobAndMultipleBlocks() 
 	txCandidate, err := s.shastaProposalBuilder.BuildShasta(
 		context.Background(),
 		txBatch,
-		common.Address{},
 	)
 	s.Nil(err)
 
@@ -444,7 +439,6 @@ func (s *ChainSyncerTestSuite) TestShastaProposalWithTooMuchBlocks() {
 	txCandidate, err := s.shastaProposalBuilder.BuildShasta(
 		context.Background(),
 		txBatch,
-		common.Address{},
 	)
 	s.Nil(err)
 	s.Nil(s.p.SendTx(context.Background(), txCandidate))
@@ -532,7 +526,6 @@ func (s *ChainSyncerTestSuite) TestShastaProposalsWithInvalidForcedInclusion() {
 	txCandidate, err := s.shastaProposalBuilder.BuildShasta(
 		context.Background(),
 		[]types.Transactions{{}},
-		common.Address{},
 	)
 	s.Nil(err)
 	txCandidate.GasLimit = 0
@@ -612,7 +605,6 @@ func (s *ChainSyncerTestSuite) TestShastaProposalsWithForcedInclusion() {
 	txCandidate, err := s.shastaProposalBuilder.BuildShasta(
 		context.Background(),
 		[]types.Transactions{{}},
-		common.Address{},
 	)
 	s.Nil(err)
 	txCandidate.GasLimit = 0

--- a/packages/taiko-client/proposer/proposer.go
+++ b/packages/taiko-client/proposer/proposer.go
@@ -508,7 +508,6 @@ func (p *Proposer) ProposeTxListShasta(ctx context.Context, txBatch []types.Tran
 	txCandidate, err := p.txBuilder.BuildShasta(
 		ctx,
 		txBatch,
-		p.preconfRouterAddress,
 	)
 	if err != nil {
 		log.Warn("Failed to build Shasta Inbox.propose transaction", "error", encoding.TryParsingCustomError(err))

--- a/packages/taiko-client/proposer/transaction_builder/blob.go
+++ b/packages/taiko-client/proposer/transaction_builder/blob.go
@@ -174,7 +174,6 @@ func (b *BlobTransactionBuilder) BuildPacaya(
 func (b *BlobTransactionBuilder) BuildShasta(
 	ctx context.Context,
 	txBatch []types.Transactions,
-	preconfRouterAddress common.Address,
 ) (*txmgr.TxCandidate, error) {
 	var (
 		to                       = &b.shastaInboxAddress

--- a/packages/taiko-client/proposer/transaction_builder/calldata.go
+++ b/packages/taiko-client/proposer/transaction_builder/calldata.go
@@ -157,8 +157,6 @@ func (b *CalldataTransactionBuilder) BuildPacaya(
 func (b *CalldataTransactionBuilder) BuildShasta(
 	ctx context.Context,
 	txBatch []types.Transactions,
-	minTxsPerForcedInclusion *big.Int,
-	preconfRouterAddress common.Address,
 ) (*txmgr.TxCandidate, error) {
 	return nil, fmt.Errorf("CalldataTransactionBuilder does not support BuildShasta")
 }

--- a/packages/taiko-client/proposer/transaction_builder/common.go
+++ b/packages/taiko-client/proposer/transaction_builder/common.go
@@ -26,7 +26,6 @@ type ProposeBatchTransactionBuilder interface {
 	BuildShasta(
 		ctx context.Context,
 		txBatch []types.Transactions,
-		preconfRouterAddress common.Address,
 	) (*txmgr.TxCandidate, error)
 }
 

--- a/packages/taiko-client/proposer/transaction_builder/fallback.go
+++ b/packages/taiko-client/proposer/transaction_builder/fallback.go
@@ -189,7 +189,6 @@ func (b *TxBuilderWithFallback) BuildPacaya(
 func (b *TxBuilderWithFallback) BuildShasta(
 	ctx context.Context,
 	txBatch []types.Transactions,
-	preconfRouterAddress common.Address,
 ) (*txmgr.TxCandidate, error) {
 	// Shasta requires blob transactions for proposal data availability.
 	if b.blobTransactionBuilder == nil {
@@ -198,7 +197,6 @@ func (b *TxBuilderWithFallback) BuildShasta(
 	return b.blobTransactionBuilder.BuildShasta(
 		ctx,
 		txBatch,
-		preconfRouterAddress,
 	)
 }
 


### PR DESCRIPTION
 In the recent commit e5312443, the redirection to preconfRouterAddress was correctly removed from BlobTransactionBuilder.BuildShasta. However, the parameter was left hanging in the interface and its implementations, forcing callers and tests to pass unused variables (or empty addresses).
  This PR cleans up the technical debt by:
   1. Removing preconfRouterAddress from the ProposeBatchTransactionBuilder.BuildShasta interface.
   2. Removing it from BlobTransactionBuilder, TxBuilderWithFallback, and CalldataTransactionBuilder.
   3. Fixing an existing signature mismatch in CalldataTransactionBuilder.BuildShasta (which incorrectly contained an extra minTxsPerForcedInclusion param, failing to strictly implement the old interface).
   4. Cleaning up all callers in proposer.go and the mock invocations in chain_syncer_test.go.