### PR TITLE
perf(eventindexer): cache ERC20/ERC1155 ABI parsing

### DIFF
--- a/packages/eventindexer/indexer/index_erc20_transfers.go
+++ b/packages/eventindexer/indexer/index_erc20_transfers.go
@@ -38,8 +38,10 @@ func getParsedERC20ABI() (*abi.ABI, error) {
 	parsedERC20ABIOnce.Do(func() {
 		parsedERC20ABI, parsedERC20ABIErr = abi.JSON(strings.NewReader(erc20ABI))
 	})
-	if parsedERC20ABIErr != nil {
-		return nil, errors.Wrap(parsedERC20ABIErr, "abi.JSON(strings.NewReader)")
+
+	err := parsedERC20ABIErr
+	if err != nil {
+		return nil, errors.Wrap(err, "abi.JSON(strings.NewReader)")
 	}
 
 	return &parsedERC20ABI, nil
@@ -49,8 +51,10 @@ func getParsedTransferABI() (*abi.ABI, error) {
 	parsedTransferABIOnce.Do(func() {
 		parsedTransferABI, parsedTransferABIErr = abi.JSON(strings.NewReader(transferEventABI))
 	})
-	if parsedTransferABIErr != nil {
-		return nil, errors.Wrap(parsedTransferABIErr, "abi.JSON(strings.NewReader)")
+
+	err := parsedTransferABIErr
+	if err != nil {
+		return nil, errors.Wrap(err, "abi.JSON(strings.NewReader)")
 	}
 
 	return &parsedTransferABI, nil

--- a/packages/eventindexer/indexer/index_erc20_transfers.go
+++ b/packages/eventindexer/indexer/index_erc20_transfers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 
 	"log/slog"
 
@@ -23,6 +24,37 @@ const erc20ABI = `[{"constant":true,"inputs":[],"name":"symbol","outputs":[{"nam
 
 // nolint: lll
 const transferEventABI = `[{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"}]`
+
+var (
+	parsedERC20ABI        abi.ABI
+	parsedERC20ABIErr     error
+	parsedERC20ABIOnce    sync.Once
+	parsedTransferABI     abi.ABI
+	parsedTransferABIErr  error
+	parsedTransferABIOnce sync.Once
+)
+
+func getParsedERC20ABI() (*abi.ABI, error) {
+	parsedERC20ABIOnce.Do(func() {
+		parsedERC20ABI, parsedERC20ABIErr = abi.JSON(strings.NewReader(erc20ABI))
+	})
+	if parsedERC20ABIErr != nil {
+		return nil, errors.Wrap(parsedERC20ABIErr, "abi.JSON(strings.NewReader)")
+	}
+
+	return &parsedERC20ABI, nil
+}
+
+func getParsedTransferABI() (*abi.ABI, error) {
+	parsedTransferABIOnce.Do(func() {
+		parsedTransferABI, parsedTransferABIErr = abi.JSON(strings.NewReader(transferEventABI))
+	})
+	if parsedTransferABIErr != nil {
+		return nil, errors.Wrap(parsedTransferABIErr, "abi.JSON(strings.NewReader)")
+	}
+
+	return &parsedTransferABI, nil
+}
 
 // indexERC20Transfers indexes from a given starting block to a given end block and parses all event logs
 // to find ERC20 transfer events and update balances
@@ -90,10 +122,9 @@ func (i *Indexer) saveERC20Transfer(ctx context.Context, chainID *big.Int, vLog 
 		Value *big.Int
 	}{}
 
-	// Parse the Transfer event ABI
-	parsedABI, err := abi.JSON(strings.NewReader(transferEventABI))
+	parsedABI, err := getParsedTransferABI()
 	if err != nil {
-		return errors.Wrap(err, "abi.JSON(strings.NewReader)")
+		return err
 	}
 
 	err = parsedABI.UnpackIntoInterface(&event, "Transfer", vLog.Data)
@@ -198,10 +229,9 @@ func getERC20Symbol(ctx context.Context, client *ethclient.Client, contractAddre
 	// Parse the contract address
 	address := common.HexToAddress(contractAddress)
 
-	// Parse the ERC20 contract ABI
-	parsedABI, err := abi.JSON(strings.NewReader(erc20ABI))
+	parsedABI, err := getParsedERC20ABI()
 	if err != nil {
-		return "", errors.Wrap(err, "abi.JSON")
+		return "", err
 	}
 
 	// Prepare the call message
@@ -234,10 +264,9 @@ func getERC20Decimals(ctx context.Context, client *ethclient.Client, contractAdd
 	// Parse the contract address
 	address := common.HexToAddress(contractAddress)
 
-	// Parse the ERC20 contract ABI
-	parsedABI, err := abi.JSON(strings.NewReader(erc20ABI))
+	parsedABI, err := getParsedERC20ABI()
 	if err != nil {
-		return 0, errors.Wrap(err, "abi.JSON")
+		return 0, err
 	}
 
 	// Prepare the call message

--- a/packages/eventindexer/indexer/index_nft_transfers.go
+++ b/packages/eventindexer/indexer/index_nft_transfers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 
 	"log/slog"
 
@@ -25,7 +26,21 @@ var (
 	transferSingleSignatureHash = crypto.Keccak256Hash(transferSingleSignature)
 	transferBatchSignature      = []byte("TransferBatch(address,address,address,uint256[],uint256[])")
 	transferBatchSignatureHash  = crypto.Keccak256Hash(transferBatchSignature)
+	parsedERC1155ABI            abi.ABI
+	parsedERC1155ABIErr         error
+	parsedERC1155ABIOnce        sync.Once
 )
+
+func getParsedERC1155ABI() (*abi.ABI, error) {
+	parsedERC1155ABIOnce.Do(func() {
+		parsedERC1155ABI, parsedERC1155ABIErr = abi.JSON(strings.NewReader(erc1155.ABI))
+	})
+	if parsedERC1155ABIErr != nil {
+		return nil, errors.Wrap(parsedERC1155ABIErr, "abi.JSON(strings.NewReader)")
+	}
+
+	return &parsedERC1155ABI, nil
+}
 
 // indexNFTTransfers indexes from a given starting block to a given end block and parses all event logs
 // to find ERC721 or ERC1155 transfer events
@@ -166,7 +181,7 @@ func (i *Indexer) saveERC1155Transfer(ctx context.Context, chainID *big.Int, vLo
 
 	slog.Info("erc1155 found")
 
-	erc1155ABI, err := abi.JSON(strings.NewReader(erc1155.ABI))
+	erc1155ABI, err := getParsedERC1155ABI()
 	if err != nil {
 		return err
 	}

--- a/packages/eventindexer/indexer/index_nft_transfers.go
+++ b/packages/eventindexer/indexer/index_nft_transfers.go
@@ -35,8 +35,10 @@ func getParsedERC1155ABI() (*abi.ABI, error) {
 	parsedERC1155ABIOnce.Do(func() {
 		parsedERC1155ABI, parsedERC1155ABIErr = abi.JSON(strings.NewReader(erc1155.ABI))
 	})
-	if parsedERC1155ABIErr != nil {
-		return nil, errors.Wrap(parsedERC1155ABIErr, "abi.JSON(strings.NewReader)")
+
+	err := parsedERC1155ABIErr
+	if err != nil {
+		return nil, errors.Wrap(err, "abi.JSON(strings.NewReader)")
 	}
 
 	return &parsedERC1155ABI, nil


### PR DESCRIPTION
Cache ERC20 transfer and ERC1155 ABI parsing with sync.Once, so the indexer no longer reparses the same ABI on every log.