### PR TITLE
fix(taiko-client): preserve Shasta base fee config

### DIFF
--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -1069,6 +1069,17 @@ func (c *Client) GetSyncedL1SnippetFromAnchor(tx *types.Transaction) (
 	return l1StateRoot, l1Height, parentGasUsed, nil
 }
 
+// Copy the shared chain defaults before injecting runtime-specific Shasta settings.
+func newShastaBaseFeeChainConfig(chainID *big.Int, forkTime uint64) *params.ChainConfig {
+	config := *params.NetworkIDToChainConfigOrDefault(chainID)
+	if chainID != nil {
+		config.ChainID = chainID
+	}
+	config.ShastaTime = &forkTime
+
+	return &config
+}
+
 // CalculateBaseFeeShasta calculates the base fee after Shasta fork from the L2 protocol.
 func (c *Client) CalculateBaseFeeShasta(ctx context.Context, l2Head *types.Header) (*big.Int, error) {
 	// Return initial Shasta base fee for the first Shasta block when the Shasta fork activated from genesis.
@@ -1081,7 +1092,7 @@ func (c *Client) CalculateBaseFeeShasta(ctx context.Context, l2Head *types.Heade
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch parent block: %w", err)
 	}
-	config := &params.ChainConfig{ShastaTime: &c.ShastaClients.ForkTime, ChainID: c.L2.ChainID}
+	config := newShastaBaseFeeChainConfig(c.L2.ChainID, c.ShastaClients.ForkTime)
 	log.Info(
 		"Params for Shasta base fee calculation",
 		"parentBlockNumber", l2Head.Number,

--- a/packages/taiko-client/pkg/rpc/methods_test.go
+++ b/packages/taiko-client/pkg/rpc/methods_test.go
@@ -3,11 +3,13 @@ package rpc
 import (
 	"context"
 	"crypto/rand"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/encoding"
@@ -17,6 +19,35 @@ import (
 var (
 	testAddress = common.HexToAddress("0x98f86166571FE624778203d87A8eD6fd84695B79")
 )
+
+func TestNewShastaBaseFeeChainConfig(t *testing.T) {
+	chainID := new(big.Int).Set(params.TaikoMainnetNetworkID)
+	forkTime := uint64(1234)
+
+	defaultConfig := params.NetworkIDToChainConfigOrDefault(chainID)
+	originalChainID := new(big.Int).Set(defaultConfig.ChainID)
+	var originalShastaTime *uint64
+	if defaultConfig.ShastaTime != nil {
+		shastaTime := *defaultConfig.ShastaTime
+		originalShastaTime = &shastaTime
+	}
+
+	config := newShastaBaseFeeChainConfig(chainID, forkTime)
+
+	require.NotSame(t, defaultConfig, config)
+	require.Zero(t, config.ChainID.Cmp(chainID))
+	require.NotNil(t, config.ShastaTime)
+	require.Equal(t, forkTime, *config.ShastaTime)
+	require.Equal(t, defaultConfig.ElasticityMultiplier(), config.ElasticityMultiplier())
+	require.Equal(t, defaultConfig.BaseFeeChangeDenominator(), config.BaseFeeChangeDenominator())
+	require.Zero(t, defaultConfig.ChainID.Cmp(originalChainID))
+	if originalShastaTime == nil {
+		require.Nil(t, defaultConfig.ShastaTime)
+	} else {
+		require.NotNil(t, defaultConfig.ShastaTime)
+		require.Equal(t, *originalShastaTime, *defaultConfig.ShastaTime)
+	}
+}
 
 func TestL2AccountNonce(t *testing.T) {
 	client := newTestClientWithTimeout(t)


### PR DESCRIPTION
  This change hardens Shasta base-fee config assembly by starting from the network defaults and then injecting the runtime `ShastaTime`, instead of relying on a partial config shape in the call site.
  That is necessary because this exact path recently regressed when switching to `NetworkIDToChainConfigOrDefault`, which dropped the fork-time input and needed a follow-up fix. The added regression test shows we now preserve the chain-specific EIP-4396 settings, keep the runtime fork time, and avoid mutating the shared default config.