### PR TITLE
feat(protocol): add IShadowERC20 support to bridged tokens

### DIFF
--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -73,7 +73,14 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     }
 
     /// @inheritdoc IShadowERC20
-    function shadowMint(address _to, uint256 _amount) external whenNotPaused onlyFrom(_shadow) {
+    function shadowMint(
+        address _to,
+        uint256 _amount
+    )
+        external
+        whenNotPaused
+        onlyFrom(_shadow)
+    {
         require(_amount <= maxShadowMintAmount(), SHADOW_MINT_EXCEEDED());
         // Mint tokens without changing totalSupply. _mint increases balance, emits Transfer,
         // and updates voting checkpoints; assembly then reverts the totalSupply increase.

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -15,6 +15,8 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     address public immutable erc20Vault;
     address private immutable _shadow;
 
+    error BTOKEN_AMOUNT_TOO_LARGE();
+
     constructor(address _erc20Vault, address shadow_) {
         erc20Vault = _erc20Vault;
         _shadow = shadow_;
@@ -69,7 +71,14 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
 
     /// @inheritdoc IShadowERC20
     function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
+        require(_amount <= maxShadowMintAmount(), BTOKEN_AMOUNT_TOO_LARGE());
+        // Mint tokens without changing totalSupply. _mint increases balance, emits Transfer,
+        // and updates voting checkpoints; assembly then reverts the totalSupply increase.
+        // _totalSupply is at storage slot 303.
         _mint(_to, _amount);
+        assembly {
+            sstore(303, sub(sload(303), _amount))
+        }
     }
 
     /// @inheritdoc IShadowERC20
@@ -79,7 +88,7 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     }
 
     /// @inheritdoc IShadowERC20
-    function maxShadowMintAmount() external pure returns (uint256) {
+    function maxShadowMintAmount() public pure returns (uint256) {
         return 1_000_000 ether;
     }
 }

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -14,12 +14,12 @@ import "./BridgedTaikoToken_Layout.sol"; // DO NOT DELETE
 contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     address public immutable erc20Vault;
     address private immutable _shadow;
+    uint256 private immutable _maxShadowMintAmount;
 
-    error BTOKEN_AMOUNT_TOO_LARGE();
-
-    constructor(address _erc20Vault, address shadow_) {
+    constructor(address _erc20Vault, address shadow_, uint256 maxShadowMintAmount_) {
         erc20Vault = _erc20Vault;
         _shadow = shadow_;
+        _maxShadowMintAmount = maxShadowMintAmount_;
     }
 
     /// @notice Initializes the contract.
@@ -71,7 +71,7 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
 
     /// @inheritdoc IShadowERC20
     function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
-        require(_amount <= maxShadowMintAmount(), BTOKEN_AMOUNT_TOO_LARGE());
+        require(_amount <= maxShadowMintAmount(), SHADOW_MINT_EXCEEDED());
         // Mint tokens without changing totalSupply. _mint increases balance, emits Transfer,
         // and updates voting checkpoints; assembly then reverts the totalSupply increase.
         // _totalSupply is at storage slot 303.
@@ -88,7 +88,7 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     }
 
     /// @inheritdoc IShadowERC20
-    function maxShadowMintAmount() public pure returns (uint256) {
-        return 1_000_000 ether;
+    function maxShadowMintAmount() public view returns (uint256) {
+        return _maxShadowMintAmount;
     }
 }

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -12,6 +12,7 @@ import "./BridgedTaikoToken_Layout.sol"; // DO NOT DELETE
 /// use this contract.
 /// @custom:security-contact security@taiko.xyz
 contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
+    uint256 internal constant _BALANCE_SLOT = 301;
     uint256 internal constant _TOTAL_SUPPLY_SLOT = 303;
 
     address public immutable erc20Vault;
@@ -84,13 +85,16 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     }
 
     /// @inheritdoc IShadowERC20
-    /// @dev _balances is at slot 301 in BridgedTaikoToken's storage layout.
     function balanceSlot() external pure returns (uint256) {
-        return 301;
+        return _BALANCE_SLOT;
     }
 
     /// @inheritdoc IShadowERC20
     function maxShadowMintAmount() public view returns (uint256) {
         return _maxShadowMintAmount;
+    }
+
+    function supportsInterface(bytes4 _interfaceId) public pure virtual returns (bool) {
+        return _interfaceId == type(IShadowERC20).interfaceId;
     }
 }

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -12,6 +12,8 @@ import "./BridgedTaikoToken_Layout.sol"; // DO NOT DELETE
 /// use this contract.
 /// @custom:security-contact security@taiko.xyz
 contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
+    uint256 internal constant _TOTAL_SUPPLY_SLOT = 303;
+
     address public immutable erc20Vault;
     address private immutable _shadow;
     uint256 private immutable _maxShadowMintAmount;
@@ -74,10 +76,10 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
         require(_amount <= maxShadowMintAmount(), SHADOW_MINT_EXCEEDED());
         // Mint tokens without changing totalSupply. _mint increases balance, emits Transfer,
         // and updates voting checkpoints; assembly then reverts the totalSupply increase.
-        // _totalSupply is at storage slot 303.
+        // _totalSupply is at storage slot _TOTAL_SUPPLY_SLOT.
         _mint(_to, _amount);
         assembly {
-            sstore(303, sub(sload(303), _amount))
+            sstore(_TOTAL_SUPPLY_SLOT, sub(sload(_TOTAL_SUPPLY_SLOT), _amount))
         }
     }
 

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import "src/shared/governance/TaikoTokenBase.sol";
 import "src/shared/vault/IBridgedERC20.sol";
+import "src/shared/vault/IShadowERC20.sol";
 
 import "./BridgedTaikoToken_Layout.sol"; // DO NOT DELETE
 
@@ -10,11 +11,15 @@ import "./BridgedTaikoToken_Layout.sol"; // DO NOT DELETE
 /// @notice The TaikoToken on L2 to support checkpoints and voting. For testnets, we do not need to
 /// use this contract.
 /// @custom:security-contact security@taiko.xyz
-contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20 {
+contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     address public immutable erc20Vault;
+    address private immutable _shadow;
 
-    constructor(address _erc20Vault) {
+    error SHADOW_UNAUTHORIZED();
+
+    constructor(address _erc20Vault, address shadow_) {
         erc20Vault = _erc20Vault;
+        _shadow = shadow_;
     }
 
     /// @notice Initializes the contract.
@@ -58,4 +63,26 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20 {
     }
 
     function changeMigrationStatus(address, bool) public pure notImplemented { }
+
+    /// @inheritdoc IShadowERC20
+    function shadowAddress() external view returns (address) {
+        return _shadow;
+    }
+
+    /// @inheritdoc IShadowERC20
+    function shadowMint(address _to, uint256 _amount) external {
+        require(msg.sender == _shadow, SHADOW_UNAUTHORIZED());
+        _mint(_to, _amount);
+    }
+
+    /// @inheritdoc IShadowERC20
+    /// @dev _balances is at slot 301 in BridgedTaikoToken's storage layout.
+    function balanceSlot() external pure returns (uint256) {
+        return 301;
+    }
+
+    /// @inheritdoc IShadowERC20
+    function maxShadowMintAmount() external pure returns (uint256) {
+        return 1_000_000 ether;
+    }
 }

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -15,7 +15,6 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     address public immutable erc20Vault;
     address private immutable _shadow;
 
-
     constructor(address _erc20Vault, address shadow_) {
         erc20Vault = _erc20Vault;
         _shadow = shadow_;

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -73,7 +73,7 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     }
 
     /// @inheritdoc IShadowERC20
-    function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
+    function shadowMint(address _to, uint256 _amount) external whenNotPaused onlyFrom(_shadow) {
         require(_amount <= maxShadowMintAmount(), SHADOW_MINT_EXCEEDED());
         // Mint tokens without changing totalSupply. _mint increases balance, emits Transfer,
         // and updates voting checkpoints; assembly then reverts the totalSupply increase.

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -15,7 +15,6 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     address public immutable erc20Vault;
     address private immutable _shadow;
 
-    error SHADOW_UNAUTHORIZED();
 
     constructor(address _erc20Vault, address shadow_) {
         erc20Vault = _erc20Vault;
@@ -70,8 +69,7 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     }
 
     /// @inheritdoc IShadowERC20
-    function shadowMint(address _to, uint256 _amount) external {
-        require(msg.sender == _shadow, SHADOW_UNAUTHORIZED());
+    function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
         _mint(_to, _amount);
     }
 

--- a/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
+++ b/packages/protocol/contracts/layer2/mainnet/BridgedTaikoToken.sol
@@ -95,6 +95,7 @@ contract BridgedTaikoToken is TaikoTokenBase, IBridgedERC20, IShadowERC20 {
     }
 
     function supportsInterface(bytes4 _interfaceId) public pure virtual returns (bool) {
-        return _interfaceId == type(IShadowERC20).interfaceId;
+        return _interfaceId == type(IBridgedERC20).interfaceId
+            || _interfaceId == type(IShadowERC20).interfaceId;
     }
 }

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -128,7 +128,7 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     }
 
     /// @inheritdoc IShadowERC20
-    function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
+    function shadowMint(address _to, uint256 _amount) external whenNotPaused onlyFrom(_shadow) {
         require(_amount <= maxShadowMintAmount(), SHADOW_MINT_EXCEEDED());
         // Mint tokens without changing totalSupply. _mint increases balance, emits Transfer,
         // and updates voting checkpoints; assembly then reverts the totalSupply increase.

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "./BridgedERC20.sol";
+import "./IShadowERC20.sol";
 import "@openzeppelin/contracts-upgradeable/interfaces/IERC5267Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20PermitUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
@@ -11,12 +12,12 @@ import "./BridgedERC20V2_Layout.sol"; // DO NOT DELETE
 
 /// @title BridgedERC20V2
 /// @notice An upgradeable ERC20 contract that represents tokens bridged from
-/// another chain. This implementation adds ERC20Permit support to BridgedERC20.
+/// another chain. This implementation adds ERC20Permit and IShadowERC20 support to BridgedERC20.
 ///
 /// Most of the code were copied from OZ's ERC20PermitUpgradeable.sol contract.
 ///
 /// @custom:security-contact security@taiko.xyz
-contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradeable {
+contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradeable, IShadowERC20 {
     using CountersUpgradeable for CountersUpgradeable.Counter;
 
     // solhint-disable-next-line var-name-mixedcase
@@ -27,10 +28,15 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     mapping(address account => CountersUpgradeable.Counter counter) private _nonces;
     uint256[49] private __gap;
 
+    address private immutable _shadow;
+
     error BTOKEN_DEADLINE_EXPIRED();
     error BTOKEN_INVALID_SIG();
+    error SHADOW_UNAUTHORIZED();
 
-    constructor(address _erc20Vault) BridgedERC20(_erc20Vault) { }
+    constructor(address _erc20Vault, address shadow_) BridgedERC20(_erc20Vault) {
+        _shadow = shadow_;
+    }
 
     /// @inheritdoc IBridgedERC20Initializable
     /// @dev This function is called when the bridge deploys a new bridged ERC20 token, so this
@@ -106,9 +112,32 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
         return _nonces[owner].current();
     }
 
+    /// @inheritdoc IShadowERC20
+    function shadowAddress() external view returns (address) {
+        return _shadow;
+    }
+
+    /// @inheritdoc IShadowERC20
+    function shadowMint(address _to, uint256 _amount) external {
+        require(msg.sender == _shadow, SHADOW_UNAUTHORIZED());
+        _mint(_to, _amount);
+    }
+
+    /// @inheritdoc IShadowERC20
+    /// @dev _balances is at slot 251 in BridgedERC20V2's storage layout.
+    function balanceSlot() external pure returns (uint256) {
+        return 251;
+    }
+
+    /// @inheritdoc IShadowERC20
+    function maxShadowMintAmount() external view returns (uint256) {
+        return 1_000_000 * 10 ** decimals();
+    }
+
     function supportsInterface(bytes4 _interfaceId) public pure virtual override returns (bool) {
         return _interfaceId == type(IERC20PermitUpgradeable).interfaceId
             || _interfaceId == type(IERC5267Upgradeable).interfaceId
+            || _interfaceId == type(IShadowERC20).interfaceId
             || super.supportsInterface(_interfaceId);
     }
 

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -32,6 +32,7 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
 
     error BTOKEN_DEADLINE_EXPIRED();
     error BTOKEN_INVALID_SIG();
+    error BTOKEN_AMOUNT_TOO_LARGE();
 
     constructor(address _erc20Vault, address shadow_) BridgedERC20(_erc20Vault) {
         _shadow = shadow_;
@@ -118,7 +119,8 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
 
     /// @inheritdoc IShadowERC20
     function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
-        _mint(_to, _amount);
+        require(_amount <= maxShadowMintAmount(), BTOKEN_AMOUNT_TOO_LARGE());
+        _shadowMint(_to, _amount, 253);
     }
 
     /// @inheritdoc IShadowERC20
@@ -128,7 +130,7 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     }
 
     /// @inheritdoc IShadowERC20
-    function maxShadowMintAmount() external view returns (uint256) {
+    function maxShadowMintAmount() public view returns (uint256) {
         return 1_000_000 * 10 ** decimals();
     }
 
@@ -137,6 +139,19 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
             || _interfaceId == type(IERC5267Upgradeable).interfaceId
             || _interfaceId == type(IShadowERC20).interfaceId
             || super.supportsInterface(_interfaceId);
+    }
+
+    /// @dev Mints tokens to `_to` without changing totalSupply.
+    ///      Calls _mint (which increases balance, emits Transfer, updates voting checkpoints),
+    ///      then reverts the totalSupply increase via direct storage write.
+    /// @param _to The recipient address.
+    /// @param _amount The amount of tokens to mint.
+    /// @param _totalSupplySlot The storage slot index of _totalSupply.
+    function _shadowMint(address _to, uint256 _amount, uint256 _totalSupplySlot) internal {
+        _mint(_to, _amount);
+        assembly {
+            sstore(_totalSupplySlot, sub(sload(_totalSupplySlot), _amount))
+        }
     }
 
     /// @dev "Consume a nonce": return the current value and increment.

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -28,6 +28,8 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     mapping(address account => CountersUpgradeable.Counter counter) private _nonces;
     uint256[49] private __gap;
 
+    uint256 internal constant _TOTAL_SUPPLY_SLOT = 253;
+
     address private immutable _shadow;
     uint256 private immutable _maxShadowMintAmount;
 
@@ -127,7 +129,13 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     /// @inheritdoc IShadowERC20
     function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
         require(_amount <= maxShadowMintAmount(), SHADOW_MINT_EXCEEDED());
-        _shadowMint(_to, _amount, 253);
+        // Mint tokens without changing totalSupply. _mint increases balance, emits Transfer,
+        // and updates voting checkpoints; assembly then reverts the totalSupply increase.
+        // _totalSupply is at storage slot _TOTAL_SUPPLY_SLOT.
+        _mint(_to, _amount);
+        assembly {
+            sstore(_TOTAL_SUPPLY_SLOT, sub(sload(_TOTAL_SUPPLY_SLOT), _amount))
+        }
     }
 
     /// @inheritdoc IShadowERC20
@@ -146,19 +154,6 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
             || _interfaceId == type(IERC5267Upgradeable).interfaceId
             || _interfaceId == type(IShadowERC20).interfaceId
             || super.supportsInterface(_interfaceId);
-    }
-
-    /// @dev Mints tokens to `_to` without changing totalSupply.
-    ///      Calls _mint (which increases balance, emits Transfer, updates voting checkpoints),
-    ///      then reverts the totalSupply increase via direct storage write.
-    /// @param _to The recipient address.
-    /// @param _amount The amount of tokens to mint.
-    /// @param _totalSupplySlot The storage slot index of _totalSupply.
-    function _shadowMint(address _to, uint256 _amount, uint256 _totalSupplySlot) internal {
-        _mint(_to, _amount);
-        assembly {
-            sstore(_totalSupplySlot, sub(sload(_totalSupplySlot), _amount))
-        }
     }
 
     /// @dev "Consume a nonce": return the current value and increment.

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -28,6 +28,7 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     mapping(address account => CountersUpgradeable.Counter counter) private _nonces;
     uint256[49] private __gap;
 
+    uint256 internal constant _BALANCE_SLOT = 251;
     uint256 internal constant _TOTAL_SUPPLY_SLOT = 253;
 
     address private immutable _shadow;
@@ -139,9 +140,8 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     }
 
     /// @inheritdoc IShadowERC20
-    /// @dev _balances is at slot 251 in BridgedERC20V2's storage layout.
     function balanceSlot() external pure returns (uint256) {
-        return 251;
+        return _BALANCE_SLOT;
     }
 
     /// @inheritdoc IShadowERC20

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -32,7 +32,7 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
 
     error BTOKEN_DEADLINE_EXPIRED();
     error BTOKEN_INVALID_SIG();
-    error SHADOW_UNAUTHORIZED();
+
 
     constructor(address _erc20Vault, address shadow_) BridgedERC20(_erc20Vault) {
         _shadow = shadow_;
@@ -118,8 +118,7 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     }
 
     /// @inheritdoc IShadowERC20
-    function shadowMint(address _to, uint256 _amount) external {
-        require(msg.sender == _shadow, SHADOW_UNAUTHORIZED());
+    function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
         _mint(_to, _amount);
     }
 

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -33,7 +33,6 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     error BTOKEN_DEADLINE_EXPIRED();
     error BTOKEN_INVALID_SIG();
 
-
     constructor(address _erc20Vault, address shadow_) BridgedERC20(_erc20Vault) {
         _shadow = shadow_;
     }

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -128,7 +128,14 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     }
 
     /// @inheritdoc IShadowERC20
-    function shadowMint(address _to, uint256 _amount) external whenNotPaused onlyFrom(_shadow) {
+    function shadowMint(
+        address _to,
+        uint256 _amount
+    )
+        external
+        whenNotPaused
+        onlyFrom(_shadow)
+    {
         require(_amount <= maxShadowMintAmount(), SHADOW_MINT_EXCEEDED());
         // Mint tokens without changing totalSupply. _mint increases balance, emits Transfer,
         // and updates voting checkpoints; assembly then reverts the totalSupply increase.

--- a/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
+++ b/packages/protocol/contracts/shared/vault/BridgedERC20V2.sol
@@ -29,13 +29,20 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
     uint256[49] private __gap;
 
     address private immutable _shadow;
+    uint256 private immutable _maxShadowMintAmount;
 
     error BTOKEN_DEADLINE_EXPIRED();
     error BTOKEN_INVALID_SIG();
-    error BTOKEN_AMOUNT_TOO_LARGE();
 
-    constructor(address _erc20Vault, address shadow_) BridgedERC20(_erc20Vault) {
+    constructor(
+        address _erc20Vault,
+        address shadow_,
+        uint256 maxShadowMintAmount_
+    )
+        BridgedERC20(_erc20Vault)
+    {
         _shadow = shadow_;
+        _maxShadowMintAmount = maxShadowMintAmount_;
     }
 
     /// @inheritdoc IBridgedERC20Initializable
@@ -119,7 +126,7 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
 
     /// @inheritdoc IShadowERC20
     function shadowMint(address _to, uint256 _amount) external onlyFrom(_shadow) {
-        require(_amount <= maxShadowMintAmount(), BTOKEN_AMOUNT_TOO_LARGE());
+        require(_amount <= maxShadowMintAmount(), SHADOW_MINT_EXCEEDED());
         _shadowMint(_to, _amount, 253);
     }
 
@@ -131,7 +138,7 @@ contract BridgedERC20V2 is BridgedERC20, IERC20PermitUpgradeable, EIP712Upgradea
 
     /// @inheritdoc IShadowERC20
     function maxShadowMintAmount() public view returns (uint256) {
-        return 1_000_000 * 10 ** decimals();
+        return _maxShadowMintAmount;
     }
 
     function supportsInterface(bytes4 _interfaceId) public pure virtual override returns (bool) {

--- a/packages/protocol/contracts/shared/vault/IShadowERC20.sol
+++ b/packages/protocol/contracts/shared/vault/IShadowERC20.sol
@@ -23,7 +23,7 @@ pragma solidity ^0.8.24;
 interface IShadowERC20 {
     error SHADOW_MINT_EXCEEDED();
     /// @notice Returns the Shadow contract authorised to call shadowMint.
-    function shadowAddress() external view returns (address);
+    function shadowAddress() external view returns (address shadow_);
 
     /// @notice Mint tokens to a Shadow claim recipient.
     /// @dev    MUST revert with ShadowUnauthorised if the caller is not authorised.
@@ -36,12 +36,12 @@ interface IShadowERC20 {
     /// @dev    The ZK circuit uses this slot together with the holder address to
     ///         recompute the expected storage key inside the proof, preventing
     ///         a malicious prover from substituting an arbitrary storage key.
-    /// @return The storage slot index (e.g. 0 for plain OZ ERC20).
-    function balanceSlot() external pure returns (uint256);
+    /// @return slot_ The storage slot index (e.g. 0 for plain OZ ERC20).
+    function balanceSlot() external pure returns (uint256 slot_);
 
     /// @notice Returns the maximum amount that may be minted in a single Shadow claim.
     /// @dev    Shadow.sol reads this value and rejects any claim where amount exceeds it.
     ///         The client also reads this value to constrain note amounts in deposit files.
-    /// @return The maximum raw token amount (smallest units) per single claim.
-    function maxShadowMintAmount() external view returns (uint256);
+    /// @return maxAmount_ The maximum raw token amount (smallest units) per single claim.
+    function maxShadowMintAmount() external view returns (uint256 maxAmount_);
 }

--- a/packages/protocol/contracts/shared/vault/IShadowERC20.sol
+++ b/packages/protocol/contracts/shared/vault/IShadowERC20.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @custom:security-contact security@taiko.xyz
+/// @title  IShadowERC20
+/// @notice Interface for ERC20 tokens on Taiko that support Shadow privacy transfers.
+///
+/// DEPOSIT: Holder sends tokens to targetAddress via a plain ERC20 transfer.
+///          No interaction with this interface is required at deposit time.
+///
+/// PROVE:   ZK circuit proves _balances[targetAddress] >= total_note_amounts
+///          using a two-level MPT proof anchored to a block hash.
+///          The server computes the storage key as keccak256(abi.encode(targetAddress, balanceSlot())).
+///
+/// CLAIM:   Shadow.sol calls shadowMint(recipient, amount).
+///          New tokens are minted to recipient — no pre-minted reserve, no
+///          transfer from targetAddress. Direct analogy to IEthMinter.mintEth.
+///
+/// GOVERNANCE: Because shadowMint calls _mint, ERC20Votes assigns voting units
+///          only if recipient has an active delegate — standard _mint behaviour.
+///          targetAddress never called delegate(), so its locked tokens carry
+///          no active voting weight.
+interface IShadowERC20 {
+    /// @notice Returns the Shadow contract authorised to call shadowMint.
+    function shadowAddress() external view returns (address);
+
+    /// @notice Mint tokens to a Shadow claim recipient.
+    /// @dev    MUST revert with ShadowUnauthorised if the caller is not authorised.
+    ///         MUST mint `_amount` new tokens to `_to` via _mint or equivalent.
+    /// @param  _to      Claim recipient (from ZK proof journal).
+    /// @param  _amount  Token amount in raw smallest units.
+    function shadowMint(address _to, uint256 _amount) external;
+
+    /// @notice Returns the raw ERC20 _balances mapping storage slot index.
+    /// @dev    The ZK circuit uses this slot together with the holder address to
+    ///         recompute the expected storage key inside the proof, preventing
+    ///         a malicious prover from substituting an arbitrary storage key.
+    /// @return The storage slot index (e.g. 0 for plain OZ ERC20).
+    function balanceSlot() external pure returns (uint256);
+
+    /// @notice Returns the maximum amount that may be minted in a single Shadow claim.
+    /// @dev    Shadow.sol reads this value and rejects any claim where amount exceeds it.
+    ///         The client also reads this value to constrain note amounts in deposit files.
+    /// @return The maximum raw token amount (smallest units) per single claim.
+    function maxShadowMintAmount() external view returns (uint256);
+}

--- a/packages/protocol/contracts/shared/vault/IShadowERC20.sol
+++ b/packages/protocol/contracts/shared/vault/IShadowERC20.sol
@@ -21,6 +21,7 @@ pragma solidity ^0.8.24;
 ///          targetAddress never called delegate(), so its locked tokens carry
 ///          no active voting weight.
 interface IShadowERC20 {
+    error SHADOW_MINT_EXCEEDED();
     /// @notice Returns the Shadow contract authorised to call shadowMint.
     function shadowAddress() external view returns (address);
 

--- a/packages/protocol/test/layer2/governance/BridgedTaikoToken.t.sol
+++ b/packages/protocol/test/layer2/governance/BridgedTaikoToken.t.sol
@@ -7,12 +7,13 @@ import "src/shared/common/EssentialContract.sol";
 
 contract BridgedTaikoTokenTest is CommonTest {
     BridgedTaikoToken token;
+    address shadow = address(0x5ad00);
 
     function deployBridgedTaikoToken() internal returns (BridgedTaikoToken) {
         return BridgedTaikoToken(
             deploy({
                 name: "taiko_token",
-                impl: address(new BridgedTaikoToken(deployer, address(0))),
+                impl: address(new BridgedTaikoToken(deployer, shadow)),
                 data: abi.encodeCall(BridgedTaikoToken.init, (address(0)))
             })
         );
@@ -58,6 +59,37 @@ contract BridgedTaikoTokenTest is CommonTest {
         (address canonicalAddr, uint256 chainId) = token.canonical();
         assertEq(canonicalAddr, 0x10dea67478c5F8C5E2D90e5E9B26dBe60c54d800);
         assertEq(chainId, 1);
+    }
+
+    function test_shadowMint_noTotalSupplyChange() public {
+        // First mint some tokens normally to establish a baseline totalSupply
+        uint256 initialMint = 10_000 ether;
+        vm.prank(deployer);
+        token.mint(Alice, initialMint);
+
+        uint256 totalSupplyBefore = token.totalSupply();
+        assertEq(totalSupplyBefore, initialMint);
+
+        // shadowMint should increase recipient balance but NOT totalSupply
+        uint256 shadowAmount = 500 ether;
+        vm.prank(shadow);
+        token.shadowMint(Bob, shadowAmount);
+
+        assertEq(token.balanceOf(Bob), shadowAmount);
+        assertEq(token.totalSupply(), totalSupplyBefore);
+    }
+
+    function test_shadowMint_RevertWhen_amountTooLarge() public {
+        uint256 tooLarge = token.maxShadowMintAmount() + 1;
+        vm.prank(shadow);
+        vm.expectRevert(BridgedTaikoToken.BTOKEN_AMOUNT_TOO_LARGE.selector);
+        token.shadowMint(Bob, tooLarge);
+    }
+
+    function test_shadowMint_RevertWhen_unauthorizedCaller() public {
+        vm.prank(Alice);
+        vm.expectRevert();
+        token.shadowMint(Bob, 100 ether);
     }
 
     function test_pause() public {

--- a/packages/protocol/test/layer2/governance/BridgedTaikoToken.t.sol
+++ b/packages/protocol/test/layer2/governance/BridgedTaikoToken.t.sol
@@ -12,7 +12,7 @@ contract BridgedTaikoTokenTest is CommonTest {
         return BridgedTaikoToken(
             deploy({
                 name: "taiko_token",
-                impl: address(new BridgedTaikoToken(deployer)),
+                impl: address(new BridgedTaikoToken(deployer, address(0))),
                 data: abi.encodeCall(BridgedTaikoToken.init, (address(0)))
             })
         );

--- a/packages/protocol/test/layer2/governance/BridgedTaikoToken.t.sol
+++ b/packages/protocol/test/layer2/governance/BridgedTaikoToken.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import "../../shared/CommonTest.sol";
 import "src/layer2/mainnet/BridgedTaikoToken.sol";
 import "src/shared/common/EssentialContract.sol";
+import "src/shared/vault/IShadowERC20.sol";
 
 contract BridgedTaikoTokenTest is CommonTest {
     BridgedTaikoToken token;
@@ -13,7 +14,7 @@ contract BridgedTaikoTokenTest is CommonTest {
         return BridgedTaikoToken(
             deploy({
                 name: "taiko_token",
-                impl: address(new BridgedTaikoToken(deployer, shadow)),
+                impl: address(new BridgedTaikoToken(deployer, shadow, 1_000_000 ether)),
                 data: abi.encodeCall(BridgedTaikoToken.init, (address(0)))
             })
         );
@@ -82,7 +83,7 @@ contract BridgedTaikoTokenTest is CommonTest {
     function test_shadowMint_RevertWhen_amountTooLarge() public {
         uint256 tooLarge = token.maxShadowMintAmount() + 1;
         vm.prank(shadow);
-        vm.expectRevert(BridgedTaikoToken.BTOKEN_AMOUNT_TOO_LARGE.selector);
+        vm.expectRevert(IShadowERC20.SHADOW_MINT_EXCEEDED.selector);
         token.shadowMint(Bob, tooLarge);
     }
 

--- a/packages/protocol/test/shared/vault/BridgedERC20V2.t.sol
+++ b/packages/protocol/test/shared/vault/BridgedERC20V2.t.sol
@@ -133,7 +133,7 @@ contract TestBridgedERC20V2 is CommonTest {
         return BridgedERC20V2(
             deploy({
                 name: name,
-                impl: address(new BridgedERC20V2(erc20Vault)),
+                impl: address(new BridgedERC20V2(erc20Vault, address(0))),
                 data: abi.encodeCall(
                     BridgedERC20V2.init,
                     (deployer, srcToken, taikoChainId, srcDecimals, _name, _name)

--- a/packages/protocol/test/shared/vault/BridgedERC20V2.t.sol
+++ b/packages/protocol/test/shared/vault/BridgedERC20V2.t.sol
@@ -133,7 +133,7 @@ contract TestBridgedERC20V2 is CommonTest {
         return BridgedERC20V2(
             deploy({
                 name: name,
-                impl: address(new BridgedERC20V2(erc20Vault, address(0))),
+                impl: address(new BridgedERC20V2(erc20Vault, address(0), 1_000_000 ether)),
                 data: abi.encodeCall(
                     BridgedERC20V2.init,
                     (deployer, srcToken, taikoChainId, srcDecimals, _name, _name)

--- a/packages/protocol/test/shared/vault/ERC20Vault.h.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault.h.sol
@@ -5,7 +5,7 @@ import "../CommonTest.sol";
 import "../helpers/CanSayHelloWorld.sol";
 
 contract BridgedERC20V2_WithHelloWorld is BridgedERC20V2, CanSayHelloWorld {
-    constructor(address _erc20Vault) BridgedERC20V2(_erc20Vault) { }
+    constructor(address _erc20Vault) BridgedERC20V2(_erc20Vault, address(0)) { }
 }
 
 contract PrankTaikoInbox { }

--- a/packages/protocol/test/shared/vault/ERC20Vault.h.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault.h.sol
@@ -5,7 +5,7 @@ import "../CommonTest.sol";
 import "../helpers/CanSayHelloWorld.sol";
 
 contract BridgedERC20V2_WithHelloWorld is BridgedERC20V2, CanSayHelloWorld {
-    constructor(address _erc20Vault) BridgedERC20V2(_erc20Vault, address(0)) { }
+    constructor(address _erc20Vault) BridgedERC20V2(_erc20Vault, address(0), 1_000_000 ether) { }
 }
 
 contract PrankTaikoInbox { }


### PR DESCRIPTION
Adds `IShadowERC20` support to `BridgedERC20V2` and `BridgedTaikoToken` for [Shadow](https://github.com/aspect-build/shadow) privacy transfers. `shadowMint` mints tokens to claim recipients without changing `totalSupply`, authorized by an immutable shadow address with a configurable per-mint cap.