### PR TITLE
fix(taiko-client): fix prover retry submission buffer cleanup

### DIFF
--- a/packages/taiko-client/prover/proof_submitter/interface.go
+++ b/packages/taiko-client/prover/proof_submitter/interface.go
@@ -19,4 +19,5 @@ type Submitter interface {
 	BatchSubmitProofs(ctx context.Context, proofsWithHeaders *proofProducer.BatchProofs) error
 	AggregateProofsByType(ctx context.Context, proofType proofProducer.ProofType) error
 	FlushCache(ctx context.Context, proofType proofProducer.ProofType) error
+	ClearProofBuffers(ctx context.Context, batchProof *proofProducer.BatchProofs) error
 }

--- a/packages/taiko-client/prover/proof_submitter/interface.go
+++ b/packages/taiko-client/prover/proof_submitter/interface.go
@@ -19,5 +19,5 @@ type Submitter interface {
 	BatchSubmitProofs(ctx context.Context, proofsWithHeaders *proofProducer.BatchProofs) error
 	AggregateProofsByType(ctx context.Context, proofType proofProducer.ProofType) error
 	FlushCache(ctx context.Context, proofType proofProducer.ProofType) error
-	ClearProofBuffers(batchProof *proofProducer.BatchProofs) error
+	ClearProofBuffers(batchProof *proofProducer.BatchProofs, resend bool) error
 }

--- a/packages/taiko-client/prover/proof_submitter/interface.go
+++ b/packages/taiko-client/prover/proof_submitter/interface.go
@@ -19,5 +19,5 @@ type Submitter interface {
 	BatchSubmitProofs(ctx context.Context, proofsWithHeaders *proofProducer.BatchProofs) error
 	AggregateProofsByType(ctx context.Context, proofType proofProducer.ProofType) error
 	FlushCache(ctx context.Context, proofType proofProducer.ProofType) error
-	ClearProofBuffers(ctx context.Context, batchProof *proofProducer.BatchProofs) error
+	ClearProofBuffers(batchProof *proofProducer.BatchProofs) error
 }

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -351,7 +351,6 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 
 	metrics.ProverSentProofCounter.Add(float64(len(batchProof.BatchIDs)))
 	metrics.ProverLatestProvenBlockIDGauge.Set(float64(latestProvenBlockID.Uint64()))
-
 	return nil
 }
 

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -338,10 +338,6 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 		s.txBuilder.BuildProveBatchesPacaya(batchProof),
 		batchProof,
 	); err != nil {
-		// Resend the proof request
-		for _, proofResp := range batchProof.ProofResponses {
-			s.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: proofResp.Meta}
-		}
 		if err.Error() == transaction.ErrUnretryableSubmission.Error() {
 			return nil
 		}
@@ -355,8 +351,17 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 }
 
 // ClearProofBuffers removes the submitted proof items from the Pacaya proof buffer.
-func (s *ProofSubmitterPacaya) ClearProofBuffers(batchProof *proofProducer.BatchProofs) error {
-	return clearProofBufferItems(s.proofBuffers, batchProof)
+func (s *ProofSubmitterPacaya) ClearProofBuffers(batchProof *proofProducer.BatchProofs, resend bool) error {
+	if err := clearProofBufferItems(s.proofBuffers, batchProof); err != nil {
+		return err
+	}
+	if resend {
+		// Resend the proof request
+		for _, proofResp := range batchProof.ProofResponses {
+			s.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: proofResp.Meta}
+		}
+	}
+	return nil
 }
 
 // AggregateProofsByType read all data from buffer and aggregate them.

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -355,6 +355,7 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 	return nil
 }
 
+// ClearProofBuffers removes the submitted proof items from the Pacaya proof buffer.
 func (s *ProofSubmitterPacaya) ClearProofBuffers(batchProof *proofProducer.BatchProofs) error {
 	return clearProofBufferItems(s.proofBuffers, batchProof)
 }

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -338,9 +338,6 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 		s.txBuilder.BuildProveBatchesPacaya(batchProof),
 		batchProof,
 	); err != nil {
-		if err.Error() == transaction.ErrUnretryableSubmission.Error() {
-			return nil
-		}
 		metrics.ProverAggregationSubmissionErrorCounter.Add(1)
 		return err
 	}

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -338,7 +338,6 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 		s.txBuilder.BuildProveBatchesPacaya(batchProof),
 		batchProof,
 	); err != nil {
-		proofBuffer.ClearItems(uint64BatchIDs...)
 		// Resend the proof request
 		for _, proofResp := range batchProof.ProofResponses {
 			s.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: proofResp.Meta}
@@ -352,6 +351,33 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 
 	metrics.ProverSentProofCounter.Add(float64(len(batchProof.BatchIDs)))
 	metrics.ProverLatestProvenBlockIDGauge.Set(float64(latestProvenBlockID.Uint64()))
+
+	return nil
+}
+
+func (s *ProofSubmitterPacaya) ClearProofBuffers(ctx context.Context, batchProof *proofProducer.BatchProofs) error {
+	log.Info(
+		"Clear proof buffers",
+		"size", len(batchProof.ProofResponses),
+		"firstID", batchProof.BatchIDs[0],
+		"lastID", batchProof.BatchIDs[len(batchProof.BatchIDs)-1],
+		"proofType", batchProof.ProofType,
+	)
+	var (
+		uint64BatchIDs []uint64
+	)
+	if len(batchProof.ProofResponses) == 0 {
+		return proofProducer.ErrInvalidLength
+	}
+	proofBuffer, exist := s.proofBuffers[batchProof.ProofType]
+	if !exist {
+		return fmt.Errorf("unexpected proof type to clear: %s", batchProof.ProofType)
+	}
+
+	// Extract all block IDs in the batches.
+	for _, proof := range batchProof.ProofResponses {
+		uint64BatchIDs = append(uint64BatchIDs, proof.BatchID.Uint64())
+	}
 
 	// Clear the items in the buffer.
 	proofBuffer.ClearItems(uint64BatchIDs...)

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -302,7 +302,6 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 	)
 	var (
 		latestProvenBlockID = common.Big0
-		uint64BatchIDs      []uint64
 	)
 	if len(batchProof.ProofResponses) == 0 {
 		return proofProducer.ErrInvalidLength
@@ -326,7 +325,6 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 
 	// Extract all block IDs and the highest block ID in the batches.
 	for _, proof := range batchProof.ProofResponses {
-		uint64BatchIDs = append(uint64BatchIDs, proof.BatchID.Uint64())
 		if new(big.Int).SetUint64(proof.Meta.Pacaya().GetLastBlockID()).Cmp(latestProvenBlockID) > 0 {
 			latestProvenBlockID = new(big.Int).SetUint64(proof.Meta.Pacaya().GetLastBlockID())
 		}

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -355,34 +355,8 @@ func (s *ProofSubmitterPacaya) BatchSubmitProofs(ctx context.Context, batchProof
 	return nil
 }
 
-func (s *ProofSubmitterPacaya) ClearProofBuffers(ctx context.Context, batchProof *proofProducer.BatchProofs) error {
-	log.Info(
-		"Clear proof buffers",
-		"size", len(batchProof.ProofResponses),
-		"firstID", batchProof.BatchIDs[0],
-		"lastID", batchProof.BatchIDs[len(batchProof.BatchIDs)-1],
-		"proofType", batchProof.ProofType,
-	)
-	var (
-		uint64BatchIDs []uint64
-	)
-	if len(batchProof.ProofResponses) == 0 {
-		return proofProducer.ErrInvalidLength
-	}
-	proofBuffer, exist := s.proofBuffers[batchProof.ProofType]
-	if !exist {
-		return fmt.Errorf("unexpected proof type to clear: %s", batchProof.ProofType)
-	}
-
-	// Extract all block IDs in the batches.
-	for _, proof := range batchProof.ProofResponses {
-		uint64BatchIDs = append(uint64BatchIDs, proof.BatchID.Uint64())
-	}
-
-	// Clear the items in the buffer.
-	proofBuffer.ClearItems(uint64BatchIDs...)
-
-	return nil
+func (s *ProofSubmitterPacaya) ClearProofBuffers(batchProof *proofProducer.BatchProofs) error {
+	return clearProofBufferItems(s.proofBuffers, batchProof)
 }
 
 // AggregateProofsByType read all data from buffer and aggregate them.

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shared.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shared.go
@@ -13,14 +13,14 @@ func clearProofBufferItems(
 	proofBuffers map[proofProducer.ProofType]*proofProducer.ProofBuffer,
 	batchProof *proofProducer.BatchProofs,
 ) error {
-	if len(batchProof.ProofResponses) == 0 || len(batchProof.BatchIDs) == 0 {
+	if len(batchProof.ProofResponses) == 0 {
 		return proofProducer.ErrInvalidLength
 	}
 	log.Info(
 		"Clear proof buffers",
 		"size", len(batchProof.ProofResponses),
-		"firstID", batchProof.BatchIDs[0],
-		"lastID", batchProof.BatchIDs[len(batchProof.BatchIDs)-1],
+		"firstID", batchProof.ProofResponses[0].BatchID,
+		"lastID", batchProof.ProofResponses[len(batchProof.BatchIDs)-1].BatchID,
 		"proofType", batchProof.ProofType,
 	)
 

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shared.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shared.go
@@ -13,7 +13,7 @@ func clearProofBufferItems(
 	proofBuffers map[proofProducer.ProofType]*proofProducer.ProofBuffer,
 	batchProof *proofProducer.BatchProofs,
 ) error {
-	if len(batchProof.ProofResponses) == 0 {
+	if len(batchProof.ProofResponses) == 0 || len(batchProof.BatchIDs) == 0 {
 		return proofProducer.ErrInvalidLength
 	}
 	log.Info(

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shared.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shared.go
@@ -8,6 +8,7 @@ import (
 	proofProducer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
 )
 
+// clearProofBufferItems removes the specified proof items from the matching proof buffer.
 func clearProofBufferItems(
 	proofBuffers map[proofProducer.ProofType]*proofProducer.ProofBuffer,
 	batchProof *proofProducer.BatchProofs,

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shared.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shared.go
@@ -1,0 +1,38 @@
+package submitter
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	proofProducer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
+)
+
+func clearProofBufferItems(
+	proofBuffers map[proofProducer.ProofType]*proofProducer.ProofBuffer,
+	batchProof *proofProducer.BatchProofs,
+) error {
+	if len(batchProof.ProofResponses) == 0 {
+		return proofProducer.ErrInvalidLength
+	}
+	log.Info(
+		"Clear proof buffers",
+		"size", len(batchProof.ProofResponses),
+		"firstID", batchProof.BatchIDs[0],
+		"lastID", batchProof.BatchIDs[len(batchProof.BatchIDs)-1],
+		"proofType", batchProof.ProofType,
+	)
+
+	proofBuffer, exist := proofBuffers[batchProof.ProofType]
+	if !exist {
+		return fmt.Errorf("unexpected proof type to clear: %s", batchProof.ProofType)
+	}
+
+	batchIDs := make([]uint64, 0, len(batchProof.ProofResponses))
+	for _, proof := range batchProof.ProofResponses {
+		batchIDs = append(batchIDs, proof.BatchID.Uint64())
+	}
+
+	proofBuffer.ClearItems(batchIDs...)
+	return nil
+}

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
@@ -399,6 +399,7 @@ func (s *ProofSubmitterShasta) BatchSubmitProofs(ctx context.Context, batchProof
 	return nil
 }
 
+// ClearProofBuffers removes the submitted proof items from the Shasta proof buffer.
 func (s *ProofSubmitterShasta) ClearProofBuffers(batchProof *proofProducer.BatchProofs) error {
 	return clearProofBufferItems(s.proofBuffers, batchProof)
 }

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
@@ -354,12 +354,10 @@ func (s *ProofSubmitterShasta) BatchSubmitProofs(ctx context.Context, batchProof
 	}
 	var (
 		latestProvenBlockID = common.Big0
-		uint64ProposalIDs   []uint64
 		lowestProposalID    uint64
 	)
 	// Extract all block IDs and the highest block ID in the batches.
 	for _, proof := range batchProof.ProofResponses {
-		uint64ProposalIDs = append(uint64ProposalIDs, proof.BatchID.Uint64())
 		currentLastBlockID := proof.Opts.ShastaOptions().L2BlockNums[len(proof.Opts.ShastaOptions().L2BlockNums)-1]
 		if currentLastBlockID.Cmp(latestProvenBlockID) > 0 {
 			latestProvenBlockID = currentLastBlockID

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
@@ -382,10 +382,6 @@ func (s *ProofSubmitterShasta) BatchSubmitProofs(ctx context.Context, batchProof
 		s.txBuilder.BuildProveBatchesShasta(ctx, batchProof),
 		batchProof,
 	); err != nil {
-		// Resend the proof request
-		for _, proofResp := range batchProof.ProofResponses {
-			s.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: proofResp.Meta}
-		}
 		if err.Error() == transaction.ErrUnretryableSubmission.Error() {
 			return nil
 		}
@@ -400,8 +396,17 @@ func (s *ProofSubmitterShasta) BatchSubmitProofs(ctx context.Context, batchProof
 }
 
 // ClearProofBuffers removes the submitted proof items from the Shasta proof buffer.
-func (s *ProofSubmitterShasta) ClearProofBuffers(batchProof *proofProducer.BatchProofs) error {
-	return clearProofBufferItems(s.proofBuffers, batchProof)
+func (s *ProofSubmitterShasta) ClearProofBuffers(batchProof *proofProducer.BatchProofs, resend bool) error {
+	if err := clearProofBufferItems(s.proofBuffers, batchProof); err != nil {
+		return err
+	}
+	if resend {
+		// Resend the proof request
+		for _, proofResp := range batchProof.ProofResponses {
+			s.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: proofResp.Meta}
+		}
+	}
+	return nil
 }
 
 // TryAggregate tries to aggregate the proofs in the buffer, if the buffer is full,

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
@@ -382,7 +382,6 @@ func (s *ProofSubmitterShasta) BatchSubmitProofs(ctx context.Context, batchProof
 		s.txBuilder.BuildProveBatchesShasta(ctx, batchProof),
 		batchProof,
 	); err != nil {
-		proofBuffer.ClearItems(uint64ProposalIDs...)
 		// Resend the proof request
 		for _, proofResp := range batchProof.ProofResponses {
 			s.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: proofResp.Meta}
@@ -394,11 +393,14 @@ func (s *ProofSubmitterShasta) BatchSubmitProofs(ctx context.Context, batchProof
 		return err
 	}
 
-	proofBuffer.ClearItems(uint64ProposalIDs...)
 	metrics.ProverSentProofCounter.Add(float64(len(batchProof.BatchIDs)))
 	metrics.ProverLatestProvenBlockIDGauge.Set(float64(latestProvenBlockID.Uint64()))
 
 	return nil
+}
+
+func (s *ProofSubmitterShasta) ClearProofBuffers(batchProof *proofProducer.BatchProofs) error {
+	return clearProofBufferItems(s.proofBuffers, batchProof)
 }
 
 // TryAggregate tries to aggregate the proofs in the buffer, if the buffer is full,

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter_shasta.go
@@ -382,9 +382,6 @@ func (s *ProofSubmitterShasta) BatchSubmitProofs(ctx context.Context, batchProof
 		s.txBuilder.BuildProveBatchesShasta(ctx, batchProof),
 		batchProof,
 	); err != nil {
-		if err.Error() == transaction.ErrUnretryableSubmission.Error() {
-			return nil
-		}
 		metrics.ProverAggregationSubmissionErrorCounter.Add(1)
 		return err
 	}

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -360,9 +360,10 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 				"error", err,
 			)
 			return nil
-		} else if strings.Contains(err.Error(), vm.ErrExecutionReverted.Error()) {
+		} else if strings.Contains(err.Error(), vm.ErrExecutionReverted.Error()) ||
+			strings.Contains(err.Error(), transaction.ErrUnretryableSubmission.Error()) {
 			log.Error(
-				"Proof submission reverted",
+				"Proof submission reverted or unretryable",
 				"blockIDs", batchProof.BatchIDs,
 				"proofType", batchProof.ProofType,
 				"error", err,

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -385,6 +385,7 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 	return nil
 }
 
+// clearProofBuffer clears the buffered proof items for the batch from the matching submitter.
 func (p *Prover) clearProofBuffer(batchProof *proofProducer.BatchProofs) error {
 	if batchProof == nil || len(batchProof.ProofResponses) == 0 {
 		return fmt.Errorf("empty batch proof")
@@ -409,7 +410,7 @@ func (p *Prover) ProverAddress() common.Address {
 	return p.txmgr.From()
 }
 
-// withRetry retries the given function with prover backoff policy.
+// withRetry retries the given function with prover backoff policy and runs callback if retries are exhausted.
 func (p *Prover) withRetry(f func() error, callback func() error) {
 	p.wg.Add(1)
 	go func() {

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -340,17 +340,10 @@ func (p *Prover) requestProofOp(meta metadata.TaikoProposalMetaData) error {
 
 // submitProofAggregationOp performs a batch proof submission operation.
 func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs) error {
-	if batchProof == nil || len(batchProof.ProofResponses) == 0 {
-		return fmt.Errorf("empty batch proof")
+	submitter, err := p.getSubmitter(batchProof)
+	if err != nil {
+		return err
 	}
-	submitter := p.proofSubmitterPacaya
-	if batchProof.ProofResponses[0].Meta.IsShasta() {
-		submitter = p.proofSubmitterShasta
-	}
-	if utils.IsNil(submitter) {
-		return fmt.Errorf("submitter not found: %s", batchProof.ProofType)
-	}
-
 	if err := submitter.BatchSubmitProofs(p.ctx, batchProof); err != nil {
 		if strings.Contains(err.Error(), proofSubmitter.ErrInvalidProof.Error()) {
 			log.Warn(
@@ -391,17 +384,26 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 
 // clearProofBuffer clears the buffered proof items for the batch from the matching submitter.
 func (p *Prover) clearProofBuffer(batchProof *proofProducer.BatchProofs, resend bool) error {
+	submitter, err := p.getSubmitter(batchProof)
+	if err != nil {
+		return err
+	}
+	return submitter.ClearProofBuffers(batchProof, resend)
+}
+
+// getSubmitter returns the mapping proof submitter if it can be found.
+func (p *Prover) getSubmitter(batchProof *proofProducer.BatchProofs) (proofSubmitter.Submitter, error) {
 	if batchProof == nil || len(batchProof.ProofResponses) == 0 {
-		return fmt.Errorf("empty batch proof")
+		return nil, fmt.Errorf("empty batch proof")
 	}
 	submitter := p.proofSubmitterPacaya
 	if batchProof.ProofResponses[0].Meta.IsShasta() {
 		submitter = p.proofSubmitterShasta
 	}
 	if utils.IsNil(submitter) {
-		return fmt.Errorf("submitter not found: %s", batchProof.ProofType)
+		return nil, fmt.Errorf("submitter not found: %s", batchProof.ProofType)
 	}
-	return submitter.ClearProofBuffers(batchProof, resend)
+	return submitter, nil
 }
 
 // Name returns the application name.

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -253,7 +253,10 @@ func (p *Prover) eventLoop() {
 		case <-p.ctx.Done():
 			return
 		case batchProof := <-p.batchProofGenerationCh:
-			p.withRetry(func() error { return p.submitProofAggregationOp(batchProof) }, func() error { return p.clearProofBuffer(batchProof) })
+			p.withRetry(
+				func() error { return p.submitProofAggregationOp(batchProof) },
+				func() error { return p.clearProofBuffer(batchProof) },
+			)
 		case req := <-p.proofSubmissionCh:
 			p.withRetry(func() error { return p.requestProofOp(req.Meta) }, nil)
 		case <-p.proveNotify:
@@ -364,8 +367,8 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 				"proofType", batchProof.ProofType,
 				"error", err,
 			)
-			if err := submitter.ClearProofBuffers(p.ctx, batchProof); err != nil {
-				// 如果我们clear buffer失败了的话，我们把error抛出去，进入下一次重试
+			if err := submitter.ClearProofBuffers(batchProof); err != nil {
+				// If clearing the proof buffer fails, return the error and retry in the next attempt.
 				return err
 			}
 			return nil
@@ -393,7 +396,7 @@ func (p *Prover) clearProofBuffer(batchProof *proofProducer.BatchProofs) error {
 	if utils.IsNil(submitter) {
 		return fmt.Errorf("submitter not found: %s", batchProof.ProofType)
 	}
-	return submitter.ClearProofBuffers(p.ctx, batchProof)
+	return submitter.ClearProofBuffers(batchProof)
 }
 
 // Name returns the application name.

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -253,33 +253,33 @@ func (p *Prover) eventLoop() {
 		case <-p.ctx.Done():
 			return
 		case batchProof := <-p.batchProofGenerationCh:
-			p.withRetry(func() error { return p.submitProofAggregationOp(batchProof) })
+			p.withRetry(func() error { return p.submitProofAggregationOp(batchProof) }, nil)
 		case req := <-p.proofSubmissionCh:
-			p.withRetry(func() error { return p.requestProofOp(req.Meta) })
+			p.withRetry(func() error { return p.requestProofOp(req.Meta) }, nil)
 		case <-p.proveNotify:
 			if err := p.proveOp(); err != nil {
 				log.Error("Prove new blocks error", "error", err)
 			}
 		case proofType := <-p.batchesAggregationNotifyPacaya:
-			p.withRetry(func() error { return p.aggregateOp(proofType, false) })
+			p.withRetry(func() error { return p.aggregateOp(proofType, false) }, nil)
 		case proofType := <-p.batchesAggregationNotifyShasta:
-			p.withRetry(func() error { return p.aggregateOp(proofType, true) })
+			p.withRetry(func() error { return p.aggregateOp(proofType, true) }, nil)
 		case proofType := <-p.flushCacheNotify:
-			p.withRetry(func() error { return p.proofSubmitterShasta.FlushCache(p.ctx, proofType) })
+			p.withRetry(func() error { return p.proofSubmitterShasta.FlushCache(p.ctx, proofType) }, nil)
 		case e := <-batchesVerifiedCh:
 			if err := p.eventHandlers.batchesVerifiedHandler.HandlePacaya(p.ctx, e); err != nil {
 				log.Error("Failed to handle new BatchesVerified event", "error", err)
 			}
 		case e := <-batchesProvedCh:
-			p.withRetry(func() error { return p.eventHandlers.batchesProvedHandler.HandlePacaya(p.ctx, e) })
+			p.withRetry(func() error { return p.eventHandlers.batchesProvedHandler.HandlePacaya(p.ctx, e) }, nil)
 		case m := <-p.assignmentExpiredCh:
-			p.withRetry(func() error { return p.eventHandlers.assignmentExpiredHandler.Handle(p.ctx, m) })
+			p.withRetry(func() error { return p.eventHandlers.assignmentExpiredHandler.Handle(p.ctx, m) }, nil)
 		case <-batchProposedCh:
 			reqProving()
 		case <-shastaProposedCh:
 			reqProving()
 		case e := <-shastaProvedCh:
-			p.withRetry(func() error { return p.eventHandlers.batchesProvedHandler.HandleShasta(p.ctx, e) })
+			p.withRetry(func() error { return p.eventHandlers.batchesProvedHandler.HandleShasta(p.ctx, e) }, nil)
 		case <-forceProvingTicker.C:
 			reqProving()
 		}
@@ -389,7 +389,7 @@ func (p *Prover) ProverAddress() common.Address {
 }
 
 // withRetry retries the given function with prover backoff policy.
-func (p *Prover) withRetry(f func() error) {
+func (p *Prover) withRetry(f func() error, callback func() error) {
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
@@ -402,6 +402,10 @@ func (p *Prover) withRetry(f func() error) {
 			p.ctx,
 		)
 		if err := backoff.Retry(f, bo); err != nil {
+			if callback != nil {
+				callbackErr := callback()
+				log.Error("Callback failed", "error", callbackErr)
+			}
 			log.Error("Operation failed", "error", err)
 		}
 	}()

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -253,7 +253,7 @@ func (p *Prover) eventLoop() {
 		case <-p.ctx.Done():
 			return
 		case batchProof := <-p.batchProofGenerationCh:
-			p.withRetry(func() error { return p.submitProofAggregationOp(batchProof) }, nil)
+			p.withRetry(func() error { return p.submitProofAggregationOp(batchProof) }, func() error { return p.clearProofBuffer(batchProof) })
 		case req := <-p.proofSubmissionCh:
 			p.withRetry(func() error { return p.requestProofOp(req.Meta) }, nil)
 		case <-p.proveNotify:
@@ -349,21 +349,25 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 	}
 
 	if err := submitter.BatchSubmitProofs(p.ctx, batchProof); err != nil {
-		if strings.Contains(err.Error(), vm.ErrExecutionReverted.Error()) {
-			log.Error(
-				"Proof submission reverted",
-				"blockIDs", batchProof.BatchIDs,
-				"proofType", batchProof.ProofType,
-				"error", err,
-			)
-			return nil
-		} else if strings.Contains(err.Error(), proofSubmitter.ErrInvalidProof.Error()) {
+		if strings.Contains(err.Error(), proofSubmitter.ErrInvalidProof.Error()) {
 			log.Warn(
 				"Detected proven blocks",
 				"blockIDs", batchProof.BatchIDs,
 				"proofType", batchProof.ProofType,
 				"error", err,
 			)
+			return nil
+		} else if strings.Contains(err.Error(), vm.ErrExecutionReverted.Error()) {
+			log.Error(
+				"Proof submission reverted",
+				"blockIDs", batchProof.BatchIDs,
+				"proofType", batchProof.ProofType,
+				"error", err,
+			)
+			if err := submitter.ClearProofBuffers(p.ctx, batchProof); err != nil {
+				// 如果我们clear buffer失败了的话，我们把error抛出去，进入下一次重试
+				return err
+			}
 			return nil
 		}
 		log.Error(
@@ -376,6 +380,20 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 	}
 
 	return nil
+}
+
+func (p *Prover) clearProofBuffer(batchProof *proofProducer.BatchProofs) error {
+	if batchProof == nil || len(batchProof.ProofResponses) == 0 {
+		return fmt.Errorf("empty batch proof")
+	}
+	submitter := p.proofSubmitterPacaya
+	if batchProof.ProofResponses[0].Meta.IsShasta() {
+		submitter = p.proofSubmitterShasta
+	}
+	if utils.IsNil(submitter) {
+		return fmt.Errorf("submitter not found: %s", batchProof.ProofType)
+	}
+	return submitter.ClearProofBuffers(p.ctx, batchProof)
 }
 
 // Name returns the application name.

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -381,6 +381,9 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 		)
 		return err
 	}
+	if err := submitter.ClearProofBuffers(batchProof); err != nil {
+		return fmt.Errorf("failed to clear proof buffers after successful submission: %w", err)
+	}
 
 	return nil
 }
@@ -426,7 +429,9 @@ func (p *Prover) withRetry(f func() error, callback func() error) {
 		if err := backoff.Retry(f, bo); err != nil {
 			if callback != nil {
 				callbackErr := callback()
-				log.Error("Callback failed", "error", callbackErr)
+				if callbackErr != nil {
+					log.Error("Callback failed", "error", callbackErr)
+				}
 			}
 			log.Error("Operation failed", "error", err)
 		}

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -255,7 +255,7 @@ func (p *Prover) eventLoop() {
 		case batchProof := <-p.batchProofGenerationCh:
 			p.withRetry(
 				func() error { return p.submitProofAggregationOp(batchProof) },
-				func() error { return p.clearProofBuffer(batchProof) },
+				func() error { return p.clearProofBuffer(batchProof, true) },
 			)
 		case req := <-p.proofSubmissionCh:
 			p.withRetry(func() error { return p.requestProofOp(req.Meta) }, nil)
@@ -367,7 +367,7 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 				"proofType", batchProof.ProofType,
 				"error", err,
 			)
-			if err := submitter.ClearProofBuffers(batchProof); err != nil {
+			if err := submitter.ClearProofBuffers(batchProof, true); err != nil {
 				// If clearing the proof buffer fails, return the error and retry in the next attempt.
 				return err
 			}
@@ -381,7 +381,7 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 		)
 		return err
 	}
-	if err := submitter.ClearProofBuffers(batchProof); err != nil {
+	if err := submitter.ClearProofBuffers(batchProof, false); err != nil {
 		return fmt.Errorf("failed to clear proof buffers after successful submission: %w", err)
 	}
 
@@ -389,7 +389,7 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 }
 
 // clearProofBuffer clears the buffered proof items for the batch from the matching submitter.
-func (p *Prover) clearProofBuffer(batchProof *proofProducer.BatchProofs) error {
+func (p *Prover) clearProofBuffer(batchProof *proofProducer.BatchProofs, resend bool) error {
 	if batchProof == nil || len(batchProof.ProofResponses) == 0 {
 		return fmt.Errorf("empty batch proof")
 	}
@@ -400,7 +400,7 @@ func (p *Prover) clearProofBuffer(batchProof *proofProducer.BatchProofs) error {
 	if utils.IsNil(submitter) {
 		return fmt.Errorf("submitter not found: %s", batchProof.ProofType)
 	}
-	return submitter.ClearProofBuffers(batchProof)
+	return submitter.ClearProofBuffers(batchProof, resend)
 }
 
 // Name returns the application name.

--- a/packages/taiko-client/prover/prover_test.go
+++ b/packages/taiko-client/prover/prover_test.go
@@ -195,7 +195,7 @@ func (s *ProverTestSuite) TestOnBatchProposed() {
 	req := <-s.p.proofSubmissionCh
 	s.Nil(s.p.requestProofOp(req.Meta))
 	s.Nil(s.p.aggregateOp(<-s.p.batchesAggregationNotifyShasta, true))
-	s.Nil(s.p.proofSubmitterShasta.BatchSubmitProofs(context.Background(), <-s.p.batchProofGenerationCh))
+	s.Nil(s.p.submitProofAggregationOp(<-s.p.batchProofGenerationCh))
 
 	// Propose and prove the second Shasta proposal.
 	m := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().EventSyncer())
@@ -203,7 +203,7 @@ func (s *ProverTestSuite) TestOnBatchProposed() {
 	req = <-s.p.proofSubmissionCh
 	s.Nil(s.p.requestProofOp(req.Meta))
 	s.Nil(s.p.aggregateOp(<-s.p.batchesAggregationNotifyShasta, true))
-	s.Nil(s.p.proofSubmitterShasta.BatchSubmitProofs(context.Background(), <-s.p.batchProofGenerationCh))
+	s.Nil(s.p.submitProofAggregationOp(<-s.p.batchProofGenerationCh))
 }
 
 func (s *ProverTestSuite) TestSubmitProofAggregationOp() {
@@ -257,7 +257,7 @@ func (s *ProverTestSuite) TestProveOp() {
 	req := <-s.p.proofSubmissionCh
 	s.Nil(s.p.requestProofOp(req.Meta))
 	s.Nil(s.p.aggregateOp(<-s.p.batchesAggregationNotifyPacaya, false))
-	s.Nil(s.p.proofSubmitterPacaya.BatchSubmitProofs(context.Background(), <-s.p.batchProofGenerationCh))
+	s.Nil(s.p.submitProofAggregationOp(<-s.p.batchProofGenerationCh))
 
 	var (
 		blockHash  common.Hash
@@ -334,7 +334,7 @@ func (s *ProverTestSuite) TestProveMultiBlobBatch() {
 		}
 		s.Nil(s.p.requestProofOp(req.Meta))
 		s.Nil(s.p.aggregateOp(<-s.p.batchesAggregationNotifyPacaya, false))
-		s.Nil(s.p.proofSubmitterPacaya.BatchSubmitProofs(context.Background(), <-s.p.batchProofGenerationCh))
+		s.Nil(s.p.submitProofAggregationOp(<-s.p.batchProofGenerationCh))
 		if req.Meta.Pacaya().GetLastBlockID() >= l2Head2.Number().Uint64() {
 			break
 		}
@@ -352,7 +352,7 @@ func (s *ProverTestSuite) TestProveMultiBlobBatch() {
 	for req := range s.p.proofSubmissionCh {
 		s.Nil(s.p.requestProofOp(req.Meta))
 		s.Nil(s.p.aggregateOp(<-s.p.batchesAggregationNotifyPacaya, false))
-		s.Nil(s.p.proofSubmitterPacaya.BatchSubmitProofs(context.Background(), <-s.p.batchProofGenerationCh))
+		s.Nil(s.p.submitProofAggregationOp(<-s.p.batchProofGenerationCh))
 		if req.Meta.Pacaya().GetLastBlockID() >= l2Head3.Number().Uint64() {
 			break
 		}
@@ -413,13 +413,15 @@ func (s *ProverTestSuite) TestAggregateProofsAlreadyProved() {
 		req2 := <-batchProver.proofSubmissionCh
 		s.Nil(batchProver.requestProofOp(req2.Meta))
 		s.Nil(s.p.aggregateOp(<-s.p.batchesAggregationNotifyPacaya, false))
-		s.Nil(s.p.proofSubmitterPacaya.BatchSubmitProofs(context.Background(), <-s.p.batchProofGenerationCh))
+		s.Nil(s.p.submitProofAggregationOp(<-s.p.batchProofGenerationCh))
 	}
 	s.Nil(batchProver.aggregateOp(<-batchProver.batchesAggregationNotifyPacaya, false))
+	batchProof := <-batchProver.batchProofGenerationCh
 	s.ErrorIs(
-		batchProver.proofSubmitterPacaya.BatchSubmitProofs(context.Background(), <-batchProver.batchProofGenerationCh),
+		batchProver.proofSubmitterPacaya.BatchSubmitProofs(context.Background(), batchProof),
 		proofSubmitter.ErrInvalidProof,
 	)
+	s.Nil(batchProver.proofSubmitterPacaya.ClearProofBuffers(batchProof, false))
 }
 
 func (s *ProverTestSuite) TestAggregateProofs() {
@@ -722,7 +724,7 @@ func (s *ProverTestSuite) TestForceAggregate() {
 	case <-time.After(3 * time.Second):
 		s.Fail("timeout waiting for agg request")
 	}
-	s.Nil(batchProver.proofSubmitterPacaya.BatchSubmitProofs(context.Background(), <-batchProver.batchProofGenerationCh))
+	s.Nil(batchProver.submitProofAggregationOp(<-batchProver.batchProofGenerationCh))
 }
 
 func TestProverTestSuite(t *testing.T) {

--- a/packages/taiko-client/prover/prover_test.go
+++ b/packages/taiko-client/prover/prover_test.go
@@ -223,7 +223,7 @@ func (s *ProverTestSuite) TestSubmitProofAggregationOp() {
 				ProofType:         proofProducer.ProofTypeOp,
 				SgxGethBatchProof: []byte{},
 			})
-		})
+		}, nil)
 	})
 }
 


### PR DESCRIPTION
## Summary

This change fixes how the prover handles failed proof submissions after aggregation.

When an aggregated proof submission hits a reverted transaction or an already-proven condition, users can otherwise get stuck with stale proof items still sitting in the in-memory buffers. That causes repeated retries against proofs that should have been dropped and can block later proof processing for the same proof type.

The root cause was that proof buffer cleanup happened inside submitter implementations at the wrong point in the flow. The buffer items were cleared too early on some error paths and not managed centrally alongside prover retry exhaustion handling, which made the retry lifecycle inconsistent.

The fix moves proof buffer cleanup behind an explicit `ClearProofBuffers` submitter interface and a shared helper used by both Pacaya and Shasta submitters. The prover now clears buffers after successful submission, clears them immediately on execution-reverted submissions that indicate the batch has already been handled, and uses the new `withRetry` callback to clear stale buffered proofs after retries are exhausted.