### PR TITLE
fix(taiko-client): fix prover support for `l1.beacon` flag

### DIFF
--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -130,6 +130,7 @@ var (
 
 // ProverFlags All prover flags.
 var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
+	L1BeaconEndpoint,
 	L2WSEndpoint,
 	L2HTTPEndpoint,
 	L2AuthEndpoint,


### PR DESCRIPTION
## Summary
- add `l1.beacon` to `ProverFlags`
- allow the `prover` command to accept the beacon endpoint flag at runtime
- align CLI flag registration with existing prover config usage

## Testing
- `go run ./cmd prover --help | rg -n -- '--l1\.beacon|l1\.beacon'`