### PR TITLE
fix(taiko-client-rs): retry timed-out preconf submissions and reconnect event sync

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -90,9 +90,12 @@ struct EventStreamStartPoint {
 fn should_probe_confirmed_sync(
     preconfirmation_enabled: bool,
     preconf_ingress_spawned: bool,
+    preconf_ingress_ready: bool,
     scanner_live: bool,
 ) -> bool {
-    preconfirmation_enabled && !preconf_ingress_spawned && scanner_live
+    preconfirmation_enabled
+        && scanner_live
+        && (!preconf_ingress_spawned || !preconf_ingress_ready)
 }
 
 /// Resolve whether confirmed-sync readiness should open ingress.
@@ -1240,6 +1243,7 @@ where
                 if should_probe_confirmed_sync(
                     self.cfg.preconfirmation_enabled,
                     preconf_ingress_spawned,
+                    self.preconf_ingress_ready.load(Ordering::Acquire),
                     scanner_live,
                 ) {
                     let confirmed_sync_probe = self.confirmed_sync_snapshot().await;
@@ -1268,9 +1272,20 @@ where
                                 self.preconf_ingress_notify.clone(),
                             );
                             preconf_ingress_spawned = true;
+                        } else if !self.preconf_ingress_ready.swap(true, Ordering::AcqRel) {
+                            info!(
+                                "re-opened preconfirmation ingress after scanner reconnect"
+                            );
+                            self.preconf_ingress_notify.notify_waiters();
                         }
                     }
                 }
+            }
+
+            // A dropped scanner forces a historical replay window again, so close ingress until
+            // the next live scanner transition and confirmed-sync probe re-open it.
+            if self.preconf_ingress_ready.swap(false, Ordering::AcqRel) {
+                info!("closing preconfirmation ingress during event scanner reconnect");
             }
 
             if let Some(block_number) = last_seen_l1_block_number {
@@ -1803,6 +1818,15 @@ mod tests {
     fn confirmed_sync_ready_reflects_snapshot_readiness() {
         let ready = resolve_confirmed_sync_ready(ConfirmedSyncSnapshot::new(0, None, None));
         assert!(ready, "resolved readiness should mirror snapshot readiness");
+    }
+
+    #[test]
+    fn confirmed_sync_probe_rearms_when_ingress_gate_closes_after_spawn() {
+        assert!(should_probe_confirmed_sync(true, true, false, true));
+        assert!(!should_probe_confirmed_sync(true, true, true, true));
+        assert!(should_probe_confirmed_sync(true, false, false, true));
+        assert!(!should_probe_confirmed_sync(true, false, false, false));
+        assert!(!should_probe_confirmed_sync(false, true, false, true));
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -1167,10 +1167,8 @@ where
             {
                 Ok(scanner) => scanner,
                 Err(err) => {
-                    let err = resolve_event_scanner_setup_error(
-                        scanner_started_once,
-                        err.to_string(),
-                    )?;
+                    let err =
+                        resolve_event_scanner_setup_error(scanner_started_once, err.to_string())?;
                     warn!(
                         error = %err,
                         start_tag = ?reconnect_start_tag,
@@ -1191,10 +1189,8 @@ where
                     proof
                 }
                 Err(err) => {
-                    let err = resolve_event_scanner_setup_error(
-                        scanner_started_once,
-                        err.to_string(),
-                    )?;
+                    let err =
+                        resolve_event_scanner_setup_error(scanner_started_once, err.to_string())?;
                     warn!(
                         error = %err,
                         start_tag = ?reconnect_start_tag,
@@ -1278,7 +1274,8 @@ where
             }
 
             if let Some(block_number) = last_seen_l1_block_number {
-                let reconnect_finalized_block_number = match self.try_finalized_l1_snapshot().await {
+                let reconnect_finalized_block_number = match self.try_finalized_l1_snapshot().await
+                {
                     Ok(snapshot) => snapshot.map(|snapshot| snapshot.block_number),
                     Err(err) => {
                         warn!(

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -27,7 +27,7 @@ use metrics::{counter, gauge, histogram};
 use tokio::{
     spawn,
     sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot},
-    time::timeout,
+    time::{sleep, timeout},
 };
 use tokio_retry::{Retry, strategy::ExponentialBackoff};
 use tokio_stream::StreamExt;
@@ -216,6 +216,67 @@ pub struct PreconfJob {
     respond_to: oneshot::Sender<Result<(), DriverError>>,
 }
 
+/// Return whether the provided preconfirmation payload already materialized into the local L2
+/// chain state.
+///
+/// Materialization requires both the per-block L1 origin record and the execution header to match
+/// the payload attributes previously submitted to the engine.
+async fn preconfirmation_payload_is_materialized<P>(
+    rpc: &Client<P>,
+    payload: &PreconfPayload,
+) -> Result<bool, DriverError>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    let block_number = payload.block_number();
+    let expected_payload = payload.payload();
+    let Some(origin) = rpc.l1_origin_by_id(U256::from(block_number)).await? else {
+        return Ok(false);
+    };
+    if origin.build_payload_args_id == [0u8; 8] ||
+        origin.build_payload_args_id != expected_payload.l1_origin.build_payload_args_id
+    {
+        return Ok(false);
+    }
+
+    let Some(block) = rpc
+        .l2_provider
+        .get_block_by_number(BlockNumberOrTag::Number(block_number))
+        .await
+        .map_err(|err| DriverError::Rpc(RpcClientError::Provider(err.to_string())))?
+    else {
+        return Ok(false);
+    };
+    let header = &block.header;
+
+    if origin.l2_block_hash != B256::ZERO && header.hash != origin.l2_block_hash {
+        return Ok(false);
+    }
+    if header.number != block_number {
+        return Ok(false);
+    }
+    if header.beneficiary != expected_payload.payload_attributes.suggested_fee_recipient {
+        return Ok(false);
+    }
+    if header.mix_hash != expected_payload.payload_attributes.prev_randao {
+        return Ok(false);
+    }
+    if header.gas_limit != expected_payload.block_metadata.gas_limit {
+        return Ok(false);
+    }
+    if header.timestamp != expected_payload.payload_attributes.timestamp {
+        return Ok(false);
+    }
+    if header.extra_data != expected_payload.block_metadata.extra_data {
+        return Ok(false);
+    }
+
+    Ok(matches!(
+        header.base_fee_per_gas,
+        Some(base_fee) if U256::from(base_fee) == expected_payload.base_fee_per_gas
+    ))
+}
+
 impl<P> EventSyncer<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
@@ -267,6 +328,29 @@ where
                 gauge!(DriverMetrics::PRECONF_QUEUE_DEPTH).set(rx.len() as f64);
                 let start = Instant::now();
                 let block_number = job.payload.block_number();
+                match preconfirmation_payload_is_materialized(&rpc, job.payload.as_ref()).await {
+                    Ok(true) => {
+                        debug!(
+                            block_number,
+                            build_payload_args_id = %PayloadId::new(job.payload.payload().l1_origin.build_payload_args_id),
+                            "acknowledging already materialized preconfirmation payload"
+                        );
+                        let _ = job.respond_to.send(Ok(()));
+                        gauge!(DriverMetrics::PRECONF_QUEUE_DEPTH).set(rx.len() as f64);
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(err) => {
+                        error!(
+                            ?err,
+                            block_number, "failed to check preconfirmation materialization state"
+                        );
+                        let _ = job.respond_to.send(Err(err));
+                        gauge!(DriverMetrics::PRECONF_QUEUE_DEPTH).set(rx.len() as f64);
+                        continue;
+                    }
+                }
+
                 let router_guard = router.lock().await;
                 // Re-check after acquiring router lock so event-sync updates cannot race this
                 // preconfirmation submission.
@@ -624,6 +708,15 @@ where
         // Reject early if strict ingress gating is not satisfied yet.
         if !self.preconf_ingress_ready.load(Ordering::Acquire) {
             return Err(DriverError::PreconfIngressNotReady);
+        }
+
+        if preconfirmation_payload_is_materialized(&self.rpc, &payload).await? {
+            debug!(
+                block_number = payload.block_number(),
+                build_payload_args_id = %PayloadId::new(payload.payload().l1_origin.build_payload_args_id),
+                "skipping already materialized preconfirmation payload"
+            );
+            return Ok(());
         }
 
         let block_number = payload.block_number();
@@ -1016,85 +1109,131 @@ where
         let derivation = Arc::new(derivation_pipeline);
         let router = self.build_router(derivation.clone());
 
-        let mut scanner = self
-            .cfg
-            .client
-            .l1_provider_source
-            .to_event_scanner_from_tag(start_tag)
-            .await
-            .map_err(|err| SyncError::EventScannerInit(err.to_string()))?;
-        let filter = EventFilter::new()
-            .contract_address(self.cfg.client.inbox_address)
-            .event(Proposed::SIGNATURE);
-
-        let mut stream = scanner.subscribe(filter).stream(
-            &scanner.start().await.map_err(|err| SyncError::EventScannerInit(err.to_string()))?,
-        );
-
-        info!("event scanner started; listening for inbox proposals");
+        let mut reconnect_start_tag = start_tag;
 
         // Strict gate state for starting preconfirmation ingress.
         let mut preconf_ingress_spawned = false;
         let mut scanner_live = false;
 
-        while let Some(message) = stream.next().await {
-            debug!(?message, "received inbox proposal message from event scanner");
-            match message {
-                Ok(ScannerMessage::Data(logs)) => {
-                    counter!(DriverMetrics::EVENT_SCANNER_BATCHES_TOTAL).increment(1);
-                    counter!(DriverMetrics::EVENT_PROPOSALS_TOTAL).increment(logs.len() as u64);
-                    self.process_log_batch(router.clone(), logs).await?;
+        loop {
+            let mut scanner = match self
+                .cfg
+                .client
+                .l1_provider_source
+                .to_event_scanner_from_tag(reconnect_start_tag)
+                .await
+            {
+                Ok(scanner) => scanner,
+                Err(err) => {
+                    warn!(
+                        ?err,
+                        start_tag = ?reconnect_start_tag,
+                        retry_after_secs = self.cfg.retry_interval.as_secs_f64(),
+                        "failed to initialize event scanner; retrying"
+                    );
+                    sleep(self.cfg.retry_interval).await;
+                    continue;
                 }
-                Ok(ScannerMessage::Notification(notification)) => {
-                    info!(?notification, "event scanner notification");
-                    if matches!(notification, Notification::SwitchingToLive) {
-                        // Scanner live is necessary but not sufficient: confirmed-sync readiness
-                        // must also pass before ingress opens.
-                        scanner_live = true;
+            };
+            let filter = EventFilter::new()
+                .contract_address(self.cfg.client.inbox_address)
+                .event(Proposed::SIGNATURE);
+            let subscription = scanner.subscribe(filter);
+            let proof = match scanner.start().await {
+                Ok(proof) => proof,
+                Err(err) => {
+                    warn!(
+                        ?err,
+                        start_tag = ?reconnect_start_tag,
+                        retry_after_secs = self.cfg.retry_interval.as_secs_f64(),
+                        "failed to start event scanner; retrying"
+                    );
+                    sleep(self.cfg.retry_interval).await;
+                    continue;
+                }
+            };
+            let mut stream = subscription.stream(&proof);
+
+            info!(
+                start_tag = ?reconnect_start_tag,
+                "event scanner started; listening for inbox proposals"
+            );
+
+            let mut last_seen_l1_block_number = None;
+
+            while let Some(message) = stream.next().await {
+                debug!(?message, "received inbox proposal message from event scanner");
+                match message {
+                    Ok(ScannerMessage::Data(logs)) => {
+                        if let Some(block_number) = logs.last().and_then(|log| log.block_number) {
+                            last_seen_l1_block_number = Some(block_number);
+                        }
+                        counter!(DriverMetrics::EVENT_SCANNER_BATCHES_TOTAL).increment(1);
+                        counter!(DriverMetrics::EVENT_PROPOSALS_TOTAL).increment(logs.len() as u64);
+                        self.process_log_batch(router.clone(), logs).await?;
+                    }
+                    Ok(ScannerMessage::Notification(notification)) => {
+                        info!(?notification, "event scanner notification");
+                        if matches!(notification, Notification::SwitchingToLive) {
+                            // Scanner live is necessary but not sufficient: confirmed-sync
+                            // readiness must also pass before ingress
+                            // opens.
+                            scanner_live = true;
+                        }
+                    }
+                    Err(err) => {
+                        counter!(DriverMetrics::EVENT_SCANNER_ERRORS_TOTAL).increment(1);
+                        error!(?err, "error receiving proposal logs from event scanner");
+                        continue;
                     }
                 }
-                Err(err) => {
-                    counter!(DriverMetrics::EVENT_SCANNER_ERRORS_TOTAL).increment(1);
-                    error!(?err, "error receiving proposal logs from event scanner");
-                    continue;
+
+                if should_probe_confirmed_sync(
+                    self.cfg.preconfirmation_enabled,
+                    preconf_ingress_spawned,
+                    scanner_live,
+                ) {
+                    let confirmed_sync_probe = self.confirmed_sync_snapshot().await;
+                    if let Err(err) = &confirmed_sync_probe {
+                        counter!(DriverMetrics::EVENT_CONFIRMED_SYNC_PROBE_ERRORS_TOTAL)
+                            .increment(1);
+                        warn!(
+                            ?err,
+                            "confirmed-sync probe failed; keeping preconfirmation ingress closed"
+                        );
+                        continue;
+                    }
+                    let confirmed_sync_ready = resolve_confirmed_sync_probe(confirmed_sync_probe);
+                    if confirmed_sync_ready {
+                        let rx = self
+                            .preconf_rx
+                            .lock()
+                            .expect("preconfirmation receiver lock should not be poisoned")
+                            .take();
+                        if let Some(rx) = rx {
+                            self.spawn_preconf_ingress(
+                                router.clone(),
+                                rx,
+                                self.rpc.clone(),
+                                self.preconf_ingress_ready.clone(),
+                                self.preconf_ingress_notify.clone(),
+                            );
+                            preconf_ingress_spawned = true;
+                        }
+                    }
                 }
             }
 
-            if should_probe_confirmed_sync(
-                self.cfg.preconfirmation_enabled,
-                preconf_ingress_spawned,
-                scanner_live,
-            ) {
-                let confirmed_sync_probe = self.confirmed_sync_snapshot().await;
-                if let Err(err) = &confirmed_sync_probe {
-                    counter!(DriverMetrics::EVENT_CONFIRMED_SYNC_PROBE_ERRORS_TOTAL).increment(1);
-                    warn!(
-                        ?err,
-                        "confirmed-sync probe failed; keeping preconfirmation ingress closed"
-                    );
-                    continue;
-                }
-                let confirmed_sync_ready = resolve_confirmed_sync_probe(confirmed_sync_probe);
-                if confirmed_sync_ready {
-                    let rx = self
-                        .preconf_rx
-                        .lock()
-                        .expect("preconfirmation receiver lock should not be poisoned")
-                        .take();
-                    if let Some(rx) = rx {
-                        self.spawn_preconf_ingress(
-                            router.clone(),
-                            rx,
-                            self.rpc.clone(),
-                            self.preconf_ingress_ready.clone(),
-                            self.preconf_ingress_notify.clone(),
-                        );
-                        preconf_ingress_spawned = true;
-                    }
-                }
+            if let Some(block_number) = last_seen_l1_block_number {
+                reconnect_start_tag = BlockNumberOrTag::Number(block_number.saturating_sub(1));
             }
+            warn!(
+                start_tag = ?reconnect_start_tag,
+                retry_after_secs = self.cfg.retry_interval.as_secs_f64(),
+                "event scanner stream ended; reconnecting"
+            );
+            sleep(self.cfg.retry_interval).await;
         }
-        Ok(())
     }
 }
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -93,9 +93,7 @@ fn should_probe_confirmed_sync(
     preconf_ingress_ready: bool,
     scanner_live: bool,
 ) -> bool {
-    preconfirmation_enabled
-        && scanner_live
-        && (!preconf_ingress_spawned || !preconf_ingress_ready)
+    preconfirmation_enabled && scanner_live && (!preconf_ingress_spawned || !preconf_ingress_ready)
 }
 
 /// Resolve whether confirmed-sync readiness should open ingress.
@@ -1273,9 +1271,7 @@ where
                             );
                             preconf_ingress_spawned = true;
                         } else if !self.preconf_ingress_ready.swap(true, Ordering::AcqRel) {
-                            info!(
-                                "re-opened preconfirmation ingress after scanner reconnect"
-                            );
+                            info!("re-opened preconfirmation ingress after scanner reconnect");
                             self.preconf_ingress_notify.notify_waiters();
                         }
                     }

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -233,6 +233,8 @@ where
     let Some(origin) = rpc.l1_origin_by_id(U256::from(block_number)).await? else {
         return Ok(false);
     };
+    // Treat a zero build-payload id as an uninitialized origin record so we fail closed and
+    // re-submit rather than falsely acknowledging a materialized payload.
     if origin.build_payload_args_id == [0u8; 8] ||
         origin.build_payload_args_id != expected_payload.l1_origin.build_payload_args_id
     {
@@ -1116,6 +1118,11 @@ where
         let mut scanner_live = false;
 
         loop {
+            if !preconf_ingress_spawned {
+                // A reconnect re-enters historical sync and must wait for a fresh
+                // `SwitchingToLive` notification before probing ingress readiness.
+                scanner_live = false;
+            }
             let mut scanner = match self
                 .cfg
                 .client
@@ -1225,6 +1232,9 @@ where
             }
 
             if let Some(block_number) = last_seen_l1_block_number {
+                // Step back one block so reconnect does not miss logs if the stream ended after
+                // yielding only part of the last block's notifications. Replaying that boundary
+                // block is safe because proposal processing is idempotent.
                 reconnect_start_tag = BlockNumberOrTag::Number(block_number.saturating_sub(1));
             }
             warn!(

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -164,6 +164,39 @@ fn resolve_target_with_optional_finalization(
     }
 }
 
+/// Resolve the reconnect start block after a scanner interruption.
+///
+/// - Rewind one block from the last seen height to cover partial delivery from the boundary block.
+/// - If a finalized L1 block exists behind that overlap point, rewind all the way to finalized so
+///   reconnect replays the entire reorg-unsafe window.
+/// - If finalization is unavailable, fall back to the original startup anchor to avoid skipping
+///   potentially replaced historical logs on fresh chains.
+fn resolve_reconnect_start_block(
+    last_seen_l1_block_number: u64,
+    finalized_l1_block_number: Option<u64>,
+    startup_anchor_block_number: u64,
+) -> u64 {
+    let overlap_start_block_number = last_seen_l1_block_number.saturating_sub(1);
+    finalized_l1_block_number
+        .map_or(startup_anchor_block_number, |finalized| overlap_start_block_number.min(finalized))
+}
+
+/// Convert a scanner setup error into either a fatal startup error or a retryable reconnect error.
+///
+/// Before the first successful scanner start, setup failures must fail fast so callers waiting on
+/// ingress readiness observe a clear startup error. After the scanner has started once, the same
+/// failures are treated as transient reconnect errors.
+fn resolve_event_scanner_setup_error(
+    scanner_started_once: bool,
+    error_message: String,
+) -> Result<String, SyncError> {
+    if scanner_started_once {
+        Ok(error_message)
+    } else {
+        Err(SyncError::EventScannerInit(error_message))
+    }
+}
+
 /// Return true when a preconfirmation target block is stale against the confirmed tip boundary.
 #[inline]
 fn is_stale_preconf(block_number: u64, confirmed_tip: u64) -> bool {
@@ -1112,10 +1145,12 @@ where
         let router = self.build_router(derivation.clone());
 
         let mut reconnect_start_tag = start_tag;
+        let startup_anchor_block_number = anchor_block_number;
 
         // Strict gate state for starting preconfirmation ingress.
         let mut preconf_ingress_spawned = false;
         let mut scanner_live = false;
+        let mut scanner_started_once = false;
 
         loop {
             if !preconf_ingress_spawned {
@@ -1132,8 +1167,12 @@ where
             {
                 Ok(scanner) => scanner,
                 Err(err) => {
+                    let err = resolve_event_scanner_setup_error(
+                        scanner_started_once,
+                        err.to_string(),
+                    )?;
                     warn!(
-                        ?err,
+                        error = %err,
                         start_tag = ?reconnect_start_tag,
                         retry_after_secs = self.cfg.retry_interval.as_secs_f64(),
                         "failed to initialize event scanner; retrying"
@@ -1147,10 +1186,17 @@ where
                 .event(Proposed::SIGNATURE);
             let subscription = scanner.subscribe(filter);
             let proof = match scanner.start().await {
-                Ok(proof) => proof,
+                Ok(proof) => {
+                    scanner_started_once = true;
+                    proof
+                }
                 Err(err) => {
+                    let err = resolve_event_scanner_setup_error(
+                        scanner_started_once,
+                        err.to_string(),
+                    )?;
                     warn!(
-                        ?err,
+                        error = %err,
                         start_tag = ?reconnect_start_tag,
                         retry_after_secs = self.cfg.retry_interval.as_secs_f64(),
                         "failed to start event scanner; retrying"
@@ -1232,10 +1278,22 @@ where
             }
 
             if let Some(block_number) = last_seen_l1_block_number {
-                // Step back one block so reconnect does not miss logs if the stream ended after
-                // yielding only part of the last block's notifications. Replaying that boundary
-                // block is safe because proposal processing is idempotent.
-                reconnect_start_tag = BlockNumberOrTag::Number(block_number.saturating_sub(1));
+                let reconnect_finalized_block_number = match self.try_finalized_l1_snapshot().await {
+                    Ok(snapshot) => snapshot.map(|snapshot| snapshot.block_number),
+                    Err(err) => {
+                        warn!(
+                            ?err,
+                            fallback_start_block = startup_anchor_block_number,
+                            "failed to resolve finalized reconnect anchor; rewinding to startup anchor"
+                        );
+                        None
+                    }
+                };
+                reconnect_start_tag = BlockNumberOrTag::Number(resolve_reconnect_start_block(
+                    block_number,
+                    reconnect_finalized_block_number,
+                    startup_anchor_block_number,
+                ));
             }
             warn!(
                 start_tag = ?reconnect_start_tag,
@@ -1835,5 +1893,34 @@ mod tests {
         let (target, safe) = resolve_target_with_optional_finalization(50, Some(120));
         assert_eq!(target, 50);
         assert_eq!(safe, 120);
+    }
+
+    #[test]
+    fn reconnect_start_rewinds_to_finalized_when_finalized_is_behind_last_seen() {
+        let reconnect_start = resolve_reconnect_start_block(120, Some(80), 10);
+        assert_eq!(reconnect_start, 80);
+    }
+
+    #[test]
+    fn reconnect_start_keeps_one_block_overlap_when_finalized_is_ahead() {
+        let reconnect_start = resolve_reconnect_start_block(120, Some(240), 10);
+        assert_eq!(reconnect_start, 119);
+    }
+
+    #[test]
+    fn reconnect_start_falls_back_to_startup_anchor_without_finalization() {
+        let reconnect_start = resolve_reconnect_start_block(120, None, 10);
+        assert_eq!(reconnect_start, 10);
+    }
+
+    #[test]
+    fn scanner_setup_errors_fail_fast_before_first_successful_start() {
+        let err = resolve_event_scanner_setup_error(false, "boom".into())
+            .expect_err("startup scanner errors should fail fast");
+        assert!(matches!(err, SyncError::EventScannerInit(reason) if reason == "boom"));
+
+        let err = resolve_event_scanner_setup_error(true, "boom".into())
+            .expect("post-start scanner errors should be retryable");
+        assert_eq!(err, "boom");
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -246,13 +246,27 @@ impl<P> EventSyncerDriverClient<EventSyncer<P>, P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    /// Build a driver client from an EventSyncer and RPC client bundle.
-    pub fn from_client(event_syncer: Arc<EventSyncer<P>>, client: rpc::client::Client<P>) -> Self {
+    /// Build a driver client from an EventSyncer and RPC client bundle with a custom
+    /// `wait_event_sync` poll interval.
+    pub fn from_client_with_poll_interval(
+        event_syncer: Arc<EventSyncer<P>>,
+        client: rpc::client::Client<P>,
+        wait_event_sync_poll_interval: Duration,
+    ) -> Self {
         let l2_provider: Arc<dyn L2Provider + Send + Sync> = Arc::new(client.l2_provider.clone());
         Self::new_with_components_and_poll_interval(
             event_syncer,
             client.shasta.inbox,
             l2_provider,
+            wait_event_sync_poll_interval,
+        )
+    }
+
+    /// Build a driver client from an EventSyncer and RPC client bundle.
+    pub fn from_client(event_syncer: Arc<EventSyncer<P>>, client: rpc::client::Client<P>) -> Self {
+        Self::from_client_with_poll_interval(
+            event_syncer,
+            client,
             DEFAULT_WAIT_EVENT_SYNC_POLL_INTERVAL,
         )
     }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -83,7 +83,19 @@ const DEFAULT_PRECONF_SUBMISSION_RETRY_POLICY: PreconfirmationSubmissionRetryPol
         max_delay: Duration::from_secs(2),
     };
 
-/// Retry a preconfirmation submission when the event syncer reports a response timeout.
+/// Return retry metadata for timeout errors that indicate transient submission backpressure.
+fn retryable_preconfirmation_timeout(err: &DriverError) -> Option<(&'static str, Duration)> {
+    match err {
+        DriverError::PreconfEnqueueTimeout { waited } => Some(("enqueue", *waited)),
+        DriverError::PreconfResponseTimeout { waited } => Some(("response", *waited)),
+        _ => None,
+    }
+}
+
+/// Retry a preconfirmation submission when the event syncer reports a retryable timeout.
+///
+/// With the current 12-second embedded driver timeout, the default policy allows up to roughly
+/// 39 seconds of wall-clock latency before surfacing the final error.
 async fn submit_preconfirmation_payload_with_retry<F, Fut>(
     policy: PreconfirmationSubmissionRetryPolicy,
     block_number: u64,
@@ -100,21 +112,28 @@ where
     loop {
         match submit().await {
             Ok(()) => return Ok(()),
-            Err(DriverError::PreconfResponseTimeout { waited }) if attempt < policy.retry_limit => {
+            Err(err) => {
+                let Some((timeout_kind, waited)) = retryable_preconfirmation_timeout(&err) else {
+                    return Err(err);
+                };
+                if attempt >= policy.retry_limit {
+                    return Err(err);
+                }
+
                 attempt += 1;
                 warn!(
                     block_number,
                     proposal_id,
                     attempt,
                     retry_limit = policy.retry_limit,
+                    timeout_kind,
                     waited_secs = waited.as_secs_f64(),
                     retry_in_secs = delay.as_secs_f64(),
-                    "preconfirmation response timed out; retrying submission"
+                    "preconfirmation submission timed out; retrying"
                 );
                 sleep(delay).await;
                 delay = (delay * 2).min(policy.max_delay);
             }
-            Err(err) => return Err(err),
         }
     }
 }
@@ -431,6 +450,59 @@ mod tests {
         .await;
 
         assert!(result.is_ok(), "timeout retries should eventually succeed");
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn submit_preconfirmation_payload_with_retry_retries_enqueue_timeouts() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let policy = super::PreconfirmationSubmissionRetryPolicy {
+            retry_limit: 2,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(2),
+        };
+
+        let result = super::submit_preconfirmation_payload_with_retry(policy, 7, 11, || {
+            let attempts = Arc::clone(&attempts);
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt < 2 {
+                    Err(driver::DriverError::PreconfEnqueueTimeout {
+                        waited: Duration::from_secs(12),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok(), "enqueue timeout retries should eventually succeed");
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn submit_preconfirmation_payload_with_retry_returns_last_timeout_after_exhaustion() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let policy = super::PreconfirmationSubmissionRetryPolicy {
+            retry_limit: 2,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(2),
+        };
+
+        let err = super::submit_preconfirmation_payload_with_retry(policy, 7, 11, || {
+            let attempts = Arc::clone(&attempts);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(driver::DriverError::PreconfResponseTimeout {
+                    waited: Duration::from_secs(12),
+                })
+            }
+        })
+        .await
+        .expect_err("persistent response timeouts should surface after exhausting retries");
+
+        assert!(matches!(err, driver::DriverError::PreconfResponseTimeout { .. }));
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -1,6 +1,6 @@
 //! Event syncer-backed driver client for runner integration.
 
-use std::{result::Result, sync::Arc, time::Duration};
+use std::{future::Future, result::Result, sync::Arc, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::U256;
@@ -13,8 +13,8 @@ use driver::{
 };
 use preconfirmation_types::uint256_to_u256;
 use protocol::shasta::constants::min_base_fee_for_chain;
-use tokio::sync::OnceCell;
-use tracing::info;
+use tokio::{sync::OnceCell, time::sleep};
+use tracing::{info, warn};
 
 use crate::{
     Result as ClientResult,
@@ -63,6 +63,61 @@ where
 pub trait L2Provider: BlockHeaderProvider + TipProvider {}
 
 impl<T> L2Provider for T where T: BlockHeaderProvider + TipProvider {}
+
+/// Retry policy applied to timed-out preconfirmation submissions.
+#[derive(Clone, Copy, Debug)]
+struct PreconfirmationSubmissionRetryPolicy {
+    /// Number of retry attempts allowed after the initial timed-out submission.
+    retry_limit: usize,
+    /// Delay used before the first retry attempt.
+    base_delay: Duration,
+    /// Upper bound for exponential backoff between retry attempts.
+    max_delay: Duration,
+}
+
+/// Default retry policy applied when a preconfirmation submission times out.
+const DEFAULT_PRECONF_SUBMISSION_RETRY_POLICY: PreconfirmationSubmissionRetryPolicy =
+    PreconfirmationSubmissionRetryPolicy {
+        retry_limit: 2,
+        base_delay: Duration::from_secs(1),
+        max_delay: Duration::from_secs(2),
+    };
+
+/// Retry a preconfirmation submission when the event syncer reports a response timeout.
+async fn submit_preconfirmation_payload_with_retry<F, Fut>(
+    policy: PreconfirmationSubmissionRetryPolicy,
+    block_number: u64,
+    proposal_id: u64,
+    mut submit: F,
+) -> Result<(), DriverError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<(), DriverError>>,
+{
+    let mut delay = policy.base_delay;
+    let mut attempt = 0usize;
+
+    loop {
+        match submit().await {
+            Ok(()) => return Ok(()),
+            Err(DriverError::PreconfResponseTimeout { waited }) if attempt < policy.retry_limit => {
+                attempt += 1;
+                warn!(
+                    block_number,
+                    proposal_id,
+                    attempt,
+                    retry_limit = policy.retry_limit,
+                    waited_secs = waited.as_secs_f64(),
+                    retry_in_secs = delay.as_secs_f64(),
+                    "preconfirmation response timed out; retrying submission"
+                );
+                sleep(delay).await;
+                delay = (delay * 2).min(policy.max_delay);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
 
 /// Minimal interface needed from the driver event syncer.
 #[async_trait]
@@ -211,12 +266,19 @@ where
         )
         .await?;
 
-        self.event_syncer
-            .submit_preconfirmation_payload(PreconfPayload::new(payload))
-            .await
-            .map_err(|err| {
-                PreconfirmationClientError::DriverInterface(DriverApiError::Driver(err))
-            })?;
+        let payload = PreconfPayload::new(payload);
+        submit_preconfirmation_payload_with_retry(
+            DEFAULT_PRECONF_SUBMISSION_RETRY_POLICY,
+            block_number,
+            proposal_id,
+            || {
+                let event_syncer = Arc::clone(&self.event_syncer);
+                let payload = payload.clone();
+                async move { event_syncer.submit_preconfirmation_payload(payload).await }
+            },
+        )
+        .await
+        .map_err(|err| PreconfirmationClientError::DriverInterface(DriverApiError::Driver(err)))?;
 
         info!(block_number, proposal_id, "submitted preconfirmation payload");
         Ok(())
@@ -342,6 +404,57 @@ mod tests {
                 head_l1_origin_block_id,
             ))
         }
+    }
+
+    #[tokio::test]
+    async fn submit_preconfirmation_payload_with_retry_retries_timeouts() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let policy = super::PreconfirmationSubmissionRetryPolicy {
+            retry_limit: 2,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(2),
+        };
+
+        let result = super::submit_preconfirmation_payload_with_retry(policy, 7, 11, || {
+            let attempts = Arc::clone(&attempts);
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt < 2 {
+                    Err(driver::DriverError::PreconfResponseTimeout {
+                        waited: Duration::from_secs(12),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok(), "timeout retries should eventually succeed");
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn submit_preconfirmation_payload_with_retry_stops_on_non_timeout_error() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let policy = super::PreconfirmationSubmissionRetryPolicy {
+            retry_limit: 2,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(2),
+        };
+
+        let err = super::submit_preconfirmation_payload_with_retry(policy, 7, 11, || {
+            let attempts = Arc::clone(&attempts);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(driver::DriverError::PreconfIngressNotReady)
+            }
+        })
+        .await
+        .expect_err("non-timeout driver errors should not be retried");
+
+        assert!(matches!(err, driver::DriverError::PreconfIngressNotReady));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -494,9 +494,7 @@ mod tests {
             let attempts = Arc::clone(&attempts);
             async move {
                 attempts.fetch_add(1, Ordering::SeqCst);
-                Err(driver::DriverError::PreconfResponseTimeout {
-                    waited: Duration::from_secs(12),
-                })
+                Err(driver::DriverError::PreconfResponseTimeout { waited: Duration::from_secs(12) })
             }
         })
         .await

--- a/packages/taiko-client-rs/crates/test-harness/src/blocks/mod.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/blocks/mod.rs
@@ -18,6 +18,9 @@ use tokio::{
     time::{Instant, sleep},
 };
 
+/// Maximum time allowed for a single block-poll RPC during test waits.
+const BLOCK_WAIT_RPC_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Fetches a block by number with full transaction details.
 ///
 /// Returns the block with transactions deserialized as `TxEnvelope`,
@@ -80,21 +83,24 @@ where
 pub async fn wait_for_block<P>(
     provider: &P,
     block_number: u64,
-    timeout: Duration,
+    timeout_duration: Duration,
 ) -> Result<RpcBlock<TxEnvelope>>
 where
     P: Provider + Send + Sync,
 {
-    let deadline = Instant::now() + timeout;
+    let deadline = Instant::now() + timeout_duration;
 
     loop {
-        if Instant::now() >= deadline {
+        let now = Instant::now();
+        if now >= deadline {
             return Err(anyhow!("timed out waiting for block {block_number}"));
         }
 
-        if let Ok(Some(block)) =
-            provider.get_block_by_number(BlockNumberOrTag::Number(block_number)).full().await
-        {
+        let remaining = deadline.saturating_duration_since(now);
+        let rpc_timeout = remaining.min(BLOCK_WAIT_RPC_TIMEOUT);
+        let block_request = provider.get_block_by_number(BlockNumberOrTag::Number(block_number));
+
+        if let Ok(Ok(Some(block))) = tokio::time::timeout(rpc_timeout, block_request.full()).await {
             return Ok(block.map_transactions(TxEnvelope::from));
         }
 

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -30,6 +30,9 @@ use tracing::{info, warn};
 
 use crate::{BeaconStubServer, ShastaEnv, fetch_block_by_number};
 
+/// Fast event-sync poll interval used by the harness to keep E2E waits responsive.
+const HARNESS_WAIT_EVENT_SYNC_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
 /// A mock driver client that records submissions for test verification.
 ///
 /// This client:
@@ -183,7 +186,13 @@ where
 {
     /// Create a new client backed by the driver event syncer.
     pub fn new(event_syncer: Arc<EventSyncer<P>>, client: Client<P>) -> Self {
-        Self { inner: RuntimeEventSyncerDriverClient::from_client(event_syncer, client) }
+        Self {
+            inner: RuntimeEventSyncerDriverClient::from_client_with_poll_interval(
+                event_syncer,
+                client,
+                HARNESS_WAIT_EVENT_SYNC_POLL_INTERVAL,
+            ),
+        }
     }
 }
 

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -22,7 +22,10 @@ use preconfirmation_driver::{
 };
 use preconfirmation_types::uint256_to_u256;
 use rpc::client::{Client, ClientConfig};
-use tokio::{sync::{Mutex, Notify}, task::JoinHandle};
+use tokio::{
+    sync::{Mutex, Notify},
+    task::JoinHandle,
+};
 use tracing::{info, warn};
 
 use crate::{BeaconStubServer, ShastaEnv, fetch_block_by_number};

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -8,30 +8,21 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::U256;
 use alloy_provider::{Provider, RootProvider};
 use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
-use bindings::inbox::Inbox::InboxInstance;
 use driver::{
-    DriverConfig, PreconfPayload,
+    DriverConfig,
     sync::{SyncStage, event::EventSyncer},
 };
 use preconfirmation_driver::{
-    DriverClient, PreconfirmationInput, Result,
-    driver_interface::payload::build_taiko_payload_attributes,
-    error::{DriverApiError, PreconfirmationClientError},
-    resolve_event_sync_tip,
+    DriverClient, EventSyncerDriverClient as RuntimeEventSyncerDriverClient, PreconfirmationInput,
+    Result,
 };
 use preconfirmation_types::uint256_to_u256;
-use protocol::shasta::constants::min_base_fee_for_chain;
 use rpc::client::{Client, ClientConfig};
-use tokio::{
-    sync::{Mutex, Notify},
-    task::JoinHandle,
-    time::sleep,
-};
+use tokio::{sync::{Mutex, Notify}, task::JoinHandle};
 use tracing::{info, warn};
 
 use crate::{BeaconStubServer, ShastaEnv, fetch_block_by_number};
@@ -176,14 +167,11 @@ impl DriverClient for MockDriverClient {
 }
 
 /// Driver client that submits payloads directly to an in-process EventSyncer.
-#[derive(Clone)]
 pub struct EventSyncerDriverClient<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    event_syncer: Arc<EventSyncer<P>>,
-    inbox: InboxInstance<P>,
-    l2_provider: RootProvider,
+    inner: RuntimeEventSyncerDriverClient<EventSyncer<P>, P>,
 }
 
 impl<P> EventSyncerDriverClient<P>
@@ -192,7 +180,7 @@ where
 {
     /// Create a new client backed by the driver event syncer.
     pub fn new(event_syncer: Arc<EventSyncer<P>>, client: Client<P>) -> Self {
-        Self { event_syncer, inbox: client.shasta.inbox, l2_provider: client.l2_provider }
+        Self { inner: RuntimeEventSyncerDriverClient::from_client(event_syncer, client) }
     }
 }
 
@@ -202,73 +190,19 @@ where
     P: Provider + Clone + Send + Sync + 'static,
 {
     async fn submit_preconfirmation(&self, input: PreconfirmationInput) -> Result<()> {
-        let preconf = &input.commitment.commitment.preconf;
-        let block_number = uint256_to_u256(&preconf.block_number).to::<u64>();
-        let proposal_id = uint256_to_u256(&preconf.proposal_id).to::<u64>();
-
-        if input.should_skip_driver_submission() {
-            tracing::debug!(block_number, proposal_id, "skipping EOP-only preconfirmation");
-            return Ok(());
-        }
-
-        let config = self.inbox.getConfig().call().await.map_err(DriverApiError::from)?;
-        let min_base_fee_to_clamp = min_base_fee_for_chain(
-            self.l2_provider.get_chain_id().await.map_err(DriverApiError::from)?,
-        );
-        let payload = build_taiko_payload_attributes(
-            &input,
-            config.basefeeSharingPctg,
-            &self.l2_provider,
-            min_base_fee_to_clamp,
-        )
-        .await?;
-
-        self.event_syncer
-            .submit_preconfirmation_payload(PreconfPayload::new(payload))
-            .await
-            .map_err(|err| {
-                PreconfirmationClientError::DriverInterface(DriverApiError::Driver(err))
-            })?;
-
-        info!(block_number, proposal_id, "submitted preconfirmation payload");
-        Ok(())
+        self.inner.submit_preconfirmation(input).await
     }
 
     async fn wait_event_sync(&self) -> Result<()> {
-        info!("starting wait for driver to sync with L1 inbox events");
-        loop {
-            if self
-                .event_syncer
-                .confirmed_sync_snapshot()
-                .await
-                .map_err(|err| DriverApiError::Driver(driver::DriverError::from(err)))?
-                .is_ready()
-            {
-                info!("driver event sync complete");
-                return Ok(());
-            }
-
-            sleep(Duration::from_millis(200)).await;
-        }
+        self.inner.wait_event_sync().await
     }
 
     async fn event_sync_tip(&self) -> Result<U256> {
-        let snapshot = self
-            .event_syncer
-            .confirmed_sync_snapshot()
-            .await
-            .map_err(|err| DriverApiError::Driver(driver::DriverError::from(err)))?;
-        resolve_event_sync_tip(&snapshot)
+        self.inner.event_sync_tip().await
     }
 
     async fn preconf_tip(&self) -> Result<U256> {
-        let block = self
-            .l2_provider
-            .get_block_by_number(BlockNumberOrTag::Latest)
-            .await
-            .map_err(DriverApiError::from)?
-            .ok_or(DriverApiError::MissingLatestBlock)?;
-        Ok(U256::from(block.number()))
+        self.inner.preconf_tip().await
     }
 }
 


### PR DESCRIPTION
 ## Summary

 This hardens the embedded `taiko-client-rs` preconfirmation flow against transient `reth` stalls and L1 WS interruptions.

  - reconnect the event syncer instead of exiting when the event scanner init/start/stream ends
  - retry timed-out preconfirmation submissions on `PreconfResponseTimeout` with bounded backoff
  - make retries idempotent by skipping already materialized preconfirmation payloads before enqueue and again in the ingress loop
  - add unit coverage for the preconfirmation timeout retry helper

  ## Why

During proposal catch-up, `reth` can stall on MDBX write-lock contention long enough for preconfirmation submissions to exceed the current response timeout. Separately, L1 WS interruptions were causing the event syncer to exit instead of recovering.

These changes make the driver tolerate both transient failure modes without crashing.