### PR TITLE
feat(taiko-client-rs): handle L1 finalized block RPC error

### DIFF
--- a/.github/workflows/taiko-client-rs--docker.yml
+++ b/.github/workflows/taiko-client-rs--docker.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    branches: [main, improve-try_finalized_l1_snapshot]
+    branches: [main]
     tags:
       - "taiko-alethia-client-rs-v*"
     paths:

--- a/.github/workflows/taiko-client-rs--docker.yml
+++ b/.github/workflows/taiko-client-rs--docker.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [main, improve-try_finalized_l1_snapshot]
     tags:
       - "taiko-alethia-client-rs-v*"
     paths:

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -757,15 +757,13 @@ where
     /// Returns `None` when the L1 chain has not yet finalized (e.g. fresh devnets).
     #[instrument(skip(self), level = "debug")]
     async fn try_finalized_l1_snapshot(&self) -> Result<Option<FinalizedL1Snapshot>, SyncError> {
-        let finalized_block = match self
-            .rpc
-            .l1_provider
-            .get_block_by_number(BlockNumberOrTag::Finalized)
-            .await
-        {
-            Ok(block) => block,
-            Err(_) => return Ok(None),
-        };
+        let finalized_block =
+            match self.rpc.l1_provider.get_block_by_number(BlockNumberOrTag::Finalized).await {
+                Ok(block) => block,
+                // If the provider returns an error instead of `Ok(None)` for the finalized block,
+                // treat it as unavailable rather than a hard error.
+                Err(_) => return Ok(None),
+            };
 
         let Some(finalized_block) = finalized_block else {
             return Ok(None);

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -1,5 +1,8 @@
 //! Event sync logic.
 
+/// Geth error message returned when no finalized block exists yet (e.g. fresh devnets).
+const FINALIZED_BLOCK_NOT_FOUND: &str = "finalized block not found";
+
 use std::{
     sync::{
         Arc,
@@ -760,9 +763,11 @@ where
         let finalized_block =
             match self.rpc.l1_provider.get_block_by_number(BlockNumberOrTag::Finalized).await {
                 Ok(block) => block,
-                // If the provider returns an error instead of `Ok(None)` for the finalized block,
-                // treat it as unavailable rather than a hard error.
-                Err(_) => return Ok(None),
+                // Geth returns JSON-RPC error -32000 "finalized block not found" on fresh
+                // devnets before the beacon chain has finalized its first block. Treat this
+                // specific error as "not yet available" rather than a fatal failure.
+                Err(err) if err.to_string().contains(FINALIZED_BLOCK_NOT_FOUND) => return Ok(None),
+                Err(err) => return Err(SyncError::Rpc(RpcClientError::Provider(err.to_string()))),
             };
 
         let Some(finalized_block) = finalized_block else {

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -757,12 +757,15 @@ where
     /// Returns `None` when the L1 chain has not yet finalized (e.g. fresh devnets).
     #[instrument(skip(self), level = "debug")]
     async fn try_finalized_l1_snapshot(&self) -> Result<Option<FinalizedL1Snapshot>, SyncError> {
-        let finalized_block = self
+        let finalized_block = match self
             .rpc
             .l1_provider
             .get_block_by_number(BlockNumberOrTag::Finalized)
             .await
-            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
+        {
+            Ok(block) => block,
+            Err(_) => return Ok(None),
+        };
 
         let Some(finalized_block) = finalized_block else {
             return Ok(None);


### PR DESCRIPTION

  ## Summary
  - Fix `try_finalized_l1_snapshot` to return `Ok(None)` when the L1 node returns an RPC error for `eth_getBlockByNumber("finalized")`, instead of propagating it as a fatal `SyncError`

  ## Context
  On networks, geth returns `-32000: finalized block not found` as an RPC error (not `null`) before the beacon chain has finalized its first block (~2 epochs). The function already documented this case ("Returns `None` when the L1 chain has not yet finalized (e.g. fresh devnets)") and handled `null` responses, but didn't handle the error response path.