### PR TITLE
feat(protocol): set new shasta fork timestamp

### DIFF
--- a/packages/protocol/script/layer1/core/DeployShastaMainnet.s.sol
+++ b/packages/protocol/script/layer1/core/DeployShastaMainnet.s.sol
@@ -33,6 +33,6 @@ contract DeployShastaMainnet is DeployShastaContracts {
         config.proverManager = LibL1Addrs.MULTISIG_ADMIN_TAIKO_ETH;
         config.provers = new address[](1);
         config.provers[0] = 0xa5cb34B75bD72f15290ef37A01F06183E8036875; // We can add new provers later using the prover manager role
-        config.shastaForkTimestamp = 1_774_530_900; // 2026-03-26 13:15:00 UTC
+        config.shastaForkTimestamp = 1_775_135_700; // 2026-04-02 13:15:00 UTC
     }
 }

--- a/packages/protocol/script/layer2/DeployShastaL2Mainnet.s.sol
+++ b/packages/protocol/script/layer2/DeployShastaL2Mainnet.s.sol
@@ -21,6 +21,6 @@ contract DeployShastaL2Mainnet is DeployShastaL2Contracts {
         config.oldSignalServiceImpl = 0xaea51c413Bd15bBee72737C8094BE942B5208762;
         config.oldAnchorImpl = 0xE6d1efcC6AC8969474308C99a3805c332D33a1E0;
 
-        config.shastaForkTimestamp = 1_774_530_900; // 2026-03-26 13:15:00 UTC
+        config.shastaForkTimestamp = 1_775_135_700; // 2026-04-02 13:15:00 UTC
     }
 }


### PR DESCRIPTION
It was risky that we were actually able to submit the proposal on-chain on time to hit the fork timestamp of March 26th. This PR pushes the fork one week at the exact same time.

The contracts have all been deployed and the deployment logs updated.

You can see a table with the addresses on #21430 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the on-chain fork activation timestamp for both L1 and L2 deployment scripts; an incorrect timestamp could cause a missed or premature network upgrade.
> 
> **Overview**
> Pushes the Shasta mainnet fork activation time out by one week by updating `config.shastaForkTimestamp` in both `DeployShastaMainnet.s.sol` (L1) and `DeployShastaL2Mainnet.s.sol` (L2).
> 
> No other deployment parameters or contract addresses are changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c66b0f8d3a6df4a213e23fb8cc8260f323235d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->