### PR TITLE
ci(repo): install make on ARC runners

### DIFF
--- a/.github/actions/ensure-make/action.yml
+++ b/.github/actions/ensure-make/action.yml
@@ -1,0 +1,49 @@
+name: Ensure make is available
+description: Install make on runners where it is missing
+
+runs:
+  using: composite
+  steps:
+    - name: Install make when missing
+      shell: bash
+      run: |
+        if command -v make >/dev/null 2>&1; then
+          echo "make already installed"
+          exit 0
+        fi
+
+        if [ "$(id -u)" -eq 0 ]; then
+          SUDO=""
+        elif command -v sudo >/dev/null 2>&1; then
+          SUDO="sudo"
+        else
+          echo "make is missing and this runner is non-root without sudo; cannot install make"
+          exit 1
+        fi
+
+        run_with_privileges() {
+          if [ -n "$SUDO" ]; then
+            $SUDO "$@"
+          else
+            "$@"
+          fi
+        }
+
+        if command -v apt-get >/dev/null 2>&1; then
+          run_with_privileges apt-get update -qq
+          run_with_privileges apt-get install -y -q make
+        elif command -v apk >/dev/null 2>&1; then
+          run_with_privileges apk add --no-cache make
+        elif command -v dnf >/dev/null 2>&1; then
+          run_with_privileges dnf install -y make
+        elif command -v yum >/dev/null 2>&1; then
+          run_with_privileges yum install -y make
+        else
+          echo "Unsupported package manager: cannot install make"
+          exit 1
+        fi
+
+        if ! command -v make >/dev/null 2>&1; then
+          echo "make installation completed but make is still not available on PATH"
+          exit 1
+        fi

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -35,42 +35,7 @@ jobs:
           cache: true
 
       - name: Ensure make is available
-        run: |
-          if command -v make >/dev/null 2>&1; then
-            echo "make already installed"
-            exit 0
-          fi
-
-          if [ "$(id -u)" -eq 0 ]; then
-            SUDO=""
-          elif command -v sudo >/dev/null 2>&1; then
-            SUDO="sudo"
-          else
-            echo "make is missing and this runner is non-root without sudo; cannot install make"
-            exit 1
-          fi
-
-          run_with_privileges() {
-            if [ -n "$SUDO" ]; then
-              $SUDO "$@"
-            else
-              "$@"
-            fi
-          }
-
-          if command -v apt-get >/dev/null 2>&1; then
-            run_with_privileges apt-get update
-            run_with_privileges apt-get install -y make
-          elif command -v apk >/dev/null 2>&1; then
-            run_with_privileges apk add --no-cache make
-          elif command -v dnf >/dev/null 2>&1; then
-            run_with_privileges dnf install -y make
-          elif command -v yum >/dev/null 2>&1; then
-            run_with_privileges yum install -y make
-          else
-            echo "Unsupported package manager: cannot install make"
-            exit 1
-          fi
+        uses: ./.github/actions/ensure-make
 
       - name: Lint
         working-directory: packages/taiko-client
@@ -112,42 +77,7 @@ jobs:
           cache: true
 
       - name: Ensure make is available
-        run: |
-          if command -v make >/dev/null 2>&1; then
-            echo "make already installed"
-            exit 0
-          fi
-
-          if [ "$(id -u)" -eq 0 ]; then
-            SUDO=""
-          elif command -v sudo >/dev/null 2>&1; then
-            SUDO="sudo"
-          else
-            echo "make is missing and this runner is non-root without sudo; cannot install make"
-            exit 1
-          fi
-
-          run_with_privileges() {
-            if [ -n "$SUDO" ]; then
-              $SUDO "$@"
-            else
-              "$@"
-            fi
-          }
-
-          if command -v apt-get >/dev/null 2>&1; then
-            run_with_privileges apt-get update
-            run_with_privileges apt-get install -y make
-          elif command -v apk >/dev/null 2>&1; then
-            run_with_privileges apk add --no-cache make
-          elif command -v dnf >/dev/null 2>&1; then
-            run_with_privileges dnf install -y make
-          elif command -v yum >/dev/null 2>&1; then
-            run_with_privileges yum install -y make
-          else
-            echo "Unsupported package manager: cannot install make"
-            exit 1
-          fi
+        uses: ./.github/actions/ensure-make
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -41,13 +41,32 @@ jobs:
             exit 0
           fi
 
+          if [ "$(id -u)" -eq 0 ]; then
+            SUDO=""
+          elif command -v sudo >/dev/null 2>&1; then
+            SUDO="sudo"
+          else
+            echo "make is missing and this runner is non-root without sudo; cannot install make"
+            exit 1
+          fi
+
+          run_with_privileges() {
+            if [ -n "$SUDO" ]; then
+              $SUDO "$@"
+            else
+              "$@"
+            fi
+          }
+
           if command -v apt-get >/dev/null 2>&1; then
-            apt-get update
-            apt-get install -y make
+            run_with_privileges apt-get update
+            run_with_privileges apt-get install -y make
           elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache make
+            run_with_privileges apk add --no-cache make
+          elif command -v dnf >/dev/null 2>&1; then
+            run_with_privileges dnf install -y make
           elif command -v yum >/dev/null 2>&1; then
-            yum install -y make
+            run_with_privileges yum install -y make
           else
             echo "Unsupported package manager: cannot install make"
             exit 1
@@ -99,13 +118,32 @@ jobs:
             exit 0
           fi
 
+          if [ "$(id -u)" -eq 0 ]; then
+            SUDO=""
+          elif command -v sudo >/dev/null 2>&1; then
+            SUDO="sudo"
+          else
+            echo "make is missing and this runner is non-root without sudo; cannot install make"
+            exit 1
+          fi
+
+          run_with_privileges() {
+            if [ -n "$SUDO" ]; then
+              $SUDO "$@"
+            else
+              "$@"
+            fi
+          }
+
           if command -v apt-get >/dev/null 2>&1; then
-            apt-get update
-            apt-get install -y make
+            run_with_privileges apt-get update
+            run_with_privileges apt-get install -y make
           elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache make
+            run_with_privileges apk add --no-cache make
+          elif command -v dnf >/dev/null 2>&1; then
+            run_with_privileges dnf install -y make
           elif command -v yum >/dev/null 2>&1; then
-            yum install -y make
+            run_with_privileges yum install -y make
           else
             echo "Unsupported package manager: cannot install make"
             exit 1

--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -34,6 +34,25 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Ensure make is available
+        run: |
+          if command -v make >/dev/null 2>&1; then
+            echo "make already installed"
+            exit 0
+          fi
+
+          if command -v apt-get >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y make
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache make
+          elif command -v yum >/dev/null 2>&1; then
+            yum install -y make
+          else
+            echo "Unsupported package manager: cannot install make"
+            exit 1
+          fi
+
       - name: Lint
         working-directory: packages/taiko-client
         run: make lint
@@ -72,6 +91,25 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Ensure make is available
+        run: |
+          if command -v make >/dev/null 2>&1; then
+            echo "make already installed"
+            exit 0
+          fi
+
+          if command -v apt-get >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y make
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache make
+          elif command -v yum >/dev/null 2>&1; then
+            yum install -y make
+          else
+            echo "Unsupported package manager: cannot install make"
+            exit 1
+          fi
 
       - name: Install pnpm dependencies
         uses: ./.github/actions/install-pnpm-dependencies


### PR DESCRIPTION
## Summary
- add a preflight step in taiko-client CI jobs to ensure `make` is available
- install `make` via the detected package manager when missing
- keep lint and integration jobs unchanged aside from dependency preflight

## Why
ARC runner images used by this workflow do not always include `make`, causing failures like:
- `make lint`: command not found
- `make test`: command not found

This makes the workflow resilient across ARC runner base images.

## Validation
- inspected failing run [22516861178](https://github.com/taikoxyz/taiko-mono/actions/runs/22516861178) and confirmed the root cause in lint + integration jobs was missing `make`.
