### PR TITLE
fix(relayer): remove deprecated cacheOption parameter

### DIFF
--- a/packages/relayer/cmd/flags/processor.go
+++ b/packages/relayer/cmd/flags/processor.go
@@ -93,14 +93,6 @@ var (
 		Required: false,
 		EnvVars:  []string{"TARGET_TX_HASH"},
 	}
-	CacheOption = &cli.IntFlag{
-		Name:     "cacheOption",
-		Usage:    "Cache option. Options: 0 - cache nothing, 1 - cache signal root, 2 - cache state root, 3 - cache both",
-		Category: processorCategory,
-		Required: false,
-		EnvVars:  []string{"CACHE_OPTION"},
-		Value:    3,
-	}
 	UnprofitableMessageQueueExpiration = &cli.StringFlag{
 		Name:     "unprofitableMessageQueueExpiration",
 		Usage:    "Time in seconds for queue message to expire when unprofitable, which will re-route it to be checked again",
@@ -146,7 +138,6 @@ var ProcessorFlags = MergeFlags(CommonFlags, QueueFlags, TxmgrFlags, []cli.Flag{
 	EnableTaikoL2,
 	DestBridgeAddress,
 	TargetTxHash,
-	CacheOption,
 	UnprofitableMessageQueueExpiration,
 	MaxMessageRetries,
 	MinFeeToProcess,

--- a/packages/relayer/pkg/encoding/types.go
+++ b/packages/relayer/pkg/encoding/types.go
@@ -37,15 +37,6 @@ type BlockHeader struct {
 	WithdrawalsRoot  [32]byte       `abi:"withdrawalsRoot"`
 }
 
-type CacheOption uint8
-
-const (
-	CACHE_NOTHING     = iota
-	CACHE_SIGNAL_ROOT = iota
-	CACHE_STATE_ROOT  = iota
-	CACHE_BOTH        = iota
-)
-
 type HopProof struct {
 	ChainID      uint64   `abi:"chainId"`
 	BlockID      uint64   `abi:"blockId"`

--- a/packages/relayer/pkg/proof/encoded_signal_proof.go
+++ b/packages/relayer/pkg/proof/encoded_signal_proof.go
@@ -47,7 +47,7 @@ func (p *Prover) EncodedSignalProof(ctx context.Context,
 		BlockID:      block.NumberU64(),
 		ChainID:      params.ChainID.Uint64(),
 		RootHash:     block.Root(),
-		CacheOption:  encoding.CACHE_NOTHING,
+		CacheOption:  0,
 		AccountProof: ethProof.AccountProof,
 		StorageProof: ethProof.StorageProof[0].Proof,
 	}})

--- a/packages/relayer/pkg/proof/prover.go
+++ b/packages/relayer/pkg/proof/prover.go
@@ -19,17 +19,15 @@ type blocker interface {
 	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
 }
 type Prover struct {
-	blocker     blocker
-	cacheOption int
+	blocker blocker
 }
 
-func New(blocker blocker, cacheOption int) (*Prover, error) {
+func New(blocker blocker) (*Prover, error) {
 	if blocker == nil {
 		return nil, relayer.ErrNoEthClient
 	}
 
 	return &Prover{
-		blocker:     blocker,
-		cacheOption: cacheOption,
+		blocker: blocker,
 	}, nil
 }

--- a/packages/relayer/pkg/proof/prover_test.go
+++ b/packages/relayer/pkg/proof/prover_test.go
@@ -5,15 +5,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
-	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/encoding"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 	"gopkg.in/go-playground/assert.v1"
 )
 
 func newTestProver() *Prover {
 	return &Prover{
-		blocker:     &mock.Blocker{},
-		cacheOption: encoding.CACHE_BOTH,
+		blocker: &mock.Blocker{},
 	}
 }
 
@@ -37,7 +35,7 @@ func Test_New(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := New(tt.blocker, encoding.CACHE_BOTH)
+			_, err := New(tt.blocker)
 			assert.Equal(t, tt.wantErr, err)
 		})
 	}

--- a/packages/relayer/processor/config.go
+++ b/packages/relayer/processor/config.go
@@ -67,7 +67,6 @@ type Config struct {
 	OpenQueueFunc    func() (queue.Queue, error)
 	OpenDBFunc       func() (db.DB, error)
 
-	CacheOption                        int
 	UnprofitableMessageQueueExpiration *string
 
 	TxmgrConfigs *txmgr.CLIConfig
@@ -136,7 +135,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		BackOffMaxRetries:                  c.Uint64(flags.BackOffMaxRetries.Name),
 		ETHClientTimeout:                   c.Uint64(flags.ETHClientTimeout.Name),
 		TargetTxHash:                       targetTxHash,
-		CacheOption:                        c.Int(flags.CacheOption.Name),
 		UnprofitableMessageQueueExpiration: unprofitableMessageQueueExpiration,
 		TxmgrConfigs: pkgFlags.InitTxmgrConfigsFromCli(
 			c.String(flags.DestRPCUrl.Name),

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -152,7 +152,7 @@ func TestGenerateEncodedSignalProofUsesDestChainCheckpoint(t *testing.T) {
 	}
 
 	ethClient := &mock.EthClient{}
-	prover, err := proof.New(ethClient, 0)
+	prover, err := proof.New(ethClient)
 	assert.Nil(t, err)
 
 	p := &Processor{

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -225,7 +225,7 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 		return err
 	}
 
-	prover, err := proof.New(srcEthClient, p.cfg.CacheOption)
+	prover, err := proof.New(srcEthClient)
 	if err != nil {
 		return err
 	}

--- a/packages/relayer/processor/processor_test.go
+++ b/packages/relayer/processor/processor_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/encoding"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/proof"
 )
@@ -17,7 +16,6 @@ func newTestProcessor(profitableOnly bool) *Processor {
 
 	prover, _ := proof.New(
 		&mock.Blocker{},
-		encoding.CACHE_NOTHING,
 	)
 
 	return &Processor{


### PR DESCRIPTION
## Summary

- Remove the `--cacheOption` CLI flag, `Config.CacheOption` field, `Prover.cacheOption` field, and `encoding.CacheOption` type with its associated constants (`CACHE_NOTHING`, `CACHE_SIGNAL_ROOT`, `CACHE_STATE_ROOT`, `CACHE_BOTH`)
- The `cacheOption` parameter was accepted by CLI but silently ignored — `encoded_signal_proof.go` always hardcoded `CacheOption: CACHE_NOTHING` regardless of user input
- This aligns with the Solidity-side deprecation ("Caching is no longer supported") and eliminates misleading operator-facing configuration

## Changed files

- `packages/relayer/cmd/flags/processor.go` — removed `CacheOption` flag definition and registration
- `packages/relayer/processor/config.go` — removed `CacheOption` field and its assignment
- `packages/relayer/pkg/proof/prover.go` — removed `cacheOption` field, simplified `New()` signature
- `packages/relayer/pkg/proof/encoded_signal_proof.go` — replaced `encoding.CACHE_NOTHING` with literal `0`
- `packages/relayer/pkg/encoding/types.go` — removed `CacheOption` type and cache constants
- `packages/relayer/pkg/proof/prover_test.go` — adapted to new signature
- `packages/relayer/processor/processor_test.go` — adapted to new signature
- `packages/relayer/processor/process_message_test.go` — adapted to new signature