### PR TITLE
fix(taiko-client): wrap prover config and init errors

### DIFF
--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -83,7 +83,11 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	if c.IsSet(flags.Allowance.Name) {
 		amt, err := utils.EtherToWei(c.Float64(flags.Allowance.Name))
 		if err != nil {
-			return nil, fmt.Errorf("invalid setting allowance config value: %v", c.Float64(flags.Allowance.Name))
+			return nil, fmt.Errorf(
+				"invalid setting allowance config value %v: %w",
+				c.Float64(flags.Allowance.Name),
+				err,
+			)
 		}
 
 		allowance = amt

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -393,14 +393,14 @@ func (p *Prover) initL1Current(startingBatchID *big.Int) error {
 
 	batch, err := p.rpc.GetBatchByID(p.ctx, startingBatchID)
 	if err != nil {
-		return fmt.Errorf("failed to get batch by ID: %d", startingBatchID)
+		return fmt.Errorf("failed to get batch by ID %d: %w", startingBatchID, err)
 	}
 	latestVerifiedHeaderL1Origin, err := p.rpc.L2.L1OriginByID(p.ctx, new(big.Int).SetUint64(batch.LastBlockId))
 	if err != nil {
 		if err.Error() == ethereum.NotFound.Error() {
 			l1Head, err := p.rpc.L1.HeaderByNumber(p.ctx, new(big.Int).SetUint64(batch.AnchorBlockId))
 			if err != nil {
-				return fmt.Errorf("failed to get L1 head for blockID: %d", batch.AnchorBlockId)
+				return fmt.Errorf("failed to get L1 head for blockID %d: %w", batch.AnchorBlockId, err)
 			}
 			p.sharedState.SetL1Current(l1Head)
 			return nil
@@ -452,7 +452,7 @@ func (p *Prover) initL1CurrentShasta(startingBatchID *big.Int) error {
 
 	_, eventLog, err := p.rpc.GetProposalByIDShasta(p.ctx, startingBatchID)
 	if err != nil {
-		return fmt.Errorf("failed to get proposal by ID: %d", startingBatchID)
+		return fmt.Errorf("failed to get proposal by ID %d: %w", startingBatchID, err)
 	}
 	l1Current, err := p.rpc.L1.HeaderByHash(p.ctx, eventLog.BlockHash)
 	if err != nil {


### PR DESCRIPTION
Wrap prover allowance and L1 cursor initialization failures with underlying errors, improve troubleshooting context without changing runtime behavior.