### PR TITLE
fix(taiko-client): enforce operator match in handover check

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -200,7 +200,7 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 		"isForcedInclusion", isForcedInclusion,
 	)
 
-	// Check if the fee recipient the current operator or the next operator if its in handover window.
+	// Check if feeRecipient matches the operator allowed for the current lookahead slot window.
 	if s.rpc.L1Beacon != nil {
 		if err := s.CheckLookaheadHandover(reqBody.ExecutableData.FeeRecipient, s.rpc.L1Beacon.CurrentSlot()); err != nil {
 			return s.returnError(c, http.StatusBadRequest, err)

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1079,14 +1079,20 @@ func (s *PreconfBlockAPIServer) CheckLookaheadHandover(feeRecipient common.Addre
 	// Check if the fee recipient is the current operator.
 	for _, r := range s.lookahead.CurrRanges {
 		if globalSlot >= r.Start && globalSlot < r.End {
-			return nil
+			if feeRecipient == s.lookahead.CurrOperator {
+				return nil
+			}
+			return errInvalidCurrOperator
 		}
 	}
 
 	// Check if the fee recipient is the next operator.
 	for _, r := range s.lookahead.NextRanges {
 		if globalSlot >= r.Start && globalSlot < r.End {
-			return nil
+			if feeRecipient == s.lookahead.NextOperator {
+				return nil
+			}
+			return errInvalidNextOperator
 		}
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -65,17 +65,13 @@ func (s *PreconfBlockAPIServerTestSuite) TestCheckLookaheadHandover() {
 		feeRecipient common.Address
 		wantErr      error
 	}{
-		// Inside CurrRanges, before handover point
-		{name: "curr allowed early slot", globalSlot: 10, feeRecipient: curr, wantErr: nil},
+		// Inside CurrRanges.
+		{name: "curr allowed in curr range", globalSlot: 10, feeRecipient: curr, wantErr: nil},
+		{name: "next rejected in curr range", globalSlot: 10, feeRecipient: next, wantErr: errInvalidCurrOperator},
 
-		// Inside CurrRanges, at handover threshold
-		{name: "next allowed at handover slot", globalSlot: 28, feeRecipient: next, wantErr: nil},
-
-		// Inside CurrRanges, after threshold
-		{name: "next allowed after handover", globalSlot: 30, feeRecipient: next, wantErr: nil},
-
-		// Inside NextRanges (next epoch)
-		{name: "next allowed next epoch", globalSlot: 33, feeRecipient: next, wantErr: nil},
+		// Inside NextRanges.
+		{name: "next allowed in next range", globalSlot: 33, feeRecipient: next, wantErr: nil},
+		{name: "curr rejected in next range", globalSlot: 33, feeRecipient: curr, wantErr: errInvalidNextOperator},
 
 		// Slot outside all ranges (invalid)
 		{


### PR DESCRIPTION
Enforce feeRecipient-to-operator matching in CheckLookaheadHandover, add in-range negative tests to prevent unauthorized preconfirmation block acceptance.