### PR TITLE
fix(taiko-client-rs): preconf_tip fallback

### DIFF
--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -160,11 +160,9 @@ impl<I: InboxReader + 'static> DriverClient for EmbeddedDriverClient<I> {
     }
 
     /// Returns the current confirmed event-sync L2 block number.
-    /// Falls back to `preconf_tip` when `head_l1_origin` has not been established yet,
-    /// which avoids a full-history catch-up on restart when preconfirmed blocks already exist.
     async fn event_sync_tip(&self) -> Result<U256> {
         let snapshot = self.inbox_reader.confirmed_sync_snapshot().await?;
-        super::traits::resolve_event_sync_tip(&snapshot, || self.preconf_tip()).await
+        super::traits::resolve_event_sync_tip(&snapshot).await
     }
 
     /// Returns the current preconfirmation tip block number.
@@ -356,17 +354,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_event_sync_tip_falls_back_to_preconf_tip_when_head_l1_origin_missing() {
+    async fn test_event_sync_tip_falls_back_to_zero_when_head_l1_origin_missing() {
         let (client, _, inbox_reader, preconf_tip_tx) = make_client();
         inbox_reader.set_head_l1_origin(None);
 
-        // With default preconf_tip (0), fallback returns 0.
-        let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
+        let tip = client.event_sync_tip().await.expect("should fall back to zero on genesis");
         assert_eq!(tip, U256::ZERO);
 
-        // When preconf_tip advances, the fallback follows it.
         preconf_tip_tx.send(U256::from(42)).unwrap();
-        let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
-        assert_eq!(tip, U256::from(42));
+        let tip = client.event_sync_tip().await.expect("should still fall back to zero on genesis");
+        assert_eq!(tip, U256::ZERO);
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -162,7 +162,7 @@ impl<I: InboxReader + 'static> DriverClient for EmbeddedDriverClient<I> {
     /// Returns the current confirmed event-sync L2 block number.
     async fn event_sync_tip(&self) -> Result<U256> {
         let snapshot = self.inbox_reader.confirmed_sync_snapshot().await?;
-        super::traits::resolve_event_sync_tip(&snapshot).await
+        super::traits::resolve_event_sync_tip(&snapshot)
     }
 
     /// Returns the current preconfirmation tip block number.
@@ -362,7 +362,8 @@ mod tests {
         assert_eq!(tip, U256::ZERO);
 
         preconf_tip_tx.send(U256::from(42)).unwrap();
-        let tip = client.event_sync_tip().await.expect("should still fall back to zero on genesis");
+    let tip =
+        client.event_sync_tip().await.expect("genesis returns 0 regardless of preconf_tip");
         assert_eq!(tip, U256::ZERO);
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -362,8 +362,10 @@ mod tests {
         assert_eq!(tip, U256::ZERO);
 
         preconf_tip_tx.send(U256::from(42)).unwrap();
-    let tip =
-        client.event_sync_tip().await.expect("genesis returns 0 regardless of preconf_tip");
+        let tip = client
+            .event_sync_tip()
+            .await
+            .expect("genesis returns 0 regardless of preconf_tip");
         assert_eq!(tip, U256::ZERO);
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -163,10 +163,8 @@ impl<I: InboxReader + 'static> DriverClient for EmbeddedDriverClient<I> {
     /// Falls back to `preconf_tip` when `head_l1_origin` has not been established yet,
     /// which avoids a full-history catch-up on restart when preconfirmed blocks already exist.
     async fn event_sync_tip(&self) -> Result<U256> {
-        match self.inbox_reader.confirmed_sync_snapshot().await?.event_sync_tip() {
-            Some(tip) => Ok(U256::from(tip)),
-            None => self.preconf_tip().await,
-        }
+        let snapshot = self.inbox_reader.confirmed_sync_snapshot().await?;
+        super::traits::resolve_event_sync_tip(&snapshot, || self.preconf_tip()).await
     }
 
     /// Returns the current preconfirmation tip block number.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -362,10 +362,7 @@ mod tests {
         assert_eq!(tip, U256::ZERO);
 
         preconf_tip_tx.send(U256::from(42)).unwrap();
-        let tip = client
-            .event_sync_tip()
-            .await
-            .expect("genesis returns 0 regardless of preconf_tip");
+        let tip = client.event_sync_tip().await.expect("genesis returns 0 regardless of preconf_tip");
         assert_eq!(tip, U256::ZERO);
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -160,13 +160,13 @@ impl<I: InboxReader + 'static> DriverClient for EmbeddedDriverClient<I> {
     }
 
     /// Returns the current confirmed event-sync L2 block number.
+    /// Falls back to `preconf_tip` when `head_l1_origin` has not been established yet,
+    /// which avoids a full-history catch-up on restart when preconfirmed blocks already exist.
     async fn event_sync_tip(&self) -> Result<U256> {
-        self.inbox_reader
-            .confirmed_sync_snapshot()
-            .await?
-            .event_sync_tip()
-            .map(U256::from)
-            .ok_or(DriverApiError::EventSyncTipUnknown.into())
+        match self.inbox_reader.confirmed_sync_snapshot().await?.event_sync_tip() {
+            Some(tip) => Ok(U256::from(tip)),
+            None => self.preconf_tip().await,
+        }
     }
 
     /// Returns the current preconfirmation tip block number.
@@ -178,7 +178,6 @@ impl<I: InboxReader + 'static> DriverClient for EmbeddedDriverClient<I> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::PreconfirmationClientError;
     use preconfirmation_types::{Bytes65, PreconfCommitment, Preconfirmation, SignedCommitment};
     use std::sync::{
         Arc,
@@ -359,14 +358,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_event_sync_tip_errors_when_head_l1_origin_missing() {
-        let (client, _, inbox_reader, _) = make_client();
+    async fn test_event_sync_tip_falls_back_to_preconf_tip_when_head_l1_origin_missing() {
+        let (client, _, inbox_reader, preconf_tip_tx) = make_client();
         inbox_reader.set_head_l1_origin(None);
 
-        let err = client.event_sync_tip().await.expect_err("missing head should error");
-        assert!(matches!(
-            err,
-            PreconfirmationClientError::DriverInterface(DriverApiError::EventSyncTipUnknown)
-        ));
+        // With default preconf_tip (0), fallback returns 0.
+        let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
+        assert_eq!(tip, U256::ZERO);
+
+        // When preconf_tip advances, the fallback follows it.
+        preconf_tip_tx.send(U256::from(42)).unwrap();
+        let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
+        assert_eq!(tip, U256::from(42));
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -362,7 +362,7 @@ mod tests {
         assert_eq!(tip, U256::ZERO);
 
         preconf_tip_tx.send(U256::from(42)).unwrap();
-        let tip = client.event_sync_tip().await.expect("genesis returns 0 regardless of preconf_tip");
+        let tip = client.event_sync_tip().await.expect("genesis returns zero despite preconf tip");
         assert_eq!(tip, U256::ZERO);
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -237,12 +237,10 @@ where
     }
 
     /// Get the current event syncer tip block number.
-    /// Falls back to `preconf_tip` when `head_l1_origin` has not been established yet,
-    /// which avoids a full-history catch-up on restart when preconfirmed blocks already exist.
     async fn event_sync_tip(&self) -> ClientResult<U256> {
         let snapshot =
             self.event_syncer.confirmed_sync_snapshot().await.map_err(DriverApiError::Driver)?;
-        super::traits::resolve_event_sync_tip(&snapshot, || self.preconf_tip()).await
+        super::traits::resolve_event_sync_tip(&snapshot).await
     }
 
     /// Get the current preconfirmation tip block number.
@@ -363,12 +361,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn event_syncer_driver_client_falls_back_to_preconf_tip_on_genesis() {
+    async fn event_syncer_driver_client_returns_zero_on_genesis_snapshot() {
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let inbox = bindings::inbox::Inbox::InboxInstance::new(Address::ZERO, provider);
 
-        // target_proposal_id=0 (fresh genesis), head_l1_origin=None → fallback to preconf_tip.
+        // target_proposal_id=0 (fresh genesis), head_l1_origin=None → confirmed tip is genesis(0).
         let client = EventSyncerDriverClient::new_with_components(
             Arc::new(FakeIngress::new(false, u64::MAX).with_target_proposal_id(0)),
             inbox,
@@ -378,8 +376,8 @@ mod tests {
         let tip = client
             .event_sync_tip()
             .await
-            .expect("should fall back to preconf_tip on fresh genesis");
-        assert_eq!(tip, U256::from(99));
+            .expect("should return genesis confirmed tip on fresh genesis");
+        assert_eq!(tip, U256::ZERO);
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -237,14 +237,19 @@ where
     }
 
     /// Get the current event syncer tip block number.
+    /// Falls back to `preconf_tip` when `head_l1_origin` has not been established yet,
+    /// which avoids a full-history catch-up on restart when preconfirmed blocks already exist.
     async fn event_sync_tip(&self) -> ClientResult<U256> {
-        self.event_syncer
+        match self
+            .event_syncer
             .confirmed_sync_snapshot()
             .await
             .map_err(DriverApiError::Driver)?
             .event_sync_tip()
-            .map(U256::from)
-            .ok_or(DriverApiError::EventSyncTipUnknown.into())
+        {
+            Some(tip) => Ok(U256::from(tip)),
+            None => self.preconf_tip().await,
+        }
     }
 
     /// Get the current preconfirmation tip block number.
@@ -348,7 +353,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn event_syncer_driver_client_returns_error_when_tip_unknown() {
+    async fn event_syncer_driver_client_falls_back_to_preconf_tip_when_tip_unknown() {
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let inbox = bindings::inbox::Inbox::InboxInstance::new(Address::ZERO, provider);
@@ -360,17 +365,15 @@ mod tests {
                 tip: Arc::new(AtomicU64::new(u64::MAX)),
             }),
             inbox,
-            Arc::new(StubL2Provider { latest: U256::ZERO }),
+            Arc::new(StubL2Provider { latest: U256::from(99) }),
         );
 
-        let err = client
+        // Falls back to preconf_tip (from StubL2Provider) when head_l1_origin is unknown.
+        let tip = client
             .event_sync_tip()
             .await
-            .expect_err("unknown event sync tip should return explicit error");
-        assert!(matches!(
-            err,
-            crate::PreconfirmationClientError::DriverInterface(DriverApiError::EventSyncTipUnknown)
-        ));
+            .expect("should fall back to preconf_tip when head_l1_origin is missing");
+        assert_eq!(tip, U256::from(99));
     }
 
     struct NoopL2Provider;

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -240,7 +240,7 @@ where
     async fn event_sync_tip(&self) -> ClientResult<U256> {
         let snapshot =
             self.event_syncer.confirmed_sync_snapshot().await.map_err(DriverApiError::Driver)?;
-        super::traits::resolve_event_sync_tip(&snapshot).await
+        super::traits::resolve_event_sync_tip(&snapshot)
     }
 
     /// Get the current preconfirmation tip block number.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -240,7 +240,8 @@ where
     /// Falls back to `preconf_tip` when `head_l1_origin` has not been established yet,
     /// which avoids a full-history catch-up on restart when preconfirmed blocks already exist.
     async fn event_sync_tip(&self) -> ClientResult<U256> {
-        let snapshot = self.event_syncer.confirmed_sync_snapshot().await.map_err(DriverApiError::Driver)?;
+        let snapshot =
+            self.event_syncer.confirmed_sync_snapshot().await.map_err(DriverApiError::Driver)?;
         super::traits::resolve_event_sync_tip(&snapshot, || self.preconf_tip()).await
     }
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -240,11 +240,7 @@ where
     /// Falls back to `preconf_tip` when `head_l1_origin` has not been established yet,
     /// which avoids a full-history catch-up on restart when preconfirmed blocks already exist.
     async fn event_sync_tip(&self) -> ClientResult<U256> {
-        let snapshot = self
-            .event_syncer
-            .confirmed_sync_snapshot()
-            .await
-            .map_err(DriverApiError::Driver)?;
+        let snapshot = self.event_syncer.confirmed_sync_snapshot().await.map_err(DriverApiError::Driver)?;
         super::traits::resolve_event_sync_tip(&snapshot, || self.preconf_tip()).await
     }
 
@@ -339,11 +335,8 @@ mod tests {
         ) -> Result<ConfirmedSyncSnapshot, driver::DriverError> {
             let tip = self.tip.load(Ordering::SeqCst);
             let head_l1_origin_block_id = (tip != u64::MAX).then_some(tip);
-            let target_block = if self.ready.load(Ordering::SeqCst) {
-                Some(0)
-            } else {
-                Some(u64::MAX - 1)
-            };
+            let target_block =
+                if self.ready.load(Ordering::SeqCst) { Some(0) } else { Some(u64::MAX - 1) };
             Ok(ConfirmedSyncSnapshot::new(
                 self.target_proposal_id,
                 target_block,
@@ -407,9 +400,7 @@ mod tests {
             .expect_err("should reject during startup catch-up window");
         assert!(matches!(
             err,
-            crate::PreconfirmationClientError::DriverInterface(
-                DriverApiError::EventSyncTipUnknown
-            )
+            crate::PreconfirmationClientError::DriverInterface(DriverApiError::EventSyncTipUnknown)
         ));
     }
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -240,16 +240,12 @@ where
     /// Falls back to `preconf_tip` when `head_l1_origin` has not been established yet,
     /// which avoids a full-history catch-up on restart when preconfirmed blocks already exist.
     async fn event_sync_tip(&self) -> ClientResult<U256> {
-        match self
+        let snapshot = self
             .event_syncer
             .confirmed_sync_snapshot()
             .await
-            .map_err(DriverApiError::Driver)?
-            .event_sync_tip()
-        {
-            Some(tip) => Ok(U256::from(tip)),
-            None => self.preconf_tip().await,
-        }
+            .map_err(DriverApiError::Driver)?;
+        super::traits::resolve_event_sync_tip(&snapshot, || self.preconf_tip()).await
     }
 
     /// Get the current preconfirmation tip block number.
@@ -309,6 +305,23 @@ mod tests {
         submits: Arc<AtomicUsize>,
         ready: Arc<AtomicBool>,
         tip: Arc<AtomicU64>,
+        target_proposal_id: u64,
+    }
+
+    impl FakeIngress {
+        fn new(ready: bool, tip: u64) -> Self {
+            Self {
+                submits: Arc::new(AtomicUsize::new(0)),
+                ready: Arc::new(AtomicBool::new(ready)),
+                tip: Arc::new(AtomicU64::new(tip)),
+                target_proposal_id: 1,
+            }
+        }
+
+        fn with_target_proposal_id(mut self, id: u64) -> Self {
+            self.target_proposal_id = id;
+            self
+        }
     }
 
     #[async_trait::async_trait]
@@ -326,9 +339,16 @@ mod tests {
         ) -> Result<ConfirmedSyncSnapshot, driver::DriverError> {
             let tip = self.tip.load(Ordering::SeqCst);
             let head_l1_origin_block_id = (tip != u64::MAX).then_some(tip);
-            let target_block =
-                if self.ready.load(Ordering::SeqCst) { Some(0) } else { Some(u64::MAX - 1) };
-            Ok(ConfirmedSyncSnapshot::new(1, target_block, head_l1_origin_block_id))
+            let target_block = if self.ready.load(Ordering::SeqCst) {
+                Some(0)
+            } else {
+                Some(u64::MAX - 1)
+            };
+            Ok(ConfirmedSyncSnapshot::new(
+                self.target_proposal_id,
+                target_block,
+                head_l1_origin_block_id,
+            ))
         }
     }
 
@@ -339,11 +359,7 @@ mod tests {
         let inbox = bindings::inbox::Inbox::InboxInstance::new(Address::ZERO, provider.clone());
 
         let client = EventSyncerDriverClient::new_with_components(
-            Arc::new(FakeIngress {
-                submits: Arc::new(AtomicUsize::new(0)),
-                ready: Arc::new(AtomicBool::new(true)),
-                tip: Arc::new(AtomicU64::new(7)),
-            }),
+            Arc::new(FakeIngress::new(true, 7)),
             inbox,
             Arc::new(StubL2Provider { latest: U256::from(12) }),
         );
@@ -353,27 +369,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn event_syncer_driver_client_falls_back_to_preconf_tip_when_tip_unknown() {
+    async fn event_syncer_driver_client_falls_back_to_preconf_tip_on_genesis() {
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let inbox = bindings::inbox::Inbox::InboxInstance::new(Address::ZERO, provider);
 
+        // target_proposal_id=0 (fresh genesis), head_l1_origin=None → fallback to preconf_tip.
         let client = EventSyncerDriverClient::new_with_components(
-            Arc::new(FakeIngress {
-                submits: Arc::new(AtomicUsize::new(0)),
-                ready: Arc::new(AtomicBool::new(false)),
-                tip: Arc::new(AtomicU64::new(u64::MAX)),
-            }),
+            Arc::new(FakeIngress::new(false, u64::MAX).with_target_proposal_id(0)),
             inbox,
             Arc::new(StubL2Provider { latest: U256::from(99) }),
         );
 
-        // Falls back to preconf_tip (from StubL2Provider) when head_l1_origin is unknown.
         let tip = client
             .event_sync_tip()
             .await
-            .expect("should fall back to preconf_tip when head_l1_origin is missing");
+            .expect("should fall back to preconf_tip on fresh genesis");
         assert_eq!(tip, U256::from(99));
+    }
+
+    #[tokio::test]
+    async fn event_syncer_driver_client_rejects_during_startup_catchup() {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let inbox = bindings::inbox::Inbox::InboxInstance::new(Address::ZERO, provider);
+
+        // target_proposal_id=1, head_l1_origin=None → startup catch-up window, fail-closed.
+        let client = EventSyncerDriverClient::new_with_components(
+            Arc::new(FakeIngress::new(false, u64::MAX)),
+            inbox,
+            Arc::new(StubL2Provider { latest: U256::from(99) }),
+        );
+
+        let err = client
+            .event_sync_tip()
+            .await
+            .expect_err("should reject during startup catch-up window");
+        assert!(matches!(
+            err,
+            crate::PreconfirmationClientError::DriverInterface(
+                DriverApiError::EventSyncTipUnknown
+            )
+        ));
     }
 
     struct NoopL2Provider;
@@ -408,6 +445,7 @@ mod tests {
                 submits: submits.clone(),
                 ready: Arc::new(AtomicBool::new(true)),
                 tip: Arc::new(AtomicU64::new(0)),
+                target_proposal_id: 1,
             }),
             inbox,
             Arc::new(NoopL2Provider),
@@ -438,6 +476,7 @@ mod tests {
                 submits: Arc::new(AtomicUsize::new(0)),
                 ready: ready.clone(),
                 tip: Arc::new(AtomicU64::new(5)),
+                target_proposal_id: 1,
             }),
             inbox,
             Arc::new(NoopL2Provider),

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/mod.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/mod.rs
@@ -46,7 +46,7 @@ impl PreconfirmationInput {
 
 pub use embedded::{ContractInboxReader, EmbeddedDriverClient};
 pub use event_syncer_client::EventSyncerDriverClient;
-pub use traits::{BlockHeaderProvider, DriverClient, InboxReader};
+pub use traits::{BlockHeaderProvider, DriverClient, InboxReader, resolve_event_sync_tip};
 
 #[cfg(test)]
 mod tests {

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
@@ -73,7 +73,10 @@ pub trait DriverClient: Send + Sync {
 ///
 /// This is the single source of truth for the fallback logic so that all
 /// [`DriverClient`] implementations stay consistent.
-pub async fn resolve_event_sync_tip<F, Fut>(snapshot: &ConfirmedSyncSnapshot, fallback: F) -> ClientResult<U256>
+pub async fn resolve_event_sync_tip<F, Fut>(
+    snapshot: &ConfirmedSyncSnapshot,
+    fallback: F,
+) -> ClientResult<U256>
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = ClientResult<U256>>,
@@ -128,20 +131,17 @@ mod tests {
     #[tokio::test]
     async fn resolve_returns_snapshot_tip_when_present() {
         let snapshot = ConfirmedSyncSnapshot::new(1, Some(10), Some(42));
-        let tip = resolve_event_sync_tip(&snapshot, || async {
-            panic!("fallback should not be called")
-        })
-        .await
-        .unwrap();
+        let tip =
+            resolve_event_sync_tip(&snapshot, || async { panic!("fallback should not be called") })
+                .await
+                .unwrap();
         assert_eq!(tip, U256::from(42));
     }
 
     #[tokio::test]
     async fn resolve_calls_fallback_when_tip_missing() {
         let snapshot = ConfirmedSyncSnapshot::new(0, None, None);
-        let tip = resolve_event_sync_tip(&snapshot, || async { Ok(U256::from(99)) })
-            .await
-            .unwrap();
+        let tip = resolve_event_sync_tip(&snapshot, || async { Ok(U256::from(99)) }).await.unwrap();
         assert_eq!(tip, U256::from(99));
     }
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
@@ -1,6 +1,6 @@
 //! Driver interface trait definitions.
 
-use std::{future::Future, result::Result, time::Duration};
+use std::{result::Result, time::Duration};
 
 use alloy_primitives::U256;
 use alloy_rpc_types::Header as RpcHeader;
@@ -58,33 +58,27 @@ pub trait DriverClient: Send + Sync {
     /// Await the driver event sync completion signal.
     async fn wait_event_sync(&self) -> ClientResult<()>;
     /// Return the latest confirmed event-sync L2 block number.
+    /// On fresh genesis with no confirmed `head_l1_origin` yet, this resolves to `0`.
     async fn event_sync_tip(&self) -> ClientResult<U256>;
     /// Return the latest preconfirmation tip block number.
     async fn preconf_tip(&self) -> ClientResult<U256>;
 }
 
-/// Resolve the event-sync tip from a [`ConfirmedSyncSnapshot`], falling back to a
-/// caller-provided future (typically `preconf_tip()`) when `head_l1_origin` has not been
-/// established yet on a fresh genesis chain (`target_proposal_id == 0`).
+/// Resolve the event-sync tip from a [`ConfirmedSyncSnapshot`].
 ///
+/// On a fresh genesis chain (`target_proposal_id == 0`) where no confirmed tip exists
+/// (`head_l1_origin == None`), this returns `0`, which is the genesis confirmed boundary.
 /// When `target_proposal_id > 0` but `head_l1_origin` is still unknown (i.e. confirmed
 /// sync has not completed), this returns [`DriverApiError::EventSyncTipUnknown`] to
 /// preserve fail-closed behavior during the startup catch-up window.
 ///
 /// This is the single source of truth for the fallback logic so that all
 /// [`DriverClient`] implementations stay consistent.
-pub async fn resolve_event_sync_tip<F, Fut>(
-    snapshot: &ConfirmedSyncSnapshot,
-    fallback: F,
-) -> ClientResult<U256>
-where
-    F: FnOnce() -> Fut,
-    Fut: Future<Output = ClientResult<U256>>,
-{
+pub async fn resolve_event_sync_tip(snapshot: &ConfirmedSyncSnapshot) -> ClientResult<U256> {
     match snapshot.event_sync_tip() {
         Some(tip) => Ok(U256::from(tip)),
-        // Fresh genesis chain — no proposals confirmed on L1 yet, safe to fall back.
-        None if snapshot.target_proposal_id == 0 => fallback().await,
+        // Fresh genesis chain — no proposals confirmed on L1 yet, confirmed boundary is 0.
+        None if snapshot.target_proposal_id == 0 => Ok(U256::ZERO),
         // Confirmed sync still catching up — reject to stay fail-closed.
         None => Err(crate::error::DriverApiError::EventSyncTipUnknown.into()),
     }
@@ -131,43 +125,22 @@ mod tests {
     #[tokio::test]
     async fn resolve_returns_snapshot_tip_when_present() {
         let snapshot = ConfirmedSyncSnapshot::new(1, Some(10), Some(42));
-        let tip =
-            resolve_event_sync_tip(&snapshot, || async { panic!("fallback should not be called") })
-                .await
-                .unwrap();
+        let tip = resolve_event_sync_tip(&snapshot).await.unwrap();
         assert_eq!(tip, U256::from(42));
     }
 
     #[tokio::test]
-    async fn resolve_calls_fallback_when_tip_missing() {
+    async fn resolve_returns_zero_when_tip_missing_on_genesis_snapshot() {
         let snapshot = ConfirmedSyncSnapshot::new(0, None, None);
-        let tip = resolve_event_sync_tip(&snapshot, || async { Ok(U256::from(99)) }).await.unwrap();
-        assert_eq!(tip, U256::from(99));
-    }
-
-    #[tokio::test]
-    async fn resolve_propagates_fallback_error() {
-        let snapshot = ConfirmedSyncSnapshot::new(0, None, None);
-        let err = resolve_event_sync_tip(&snapshot, || async {
-            Err(PreconfirmationClientError::Network("provider unreachable".into()))
-        })
-        .await
-        .unwrap_err();
-        assert!(
-            matches!(err, PreconfirmationClientError::Network(_)),
-            "expected Network error, got: {err:?}"
-        );
+        let tip = resolve_event_sync_tip(&snapshot).await.unwrap();
+        assert_eq!(tip, U256::ZERO);
     }
 
     #[tokio::test]
     async fn resolve_rejects_when_confirmed_sync_not_ready() {
         // target_proposal_id > 0 but head_l1_origin is None → startup catch-up window.
         let snapshot = ConfirmedSyncSnapshot::new(5, Some(10), None);
-        let err = resolve_event_sync_tip(&snapshot, || async {
-            panic!("fallback should not be called during catch-up window")
-        })
-        .await
-        .unwrap_err();
+        let err = resolve_event_sync_tip(&snapshot).await.unwrap_err();
         assert!(
             matches!(
                 err,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
@@ -74,7 +74,7 @@ pub trait DriverClient: Send + Sync {
 ///
 /// This is the single source of truth for the fallback logic so that all
 /// [`DriverClient`] implementations stay consistent.
-pub async fn resolve_event_sync_tip(snapshot: &ConfirmedSyncSnapshot) -> ClientResult<U256> {
+pub fn resolve_event_sync_tip(snapshot: &ConfirmedSyncSnapshot) -> ClientResult<U256> {
     match snapshot.event_sync_tip() {
         Some(tip) => Ok(U256::from(tip)),
         // Fresh genesis chain — no proposals confirmed on L1 yet, confirmed boundary is 0.
@@ -125,14 +125,14 @@ mod tests {
     #[tokio::test]
     async fn resolve_returns_snapshot_tip_when_present() {
         let snapshot = ConfirmedSyncSnapshot::new(1, Some(10), Some(42));
-        let tip = resolve_event_sync_tip(&snapshot).await.unwrap();
+        let tip = resolve_event_sync_tip(&snapshot).unwrap();
         assert_eq!(tip, U256::from(42));
     }
 
     #[tokio::test]
     async fn resolve_returns_zero_when_tip_missing_on_genesis_snapshot() {
         let snapshot = ConfirmedSyncSnapshot::new(0, None, None);
-        let tip = resolve_event_sync_tip(&snapshot).await.unwrap();
+        let tip = resolve_event_sync_tip(&snapshot).unwrap();
         assert_eq!(tip, U256::ZERO);
     }
 
@@ -140,7 +140,7 @@ mod tests {
     async fn resolve_rejects_when_confirmed_sync_not_ready() {
         // target_proposal_id > 0 but head_l1_origin is None → startup catch-up window.
         let snapshot = ConfirmedSyncSnapshot::new(5, Some(10), None);
-        let err = resolve_event_sync_tip(&snapshot).await.unwrap_err();
+        let err = resolve_event_sync_tip(&snapshot).unwrap_err();
         assert!(
             matches!(
                 err,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
@@ -63,6 +63,30 @@ pub trait DriverClient: Send + Sync {
     async fn preconf_tip(&self) -> ClientResult<U256>;
 }
 
+/// Resolve the event-sync tip from a [`ConfirmedSyncSnapshot`], falling back to a
+/// caller-provided future (typically `preconf_tip()`) when `head_l1_origin` has not been
+/// established yet on a fresh genesis chain (`target_proposal_id == 0`).
+///
+/// When `target_proposal_id > 0` but `head_l1_origin` is still unknown (i.e. confirmed
+/// sync has not completed), this returns [`DriverApiError::EventSyncTipUnknown`] to
+/// preserve fail-closed behavior during the startup catch-up window.
+///
+/// This is the single source of truth for the fallback logic so that all
+/// [`DriverClient`] implementations stay consistent.
+pub async fn resolve_event_sync_tip<F, Fut>(snapshot: &ConfirmedSyncSnapshot, fallback: F) -> ClientResult<U256>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ClientResult<U256>>,
+{
+    match snapshot.event_sync_tip() {
+        Some(tip) => Ok(U256::from(tip)),
+        // Fresh genesis chain — no proposals confirmed on L1 yet, safe to fall back.
+        None if snapshot.target_proposal_id == 0 => fallback().await,
+        // Confirmed sync still catching up — reject to stay fail-closed.
+        None => Err(crate::error::DriverApiError::EventSyncTipUnknown.into()),
+    }
+}
+
 /// Wait for strict confirmed-sync readiness by polling a caller-provided snapshot source.
 pub(crate) async fn wait_for_confirmed_sync<F, Fut, E>(
     mut snapshot: F,
@@ -93,5 +117,65 @@ where
         );
 
         sleep(poll_interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::PreconfirmationClientError;
+
+    #[tokio::test]
+    async fn resolve_returns_snapshot_tip_when_present() {
+        let snapshot = ConfirmedSyncSnapshot::new(1, Some(10), Some(42));
+        let tip = resolve_event_sync_tip(&snapshot, || async {
+            panic!("fallback should not be called")
+        })
+        .await
+        .unwrap();
+        assert_eq!(tip, U256::from(42));
+    }
+
+    #[tokio::test]
+    async fn resolve_calls_fallback_when_tip_missing() {
+        let snapshot = ConfirmedSyncSnapshot::new(0, None, None);
+        let tip = resolve_event_sync_tip(&snapshot, || async { Ok(U256::from(99)) })
+            .await
+            .unwrap();
+        assert_eq!(tip, U256::from(99));
+    }
+
+    #[tokio::test]
+    async fn resolve_propagates_fallback_error() {
+        let snapshot = ConfirmedSyncSnapshot::new(0, None, None);
+        let err = resolve_event_sync_tip(&snapshot, || async {
+            Err(PreconfirmationClientError::Network("provider unreachable".into()))
+        })
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, PreconfirmationClientError::Network(_)),
+            "expected Network error, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_when_confirmed_sync_not_ready() {
+        // target_proposal_id > 0 but head_l1_origin is None → startup catch-up window.
+        let snapshot = ConfirmedSyncSnapshot::new(5, Some(10), None);
+        let err = resolve_event_sync_tip(&snapshot, || async {
+            panic!("fallback should not be called during catch-up window")
+        })
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PreconfirmationClientError::DriverInterface(
+                    crate::error::DriverApiError::EventSyncTipUnknown
+                )
+            ),
+            "expected EventSyncTipUnknown, got: {err:?}"
+        );
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/error.rs
@@ -76,9 +76,6 @@ pub enum DriverApiError {
     /// Latest block not found on the L2 provider.
     #[error("missing latest block")]
     MissingLatestBlock,
-    /// Event sync tip is unknown because `head_l1_origin` has not been established yet.
-    #[error("event sync tip is unknown")]
-    EventSyncTipUnknown,
     /// Missing transactions in the preconfirmation input.
     #[error("missing transactions for execution payload")]
     MissingTransactions,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/error.rs
@@ -76,6 +76,10 @@ pub enum DriverApiError {
     /// Latest block not found on the L2 provider.
     #[error("missing latest block")]
     MissingLatestBlock,
+    /// Event sync tip is unknown because confirmed sync has not completed yet
+    /// (target_proposal_id > 0 but `head_l1_origin` is still missing).
+    #[error("event sync tip is unknown (confirmed sync not ready)")]
+    EventSyncTipUnknown,
     /// Missing transactions in the preconfirmation input.
     #[error("missing transactions for execution payload")]
     MissingTransactions,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/lib.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/lib.rs
@@ -55,7 +55,7 @@ pub use client::{EventLoop, PreconfirmationClient};
 pub use config::PreconfirmationClientConfig;
 pub use driver_interface::{
     ContractInboxReader, DriverClient, EmbeddedDriverClient, EventSyncerDriverClient, InboxReader,
-    PreconfirmationInput,
+    PreconfirmationInput, resolve_event_sync_tip,
 };
 pub use error::{DriverApiError, PreconfirmationClientError, Result};
 pub use metrics::PreconfirmationClientMetrics;

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/types.rs
@@ -58,6 +58,7 @@ pub struct NodeStatus {
     /// Whether the node has completed sync with L1 inbox events.
     pub is_synced_with_inbox: bool,
     /// The highest confirmed event-sync tip from `head_l1_origin`.
+    /// May be `None` before confirmed sync is available.
     pub event_sync_tip: Option<U256>,
     /// The highest preconfirmed block number known to this node.
     pub preconf_tip: U256,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/tests/dual_driver_e2e.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/tests/dual_driver_e2e.rs
@@ -31,7 +31,7 @@ use test_harness::{
     BeaconStubServer, PreconfTxList, ShastaEnv, build_preconf_txlist, compute_next_block_base_fee,
     fetch_block_by_number,
     preconfirmation::{
-        EventSyncerDriverClient, SafeTipDriverClient, StaticLookaheadResolver,
+        EventSyncerDriverClient, LoggingDriverClient, StaticLookaheadResolver,
         build_publish_payloads_with_txs, derive_signer, test_p2p_config,
         wait_for_commitment_and_txlist, wait_for_peer_connected,
     },
@@ -156,11 +156,11 @@ async fn dual_driver_p2p_gossip_syncs_both_nodes(env: &mut ShastaEnv) -> Result<
 
     let driver1_embedded =
         EventSyncerDriverClient::new(driver1.event_syncer.clone(), driver1.rpc_client.clone());
-    let driver1_client = SafeTipDriverClient::new(Arc::new(driver1_embedded));
+    let driver1_client = LoggingDriverClient::new(Arc::new(driver1_embedded));
 
     let driver2_embedded =
         EventSyncerDriverClient::new(driver2.event_syncer.clone(), driver2.rpc_client.clone());
-    let driver2_client = SafeTipDriverClient::new(Arc::new(driver2_embedded));
+    let driver2_client = LoggingDriverClient::new(Arc::new(driver2_embedded));
 
     let (signer_sk, signer) = derive_signer(1);
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/tests/node_integration.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/tests/node_integration.rs
@@ -148,19 +148,17 @@ async fn test_submit_preconfirmation_closed_channel() {
 }
 
 #[tokio::test]
-async fn test_event_sync_tip_falls_back_to_preconf_tip_on_genesis() {
+async fn test_event_sync_tip_falls_back_to_zero_on_genesis() {
     // make_client() sets next_proposal_id=0, so target_proposal_id=0 (fresh genesis).
     let (client, _input_rx, inbox_reader, preconf_tip_tx) = make_client();
     inbox_reader.set_head_l1_origin(None);
 
-    // Default preconf_tip is 0.
-    let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
+    let tip = client.event_sync_tip().await.expect("should fall back to confirmed genesis tip");
     assert_eq!(tip, alloy::primitives::U256::ZERO);
 
-    // When preconf_tip advances, the fallback follows it.
     preconf_tip_tx.send(alloy::primitives::U256::from(50)).unwrap();
-    let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
-    assert_eq!(tip, alloy::primitives::U256::from(50));
+    let tip = client.event_sync_tip().await.expect("should still return confirmed genesis tip");
+    assert_eq!(tip, alloy::primitives::U256::ZERO);
 }
 
 #[tokio::test]
@@ -170,6 +168,27 @@ async fn test_event_sync_tip_rejects_during_startup_catchup() {
     inbox_reader.set_next_proposal_id(5);
     inbox_reader.set_head_l1_origin(None);
 
+    let err = client.event_sync_tip().await.unwrap_err();
+    assert!(matches!(
+        err,
+        preconfirmation_driver::PreconfirmationClientError::DriverInterface(
+            preconfirmation_driver::DriverApiError::EventSyncTipUnknown
+        )
+    ));
+}
+
+#[tokio::test]
+async fn test_event_sync_tip_transitions_from_genesis_zero_to_startup_unknown() {
+    let (client, _input_rx, inbox_reader, _preconf_tip_tx) = make_client();
+
+    // Fresh genesis-like state: no confirmed `head_l1_origin` yet → confirmed boundary is 0.
+    inbox_reader.set_head_l1_origin(None);
+    let tip = client.event_sync_tip().await.expect("genesis path should still return zero");
+    assert_eq!(tip, alloy::primitives::U256::ZERO);
+
+    // Once proposals exist (target_proposal_id > 0), missing `head_l1_origin` is no longer
+    // a genesis fallback and must be treated as unknown startup state.
+    inbox_reader.set_next_proposal_id(1);
     let err = client.event_sync_tip().await.unwrap_err();
     assert!(matches!(
         err,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/tests/node_integration.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/tests/node_integration.rs
@@ -186,9 +186,10 @@ async fn test_event_sync_tip_transitions_from_genesis_zero_to_startup_unknown() 
     let tip = client.event_sync_tip().await.expect("genesis path should still return zero");
     assert_eq!(tip, alloy::primitives::U256::ZERO);
 
-    // Once proposals exist (target_proposal_id > 0), missing `head_l1_origin` is no longer
-    // a genesis fallback and must be treated as unknown startup state.
-    inbox_reader.set_next_proposal_id(1);
+    // Once proposals exist (nextProposalId > 1 → target_proposal_id > 0), missing
+    // `head_l1_origin` is no longer a genesis fallback and must be treated as
+    // unknown startup state.
+    inbox_reader.set_next_proposal_id(2);
     let err = client.event_sync_tip().await.unwrap_err();
     assert!(matches!(
         err,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/tests/node_integration.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/tests/node_integration.rs
@@ -144,15 +144,16 @@ async fn test_submit_preconfirmation_closed_channel() {
 }
 
 #[tokio::test]
-async fn test_event_sync_tip_errors_when_head_l1_origin_missing() {
-    let (client, _input_rx, inbox_reader, _preconf_tip_tx) = make_client();
+async fn test_event_sync_tip_falls_back_to_preconf_tip_when_head_l1_origin_missing() {
+    let (client, _input_rx, inbox_reader, preconf_tip_tx) = make_client();
     inbox_reader.set_head_l1_origin(None);
 
-    let err = client.event_sync_tip().await.unwrap_err();
-    assert!(matches!(
-        err,
-        preconfirmation_driver::PreconfirmationClientError::DriverInterface(
-            preconfirmation_driver::DriverApiError::EventSyncTipUnknown
-        )
-    ));
+    // Default preconf_tip is 0.
+    let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
+    assert_eq!(tip, alloy::primitives::U256::ZERO);
+
+    // When preconf_tip advances, the fallback follows it.
+    preconf_tip_tx.send(alloy::primitives::U256::from(50)).unwrap();
+    let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
+    assert_eq!(tip, alloy::primitives::U256::from(50));
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/tests/node_integration.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/tests/node_integration.rs
@@ -36,6 +36,10 @@ impl MockInboxReader {
         }
     }
 
+    fn set_next_proposal_id(&self, value: u64) {
+        self.next_proposal_id.store(value, Ordering::SeqCst);
+    }
+
     fn set_head_l1_origin(&self, value: Option<u64>) {
         self.head_l1_origin_block_id.store(value.unwrap_or(NONE_SENTINEL), Ordering::SeqCst);
     }
@@ -144,7 +148,8 @@ async fn test_submit_preconfirmation_closed_channel() {
 }
 
 #[tokio::test]
-async fn test_event_sync_tip_falls_back_to_preconf_tip_when_head_l1_origin_missing() {
+async fn test_event_sync_tip_falls_back_to_preconf_tip_on_genesis() {
+    // make_client() sets next_proposal_id=0, so target_proposal_id=0 (fresh genesis).
     let (client, _input_rx, inbox_reader, preconf_tip_tx) = make_client();
     inbox_reader.set_head_l1_origin(None);
 
@@ -156,4 +161,20 @@ async fn test_event_sync_tip_falls_back_to_preconf_tip_when_head_l1_origin_missi
     preconf_tip_tx.send(alloy::primitives::U256::from(50)).unwrap();
     let tip = client.event_sync_tip().await.expect("should fall back to preconf_tip");
     assert_eq!(tip, alloy::primitives::U256::from(50));
+}
+
+#[tokio::test]
+async fn test_event_sync_tip_rejects_during_startup_catchup() {
+    let (client, _input_rx, inbox_reader, _preconf_tip_tx) = make_client();
+    // Simulate target_proposal_id > 0 (proposals exist on L1) with head_l1_origin missing.
+    inbox_reader.set_next_proposal_id(5);
+    inbox_reader.set_head_l1_origin(None);
+
+    let err = client.event_sync_tip().await.unwrap_err();
+    assert!(matches!(
+        err,
+        preconfirmation_driver::PreconfirmationClientError::DriverInterface(
+            preconfirmation_driver::DriverApiError::EventSyncTipUnknown
+        )
+    ));
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/tests/preconf_e2e.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/tests/preconf_e2e.rs
@@ -27,7 +27,7 @@ use test_harness::{
     BeaconStubServer, PreconfTxList, ShastaEnv, TransferPayload, build_preconf_txlist,
     compute_next_block_base_fee, fetch_block_by_number,
     preconfirmation::{
-        EventSyncerDriverClient, SafeTipDriverClient, StaticLookaheadResolver,
+        EventSyncerDriverClient, LoggingDriverClient, StaticLookaheadResolver,
         build_publish_payloads_with_txs, derive_signer, test_p2p_config,
         wait_for_commitment_and_txlist, wait_for_peer_connected,
     },
@@ -225,9 +225,9 @@ async fn p2p_preconfirmation_produces_block(env: &mut ShastaEnv) -> Result<()> {
         .await
         .map_err(|err| anyhow!("preconfirmation ingress unavailable: {err}"))?;
 
-    // Set up driver client with safe-tip fallback.
+    // Set up driver client with logging wrapper.
     let embedded_client = EventSyncerDriverClient::new(event_syncer.clone(), rpc_client.clone());
-    let driver_client = SafeTipDriverClient::new(Arc::new(embedded_client));
+    let driver_client = LoggingDriverClient::new(Arc::new(embedded_client));
 
     // Derive signer from deterministic secret key.
     let (signer_sk, signer) = derive_signer(1);

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -258,7 +258,7 @@ where
             .confirmed_sync_snapshot()
             .await
             .map_err(|err| DriverApiError::Driver(driver::DriverError::from(err)))?;
-        resolve_event_sync_tip(&snapshot).await
+        resolve_event_sync_tip(&snapshot)
     }
 
     async fn preconf_tip(&self) -> Result<U256> {

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -258,7 +258,7 @@ where
             .confirmed_sync_snapshot()
             .await
             .map_err(|err| DriverApiError::Driver(driver::DriverError::from(err)))?;
-        resolve_event_sync_tip(&snapshot, || self.preconf_tip()).await
+        resolve_event_sync_tip(&snapshot).await
     }
 
     async fn preconf_tip(&self) -> Result<U256> {

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -3,7 +3,7 @@
 //! This module provides:
 //! - [`MockDriverClient`]: Records submissions for unit-style tests.
 //! - [`EventSyncerDriverClient`]: Submits directly to an in-process event syncer.
-//! - [`SafeTipDriverClient`]: Wraps a driver client with safe-tip fallback.
+//! - [`LoggingDriverClient`]: Wraps a driver client with submission logging.
 //! - [`RealDriverSetup`]: Full driver setup for E2E tests with actual block production.
 
 use std::{sync::Arc, time::Duration};
@@ -252,13 +252,16 @@ where
     }
 
     async fn event_sync_tip(&self) -> Result<U256> {
-        self.event_syncer
+        match self
+            .event_syncer
             .confirmed_sync_snapshot()
             .await
             .map_err(|err| DriverApiError::Driver(driver::DriverError::from(err)))?
             .event_sync_tip()
-            .map(U256::from)
-            .ok_or(DriverApiError::EventSyncTipUnknown.into())
+        {
+            Some(tip) => Ok(U256::from(tip)),
+            None => self.preconf_tip().await,
+        }
     }
 
     async fn preconf_tip(&self) -> Result<U256> {
@@ -272,24 +275,21 @@ where
     }
 }
 
-/// Wraps a driver client with fallback tip handling for event sync.
-///
-/// When `event_sync_tip` returns `EventSyncTipUnknown`, falls back to `preconf_tip`.
-/// Also logs submission results for debugging.
+/// Wraps a driver client with logging for submission results.
 #[derive(Clone)]
-pub struct SafeTipDriverClient {
+pub struct LoggingDriverClient {
     inner: Arc<dyn DriverClient>,
 }
 
-impl SafeTipDriverClient {
-    /// Create a new safe-tip driver client wrapper.
+impl LoggingDriverClient {
+    /// Create a new logging driver client wrapper.
     pub fn new(inner: Arc<dyn DriverClient>) -> Self {
         Self { inner }
     }
 }
 
 #[async_trait]
-impl DriverClient for SafeTipDriverClient {
+impl DriverClient for LoggingDriverClient {
     async fn submit_preconfirmation(&self, input: PreconfirmationInput) -> Result<()> {
         let block_number =
             uint256_to_u256(&input.commitment.commitment.preconf.block_number).to::<u64>();
@@ -309,12 +309,7 @@ impl DriverClient for SafeTipDriverClient {
     }
 
     async fn event_sync_tip(&self) -> Result<U256> {
-        match self.inner.event_sync_tip().await {
-            Err(PreconfirmationClientError::DriverInterface(
-                DriverApiError::EventSyncTipUnknown,
-            )) => self.inner.preconf_tip().await,
-            other => other,
-        }
+        self.inner.event_sync_tip().await
     }
 
     async fn preconf_tip(&self) -> Result<U256> {
@@ -349,7 +344,7 @@ impl DriverClient for SafeTipDriverClient {
 /// ```
 pub struct RealDriverSetup {
     /// Driver client for preconfirmation submission.
-    pub driver_client: SafeTipDriverClient,
+    pub driver_client: LoggingDriverClient,
     /// L2 provider for block queries.
     pub l2_provider: RootProvider,
     /// Beacon stub server.
@@ -364,7 +359,7 @@ impl RealDriverSetup {
     /// This sets up:
     /// 1. Beacon stub server
     /// 2. Event syncer with preconfirmation enabled
-    /// 3. Embedded driver client with safe-tip fallback
+    /// 3. Embedded driver client with logging wrapper
     pub async fn start(env: &ShastaEnv) -> AnyhowResult<Self> {
         let beacon_server = BeaconStubServer::start().await?;
 
@@ -399,7 +394,7 @@ impl RealDriverSetup {
         let l2_provider = rpc_client.l2_provider.clone();
         let embedded_client =
             EventSyncerDriverClient::new(event_syncer.clone(), rpc_client.clone());
-        let driver_client = SafeTipDriverClient::new(Arc::new(embedded_client));
+        let driver_client = LoggingDriverClient::new(Arc::new(embedded_client));
 
         Ok(Self { driver_client, l2_provider, beacon_server, event_handle })
     }

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -19,9 +19,10 @@ use driver::{
     sync::{SyncStage, event::EventSyncer},
 };
 use preconfirmation_driver::{
-    DriverClient, PreconfirmationInput, Result, resolve_event_sync_tip,
+    DriverClient, PreconfirmationInput, Result,
     driver_interface::payload::build_taiko_payload_attributes,
     error::{DriverApiError, PreconfirmationClientError},
+    resolve_event_sync_tip,
 };
 use preconfirmation_types::uint256_to_u256;
 use protocol::shasta::constants::min_base_fee_for_chain;

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -19,7 +19,7 @@ use driver::{
     sync::{SyncStage, event::EventSyncer},
 };
 use preconfirmation_driver::{
-    DriverClient, PreconfirmationInput, Result,
+    DriverClient, PreconfirmationInput, Result, resolve_event_sync_tip,
     driver_interface::payload::build_taiko_payload_attributes,
     error::{DriverApiError, PreconfirmationClientError},
 };
@@ -252,16 +252,12 @@ where
     }
 
     async fn event_sync_tip(&self) -> Result<U256> {
-        match self
+        let snapshot = self
             .event_syncer
             .confirmed_sync_snapshot()
             .await
-            .map_err(|err| DriverApiError::Driver(driver::DriverError::from(err)))?
-            .event_sync_tip()
-        {
-            Some(tip) => Ok(U256::from(tip)),
-            None => self.preconf_tip().await,
-        }
+            .map_err(|err| DriverApiError::Driver(driver::DriverError::from(err)))?;
+        resolve_event_sync_tip(&snapshot, || self.preconf_tip()).await
     }
 
     async fn preconf_tip(&self) -> Result<U256> {
@@ -308,6 +304,8 @@ impl DriverClient for LoggingDriverClient {
         self.inner.wait_event_sync().await
     }
 
+    // Delegation only — fallback logic lives in the inner implementation via
+    // `resolve_event_sync_tip`, so no logging or mutation is needed here.
     async fn event_sync_tip(&self) -> Result<U256> {
         self.inner.event_sync_tip().await
     }

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/mod.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Driver Implementations
 //! - [`MockDriverClient`]: A mock driver client that records submissions for verification.
-//! - [`SafeTipDriverClient`]: Wraps a real driver client with safe-tip fallback.
+//! - [`LoggingDriverClient`]: Wraps a real driver client with submission logging.
 //! - [`RealDriverSetup`]: Full driver setup for E2E tests with actual block production.
 //!
 //! ## Lookahead Resolvers
@@ -39,7 +39,7 @@ mod payloads;
 
 pub use client::{RunningPreconfClient, TestPreconfClientConfig, spawn_test_preconf_client};
 pub use driver::{
-    EventSyncerDriverClient, MockDriverClient, RealDriverSetup, SafeTipDriverClient,
+    EventSyncerDriverClient, MockDriverClient, RealDriverSetup, LoggingDriverClient,
     StartingBlockInfo,
 };
 pub use events::{

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/mod.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/mod.rs
@@ -39,7 +39,7 @@ mod payloads;
 
 pub use client::{RunningPreconfClient, TestPreconfClientConfig, spawn_test_preconf_client};
 pub use driver::{
-    EventSyncerDriverClient, MockDriverClient, RealDriverSetup, LoggingDriverClient,
+    EventSyncerDriverClient, LoggingDriverClient, MockDriverClient, RealDriverSetup,
     StartingBlockInfo,
 };
 pub use events::{


### PR DESCRIPTION
Fix based on the report from NM:
```
WARN preconfirmation_driver::rpc::server: RPC request failed method="preconf_publishBlock" err=DriverInterface(EventSyncTipUnknown) duration_secs=0.000831682
```