### PR TITLE
refactor(taiko-client-rs): use AtomicU64 for highest unsafe id

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -1,6 +1,9 @@
 //! Whitelist preconfirmation API service implementation.
 
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::{Arc, atomic::AtomicU64},
+    time::Instant,
+};
 
 use alethia_reth_primitives::payload::{
     attributes::{RpcL1Origin, TaikoBlockMetadata, TaikoPayloadAttributes},
@@ -75,7 +78,7 @@ where
     /// Local peer ID string.
     local_peer_id: String,
     /// Highest unsafe payload block ID tracked by this node (shared with importer).
-    highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
+    highest_unsafe_l2_payload_block_id: Arc<AtomicU64>,
     /// Cached lookahead status used for fee-recipient validation.
     lookahead_status: RwLock<Option<LookaheadStatus>>,
     /// Shared cache state used to back `/status` and EOS visibility.
@@ -102,7 +105,7 @@ where
     /// Pre-built fetcher for cached whitelist operator lookups.
     pub(crate) sequencer_fetcher: WhitelistSequencerFetcher<P>,
     /// Shared highest unsafe payload block ID (also updated by importer on P2P import).
-    pub(crate) highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
+    pub(crate) highest_unsafe_l2_payload_block_id: Arc<AtomicU64>,
     /// Network command sender for gossip publishing.
     pub(crate) network_command_tx: mpsc::Sender<NetworkCommand>,
     /// Shared preconfirmation cache state.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
@@ -1,5 +1,7 @@
 //! Payload build/signing helpers used by `build_preconf_block`.
 
+use std::sync::atomic::Ordering;
+
 use super::*;
 
 impl<P> WhitelistApiService<P>
@@ -129,6 +131,6 @@ where
 
     /// Update highest unsafe block tracking on each insertion/reorg point.
     pub(super) async fn update_highest_unsafe(&self, block_number: u64) {
-        *self.highest_unsafe_l2_payload_block_id.lock().await = block_number;
+        self.highest_unsafe_l2_payload_block_id.store(block_number, Ordering::Relaxed);
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -1,5 +1,7 @@
 //! Status and websocket-subscription helpers for the REST handler.
 
+use std::sync::atomic::Ordering;
+
 use super::*;
 
 impl<P> WhitelistApiService<P>
@@ -9,7 +11,7 @@ where
     /// Build the current status snapshot served by the REST `/status` route.
     pub(super) async fn get_status_snapshot(&self) -> Result<WhitelistStatus> {
         let head_l1_origin = self.rpc.head_l1_origin().await?;
-        let highest_unsafe = *self.highest_unsafe_l2_payload_block_id.lock().await;
+        let highest_unsafe = self.highest_unsafe_l2_payload_block_id.load(Ordering::Relaxed);
         let current_epoch = self.beacon_client.current_epoch();
         let end_of_sequencing_block_hash = self
             .cache_state

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::{sync::atomic::Ordering, time::Instant};
 
 use driver::production::PreconfPayload;
 use tracing::{debug, info, warn};
@@ -214,8 +214,7 @@ where
         );
 
         if let Some(ref highest) = self.highest_unsafe_l2_payload_block_id {
-            let mut guard = highest.lock().await;
-            *guard = block_number.max(*guard);
+            highest.fetch_max(block_number, Ordering::Relaxed);
         }
 
         Ok(true)

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -1,12 +1,12 @@
 //! Whitelist preconfirmation envelope importer.
 
-use std::sync::Arc;
+use std::sync::{Arc, atomic::AtomicU64};
 
 use alloy_primitives::{Address, B256};
 use alloy_provider::Provider;
 use driver::sync::event::EventSyncer;
 use rpc::{beacon::BeaconClient, client::Client};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -57,7 +57,7 @@ where
     /// Beacon client used for EOS epoch validation.
     pub(crate) beacon_client: Arc<BeaconClient>,
     /// Shared highest unsafe L2 payload block ID (updated on P2P import when REST server enabled).
-    pub(crate) highest_unsafe_l2_payload_block_id: Option<Arc<Mutex<u64>>>,
+    pub(crate) highest_unsafe_l2_payload_block_id: Option<Arc<AtomicU64>>,
 }
 
 /// Imports whitelist preconfirmation payloads into the driver after event sync catches up.
@@ -90,7 +90,7 @@ where
     /// Command channel used to publish P2P requests/responses.
     network_command_tx: mpsc::Sender<NetworkCommand>,
     /// Shared highest unsafe L2 payload block ID (updated on P2P import when REST server enabled).
-    highest_unsafe_l2_payload_block_id: Option<Arc<Mutex<u64>>>,
+    highest_unsafe_l2_payload_block_id: Option<Arc<AtomicU64>>,
     /// Latched flag indicating event sync has exposed a head L1 origin.
     sync_ready: bool,
     /// Shasta anchor contract address used to validate the first transaction.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -1,6 +1,10 @@
 //! Whitelist preconfirmation runner orchestration.
 
-use std::{net::SocketAddr, sync::Arc, time::Instant};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, atomic::AtomicU64},
+    time::Instant,
+};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::Address;
@@ -9,7 +13,6 @@ use driver::{DriverConfig, map_driver_error};
 use preconfirmation_net::P2pConfig;
 use protocol::signer::FixedKSigner;
 use rpc::beacon::BeaconClient;
-use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use crate::{
@@ -153,7 +156,8 @@ impl WhitelistPreconfirmationDriverRunner {
                     0
                 }
             };
-            let shared_highest = Arc::new(Mutex::new(initial_highest_unsafe_l2_payload_block_id));
+            let shared_highest =
+                Arc::new(AtomicU64::new(initial_highest_unsafe_l2_payload_block_id));
 
             let rest_sequencer_fetcher = WhitelistSequencerFetcher::new(
                 self.config.whitelist_address,


### PR DESCRIPTION
Replace `Arc<Mutex<u64>>` with `Arc<AtomicU64>` for highest unsafe payload tracking, preserving existing store/max semantics while removing async lock contention.