### PR TITLE
refactor(taiko-client-rs): simplify some implementations in `whitelist-preconfirmation-driver` crate

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -356,11 +356,9 @@ impl WhitelistSequencerCache {
         l1_block_timestamp: u64,
         epoch_duration_secs: u64,
     ) -> bool {
-        self.current_epoch_start_timestamp
-            .map(|cached_epoch_start| {
-                l1_block_timestamp >= cached_epoch_start.saturating_add(epoch_duration_secs)
-            })
-            .unwrap_or(false)
+        self.current_epoch_start_timestamp.is_some_and(|cached_epoch_start| {
+            l1_block_timestamp >= cached_epoch_start.saturating_add(epoch_duration_secs)
+        })
     }
 
     /// Return `true` if a snapshot taken at `block_timestamp` can replace cached values.
@@ -368,13 +366,11 @@ impl WhitelistSequencerCache {
     /// This prevents a lagging RPC node from overwriting a newer-epoch cached snapshot and
     /// rejects implausibly far-future timestamps from a misbehaving node.
     pub fn should_accept_block_timestamp(&self, block_timestamp: u64) -> bool {
-        self.current_epoch_start_timestamp
-            .map(|cached_epoch_start| {
-                let max_reasonable_timestamp =
-                    cached_epoch_start.saturating_add(L1_EPOCH_DURATION_SECS.saturating_mul(2));
-                block_timestamp >= cached_epoch_start && block_timestamp < max_reasonable_timestamp
-            })
-            .unwrap_or(true)
+        self.current_epoch_start_timestamp.is_none_or(|cached_epoch_start| {
+            let max_reasonable_timestamp =
+                cached_epoch_start.saturating_add(L1_EPOCH_DURATION_SECS.saturating_mul(2));
+            block_timestamp >= cached_epoch_start && block_timestamp < max_reasonable_timestamp
+        })
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
@@ -211,8 +211,7 @@ pub(crate) fn decode_envelope_ssz(bytes: &[u8]) -> Result<WhitelistExecutionPayl
     let has_signature = flags1 & 0x02 != 0;
 
     let root = &bytes[2..ENVELOPE_HEADER_LEN];
-    let parent_beacon_block_root =
-        root.iter().any(|&b| b != 0).then(|| B256::from_slice(root));
+    let parent_beacon_block_root = root.iter().any(|&b| b != 0).then(|| B256::from_slice(root));
 
     let signature_len = if has_signature { SIGNATURE_LEN } else { 0 };
     if bytes.len() < ENVELOPE_HEADER_LEN + signature_len {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
@@ -148,10 +148,9 @@ pub(crate) fn encode_unsafe_request_message(hash: B256) -> Vec<u8> {
 
 /// Encode Taiko whitelist preconfirmation SSZ envelope bytes.
 pub(crate) fn encode_envelope_ssz(envelope: &WhitelistExecutionPayloadEnvelope) -> Vec<u8> {
+    let sig_len = if envelope.signature.is_some() { SIGNATURE_LEN } else { 0 };
     let mut out = Vec::with_capacity(
-        ENVELOPE_HEADER_LEN +
-            envelope.execution_payload.as_ssz_bytes().len() +
-            envelope.signature.map(|_| SIGNATURE_LEN).unwrap_or_default(),
+        ENVELOPE_HEADER_LEN + envelope.execution_payload.as_ssz_bytes().len() + sig_len,
     );
 
     let mut flags0 = 0u8;
@@ -212,7 +211,8 @@ pub(crate) fn decode_envelope_ssz(bytes: &[u8]) -> Result<WhitelistExecutionPayl
     let has_signature = flags1 & 0x02 != 0;
 
     let root = &bytes[2..ENVELOPE_HEADER_LEN];
-    let parent_beacon_block_root = root.iter().any(|b| *b != 0).then(|| B256::from_slice(root));
+    let parent_beacon_block_root =
+        root.iter().any(|&b| b != 0).then(|| B256::from_slice(root));
 
     let signature_len = if has_signature { SIGNATURE_LEN } else { 0 };
     if bytes.len() < ENVELOPE_HEADER_LEN + signature_len {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/response.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/response.rs
@@ -82,7 +82,7 @@ where
             .cache
             .get(&hash)
             .and_then(|envelope| envelope.end_of_sequencing)
-            .filter(|enabled| *enabled);
+            .filter(|&enabled| enabled);
         let base_fee = block.header.base_fee_per_gas.ok_or_else(|| {
             WhitelistPreconfirmationDriverError::invalid_payload(format!(
                 "request-response block {} missing base fee",

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/event_loop.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/event_loop.rs
@@ -233,22 +233,12 @@ pub(super) async fn handle_gossipsub_event(
     let from = propagation_source;
     let now = Instant::now();
 
-    let copy_acceptance =
-        |acceptance: &gossipsub::MessageAcceptance| -> gossipsub::MessageAcceptance {
-            match acceptance {
-                gossipsub::MessageAcceptance::Accept => gossipsub::MessageAcceptance::Accept,
-                gossipsub::MessageAcceptance::Ignore => gossipsub::MessageAcceptance::Ignore,
-                gossipsub::MessageAcceptance::Reject => gossipsub::MessageAcceptance::Reject,
-            }
-        };
-
-    let mut report = |acceptance: &gossipsub::MessageAcceptance| {
+    let mut report = |acceptance: gossipsub::MessageAcceptance| {
         // Explicitly report every decision so mesh scoring remains aligned with local validation.
-        let _ = swarm.behaviour_mut().gossipsub.report_message_validation_result(
-            &message_id,
-            &from,
-            copy_acceptance(acceptance),
-        );
+        let _ = swarm
+            .behaviour_mut()
+            .gossipsub
+            .report_message_validation_result(&message_id, &from, acceptance);
     };
     if *topic == topics.preconf_blocks.hash() {
         let (acceptance, inbound_label) = match decode_unsafe_payload_signature(&message.data) {
@@ -266,7 +256,7 @@ pub(super) async fn handle_gossipsub_event(
                     {
                         // If forwarding to importer fails, reject to avoid silently accepting
                         // data that local consumers could not process.
-                        report(&gossipsub::MessageAcceptance::Reject);
+                        report(gossipsub::MessageAcceptance::Reject);
                         return Err(err);
                     }
 
@@ -292,7 +282,7 @@ pub(super) async fn handle_gossipsub_event(
             "result" => inbound_label,
         )
         .increment(1);
-        report(&acceptance);
+        report(acceptance);
         return Ok(());
     }
 
@@ -305,7 +295,7 @@ pub(super) async fn handle_gossipsub_event(
                         forward_event(event_tx, NetworkEvent::UnsafeResponse { from, envelope })
                             .await
                 {
-                    report(&gossipsub::MessageAcceptance::Reject);
+                    report(gossipsub::MessageAcceptance::Reject);
                     return Err(err);
                 }
 
@@ -325,7 +315,7 @@ pub(super) async fn handle_gossipsub_event(
             "result" => inbound_label,
         )
         .increment(1);
-        report(&acceptance);
+        report(acceptance);
         return Ok(());
     }
 
@@ -338,7 +328,7 @@ pub(super) async fn handle_gossipsub_event(
                 "result" => inbound_label,
             )
             .increment(1);
-            report(&acceptance);
+            report(acceptance);
             return Ok(());
         };
 
@@ -354,7 +344,7 @@ pub(super) async fn handle_gossipsub_event(
             "result" => acceptance_label(&acceptance),
         )
         .increment(1);
-        report(&acceptance);
+        report(acceptance);
         return Ok(());
     }
 
@@ -367,7 +357,7 @@ pub(super) async fn handle_gossipsub_event(
                 "result" => inbound_label,
             )
             .increment(1);
-            report(&acceptance);
+            report(acceptance);
             return Ok(());
         };
 
@@ -383,7 +373,7 @@ pub(super) async fn handle_gossipsub_event(
             "result" => acceptance_label(&acceptance),
         )
         .increment(1);
-        report(&acceptance);
+        report(acceptance);
     }
 
     Ok(())
@@ -392,12 +382,12 @@ pub(super) async fn handle_gossipsub_event(
 /// Decode an end-of-sequencing request epoch from big-endian bytes.
 #[cfg(test)]
 pub(super) fn decode_eos_epoch(payload: &[u8]) -> u64 {
-    let mut bytes = [0u8; std::mem::size_of::<u64>()];
-    let to_copy = payload.len().min(std::mem::size_of::<u64>());
+    let mut bytes = [0u8; 8];
+    let to_copy = payload.len().min(8);
 
     if to_copy > 0 {
         let source_start = payload.len() - to_copy;
-        bytes[std::mem::size_of::<u64>() - to_copy..].copy_from_slice(&payload[source_start..]);
+        bytes[8 - to_copy..].copy_from_slice(&payload[source_start..]);
     }
 
     u64::from_be_bytes(bytes)
@@ -405,23 +395,19 @@ pub(super) fn decode_eos_epoch(payload: &[u8]) -> u64 {
 
 /// Decode an end-of-sequencing epoch when the payload is exactly 8 bytes.
 pub(super) fn decode_eos_epoch_exact(payload: &[u8]) -> Option<u64> {
-    if payload.len() != std::mem::size_of::<u64>() {
-        return None;
-    }
-
-    let bytes: [u8; std::mem::size_of::<u64>()] = payload.try_into().ok()?;
+    let bytes: [u8; 8] = payload.try_into().ok()?;
     Some(u64::from_be_bytes(bytes))
 }
 
 /// Decode a request hash from big-endian bytes with set-bytes compatibility semantics.
 #[cfg(test)]
 pub(super) fn decode_request_hash(payload: &[u8]) -> B256 {
-    let mut bytes = [0u8; std::mem::size_of::<B256>()];
-    let to_copy = payload.len().min(std::mem::size_of::<B256>());
+    let mut bytes = [0u8; 32];
+    let to_copy = payload.len().min(32);
 
     if to_copy > 0 {
         let source_start = payload.len() - to_copy;
-        bytes[std::mem::size_of::<B256>() - to_copy..].copy_from_slice(&payload[source_start..]);
+        bytes[32 - to_copy..].copy_from_slice(&payload[source_start..]);
     }
 
     B256::from(bytes)
@@ -429,11 +415,7 @@ pub(super) fn decode_request_hash(payload: &[u8]) -> B256 {
 
 /// Decode a 32-byte request hash payload exactly (non-padded path).
 pub(super) fn decode_request_hash_exact(payload: &[u8]) -> Option<B256> {
-    if payload.len() != std::mem::size_of::<B256>() {
-        return None;
-    }
-
-    let bytes: [u8; std::mem::size_of::<B256>()] = payload.try_into().ok()?;
+    let bytes: [u8; 32] = payload.try_into().ok()?;
     Some(B256::from(bytes))
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/event_loop.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/event_loop.rs
@@ -235,10 +235,11 @@ pub(super) async fn handle_gossipsub_event(
 
     let mut report = |acceptance: gossipsub::MessageAcceptance| {
         // Explicitly report every decision so mesh scoring remains aligned with local validation.
-        let _ = swarm
-            .behaviour_mut()
-            .gossipsub
-            .report_message_validation_result(&message_id, &from, acceptance);
+        let _ = swarm.behaviour_mut().gossipsub.report_message_validation_result(
+            &message_id,
+            &from,
+            acceptance,
+        );
     };
     if *topic == topics.preconf_blocks.hash() {
         let (acceptance, inbound_label) = match decode_unsafe_payload_signature(&message.data) {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/inbound.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/inbound.rs
@@ -147,11 +147,7 @@ pub(crate) struct HeightSeenTracker {
 impl HeightSeenTracker {
     /// Whether another hash can be accepted for the supplied block height.
     pub(crate) fn can_accept(&mut self, height: u64, hash: B256, max_per_height: usize) -> bool {
-        if self
-            .seen_by_height
-            .get(&height)
-            .is_some_and(|hashes| hashes.len() > max_per_height)
-        {
+        if self.seen_by_height.get(&height).is_some_and(|hashes| hashes.len() > max_per_height) {
             return false;
         }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/inbound.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/inbound.rs
@@ -147,8 +147,10 @@ pub(crate) struct HeightSeenTracker {
 impl HeightSeenTracker {
     /// Whether another hash can be accepted for the supplied block height.
     pub(crate) fn can_accept(&mut self, height: u64, hash: B256, max_per_height: usize) -> bool {
-        if let Some(hashes) = self.seen_by_height.get(&height) &&
-            hashes.len() > max_per_height
+        if self
+            .seen_by_height
+            .get(&height)
+            .is_some_and(|hashes| hashes.len() > max_per_height)
         {
             return false;
         }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/whitelist_fetcher.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/whitelist_fetcher.rs
@@ -262,9 +262,9 @@ where
     /// Check whether the L1 head has advanced past the cached epoch boundary and, if so,
     /// invalidate the sequencer cache to force a fresh L1 read on the next access.
     pub(crate) async fn maybe_invalidate_for_epoch_advance(&mut self) -> Result<()> {
-        let Some(_) = self.sequencer_cache.current_epoch_start_timestamp() else {
+        if self.sequencer_cache.current_epoch_start_timestamp().is_none() {
             return Ok(());
-        };
+        }
 
         let latest_block = self
             .l1_provider


### PR DESCRIPTION


  ## Summary
  - Simplify idiomatic Rust patterns across the `whitelist-preconfirmation-driver` crate without changing behavior

  ## Changes
  - Remove unnecessary `copy_acceptance` closure in `event_loop.rs` since `MessageAcceptance` is `Copy`
  - Simplify `decode_eos_epoch_exact` and `decode_request_hash_exact` to single `try_into` calls
  - Replace `.map(...).unwrap_or(false)` with `.is_some_and(...)` and `.map(...).unwrap_or(true)` with `.is_none_or(...)`
  - Replace `if let Some(...) &&` with `.is_some_and(...)` in `inbound.rs`
  - Replace `let Some(_) = expr else { return }` with `if expr.is_none() { return }` in `whitelist_fetcher.rs`
  - Use pattern matching (`|&b|`) instead of dereference (`|b| *b`) consistently across the crate
  - Simplify signature length calculation from `.map(|_| SIGNATURE_LEN).unwrap_or_default()` to `if`/`else`

  ## Test plan
  - [x] All 127 existing tests pass
  - [x] Crate compiles cleanly
