### PR TITLE
chore(taiko-client-rs): bump `alethia-reth` dependencies

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=9705d857c8ae365e6abb6273b843aab88d98ef87#9705d857c8ae365e6abb6273b843aab88d98ef87"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=432362e14ee69d6b1affb5ba3108cd62e2b2e7dd#432362e14ee69d6b1affb5ba3108cd62e2b2e7dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=9705d857c8ae365e6abb6273b843aab88d98ef87#9705d857c8ae365e6abb6273b843aab88d98ef87"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=432362e14ee69d6b1affb5ba3108cd62e2b2e7dd#432362e14ee69d6b1affb5ba3108cd62e2b2e7dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=9705d857c8ae365e6abb6273b843aab88d98ef87#9705d857c8ae365e6abb6273b843aab88d98ef87"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=432362e14ee69d6b1affb5ba3108cd62e2b2e7dd#432362e14ee69d6b1affb5ba3108cd62e2b2e7dd"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -2566,7 +2566,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2867,7 +2867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5376,7 +5376,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6536,7 +6536,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8984,7 +8984,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9854,7 +9854,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10990,7 +10990,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -78,11 +78,11 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "9705d857c8ae365e6abb6273b843aab88d98ef87", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "9705d857c8ae365e6abb6273b843aab88d98ef87", features = [
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "432362e14ee69d6b1affb5ba3108cd62e2b2e7dd", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "432362e14ee69d6b1affb5ba3108cd62e2b2e7dd", features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "9705d857c8ae365e6abb6273b843aab88d98ef87" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "432362e14ee69d6b1affb5ba3108cd62e2b2e7dd" }
 # types
 anyhow = "1"
 dashmap = "6.1.0"

--- a/packages/taiko-client-rs/crates/rpc/src/auth.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/auth.rs
@@ -17,7 +17,10 @@ use anyhow::anyhow;
 use serde_json::Value;
 
 use super::client::Client;
-use crate::error::{Result, RpcClientError};
+use crate::{
+    error::{Result, RpcClientError},
+    l1_origin::EngineRpcL1Origin,
+};
 
 /// Re-export of Taiko's pre-built transaction list type using untyped transactions.
 pub type PreBuiltTxList = TaikoPreBuiltTxList<Value>;
@@ -121,9 +124,14 @@ impl<P: Provider + Clone> Client<P> {
 
     /// Update the execution engine's L1 origin metadata for a given block.
     pub async fn update_l1_origin(&self, origin: &RpcL1Origin) -> Result<Option<RpcL1Origin>> {
+        let origin = EngineRpcL1Origin::from(origin.clone());
         self.l2_auth_provider
-            .raw_request(Cow::Borrowed(TaikoAuthMethod::UpdateL1Origin.as_str()), (origin,))
+            .raw_request::<_, Option<EngineRpcL1Origin>>(
+                Cow::Borrowed(TaikoAuthMethod::UpdateL1Origin.as_str()),
+                (origin,),
+            )
             .await
+            .map(|origin| origin.map(Into::into))
             .map_err(Into::into)
     }
 
@@ -134,11 +142,12 @@ impl<P: Provider + Clone> Client<P> {
         signature: FixedBytes<65>,
     ) -> Result<Option<RpcL1Origin>> {
         self.l2_auth_provider
-            .raw_request(
+            .raw_request::<_, Option<EngineRpcL1Origin>>(
                 Cow::Borrowed(TaikoAuthMethod::SetL1OriginSignature.as_str()),
                 (block_id, signature),
             )
             .await
+            .map(|origin| origin.map(Into::into))
             .map_err(Into::into)
     }
 
@@ -172,12 +181,13 @@ impl<P: Provider + Clone> Client<P> {
         proposal_id: U256,
     ) -> Result<Option<RpcL1Origin>> {
         self.l2_auth_provider
-            .raw_request(
+            .raw_request::<_, Option<EngineRpcL1Origin>>(
                 Cow::Borrowed(TaikoAuthMethod::LastL1OriginByBatchId.as_str()),
                 (proposal_id,),
             )
             .await
             .or_else(handle_ignorable_origin_error)
+            .map(|origin| origin.map(Into::into))
     }
 
     /// Fetch the last block id that corresponds to the provided batch id via the authenticated

--- a/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs
@@ -9,6 +9,9 @@ use alloy_provider::Provider;
 /// Public alias for execution-engine L1 origin payloads.
 pub type L1Origin = RpcL1Origin;
 
+/// Engine-compatible transport wrapper for [`RpcL1Origin`].
+pub(crate) use alethia_reth_primitives::payload::attributes::EngineRpcL1Origin;
+
 use crate::{auth::handle_ignorable_origin_error, client::Client, error::Result};
 
 /// Engine RPC method names used for public L1 origin queries.
@@ -34,16 +37,24 @@ impl<P: Provider + Clone> Client<P> {
     /// Fetch the L1 origin payload for the given block id via the public engine API.
     pub async fn l1_origin_by_id(&self, block_id: U256) -> Result<Option<L1Origin>> {
         self.l2_provider
-            .raw_request(Cow::Borrowed(TaikoOriginMethod::L1OriginById.as_str()), (block_id,))
+            .raw_request::<_, Option<EngineRpcL1Origin>>(
+                Cow::Borrowed(TaikoOriginMethod::L1OriginById.as_str()),
+                (block_id,),
+            )
             .await
             .or_else(handle_ignorable_origin_error)
+            .map(|origin| origin.map(Into::into))
     }
 
     /// Fetch the latest head L1 origin pointer from the public engine API.
     pub async fn head_l1_origin(&self) -> Result<Option<L1Origin>> {
         self.l2_provider
-            .raw_request(Cow::Borrowed(TaikoOriginMethod::HeadL1Origin.as_str()), ())
+            .raw_request::<_, Option<EngineRpcL1Origin>>(
+                Cow::Borrowed(TaikoOriginMethod::HeadL1Origin.as_str()),
+                (),
+            )
             .await
             .or_else(handle_ignorable_origin_error)
+            .map(|origin| origin.map(Into::into))
     }
 }


### PR DESCRIPTION
## Summary
- bump `alethia-reth` git dependencies to `432362e14ee69d6b1affb5ba3108cd62e2b2e7dd`
- refresh `Cargo.lock` to the new upstream revision
- replace the local `RpcL1Origin` transport shim with upstream `EngineRpcL1Origin`

## Details
This updates the workspace to the current `alethia-reth` `main` revision after the upstream transport serde helpers and `EngineRpcL1Origin` wrapper landed.

Locally, the RPC crate no longer needs to duplicate the L1-origin transport struct or carry its own `signature_hex_serde` module. The RPC boundary now uses upstream `EngineRpcL1Origin` directly while preserving the existing `RpcL1Origin` API in this repo.

## Files Changed
- [Cargo.toml](/Users/davidcai/taiko/taiko-mono/packages/taiko-client-rs/Cargo.toml)
- [Cargo.lock](/Users/davidcai/taiko/taiko-mono/packages/taiko-client-rs/Cargo.lock)
- [auth.rs](/Users/davidcai/taiko/taiko-mono/packages/taiko-client-rs/crates/rpc/src/auth.rs)
- [l1_origin.rs](/Users/davidcai/taiko/taiko-mono/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs)

## Verification
- `just fmt`
- `just clippy-fix`
- `just clippy`
- `just test`

All checks passed, including `351 tests run: 351 passed, 0 skipped`.
