### PR TITLE
chore(taiko-client): revert changes for `--allow-all-sequencers` flag

### DIFF
--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -25,13 +25,6 @@ var (
 		Category: driverCategory,
 		EnvVars:  []string{"P2P_SYNC_TIMEOUT"},
 	}
-	P2PAllowAllSequencers = &cli.BoolFlag{
-		Name:     "p2p.allow-all-sequencers",
-		Usage:    "Allow all currently active preconfirmation sequencer addresses in P2P signer validation",
-		Value:    false,
-		Category: driverCategory,
-		EnvVars:  []string{"P2P_ALLOW_ALL_SEQUENCERS"},
-	}
 	CheckPointSyncURL = &cli.StringFlag{
 		Name:     "p2p.checkPointSyncUrl",
 		Usage:    "HTTP RPC endpoint of another synced L2 execution engine node",
@@ -89,7 +82,6 @@ var DriverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	JWTSecret,
 	P2PSync,
 	P2PSyncTimeout,
-	P2PAllowAllSequencers,
 	CheckPointSyncURL,
 	BlobServerEndpoint,
 	PreconfBlockServerPort,

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -26,7 +26,6 @@ type Config struct {
 	*rpc.ClientConfig
 	P2PSync                       bool
 	P2PSyncTimeout                time.Duration
-	P2PAllowAllSequencers         bool
 	RetryInterval                 time.Duration
 	BlobServerEndpoint            *url.URL
 	PreconfBlockServerPort        uint64
@@ -46,18 +45,12 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	}
 
 	var (
-		p2pSync               = c.Bool(flags.P2PSync.Name)
-		p2pAllowAllSequencers = c.Bool(flags.P2PAllowAllSequencers.Name)
-		l2CheckPoint          = c.String(flags.CheckPointSyncURL.Name)
-		preconfWhitelist      = common.HexToAddress(c.String(flags.PreconfWhitelistAddress.Name))
+		p2pSync      = c.Bool(flags.P2PSync.Name)
+		l2CheckPoint = c.String(flags.CheckPointSyncURL.Name)
 	)
 
 	if p2pSync && len(l2CheckPoint) == 0 {
 		return nil, errors.New("empty L2 check point URL")
-	}
-
-	if p2pAllowAllSequencers && preconfWhitelist == (common.Address{}) {
-		return nil, errors.New("--p2p.allow-all-sequencers requires --preconfirmation.whitelist to be set")
 	}
 
 	var beaconEndpoint string
@@ -97,7 +90,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			PacayaInboxAddress:      common.HexToAddress(c.String(flags.PacayaInboxAddress.Name)),
 			ShastaInboxAddress:      common.HexToAddress(c.String(flags.ShastaInboxAddress.Name)),
 			TaikoAnchorAddress:      common.HexToAddress(c.String(flags.TaikoAnchorAddress.Name)),
-			PreconfWhitelistAddress: preconfWhitelist,
+			PreconfWhitelistAddress: common.HexToAddress(c.String(flags.PreconfWhitelistAddress.Name)),
 			L2EngineEndpoint:        c.String(flags.L2AuthEndpoint.Name),
 			JwtSecret:               string(jwtSecret),
 			Timeout:                 c.Duration(flags.RPCTimeout.Name),
@@ -142,7 +135,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		RetryInterval:                 c.Duration(flags.BackOffRetryInterval.Name),
 		P2PSync:                       p2pSync,
 		P2PSyncTimeout:                c.Duration(flags.P2PSyncTimeout.Name),
-		P2PAllowAllSequencers:         p2pAllowAllSequencers,
 		BlobServerEndpoint:            blobServerEndpoint,
 		PreconfBlockServerPort:        c.Uint64(flags.PreconfBlockServerPort.Name),
 		PreconfBlockServerJWTSecret:   preconfBlockServerJWTSecret,

--- a/packages/taiko-client/driver/config_test.go
+++ b/packages/taiko-client/driver/config_test.go
@@ -87,47 +87,6 @@ func (s *DriverTestSuite) TestNewConfigFromCliContextEmptyL2CheckPoint() {
 	}), "empty L2 check point URL")
 }
 
-func (s *DriverTestSuite) TestNewConfigFromCliContextAllowAllSequencersRequiresWhitelist() {
-	app := s.SetupApp()
-	s.ErrorContains(app.Run([]string{
-		"TestNewConfigFromCliContext",
-		"--" + flags.JWTSecret.Name, os.Getenv("JWT_SECRET"),
-		"--" + flags.P2PAllowAllSequencers.Name,
-	}), "--p2p.allow-all-sequencers requires --preconfirmation.whitelist to be set")
-}
-
-func (s *DriverTestSuite) TestNewConfigFromCliContextAllowAllSequencers() {
-	app := s.SetupApp()
-
-	app.Action = func(ctx *cli.Context) error {
-		c, err := NewConfigFromCliContext(ctx)
-		s.Nil(err)
-		s.True(c.P2PAllowAllSequencers)
-
-		return err
-	}
-
-	s.Nil(app.Run([]string{
-		"TestNewConfigFromCliContextAllowAllSequencers",
-		"--" + flags.L1WSEndpoint.Name, l1Endpoint,
-		"--" + flags.L1BeaconEndpoint.Name, l1BeaconEndpoint,
-		"--" + flags.L2WSEndpoint.Name, l2Endpoint,
-		"--" + flags.L2AuthEndpoint.Name, l2EngineEndpoint,
-		"--" + flags.PacayaInboxAddress.Name, pacayaInbox,
-		"--" + flags.ShastaInboxAddress.Name, shastaInbox,
-		"--" + flags.TaikoAnchorAddress.Name, taikoAnchor,
-		"--" + flags.PreconfWhitelistAddress.Name, taikoAnchor,
-		"--" + flags.JWTSecret.Name, os.Getenv("JWT_SECRET"),
-		"--" + flags.P2PSyncTimeout.Name, "120s",
-		"--" + flags.RPCTimeout.Name, "5s",
-		"--" + flags.P2PAllowAllSequencers.Name,
-		"--" + p2pFlags.P2PPrivPathName, os.Getenv("JWT_SECRET"),
-		"--" + p2pFlags.DiscoveryPathName, "memory",
-		"--" + p2pFlags.PeerstorePathName, "memory",
-		"--" + p2pFlags.SequencerP2PKeyName, os.Getenv("L1_PROPOSER_PRIVATE_KEY"),
-	}))
-}
-
 func (s *DriverTestSuite) SetupApp() *cli.App {
 	app := cli.NewApp()
 	app.Flags = flags.MergeFlags([]cli.Flag{
@@ -138,10 +97,8 @@ func (s *DriverTestSuite) SetupApp() *cli.App {
 		&cli.StringFlag{Name: flags.PacayaInboxAddress.Name},
 		&cli.StringFlag{Name: flags.ShastaInboxAddress.Name},
 		&cli.StringFlag{Name: flags.TaikoAnchorAddress.Name},
-		&cli.StringFlag{Name: flags.PreconfWhitelistAddress.Name},
 		&cli.StringFlag{Name: flags.JWTSecret.Name},
 		&cli.BoolFlag{Name: flags.P2PSync.Name},
-		&cli.BoolFlag{Name: flags.P2PAllowAllSequencers.Name},
 		&cli.DurationFlag{Name: flags.P2PSyncTimeout.Name},
 		&cli.DurationFlag{Name: flags.RPCTimeout.Name},
 		&cli.StringFlag{Name: flags.CheckPointSyncURL.Name},

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -142,15 +142,6 @@ func (d *Driver) InitFromConfig(ctx context.Context, cfg *Config) (err error) {
 		); err != nil {
 			return fmt.Errorf("failed to create preconf block server: %w", err)
 		}
-		d.preconfBlockServer.SetAllowAllSequencers(cfg.P2PAllowAllSequencers)
-		if cfg.P2PAllowAllSequencers {
-			activeSequencers, err := d.rpc.GetAllActiveOperators(nil)
-			if err != nil {
-				return fmt.Errorf("failed to fetch active preconfirmation sequencers: %w", err)
-			}
-
-			d.preconfBlockServer.UpdateActiveSequencerAddresses(activeSequencers)
-		}
 		log.Info("Preconf Operator Address", "PreconfOperatorAddress", d.PreconfOperatorAddress)
 
 		// Enable P2P network for preconfirmation block propagation.
@@ -547,15 +538,6 @@ func (d *Driver) cacheLookaheadLoop() {
 			log.Warn("Could not fetch next operator", "err", err)
 
 			return fmt.Errorf("failed to fetch next operator: %w", err)
-		}
-
-		if d.P2PAllowAllSequencers {
-			activeSequencers, err := d.rpc.GetAllActiveOperators(nil)
-			if err != nil {
-				log.Warn("Could not fetch active preconfirmation sequencers", "err", err)
-			} else {
-				d.preconfBlockServer.UpdateActiveSequencerAddresses(activeSequencers)
-			}
 		}
 
 		lookahead := d.preconfBlockServer.GetLookahead()

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -76,9 +76,6 @@ type PreconfBlockAPIServer struct {
 	// P2P network for preconfirmation block propagation
 	p2pNode   *p2p.NodeP2P
 	p2pSigner p2p.Signer
-	// P2P signer allowlist runtime configuration
-	allowAllSequencers          bool
-	allActiveSequencerAddresses []common.Address
 	// WebSocket server for preconfirmation block notifications
 	ws *webSocketSever
 	// Lookahead information for the current and next operator
@@ -178,22 +175,6 @@ func (s *PreconfBlockAPIServer) SetP2PNode(p2pNode *p2p.NodeP2P) {
 // SetP2PSigner sets the P2P signer for the preconfirmation block server.
 func (s *PreconfBlockAPIServer) SetP2PSigner(p2pSigner p2p.Signer) {
 	s.p2pSigner = p2pSigner
-}
-
-// SetAllowAllSequencers toggles the all-active-sequencers P2P allowlist mode.
-func (s *PreconfBlockAPIServer) SetAllowAllSequencers(allow bool) {
-	s.lookaheadMutex.Lock()
-	defer s.lookaheadMutex.Unlock()
-
-	s.allowAllSequencers = allow
-}
-
-// UpdateActiveSequencerAddresses updates the cached active sequencer addresses used by P2P validation.
-func (s *PreconfBlockAPIServer) UpdateActiveSequencerAddresses(addresses []common.Address) {
-	s.lookaheadMutex.Lock()
-	defer s.lookaheadMutex.Unlock()
-
-	s.allActiveSequencerAddresses = append([]common.Address(nil), addresses...)
 }
 
 // SetSyncReady toggles readiness for preconfirmation inserts.
@@ -1019,22 +1000,6 @@ func (s *PreconfBlockAPIServer) P2PSequencerAddress() common.Address {
 func (s *PreconfBlockAPIServer) P2PSequencerAddresses() []common.Address {
 	s.lookaheadMutex.Lock()
 	defer s.lookaheadMutex.Unlock()
-
-	if s.allowAllSequencers {
-		if len(s.allActiveSequencerAddresses) > 0 {
-			log.Debug("Active operator addresses as P2P sequencer", "addresses", s.allActiveSequencerAddresses)
-
-			return append([]common.Address(nil), s.allActiveSequencerAddresses...)
-		}
-
-		log.Warn("Allow-all-sequencers mode enabled but active operator cache is empty")
-		return nil
-	}
-
-	if s.lookahead == nil {
-		log.Warn("Lookahead information not initialized for P2P sequencer addresses")
-		return nil
-	}
 
 	log.Debug(
 		"Operator addresses as P2P sequencer",

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -128,31 +128,6 @@ func (s *PreconfBlockAPIServerTestSuite) TestTryPutEnvelopeIntoCache() {
 	s.Equal(totalCached+1, s.s.envelopesCache.totalCached)
 }
 
-func (s *PreconfBlockAPIServerTestSuite) TestP2PSequencerAddresses() {
-	curr := common.HexToAddress("0xAAA0000000000000000000000000000000000000")
-	next := common.HexToAddress("0xBBB0000000000000000000000000000000000000")
-	active := []common.Address{
-		common.HexToAddress("0x1110000000000000000000000000000000000000"),
-		common.HexToAddress("0x2220000000000000000000000000000000000000"),
-	}
-
-	s.s.UpdateLookahead(&Lookahead{
-		CurrOperator: curr,
-		NextOperator: next,
-	})
-
-	s.Equal([]common.Address{curr, next}, s.s.P2PSequencerAddresses())
-
-	s.s.SetAllowAllSequencers(true)
-	s.s.UpdateActiveSequencerAddresses(active)
-
-	s.Equal(active, s.s.P2PSequencerAddresses())
-
-	s.s.UpdateActiveSequencerAddresses(nil)
-
-	s.Empty(s.s.P2PSequencerAddresses())
-}
-
 func (s *PreconfBlockAPIServerTestSuite) TestShutdown() {
 	s.Nil(s.s.Shutdown(context.Background()))
 }

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -1272,12 +1272,6 @@ func (c *Client) GetAllActiveOperators(opts *bind.CallOpts) ([]common.Address, e
 	opts.Context, cancel = CtxWithTimeoutOrDefault(opts.Context, DefaultRpcTimeout)
 	defer cancel()
 
-	// offset=0 returns the current epoch's start timestamp.
-	currentEpochTimestamp, err := c.PacayaClients.PreconfWhitelist.EpochStartTimestamp(opts, big.NewInt(0))
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current epoch timestamp: %w", err)
-	}
-
 	count, err := c.PacayaClients.PreconfWhitelist.OperatorCount(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get total preconfirmation whitelist operators: %w", err)
@@ -1293,16 +1287,12 @@ func (c *Client) GetAllActiveOperators(opts *bind.CallOpts) ([]common.Address, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to get preconfirmation whitelist operator info: %w", err)
 		}
-		if isPreconfOperatorActiveAtEpoch(opInfo.ActiveSince, opInfo.InactiveSince, currentEpochTimestamp) {
+		if opInfo.InactiveSince == 0 {
 			operators = append(operators, opInfo.SequencerAddress)
 		}
 	}
 
 	return operators, nil
-}
-
-func isPreconfOperatorActiveAtEpoch(activeSince, inactiveSince, currentEpochTimestamp uint32) bool {
-	return inactiveSince == 0 && activeSince != 0 && activeSince <= currentEpochTimestamp
 }
 
 // GetForcedInclusionPacaya resolves the Pacaya forced inclusion contract address.

--- a/packages/taiko-client/pkg/rpc/methods_test.go
+++ b/packages/taiko-client/pkg/rpc/methods_test.go
@@ -123,59 +123,6 @@ func TestWaitTillL2ExecutionEngineSyncedContextErr(t *testing.T) {
 	require.ErrorContains(t, err, "context canceled")
 }
 
-func TestIsPreconfOperatorActiveAtEpoch(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name                 string
-		activeSince          uint32
-		inactiveSince        uint32
-		currentEpochStart    uint32
-		expectedActiveStatus bool
-	}{
-		{
-			name:                 "active when activation epoch has started",
-			activeSince:          100,
-			inactiveSince:        0,
-			currentEpochStart:    100,
-			expectedActiveStatus: true,
-		},
-		{
-			name:                 "inactive when activation epoch is in the future",
-			activeSince:          101,
-			inactiveSince:        0,
-			currentEpochStart:    100,
-			expectedActiveStatus: false,
-		},
-		{
-			name:                 "inactive when removed",
-			activeSince:          100,
-			inactiveSince:        150,
-			currentEpochStart:    200,
-			expectedActiveStatus: false,
-		},
-		{
-			name:                 "inactive when never activated",
-			activeSince:          0,
-			inactiveSince:        0,
-			currentEpochStart:    100,
-			expectedActiveStatus: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			require.Equal(
-				t,
-				tc.expectedActiveStatus,
-				isPreconfOperatorActiveAtEpoch(tc.activeSince, tc.inactiveSince, tc.currentEpochStart),
-			)
-		})
-	}
-}
-
 // randomHash generates a random blob of data and returns it as a hash.
 func randomHash() common.Hash {
 	var hash common.Hash


### PR DESCRIPTION
ref: https://github.com/taikoxyz/taiko-mono/pull/21510

Since we are not using it, and we should investigate why the L1 node is so laggy instead of adding this patch when the issue that PR tried to address happens again.