### PR TITLE
fix(taiko-client): reject oversized Shasta manifest headers

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher.go
+++ b/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher.go
@@ -208,8 +208,8 @@ func ExtractVersion(data []byte, offset int) (uint32, error) {
 	version := new(big.Int).SetBytes(data[offset : offset+32])
 
 	// Check if version fits in uint32
-	if !version.IsUint64() {
-		return 0, fmt.Errorf("version number %d too large", version)
+	if version.BitLen() > 32 {
+		return 0, fmt.Errorf("version number %s too large", version.String())
 	}
 
 	return uint32(version.Uint64()), nil
@@ -224,6 +224,10 @@ func ExtractSize(data []byte, offset int) (uint64, error) {
 
 	// Extract 32 bytes for size
 	size := new(big.Int).SetBytes(data[offset+32 : offset+64])
+
+	if !size.IsUint64() {
+		return 0, fmt.Errorf("size %s too large", size.String())
+	}
 
 	return size.Uint64(), nil
 }

--- a/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher_test.go
+++ b/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/manifest"
@@ -62,7 +63,7 @@ func (s *DerivationSourceFetcherTestSuite) TestManifestEncodeDecode() {
 	s.Equal(len(m.Blocks[0].Transactions), len(decoded.BlockPayloads[0].Transactions))
 }
 
-func (s *DerivationSourceFetcherTestSuite) TestExtractVersionAndSize() {
+func TestExtractVersionAndSize(t *testing.T) {
 	version := uint32(1)
 	size := uint64(1024) // Use a reasonable test size since ProposalMaxBytes was removed
 	sourceManifestBytes := testutils.RandomBytes(int(size))
@@ -79,9 +80,37 @@ func (s *DerivationSourceFetcherTestSuite) TestExtractVersionAndSize() {
 	blobBytesPrefix = append(blobBytesPrefix, lenBytes...)
 
 	decodedVersion, decodedSize, err := ExtractVersionAndSize(blobBytesPrefix, 0)
-	s.Nil(err)
-	s.Equal(version, decodedVersion)
-	s.Equal(uint64(len(sourceManifestBytes)), decodedSize)
+	require.NoError(t, err)
+	require.Equal(t, version, decodedVersion)
+	require.Equal(t, uint64(len(sourceManifestBytes)), decodedSize)
+}
+
+func TestExtractVersionRejectsUint32Overflow(t *testing.T) {
+	versionBytes := make([]byte, 32)
+	new(big.Int).SetUint64(1 << 32).FillBytes(versionBytes)
+
+	sizeBytes := make([]byte, 32)
+	new(big.Int).SetUint64(1).FillBytes(sizeBytes)
+
+	blobBytesPrefix := append(versionBytes, sizeBytes...)
+
+	_, _, err := ExtractVersionAndSize(blobBytesPrefix, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "version number")
+}
+
+func TestExtractSizeRejectsUint64Overflow(t *testing.T) {
+	versionBytes := make([]byte, 32)
+	versionBytes[31] = byte(manifest.ShastaPayloadVersion)
+
+	sizeBytes := make([]byte, 32)
+	new(big.Int).Lsh(big.NewInt(1), 64).FillBytes(sizeBytes)
+
+	blobBytesPrefix := append(versionBytes, sizeBytes...)
+
+	_, _, err := ExtractVersionAndSize(blobBytesPrefix, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "size")
 }
 
 func TestDerivationSourceFetcherTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary
- Reject manifest `version` values that do not fit in `uint32`
- Reject manifest `size` values that do not fit in `uint64`
- Move manifest header extraction tests out of `ClientTestSuite` and add overflow regression coverage

## Changes

### taiko-client (Go)
- `driver/chain_syncer/event/derivation/source_fetcher.go`: add strict upper-bound checks before converting manifest header fields
- `driver/chain_syncer/event/derivation/source_fetcher_test.go`: add standalone regression tests for `uint32` / `uint64` overflow cases