### PR TITLE
refactor(protocol): simplify ProverMarket and decouple from Inbox

### DIFF
--- a/packages/protocol/contracts/layer1/core/iface/IInbox.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IInbox.sol
@@ -13,18 +13,10 @@ interface IInbox {
         address proofVerifier;
         /// @notice The proposer checker contract
         address proposerChecker;
-        /// @notice The prover market contract (address(0) means proving is permissionless)
+        /// @notice The prover market contract (must be non-zero)
         address proverMarket;
         /// @notice The signal service contract address
         address signalService;
-        /// @notice The ERC20 bond token address
-        address bondToken;
-        /// @notice The proving window in seconds
-        uint48 provingWindow;
-        /// @notice The delay after which proving becomes permissionless when the prover market is
-        /// enabled
-        /// @dev Must be greater than provingWindow
-        uint48 permissionlessProvingDelay;
         /// @notice Maximum delay allowed between consecutive proofs to still be on time.
         /// @dev Must be shorter than the expected proposal cadence to prevent backlog growth.
         uint48 maxProofSubmissionDelay;
@@ -189,7 +181,7 @@ interface IInbox {
     /// @notice Proposes new L2 blocks and forced inclusions to the rollup using blobs for DA.
     /// @param _lookahead Encoded data forwarded to the proposer checker (i.e. lookahead payloads).
     /// @param _data The encoded ProposeInput struct.
-    function propose(bytes calldata _lookahead, bytes calldata _data) external;
+    function propose(bytes calldata _lookahead, bytes calldata _data) external payable;
 
     /// @notice Verifies a batch proof covering multiple consecutive proposals and finalizes them.
     /// @param _data The encoded ProveInput struct.

--- a/packages/protocol/contracts/layer1/core/iface/IProverMarket.sol
+++ b/packages/protocol/contracts/layer1/core/iface/IProverMarket.sol
@@ -7,9 +7,8 @@ pragma solidity ^0.8.24;
 /// @custom:security-contact security@taiko.xyz
 interface IProverMarket {
     /// @notice Places or updates a bid for a future proving epoch
-    /// @param _feeRecipient The address that should receive proving fees for the bid
     /// @param _feeInGwei The fee quote in gwei for each assigned proposal
-    function bid(address _feeRecipient, uint64 _feeInGwei) external;
+    function bid(uint64 _feeInGwei) external;
 
     /// @notice Requests exit from the market for the caller's active or pending position
     function exit() external;
@@ -22,28 +21,28 @@ interface IProverMarket {
     /// @param _amount The bond amount in gwei
     function withdrawBond(uint64 _amount) external;
 
-    /// @notice Deposits proposer fee credit for future proposal reservations
-    function depositFeeCredit() external payable;
-
-    /// @notice Withdraws unused proposer fee credit or accrued prover fees
+    /// @notice Withdraws accrued prover fees
     /// @param _amount The amount in wei to withdraw
-    function withdrawFeeCredit(uint256 _amount) external;
+    function withdrawFees(uint256 _amount) external;
 
-    /// @notice Checks whether a proof submission is authorized under the current market state
-    /// @param _caller The account submitting the proof transaction
+    /// @notice Checks whether a caller is authorized to submit a proof for a given proposal.
+    /// @dev Intended for off-chain use by provers before submitting a prove transaction.
+    /// @param _caller The account that would submit the proof
     /// @param _firstNewProposalId The first proposal id that would be newly finalized
-    /// @param _proposalTimestamp The timestamp of the first newly finalized proposal
     /// @param _proposalAge The age in seconds of the first newly finalized proposal
-    function beforeProofSubmission(
+    /// @return True if the caller is authorized to prove
+    function canSubmitProof(
         address _caller,
         uint48 _firstNewProposalId,
-        uint48 _proposalTimestamp,
         uint256 _proposalAge
     )
         external
-        view;
+        view
+        returns (bool);
 
     /// @notice Notifies the market that Inbox accepted a new proposal
+    /// @dev Receives ETH from proposer via Inbox. Takes the active epoch fee and refunds
+    ///      any excess directly to the proposer.
     /// @param _proposalId The accepted proposal id
     /// @param _proposer The proposer that created the proposal
     /// @param _proposalTimestamp The proposal timestamp
@@ -52,22 +51,20 @@ interface IProverMarket {
         address _proposer,
         uint48 _proposalTimestamp
     )
-        external;
+        external
+        payable;
 
-    /// @notice Notifies the market that Inbox finalized a new proof range
+    /// @notice Notifies the market that Inbox finalized a new proof range.
+    /// @dev Enforces prover authorization and handles slashing, bond release, and degraded mode.
     /// @param _caller The account that submitted the proof transaction
-    /// @param _actualProver The prover recorded in the commitment
     /// @param _firstNewProposalId The first proposal id that was newly finalized
     /// @param _lastProposalId The last proposal id in the finalized range
     /// @param _proposalAge The age in seconds of the first newly finalized proposal
-    /// @param _finalizedAt The timestamp when finalization occurred
     function onProofAccepted(
         address _caller,
-        address _actualProver,
         uint48 _firstNewProposalId,
         uint48 _lastProposalId,
-        uint256 _proposalAge,
-        uint48 _finalizedAt
+        uint256 _proposalAge
     )
         external;
 
@@ -80,4 +77,28 @@ interface IProverMarket {
     /// @param _account The account to credit the bond to
     /// @param _amount The bond amount in gwei
     function creditMigratedBond(address _account, uint64 _amount) external;
+
+    /// @notice Returns the bond balance for an account in gwei
+    /// @param _account The account to query
+    function bondBalances(address _account) external view returns (uint64);
+
+    /// @notice Returns the accrued fee balance for an account in wei
+    /// @param _account The account to query
+    function feeBalances(address _account) external view returns (uint256);
+
+    /// @notice Returns the bond token address used by this market
+    function bondToken() external view returns (address);
+
+    /// @notice Returns the exclusive proving window in seconds
+    function provingWindow() external view returns (uint48);
+
+    /// @notice Returns the fee in gwei that the next proposal will be charged
+    /// @dev Accounts for pending epoch transitions. Useful for off-chain fee estimation.
+    function activeFeeInGwei() external view returns (uint64);
+
+    /// @notice Returns the minimum bond in gwei required to place a bid
+    function minBond() external view returns (uint64);
+
+    /// @notice Returns the permissionless proving delay in seconds
+    function permissionlessProvingDelay() external view returns (uint48);
 }

--- a/packages/protocol/contracts/layer1/core/impl/Inbox.sol
+++ b/packages/protocol/contracts/layer1/core/impl/Inbox.sol
@@ -80,16 +80,6 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
     /// @notice Signal service responsible for checkpoints.
     ISignalService internal immutable _signalService;
 
-    /// @notice ERC20 token used as bond.
-    IERC20 internal immutable _bondToken;
-
-    /// @notice The proving window in seconds.
-    uint48 internal immutable _provingWindow;
-
-    /// @notice The delay after which proving becomes permissionless when the prover market is
-    /// enabled.
-    uint48 internal immutable _permissionlessProvingDelay;
-
     /// @notice Maximum delay allowed between sequential proofs to remain on time.
     uint48 internal immutable _maxProofSubmissionDelay;
 
@@ -142,16 +132,13 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
 
     /// @notice Initializes the Inbox contract
     /// @param _config Configuration struct containing all constructor parameters
-    constructor(Config memory _config) {
+    constructor(Config memory _config) nonZeroAddr(_config.proverMarket) {
         LibInboxSetup.validateConfig(_config);
 
         _proofVerifier = IProofVerifier(_config.proofVerifier);
         _proposerChecker = IProposerChecker(_config.proposerChecker);
         _proverMarket = IProverMarket(_config.proverMarket);
         _signalService = ISignalService(_config.signalService);
-        _bondToken = IERC20(_config.bondToken);
-        _provingWindow = _config.provingWindow;
-        _permissionlessProvingDelay = _config.permissionlessProvingDelay;
         _maxProofSubmissionDelay = _config.maxProofSubmissionDelay;
         _ringBufferSize = _config.ringBufferSize;
         _basefeeSharingPctg = _config.basefeeSharingPctg;
@@ -199,7 +186,7 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
     ///      3. Updates core state and emits `Proposed` event
     /// NOTE: This function can only be called once per block to prevent spams that can fill the
     /// ring buffer.
-    function propose(bytes calldata _lookahead, bytes calldata _data) external nonReentrant {
+    function propose(bytes calldata _lookahead, bytes calldata _data) external payable nonReentrant {
         unchecked {
             ProposeInput memory input = LibCodec.decodeProposeInput(_data);
             _validateProposeInput(input);
@@ -218,17 +205,15 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
             _setProposalHash(proposal.id, LibHashOptimized.hashProposal(proposal));
 
             _emitProposedEvent(proposal);
-            if (address(_proverMarket) != address(0)) {
-                _proverMarket.onProposalAccepted(proposal.id, proposal.proposer, proposal.timestamp);
-            }
+            _proverMarket.onProposalAccepted{ value: msg.value }(
+                proposal.id, proposal.proposer, proposal.timestamp
+            );
         }
     }
 
     /// @inheritdoc IInbox
-    /// @dev When the prover market is enabled, only market-authorized
-    ///      provers may prove until a proposal becomes older than
-    ///      `permissionlessProvingDelay`, after which proving becomes permissionless for that
-    ///      proposal.
+    /// @dev When the prover market is enabled, only market-authorized provers may prove until
+    ///      the permissionless proving delay elapses, after which proving is open to anyone.
     /// @dev The proof covers a contiguous range of proposals. The input contains an array of
     ///      Transition structs, each with the proposal metadata and end block hash. The proof
     ///      range can start at or before the last finalized proposal to handle race conditions
@@ -273,12 +258,7 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
             uint48 firstNewProposalId = uint48(state.lastFinalizedProposalId + 1);
             uint256 proposalAge;
             {
-                uint48 firstNewProposalTimestamp = commitment.transitions[offset].timestamp;
-                proposalAge = block.timestamp - firstNewProposalTimestamp;
-
-                _checkProverMarket(
-                    msg.sender, firstNewProposalId, firstNewProposalTimestamp, proposalAge
-                );
+                proposalAge = block.timestamp - commitment.transitions[offset].timestamp;
 
                 // ---------------------------------------------------------
                 // 2. Verify parent block-hash continuity and last proposal hash
@@ -335,32 +315,26 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
                 LibHashOptimized.hashCommitment(commitment),
                 _proof
             );
-            if (address(_proverMarket) != address(0)) {
-                _proverMarket.onProofAccepted(
-                    msg.sender,
-                    commitment.actualProver,
-                    firstNewProposalId,
-                    uint48(lastProposalId),
-                    proposalAge,
-                    state.lastFinalizedTimestamp
-                );
-            }
+            _proverMarket.onProofAccepted(
+                msg.sender, firstNewProposalId, uint48(lastProposalId), proposalAge
+            );
         }
     }
 
-    /// @notice Migrates a user's bond balance from Inbox to the ProverMarket contract.
+    /// @notice Migrates a bond balance from Inbox to the ProverMarket contract.
     /// @dev One-step migration: reads bond, zeroes it, transfers tokens to market,
     ///      and credits the bond on ProverMarket.
-    function migrateBond() external nonReentrant {
-        require(address(_proverMarket) != address(0), ProverMarketNotSet());
-        LibBonds.Bond storage bond = _bondStorage.bonds[msg.sender];
+    /// @param _account The address to migrate bond for. If address(0), migrates for msg.sender.
+    function migrateBond(address _account) external nonReentrant {
+        if (_account == address(0)) _account = msg.sender;
+        LibBonds.Bond storage bond = _bondStorage.bonds[_account];
         uint64 balance = bond.balance;
         require(balance > 0, NoBondToMigrate());
         bond.balance = 0;
         bond.withdrawalRequestedAt = 0;
         uint256 tokenAmount = uint256(balance) * 1 gwei;
-        _bondToken.safeTransfer(address(_proverMarket), tokenAmount);
-        _proverMarket.creditMigratedBond(msg.sender, balance);
+        IERC20(_proverMarket.bondToken()).safeTransfer(address(_proverMarket), tokenAmount);
+        _proverMarket.creditMigratedBond(_account, balance);
     }
 
     /// @inheritdoc IForcedInclusionStore
@@ -465,9 +439,6 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
             proposerChecker: address(_proposerChecker),
             proverMarket: address(_proverMarket),
             signalService: address(_signalService),
-            bondToken: address(_bondToken),
-            provingWindow: _provingWindow,
-            permissionlessProvingDelay: _permissionlessProvingDelay,
             maxProofSubmissionDelay: _maxProofSubmissionDelay,
             ringBufferSize: _ringBufferSize,
             basefeeSharingPctg: _basefeeSharingPctg,
@@ -678,26 +649,6 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
         require(_input.deadline == 0 || block.timestamp <= _input.deadline, DeadlineExceeded());
     }
 
-    /// @dev Checks if the caller is authorized by the prover market.
-    /// @param _addr The address of the caller to check.
-    /// @param _firstNewProposalId The first proposal id that would be newly finalized.
-    /// @param _proposalTimestamp The timestamp of the first newly finalized proposal.
-    /// @param _proposalAge The age in seconds since the proposal became available for proving.
-    function _checkProverMarket(
-        address _addr,
-        uint48 _firstNewProposalId,
-        uint48 _proposalTimestamp,
-        uint256 _proposalAge
-    )
-        private
-        view
-    {
-        if (address(_proverMarket) == address(0)) return;
-        _proverMarket.beforeProofSubmission(
-            _addr, _firstNewProposalId, _proposalTimestamp, _proposalAge
-        );
-    }
-
     /// @dev Validates the batch bounds in the Commitment and calculates the offset
     ///      to the first unfinalized proposal.
     /// @param _state The core state.
@@ -746,6 +697,5 @@ contract Inbox is IInbox, ICodec, IForcedInclusionStore, EssentialContract {
     error NotEnoughCapacity();
     error ParentBlockHashMismatch();
     error NoBondToMigrate();
-    error ProverMarketNotSet();
     error UnprocessedForcedInclusionIsDue();
 }

--- a/packages/protocol/contracts/layer1/core/impl/ProverMarket.sol
+++ b/packages/protocol/contracts/layer1/core/impl/ProverMarket.sol
@@ -23,13 +23,12 @@ contract ProverMarket is EssentialContract, IProverMarket {
 
     /// @notice Market-owned liability interval for a prover epoch.
     struct Epoch {
-        address operator;
-        address feeRecipient;
+        address prover;
         uint64 feeInGwei;
         uint64 bondedAmount;
         uint48 activatedAt;
         uint48 firstProposalId;
-        uint48 lastAssignedProposalId;
+        uint48 lastProposalId;
     }
 
     /// @notice Top-level market state shared across epochs.
@@ -40,7 +39,6 @@ contract ProverMarket is EssentialContract, IProverMarket {
         uint48 nextEpochId;
         bool permissionlessMode;
         bool activeEpochExiting;
-        bool degradedMode;
     }
 
     // ---------------------------------------------------------------
@@ -59,14 +57,8 @@ contract ProverMarket is EssentialContract, IProverMarket {
     /// @dev Seconds after which proving becomes permissionless for a proposal.
     uint48 internal immutable _permissionlessProvingDelay;
 
-    /// @dev Maximum displaced epochs tracked for bond release.
-    uint8 internal constant MAX_DISPLACED_EPOCHS = 8;
-
-    /// @dev Enter degraded mode before the displaced queue is full so one slot remains reserved.
-    uint8 internal constant ENTER_DEGRADED_AT = MAX_DISPLACED_EPOCHS - 1;
-
-    /// @dev Exit degraded mode only after the displaced backlog is fully drained.
-    uint8 internal constant EXIT_DEGRADED_AT = 0;
+    /// @dev Exclusive proving window in seconds before permissionless proving opens.
+    uint48 internal immutable _provingWindow;
 
     // ---------------------------------------------------------------
     // State Variables
@@ -81,15 +73,11 @@ contract ProverMarket is EssentialContract, IProverMarket {
     /// @notice Bond balances tracked by account in gwei.
     mapping(address account => uint64 bondBalance) public bondBalances;
 
-    /// @notice Deposited proposer credits and accrued prover fees tracked by account in wei.
-    mapping(address account => uint256 feeCreditBalance) public feeCreditBalances;
-
-    /// @notice Maps proposal id to the epoch that owns it.
-    mapping(uint48 proposalId => uint48 epochId) public proposalEpochs;
+    /// @notice Accrued prover fees tracked by account in wei.
+    mapping(address account => uint256 feeBalance) public feeBalances;
 
     /// @dev Displaced epochs awaiting bond release after finalization.
-    uint48[8] internal _displacedEpochIds;
-    uint8 internal _numDisplacedEpochs;
+    uint48[] internal _displacedEpochIds;
 
     /// @notice Slashed bond retained in-market and paid out to future rescue provers.
     uint64 public rescueRewardPool;
@@ -101,14 +89,12 @@ contract ProverMarket is EssentialContract, IProverMarket {
     // ---------------------------------------------------------------
 
     /// @notice Emitted when a bid is placed or updated.
-    event BidPlaced(
-        uint48 indexed epochId, address indexed operator, address feeRecipient, uint64 feeInGwei
-    );
+    event BidPlaced(uint48 indexed epochId, address indexed prover, uint64 feeInGwei);
 
     /// @notice Emitted when a pending epoch becomes active.
     event EpochActivated(uint48 indexed epochId, uint48 firstProposalId);
 
-    /// @notice Emitted when an operator exits their position.
+    /// @notice Emitted when a prover exits their position.
     event EpochExited(uint48 indexed epochId);
 
     /// @notice Emitted when bond is deposited.
@@ -117,28 +103,22 @@ contract ProverMarket is EssentialContract, IProverMarket {
     /// @notice Emitted when bond is withdrawn.
     event BondWithdrawn(address indexed account, uint64 amount);
 
-    /// @notice Emitted when locked bond is released back to operator after finalization.
-    event BondReleased(uint48 indexed epochId, address indexed operator, uint64 amount);
+    /// @notice Emitted when locked bond is released back to prover after finalization.
+    event BondReleased(uint48 indexed epochId, address indexed prover, uint64 amount);
 
-    /// @notice Emitted when fee credit is deposited.
-    event FeeCreditDeposited(address indexed account, uint256 amount);
+    /// @notice Emitted when a prover fee is charged from proposer ETH.
+    event FeeCharged(uint48 indexed proposalId, address indexed proposer, uint64 feeInGwei);
 
-    /// @notice Emitted when fee credit is withdrawn.
-    event FeeCreditWithdrawn(address indexed account, uint256 amount);
-
-    /// @notice Emitted when a prover fee is reserved from proposer credit.
-    event FeeReserved(uint48 indexed proposalId, address indexed proposer, uint64 feeInGwei);
+    /// @notice Emitted when accrued prover fees are withdrawn.
+    event FeesWithdrawn(address indexed account, uint256 amount);
 
     /// @notice Emitted when emergency permissionless mode changes.
     event PermissionlessModeUpdated(bool enabled);
 
-    /// @notice Emitted when protocol churn safety disables or restores exclusive assignments.
-    event DegradedModeUpdated(bool enabled);
-
     /// @notice Emitted when a prover misses the exclusive proving window and is slashed.
     event EpochSlashed(
         uint48 indexed epochId,
-        address indexed operator,
+        address indexed prover,
         address indexed proofSubmitter,
         uint64 slashedAmount,
         uint64 rewardAmount
@@ -153,20 +133,29 @@ contract ProverMarket is EssentialContract, IProverMarket {
     /// @param _bondTokenAddr The bond token address.
     /// @param _minBondGwei The minimum bond in gwei required to bid.
     /// @param _permissionlessProvingDelaySeconds Seconds until proving becomes open.
+    /// @param _provingWindowSeconds The exclusive proving window in seconds.
     constructor(
         address _inboxAddr,
         address _bondTokenAddr,
         uint64 _minBondGwei,
-        uint48 _permissionlessProvingDelaySeconds
-    ) {
-        require(_inboxAddr != address(0), ZeroAddress());
-        require(_bondTokenAddr != address(0), ZeroAddress());
-        require(_minBondGwei != 0, ZeroValue());
+        uint48 _permissionlessProvingDelaySeconds,
+        uint48 _provingWindowSeconds
+    )
+        nonZeroAddr(_inboxAddr)
+        nonZeroAddr(_bondTokenAddr)
+        nonZeroValue(_minBondGwei)
+        nonZeroValue(_permissionlessProvingDelaySeconds)
+        nonZeroValue(_provingWindowSeconds)
+    {
+        require(
+            _permissionlessProvingDelaySeconds > _provingWindowSeconds, PermissionlessDelayTooSmall()
+        );
 
         _inbox = IInbox(_inboxAddr);
         _bondToken = IERC20(_bondTokenAddr);
         _minBond = _minBondGwei;
         _permissionlessProvingDelay = _permissionlessProvingDelaySeconds;
+        _provingWindow = _provingWindowSeconds;
     }
 
     // ---------------------------------------------------------------
@@ -180,16 +169,14 @@ contract ProverMarket is EssentialContract, IProverMarket {
     }
 
     /// @inheritdoc IProverMarket
-    function depositBond(uint64 _amount) external nonReentrant {
-        require(_amount != 0, ZeroValue());
+    function depositBond(uint64 _amount) external nonReentrant nonZeroValue(_amount) {
         _bondToken.safeTransferFrom(msg.sender, address(this), uint256(_amount) * 1 gwei);
         bondBalances[msg.sender] += _amount;
         emit BondDeposited(msg.sender, _amount);
     }
 
     /// @inheritdoc IProverMarket
-    function withdrawBond(uint64 _amount) external nonReentrant {
-        require(_amount != 0, ZeroValue());
+    function withdrawBond(uint64 _amount) external nonReentrant nonZeroValue(_amount) {
         require(bondBalances[msg.sender] >= _amount, InsufficientBond());
         bondBalances[msg.sender] -= _amount;
         _bondToken.safeTransfer(msg.sender, uint256(_amount) * 1 gwei);
@@ -197,24 +184,15 @@ contract ProverMarket is EssentialContract, IProverMarket {
     }
 
     /// @inheritdoc IProverMarket
-    function depositFeeCredit() external payable {
-        require(msg.value != 0, ZeroValue());
-        feeCreditBalances[msg.sender] += msg.value;
-        emit FeeCreditDeposited(msg.sender, msg.value);
-    }
-
-    /// @inheritdoc IProverMarket
-    function withdrawFeeCredit(uint256 _amount) external nonReentrant {
-        require(_amount != 0, ZeroValue());
-        require(feeCreditBalances[msg.sender] >= _amount, InsufficientFeeCredit());
-        feeCreditBalances[msg.sender] -= _amount;
+    function withdrawFees(uint256 _amount) external nonReentrant nonZeroValue(_amount) {
+        require(feeBalances[msg.sender] >= _amount, InsufficientFees());
+        feeBalances[msg.sender] -= _amount;
         msg.sender.sendEtherAndVerify(_amount);
-        emit FeeCreditWithdrawn(msg.sender, _amount);
+        emit FeesWithdrawn(msg.sender, _amount);
     }
 
     /// @inheritdoc IProverMarket
-    function bid(address _feeRecipient, uint64 _feeInGwei) external whenNotPaused {
-        require(_feeRecipient != address(0), ZeroAddress());
+    function bid(uint64 _feeInGwei) external nonReentrant whenNotPaused {
         require(bondBalances[msg.sender] >= _minBond, InsufficientBond());
 
         MarketState memory state = marketState;
@@ -224,15 +202,15 @@ contract ProverMarket is EssentialContract, IProverMarket {
             require(_feeInGwei < epochs[state.activeEpochId].feeInGwei, BidFeeTooHigh());
         }
 
-        // If there is an existing pending epoch from a different operator, must also undercut it.
-        // Refund the displaced pending operator's bond.
+        // If there is an existing pending epoch from a different prover, must also undercut it.
+        // Refund the displaced pending prover's bond.
         if (state.pendingEpochId != 0) {
             Epoch storage pending = epochs[state.pendingEpochId];
-            if (pending.operator != msg.sender) {
+            if (pending.prover != msg.sender) {
                 require(_feeInGwei < pending.feeInGwei, BidFeeTooHigh());
-                bondBalances[pending.operator] += pending.bondedAmount;
+                bondBalances[pending.prover] += pending.bondedAmount;
             } else {
-                // Same operator re-bidding: refund old bond before locking fresh.
+                // Same prover re-bidding: refund old bond before locking fresh.
                 bondBalances[msg.sender] += pending.bondedAmount;
             }
         }
@@ -242,19 +220,18 @@ contract ProverMarket is EssentialContract, IProverMarket {
         uint48 newEpochId = ++state.nextEpochId;
 
         epochs[newEpochId] = Epoch({
-            operator: msg.sender,
-            feeRecipient: _feeRecipient,
+            prover: msg.sender,
             feeInGwei: _feeInGwei,
             bondedAmount: _minBond,
             activatedAt: 0,
             firstProposalId: 0,
-            lastAssignedProposalId: 0
+            lastProposalId: 0
         });
 
         state.pendingEpochId = newEpochId;
         marketState = state;
 
-        emit BidPlaced(newEpochId, msg.sender, _feeRecipient, _feeInGwei);
+        emit BidPlaced(newEpochId, msg.sender, _feeInGwei);
     }
 
     /// @inheritdoc IProverMarket
@@ -262,7 +239,7 @@ contract ProverMarket is EssentialContract, IProverMarket {
         MarketState memory state = marketState;
 
         // Check pending first (can fully clear it).
-        if (state.pendingEpochId != 0 && epochs[state.pendingEpochId].operator == msg.sender) {
+        if (state.pendingEpochId != 0 && epochs[state.pendingEpochId].prover == msg.sender) {
             Epoch storage pending = epochs[state.pendingEpochId];
             bondBalances[msg.sender] += pending.bondedAmount;
             pending.bondedAmount = 0;
@@ -274,7 +251,7 @@ contract ProverMarket is EssentialContract, IProverMarket {
         }
 
         // Check active (mark as exiting, stays liable for assigned proposals).
-        if (state.activeEpochId != 0 && epochs[state.activeEpochId].operator == msg.sender) {
+        if (state.activeEpochId != 0 && epochs[state.activeEpochId].prover == msg.sender) {
             require(!state.activeEpochExiting, NoBidToExit());
             state.activeEpochExiting = true;
             marketState = state;
@@ -292,117 +269,94 @@ contract ProverMarket is EssentialContract, IProverMarket {
         uint48 _proposalTimestamp
     )
         external
+        payable
         onlyFrom(address(_inbox))
     {
         MarketState memory state = marketState;
+        uint256 feeConsumed;
+        bool stateChanged;
 
-        if (!state.permissionlessMode && !state.degradedMode) {
-            if (state.activeEpochId == 0) {
-                if (state.pendingEpochId != 0) {
-                    if (_numDisplacedEpochs >= ENTER_DEGRADED_AT) {
-                        state.degradedMode = true;
-                        emit DegradedModeUpdated(true);
-                    } else {
-                        _activatePendingEpoch(state, _proposalId, _proposalTimestamp);
-                    }
-                }
-            } else if (state.activeEpochExiting) {
-                if (state.pendingEpochId != 0 && _numDisplacedEpochs >= ENTER_DEGRADED_AT) {
-                    _retireActiveEpoch(state);
-                    state.degradedMode = true;
-                    emit DegradedModeUpdated(true);
-                } else {
-                    _retireActiveEpoch(state);
-                    if (state.pendingEpochId != 0) {
-                        _activatePendingEpoch(state, _proposalId, _proposalTimestamp);
-                    }
-                }
-            } else if (state.pendingEpochId != 0) {
-                if (_numDisplacedEpochs >= ENTER_DEGRADED_AT) {
-                    _retireActiveEpoch(state);
-                    state.degradedMode = true;
-                    emit DegradedModeUpdated(true);
-                } else {
-                    _retireActiveEpoch(state);
-                    _activatePendingEpoch(state, _proposalId, _proposalTimestamp);
+        if (!state.permissionlessMode) {
+            // Retire the active epoch if it is exiting or being displaced by a pending bid.
+            if (state.activeEpochId != 0 && (state.activeEpochExiting || state.pendingEpochId != 0))
+            {
+                _retireActiveEpoch(state);
+                stateChanged = true;
+            }
+
+            // Activate the pending epoch if there is no active epoch.
+            if (state.activeEpochId == 0 && state.pendingEpochId != 0) {
+                _activatePendingEpoch(state, _proposalId, _proposalTimestamp);
+                stateChanged = true;
+            }
+
+            // Assign proposal to the active epoch and charge fee.
+            uint48 activeId = state.activeEpochId;
+            if (activeId != 0) {
+                epochs[activeId].lastProposalId = _proposalId;
+
+                uint256 feeWei = uint256(epochs[activeId].feeInGwei) * 1 gwei;
+                if (feeWei > 0) {
+                    require(msg.value >= feeWei, InsufficientFee());
+                    feeBalances[epochs[activeId].prover] += feeWei;
+                    feeConsumed = feeWei;
+                    emit FeeCharged(_proposalId, _proposer, epochs[activeId].feeInGwei);
                 }
             }
         }
 
-        // Assign proposal to the active epoch.
-        uint48 activeId = state.activeEpochId;
-        if (activeId != 0 && !state.permissionlessMode && !state.degradedMode) {
-            epochs[activeId].lastAssignedProposalId = _proposalId;
-            proposalEpochs[_proposalId] = activeId;
+        if (stateChanged) marketState = state;
 
-            // Reserve fee from proposer's credit balance.
-            uint256 feeWei = uint256(epochs[activeId].feeInGwei) * 1 gwei;
-            if (feeWei > 0 && feeCreditBalances[_proposer] >= feeWei) {
-                feeCreditBalances[_proposer] -= feeWei;
-                feeCreditBalances[epochs[activeId].feeRecipient] += feeWei;
-                emit FeeReserved(_proposalId, _proposer, epochs[activeId].feeInGwei);
-            }
+        // Refund excess ETH to proposer (CEI: state writes above, external call below).
+        uint256 excess = msg.value - feeConsumed;
+        if (excess > 0) {
+            _proposer.sendEtherAndVerify(excess);
         }
-
-        marketState = state;
     }
 
     /// @inheritdoc IProverMarket
-    function beforeProofSubmission(
+    function canSubmitProof(
         address _caller,
         uint48 _firstNewProposalId,
-        uint48 _proposalTimestamp,
         uint256 _proposalAge
     )
-        external
+        public
         view
-        onlyFrom(address(_inbox))
+        returns (bool)
     {
-        _proposalTimestamp; // unused but part of interface
-
         // Permissionless mode: anyone can prove.
-        if (marketState.permissionlessMode) return;
+        if (marketState.permissionlessMode) return true;
 
         // After the permissionless delay, anyone can prove.
-        if (_proposalAge >= uint256(_permissionlessProvingDelay)) return;
+        if (_proposalAge >= uint256(_permissionlessProvingDelay)) return true;
 
-        // Look up which epoch owns this proposal.
-        uint48 epochId = proposalEpochs[_firstNewProposalId];
+        // Look up which epoch owns this proposal by range.
+        uint48 epochId = _findEpochForProposal(_firstNewProposalId);
 
         // No epoch assigned (proposal accepted without active market): permissionless.
-        if (epochId == 0) return;
+        if (epochId == 0) return true;
 
-        // During the exclusive window, only the epoch operator may prove.
-        require(_caller == epochs[epochId].operator, NotAuthorizedProver());
+        // During the exclusive window, only the epoch prover may prove.
+        return _caller == epochs[epochId].prover;
     }
 
     /// @inheritdoc IProverMarket
     function onProofAccepted(
         address _caller,
-        address _actualProver,
         uint48 _firstNewProposalId,
         uint48 _lastProposalId,
-        uint256 _proposalAge,
-        uint48 _finalizedAt
+        uint256 _proposalAge
     )
         external
         onlyFrom(address(_inbox))
     {
-        _actualProver; // unused but part of interface
-        _finalizedAt; // unused but part of interface
-
         MarketState memory state = marketState;
         state.lastFinalizedProposalId = _lastProposalId;
 
-        _maybeSlashLateProof(state, _caller, _firstNewProposalId, _proposalAge);
+        _checkAndSlash(state, _caller, _firstNewProposalId, _proposalAge);
 
         // Release bonds for displaced epochs whose proposals are now fully finalized.
         _releaseDisplacedBonds(_lastProposalId);
-
-        if (state.degradedMode && _numDisplacedEpochs <= EXIT_DEGRADED_AT) {
-            state.degradedMode = false;
-            emit DegradedModeUpdated(false);
-        }
 
         marketState = state;
     }
@@ -411,6 +365,44 @@ contract ProverMarket is EssentialContract, IProverMarket {
     function forcePermissionlessMode(bool _enabled) external onlyOwner {
         marketState.permissionlessMode = _enabled;
         emit PermissionlessModeUpdated(_enabled);
+    }
+
+    /// @inheritdoc IProverMarket
+    function bondToken() external view returns (address) {
+        return address(_bondToken);
+    }
+
+    /// @inheritdoc IProverMarket
+    function provingWindow() external view returns (uint48) {
+        return _provingWindow;
+    }
+
+    /// @inheritdoc IProverMarket
+    function activeFeeInGwei() external view returns (uint64) {
+        MarketState memory state = marketState;
+        if (state.permissionlessMode) return 0;
+
+        // Simulate the epoch transition that would happen on next proposal.
+        if (state.activeEpochId != 0 && (state.activeEpochExiting || state.pendingEpochId != 0)) {
+            // Active will be retired; pending (if any) will activate.
+            if (state.pendingEpochId != 0) return epochs[state.pendingEpochId].feeInGwei;
+            return 0;
+        }
+        if (state.activeEpochId == 0 && state.pendingEpochId != 0) {
+            return epochs[state.pendingEpochId].feeInGwei;
+        }
+        if (state.activeEpochId != 0) return epochs[state.activeEpochId].feeInGwei;
+        return 0;
+    }
+
+    /// @inheritdoc IProverMarket
+    function minBond() external view returns (uint64) {
+        return _minBond;
+    }
+
+    /// @inheritdoc IProverMarket
+    function permissionlessProvingDelay() external view returns (uint48) {
+        return _permissionlessProvingDelay;
     }
 
     /// @inheritdoc IProverMarket
@@ -456,9 +448,9 @@ contract ProverMarket is EssentialContract, IProverMarket {
         _state.activeEpochExiting = false;
     }
 
-    /// @dev Slashes the owning epoch if the first newly finalized proposal aged into the
-    ///      permissionless window before proof submission.
-    function _maybeSlashLateProof(
+    /// @dev Enforces prover authorization and slashes the owning epoch when the proof arrives
+    ///      after the permissionless proving delay.
+    function _checkAndSlash(
         MarketState memory _state,
         address _caller,
         uint48 _firstNewProposalId,
@@ -466,11 +458,20 @@ contract ProverMarket is EssentialContract, IProverMarket {
     )
         private
     {
-        if (_state.permissionlessMode || _proposalAge < uint256(_permissionlessProvingDelay)) {
+        // Permissionless mode: anyone can prove, no slashing.
+        if (_state.permissionlessMode) return;
+
+        uint48 epochId = _findEpochForProposal(_firstNewProposalId);
+
+        // Within the exclusive window: only the epoch prover may prove.
+        if (_proposalAge < uint256(_permissionlessProvingDelay)) {
+            if (epochId != 0) {
+                require(_caller == epochs[epochId].prover, NotAuthorizedProver());
+            }
             return;
         }
 
-        uint48 epochId = proposalEpochs[_firstNewProposalId];
+        // Past the permissionless delay: anyone can prove, slash the epoch.
         if (epochId == 0) return;
 
         Epoch storage epoch = epochs[epochId];
@@ -480,7 +481,7 @@ contract ProverMarket is EssentialContract, IProverMarket {
         epoch.bondedAmount = 0;
 
         uint64 rewardAmount;
-        if (_caller == epoch.operator) {
+        if (_caller == epoch.prover) {
             rescueRewardPool += slashedAmount;
         } else {
             rewardAmount = rescueRewardPool + slashedAmount;
@@ -493,48 +494,69 @@ contract ProverMarket is EssentialContract, IProverMarket {
             _state.activeEpochExiting = false;
         }
 
-        emit EpochSlashed(epochId, epoch.operator, _caller, slashedAmount, rewardAmount);
+        emit EpochSlashed(epochId, epoch.prover, _caller, slashedAmount, rewardAmount);
+    }
+
+    /// @dev Finds which epoch owns a proposal by checking active and displaced epoch ranges.
+    /// @return epochId_ The epoch that owns the proposal, or 0 if none.
+    function _findEpochForProposal(uint48 _proposalId) private view returns (uint48 epochId_) {
+        // Check active epoch.
+        uint48 activeId = marketState.activeEpochId;
+        if (activeId != 0) {
+            Epoch storage e = epochs[activeId];
+            if (_proposalId >= e.firstProposalId && _proposalId <= e.lastProposalId) {
+                return activeId;
+            }
+        }
+
+        // Check displaced epochs.
+        uint256 n = _displacedEpochIds.length;
+        for (uint256 i; i < n; ++i) {
+            uint48 eid = _displacedEpochIds[i];
+            Epoch storage e = epochs[eid];
+            if (_proposalId >= e.firstProposalId && _proposalId <= e.lastProposalId) {
+                return eid;
+            }
+        }
     }
 
     /// @dev Adds an epoch to the displaced tracking array for future bond release.
     function _addDisplacedEpoch(uint48 _epochId) private {
-        uint8 n = _numDisplacedEpochs;
-        require(n < MAX_DISPLACED_EPOCHS, TooManyDisplacedEpochs());
-        _displacedEpochIds[n] = _epochId;
-        _numDisplacedEpochs = n + 1;
+        _displacedEpochIds.push(_epochId);
     }
 
     /// @dev Releases bonds for displaced epochs whose proposals are all finalized.
     function _releaseDisplacedBonds(uint48 _lastFinalizedProposalId) private {
-        uint8 n = _numDisplacedEpochs;
-        uint8 remaining;
-        for (uint8 i; i < n; ++i) {
+        uint256 n = _displacedEpochIds.length;
+        uint256 remaining;
+        for (uint256 i; i < n; ++i) {
             uint48 eid = _displacedEpochIds[i];
             Epoch storage e = epochs[eid];
-            if (e.lastAssignedProposalId <= _lastFinalizedProposalId) {
+            if (e.lastProposalId <= _lastFinalizedProposalId) {
                 if (e.bondedAmount > 0) {
-                    bondBalances[e.operator] += e.bondedAmount;
-                    emit BondReleased(eid, e.operator, e.bondedAmount);
+                    bondBalances[e.prover] += e.bondedAmount;
+                    emit BondReleased(eid, e.prover, e.bondedAmount);
                     e.bondedAmount = 0;
                 }
             } else {
-                _displacedEpochIds[remaining] = eid;
-                ++remaining;
+                _displacedEpochIds[remaining++] = eid;
             }
         }
-        _numDisplacedEpochs = remaining;
+        // Trim released entries from the end using cached length.
+        for (uint256 j = remaining; j < n; ++j) {
+            _displacedEpochIds.pop();
+        }
     }
 
     // ---------------------------------------------------------------
     // Errors
     // ---------------------------------------------------------------
 
-    error ZeroAddress();
-    error ZeroValue();
+    error PermissionlessDelayTooSmall();
     error InsufficientBond();
-    error InsufficientFeeCredit();
+    error InsufficientFee();
+    error InsufficientFees();
     error NoBidToExit();
     error BidFeeTooHigh();
     error NotAuthorizedProver();
-    error TooManyDisplacedEpochs();
 }

--- a/packages/protocol/contracts/layer1/core/libs/LibInboxSetup.sol
+++ b/packages/protocol/contracts/layer1/core/libs/LibInboxSetup.sol
@@ -26,12 +26,6 @@ library LibInboxSetup {
         require(_config.proofVerifier != address(0), ProofVerifierZero());
         require(_config.proposerChecker != address(0), ProposerCheckerZero());
         require(_config.signalService != address(0), SignalServiceZero());
-        require(_config.bondToken != address(0), BondTokenZero());
-        require(_config.provingWindow != 0, ProvingWindowZero());
-        require(
-            _config.permissionlessProvingDelay > _config.provingWindow,
-            PermissionlessProvingDelayTooSmall()
-        );
         require(_config.ringBufferSize >= MIN_RING_BUFFER_SIZE, RingBufferSizeTooSmall());
         require(_config.basefeeSharingPctg <= 100, BasefeeSharingPctgTooLarge());
         require(_config.forcedInclusionFeeInGwei != 0, ForcedInclusionFeeInGweiZero());
@@ -94,15 +88,12 @@ library LibInboxSetup {
 
     error ActivationPeriodExpired();
     error BasefeeSharingPctgTooLarge();
-    error BondTokenZero();
     error ForcedInclusionFeeDoubleThresholdZero();
     error ForcedInclusionFeeInGweiZero();
     error InvalidLastPacayaBlockHash();
-    error PermissionlessProvingDelayTooSmall();
     error PermissionlessInclusionMultiplierTooSmall();
     error ProofVerifierZero();
     error ProposerCheckerZero();
-    error ProvingWindowZero();
     error RingBufferSizeTooSmall();
     error SignalServiceZero();
 }

--- a/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetInbox.sol
@@ -25,8 +25,7 @@ contract DevnetInbox is Inbox {
         address _proofVerifier,
         address _proposerChecker,
         address _proverMarket,
-        address _signalService,
-        address _bondToken
+        address _signalService
     )
         // See `MainnetInbox.sol` for details on the configuration.
         Inbox(Config({
@@ -34,9 +33,6 @@ contract DevnetInbox is Inbox {
                 proposerChecker: _proposerChecker,
                 proverMarket: _proverMarket,
                 signalService: _signalService,
-                bondToken: _bondToken,
-                provingWindow: 4 hours,
-                permissionlessProvingDelay: 5 days,
                 maxProofSubmissionDelay: 3 minutes,
                 ringBufferSize: _RING_BUFFER_SIZE,
                 basefeeSharingPctg: 75,

--- a/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetInbox.sol
@@ -27,18 +27,13 @@ contract MainnetInbox is Inbox {
         address _proofVerifier,
         address _proposerChecker,
         address _proverMarket,
-        address _signalService,
-        address _bondToken
+        address _signalService
     )
         Inbox(Config({
                 proofVerifier: _proofVerifier,
                 proposerChecker: _proposerChecker,
                 proverMarket: _proverMarket,
                 signalService: _signalService,
-                bondToken: _bondToken,
-                provingWindow: 4 hours, // internal target is still to submit every ~2 hours
-                // Allows the security council time to intervene if a bug is found.
-                permissionlessProvingDelay: 5 days,
                 maxProofSubmissionDelay: 3 minutes, // We want this to be lower than the expected cadence
                 ringBufferSize: _RING_BUFFER_SIZE,
                 basefeeSharingPctg: 75,

--- a/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol
@@ -209,7 +209,7 @@ contract DeployProtocolOnL1 is DeployCapability {
         shastaInbox = deployProxy({
             name: "shasta_inbox",
             impl: address(
-                new DevnetInbox(proofVerifier, whitelist, address(0), signalService, taikoToken)
+                new DevnetInbox(proofVerifier, whitelist, address(0), signalService)
             ),
             data: abi.encodeCall(Inbox.init, (msg.sender))
         });

--- a/packages/protocol/script/layer1/core/DeployShastaContracts.s.sol
+++ b/packages/protocol/script/layer1/core/DeployShastaContracts.s.sol
@@ -97,8 +97,7 @@ abstract contract DeployShastaContracts is DeployCapability {
                     proofVerifier,
                     config.preconfWhitelist,
                     address(0),
-                    config.l1SignalService,
-                    config.taikoToken
+                    config.l1SignalService
                 )
             ),
             data: abi.encodeCall(Inbox.init, config.activator)

--- a/packages/protocol/snapshots/shasta-propose.json
+++ b/packages/protocol/snapshots/shasta-propose.json
@@ -1,5 +1,5 @@
 {
-  "propose_after_ring_buffer_wrap": "41625",
-  "propose_forced_inclusion": "55790",
-  "propose_single": "68725"
+  "propose_after_ring_buffer_wrap": "42502",
+  "propose_forced_inclusion": "56667",
+  "propose_single": "72102"
 }

--- a/packages/protocol/snapshots/shasta-prove.json
+++ b/packages/protocol/snapshots/shasta-prove.json
@@ -1,7 +1,7 @@
 {
-  "prove_batch_10": "78388",
-  "prove_batch_2": "72245",
-  "prove_batch_3": "73006",
-  "prove_batch_5": "74536",
-  "prove_single": "71478"
+  "prove_batch_10": "79185",
+  "prove_batch_2": "73042",
+  "prove_batch_3": "73803",
+  "prove_batch_5": "75333",
+  "prove_single": "72275"
 }

--- a/packages/protocol/test/layer1/core/inbox/InboxActivation.t.sol
+++ b/packages/protocol/test/layer1/core/inbox/InboxActivation.t.sol
@@ -98,12 +98,6 @@ contract InboxActivationTest is InboxTestBase {
         IInbox.Config memory cfg = inbox.getConfig();
 
         // Verify key config values match what was set during construction
-        assertEq(cfg.provingWindow, config.provingWindow, "provingWindow mismatch");
-        assertEq(
-            cfg.permissionlessProvingDelay,
-            config.permissionlessProvingDelay,
-            "permissionlessProvingDelay mismatch"
-        );
         assertEq(cfg.ringBufferSize, config.ringBufferSize, "ringBufferSize mismatch");
         assertEq(cfg.basefeeSharingPctg, config.basefeeSharingPctg, "basefeeSharingPctg mismatch");
         assertEq(
@@ -114,7 +108,6 @@ contract InboxActivationTest is InboxTestBase {
         assertEq(cfg.proofVerifier, config.proofVerifier, "proofVerifier mismatch");
         assertEq(cfg.proposerChecker, config.proposerChecker, "proposerChecker mismatch");
         assertEq(cfg.signalService, config.signalService, "signalService mismatch");
-        assertEq(cfg.bondToken, config.bondToken, "bondToken mismatch");
     }
 }
 
@@ -141,30 +134,6 @@ contract LibInboxSetupConfigValidationTest is InboxTestBase {
         cfg.signalService = address(0);
 
         vm.expectRevert(LibInboxSetup.SignalServiceZero.selector);
-        new Inbox(cfg);
-    }
-
-    function test_validateConfig_RevertWhen_BondTokenZero() public {
-        IInbox.Config memory cfg = _buildConfig();
-        cfg.bondToken = address(0);
-
-        vm.expectRevert(LibInboxSetup.BondTokenZero.selector);
-        new Inbox(cfg);
-    }
-
-    function test_validateConfig_RevertWhen_ProvingWindowZero() public {
-        IInbox.Config memory cfg = _buildConfig();
-        cfg.provingWindow = 0;
-
-        vm.expectRevert(LibInboxSetup.ProvingWindowZero.selector);
-        new Inbox(cfg);
-    }
-
-    function test_validateConfig_RevertWhen_PermissionlessProvingDelayTooSmall() public {
-        IInbox.Config memory cfg = _buildConfig();
-        cfg.permissionlessProvingDelay = cfg.provingWindow;
-
-        vm.expectRevert(LibInboxSetup.PermissionlessProvingDelayTooSmall.selector);
         new Inbox(cfg);
     }
 

--- a/packages/protocol/test/layer1/core/inbox/InboxTestBase.sol
+++ b/packages/protocol/test/layer1/core/inbox/InboxTestBase.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { MockProofVerifier } from "./mocks/MockContracts.sol";
+import { MockProofVerifier, MockProverMarket } from "./mocks/MockContracts.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { Vm } from "forge-std/src/Vm.sol";
 import { ICodec } from "src/layer1/core/iface/ICodec.sol";
@@ -74,11 +74,8 @@ abstract contract InboxTestBase is CommonTest {
         return IInbox.Config({
             proofVerifier: address(verifier),
             proposerChecker: address(proposerChecker),
-            proverMarket: address(0),
+            proverMarket: address(new MockProverMarket(address(bondToken), 2 hours)),
             signalService: address(signalService),
-            bondToken: address(bondToken),
-            provingWindow: 2 hours,
-            permissionlessProvingDelay: 24 hours,
             maxProofSubmissionDelay: 3 minutes,
             ringBufferSize: 100,
             basefeeSharingPctg: 0,
@@ -181,6 +178,7 @@ abstract contract InboxTestBase is CommonTest {
         string memory _benchName
     )
         internal
+        virtual
         returns (ProposedEvent memory payload_)
     {
         bytes memory encodedInput = codec.encodeProposeInput(_input);

--- a/packages/protocol/test/layer1/core/inbox/ProverMarket.t.sol
+++ b/packages/protocol/test/layer1/core/inbox/ProverMarket.t.sol
@@ -3,30 +3,11 @@ pragma solidity ^0.8.24;
 
 import { InboxTestBase } from "./InboxTestBase.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Vm } from "forge-std/src/Vm.sol";
 import { IInbox } from "src/layer1/core/iface/IInbox.sol";
 import { Inbox } from "src/layer1/core/impl/Inbox.sol";
 import { ProverMarket } from "src/layer1/core/impl/ProverMarket.sol";
-
-contract RejectingFeeRecipient {
-    function depositBondAndBid(
-        ProverMarket _market,
-        IERC20 _bondToken,
-        uint64 _bondAmount,
-        uint64 _feeInGwei
-    )
-        external
-    {
-        _bondToken.approve(address(_market), type(uint256).max);
-        _market.depositBond(_bondAmount);
-        _market.bid(address(this), _feeInGwei);
-    }
-
-    receive() external payable {
-        revert("reject ether");
-    }
-}
+import { EssentialContract } from "src/shared/common/EssentialContract.sol";
 
 /// @title ProverMarketTestBase
 /// @notice Shared setup for ProverMarket tests — deploys a real ProverMarket wired to Inbox.
@@ -46,29 +27,12 @@ abstract contract ProverMarketTestBase is InboxTestBase {
     }
 
     function _buildConfig() internal virtual override returns (IInbox.Config memory) {
-        // Deploy ProverMarket first so we can reference it in the Inbox config.
-        // We need the Inbox address for the market constructor, but Inbox needs the market address.
-        // Solution: deploy market with a placeholder, then redeploy Inbox referencing the market.
-        // Actually, Inbox is deployed after _buildConfig, so we can deploy market with a
-        // predicted address. But that's complex. Instead, deploy market with a temporary inbox,
-        // then redeploy everything properly.
-        //
-        // Simpler: Deploy market pointing to address(1) temporarily, build config, then after
-        // Inbox is deployed we won't need to change it because the market's _inbox is immutable.
-        // We need the real inbox address.
-        //
-        // Best approach: pre-compute the inbox address or use a two-phase setup.
-        // Let's just deploy the market after Inbox by overriding setUp.
-
-        // Return config with address(0) for now; we override setUp to handle the full wiring.
+        // proverMarket is set in _deployInbox() via address prediction; use a placeholder here.
         return IInbox.Config({
             proofVerifier: address(verifier),
             proposerChecker: address(proposerChecker),
-            proverMarket: address(0), // overridden in setUp
+            proverMarket: address(1), // overridden in _deployInbox
             signalService: address(signalService),
-            bondToken: address(bondToken),
-            provingWindow: 2 hours,
-            permissionlessProvingDelay: PERMISSIONLESS_PROVING_DELAY,
             maxProofSubmissionDelay: 3 minutes,
             ringBufferSize: 100,
             basefeeSharingPctg: 0,
@@ -80,23 +44,19 @@ abstract contract ProverMarketTestBase is InboxTestBase {
     }
 
     /// @dev Override to deploy Inbox with a real ProverMarket.
-    /// We deploy market first with a known inbox address using CREATE2-like prediction,
-    /// or simply deploy everything in sequence.
+    /// Uses vm.computeCreateAddress to predict the Inbox proxy address, breaking the circular
+    /// dependency: ProverMarket needs the Inbox address, Inbox needs the ProverMarket address.
+    /// Deployment order: market impl (+0), market proxy (+1), inbox impl (+2), inbox proxy (+3).
     function _deployInbox() internal virtual override returns (Inbox) {
-        // Step 1: Deploy Inbox with proverMarket = address(0) to get a working instance.
-        // Step 2: Deploy ProverMarket pointing to that Inbox.
-        // Step 3: Redeploy Inbox with the real proverMarket address.
-        // Since Inbox is behind a proxy, we can upgrade the implementation.
+        address predictedInboxProxy =
+            vm.computeCreateAddress(address(this), vm.getNonce(address(this)) + 3);
 
-        // Deploy initial Inbox (proverMarket = address(0))
-        Inbox firstInbox = super._deployInbox();
-
-        // Deploy ProverMarket pointing to the Inbox proxy address
         ProverMarket marketImpl = new ProverMarket(
-            address(firstInbox),
+            predictedInboxProxy,
             address(bondToken),
             MARKET_MIN_BOND_GWEI,
-            PERMISSIONLESS_PROVING_DELAY
+            PERMISSIONLESS_PROVING_DELAY,
+            2 hours
         );
         market = ProverMarket(
             address(
@@ -106,12 +66,10 @@ abstract contract ProverMarketTestBase is InboxTestBase {
             )
         );
 
-        // Upgrade Inbox implementation to one that has proverMarket set
         config.proverMarket = address(market);
-        address newImpl = address(new Inbox(config));
-        firstInbox.upgradeTo(newImpl);
-
-        return firstInbox;
+        Inbox inbox = super._deployInbox();
+        assertEq(address(inbox), predictedInboxProxy, "inbox proxy address mismatch");
+        return inbox;
     }
 
     /// @dev Override to find the Proposed event by topic instead of assuming last log.
@@ -150,31 +108,45 @@ abstract contract ProverMarketTestBase is InboxTestBase {
         vm.stopPrank();
     }
 
-    /// @dev Deposits fee credit into the ProverMarket for the given account.
-    function _depositFeeCredit(address _account, uint256 _amount) internal {
-        vm.deal(_account, _amount);
-        vm.prank(_account);
-        market.depositFeeCredit{ value: _amount }();
-    }
-
     /// @dev Sets up a prover with a bid in the market and proposes so the epoch activates.
     function _setupActiveBid(
-        address _operator,
+        address _prover,
         uint64 _feeInGwei
     )
         internal
         returns (uint48 epochId_)
     {
-        _depositMarketBond(_operator, MARKET_MIN_BOND_GWEI);
-        vm.prank(_operator);
-        market.bid(_operator, _feeInGwei);
+        _depositMarketBond(_prover, MARKET_MIN_BOND_GWEI);
+        vm.prank(_prover);
+        market.bid(_feeInGwei);
 
-        (, uint48 pendingEpochId,,,,,) = market.marketState();
+        (, uint48 pendingEpochId,,,,) = market.marketState();
         epochId_ = pendingEpochId;
 
         // Propose to activate the epoch
         _advanceBlock();
         _proposeOne();
+    }
+
+    /// @dev Override to send ETH with every propose (covers prover fee + refund).
+    function _proposeAndDecodeWithGas(
+        IInbox.ProposeInput memory _input,
+        string memory _benchName
+    )
+        internal
+        override
+        returns (ProposedEvent memory payload_)
+    {
+        bytes memory encodedInput = codec.encodeProposeInput(_input);
+        vm.recordLogs();
+        vm.startPrank(proposer);
+
+        if (bytes(_benchName).length > 0) vm.startSnapshotGas("shasta-propose", _benchName);
+        inbox.propose{ value: 1 ether }(bytes(""), encodedInput);
+        if (bytes(_benchName).length > 0) vm.stopSnapshotGas();
+
+        vm.stopPrank();
+        payload_ = _readProposedEvent();
     }
 
     /// @dev Proposes once and records the proposal timestamp for later proof construction.
@@ -266,7 +238,7 @@ contract ProverMarketBondTest is ProverMarketTestBase {
     }
 
     function test_depositBond_RevertWhen_ZeroAmount() external {
-        vm.expectRevert(ProverMarket.ZeroValue.selector);
+        vm.expectRevert(EssentialContract.ZERO_VALUE.selector);
         market.depositBond(0);
     }
 
@@ -291,36 +263,91 @@ contract ProverMarketBondTest is ProverMarketTestBase {
 }
 
 // =======================================================================
-// Fee Credit Tests
+// Fee Tests
 // =======================================================================
 
-contract ProverMarketFeeCreditTest is ProverMarketTestBase {
-    function test_depositFeeCredit_creditsBalance() external {
-        _depositFeeCredit(Alice, 1 ether);
-        assertEq(market.feeCreditBalances(Alice), 1 ether);
+contract ProverMarketFeeTest is ProverMarketTestBase {
+    function test_propose_chargesProverFee() external {
+        uint64 fee = 100; // 100 gwei per proposal
+        _setupActiveBid(Alice, fee);
+
+        uint256 feeBefore = market.feeBalances(Alice);
+        _advanceBlock();
+        _proposeOne();
+
+        uint256 feeWei = uint256(fee) * 1 gwei;
+        assertEq(market.feeBalances(Alice) - feeBefore, feeWei);
     }
 
-    function test_depositFeeCredit_RevertWhen_ZeroValue() external {
-        vm.expectRevert(ProverMarket.ZeroValue.selector);
-        market.depositFeeCredit{ value: 0 }();
+    function test_propose_refundsExcessEth() external {
+        uint64 fee = 100;
+        _setupActiveBid(Alice, fee);
+
+        uint256 balBefore = proposer.balance;
+        _advanceBlock();
+        _proposeOne(); // sends 1 ether, gets refund
+
+        uint256 feeWei = uint256(fee) * 1 gwei;
+        // Proposer paid exactly the fee (refund covers the rest)
+        assertEq(balBefore - proposer.balance, feeWei);
     }
 
-    function test_withdrawFeeCredit_sendsEth() external {
-        _depositFeeCredit(Alice, 2 ether);
+    function test_propose_RevertWhen_InsufficientFee() external {
+        uint64 fee = 100;
+        _setupActiveBid(Alice, fee);
+
+        _advanceBlock();
+        _setBlobHashes(3);
+        bytes memory encodedInput = codec.encodeProposeInput(_defaultProposeInput());
+        vm.prank(proposer);
+        vm.expectRevert(ProverMarket.InsufficientFee.selector);
+        inbox.propose{ value: 0 }(bytes(""), encodedInput);
+    }
+
+    function test_withdrawFees_sendsEth() external {
+        uint64 fee = 100;
+        _setupActiveBid(Alice, fee);
+
+        _advanceBlock();
+        _proposeOne();
+
+        uint256 totalFees = market.feeBalances(Alice);
+        assertGt(totalFees, 0);
 
         uint256 balBefore = Alice.balance;
         vm.prank(Alice);
-        market.withdrawFeeCredit(1 ether);
+        market.withdrawFees(totalFees);
 
-        assertEq(Alice.balance - balBefore, 1 ether);
-        assertEq(market.feeCreditBalances(Alice), 1 ether);
+        assertEq(Alice.balance - balBefore, totalFees);
+        assertEq(market.feeBalances(Alice), 0);
     }
 
-    function test_withdrawFeeCredit_RevertWhen_InsufficientBalance() external {
-        _depositFeeCredit(Alice, 1 ether);
+    function test_withdrawFees_RevertWhen_InsufficientBalance() external {
         vm.prank(Alice);
-        vm.expectRevert(ProverMarket.InsufficientFeeCredit.selector);
-        market.withdrawFeeCredit(2 ether);
+        vm.expectRevert(ProverMarket.InsufficientFees.selector);
+        market.withdrawFees(1 ether);
+    }
+
+    function test_activeFeeInGwei_returnsActiveEpochFee() external {
+        _setupActiveBid(Alice, 100);
+        assertEq(market.activeFeeInGwei(), 100);
+    }
+
+    function test_activeFeeInGwei_returnsPendingFeeWhenActiveDisplaced() external {
+        _setupActiveBid(Alice, 100);
+
+        _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
+        vm.prank(Bob);
+        market.bid(50);
+
+        // Pending will activate on next proposal, so activeFeeInGwei returns pending's fee
+        assertEq(market.activeFeeInGwei(), 50);
+    }
+
+    function test_activeFeeInGwei_returnsZeroInPermissionlessMode() external {
+        _setupActiveBid(Alice, 100);
+        market.forcePermissionlessMode(true);
+        assertEq(market.activeFeeInGwei(), 0);
     }
 }
 
@@ -333,15 +360,13 @@ contract ProverMarketBidTest is ProverMarketTestBase {
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
 
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
-        (, uint48 pendingEpochId,,,,,) = market.marketState();
+        (, uint48 pendingEpochId,,,,) = market.marketState();
         assertEq(pendingEpochId, 1);
 
-        (address op, address feeRecipient, uint64 fee, uint64 bonded,,,) =
-            market.epochs(pendingEpochId);
-        assertEq(op, Alice);
-        assertEq(feeRecipient, Alice);
+        (address prv, uint64 fee, uint64 bonded,,,) = market.epochs(pendingEpochId);
+        assertEq(prv, Alice);
         assertEq(fee, 100);
         assertEq(bonded, MARKET_MIN_BOND_GWEI);
 
@@ -352,13 +377,13 @@ contract ProverMarketBidTest is ProverMarketTestBase {
     function test_bid_activatesOnFirstProposal() external {
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
         // Propose to trigger activation
         _advanceBlock();
         _proposeOne();
 
-        (uint48 activeEpochId, uint48 pendingEpochId,,,,,) = market.marketState();
+        (uint48 activeEpochId, uint48 pendingEpochId,,,,) = market.marketState();
         assertEq(activeEpochId, 1);
         assertEq(pendingEpochId, 0);
     }
@@ -370,11 +395,11 @@ contract ProverMarketBidTest is ProverMarketTestBase {
         // Bob must bid lower to outbid
         _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
         vm.prank(Bob);
-        market.bid(Bob, 50);
+        market.bid(50);
 
-        (, uint48 pendingEpochId,,,,,) = market.marketState();
-        (address op,,,,,,) = market.epochs(pendingEpochId);
-        assertEq(op, Bob);
+        (, uint48 pendingEpochId,,,,) = market.marketState();
+        (address prv,,,,,) = market.epochs(pendingEpochId);
+        assertEq(prv, Bob);
     }
 
     function test_bid_RevertWhen_FeeTooHigh() external {
@@ -383,19 +408,19 @@ contract ProverMarketBidTest is ProverMarketTestBase {
         _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
         vm.prank(Bob);
         vm.expectRevert(ProverMarket.BidFeeTooHigh.selector);
-        market.bid(Bob, 100); // must be strictly less
+        market.bid(100); // must be strictly less
     }
 
     function test_bid_RevertWhen_InsufficientBond() external {
         vm.expectRevert(ProverMarket.InsufficientBond.selector);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
     }
 
     function test_bid_refundsDisplacedPendingOperator() external {
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
         // Alice's bond is locked
         assertEq(market.bondBalances(Alice), 0);
@@ -405,18 +430,12 @@ contract ProverMarketBidTest is ProverMarketTestBase {
         // But the pending check requires Bob < Alice's fee.
         _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
         vm.prank(Bob);
-        market.bid(Bob, 50);
+        market.bid(50);
 
         // Alice's bond should be refunded
         assertEq(market.bondBalances(Alice), MARKET_MIN_BOND_GWEI);
     }
 
-    function test_bid_RevertWhen_ZeroFeeRecipient() external {
-        _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
-        vm.prank(Alice);
-        vm.expectRevert(ProverMarket.ZeroAddress.selector);
-        market.bid(address(0), 100);
-    }
 }
 
 // =======================================================================
@@ -427,7 +446,7 @@ contract ProverMarketExitTest is ProverMarketTestBase {
     function test_exit_clearsPendingEpoch() external {
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
         // Bond is locked
         assertEq(market.bondBalances(Alice), 0);
@@ -435,7 +454,7 @@ contract ProverMarketExitTest is ProverMarketTestBase {
         vm.prank(Alice);
         market.exit();
 
-        (, uint48 pendingEpochId,,,,,) = market.marketState();
+        (, uint48 pendingEpochId,,,,) = market.marketState();
         assertEq(pendingEpochId, 0);
 
         // Bond refunded
@@ -448,9 +467,8 @@ contract ProverMarketExitTest is ProverMarketTestBase {
         vm.prank(Alice);
         market.exit();
 
-        (,,,,, bool exiting, bool degraded) = market.marketState();
+        (,,,,, bool exiting) = market.marketState();
         assertTrue(exiting);
-        assertFalse(degraded);
     }
 
     function test_exit_RevertWhen_NoBid() external {
@@ -479,13 +497,10 @@ contract ProverMarketExitTest is ProverMarketTestBase {
         _advanceBlock();
         RecordedProposal memory proposal = _proposeRecordedOne();
 
-        (uint48 activeEpochId,,,, bool permissionless, bool exiting, bool degraded) =
-            market.marketState();
+        (uint48 activeEpochId,,,, bool permissionless, bool exiting) = market.marketState();
         assertEq(activeEpochId, 0);
         assertFalse(permissionless);
         assertFalse(exiting);
-        assertFalse(degraded);
-        assertEq(market.proposalEpochs(proposal.payload.id), 0);
         assertEq(market.bondBalances(Alice), 0, "exiting prover stays liable for assigned work");
     }
 }
@@ -503,9 +518,9 @@ contract ProverMarketProposalTest is ProverMarketTestBase {
         _advanceBlock();
         ProposedEvent memory payload = _proposeOne();
 
-        uint48 epochId = market.proposalEpochs(payload.id);
-        (uint48 activeEpochId,,,,,,) = market.marketState();
-        assertEq(epochId, activeEpochId);
+        (uint48 activeEpochId,,,,,) = market.marketState();
+        (,,,,, uint48 lastPropId) = market.epochs(activeEpochId);
+        assertEq(lastPropId, payload.id);
     }
 
     function test_onProposalAccepted_activatesPendingWhenExiting() external {
@@ -515,7 +530,7 @@ contract ProverMarketProposalTest is ProverMarketTestBase {
         // Bob bids lower, becomes pending
         _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
         vm.prank(Bob);
-        market.bid(Bob, 50);
+        market.bid(50);
 
         // Alice exits
         vm.prank(Alice);
@@ -525,61 +540,23 @@ contract ProverMarketProposalTest is ProverMarketTestBase {
         _advanceBlock();
         _proposeOne();
 
-        (uint48 activeEpochId,,,,,,) = market.marketState();
-        (address op,,,,,,) = market.epochs(activeEpochId);
-        assertEq(op, Bob);
+        (uint48 activeEpochId,,,,,) = market.marketState();
+        (address prv,,,,,) = market.epochs(activeEpochId);
+        assertEq(prv, Bob);
     }
 
-    function test_onProposalAccepted_accruesFeeForRecipient() external {
+    function test_onProposalAccepted_accruesFeeForProver() external {
         uint64 fee = 100; // 100 gwei per proposal
         _setupActiveBid(Alice, fee);
 
-        // Deposit fee credit for proposer
+        uint256 feeBefore = market.feeBalances(Alice);
         uint256 feeWei = uint256(fee) * 1 gwei;
-        _depositFeeCredit(proposer, feeWei * 5);
-
-        uint256 creditBefore = market.feeCreditBalances(proposer);
-        uint256 recipientCreditBefore = market.feeCreditBalances(Alice);
-        uint256 recipientEthBefore = Alice.balance;
 
         _advanceBlock();
         _proposeOne();
 
-        // Fee should be deducted from proposer and accrued to the fee recipient.
-        assertEq(market.feeCreditBalances(proposer), creditBefore - feeWei);
-        assertEq(market.feeCreditBalances(Alice), recipientCreditBefore + feeWei);
-        assertEq(Alice.balance, recipientEthBefore);
-    }
-
-    function test_onProposalAccepted_skipsFeeIfInsufficientCredit() external {
-        uint64 fee = 100;
-        _setupActiveBid(Alice, fee);
-
-        // Don't deposit any fee credit for proposer
-        uint256 recipientBefore = market.feeCreditBalances(Alice);
-
-        _advanceBlock();
-        _proposeOne(); // should not revert
-
-        // No fee paid
-        assertEq(market.feeCreditBalances(Alice), recipientBefore);
-    }
-
-    function test_onProposalAccepted_DoesNotRevertWhen_FeeRecipientRejectsEth() external {
-        RejectingFeeRecipient recipient = new RejectingFeeRecipient();
-        uint64 fee = 100;
-        uint256 feeWei = uint256(fee) * 1 gwei;
-
-        bondToken.mint(address(recipient), _toTokenAmount(MARKET_MIN_BOND_GWEI));
-        recipient.depositBondAndBid(market, IERC20(address(bondToken)), MARKET_MIN_BOND_GWEI, fee);
-
-        _depositFeeCredit(proposer, feeWei);
-
-        _advanceBlock();
-        ProposedEvent memory payload = _proposeOne();
-
-        assertEq(market.proposalEpochs(payload.id), 1);
-        assertEq(market.feeCreditBalances(address(recipient)), feeWei);
+        // Fee should be accrued to the epoch prover.
+        assertEq(market.feeBalances(Alice) - feeBefore, feeWei);
     }
 
     function test_onProposalAccepted_activatesPendingOnNewProposal() external {
@@ -589,89 +566,15 @@ contract ProverMarketProposalTest is ProverMarketTestBase {
         // Bob outbids with lower fee, becomes pending
         _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
         vm.prank(Bob);
-        market.bid(Bob, 500);
+        market.bid(500);
 
         // Next proposal should activate Bob's epoch (pending gets activated on proposal)
         _advanceBlock();
         _proposeOne();
 
-        (uint48 activeEpochId,,,,,,) = market.marketState();
-        (address op,,,,,,) = market.epochs(activeEpochId);
-        assertEq(op, Bob);
-    }
-}
-
-contract ProverMarketDegradedModeTest is ProverMarketTestBase {
-    function test_onProposalAccepted_entersDegradedModeAndParksPendingBid() external {
-        address[9] memory operators =
-            [Alice, Bob, Carol, David, Emma, Frank, Grace, Henry, Isabella];
-        uint64 baseFee = 1000;
-        RecordedProposal memory lastProposal;
-
-        for (uint256 i; i < operators.length; ++i) {
-            _depositMarketBond(operators[i], MARKET_MIN_BOND_GWEI);
-            vm.prank(operators[i]);
-            market.bid(operators[i], baseFee - uint64(i));
-
-            _advanceBlock();
-            lastProposal = _proposeRecordedOne();
-        }
-
-        (
-            uint48 activeEpochId,
-            uint48 pendingEpochId,,,
-            bool permissionless,
-            bool exiting,
-            bool degraded
-        ) = market.marketState();
-        assertEq(activeEpochId, 0);
-        assertGt(pendingEpochId, 0);
-        assertFalse(permissionless);
-        assertFalse(exiting);
-        assertTrue(degraded);
-        assertEq(market.proposalEpochs(lastProposal.payload.id), 0);
-
-        (address pendingOperator,,,,,,) = market.epochs(pendingEpochId);
-        assertEq(pendingOperator, Isabella);
-    }
-
-    function test_onProofAccepted_clearsDegradedModeAfterBacklogDrains() external {
-        address[9] memory operators =
-            [Alice, Bob, Carol, David, Emma, Frank, Grace, Henry, Isabella];
-        uint64 baseFee = 1000;
-        RecordedProposal[] memory proposals = new RecordedProposal[](operators.length);
-
-        for (uint256 i; i < operators.length; ++i) {
-            _depositMarketBond(operators[i], MARKET_MIN_BOND_GWEI);
-            vm.prank(operators[i]);
-            market.bid(operators[i], baseFee - uint64(i));
-
-            _advanceBlock();
-            proposals[i] = _proposeRecordedOne();
-        }
-
-        vm.warp(block.timestamp + PERMISSIONLESS_PROVING_DELAY);
-        _proveRecordedRangeAs(proposals, Isabella, Isabella);
-
-        (uint48 activeEpochId, uint48 pendingEpochId, uint48 lastFinalized,,,, bool degraded) =
-            market.marketState();
-        assertEq(activeEpochId, 0);
-        assertGt(pendingEpochId, 0);
-        assertEq(lastFinalized, proposals[proposals.length - 1].payload.id);
-        assertFalse(degraded);
-        assertEq(market.bondBalances(Isabella), MARKET_MIN_BOND_GWEI);
-
-        _advanceBlock();
-        RecordedProposal memory nextProposal = _proposeRecordedOne();
-
-        (activeEpochId, pendingEpochId,,,,, degraded) = market.marketState();
-        assertGt(activeEpochId, 0);
-        assertEq(pendingEpochId, 0);
-        assertFalse(degraded);
-        assertEq(market.proposalEpochs(nextProposal.payload.id), activeEpochId);
-
-        (address activeOperator,,,,,,) = market.epochs(activeEpochId);
-        assertEq(activeOperator, Isabella);
+        (uint48 activeEpochId,,,,,) = market.marketState();
+        (address prv,,,,,) = market.epochs(activeEpochId);
+        assertEq(prv, Bob);
     }
 }
 
@@ -680,11 +583,11 @@ contract ProverMarketDegradedModeTest is ProverMarketTestBase {
 // =======================================================================
 
 contract ProverMarketProofAuthTest is ProverMarketTestBase {
-    function test_beforeProofSubmission_allowsEpochOperator() external {
+    function test_canSubmitProof_allowsEpochOperator() external {
         // Set up prover (Carol) as the epoch operator — bid but don't propose yet
         _depositMarketBond(prover, MARKET_MIN_BOND_GWEI);
         vm.prank(prover);
-        market.bid(prover, 100);
+        market.bid(100);
 
         // Build batch — _buildBatchInput proposes internally, which also activates the epoch
         _advanceBlock();
@@ -692,11 +595,11 @@ contract ProverMarketProofAuthTest is ProverMarketTestBase {
         _prove(input); // _prove uses `prover` as caller (the epoch operator)
     }
 
-    function test_beforeProofSubmission_RevertWhen_NotOperator() external {
+    function test_canSubmitProof_RevertWhen_NotOperator() external {
         // Set up Alice as the epoch operator — bid but don't propose yet
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
         // Build batch — activates Alice's epoch
         _advanceBlock();
@@ -706,15 +609,15 @@ contract ProverMarketProofAuthTest is ProverMarketTestBase {
         // We encode first, then expectRevert before the actual prove call.
         bytes memory encodedInput = codec.encodeProveInput(input);
         vm.prank(prover);
-        vm.expectRevert();
+        vm.expectRevert(ProverMarket.NotAuthorizedProver.selector);
         inbox.prove(encodedInput, bytes("proof"));
     }
 
-    function test_beforeProofSubmission_allowsAnyoneAfterDelay() external {
+    function test_canSubmitProof_allowsAnyoneAfterDelay() external {
         // Set up Alice as the epoch operator
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
         _advanceBlock();
         IInbox.ProveInput memory input = _buildBatchInput(1);
@@ -726,11 +629,11 @@ contract ProverMarketProofAuthTest is ProverMarketTestBase {
         _prove(input);
     }
 
-    function test_beforeProofSubmission_allowsAnyoneInPermissionlessMode() external {
+    function test_canSubmitProof_allowsAnyoneInPermissionlessMode() external {
         // Set up Alice as the epoch operator
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
         _advanceBlock();
         IInbox.ProveInput memory input = _buildBatchInput(1);
@@ -752,13 +655,13 @@ contract ProverMarketProofAcceptedTest is ProverMarketTestBase {
         // Set up prover as epoch operator without pre-proposing
         _depositMarketBond(prover, MARKET_MIN_BOND_GWEI);
         vm.prank(prover);
-        market.bid(prover, 100);
+        market.bid(100);
 
         _advanceBlock();
         IInbox.ProveInput memory input = _buildBatchInput(1);
         _prove(input);
 
-        (,, uint48 lastFinalized,,,,) = market.marketState();
+        (,, uint48 lastFinalized,,,) = market.marketState();
         assertGt(lastFinalized, 0);
     }
 
@@ -769,7 +672,7 @@ contract ProverMarketProofAcceptedTest is ProverMarketTestBase {
         // Bob outbids, becomes pending
         _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
         vm.prank(Bob);
-        market.bid(Bob, 500);
+        market.bid(500);
 
         // Next proposal activates Bob, displaces Alice
         _advanceBlock();
@@ -782,7 +685,7 @@ contract ProverMarketProofAcceptedTest is ProverMarketTestBase {
     function test_onProofAccepted_lateSelfProofMovesSlashIntoRewardPool() external {
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
         _advanceBlock();
         RecordedProposal[] memory proposals = new RecordedProposal[](1);
@@ -791,7 +694,7 @@ contract ProverMarketProofAcceptedTest is ProverMarketTestBase {
         vm.warp(block.timestamp + PERMISSIONLESS_PROVING_DELAY);
         _proveRecordedRangeAs(proposals, Alice, Alice);
 
-        (uint48 activeEpochId,,,,,,) = market.marketState();
+        (uint48 activeEpochId,,,,,) = market.marketState();
         assertEq(activeEpochId, 0);
         assertEq(market.bondBalances(Alice), 0);
         assertEq(market.rescueRewardPool(), MARKET_MIN_BOND_GWEI);
@@ -800,7 +703,7 @@ contract ProverMarketProofAcceptedTest is ProverMarketTestBase {
     function test_onProofAccepted_rescueProofClaimsCurrentSlashAndRewardPool() external {
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 100);
+        market.bid(100);
 
         _advanceBlock();
         RecordedProposal[] memory firstRange = new RecordedProposal[](1);
@@ -811,7 +714,7 @@ contract ProverMarketProofAcceptedTest is ProverMarketTestBase {
 
         _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
         vm.prank(Bob);
-        market.bid(Bob, 50);
+        market.bid(50);
 
         _advanceBlock();
         RecordedProposal[] memory secondRange = new RecordedProposal[](1);
@@ -833,11 +736,11 @@ contract ProverMarketProofAcceptedTest is ProverMarketTestBase {
 contract ProverMarketEmergencyTest is ProverMarketTestBase {
     function test_forcePermissionlessMode_toggles() external {
         market.forcePermissionlessMode(true);
-        (,,,, bool permissionless,,) = market.marketState();
+        (,,,, bool permissionless,) = market.marketState();
         assertTrue(permissionless);
 
         market.forcePermissionlessMode(false);
-        (,,,, permissionless,,) = market.marketState();
+        (,,,, permissionless,) = market.marketState();
         assertFalse(permissionless);
     }
 
@@ -863,44 +766,143 @@ contract ProverMarketE2ETest is ProverMarketTestBase {
         // 1. Prover deposits bond and bids
         _depositMarketBond(prover, MARKET_MIN_BOND_GWEI);
         vm.prank(prover);
-        market.bid(prover, 50);
+        market.bid(50);
 
-        // 2. Proposer deposits fee credit
-        _depositFeeCredit(proposer, 1 ether);
-
-        // 3. Propose + Prove via _buildBatchInput (activates epoch, assigns, then prove)
+        // 2. Propose + Prove via _buildBatchInput (activates epoch, assigns, then prove)
+        // Proposer sends ETH with propose to pay prover fee.
         _advanceBlock();
         IInbox.ProveInput memory input = _buildBatchInput(1);
 
         // Verify epoch is active
-        (uint48 activeEpochId,,,,,,) = market.marketState();
+        (uint48 activeEpochId,,,,,) = market.marketState();
         assertGt(activeEpochId, 0);
 
-        // 4. Prove (as the epoch operator)
+        // 3. Prove (as the epoch operator)
         _prove(input);
 
-        // 5. Verify finalization tracked
-        (,, uint48 lastFinalized,,,,) = market.marketState();
+        // 4. Verify finalization tracked
+        (,, uint48 lastFinalized,,,) = market.marketState();
         assertGt(lastFinalized, 0);
+    }
+
+    function test_fullLifecycle_bidProposeProveFeeWithdraw() external {
+        // 1. Prover deposits bond (extra for withdrawal after bid locks _minBond)
+        _depositMarketBond(prover, MARKET_MIN_BOND_GWEI);
+        vm.prank(prover);
+        market.bid(50);
+
+        // 2. Propose (pays prover fee via msg.value)
+        _advanceBlock();
+        RecordedProposal[] memory proposals = new RecordedProposal[](1);
+        proposals[0] = _proposeRecordedOne();
+
+        // 3. Prove (as epoch operator, within window)
+        _proveRecordedRangeAs(proposals, prover, prover);
+
+        // 4. Verify fee accrued and withdraw
+        uint256 fees = market.feeBalances(prover);
+        assertGt(fees, 0);
+        uint256 balBefore = prover.balance;
+        vm.prank(prover);
+        market.withdrawFees(fees);
+        assertEq(prover.balance - balBefore, fees);
+
+        // 5. Bond is still locked in active epoch (not displaced/finalized yet)
+        assertEq(market.bondBalances(prover), 0);
+    }
+
+    function test_displacedBondRelease_fullFlow() external {
+        // Alice becomes active (epoch 1 activated on proposal 1)
+        _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
+        vm.prank(Alice);
+        market.bid(1000);
+
+        // Record Alice's activation proposal
+        _advanceBlock();
+        RecordedProposal[] memory allProposals = new RecordedProposal[](2);
+        allProposals[0] = _proposeRecordedOne();
+
+        // Bob outbids — becomes pending
+        _depositMarketBond(Bob, MARKET_MIN_BOND_GWEI);
+        vm.prank(Bob);
+        market.bid(500);
+
+        // Propose again: displaces Alice (epoch 1 → displaced), activates Bob (epoch 2)
+        _advanceBlock();
+        allProposals[1] = _proposeRecordedOne();
+
+        // Alice's bond is locked (displaced, proposals not yet finalized)
+        assertEq(market.bondBalances(Alice), 0);
+
+        // Wait for permissionless delay so anyone can prove the full range
+        vm.warp(block.timestamp + PERMISSIONLESS_PROVING_DELAY);
+
+        // Prove both proposals — covers Alice's range, should release her bond
+        // (slashing also applies since we're past the delay)
+        _proveRecordedRangeAs(allProposals, prover, prover);
+
+        // Alice's displaced bond was slashed (past permissionless delay), goes to rescue prover
+        // Bob's active epoch was NOT slashed (only firstNewProposalId's epoch is checked)
+        assertEq(market.bondBalances(prover), MARKET_MIN_BOND_GWEI, "rescue prover gets slashed bond");
+    }
+
+    function test_zeroFeeEpoch_chargesNothing() external {
+        // Prover bids with zero fee
+        _setupActiveBid(Alice, 0);
+
+        uint256 balBefore = proposer.balance;
+        _advanceBlock();
+        _proposeOne();
+
+        // No fee charged, all ETH refunded
+        assertEq(market.feeBalances(Alice), 0);
+        // Proposer only lost gas, not fee (1 ether sent, 1 ether refunded)
+        assertEq(balBefore - proposer.balance, 0);
+    }
+
+    function test_canSubmitProof_directViewCall() external {
+        _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
+        vm.prank(Alice);
+        market.bid(100);
+
+        // Activate by proposing
+        _advanceBlock();
+        ProposedEvent memory payload = _proposeOne();
+
+        // Alice is the epoch prover — should be authorized
+        assertTrue(market.canSubmitProof(Alice, payload.id, 0));
+
+        // Bob is not the epoch prover — should be denied within window
+        assertFalse(market.canSubmitProof(Bob, payload.id, 0));
+
+        // Anyone authorized after permissionless delay
+        assertTrue(market.canSubmitProof(Bob, payload.id, PERMISSIONLESS_PROVING_DELAY));
+    }
+
+    function test_viewFunctions_returnCorrectImmutables() external view {
+        assertEq(market.minBond(), MARKET_MIN_BOND_GWEI);
+        assertEq(market.permissionlessProvingDelay(), PERMISSIONLESS_PROVING_DELAY);
+        assertEq(market.provingWindow(), 2 hours);
+        assertEq(market.bondToken(), address(bondToken));
     }
 
     function test_epochTransition_outbidAndProve() external {
         // Alice bids (pending), prover outbids (also pending, displaces Alice)
         _depositMarketBond(Alice, MARKET_MIN_BOND_GWEI);
         vm.prank(Alice);
-        market.bid(Alice, 1000);
+        market.bid(1000);
 
         _depositMarketBond(prover, MARKET_MIN_BOND_GWEI);
         vm.prank(prover);
-        market.bid(prover, 100);
+        market.bid(100);
 
         // Propose via _buildBatchInput — activates prover's epoch
         _advanceBlock();
         IInbox.ProveInput memory input = _buildBatchInput(1);
 
-        (uint48 activeEpochId,,,,,,) = market.marketState();
-        (address op,,,,,,) = market.epochs(activeEpochId);
-        assertEq(op, prover, "prover should be active operator");
+        (uint48 activeEpochId,,,,,) = market.marketState();
+        (address prv,,,,,) = market.epochs(activeEpochId);
+        assertEq(prv, prover, "prover should be active operator");
 
         // Prove as prover
         _prove(input);

--- a/packages/protocol/test/layer1/core/inbox/mocks/MockContracts.sol
+++ b/packages/protocol/test/layer1/core/inbox/mocks/MockContracts.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IProofVerifier } from "src/layer1/verifiers/IProofVerifier.sol";
+import { IProverMarket } from "src/layer1/core/iface/IProverMarket.sol";
 import { ISignalService } from "src/shared/signal/ISignalService.sol";
 
 contract MockERC20 is ERC20 {
@@ -13,6 +14,38 @@ contract MockERC20 is ERC20 {
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
     }
+}
+
+contract MockProverMarket is IProverMarket {
+    address private _bondToken;
+    uint48 private _provingWindow;
+
+    constructor(address bondToken_, uint48 provingWindow_) {
+        _bondToken = bondToken_;
+        _provingWindow = provingWindow_;
+    }
+
+    function bid(uint64) external { }
+    function exit() external { }
+    function depositBond(uint64) external { }
+    function withdrawBond(uint64) external { }
+    function withdrawFees(uint256) external { }
+    function bondBalances(address) external pure returns (uint64) { return 0; }
+    function feeBalances(address) external pure returns (uint256) { return 0; }
+    function canSubmitProof(address, uint48, uint256) external pure returns (bool) { return true; }
+
+    function onProposalAccepted(uint48, address _proposer, uint48) external payable {
+        if (msg.value > 0) payable(_proposer).transfer(msg.value);
+    }
+
+    function onProofAccepted(address, uint48, uint48, uint256) external { }
+    function forcePermissionlessMode(bool) external { }
+    function creditMigratedBond(address, uint64) external { }
+    function bondToken() external view returns (address) { return _bondToken; }
+    function provingWindow() external view returns (uint48) { return _provingWindow; }
+    function activeFeeInGwei() external pure returns (uint64) { return 0; }
+    function minBond() external pure returns (uint64) { return 0; }
+    function permissionlessProvingDelay() external pure returns (uint48) { return 0; }
 }
 
 contract MockProofVerifier is IProofVerifier {


### PR DESCRIPTION
## Summary
- Moves `provingWindow`, `bondToken`, and `permissionlessProvingDelay` from Inbox to ProverMarket as immutables, making ProverMarket self-contained
- Makes `propose()` payable so proposers pay ETH fees directly with `msg.value` instead of a deposit/credit system
- Replaces per-proposal `proposalEpochs` mapping with epoch range lookup via `_findEpochForProposal`, saving ~20k gas per proposal (cold SSTORE avoided)
- Replaces fixed-size `uint48[8]` displaced array with unbounded dynamic array, removing all degraded mode logic
- Merges `beforeProofSubmission()` into `onProofAccepted()` and adds `canSubmitProof()` as a read-only view for off-chain pre-checks
- Removes `feeRecipient` from epochs — prover always receives fees directly
- Adds `migrateBond(address)` so anyone can migrate bonds on behalf of another account
- Adds missing view functions (`bondToken()`, `provingWindow()`, `minBond()`) and uses EssentialContract modifiers for constructor validation

## Test plan
- [x] All 114 inbox tests pass
- [ ] Review `_findEpochForProposal` correctness for edge cases (epoch boundaries, slashed epochs)
- [ ] Verify storage layout compatibility with `pnpm layout`
- [ ] Gas snapshot comparison with `pnpm snapshot:l1`