### PR TITLE
fix(taiko-client): guard nil Shasta LastBlockIDByBatchID

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta.go
@@ -59,6 +59,13 @@ func tryLastFinalizedCheckpointShasta(
 		)
 		return nil, nil
 	}
+	if blockID == nil {
+		log.Warn(
+			"No last block ID found for finalized proposal, continue inserting blocks",
+			"finalizedProposalID", coreState.LastFinalizedProposalId,
+		)
+		return nil, nil
+	}
 
 	lastFinalizedHeader, err := headerByNumber(ctx, blockID.ToInt())
 	if err != nil {

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta_test.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/shasta_test.go
@@ -1,0 +1,39 @@
+package blocksinserter
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
+)
+
+func TestTryLastFinalizedCheckpointShastaReturnsNilWhenBatchMappingMissing(t *testing.T) {
+	var headerRequested bool
+
+	checkpoint, err := tryLastFinalizedCheckpointShasta(
+		context.Background(),
+		big.NewInt(10),
+		func(*bind.CallOpts) (*shastaBindings.IInboxCoreState, error) {
+			return &shastaBindings.IInboxCoreState{
+				LastFinalizedProposalId: big.NewInt(10),
+			}, nil
+		},
+		func(context.Context, *big.Int) (*hexutil.Big, error) {
+			return nil, nil
+		},
+		func(context.Context, *big.Int) (*types.Header, error) {
+			headerRequested = true
+			return nil, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Nil(t, checkpoint)
+	require.False(t, headerRequested)
+}

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1204,6 +1204,13 @@ func (s *PreconfBlockAPIServer) handleShastaProposalReorg(ctx context.Context, l
 		)
 		return
 	}
+	if blockID == nil {
+		log.Error(
+			"No last block ID found for shasta proposal",
+			"proposalId", recordedProposal.Id,
+		)
+		return
+	}
 
 	header, err := s.rpc.L1.HeaderByHash(ctx, eventLog.BlockHash)
 	if err != nil {

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -1526,6 +1526,14 @@ func (c *Client) GetCoreStateShasta(opts *bind.CallOpts) (*shastaBindings.IInbox
 	return &state, nil
 }
 
+func requiredBatchLastBlockNumber(proposalID *big.Int, blockID *hexutil.Big) (*big.Int, error) {
+	if blockID == nil {
+		return nil, fmt.Errorf("no last block ID found for proposal ID %d", proposalID)
+	}
+
+	return blockID.ToInt(), nil
+}
+
 // GetProposalByIDShasta gets the proposal by ID from Shasta Inbox contract.
 func (c *Client) GetProposalByIDShasta(
 	ctx context.Context,
@@ -1539,9 +1547,14 @@ func (c *Client) GetProposalByIDShasta(
 		return nil, nil, fmt.Errorf("failed to get last block ID by batch ID %d: %w", proposalID, err)
 	}
 
-	block, err := c.L2.BlockByNumber(ctxWithTimeout, blockID.ToInt())
+	blockNumber, err := requiredBatchLastBlockNumber(proposalID, blockID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get L2 block by ID %d: %w", blockID.ToInt(), err)
+		return nil, nil, err
+	}
+
+	block, err := c.L2.BlockByNumber(ctxWithTimeout, blockNumber)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get L2 block by ID %d: %w", blockNumber, err)
 	}
 
 	_, anchorNumber, _, err := c.GetSyncedL1SnippetFromAnchor(block.Transactions()[0])

--- a/packages/taiko-client/pkg/rpc/methods_test.go
+++ b/packages/taiko-client/pkg/rpc/methods_test.go
@@ -3,10 +3,12 @@ package rpc
 import (
 	"context"
 	"crypto/rand"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
@@ -64,6 +66,25 @@ func TestL2ExecutionEngineSyncProgress(t *testing.T) {
 	progress, err := client.L2ExecutionEngineSyncProgress(context.Background())
 	require.Nil(t, err)
 	require.NotNil(t, progress)
+}
+
+func TestRequiredBatchLastBlockNumber(t *testing.T) {
+	proposalID := big.NewInt(12)
+
+	t.Run("nil block ID", func(t *testing.T) {
+		blockNumber, err := requiredBatchLastBlockNumber(proposalID, nil)
+		require.Nil(t, blockNumber)
+		require.ErrorContains(t, err, "no last block ID found for proposal ID 12")
+	})
+
+	t.Run("valid block ID", func(t *testing.T) {
+		blockID := (*hexutil.Big)(big.NewInt(34))
+
+		blockNumber, err := requiredBatchLastBlockNumber(proposalID, blockID)
+		require.NoError(t, err)
+		require.NotNil(t, blockNumber)
+		require.Zero(t, blockNumber.Cmp(big.NewInt(34)))
+	})
 }
 
 func TestGetProtocolStateVariables(t *testing.T) {


### PR DESCRIPTION
Guard nil LastBlockIDByBatchID results across Shasta recovery paths, preventing panics when taiko-geth returns no batch mapping.