### PR TITLE
fix(taiko-client): avoid errgroup err data races

### DIFF
--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -684,17 +684,24 @@ func (c *Client) GetProtocolStateVariablesPacaya(opts *bind.CallOpts) (*struct {
 			Stats1 pacayaBindings.ITaikoInboxStats1
 			Stats2 pacayaBindings.ITaikoInboxStats2
 		})
-		err error
 	)
 
 	g := new(errgroup.Group)
 	g.Go(func() error {
-		states.Stats1, err = c.PacayaClients.TaikoInbox.GetStats1(opts)
-		return err
+		stats1, err := c.PacayaClients.TaikoInbox.GetStats1(opts)
+		if err != nil {
+			return err
+		}
+		states.Stats1 = stats1
+		return nil
 	})
 	g.Go(func() error {
-		states.Stats2, err = c.PacayaClients.TaikoInbox.GetStats2(opts)
-		return err
+		stats2, err := c.PacayaClients.TaikoInbox.GetStats2(opts)
+		if err != nil {
+			return err
+		}
+		states.Stats2 = stats2
+		return nil
 	})
 
 	return states, g.Wait()
@@ -1314,17 +1321,24 @@ func (c *Client) GetForcedInclusionPacaya(ctx context.Context) (
 	var (
 		head uint64
 		tail uint64
-		err  error
 	)
 
 	g := new(errgroup.Group)
 	g.Go(func() error {
-		head, err = c.PacayaClients.ForcedInclusionStore.Head(&bind.CallOpts{Context: ctxWithTimeout})
-		return err
+		res, err := c.PacayaClients.ForcedInclusionStore.Head(&bind.CallOpts{Context: ctxWithTimeout})
+		if err != nil {
+			return err
+		}
+		head = res
+		return nil
 	})
 	g.Go(func() error {
-		tail, err = c.PacayaClients.ForcedInclusionStore.Tail(&bind.CallOpts{Context: ctxWithTimeout})
-		return err
+		res, err := c.PacayaClients.ForcedInclusionStore.Tail(&bind.CallOpts{Context: ctxWithTimeout})
+		if err != nil {
+			return err
+		}
+		tail = res
+		return nil
 	})
 	if err := g.Wait(); err != nil {
 		return nil, nil, encoding.TryParsingCustomError(err)

--- a/packages/taiko-client/proposer/transaction_builder/fallback.go
+++ b/packages/taiko-client/proposer/transaction_builder/fallback.go
@@ -113,43 +113,50 @@ func (b *TxBuilderWithFallback) BuildPacaya(
 		txWithBlob     *txmgr.TxCandidate
 		costCalldata   *big.Int
 		costBlob       *big.Int
-		err            error
 	)
 
 	g.Go(func() error {
-		if txWithCalldata, err = b.calldataTransactionBuilder.BuildPacaya(
+		tx, err := b.calldataTransactionBuilder.BuildPacaya(
 			ctx,
 			txBatch,
 			forcedInclusion,
 			minTxsPerForcedInclusion,
 			parentMetahash,
 			preconfRouterAddress,
-		); err != nil {
+		)
+		if err != nil {
 			return fmt.Errorf("failed to build type-2 transaction: %w", err)
 		}
-		if costCalldata, err = b.estimateCandidateCost(ctx, txWithCalldata); err != nil {
+		cost, err := b.estimateCandidateCost(ctx, tx)
+		if err != nil {
 			return fmt.Errorf("failed to estimate type-2 transaction cost: %w", encoding.TryParsingCustomError(err))
 		}
+		txWithCalldata = tx
+		costCalldata = cost
 		return nil
 	})
 	g.Go(func() error {
-		if txWithBlob, err = b.blobTransactionBuilder.BuildPacaya(
+		tx, err := b.blobTransactionBuilder.BuildPacaya(
 			ctx,
 			txBatch,
 			forcedInclusion,
 			minTxsPerForcedInclusion,
 			parentMetahash,
 			preconfRouterAddress,
-		); err != nil {
+		)
+		if err != nil {
 			return fmt.Errorf("failed to build type-3 transaction: %w", err)
 		}
-		if costBlob, err = b.estimateCandidateCost(ctx, txWithBlob); err != nil {
+		cost, err := b.estimateCandidateCost(ctx, tx)
+		if err != nil {
 			return fmt.Errorf("failed to estimate type-3 transaction cost: %w", encoding.TryParsingCustomError(err))
 		}
+		txWithBlob = tx
+		costBlob = cost
 		return nil
 	})
 
-	if err = g.Wait(); err != nil {
+	if err := g.Wait(); err != nil {
 		log.Error("Failed to estimate transactions cost, will build a type-3 transaction", "error", err)
 		metrics.ProposerCostEstimationError.Inc()
 		// If there is an error, just build a blob transaction.


### PR DESCRIPTION
Use goroutine-local errors in errgroup branches to remove shared err races.