### PR TITLE
fix(taiko-client): guard FindBatchForBlockID underflow

### DIFF
--- a/packages/taiko-client/driver/state/l1_current.go
+++ b/packages/taiko-client/driver/state/l1_current.go
@@ -119,21 +119,47 @@ func (s *State) FindBatchForBlockID(ctx context.Context, blockID uint64) (*pacay
 	if err != nil {
 		return nil, fmt.Errorf("failed to get protocol state variables: %w", err)
 	}
+	return findBatchForBlockIDByCount(
+		blockID,
+		stateVars.Stats2.NumBatches,
+		func(batchID uint64) (*pacayaBindings.ITaikoInboxBatch, error) {
+			batch, err := s.rpc.GetBatchByID(ctx, new(big.Int).SetUint64(batchID))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get batch by ID %d: %w", batchID, err)
+			}
 
-	var (
-		lastBatchID = stateVars.Stats2.NumBatches - 1
-		lastBatch   *pacayaBindings.ITaikoInboxBatch
+			return batch, nil
+		},
 	)
-	batch, err := s.rpc.GetBatchByID(ctx, new(big.Int).SetUint64(lastBatchID))
-	if err != nil {
-		return nil, fmt.Errorf("failed to get batch by ID %d: %w", lastBatchID, err)
-	}
-	lastBatch = batch
+}
 
-	for {
-		batch, err := s.rpc.GetBatchByID(ctx, new(big.Int).SetUint64(lastBatchID-1))
+func findBatchForBlockIDByCount(
+	blockID uint64,
+	numBatches uint64,
+	getBatchByID func(batchID uint64) (*pacayaBindings.ITaikoInboxBatch, error),
+) (*pacayaBindings.ITaikoInboxBatch, error) {
+	if numBatches == 0 {
+		return nil, errors.New("no batches found")
+	}
+
+	return findBatchForBlockIDFromLatest(blockID, numBatches-1, getBatchByID)
+}
+
+func findBatchForBlockIDFromLatest(
+	blockID uint64,
+	lastBatchID uint64,
+	getBatchByID func(batchID uint64) (*pacayaBindings.ITaikoInboxBatch, error),
+) (*pacayaBindings.ITaikoInboxBatch, error) {
+	lastBatch, err := getBatchByID(lastBatchID)
+	if err != nil {
+		return nil, err
+	}
+
+	for lastBatchID > 0 {
+		prevBatchID := lastBatchID - 1
+		batch, err := getBatchByID(prevBatchID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get batch by ID %d: %w", lastBatchID-1, err)
+			return nil, err
 		}
 
 		if batch.LastBlockId < blockID {
@@ -141,7 +167,8 @@ func (s *State) FindBatchForBlockID(ctx context.Context, blockID uint64) (*pacay
 		}
 
 		lastBatch = batch
-		lastBatchID = batch.BatchId
-		continue
+		lastBatchID = prevBatchID
 	}
+
+	return lastBatch, nil
 }

--- a/packages/taiko-client/driver/state/l1_current_unit_test.go
+++ b/packages/taiko-client/driver/state/l1_current_unit_test.go
@@ -1,0 +1,102 @@
+package state
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	pacayaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/pacaya"
+)
+
+func TestFindBatchForBlockIDByCountEmptyBatches(t *testing.T) {
+	_, err := findBatchForBlockIDByCount(10, 0, func(uint64) (*pacayaBindings.ITaikoInboxBatch, error) {
+		t.Fatal("getBatchByID should not be called when numBatches is zero")
+		return nil, nil
+	})
+	if err == nil || err.Error() != "no batches found" {
+		t.Fatalf("expected no batches found error, got: %v", err)
+	}
+}
+
+func TestFindBatchForBlockIDFromLatestOneBatchNoUnderflow(t *testing.T) {
+	calls := make([]uint64, 0, 1)
+	getBatchByID := func(batchID uint64) (*pacayaBindings.ITaikoInboxBatch, error) {
+		calls = append(calls, batchID)
+		if batchID != 0 {
+			t.Fatalf("unexpected batch ID: %d", batchID)
+		}
+		return &pacayaBindings.ITaikoInboxBatch{
+			BatchId:     0,
+			LastBlockId: 100,
+		}, nil
+	}
+
+	batch, err := findBatchForBlockIDByCount(50, 1, getBatchByID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if batch == nil || batch.BatchId != 0 {
+		t.Fatalf("unexpected batch: %+v", batch)
+	}
+	if !reflect.DeepEqual(calls, []uint64{0}) {
+		t.Fatalf("unexpected call sequence: %+v", calls)
+	}
+}
+
+func TestFindBatchForBlockIDFromLatestReturnsLastMatchedBatch(t *testing.T) {
+	batches := map[uint64]*pacayaBindings.ITaikoInboxBatch{
+		2: {BatchId: 2, LastBlockId: 30},
+		1: {BatchId: 1, LastBlockId: 20},
+		0: {BatchId: 0, LastBlockId: 10},
+	}
+	calls := make([]uint64, 0, 2)
+
+	getBatchByID := func(batchID uint64) (*pacayaBindings.ITaikoInboxBatch, error) {
+		calls = append(calls, batchID)
+		b, ok := batches[batchID]
+		if !ok {
+			return nil, errors.New("missing batch")
+		}
+		return b, nil
+	}
+
+	batch, err := findBatchForBlockIDFromLatest(25, 2, getBatchByID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if batch == nil || batch.BatchId != 2 {
+		t.Fatalf("expected batch 2, got: %+v", batch)
+	}
+	if !reflect.DeepEqual(calls, []uint64{2, 1}) {
+		t.Fatalf("unexpected call sequence: %+v", calls)
+	}
+}
+
+func TestFindBatchForBlockIDFromLatestStopsAtZeroBoundary(t *testing.T) {
+	batches := map[uint64]*pacayaBindings.ITaikoInboxBatch{
+		2: {BatchId: 2, LastBlockId: 30},
+		1: {BatchId: 1, LastBlockId: 29},
+		0: {BatchId: 0, LastBlockId: 28},
+	}
+	calls := make([]uint64, 0, 3)
+
+	getBatchByID := func(batchID uint64) (*pacayaBindings.ITaikoInboxBatch, error) {
+		calls = append(calls, batchID)
+		b, ok := batches[batchID]
+		if !ok {
+			return nil, errors.New("missing batch")
+		}
+		return b, nil
+	}
+
+	batch, err := findBatchForBlockIDFromLatest(28, 2, getBatchByID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if batch == nil || batch.BatchId != 0 {
+		t.Fatalf("expected batch 0, got: %+v", batch)
+	}
+	if !reflect.DeepEqual(calls, []uint64{2, 1, 0}) {
+		t.Fatalf("unexpected call sequence: %+v", calls)
+	}
+}


### PR DESCRIPTION
Add zero-batch and lower-bound guards to FindBatchForBlockID, and add unit tests for underflow and rollback boundaries.