### PR TITLE
docs(preconfirmation-p2p): sync net docs with current behavior

### DIFF
--- a/packages/preconfirmation-p2p/ARCHITECTURE.md
+++ b/packages/preconfirmation-p2p/ARCHITECTURE.md
@@ -16,8 +16,8 @@ This crate group is a library-only scaffold for the Taiko preconfirmation P2P la
 
 - **libp2p** (0.56.x): transport, gossipsub, request/response (now varint-framed per spec), ping,
   identify, allow/block list, connection limits.
-- **reth-discv5** (tag `v1.9.3`, feature `reth-discovery`): discovery wrapper; reused to avoid
-  custom ENR/UDP wiring.
+- **reth-discv5** (tag `v1.9.3`): discovery wrapper; reused to avoid custom ENR/UDP wiring and
+  toggled at runtime with `enable_discovery`.
 - **Kona gossipsub defaults** (tag `kona-client/v1.2.4`, always on): mesh/score defaults +
   heartbeat; we override only spec-required bits (max transmit size, validation mode).
 - **Reputation via reth**: `ReputationChangeWeights` defaults come from reth and feed the local
@@ -28,15 +28,15 @@ This crate group is a library-only scaffold for the Taiko preconfirmation P2P la
   replacing the old fixed window limiter.
 - Discovery uses conservative discv5 timing defaults (aligned with prior production tuning).
 - Connection caps and dial concurrency default to production-safe values and can be tuned directly.
-  Event fanout uses broadcast so handlers, blocking helpers, and `next_event` can run concurrently.
+  Event delivery uses a single-consumer `mpsc` receiver surfaced through `P2pHandle::events()` and
+  the `wait_*` helpers on a mutable handle.
 
-## Feature flags
+## Compile-time and runtime switches
 
-- `reth-discovery` (default on): enable discovery via `reth-discv5` wrapper.
-- `kona-presets`: always on (Kona gossipsub mesh/score defaults).
-- `kona-gater`: always on (Kona connection gater reused in dial/ban path).
-- `real-transport-test`: real TCP integration test now runs by default with retries; use this
-  feature only to disable it in constrained environments. In-memory transport tests always run.
+- `quic-transport`: enables QUIC transport support when `enable_quic` is set.
+- `enable_discovery`: runtime toggle for discv5 peer discovery.
+- Kona gossipsub defaults and the Kona connection gater are always on.
+- Real TCP integration tests run by default with retries. In-memory transport tests always run.
 - Lighthouse-style peer scoring/gating: blocked (no published crate compatible with libp2p 0.56).
 
 Note: Reth peer-id keyed reputation is always enabled and is the sole backend; it mirrors bans to
@@ -49,8 +49,8 @@ gating/scoring remains blocked until upstream publishes a compatible crate/API f
 - Gossip: Kona gossipsub defaults with max transmit size = `preconfirmation_types::MAX_GOSSIP_SIZE_BYTES`.
 - Req/Resp: SSZ payloads framed with unsigned-varint length (libp2p style), protocol IDs from
   `preconfirmation_types`, per-message size caps enforced in codecs.
-- Rate limits: fixed (tumbling) per-peer window (`P2pConfig.rate_limit`), rate-limit errors
-  surface as NetworkEvent errors and reputation timeouts.
+- Rate limits: per-peer/per-protocol token buckets configured via `P2pConfig.rate_limit`; rate-limit
+  errors surface as `NetworkEvent::Error` values and reputation timeouts.
 
 ## Typical usage flow
 
@@ -68,7 +68,7 @@ gating/scoring remains blocked until upstream publishes a compatible crate/API f
   - `p2p_discovery_event{kind=lookup_success|lookup_failure}`, `p2p_discovery_lookup_latency_seconds{outcome}`.
   - `p2p_conn_rejected_total`, `p2p_dial_throttled_total` for limit hits; `p2p_conn_error` for other transport errors.
 - Config knobs (user-facing `P2pConfig`):
-  - Rate limit: `rate_limit.window`, `rate_limit.max_requests` (per-peer fixed window).
+  - Rate limit: `rate_limit.window`, `rate_limit.max_requests` (per-peer/per-protocol token-bucket parameters).
   - Reputation: `reputation.greylist_threshold`, `reputation.ban_threshold`, `reputation.halflife`.
   - Discovery: `enable_discovery`, `discovery_listen`, `bootnodes`.
   - Request/response: `request_timeout`, `max_reqresp_concurrent_streams`.

--- a/packages/preconfirmation-p2p/README.md
+++ b/packages/preconfirmation-p2p/README.md
@@ -7,9 +7,9 @@ Project for the Taiko permissionless preconfirmation P2P layer (libp2p + discv5,
 - `crates/types`: Spec-driven SSZ types and helpers (hashing/signing/validation). Provides
   topic/protocol ID helpers used by the network.
 - `crates/net`: libp2p transport + behaviours (ping, identify, gossipsub, req/resp) and
-  scaffolds for discovery (`discovery`, now backed by `reth-discv5` behind the `reth-discovery`
-  feature) and peer reputation. Kona gossipsub presets + connection gater are always applied;
-  req/resp uses SSZ with libp2p varint framing and per-message size caps. Public API:
+  discovery scaffolds backed by `reth-discv5`, plus peer reputation. Kona gossipsub presets +
+  connection gater are always applied; req/resp uses SSZ with libp2p varint framing, per-message
+  size caps, and per-peer/per-protocol token-bucket rate limiting. Public API:
   `P2pConfig`, `P2pNode`, `P2pHandle`, `NetworkCommand` (publish/request), `NetworkEvent`
   (gossip/req-resp/lifecycle).
 - `crates/net/examples/p2p-node.rs`: Minimal CLI example that starts the node and logs
@@ -27,21 +27,22 @@ Project for the Taiko permissionless preconfirmation P2P layer (libp2p + discv5,
 
 ## Upstream reuse and compatibility
 
-- Discovery is backed by `reth-discv5` (git tag `v1.9.3`) behind the `reth-discovery` feature.
+- Discovery is backed by `reth-discv5` (git tag `v1.9.3`) and toggled at runtime via
+  `P2pConfig.enable_discovery`.
 - Gossip and gating reuse Kona (`kona-client/v1.2.4`): gossipsub presets (mesh/score/heartbeat,
   max transmit size tied to `preconfirmation_types::MAX_GOSSIP_SIZE_BYTES`) and the connection
   gater (blocked subnets/redial limits).
 - Reputation weights come from reth (`ReputationChangeWeights`); bans mirror to libp2p IDs.
 - Req/resp: SSZ messages framed with libp2p unsigned-varint lengths, protocol IDs and size caps
-  from `preconfirmation_types`; per-peer fixed-window rate limiting lives in `P2pConfig.rate_limit`.
+  from `preconfirmation_types`; per-peer/per-protocol token-bucket rate limiting is configured via
+  `P2pConfig.rate_limit`.
 - This package is library-only; runnable smoke testing lives in `crates/net/examples/p2p-node.rs`.
 
 ## Reputation & Scoring
 
 - Default: local `PeerReputationStore` with decay/thresholds, libp2p block-list enforcement, and
   rate limiting.
-- Upstream request-rate limiter swap: still local; no compatible upstream rate-limit module is
-  published for our libp2p/reth/Lighthouse versions, so no code change here yet.
+- Req/resp rate limiting uses `reth-tokio-util` token buckets with per-peer/per-protocol state.
 - `kona-presets`: (removed, always on). Gossipsub config now comes from Kona’s preset helper.
 - `reth-peers`: always on. Reputation is keyed by reth `PeerId` when conversion succeeds; bans are
   mirrored to libp2p `PeerId`. Scoring still uses the local decay/threshold logic and falls back to
@@ -63,18 +64,15 @@ preconfirmation-net = { path = "packages/preconfirmation-p2p/crates/net" }
 Key types: `P2pConfig`, `P2pNode`, `P2pHandle`, `NetworkCommand`, `NetworkEvent`, and the SSZ
 message types in `preconfirmation_p2p_types` (e.g., `SignedCommitment`, `RawTxListGossip`).
 
-Feature switches:
+Compile-time and runtime switches:
 
-- `reth-discovery`: use reth-discv5 wrapper for peer discovery (default on in p2p-net).
-- `kona-presets`: (removed, always on).
-- `kona-gater`: (removed, always on). Gossip scoring/gating is handled by Kona gossipsub; the
-  local reputation backend focuses on request/response and dial behaviour.
-- Req/resp rate limiting now uses upstream `reth-tokio-util` token buckets (per-peer, per-protocol).
+- `quic-transport`: enables QUIC transport support for `enable_quic`.
+- `enable_discovery`: runtime toggle for discv5 peer discovery.
+- Kona gossipsub defaults and the Kona connection gater are always on.
 - Discovery uses conservative discv5 timing defaults (aligned with prior production tuning).
 - Connection caps and dial concurrency are configured directly (defaults match prior production
   values).
-- `real-transport-test`: the real TCP integration test now runs by default with retries; enable
-  this feature only to disable the test in constrained environments.
+- Real TCP integration tests run by default with retries.
 
 Typical flow:
 

--- a/packages/preconfirmation-p2p/crates/net/README.md
+++ b/packages/preconfirmation-p2p/crates/net/README.md
@@ -3,6 +3,7 @@
 libp2p + discv5 networking layer for Taiko preconfirmation P2P. It wires gossip and req/resp, adds reputation + per-peer rate limiting, and integrates Kona’s gating and connection limits.
 
 ## What to read first
+
 - `src/lib.rs`: crate surface and re-exports.
 - `src/config.rs`: `P2pConfig` (user-facing) plus internal knobs (listen/discv5, reputation, rate
   limits, gater).
@@ -12,6 +13,7 @@ libp2p + discv5 networking layer for Taiko preconfirmation P2P. It wires gossip 
 - `src/reputation.rs`: scoring, bans/greylists, per-peer rate limiter.
 
 ## Data flow (high level)
+
 - Commands/events: the driver owns the swarm; callers use `P2pNode` + `P2pHandle` or send `NetworkCommand`
   and receive `NetworkEvent` directly.
 - Gossip: topics built from `preconfirmation_types::topic_*` for commitments and raw txlists.
@@ -19,9 +21,11 @@ libp2p + discv5 networking layer for Taiko preconfirmation P2P. It wires gossip 
 - Gating/DoS: Kona gater for dial decisions (subnet/redial limits), per-peer req/resp rate limit, reputation decay/ban/greylist (reth weights), txlist size caps.
 
 ## Spec & integration
+
 - Protocol spec: `docs/specification.md` (authoritative P2P specification).
 - Typical integration: use `P2pNode` + `P2pHandle` (see `crates/net/examples/p2p-node.rs`).
 
 ## Testing
+
 - Unit + integration: `cargo test -p preconfirmation-net` (includes memory-transport and real TCP tests with retries).
-- Default real TCP test runs; if needed in constrained environments, see crate docs/feature notes for disabling.
+- Default real TCP test runs with retries.

--- a/packages/preconfirmation-p2p/crates/net/src/config.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/config.rs
@@ -93,9 +93,9 @@ pub struct NetworkConfig {
     pub reputation_ban: f64,
     /// Exponential-decay halflife for scores. Determines how quickly peer scores decay over time.
     pub reputation_halflife: Duration,
-    /// Fixed (tumbling) window size for req/resp rate limiting.
+    /// Token-bucket refill period for req/resp rate limiting.
     pub request_window: Duration,
-    /// Maximum number of requests allowed per peer within the `request_window`.
+    /// Number of tokens added per peer/protocol bucket within each `request_window`.
     pub max_requests_per_window: u32,
     /// Maximum concurrent inbound+outbound req/resp streams (libp2p request-response config).
     pub max_reqresp_concurrent_streams: usize,
@@ -225,18 +225,18 @@ impl NetworkConfig {
 
 /// Rate limit configuration for req/resp protocols.
 ///
-/// This struct defines the parameters for a fixed (tumbling) window rate limiter
-/// that restricts the number of requests a peer can make within a given time window.
+/// This struct defines the parameters for the per-peer/per-protocol token-bucket limiter used by
+/// req/resp handling.
 #[derive(Debug, Clone, Copy)]
 pub struct RateLimitConfig {
-    /// The duration of the rate limiting window.
+    /// The token-bucket refill period.
     pub window: Duration,
-    /// Maximum number of requests allowed per peer within the window.
+    /// Number of tokens added per peer/protocol bucket within each refill period.
     pub max_requests: u32,
 }
 
 impl Default for RateLimitConfig {
-    /// Provides default rate limit settings: 10s window, 8 requests.
+    /// Provides default rate limit settings: 10s refill period, 8 tokens.
     fn default() -> Self {
         Self { window: Duration::from_secs(10), max_requests: 8 }
     }

--- a/packages/preconfirmation-p2p/crates/net/src/lib.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/lib.rs
@@ -5,9 +5,9 @@
 //! This crate wires libp2p + discv5 into a small, service-friendly API. It provides:
 //! - Transport/builder for libp2p (TCP/QUIC-ready) and a combined behaviour (ping, identify,
 //!   gossipsub, request-response, gating).
-//! - Discovery scaffold (backed by `reth-discv5` when enabled).
-//! - Reputation + per-peer fixed-window request rate limiting (default 10s window / 8 requests;
-//!   Kona mesh/score defaults).
+//! - Discovery scaffold (backed by `reth-discv5` and toggled by config).
+//! - Reputation + per-peer/per-protocol token-bucket request rate limiting (default 10s / 8
+//!   requests; Kona mesh/score defaults).
 //! - Driver emitting `NetworkEvent`s and receiving `NetworkCommand`s for the service facade.
 
 mod behaviour;


### PR DESCRIPTION
  Sync the preconfirmation-p2p docs with the current networking implementation, removing stale feature references and correcting the rate-limit and event-delivery descriptions. 