### PR TITLE
fix(preconfirmation-p2p): enforce runtime rate-limit validation

### DIFF
--- a/packages/preconfirmation-p2p/crates/net/src/config.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/config.rs
@@ -255,7 +255,6 @@ impl Default for RateLimitConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     #[test]
     fn validate_request_rate_limits_accepts_defaults() {

--- a/packages/preconfirmation-p2p/crates/net/src/config.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/config.rs
@@ -12,6 +12,7 @@ use std::{
 
 use crate::reputation::ReputationConfig;
 use alloy_primitives::Address;
+use anyhow::ensure;
 use libp2p::Multiaddr;
 
 /// Configuration for the P2P.
@@ -217,9 +218,18 @@ impl Default for NetworkConfig {
 
 impl NetworkConfig {
     /// Ensure rate-limit parameters are sane before constructing a limiter.
-    pub(crate) fn validate_request_rate_limits(&self) {
-        debug_assert!(self.request_window > Duration::ZERO, "request_window must be > 0");
-        debug_assert!(self.max_requests_per_window > 0, "max_requests_per_window must be > 0");
+    pub(crate) fn validate_request_rate_limits(&self) -> anyhow::Result<()> {
+        ensure!(
+            self.request_window > Duration::ZERO,
+            "request_window must be > 0, got {:?}",
+            self.request_window
+        );
+        ensure!(
+            self.max_requests_per_window > 0,
+            "max_requests_per_window must be > 0, got {}",
+            self.max_requests_per_window
+        );
+        Ok(())
     }
 }
 
@@ -239,5 +249,34 @@ impl Default for RateLimitConfig {
     /// Provides default rate limit settings: 10s window, 8 requests.
     fn default() -> Self {
         Self { window: Duration::from_secs(10), max_requests: 8 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn validate_request_rate_limits_accepts_defaults() {
+        let cfg = NetworkConfig::default();
+        assert!(cfg.validate_request_rate_limits().is_ok());
+    }
+
+    #[test]
+    fn validate_request_rate_limits_rejects_zero_window() {
+        let cfg = NetworkConfig { request_window: Duration::ZERO, ..Default::default() };
+        let err =
+            cfg.validate_request_rate_limits().expect_err("zero request_window must be rejected");
+        assert!(err.to_string().contains("request_window"));
+    }
+
+    #[test]
+    fn validate_request_rate_limits_rejects_zero_max_requests() {
+        let cfg = NetworkConfig { max_requests_per_window: 0, ..Default::default() };
+        let err = cfg
+            .validate_request_rate_limits()
+            .expect_err("zero max_requests_per_window must be rejected");
+        assert!(err.to_string().contains("max_requests_per_window"));
     }
 }

--- a/packages/preconfirmation-p2p/crates/net/src/driver/mod.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/driver/mod.rs
@@ -115,6 +115,8 @@ impl NetworkDriver {
         validator: Box<dyn ValidationAdapter>,
         storage: Option<Arc<dyn PreconfStorage>>,
     ) -> anyhow::Result<(Self, NetworkHandle)> {
+        cfg.validate_request_rate_limits()?;
+
         let dial_factor =
             NonZeroU8::new(cfg.dial_concurrency_factor).unwrap_or(NonZeroU8::new(1).unwrap());
 
@@ -150,8 +152,6 @@ impl NetworkDriver {
 
         let _ = events_tx.try_send(NetworkEvent::Started);
 
-        cfg.validate_request_rate_limits();
-
         let mut discovery_rx = None;
         if cfg.enable_discovery {
             discovery_rx = spawn_discovery(cfg.discv5_listen, cfg.bootnodes.clone()).ok();
@@ -171,7 +171,7 @@ impl NetworkDriver {
                 request_limiter: RequestRateLimiter::new(
                     cfg.request_window,
                     cfg.max_requests_per_window,
-                ),
+                )?,
                 pending_requests: HashMap::new(),
                 validator,
                 discovery_rx,

--- a/packages/preconfirmation-p2p/crates/net/src/driver/tests.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/driver/tests.rs
@@ -155,7 +155,7 @@ fn driver_from_parts(
     let config = libp2p::swarm::Config::with_tokio_executor();
     let swarm = Swarm::new(parts.transport, parts.behaviour, peer_id, config);
 
-    cfg.validate_request_rate_limits();
+    cfg.validate_request_rate_limits().expect("valid request rate-limit config for test");
 
     let (events_tx, events_rx) = mpsc::channel(256);
     let (cmd_tx, cmd_rx) = mpsc::channel(256);
@@ -175,7 +175,8 @@ fn driver_from_parts(
             request_limiter: RequestRateLimiter::new(
                 cfg.request_window,
                 cfg.max_requests_per_window,
-            ),
+            )
+            .expect("valid request rate-limit config for test"),
             pending_requests: HashMap::new(),
             validator: Box::new(LookaheadValidationAdapter::new(None, lookahead)),
             discovery_rx: None,

--- a/packages/preconfirmation-p2p/crates/net/src/reputation.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/reputation.rs
@@ -9,6 +9,7 @@
 //! The Kona connection gater from `kona_gossip` is used for low-level connection
 //! management, while this module focuses on application-level reputation.
 
+use anyhow::ensure;
 use libp2p::PeerId;
 use reth_network_types::peers::reputation::ReputationChangeWeights;
 use std::{
@@ -257,12 +258,16 @@ pub enum ReqRespKind {
 
 impl RequestRateLimiter {
     /// Creates a new `RequestRateLimiter` with a specified period and max requests.
-    pub fn new(window: Duration, max_requests: u32) -> Self {
-        debug_assert!(window > Duration::ZERO, "RequestRateLimiter window must be > 0");
-        debug_assert!(max_requests > 0, "RequestRateLimiter max_requests must be > 0");
+    pub fn new(window: Duration, max_requests: u32) -> anyhow::Result<Self> {
+        ensure!(window > Duration::ZERO, "RequestRateLimiter window must be > 0, got {:?}", window);
+        ensure!(
+            max_requests > 0,
+            "RequestRateLimiter max_requests must be > 0, got {}",
+            max_requests
+        );
         let rate = reth_tokio_util::ratelimit::Rate::new(max_requests as u64, window);
         let horizon = window * 4;
-        Self { rate, horizon, state: HashMap::new() }
+        Ok(Self { rate, horizon, state: HashMap::new() })
     }
 
     /// Drop idle limiters whose buckets have not been used within the horizon.
@@ -354,7 +359,8 @@ mod tests {
     /// Allows within quota then limits until bucket refills.
     #[tokio::test]
     async fn request_rate_limiter_under_and_over_limit() {
-        let mut rl = RequestRateLimiter::new(Duration::from_secs(1), 2);
+        let mut rl =
+            RequestRateLimiter::new(Duration::from_secs(1), 2).expect("valid rate-limit config");
         let peer = PeerId::random();
 
         for _ in 0..2 {
@@ -386,7 +392,8 @@ mod tests {
     /// Buckets are independent per peer.
     #[tokio::test]
     async fn request_rate_limiter_is_per_peer() {
-        let mut rl = RequestRateLimiter::new(Duration::from_secs(5), 1);
+        let mut rl =
+            RequestRateLimiter::new(Duration::from_secs(5), 1).expect("valid rate-limit config");
         let a = PeerId::random();
         let b = PeerId::random();
 
@@ -413,7 +420,7 @@ mod tests {
     #[tokio::test]
     async fn request_rate_limiter_evicts_idle_entries() {
         let window = Duration::from_millis(100);
-        let mut rl = RequestRateLimiter::new(window, 2);
+        let mut rl = RequestRateLimiter::new(window, 2).expect("valid rate-limit config");
         let a = PeerId::random();
         let b = PeerId::random();
 
@@ -436,5 +443,18 @@ mod tests {
 
         assert_eq!(rl.state.len(), 1);
         assert!(rl.state.contains_key(&(b, ReqRespKind::Head)));
+    }
+
+    #[test]
+    fn request_rate_limiter_rejects_invalid_limits() {
+        let err = RequestRateLimiter::new(Duration::ZERO, 1);
+        assert!(err.is_err(), "zero window must be rejected");
+        let err = err.err().expect("error expected");
+        assert!(err.to_string().contains("window"));
+
+        let err = RequestRateLimiter::new(Duration::from_secs(1), 0);
+        assert!(err.is_err(), "zero max_requests must be rejected");
+        let err = err.err().expect("error expected");
+        assert!(err.to_string().contains("max_requests"));
     }
 }

--- a/packages/preconfirmation-p2p/crates/net/src/reputation.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/reputation.rs
@@ -259,10 +259,10 @@ pub enum ReqRespKind {
 impl RequestRateLimiter {
     /// Creates a new `RequestRateLimiter` with a specified period and max requests.
     pub fn new(window: Duration, max_requests: u32) -> anyhow::Result<Self> {
-        ensure!(window > Duration::ZERO, "RequestRateLimiter window must be > 0, got {:?}", window);
+        ensure!(window > Duration::ZERO, "request_window must be > 0, got {:?}", window);
         ensure!(
             max_requests > 0,
-            "RequestRateLimiter max_requests must be > 0, got {}",
+            "max_requests_per_window must be > 0, got {}",
             max_requests
         );
         let rate = reth_tokio_util::ratelimit::Rate::new(max_requests as u64, window);
@@ -450,11 +450,11 @@ mod tests {
         let err = RequestRateLimiter::new(Duration::ZERO, 1);
         assert!(err.is_err(), "zero window must be rejected");
         let err = err.err().expect("error expected");
-        assert!(err.to_string().contains("window"));
+        assert!(err.to_string().contains("request_window"));
 
         let err = RequestRateLimiter::new(Duration::from_secs(1), 0);
         assert!(err.is_err(), "zero max_requests must be rejected");
         let err = err.err().expect("error expected");
-        assert!(err.to_string().contains("max_requests"));
+        assert!(err.to_string().contains("max_requests_per_window"));
     }
 }


### PR DESCRIPTION
Enforce runtime validation for request rate-limit configuration before driver and limiter initialization, add tests for zero-window and zero-max edge cases in config and reputation paths.