### PR TITLE
fix(repo): add checkout step to claude layout review

### DIFF
--- a/.github/workflows/claude-layout-review.yml
+++ b/.github/workflows/claude-layout-review.yml
@@ -21,6 +21,10 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

The `claude-layout-review` workflow was failing with `fatal: not in a git directory` because it was missing a repository checkout step before running `claude-code-action`. This adds `actions/checkout@v4` with full history (`fetch-depth: 0`) so the action can configure git and analyze diffs.

Fixes: https://github.com/taikoxyz/taiko-mono/actions/runs/23532418321/job/68499215541