### PR TITLE
chore(ejector): remove redundant URL clone in eject path

### DIFF
--- a/packages/ejector/src/utils/eject.rs
+++ b/packages/ejector/src/utils/eject.rs
@@ -23,7 +23,7 @@ async fn eject_operator_internal(
         return Ok(());
     }
 
-    let l1 = ProviderBuilder::new().wallet(signer.clone()).connect_http(l1_http_url.clone());
+    let l1 = ProviderBuilder::new().wallet(signer.clone()).connect_http(l1_http_url);
     let preconf_whitelist = bindings::IPreconfWhitelist::new(whitelist_addr, l1.clone());
 
     let info = preconf_whitelist.operators(operator).call().await?;


### PR DESCRIPTION
Remove an unnecessary `Url` clone in the ejector operator ejection setup, preserving behavior while simplifying ownership flow.