### PR TITLE
chore(docs-site): fix Alethia docs wording consistency

### DIFF
--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/codebase-analysis/sgxverifier-contract.md
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/codebase-analysis/sgxverifier-contract.md
@@ -3,7 +3,7 @@ title: SGXVerifier
 description: Taiko Alethia protocol page for "SGXVerifier.sol".
 ---
 
-[SGXVerifier](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v2.3.0/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol)is a smart contract that implements **SGX (Software Guard Extensions) signature proof verification** on-chain. It ensures the integrity and security of rollup state transitions by **validating SGX-generated signatures**. The contract also manages SGX instance registration, tracking, and lifecycle operations.
+[SGXVerifier](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v2.3.0/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol) is a smart contract that implements **SGX (Software Guard Extensions) signature proof verification** on-chain. It ensures the integrity and security of rollup state transitions by **validating SGX-generated signatures**. The contract also manages SGX instance registration, tracking, and lifecycle operations.
 
 SGX instances are uniquely identified by Ethereum addresses, derived from **an ECDSA public-private key pair** generated within the SGX enclave. The SGXVerifier contract ensures **only authorized instances participate in rollup verification**.
 

--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/codebase-analysis/signalservice-contract.md
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/codebase-analysis/signalservice-contract.md
@@ -3,7 +3,7 @@ title: SignalService
 description: Taiko Alethia protocol page for "SignalService.sol".
 ---
 
-[SignalService](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v2.3.0/packages/protocol/contracts/shared/signal/SignalService.sol) is a **cross-chain signaling contract** that enables **secure message passing** Taiko Alethia. It allows applications to **send signals**, **synchronize chain data**, and **verify signals using Merkle proofs**. The contract ensures that cross-chain messages are **securely persisted and verifiable** without introducing additional trust assumptions.
+[SignalService](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v2.3.0/packages/protocol/contracts/shared/signal/SignalService.sol) is a **cross-chain signaling contract** that enables **secure message passing in Taiko Alethia**. It allows applications to **send signals**, **synchronize chain data**, and **verify signals using Merkle proofs**. The contract ensures that cross-chain messages are **securely persisted and verifiable** without introducing additional trust assumptions.
 
 ## Features
 

--- a/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-design/pacaya-fork-taiko-alethia.mdx
+++ b/packages/docs-site/src/content/docs/taiko-alethia-protocol/protocol-design/pacaya-fork-taiko-alethia.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pacaya Fork Taiko Alethia
-description: Taiko Alethia protocol page for the upcoming Pacaya fork.
+description: Taiko Alethia protocol page for the Pacaya fork.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -31,7 +31,7 @@ The Pacaya fork will contain some major protocol contract changes. Here is a bri
 
 - **TaikoL2 Contract:** The TaikoL2 contract has been replaced by the [TaikoAnchor contract](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v2.3.0/packages/protocol/contracts/layer2/based/TaikoAnchor.sol). The only new function is the `anchorV3` function, which will be used post Pacaya fork. Everything else remains the same.
 
-- **ForcedInclusionStore Contract:** The [ForcedInclusionStore contract](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v2.3.0/packages/protocol/contracts/layer1/forced-inclusion/ForcedInclusionStore.sol) allows the protocol to remain censorship-resistant while in Stage 1 Preconfs. It allows users to submit transactions and force their inclusion irregardless of the preconfers, preventing targeted censorship from malicious preconfers.
+- **ForcedInclusionStore Contract:** The [ForcedInclusionStore contract](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v2.3.0/packages/protocol/contracts/layer1/forced-inclusion/ForcedInclusionStore.sol) allows the protocol to remain censorship-resistant while in Stage 1 Preconfs. It allows users to submit transactions and force their inclusion regardless of the preconfers, preventing targeted censorship from malicious preconfers.
 
 - **ComposeVerifier Contract:** The [ComposeVerifier contract](https://github.com/taikoxyz/taiko-mono/blob/taiko-alethia-protocol-v2.3.0/packages/protocol/contracts/layer1/verifiers/compose/ComposeVerifier.sol) is a new contract that will be used to verify the sgxGeth and sgxReth proofs. It will be responsible for verifying the proofs and ensuring that the batch proofs are valid.
 


### PR DESCRIPTION
  This PR applies four docs-only wording fixes in Taiko Alethia pages to remove inconsistencies and improve clarity, with no change to technical meaning.

  - `pacaya-fork-taiko-alethia.mdx`: changes frontmatter from “upcoming Pacaya fork” to “Pacaya fork”, aligning with the same
  page text that says the transition already happened on May 21, 2025.
  - Replaces “irregardless” with “regardless” (standard usage), also consistent with wording used in `based-
  preconfirmation.mdx`.
  - Fixes a missing space after a Markdown link in `sgxverifier-contract.md`.
  - Fixes grammar in `signalservice-contract.md` (“secure message passing in Taiko Alethia”).

  These are factual/grammar corrections only; protocol logic and behavior are unchanged.