### PR TITLE
chore(taiko-client-rs): align Shasta parent anchor decoding with `taiko-client`

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -119,7 +119,7 @@ fn is_source_offset_valid(source: &DerivationSource) -> bool {
         source.blobSlice.offset.to::<usize>() <= PROPOSAL_MAX_BLOB_BYTES - 64
 }
 
-/// Return whether parent-anchor recovery should decode the parent block's `anchorV4`
+/// Return whether parent-anchor recovery should decode the parent block's `anchorV4` / `anchorV3`
 /// transaction instead of consulting the anchor contract state.
 fn should_decode_parent_anchor_from_tx(chain_id: u64, proposal_id: u64) -> bool {
     chain_id == TAIKO_MAINNET_CHAIN_ID && proposal_id <= MAINNET_ANCHOR_CHECK_SKIP_PROPOSAL_OFFSET

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -1,20 +1,25 @@
 use std::sync::Arc;
 
+use alethia_reth_consensus::anchor_constants::{anchorV3Call, anchorV4Call};
 use alloy::{
     eips::{BlockId, BlockNumberOrTag, eip1898::RpcBlockHash},
-    primitives::{B256, U256},
+    primitives::{Address, B256, U256},
     providers::Provider,
     rpc::types::Log,
-    sol_types::SolEvent,
+    sol_types::{SolCall, SolEvent},
 };
-use alloy_consensus::TxEnvelope;
+use alloy_consensus::{Transaction, TxEnvelope};
 use alloy_provider::RootProvider;
 use alloy_rpc_types::{Transaction as RpcTransaction, eth::Block as RpcBlock};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use bindings::inbox::{IInbox::DerivationSource, Inbox::Proposed};
 use metrics::{counter, gauge};
 use protocol::shasta::{
-    constants::{PROPOSAL_MAX_BLOB_BYTES, min_base_fee_for_chain, shasta_fork_timestamp_for_chain},
+    constants::{
+        MAINNET_ANCHOR_CHECK_SKIP_PROPOSAL_OFFSET, PROPOSAL_MAX_BLOB_BYTES, TAIKO_MAINNET_CHAIN_ID,
+        min_base_fee_for_chain, shasta_fork_timestamp_for_chain,
+    },
     manifest::DerivationSourceManifest,
 };
 use rpc::{blob::BlobDataSource, client::Client};
@@ -112,6 +117,51 @@ fn derivation_source_to_blob_hashes(source: &DerivationSource) -> Vec<B256> {
 fn is_source_offset_valid(source: &DerivationSource) -> bool {
     !source.blobSlice.blobHashes.is_empty() &&
         source.blobSlice.offset.to::<usize>() <= PROPOSAL_MAX_BLOB_BYTES - 64
+}
+
+/// Return whether parent-anchor recovery should decode the parent block's `anchorV4`
+/// transaction instead of consulting the anchor contract state.
+fn should_decode_parent_anchor_from_tx(chain_id: u64, proposal_id: u64) -> bool {
+    chain_id == TAIKO_MAINNET_CHAIN_ID && proposal_id <= MAINNET_ANCHOR_CHECK_SKIP_PROPOSAL_OFFSET
+}
+
+/// Decode the parent block's advertised anchor block number from its first `anchorV4`
+/// transaction.
+fn decode_parent_anchor_block_number(
+    parent_block: &RpcBlock<TxEnvelope>,
+    anchor_address: Address,
+) -> Result<u64, DerivationError> {
+    let block_number = parent_block.header.number;
+    let txs = parent_block.transactions.as_transactions().ok_or_else(|| {
+        DerivationError::Other(anyhow!(
+            "parent block {block_number} returned only transaction hashes"
+        ))
+    })?;
+    let first_tx = txs.first().ok_or_else(|| {
+        DerivationError::Other(anyhow!("parent block {block_number} contains no transactions"))
+    })?;
+    let destination = first_tx.to().ok_or_else(|| {
+        DerivationError::Other(anyhow!(
+            "unable to determine anchor transaction recipient for parent block {block_number}"
+        ))
+    })?;
+    if destination != anchor_address {
+        return Err(DerivationError::Other(anyhow!(
+            "parent block {block_number} first transaction is not the anchor contract"
+        )));
+    }
+
+    let input = first_tx.input();
+    if let Ok(call) = anchorV4Call::abi_decode(input) {
+        return Ok(call.0.0.to::<u64>());
+    }
+    if let Ok(call) = anchorV3Call::abi_decode(input) {
+        return Ok(call._0);
+    }
+
+    Err(DerivationError::Other(anyhow!(
+        "failed to decode anchorV3/anchorV4 calldata in parent block {block_number}"
+    )))
 }
 
 /// Ensure forced-inclusion manifests adhere to protocol rules (single block) or default them.
@@ -366,9 +416,15 @@ where
     async fn initialize_parent_state(
         &self,
         parent_block: &RpcBlock<TxEnvelope>,
+        proposal_id: u64,
     ) -> Result<ParentState, DerivationError> {
-        let anchor_state = self.rpc.shasta_anchor_state_by_hash(parent_block.hash()).await?;
         let parent_header = parent_block.header.inner.clone();
+        let anchor_block_number = if should_decode_parent_anchor_from_tx(self.chain_id, proposal_id)
+        {
+            decode_parent_anchor_block_number(parent_block, *self.rpc.shasta.anchor.address())?
+        } else {
+            self.rpc.shasta_anchor_state_by_hash(parent_block.hash()).await?.anchor_block_number
+        };
 
         let grandparent_timestamp = if parent_header.number == 0 {
             parent_header.timestamp
@@ -390,7 +446,7 @@ where
                 .timestamp
                 .saturating_sub(grandparent_timestamp),
             header: parent_header,
-            anchor_block_number: anchor_state.anchor_block_number,
+            anchor_block_number,
             shasta_fork_timestamp: self.shasta_fork_timestamp,
             min_base_fee_to_clamp: self.min_base_fee_to_clamp,
             chain_id: self.chain_id,
@@ -449,7 +505,8 @@ where
         );
 
         let parent_block = self.load_parent_block(meta.proposal_id).await?;
-        let mut parent_state = self.initialize_parent_state(&parent_block).await?;
+        let mut parent_state =
+            self.initialize_parent_state(&parent_block, meta.proposal_id).await?;
 
         // If every block already sits in the canonical chain we skip payload submission and only
         // refresh L1 origins.
@@ -517,24 +574,37 @@ where
 mod tests {
     use super::*;
     use alloy::{
+        consensus::{EthereumTypedTransaction, SignableTransaction, TxEip1559},
+        eips::eip2930::AccessList,
         primitives::{
-            Address, B256, Bytes, FixedBytes,
+            Address, B256, Bytes, FixedBytes, TxKind,
             aliases::{U24, U48},
         },
+        rpc::types::eth::BlockTransactions,
         sol_types::SolCall,
     };
     use alloy_provider::{ProviderBuilder, RootProvider};
     use alloy_transport::mock::Asserter;
     use bindings::{
-        anchor::Anchor::AnchorInstance,
+        anchor::{Anchor::AnchorInstance, ICheckpointStore::Checkpoint},
         inbox::{
             IInbox,
             Inbox::{InboxInstance, getCoreStateCall},
             LibBlobs::BlobSlice,
         },
     };
-    use protocol::shasta::manifest::{BlockManifest, DerivationSourceManifest};
-    use rpc::client::{Client, ShastaProtocolInstance};
+    use protocol::{
+        FixedKSigner,
+        shasta::{
+            AnchorTxConstructor,
+            constants::{TAIKO_MAINNET_CHAIN_ID, min_base_fee_for_chain},
+            manifest::{BlockManifest, DerivationSourceManifest},
+        },
+    };
+    use rpc::{
+        blob::BlobDataSource,
+        client::{Client, ShastaProtocolInstance},
+    };
 
     fn sample_derivation_source(
         blob_hashes: Vec<FixedBytes<32>>,
@@ -567,19 +637,84 @@ mod tests {
     }
 
     fn mock_client_with_l1_asserter(l1_asserter: Asserter) -> Client<RootProvider> {
+        mock_client_with_asserters(l1_asserter, Asserter::new(), Asserter::new(), Address::ZERO)
+    }
+
+    fn mock_client_with_asserters(
+        l1_asserter: Asserter,
+        l2_asserter: Asserter,
+        l2_auth_asserter: Asserter,
+        anchor_address: Address,
+    ) -> Client<RootProvider> {
         let l1_provider =
             ProviderBuilder::new().disable_recommended_fillers().connect_mocked_client(l1_asserter);
-        let l2_provider = ProviderBuilder::new()
-            .disable_recommended_fillers()
-            .connect_mocked_client(Asserter::new());
+        let l2_provider =
+            ProviderBuilder::new().disable_recommended_fillers().connect_mocked_client(l2_asserter);
         let l2_auth_provider = ProviderBuilder::new()
             .disable_recommended_fillers()
-            .connect_mocked_client(Asserter::new());
+            .connect_mocked_client(l2_auth_asserter);
         let inbox = InboxInstance::new(Address::ZERO, l1_provider.clone());
-        let anchor = AnchorInstance::new(Address::ZERO, l2_auth_provider.clone());
+        let anchor = AnchorInstance::new(anchor_address, l2_auth_provider.clone());
         let shasta = ShastaProtocolInstance { inbox, anchor };
 
         Client { l1_provider, l2_provider, l2_auth_provider, shasta }
+    }
+
+    fn sign_test_anchor_tx(anchor_address: Address, input: Bytes) -> TxEnvelope {
+        let signer = FixedKSigner::golden_touch().expect("golden touch signer should load");
+        let tx = TxEip1559 {
+            chain_id: TAIKO_MAINNET_CHAIN_ID,
+            nonce: 0,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 0,
+            gas_limit: 250_000,
+            to: TxKind::Call(anchor_address),
+            value: U256::ZERO,
+            access_list: AccessList::default(),
+            input,
+        };
+        let sighash = tx.signature_hash();
+        let mut hash_bytes = [0u8; 32];
+        hash_bytes.copy_from_slice(sighash.as_slice());
+        let signature =
+            signer.sign_with_predefined_k(&hash_bytes).expect("test anchor tx should sign");
+
+        TxEnvelope::new_unchecked(
+            EthereumTypedTransaction::Eip1559(tx),
+            signature.signature,
+            sighash,
+        )
+    }
+
+    fn sample_anchor_transaction(anchor_address: Address, anchor_block_number: u64) -> TxEnvelope {
+        let checkpoint = Checkpoint {
+            blockNumber: U48::from(anchor_block_number),
+            blockHash: B256::from([0x22; 32]),
+            stateRoot: B256::from([0x33; 32]),
+        };
+        sign_test_anchor_tx(
+            anchor_address,
+            Bytes::from(anchorV4Call(checkpoint.into()).abi_encode()),
+        )
+    }
+
+    fn sample_anchor_v3_transaction(
+        anchor_address: Address,
+        anchor_block_number: u64,
+    ) -> TxEnvelope {
+        sign_test_anchor_tx(
+            anchor_address,
+            Bytes::from(
+                anchorV3Call {
+                    _0: anchor_block_number,
+                    _1: B256::from([0x33; 32]),
+                    _2: 0,
+                    _3: (1, 0, 1, 0, 1),
+                    _4: Vec::new(),
+                }
+                .abi_encode(),
+            ),
+        )
     }
 
     #[test]
@@ -615,6 +750,87 @@ mod tests {
         assert_eq!(meta.proposal_id, 11);
         assert_eq!(meta.last_finalized_proposal_id, None);
         assert_eq!(meta.origin_block_number, 9);
+    }
+
+    #[test]
+    fn mainnet_bootstrap_proposals_skip_anchor_state_lookup() {
+        assert!(should_decode_parent_anchor_from_tx(TAIKO_MAINNET_CHAIN_ID, 1));
+        assert!(should_decode_parent_anchor_from_tx(TAIKO_MAINNET_CHAIN_ID, 7));
+        assert!(!should_decode_parent_anchor_from_tx(TAIKO_MAINNET_CHAIN_ID, 8));
+        assert!(!should_decode_parent_anchor_from_tx(167_013, 7));
+    }
+
+    #[test]
+    fn decode_parent_anchor_block_number_accepts_anchor_v3() {
+        let anchor_address = Address::repeat_byte(0x44);
+        let anchor_block_number = 55u64;
+        let mut parent_block = RpcBlock::<TxEnvelope>::default();
+        parent_block.header.number = 1;
+        parent_block.transactions = BlockTransactions::Full(vec![sample_anchor_v3_transaction(
+            anchor_address,
+            anchor_block_number,
+        )]);
+
+        let decoded = decode_parent_anchor_block_number(&parent_block, anchor_address)
+            .expect("anchorV3 calldata should decode");
+
+        assert_eq!(decoded, anchor_block_number);
+    }
+
+    #[tokio::test]
+    async fn initialize_parent_state_decodes_anchor_from_parent_tx_on_mainnet_bootstrap() {
+        let l2_asserter = Asserter::new();
+        let anchor_address = Address::repeat_byte(0x44);
+        let parent_anchor_block_number = 55u64;
+        l2_asserter.push_success(&TAIKO_MAINNET_CHAIN_ID);
+        let mut grandparent_block = RpcBlock::<TxEnvelope>::default();
+        grandparent_block.header.number = 0;
+        grandparent_block.header.timestamp = 100;
+        l2_asserter.push_success(&Some(grandparent_block));
+
+        let client = mock_client_with_asserters(
+            Asserter::new(),
+            l2_asserter,
+            Asserter::new(),
+            anchor_address,
+        );
+        let blob_source = Arc::new(
+            BlobDataSource::new(None, None, true)
+                .await
+                .expect("blob data source should initialise"),
+        );
+        let anchor_constructor =
+            AnchorTxConstructor::new(client.l2_provider.clone(), anchor_address)
+                .await
+                .expect("anchor constructor should initialise");
+        let pipeline = ShastaDerivationPipeline {
+            rpc: client,
+            anchor_constructor,
+            derivation_source_manifest_fetcher: Arc::new(ShastaSourceManifestFetcher::new(
+                blob_source,
+            )),
+            shasta_fork_timestamp: 0,
+            min_base_fee_to_clamp: min_base_fee_for_chain(TAIKO_MAINNET_CHAIN_ID),
+            chain_id: TAIKO_MAINNET_CHAIN_ID,
+            initial_proposal_id: U256::ZERO,
+        };
+
+        let mut parent_block = RpcBlock::<TxEnvelope>::default();
+        parent_block.header.number = 1;
+        parent_block.header.timestamp = 112;
+        parent_block.header.parent_hash = B256::from([0x11; 32]);
+        parent_block.transactions = BlockTransactions::Full(vec![sample_anchor_transaction(
+            anchor_address,
+            parent_anchor_block_number,
+        )]);
+
+        let state = pipeline
+            .initialize_parent_state(&parent_block, 7)
+            .await
+            .expect("mainnet bootstrap should decode parent anchor from tx");
+
+        assert_eq!(state.anchor_block_number, parent_anchor_block_number);
+        assert_eq!(state.parent_block_time_delta_secs, 12);
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
@@ -34,6 +34,10 @@ pub const GAS_LIMIT_DENOMINATOR: u64 = 1_000_000;
 /// The delay in processing bond instructions relative to the current proposal.
 pub const BOND_PROCESSING_DELAY: u64 = 6;
 
+/// On Taiko mainnet, early bootstrap proposals recover the parent anchor from the embedded
+/// `anchorV4` / `anchorV3` transaction instead of the anchor contract state.
+pub const MAINNET_ANCHOR_CHECK_SKIP_PROPOSAL_OFFSET: u64 = 7;
+
 /// The current version of the Shasta protocol payload format.
 pub const SHASTA_PAYLOAD_VERSION: u8 = 0x1;
 


### PR DESCRIPTION
Ref: https://github.com/taikoxyz/taiko-mono/pull/21529
## Summary
- align Rust Shasta parent-anchor decoding with `../taiko-client` bootstrap behavior
- decode parent anchor block numbers from either `anchorV4` or `anchorV3` calldata
- reuse the shared ABI definitions from `alethia-reth-consensus` instead of keeping a local duplicate
- add regression coverage for `anchorV3` decoding and the mainnet bootstrap fallback path

## Motivation
`taiko-client` now falls back to decoding the parent anchor transaction during early mainnet bootstrap proposals. Rust had started adding that fallback, but the decoder only handled `anchorV4`.

To stay compatible with Pacaya-era parent blocks and match the Go client more closely, this change makes the Rust decoder accept both `anchorV3` and `anchorV4`, using the ABI definitions already maintained in `alethia-reth-consensus`.

## Changes
- import `anchorV3Call` and `anchorV4Call` from `alethia-reth-consensus::anchor_constants`
- update parent-anchor decoding to:
  - try `anchorV4`
  - fall back to `anchorV3`
- remove the local ad hoc `anchorV3` ABI definition
- add regression tests for:
  - `anchorV3` parent-anchor decoding
  - mainnet bootstrap proposal fallback gating
  - mainnet bootstrap parent-state initialization

## Testing
- `cargo test -p driver decode_parent_anchor_block_number_accepts_anchor_v3`
- `cargo test -p driver mainnet_bootstrap`
- `just fmt && just clippy-fix && just clippy`

## Notes
- this keeps the scope narrow to `anchorV3` + `anchorV4`, as requested
- this does not yet address the separate parity gaps around proposal-1 parent selection / full parent-block loading