### PR TITLE
fix(taiko-client): add missing error key in SGXVerifier log

### DIFF
--- a/packages/taiko-client/bindings/encoding/input.go
+++ b/packages/taiko-client/bindings/encoding/input.go
@@ -170,7 +170,7 @@ func init() {
 	}
 
 	if SGXVerifierABI, err = ontakeBindings.SgxVerifierMetaData.GetAbi(); err != nil {
-		log.Crit("Get SGXVerifier ABI error", err)
+		log.Crit("Get SGXVerifier ABI error", "error", err)
 	}
 
 	if ProverSetABI, err = ontakeBindings.ProverSetMetaData.GetAbi(); err != nil {


### PR DESCRIPTION
Add the missing `"error"` key to the SGXVerifier ABI init `log.Crit` call, keeping ABI initialization error logs in taiko-client consistent with structured key-value logging.