### PR TITLE
fix(relayer): standardize bridge gas estimation error log key

### DIFF
--- a/packages/relayer/bridge/bridge.go
+++ b/packages/relayer/bridge/bridge.go
@@ -229,7 +229,7 @@ func (b *Bridge) submitBridgeTx(ctx context.Context) error {
 
 	gas, err := b.estimateGas(ctx, message)
 	if err != nil || gas == 0 {
-		slog.Info("gas estimation failed, hardcoding gas limit", "b.estimateGas:", err)
+		slog.Info("gas estimation failed, hardcoding gas limit", "error", err)
 	}
 
 	auth.GasLimit = gas


### PR DESCRIPTION
Use the standard `error` field when gas estimation falls back, improving structured log filtering for relayer bridge operators. 