### PR TITLE
fix(taiko-client): tolerate transient L1 sync read failures

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -269,8 +269,8 @@ where
     };
     // Treat a zero build-payload id as an uninitialized origin record so we fail closed and
     // re-submit rather than falsely acknowledging a materialized payload.
-    if origin.build_payload_args_id == [0u8; 8]
-        || origin.build_payload_args_id != expected_payload.l1_origin.build_payload_args_id
+    if origin.build_payload_args_id == [0u8; 8] ||
+        origin.build_payload_args_id != expected_payload.l1_origin.build_payload_args_id
     {
         return Ok(false);
     }
@@ -877,8 +877,7 @@ where
                 .l2_provider
                 .get_block_number()
                 .await
-                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
-                == 0
+                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))? == 0
         };
 
         let resume_head_block_number = resolve_resume_head_block_number(

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -269,8 +269,8 @@ where
     };
     // Treat a zero build-payload id as an uninitialized origin record so we fail closed and
     // re-submit rather than falsely acknowledging a materialized payload.
-    if origin.build_payload_args_id == [0u8; 8] ||
-        origin.build_payload_args_id != expected_payload.l1_origin.build_payload_args_id
+    if origin.build_payload_args_id == [0u8; 8]
+        || origin.build_payload_args_id != expected_payload.l1_origin.build_payload_args_id
     {
         return Ok(false);
     }
@@ -670,7 +670,7 @@ where
     /// - otherwise readiness requires both:
     ///   - `last_block_id_by_batch_id(target)` exists
     ///   - `head_l1_origin` exists and `head >= target_block`
-    pub async fn confirmed_sync_snapshot(&self) -> Result<ConfirmedSyncSnapshot, SyncError> {
+    pub async fn next_proposal_id(&self) -> Result<u64, SyncError> {
         let core_state = self
             .rpc
             .shasta
@@ -679,7 +679,17 @@ where
             .call()
             .await
             .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
-        let target_proposal_id = core_state.nextProposalId.to::<u64>().saturating_sub(1);
+        Ok(core_state.nextProposalId.to::<u64>())
+    }
+
+    /// Return strict confirmed-sync state using a caller-provided target proposal id.
+    ///
+    /// This keeps the L1 core-state read separate from local engine/auth table lookups so callers
+    /// can cache only the L1-derived target while still surfacing local failures immediately.
+    pub async fn confirmed_sync_snapshot_for_target(
+        &self,
+        target_proposal_id: u64,
+    ) -> Result<ConfirmedSyncSnapshot, SyncError> {
         build_confirmed_sync_snapshot(
             target_proposal_id,
             |target| async move {
@@ -694,6 +704,15 @@ where
             },
         )
         .await
+    }
+
+    /// Return strict confirmed-sync state from on-chain core state and custom execution tables.
+    ///
+    /// This fetches the current `nextProposalId` from L1 and then evaluates the local
+    /// engine/auth-derived readiness checks against that target.
+    pub async fn confirmed_sync_snapshot(&self) -> Result<ConfirmedSyncSnapshot, SyncError> {
+        let target_proposal_id = self.next_proposal_id().await?.saturating_sub(1);
+        self.confirmed_sync_snapshot_for_target(target_proposal_id).await
     }
 
     /// Wait until strict preconfirmation ingress gating is satisfied and ingress accepts
@@ -858,8 +877,8 @@ where
                 .l2_provider
                 .get_block_number()
                 .await
-                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))? ==
-                0
+                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
+                == 0
         };
 
         let resume_head_block_number = resolve_resume_head_block_number(

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -877,7 +877,8 @@ where
                 .l2_provider
                 .get_block_number()
                 .await
-                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))? == 0
+                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))? ==
+                0
         };
 
         let resume_head_block_number = resolve_resume_head_block_number(

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -136,6 +136,7 @@ impl<I: InboxReader> EmbeddedDriverClient<I> {
         &self.inbox_reader
     }
 
+    /// Returns the next proposal id, falling back to the cached value during transient L1 errors.
     async fn next_proposal_id_with_cache(&self) -> Result<u64> {
         match self.inbox_reader.get_next_proposal_id().await {
             Ok(id) => {
@@ -158,6 +159,7 @@ impl<I: InboxReader> EmbeddedDriverClient<I> {
         }
     }
 
+    /// Builds a confirmed-sync snapshot using the cached target proposal id when L1 is unreachable.
     async fn confirmed_sync_snapshot_with_cached_target(
         &self,
     ) -> Result<driver::sync::ConfirmedSyncSnapshot> {

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -136,6 +136,40 @@ impl<I: InboxReader> EmbeddedDriverClient<I> {
     pub fn inbox_reader(&self) -> &I {
         &self.inbox_reader
     }
+
+    async fn next_proposal_id_with_cache(&self) -> Result<u64> {
+        match self.inbox_reader.get_next_proposal_id().await {
+            Ok(id) => {
+                *self.cached_next_proposal_id.lock().await = Some(id);
+                Ok(id)
+            }
+            Err(err) => {
+                let cached = self.cached_next_proposal_id.lock().await;
+                if let Some(cached_id) = *cached {
+                    warn!(
+                        error = %err,
+                        cached_next_proposal_id = cached_id,
+                        "L1 unreachable for next_proposal_id, using cached value"
+                    );
+                    Ok(cached_id)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    async fn confirmed_sync_snapshot_with_cached_target(
+        &self,
+    ) -> Result<driver::sync::ConfirmedSyncSnapshot> {
+        let target_proposal_id = self.next_proposal_id_with_cache().await?.saturating_sub(1);
+        driver::sync::build_confirmed_sync_snapshot(
+            target_proposal_id,
+            |target| self.inbox_reader.get_last_block_id_by_batch_id(target),
+            || self.inbox_reader.get_head_l1_origin_block_id(),
+        )
+        .await
+    }
 }
 
 #[async_trait]
@@ -158,10 +192,13 @@ impl<I: InboxReader + 'static> DriverClient for EmbeddedDriverClient<I> {
     /// - Otherwise, readiness requires both:
     ///   - `lastBlockIDByBatchID(nextProposalId - 1)` exists
     ///   - `head_l1_origin` exists and `head >= target_block`.
+    ///
+    /// The L1 target proposal read uses the same cached fallback as `event_sync_tip()` so a
+    /// transient L1 outage during startup does not break readiness once a target has been seen.
     async fn wait_event_sync(&self) -> Result<()> {
         info!("starting wait for driver to sync with L1 inbox events");
         wait_for_confirmed_sync(
-            || self.inbox_reader.confirmed_sync_snapshot(),
+            || self.confirmed_sync_snapshot_with_cached_target(),
             self.wait_event_sync_poll_interval,
         )
         .await?;
@@ -176,35 +213,7 @@ impl<I: InboxReader + 'static> DriverClient for EmbeddedDriverClient<I> {
     /// gossip processing. Local L2 engine calls are always executed and their errors
     /// propagated immediately.
     async fn event_sync_tip(&self) -> Result<U256> {
-        // Try L1 call; on failure, fall back to cached proposal ID.
-        let next_proposal_id = match self.inbox_reader.get_next_proposal_id().await {
-            Ok(id) => {
-                *self.cached_next_proposal_id.lock().await = Some(id);
-                id
-            }
-            Err(err) => {
-                let cached = self.cached_next_proposal_id.lock().await;
-                if let Some(cached_id) = *cached {
-                    warn!(
-                        error = %err,
-                        cached_next_proposal_id = cached_id,
-                        "L1 unreachable for next_proposal_id, using cached value"
-                    );
-                    cached_id
-                } else {
-                    return Err(err);
-                }
-            }
-        };
-
-        // L2 engine calls — always execute, propagate errors immediately.
-        let target_proposal_id = next_proposal_id.saturating_sub(1);
-        let snapshot = driver::sync::build_confirmed_sync_snapshot(
-            target_proposal_id,
-            |target| self.inbox_reader.get_last_block_id_by_batch_id(target),
-            || self.inbox_reader.get_head_l1_origin_block_id(),
-        )
-        .await?;
+        let snapshot = self.confirmed_sync_snapshot_with_cached_target().await?;
         super::traits::resolve_event_sync_tip(&snapshot)
     }
 
@@ -492,5 +501,34 @@ mod tests {
         inbox_reader.set_fail_l1(true);
         let result = client.event_sync_tip().await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_wait_event_sync_uses_cache_on_l1_failure() {
+        let inbox_reader = FailableInboxReader::new(5, Some(99));
+        let (input_tx, _) = mpsc::channel::<PreconfirmationInput>(16);
+        let (_, preconf_tip_rx) = watch::channel(U256::ZERO);
+        let client = EmbeddedDriverClient::new_with_poll_interval(
+            input_tx,
+            preconf_tip_rx,
+            inbox_reader.clone(),
+            Duration::from_millis(10),
+        );
+
+        let wait_client = client.clone();
+        let wait_handle = tokio::spawn(async move { wait_client.wait_event_sync().await });
+
+        tokio::time::sleep(Duration::from_millis(15)).await;
+        inbox_reader.set_fail_l1(true);
+        inbox_reader.inner.set_head_l1_origin(Some(100));
+
+        let result = tokio::time::timeout(Duration::from_millis(120), wait_handle)
+            .await
+            .expect("wait_event_sync should complete before timeout")
+            .expect("wait_event_sync task should not panic");
+        assert!(
+            result.is_ok(),
+            "cached target should keep wait_event_sync alive during L1 outages"
+        );
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -1,13 +1,14 @@
 //! Embedded driver client for direct in-process communication via channels.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::U256;
 use alloy_provider::Provider;
 use async_trait::async_trait;
 use rpc::client::Client;
-use tokio::sync::{mpsc, watch};
-use tracing::info;
+use tokio::sync::{Mutex, mpsc, watch};
+use tracing::{info, warn};
 
 use crate::error::{DriverApiError, Result};
 
@@ -95,6 +96,9 @@ pub struct EmbeddedDriverClient<I: InboxReader> {
     inbox_reader: I,
     /// Poll interval for `wait_event_sync`.
     wait_event_sync_poll_interval: Duration,
+    /// Cached next_proposal_id for fallback during transient L1 failures.
+    /// Only the L1 contract call is cached — L2 engine calls are always executed live.
+    cached_next_proposal_id: Arc<Mutex<Option<u64>>>,
 }
 
 impl<I: InboxReader> EmbeddedDriverClient<I> {
@@ -119,7 +123,13 @@ impl<I: InboxReader> EmbeddedDriverClient<I> {
         inbox_reader: I,
         wait_event_sync_poll_interval: Duration,
     ) -> Self {
-        Self { input_tx, preconf_tip_rx, inbox_reader, wait_event_sync_poll_interval }
+        Self {
+            input_tx,
+            preconf_tip_rx,
+            inbox_reader,
+            wait_event_sync_poll_interval,
+            cached_next_proposal_id: Arc::new(Mutex::new(None)),
+        }
     }
 
     /// Returns a reference to the inbox reader.
@@ -160,8 +170,41 @@ impl<I: InboxReader + 'static> DriverClient for EmbeddedDriverClient<I> {
     }
 
     /// Returns the current confirmed event-sync L2 block number.
+    ///
+    /// The L1 contract call (`get_next_proposal_id`) is attempted first. On failure,
+    /// the last known proposal ID is used so that a transient L1 outage does not stall
+    /// gossip processing. Local L2 engine calls are always executed and their errors
+    /// propagated immediately.
     async fn event_sync_tip(&self) -> Result<U256> {
-        let snapshot = self.inbox_reader.confirmed_sync_snapshot().await?;
+        // Try L1 call; on failure, fall back to cached proposal ID.
+        let next_proposal_id = match self.inbox_reader.get_next_proposal_id().await {
+            Ok(id) => {
+                *self.cached_next_proposal_id.lock().await = Some(id);
+                id
+            }
+            Err(err) => {
+                let cached = self.cached_next_proposal_id.lock().await;
+                if let Some(cached_id) = *cached {
+                    warn!(
+                        error = %err,
+                        cached_next_proposal_id = cached_id,
+                        "L1 unreachable for next_proposal_id, using cached value"
+                    );
+                    cached_id
+                } else {
+                    return Err(err);
+                }
+            }
+        };
+
+        // L2 engine calls — always execute, propagate errors immediately.
+        let target_proposal_id = next_proposal_id.saturating_sub(1);
+        let snapshot = driver::sync::build_confirmed_sync_snapshot(
+            target_proposal_id,
+            |target| self.inbox_reader.get_last_block_id_by_batch_id(target),
+            || self.inbox_reader.get_head_l1_origin_block_id(),
+        )
+        .await?;
         super::traits::resolve_event_sync_tip(&snapshot)
     }
 
@@ -364,5 +407,90 @@ mod tests {
         preconf_tip_tx.send(U256::from(42)).unwrap();
         let tip = client.event_sync_tip().await.expect("genesis returns zero despite preconf tip");
         assert_eq!(tip, U256::ZERO);
+    }
+
+    /// Mock inbox reader that can simulate L1 failures on get_next_proposal_id.
+    #[derive(Clone)]
+    struct FailableInboxReader {
+        inner: MockInboxReader,
+        fail_l1: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl FailableInboxReader {
+        fn new(next_proposal_id: u64, head_l1_origin: Option<u64>) -> Self {
+            Self {
+                inner: MockInboxReader::new(next_proposal_id, Some(100), head_l1_origin),
+                fail_l1: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            }
+        }
+
+        fn set_fail_l1(&self, fail: bool) {
+            self.fail_l1.store(fail, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl InboxReader for FailableInboxReader {
+        async fn get_next_proposal_id(&self) -> Result<u64> {
+            if self.fail_l1.load(Ordering::SeqCst) {
+                Err(crate::error::DriverApiError::EventSyncTipUnknown.into())
+            } else {
+                self.inner.get_next_proposal_id().await
+            }
+        }
+
+        async fn get_last_block_id_by_batch_id(&self, proposal_id: u64) -> Result<Option<u64>> {
+            self.inner.get_last_block_id_by_batch_id(proposal_id).await
+        }
+
+        async fn get_head_l1_origin_block_id(&self) -> Result<Option<u64>> {
+            self.inner.get_head_l1_origin_block_id().await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_event_sync_tip_uses_cache_on_l1_failure() {
+        let inbox_reader = FailableInboxReader::new(5, Some(42));
+        let (input_tx, _) = mpsc::channel::<PreconfirmationInput>(16);
+        let (_, preconf_tip_rx) = watch::channel(U256::ZERO);
+        let client = EmbeddedDriverClient::new_with_poll_interval(
+            input_tx,
+            preconf_tip_rx,
+            inbox_reader.clone(),
+            Duration::from_millis(10),
+        );
+
+        // First call succeeds and populates the cache.
+        let tip = client.event_sync_tip().await.unwrap();
+        assert_eq!(tip, U256::from(42));
+
+        // Simulate L1 failure — should fall back to cached proposal ID.
+        inbox_reader.set_fail_l1(true);
+        let tip = client.event_sync_tip().await.unwrap();
+        assert_eq!(tip, U256::from(42));
+
+        // L1 recovers — should use fresh value again.
+        inbox_reader.set_fail_l1(false);
+        inbox_reader.inner.set_head_l1_origin(Some(99));
+        let tip = client.event_sync_tip().await.unwrap();
+        assert_eq!(tip, U256::from(99));
+    }
+
+    #[tokio::test]
+    async fn test_event_sync_tip_propagates_error_when_cache_cold() {
+        let inbox_reader = FailableInboxReader::new(5, Some(42));
+        let (input_tx, _) = mpsc::channel::<PreconfirmationInput>(16);
+        let (_, preconf_tip_rx) = watch::channel(U256::ZERO);
+        let client = EmbeddedDriverClient::new_with_poll_interval(
+            input_tx,
+            preconf_tip_rx,
+            inbox_reader.clone(),
+            Duration::from_millis(10),
+        );
+
+        // L1 fails before any successful call — no cache, should propagate error.
+        inbox_reader.set_fail_l1(true);
+        let result = client.event_sync_tip().await;
+        assert!(result.is_err());
     }
 }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/embedded.rs
@@ -1,7 +1,6 @@
 //! Embedded driver client for direct in-process communication via channels.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::U256;
 use alloy_provider::Provider;

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -147,8 +147,15 @@ pub trait PreconfirmationIngress: Send + Sync {
         payload: PreconfPayload,
     ) -> Result<(), DriverError>;
 
-    /// Return strict confirmed-sync state derived from inbox core state + custom tables.
-    async fn confirmed_sync_snapshot(&self) -> Result<ConfirmedSyncSnapshot, DriverError>;
+    /// Return the next proposal id from the L1 inbox contract.
+    async fn next_proposal_id(&self) -> Result<u64, DriverError>;
+
+    /// Return strict confirmed-sync state for the provided target proposal id using local
+    /// engine/auth state only.
+    async fn confirmed_sync_snapshot_for_target(
+        &self,
+        target_proposal_id: u64,
+    ) -> Result<ConfirmedSyncSnapshot, DriverError>;
 }
 
 #[async_trait]
@@ -164,9 +171,20 @@ where
         self.submit_preconfirmation_payload(payload).await
     }
 
-    /// Return strict confirmed-sync state derived from inbox core state + custom tables.
-    async fn confirmed_sync_snapshot(&self) -> Result<ConfirmedSyncSnapshot, DriverError> {
-        EventSyncer::confirmed_sync_snapshot(self).await.map_err(DriverError::from)
+    /// Return the next proposal id from the L1 inbox contract.
+    async fn next_proposal_id(&self) -> Result<u64, DriverError> {
+        EventSyncer::next_proposal_id(self).await.map_err(DriverError::from)
+    }
+
+    /// Return strict confirmed-sync state for the provided target proposal id using local
+    /// engine/auth state only.
+    async fn confirmed_sync_snapshot_for_target(
+        &self,
+        target_proposal_id: u64,
+    ) -> Result<ConfirmedSyncSnapshot, DriverError> {
+        EventSyncer::confirmed_sync_snapshot_for_target(self, target_proposal_id)
+            .await
+            .map_err(DriverError::from)
     }
 }
 
@@ -186,6 +204,8 @@ where
     min_base_fee_to_clamp: OnceCell<u64>,
     /// Poll interval for confirmed-sync checks while waiting for event sync readiness.
     wait_event_sync_poll_interval: Duration,
+    /// Cached next proposal id for fallback during transient L1 failures.
+    cached_next_proposal_id: Arc<tokio::sync::Mutex<Option<u64>>>,
 }
 
 impl<E, P> EventSyncerDriverClient<E, P>
@@ -206,6 +226,7 @@ where
             l2_provider,
             min_base_fee_to_clamp: OnceCell::new(),
             wait_event_sync_poll_interval,
+            cached_next_proposal_id: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 
@@ -239,6 +260,38 @@ where
             })
             .await?;
         Ok(*min_base_fee_to_clamp)
+    }
+
+    async fn next_proposal_id_with_cache(&self) -> ClientResult<u64> {
+        match self.event_syncer.next_proposal_id().await {
+            Ok(id) => {
+                *self.cached_next_proposal_id.lock().await = Some(id);
+                Ok(id)
+            }
+            Err(err) => {
+                let cached = self.cached_next_proposal_id.lock().await;
+                if let Some(id) = *cached {
+                    warn!(
+                        error = %err,
+                        cached_next_proposal_id = id,
+                        "next_proposal_id failed, using cached value"
+                    );
+                    Ok(id)
+                } else {
+                    Err(DriverApiError::Driver(err).into())
+                }
+            }
+        }
+    }
+
+    async fn confirmed_sync_snapshot_with_cached_target(
+        &self,
+    ) -> ClientResult<ConfirmedSyncSnapshot> {
+        let target_proposal_id = self.next_proposal_id_with_cache().await?.saturating_sub(1);
+        self.event_syncer
+            .confirmed_sync_snapshot_for_target(target_proposal_id)
+            .await
+            .map_err(|err| DriverApiError::Driver(err).into())
     }
 }
 
@@ -321,9 +374,7 @@ where
     async fn wait_event_sync(&self) -> ClientResult<()> {
         info!("starting wait for driver to sync with L1 inbox events");
         wait_for_confirmed_sync(
-            || async {
-                self.event_syncer.confirmed_sync_snapshot().await.map_err(DriverApiError::Driver)
-            },
+            || async { self.confirmed_sync_snapshot_with_cached_target().await },
             self.wait_event_sync_poll_interval,
         )
         .await?;
@@ -332,9 +383,11 @@ where
     }
 
     /// Get the current event syncer tip block number.
+    ///
+    /// On transient L1 failures, falls back to the last known proposal target while always
+    /// re-running the local engine/auth checks. Local failures are propagated immediately.
     async fn event_sync_tip(&self) -> ClientResult<U256> {
-        let snapshot =
-            self.event_syncer.confirmed_sync_snapshot().await.map_err(DriverApiError::Driver)?;
+        let snapshot = self.confirmed_sync_snapshot_with_cached_target().await?;
         super::traits::resolve_event_sync_tip(&snapshot)
     }
 
@@ -396,6 +449,8 @@ mod tests {
         ready: Arc<AtomicBool>,
         tip: Arc<AtomicU64>,
         target_proposal_id: u64,
+        fail_next_proposal_id: Arc<AtomicBool>,
+        fail_local_snapshot: Arc<AtomicBool>,
     }
 
     impl FakeIngress {
@@ -405,6 +460,8 @@ mod tests {
                 ready: Arc::new(AtomicBool::new(ready)),
                 tip: Arc::new(AtomicU64::new(tip)),
                 target_proposal_id: 1,
+                fail_next_proposal_id: Arc::new(AtomicBool::new(false)),
+                fail_local_snapshot: Arc::new(AtomicBool::new(false)),
             }
         }
 
@@ -424,15 +481,26 @@ mod tests {
             Ok(())
         }
 
-        async fn confirmed_sync_snapshot(
+        async fn next_proposal_id(&self) -> Result<u64, driver::DriverError> {
+            if self.fail_next_proposal_id.load(Ordering::SeqCst) {
+                return Err(driver::DriverError::PreconfIngressNotReady);
+            }
+            Ok(self.target_proposal_id.saturating_add(1))
+        }
+
+        async fn confirmed_sync_snapshot_for_target(
             &self,
+            target_proposal_id: u64,
         ) -> Result<ConfirmedSyncSnapshot, driver::DriverError> {
+            if self.fail_local_snapshot.load(Ordering::SeqCst) {
+                return Err(driver::DriverError::PreconfIngressNotReady);
+            }
             let tip = self.tip.load(Ordering::SeqCst);
             let head_l1_origin_block_id = (tip != u64::MAX).then_some(tip);
             let target_block =
                 if self.ready.load(Ordering::SeqCst) { Some(0) } else { Some(u64::MAX - 1) };
             Ok(ConfirmedSyncSnapshot::new(
-                self.target_proposal_id,
+                target_proposal_id,
                 target_block,
                 head_l1_origin_block_id,
             ))
@@ -600,6 +668,61 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn event_syncer_driver_client_does_not_fallback_on_local_snapshot_error() {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let inbox = bindings::inbox::Inbox::InboxInstance::new(Address::ZERO, provider);
+
+        let ingress = Arc::new(FakeIngress::new(true, 7));
+        let client = EventSyncerDriverClient::new_with_components(
+            ingress.clone(),
+            inbox,
+            Arc::new(NoopL2Provider),
+        );
+
+        // Warm the cache with a successful read.
+        assert_eq!(client.event_sync_tip().await.unwrap(), U256::from(7));
+
+        // A local snapshot failure should be propagated, not masked by cached tip data.
+        ingress.fail_local_snapshot.store(true, Ordering::SeqCst);
+        let err = client
+            .event_sync_tip()
+            .await
+            .expect_err("local snapshot failures must not fall back to cached tips");
+        assert!(matches!(
+            err,
+            crate::PreconfirmationClientError::DriverInterface(DriverApiError::Driver(
+                driver::DriverError::PreconfIngressNotReady
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn event_syncer_driver_client_uses_cached_target_on_l1_failure() {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let inbox = bindings::inbox::Inbox::InboxInstance::new(Address::ZERO, provider);
+
+        let ingress = Arc::new(FakeIngress::new(true, 7));
+        let client = EventSyncerDriverClient::new_with_components(
+            ingress.clone(),
+            inbox,
+            Arc::new(NoopL2Provider),
+        );
+
+        assert_eq!(client.event_sync_tip().await.unwrap(), U256::from(7));
+
+        ingress.fail_next_proposal_id.store(true, Ordering::SeqCst);
+        ingress.tip.store(9, Ordering::SeqCst);
+
+        let tip = client
+            .event_sync_tip()
+            .await
+            .expect("cached next_proposal_id should keep L1 outages from stalling tip reads");
+        assert_eq!(tip, U256::from(9));
+    }
+
     struct NoopL2Provider;
 
     #[async_trait::async_trait]
@@ -633,6 +756,8 @@ mod tests {
                 ready: Arc::new(AtomicBool::new(true)),
                 tip: Arc::new(AtomicU64::new(0)),
                 target_proposal_id: 1,
+                fail_next_proposal_id: Arc::new(AtomicBool::new(false)),
+                fail_local_snapshot: Arc::new(AtomicBool::new(false)),
             }),
             inbox,
             Arc::new(NoopL2Provider),
@@ -664,6 +789,8 @@ mod tests {
                 ready: ready.clone(),
                 tip: Arc::new(AtomicU64::new(5)),
                 target_proposal_id: 1,
+                fail_next_proposal_id: Arc::new(AtomicBool::new(false)),
+                fail_local_snapshot: Arc::new(AtomicBool::new(false)),
             }),
             inbox,
             Arc::new(NoopL2Provider),

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs
@@ -262,6 +262,7 @@ where
         Ok(*min_base_fee_to_clamp)
     }
 
+    /// Returns the next proposal id, falling back to the cached value during transient L1 errors.
     async fn next_proposal_id_with_cache(&self) -> ClientResult<u64> {
         match self.event_syncer.next_proposal_id().await {
             Ok(id) => {
@@ -284,6 +285,7 @@ where
         }
     }
 
+    /// Builds a confirmed-sync snapshot using the cached target proposal id when L1 is unreachable.
     async fn confirmed_sync_snapshot_with_cached_target(
         &self,
     ) -> ClientResult<ConfirmedSyncSnapshot> {

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
@@ -85,8 +85,9 @@ pub fn resolve_event_sync_tip(snapshot: &ConfirmedSyncSnapshot) -> ClientResult<
 }
 
 /// Maximum consecutive snapshot errors before propagating during startup.
-/// This allows transient L1 blips (a few missed polls) without masking persistent
-/// local failures (geth/auth down).
+/// This allows transient L1 blips without masking persistent local failures
+/// (geth/auth down). The worst-case retry window is roughly
+/// `MAX_CONSECUTIVE_SNAPSHOT_ERRORS * poll_interval`.
 const MAX_CONSECUTIVE_SNAPSHOT_ERRORS: u32 = 5;
 
 /// Wait for strict confirmed-sync readiness by polling a caller-provided snapshot source.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/traits.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types::Header as RpcHeader;
 use async_trait::async_trait;
 use driver::sync::{ConfirmedSyncSnapshot, build_confirmed_sync_snapshot};
 use tokio::time::sleep;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::error::Result as ClientResult;
 
@@ -84,7 +84,16 @@ pub fn resolve_event_sync_tip(snapshot: &ConfirmedSyncSnapshot) -> ClientResult<
     }
 }
 
+/// Maximum consecutive snapshot errors before propagating during startup.
+/// This allows transient L1 blips (a few missed polls) without masking persistent
+/// local failures (geth/auth down).
+const MAX_CONSECUTIVE_SNAPSHOT_ERRORS: u32 = 5;
+
 /// Wait for strict confirmed-sync readiness by polling a caller-provided snapshot source.
+///
+/// Transient errors are retried up to [`MAX_CONSECUTIVE_SNAPSHOT_ERRORS`] times.
+/// If the error persists beyond that, it is propagated—this avoids masking
+/// persistent local failures (e.g. broken geth/auth) as transient L1 outages.
 pub(crate) async fn wait_for_confirmed_sync<F, Fut, E>(
     mut snapshot: F,
     poll_interval: Duration,
@@ -92,9 +101,33 @@ pub(crate) async fn wait_for_confirmed_sync<F, Fut, E>(
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<ConfirmedSyncSnapshot, E>>,
+    E: std::fmt::Display,
 {
+    let mut consecutive_errors: u32 = 0;
     loop {
-        let sync_snapshot = snapshot().await?;
+        let sync_snapshot = match snapshot().await {
+            Ok(s) => {
+                consecutive_errors = 0;
+                s
+            }
+            Err(err) => {
+                consecutive_errors += 1;
+                if consecutive_errors > MAX_CONSECUTIVE_SNAPSHOT_ERRORS {
+                    warn!(
+                        consecutive_errors,
+                        "confirmed sync snapshot failed repeatedly, propagating: {err}"
+                    );
+                    return Err(err);
+                }
+                warn!(
+                    consecutive_errors,
+                    max = MAX_CONSECUTIVE_SNAPSHOT_ERRORS,
+                    "confirmed sync snapshot failed, retrying: {err}"
+                );
+                sleep(poll_interval).await;
+                continue;
+            }
+        };
 
         if sync_snapshot.is_ready() {
             info!(

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -197,6 +197,7 @@ func (d *Driver) Start() error {
 		}()
 
 		go d.preconfBlockServer.LatestSeenProposalEventLoop(d.ctx)
+		d.preconfBlockServer.StartBackgroundL1Refresh(d.ctx)
 	}
 
 	if d.p2pNode != nil && d.p2pNode.Dv5Udp() != nil {

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -109,7 +109,7 @@ func (s *DriverTestSuite) assertPreconfImportResult(
 	revertedNumber uint64,
 	revertedHash common.Hash,
 	importedNumber uint64,
-	importedHash common.Hash,
+	importedHash *common.Hash,
 ) {
 	l2Head, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -121,7 +121,12 @@ func (s *DriverTestSuite) assertPreconfImportResult(
 	}
 
 	s.Equal(importedNumber, l2Head.Number().Uint64())
-	s.Equal(importedHash, l2Head.Hash())
+	if importedHash != nil {
+		s.Equal(*importedHash, l2Head.Hash())
+		return
+	}
+
+	s.NotEqual(revertedHash, l2Head.Hash())
 }
 
 func (s *DriverTestSuite) TestName() {
@@ -1166,7 +1171,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 		l2Head1.Number().Uint64(),
 		l2Head1.Hash(),
 		l2Head2.Number.Uint64(),
-		l2Head2.Hash(),
+		nil,
 	)
 }
 
@@ -1247,12 +1252,13 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 	s.Nil(s.d.preconfBlockServer.ImportPendingBlocksFromCache(context.Background()))
 
 	// ImportPendingBlocksFromCache only imports once the local engine has finished syncing.
+	expectedImportedHash := l2Head2.Hash()
 	s.assertPreconfImportResult(
 		localProgress.SyncProgress != nil,
 		l2Head1.Number().Uint64(),
 		l2Head1.Hash(),
 		l2Head2.Number.Uint64(),
-		l2Head2.Hash(),
+		&expectedImportedHash,
 	)
 
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -104,6 +104,26 @@ func (s *DriverTestSuite) setPreconfL1SyncCache(blockID uint64) {
 	s.d.preconfBlockServer.SetCachedHighestOriginBlockID(new(big.Int).SetUint64(blockID))
 }
 
+func (s *DriverTestSuite) assertPreconfImportResult(
+	wasSyncing bool,
+	revertedNumber uint64,
+	revertedHash common.Hash,
+	importedNumber uint64,
+	importedHash common.Hash,
+) {
+	l2Head, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
+	s.Nil(err)
+
+	if wasSyncing {
+		s.Equal(revertedNumber, l2Head.Number().Uint64())
+		s.Equal(revertedHash, l2Head.Hash())
+		return
+	}
+
+	s.Equal(importedNumber, l2Head.Number().Uint64())
+	s.Equal(importedHash, l2Head.Hash())
+}
+
 func (s *DriverTestSuite) TestName() {
 	s.Equal("driver", s.d.Name())
 }
@@ -1136,11 +1156,18 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 
 	block = getBlock(l2Head1.Number().Uint64() + 2)
 	s.NotNil(block)
+	localProgress, err := s.d.rpc.L2ExecutionEngineSyncProgressLocal(context.Background())
+	s.Nil(err)
 	insertPayloadFromBlock(block, false)
 
-	l2Head5, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
-	s.Nil(err)
-	s.Equal(l2Head2.Number.Uint64(), l2Head5.Number().Uint64())
+	// Importing cached preconfirmation blocks is only allowed once the local engine is not syncing.
+	s.assertPreconfImportResult(
+		localProgress.SyncProgress != nil,
+		l2Head1.Number().Uint64(),
+		l2Head1.Hash(),
+		l2Head2.Number.Uint64(),
+		l2Head2.Hash(),
+	)
 }
 
 func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
@@ -1215,12 +1242,18 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 	// Simulate the first post-beacon event sync enabling preconf imports.
 	s.d.preconfBlockServer.SetSyncReady(true)
 	s.setPreconfL1SyncCache(headL1Origin.BlockID.Uint64())
+	localProgress, err := s.d.rpc.L2ExecutionEngineSyncProgressLocal(context.Background())
+	s.Nil(err)
 	s.Nil(s.d.preconfBlockServer.ImportPendingBlocksFromCache(context.Background()))
 
-	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
-	s.Nil(err)
-	s.Equal(l2Head2.Number.Uint64(), l2Head4.Number.Uint64())
-	s.Equal(l2Head2.Hash(), l2Head4.Hash())
+	// ImportPendingBlocksFromCache only imports once the local engine has finished syncing.
+	s.assertPreconfImportResult(
+		localProgress.SyncProgress != nil,
+		l2Head1.Number().Uint64(),
+		l2Head1.Hash(),
+		l2Head2.Number.Uint64(),
+		l2Head2.Hash(),
+	)
 
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
 	s.Nil(err)

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -1140,9 +1140,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 
 	l2Head5, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
-	// The last missing ancestor is still replayed through OnUnsafeL2Payload, which now keeps
-	// payloads cached while the local engine reports sync progress after the reset.
-	s.Equal(l2Head1.Number().Uint64(), l2Head5.Number().Uint64())
+	s.Equal(l2Head2.Number.Uint64(), l2Head5.Number().Uint64())
 }
 
 func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
@@ -1221,11 +1219,8 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 
 	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
-	// ImportPendingBlocksFromCache replays the latest cached payload through OnUnsafeL2Payload.
-	// That path stays fail-closed while the local engine is still syncing after the reset, so
-	// cached preconfirmation blocks remain queued until local sync clears.
-	s.Equal(l2Head1.Number().Uint64(), l2Head4.Number.Uint64())
-	s.Equal(l2Head1.Hash(), l2Head4.Hash())
+	s.Equal(l2Head2.Number.Uint64(), l2Head4.Number.Uint64())
+	s.Equal(l2Head2.Hash(), l2Head4.Hash())
 
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
 	s.Nil(err)

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -1140,7 +1140,9 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 
 	l2Head5, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
-	s.Equal(l2Head2.Number.Uint64(), l2Head5.Number().Uint64())
+	// The last missing ancestor is still replayed through OnUnsafeL2Payload, which now keeps
+	// payloads cached while the local engine reports sync progress after the reset.
+	s.Equal(l2Head1.Number().Uint64(), l2Head5.Number().Uint64())
 }
 
 func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
@@ -1219,8 +1221,11 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 
 	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
-	s.Equal(l2Head2.Number.Uint64(), l2Head4.Number.Uint64())
-	s.Equal(l2Head2.Hash(), l2Head4.Hash())
+	// ImportPendingBlocksFromCache replays the latest cached payload through OnUnsafeL2Payload.
+	// That path stays fail-closed while the local engine is still syncing after the reset, so
+	// cached preconfirmation blocks remain queued until local sync clears.
+	s.Equal(l2Head1.Number().Uint64(), l2Head4.Number.Uint64())
+	s.Equal(l2Head1.Hash(), l2Head4.Hash())
 
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
 	s.Nil(err)

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -100,6 +100,10 @@ func (s *DriverTestSuite) SetupTest() {
 	s.InitProposer()
 }
 
+func (s *DriverTestSuite) primePreconfL1SyncCache() {
+	s.Nil(s.d.preconfBlockServer.PrimeL1SyncCache(context.Background()))
+}
+
 func (s *DriverTestSuite) TestName() {
 	s.Equal("driver", s.d.Name())
 }
@@ -589,6 +593,7 @@ func (s *DriverTestSuite) TestInsertPreconfBlocksNotReorg() {
 func (s *DriverTestSuite) TestOnUnsafeL2Payload() {
 	// Propose some valid L2 blocks
 	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().EventSyncer())
+	s.primePreconfL1SyncCache()
 
 	l2Head1, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -837,6 +842,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
 	s.Nil(err)
 	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
+	s.primePreconfL1SyncCache()
 
 	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -976,6 +982,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
 	s.Nil(err)
 	s.Equal(l2Head1.Number().Uint64(), headL1Origin.BlockID.Uint64())
+	s.primePreconfL1SyncCache()
 
 	l2Head3, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -1207,6 +1214,7 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 
 	// Simulate the first post-beacon event sync enabling preconf imports.
 	s.d.preconfBlockServer.SetSyncReady(true)
+	s.primePreconfL1SyncCache()
 	s.Nil(s.d.preconfBlockServer.ImportPendingBlocksFromCache(context.Background()))
 
 	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -100,8 +100,8 @@ func (s *DriverTestSuite) SetupTest() {
 	s.InitProposer()
 }
 
-func (s *DriverTestSuite) primePreconfL1SyncCache() {
-	s.Nil(s.d.preconfBlockServer.PrimeL1SyncCache(context.Background()))
+func (s *DriverTestSuite) setPreconfL1SyncCache(blockID uint64) {
+	s.d.preconfBlockServer.SetCachedHighestOriginBlockID(new(big.Int).SetUint64(blockID))
 }
 
 func (s *DriverTestSuite) TestName() {
@@ -593,10 +593,10 @@ func (s *DriverTestSuite) TestInsertPreconfBlocksNotReorg() {
 func (s *DriverTestSuite) TestOnUnsafeL2Payload() {
 	// Propose some valid L2 blocks
 	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().EventSyncer())
-	s.primePreconfL1SyncCache()
 
 	l2Head1, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
+	s.setPreconfL1SyncCache(l2Head1.Number.Uint64())
 
 	l1Head, err := s.d.rpc.L1.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -842,7 +842,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
 	s.Nil(err)
 	s.Equal(l2Head1.Number.Uint64(), headL1Origin.BlockID.Uint64())
-	s.primePreconfL1SyncCache()
+	s.setPreconfL1SyncCache(headL1Origin.BlockID.Uint64())
 
 	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -982,7 +982,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 	headL1Origin, err = s.RPCClient.L2.HeadL1Origin(context.Background())
 	s.Nil(err)
 	s.Equal(l2Head1.Number().Uint64(), headL1Origin.BlockID.Uint64())
-	s.primePreconfL1SyncCache()
+	s.setPreconfL1SyncCache(headL1Origin.BlockID.Uint64())
 
 	l2Head3, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -1214,7 +1214,7 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 
 	// Simulate the first post-beacon event sync enabling preconf imports.
 	s.d.preconfBlockServer.SetSyncReady(true)
-	s.primePreconfL1SyncCache()
+	s.setPreconfL1SyncCache(headL1Origin.BlockID.Uint64())
 	s.Nil(s.d.preconfBlockServer.ImportPendingBlocksFromCache(context.Background()))
 
 	l2Head4, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -100,10 +100,6 @@ type PreconfBlockAPIServer struct {
 	cachedHighestOriginBlockID   *big.Int
 	cachedHighestOriginBlockIDMu sync.RWMutex
 
-	// Allow all active operator sequencer addresses in P2P validation.
-	allowAllSequencers          bool
-	allActiveSequencerAddresses []common.Address
-
 	// Mutex for P2P message handlers
 	mutex sync.Mutex
 }
@@ -244,7 +240,8 @@ func (s *PreconfBlockAPIServer) Shutdown(ctx context.Context) error {
 // to call L1 directly.
 func (s *PreconfBlockAPIServer) StartBackgroundL1Refresh(ctx context.Context) {
 	go func() {
-		// Prime the cache immediately so it is warm before the first gossip message arrives.
+		// Prime the cache immediately. Until the first successful refresh populates the cache,
+		// ingress keeps payloads cached and does not import them.
 		if highestOriginBlockID, err := s.rpc.FetchHighestOriginBlockIDFromL1(ctx); err != nil {
 			log.Warn("Initial L1 sync cache prime failed", "error", err)
 		} else {
@@ -253,7 +250,7 @@ func (s *PreconfBlockAPIServer) StartBackgroundL1Refresh(ctx context.Context) {
 			s.cachedHighestOriginBlockIDMu.Unlock()
 		}
 
-		ticker := time.NewTicker(10 * time.Second)
+		ticker := time.NewTicker(monitorLatestProposalOnChainInterval)
 		defer ticker.Stop()
 
 		for {
@@ -272,6 +269,22 @@ func (s *PreconfBlockAPIServer) StartBackgroundL1Refresh(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+func shouldCachePayloadForSync(localProgress *rpc.L2SyncProgress, highestOriginBlockID *big.Int) bool {
+	if localProgress == nil {
+		return true
+	}
+
+	if localProgress.SyncProgress != nil {
+		return true
+	}
+
+	if highestOriginBlockID == nil || localProgress.CurrentBlockID == nil {
+		return true
+	}
+
+	return localProgress.CurrentBlockID.Cmp(highestOriginBlockID) < 0
 }
 
 // configureRoutes contains all routes which will be used by the HTTP / WS server.
@@ -380,9 +393,15 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 	highestOriginBlockID := s.cachedHighestOriginBlockID
 	s.cachedHighestOriginBlockIDMu.RUnlock()
 
-	if highestOriginBlockID != nil &&
-		localProgress.CurrentBlockID != nil &&
-		localProgress.CurrentBlockID.Cmp(highestOriginBlockID) < 0 {
+	if shouldCachePayloadForSync(localProgress, highestOriginBlockID) {
+		if highestOriginBlockID == nil {
+			log.Debug(
+				"L1-derived sync target unavailable, caching preconfirmation block until cache is primed",
+				"peer", from,
+				"blockID", uint64(msg.ExecutionPayload.BlockNumber),
+				"hash", msg.ExecutionPayload.BlockHash.Hex(),
+			)
+		}
 		s.tryPutEnvelopeIntoCache(msg, from)
 		return nil
 	}
@@ -850,14 +869,21 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 				}
 
 				// Use cached L1-derived highest origin block ID for staleness check.
-				// This is best-effort: if no cached value exists, skip the staleness filter.
+				// This is fail-closed: if no cached value exists, skip the request until the
+				// background refresher has primed the L1-derived target.
 				s.cachedHighestOriginBlockIDMu.RLock()
 				cachedTip := s.cachedHighestOriginBlockID
 				s.cachedHighestOriginBlockIDMu.RUnlock()
-				var tip uint64
-				if cachedTip != nil {
-					tip = cachedTip.Uint64()
+
+				if cachedTip == nil {
+					log.Debug(
+						"Skip publishing L2Request until L1-derived sync target cache is primed",
+						"blockID", parentNum,
+						"hash", currentPayload.Payload.ParentHash.Hex(),
+					)
+					return nil
 				}
+				tip := cachedTip.Uint64()
 
 				if tip >= requestSyncMargin && parentNum <= tip-requestSyncMargin {
 					log.Debug(

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -95,6 +95,15 @@ type PreconfBlockAPIServer struct {
 	// Sync readiness gate for preconfirmation inserts.
 	syncReady bool
 
+	// Cached L1-derived sync state, refreshed by a background goroutine.
+	// The hot path (OnUnsafeL2Payload) only reads from this cache—never calls L1 directly.
+	cachedHighestOriginBlockID   *big.Int
+	cachedHighestOriginBlockIDMu sync.RWMutex
+
+	// Allow all active operator sequencer addresses in P2P validation.
+	allowAllSequencers          bool
+	allActiveSequencerAddresses []common.Address
+
 	// Mutex for P2P message handlers
 	mutex sync.Mutex
 }
@@ -229,6 +238,42 @@ func (s *PreconfBlockAPIServer) Shutdown(ctx context.Context) error {
 	return s.echo.Shutdown(ctx)
 }
 
+// StartBackgroundL1Refresh starts a background goroutine that periodically
+// fetches the highest origin block ID from L1 and updates the cache.
+// This keeps the L1-derived sync state warm so the gossip hot path never needs
+// to call L1 directly.
+func (s *PreconfBlockAPIServer) StartBackgroundL1Refresh(ctx context.Context) {
+	go func() {
+		// Prime the cache immediately so it is warm before the first gossip message arrives.
+		if highestOriginBlockID, err := s.rpc.FetchHighestOriginBlockIDFromL1(ctx); err != nil {
+			log.Warn("Initial L1 sync cache prime failed", "error", err)
+		} else {
+			s.cachedHighestOriginBlockIDMu.Lock()
+			s.cachedHighestOriginBlockID = highestOriginBlockID
+			s.cachedHighestOriginBlockIDMu.Unlock()
+		}
+
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				highestOriginBlockID, err := s.rpc.FetchHighestOriginBlockIDFromL1(ctx)
+				if err != nil {
+					log.Debug("Background L1 sync refresh failed", "error", err)
+					continue
+				}
+				s.cachedHighestOriginBlockIDMu.Lock()
+				s.cachedHighestOriginBlockID = highestOriginBlockID
+				s.cachedHighestOriginBlockIDMu.Unlock()
+			}
+		}
+	}()
+}
+
 // configureRoutes contains all routes which will be used by the HTTP / WS server.
 func (s *PreconfBlockAPIServer) configureRoutes() {
 	// HTTP routes
@@ -318,13 +363,26 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 		return nil
 	}
 
-	// Check if the L2 execution engine is syncing from L1.
-	progress, err := s.rpc.L2ExecutionEngineSyncProgress(ctx)
+	// Check local L2 sync state (no L1 dependency — always works if geth is up).
+	localProgress, err := s.rpc.L2ExecutionEngineSyncProgressLocal(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get L2 execution engine sync progress: %w", err)
+		return fmt.Errorf("failed to get local L2 sync progress: %w", err)
 	}
 
-	if progress.IsSyncing() {
+	// If L2 EE is beacon-syncing, cache and return.
+	if localProgress.SyncProgress != nil {
+		s.tryPutEnvelopeIntoCache(msg, from)
+		return nil
+	}
+
+	// L1-derived sync check: read from background-refreshed cache only (no L1 call on hot path).
+	s.cachedHighestOriginBlockIDMu.RLock()
+	highestOriginBlockID := s.cachedHighestOriginBlockID
+	s.cachedHighestOriginBlockIDMu.RUnlock()
+
+	if highestOriginBlockID != nil &&
+		localProgress.CurrentBlockID != nil &&
+		localProgress.CurrentBlockID.Cmp(highestOriginBlockID) < 0 {
 		s.tryPutEnvelopeIntoCache(msg, from)
 		return nil
 	}
@@ -762,12 +820,12 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 			// If the parent payload is not found in the cache and chain is not syncing,
 			// we publish a request to the P2P network.
 			if !s.blockRequestsCache.Contains(currentPayload.Payload.ParentHash) {
-				progress, err := s.rpc.L2ExecutionEngineSyncProgress(ctx)
+				localProgress, err := s.rpc.L2ExecutionEngineSyncProgressLocal(ctx)
 				if err != nil {
-					return fmt.Errorf("failed to get L2 execution engine sync progress: %w", err)
+					return fmt.Errorf("failed to get local L2 sync progress: %w", err)
 				}
 
-				if progress.IsSyncing() {
+				if localProgress.SyncProgress != nil {
 					log.Debug("Parent payload not in the cache, but the node is syncing, skip publishing L2Request")
 					return nil
 				}
@@ -791,7 +849,15 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 					}
 				}
 
-				tip := progress.HighestOriginBlockID.Uint64()
+				// Use cached L1-derived highest origin block ID for staleness check.
+				// This is best-effort: if no cached value exists, skip the staleness filter.
+				s.cachedHighestOriginBlockIDMu.RLock()
+				cachedTip := s.cachedHighestOriginBlockID
+				s.cachedHighestOriginBlockIDMu.RUnlock()
+				var tip uint64
+				if cachedTip != nil {
+					tip = cachedTip.Uint64()
+				}
 
 				if tip >= requestSyncMargin && parentNum <= tip-requestSyncMargin {
 					log.Debug(

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -248,6 +248,19 @@ func (s *PreconfBlockAPIServer) PrimeL1SyncCache(ctx context.Context) error {
 	return nil
 }
 
+// SetCachedHighestOriginBlockID overrides the cached L1-derived sync target.
+func (s *PreconfBlockAPIServer) SetCachedHighestOriginBlockID(blockID *big.Int) {
+	s.cachedHighestOriginBlockIDMu.Lock()
+	defer s.cachedHighestOriginBlockIDMu.Unlock()
+
+	if blockID == nil {
+		s.cachedHighestOriginBlockID = nil
+		return
+	}
+
+	s.cachedHighestOriginBlockID = new(big.Int).Set(blockID)
+}
+
 // StartBackgroundL1Refresh starts a background goroutine that periodically
 // fetches the highest origin block ID from L1 and updates the cache.
 // This keeps the L1-derived sync state warm so the gossip hot path never needs

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -234,6 +234,20 @@ func (s *PreconfBlockAPIServer) Shutdown(ctx context.Context) error {
 	return s.echo.Shutdown(ctx)
 }
 
+// PrimeL1SyncCache synchronously refreshes the cached L1-derived sync target.
+func (s *PreconfBlockAPIServer) PrimeL1SyncCache(ctx context.Context) error {
+	highestOriginBlockID, err := s.rpc.FetchHighestOriginBlockIDFromL1(ctx)
+	if err != nil {
+		return err
+	}
+
+	s.cachedHighestOriginBlockIDMu.Lock()
+	s.cachedHighestOriginBlockID = highestOriginBlockID
+	s.cachedHighestOriginBlockIDMu.Unlock()
+
+	return nil
+}
+
 // StartBackgroundL1Refresh starts a background goroutine that periodically
 // fetches the highest origin block ID from L1 and updates the cache.
 // This keeps the L1-derived sync state warm so the gossip hot path never needs
@@ -242,12 +256,8 @@ func (s *PreconfBlockAPIServer) StartBackgroundL1Refresh(ctx context.Context) {
 	go func() {
 		// Prime the cache immediately. Until the first successful refresh populates the cache,
 		// ingress keeps payloads cached and does not import them.
-		if highestOriginBlockID, err := s.rpc.FetchHighestOriginBlockIDFromL1(ctx); err != nil {
+		if err := s.PrimeL1SyncCache(ctx); err != nil {
 			log.Warn("Initial L1 sync cache prime failed", "error", err)
-		} else {
-			s.cachedHighestOriginBlockIDMu.Lock()
-			s.cachedHighestOriginBlockID = highestOriginBlockID
-			s.cachedHighestOriginBlockIDMu.Unlock()
 		}
 
 		ticker := time.NewTicker(monitorLatestProposalOnChainInterval)
@@ -258,14 +268,9 @@ func (s *PreconfBlockAPIServer) StartBackgroundL1Refresh(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				highestOriginBlockID, err := s.rpc.FetchHighestOriginBlockIDFromL1(ctx)
-				if err != nil {
+				if err := s.PrimeL1SyncCache(ctx); err != nil {
 					log.Debug("Background L1 sync refresh failed", "error", err)
-					continue
 				}
-				s.cachedHighestOriginBlockIDMu.Lock()
-				s.cachedHighestOriginBlockID = highestOriginBlockID
-				s.cachedHighestOriginBlockIDMu.Unlock()
 			}
 		}
 	}()

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -272,10 +272,6 @@ func (s *PreconfBlockAPIServer) StartBackgroundL1Refresh(ctx context.Context) {
 }
 
 func shouldCachePayloadForSync(localProgress *rpc.L2SyncProgress, highestOriginBlockID *big.Int) bool {
-	if localProgress == nil {
-		return true
-	}
-
 	if localProgress.SyncProgress != nil {
 		return true
 	}
@@ -844,6 +840,9 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 					return fmt.Errorf("failed to get local L2 sync progress: %w", err)
 				}
 
+				// Only local beacon-sync state is a hard blocker here. L1-derived lag is checked
+				// below via the cached highest origin block ID so transient L1 outages do not
+				// turn parent-request handling into a hard failure.
 				if localProgress.SyncProgress != nil {
 					log.Debug("Parent payload not in the cache, but the node is syncing, skip publishing L2Request")
 					return nil

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -16,6 +17,55 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
+
+func TestShouldCachePayloadForSync(t *testing.T) {
+	tests := []struct {
+		name                string
+		localProgress       *rpc.L2SyncProgress
+		highestOriginBlock  *big.Int
+		shouldCacheEnvelope bool
+	}{
+		{
+			name:                "beacon syncing always caches",
+			localProgress:       &rpc.L2SyncProgress{SyncProgress: &ethereum.SyncProgress{}},
+			highestOriginBlock:  big.NewInt(10),
+			shouldCacheEnvelope: true,
+		},
+		{
+			name:                "missing L1 target cache is fail closed",
+			localProgress:       &rpc.L2SyncProgress{CurrentBlockID: big.NewInt(10)},
+			highestOriginBlock:  nil,
+			shouldCacheEnvelope: true,
+		},
+		{
+			name:                "missing current block id caches",
+			localProgress:       &rpc.L2SyncProgress{},
+			highestOriginBlock:  big.NewInt(10),
+			shouldCacheEnvelope: true,
+		},
+		{
+			name:                "local chain behind cached target caches",
+			localProgress:       &rpc.L2SyncProgress{CurrentBlockID: big.NewInt(9)},
+			highestOriginBlock:  big.NewInt(10),
+			shouldCacheEnvelope: true,
+		},
+		{
+			name:                "local chain caught up can import",
+			localProgress:       &rpc.L2SyncProgress{CurrentBlockID: big.NewInt(10)},
+			highestOriginBlock:  big.NewInt(10),
+			shouldCacheEnvelope: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldCachePayloadForSync(tt.localProgress, tt.highestOriginBlock)
+			if got != tt.shouldCacheEnvelope {
+				t.Fatalf("shouldCachePayloadForSync() = %v, want %v", got, tt.shouldCacheEnvelope)
+			}
+		})
+	}
+}
 
 type PreconfBlockAPIServerTestSuite struct {
 	testutils.ClientTestSuite

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -582,6 +582,61 @@ func (p *L2SyncProgress) IsSyncing() bool {
 	return p.CurrentBlockID.Cmp(p.HighestOriginBlockID) < 0
 }
 
+func latestPacayaBatchID(numBatches uint64) (uint64, bool) {
+	if numBatches == 0 {
+		return 0, false
+	}
+
+	return numBatches - 1, true
+}
+
+// fetchHighestOriginBlockIDFromContracts resolves the latest L1-derived origin block ID used by
+// both L2ExecutionEngineSyncProgress and FetchHighestOriginBlockIDFromL1 so the Shasta/Pacaya
+// dispatch and edge-case handling stay consistent.
+func (c *Client) fetchHighestOriginBlockIDFromContracts(ctx context.Context) (*big.Int, error) {
+	coreState, err := c.GetCoreStateShasta(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, err
+	}
+
+	// If the next proposal ID is 1, it means there is no Shasta proposal has been made on L2 yet.
+	if coreState.NextProposalId.Cmp(common.Big1) > 0 {
+		l1Origin, err := c.L2Engine.LastL1OriginByBatchID(
+			ctx,
+			new(big.Int).Sub(coreState.NextProposalId, common.Big1),
+		)
+		if err != nil &&
+			err.Error() != ethereum.NotFound.Error() &&
+			err.Error() != eth.ErrProposalLastBlockUncertain.Error() {
+			return nil, err
+		}
+		// If the L1Origin is not found, it means the L2 execution engine has not synced yet,
+		// we set the highest origin block ID to max uint64.
+		if l1Origin == nil {
+			return new(big.Int).SetUint64(^uint64(0)), nil
+		}
+		return l1Origin.BlockID, nil
+	}
+
+	stateVars, err := c.GetProtocolStateVariablesPacaya(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, err
+	}
+
+	latestBatchID, ok := latestPacayaBatchID(stateVars.Stats2.NumBatches)
+	if !ok {
+		// Fresh Pacaya chain: there is no on-chain batch yet, so no L1-derived target exists.
+		return nil, nil
+	}
+
+	batch, err := c.PacayaClients.TaikoInbox.GetBatch(&bind.CallOpts{Context: ctx}, latestBatchID)
+	if err != nil {
+		return nil, err
+	}
+
+	return new(big.Int).SetUint64(batch.LastBlockId), nil
+}
+
 // L2ExecutionEngineSyncProgress fetches the sync progress of the given L2 execution engine.
 func (c *Client) L2ExecutionEngineSyncProgress(ctx context.Context) (*L2SyncProgress, error) {
 	ctxWithTimeout, cancel := CtxWithTimeoutOrDefault(ctx, DefaultRpcTimeout)
@@ -598,44 +653,11 @@ func (c *Client) L2ExecutionEngineSyncProgress(ctx context.Context) (*L2SyncProg
 		return err
 	})
 	g.Go(func() error {
-		coreState, err := c.GetCoreStateShasta(&bind.CallOpts{Context: ctx})
+		highestOriginBlockID, err := c.fetchHighestOriginBlockIDFromContracts(ctx)
 		if err != nil {
 			return err
 		}
-
-		// If the next proposal ID is 1, it means there is no Shasta proposal has been made on L2 yet.
-		if coreState.NextProposalId.Cmp(common.Big1) > 0 {
-			l1Origin, err := c.L2Engine.LastL1OriginByBatchID(
-				ctx,
-				new(big.Int).Sub(coreState.NextProposalId, common.Big1),
-			)
-			if err != nil &&
-				err.Error() != ethereum.NotFound.Error() &&
-				err.Error() != eth.ErrProposalLastBlockUncertain.Error() {
-				return err
-			}
-			// If the L1Origin is not found, it means the L2 execution engine has not synced yet,
-			// we set the highest origin block ID to max uint64.
-			if l1Origin == nil {
-				progress.HighestOriginBlockID = new(big.Int).SetUint64(^uint64(0)) // Max uint64
-				return nil
-			}
-			progress.HighestOriginBlockID = l1Origin.BlockID
-			return nil
-		}
-		// Try get the highest block ID from the Pacaya protocol state variables.
-		stateVars, err := c.GetProtocolStateVariablesPacaya(&bind.CallOpts{Context: ctx})
-		if err != nil {
-			return err
-		}
-
-		batch, err := c.PacayaClients.TaikoInbox.GetBatch(&bind.CallOpts{Context: ctx}, stateVars.Stats2.NumBatches-1)
-		if err != nil {
-			return err
-		}
-
-		progress.HighestOriginBlockID = new(big.Int).SetUint64(batch.LastBlockId)
-
+		progress.HighestOriginBlockID = highestOriginBlockID
 		return nil
 	})
 	g.Go(func() error {
@@ -703,38 +725,7 @@ func (c *Client) FetchHighestOriginBlockIDFromL1(ctx context.Context) (*big.Int,
 	ctxWithTimeout, cancel := CtxWithTimeoutOrDefault(ctx, DefaultRpcTimeout)
 	defer cancel()
 
-	coreState, err := c.GetCoreStateShasta(&bind.CallOpts{Context: ctxWithTimeout})
-	if err != nil {
-		return nil, err
-	}
-
-	if coreState.NextProposalId.Cmp(common.Big1) > 0 {
-		l1Origin, err := c.L2Engine.LastL1OriginByBatchID(
-			ctxWithTimeout,
-			new(big.Int).Sub(coreState.NextProposalId, common.Big1),
-		)
-		if err != nil &&
-			err.Error() != ethereum.NotFound.Error() &&
-			err.Error() != eth.ErrProposalLastBlockUncertain.Error() {
-			return nil, err
-		}
-		if l1Origin == nil {
-			return new(big.Int).SetUint64(^uint64(0)), nil
-		}
-		return l1Origin.BlockID, nil
-	}
-
-	stateVars, err := c.GetProtocolStateVariablesPacaya(&bind.CallOpts{Context: ctxWithTimeout})
-	if err != nil {
-		return nil, err
-	}
-
-	batch, err := c.PacayaClients.TaikoInbox.GetBatch(&bind.CallOpts{Context: ctxWithTimeout}, stateVars.Stats2.NumBatches-1)
-	if err != nil {
-		return nil, err
-	}
-
-	return new(big.Int).SetUint64(batch.LastBlockId), nil
+	return c.fetchHighestOriginBlockIDFromContracts(ctxWithTimeout)
 }
 
 // GetProtocolStateVariablesPacaya gets the protocol states from Pacaya TaikoInbox contract.

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -662,6 +662,81 @@ func (c *Client) L2ExecutionEngineSyncProgress(ctx context.Context) (*L2SyncProg
 	return progress, nil
 }
 
+// L2ExecutionEngineSyncProgressLocal fetches only the local L2 sync state (no L1 calls).
+// This is safe to call even when L1 is unreachable.
+func (c *Client) L2ExecutionEngineSyncProgressLocal(ctx context.Context) (*L2SyncProgress, error) {
+	ctxWithTimeout, cancel := CtxWithTimeoutOrDefault(ctx, DefaultRpcTimeout)
+	defer cancel()
+
+	var progress = new(L2SyncProgress)
+	g, ctx := errgroup.WithContext(ctxWithTimeout)
+
+	g.Go(func() error {
+		var err error
+		progress.SyncProgress, err = c.L2.SyncProgress(ctx)
+		return err
+	})
+	g.Go(func() error {
+		headL1Origin, err := c.L2.HeadL1Origin(ctx)
+		if err != nil {
+			if err.Error() == ethereum.NotFound.Error() {
+				progress.CurrentBlockID = common.Big0
+				return nil
+			}
+			return err
+		}
+		progress.CurrentBlockID = headL1Origin.BlockID
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return progress, nil
+}
+
+// FetchHighestOriginBlockIDFromL1 fetches the highest origin block ID by querying L1 contracts
+// and the local L2 engine. This method is called from a background goroutine only—never from
+// the gossip hot path. Any error (L1 or L2) simply means the background cache is not updated.
+func (c *Client) FetchHighestOriginBlockIDFromL1(ctx context.Context) (*big.Int, error) {
+	ctxWithTimeout, cancel := CtxWithTimeoutOrDefault(ctx, DefaultRpcTimeout)
+	defer cancel()
+
+	coreState, err := c.GetCoreStateShasta(&bind.CallOpts{Context: ctxWithTimeout})
+	if err != nil {
+		return nil, err
+	}
+
+	if coreState.NextProposalId.Cmp(common.Big1) > 0 {
+		l1Origin, err := c.L2Engine.LastL1OriginByBatchID(
+			ctxWithTimeout,
+			new(big.Int).Sub(coreState.NextProposalId, common.Big1),
+		)
+		if err != nil &&
+			err.Error() != ethereum.NotFound.Error() &&
+			err.Error() != eth.ErrProposalLastBlockUncertain.Error() {
+			return nil, err
+		}
+		if l1Origin == nil {
+			return new(big.Int).SetUint64(^uint64(0)), nil
+		}
+		return l1Origin.BlockID, nil
+	}
+
+	stateVars, err := c.GetProtocolStateVariablesPacaya(&bind.CallOpts{Context: ctxWithTimeout})
+	if err != nil {
+		return nil, err
+	}
+
+	batch, err := c.PacayaClients.TaikoInbox.GetBatch(&bind.CallOpts{Context: ctxWithTimeout}, stateVars.Stats2.NumBatches-1)
+	if err != nil {
+		return nil, err
+	}
+
+	return new(big.Int).SetUint64(batch.LastBlockId), nil
+}
+
 // GetProtocolStateVariablesPacaya gets the protocol states from Pacaya TaikoInbox contract.
 func (c *Client) GetProtocolStateVariablesPacaya(opts *bind.CallOpts) (*struct {
 	Stats1 pacayaBindings.ITaikoInboxStats1

--- a/packages/taiko-client/pkg/rpc/methods_test.go
+++ b/packages/taiko-client/pkg/rpc/methods_test.go
@@ -66,6 +66,27 @@ func TestL2ExecutionEngineSyncProgress(t *testing.T) {
 	require.NotNil(t, progress)
 }
 
+func TestLatestPacayaBatchID(t *testing.T) {
+	tests := []struct {
+		name       string
+		numBatches uint64
+		want       uint64
+		ok         bool
+	}{
+		{name: "no batches", numBatches: 0, want: 0, ok: false},
+		{name: "first batch", numBatches: 1, want: 0, ok: true},
+		{name: "multiple batches", numBatches: 7, want: 6, ok: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := latestPacayaBatchID(tt.numBatches)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetProtocolStateVariables(t *testing.T) {
 	client := newTestClient(t)
 	_, err := client.GetLastVerifiedTransitionPacaya(context.Background())


### PR DESCRIPTION
## Summary

  This PR makes preconfirmation sync gating resilient to transient L1 read failures in both `taiko-client` and `taiko-client-rs`.

  Previously, gossip/block import could stall if the driver briefly lost access to L1 while checking confirmed sync progress. That made L1 WS instability a liveness risk for local preconfirmation handling.

  ## What Changed

  - Keep local engine/auth checks hard-blocking.
  - Treat L1-derived sync target reads as best-effort and cached.
  - In `taiko-client`, refresh and cache the highest relevant L1 origin in the background and use that cache on transient L1 failures.
  - In `taiko-client-rs`, split the confirmed-sync probe into:
    - `next_proposal_id()` from L1
    - local confirmed-sync evaluation for a provided target proposal id
  - Cache the last successful L1 proposal target and reuse it during transient L1 failures.
  - Do not mask local engine/auth failures with cached fallback behavior.

  ## Why

  This preserves the intended safety boundary:

  - Local execution/auth state remains authoritative and must be healthy.
  - Temporary L1 WS/RPC issues no longer cause the driver to reject or stall otherwise valid gossip/import work.