### PR TITLE
feat(taiko-client,taiko-client-rs): add devnet Uzen time override flag

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -9249,6 +9249,7 @@ dependencies = [
  "preconfirmation-driver",
  "preconfirmation-net",
  "proposer",
+ "protocol",
  "rpc",
  "thiserror 2.0.18",
  "tokio",

--- a/packages/taiko-client-rs/bin/client/Cargo.toml
+++ b/packages/taiko-client-rs/bin/client/Cargo.toml
@@ -32,6 +32,7 @@ driver = { path = "../../crates/driver" }
 preconfirmation-driver = { path = "../../crates/preconfirmation-driver" }
 preconfirmation-net = { path = "../../../preconfirmation-p2p/crates/net" }
 proposer = { path = "../../crates/proposer" }
+protocol = { path = "../../crates/protocol" }
 rpc = { path = "../../crates/rpc" }
 whitelist-preconfirmation-driver = { path = "../../crates/whitelist-preconfirmation-driver" }
 

--- a/packages/taiko-client-rs/bin/client/src/commands/driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/driver.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use clap::Parser;
 use driver::{Driver, DriverConfig, metrics::DriverMetrics};
+use protocol::shasta::set_devnet_uzen_override;
 use rpc::client::ClientConfig;
 
 use crate::{
@@ -71,6 +72,7 @@ impl Subcommand for DriverSubCommand {
 
     /// Run the driver.
     async fn run(&self) -> Result<()> {
+        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_logs()?;
         self.init_metrics()?;
 

--- a/packages/taiko-client-rs/bin/client/src/commands/preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/preconfirmation_driver.rs
@@ -8,6 +8,7 @@ use preconfirmation_driver::{
     rpc::PreconfRpcServerConfig,
 };
 use preconfirmation_net::P2pConfig;
+use protocol::shasta::set_devnet_uzen_override;
 use rpc::client::ClientConfig;
 use tracing::warn;
 
@@ -107,6 +108,7 @@ impl Subcommand for PreconfirmationDriverSubCommand {
 
     /// Runs the preconfirmation driver with embedded P2P client.
     async fn run(&self) -> Result<()> {
+        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_logs()?;
         self.init_metrics()?;
 

--- a/packages/taiko-client-rs/bin/client/src/commands/proposer.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/proposer.rs
@@ -5,6 +5,7 @@ use crate::error::Result;
 use async_trait::async_trait;
 use clap::Parser;
 use proposer::{config::ProposerConfigs, metrics::ProposerMetrics, proposer::Proposer};
+use protocol::shasta::set_devnet_uzen_override;
 
 use crate::{
     commands::Subcommand,
@@ -77,6 +78,7 @@ impl Subcommand for ProposerSubCommand {
 
     /// Execute the proposer subcommand flow.
     async fn run(&self) -> Result<()> {
+        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_logs()?;
         self.init_metrics()?;
 

--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -6,6 +6,7 @@ use alloy_primitives::Address;
 use async_trait::async_trait;
 use clap::Parser;
 use driver::{DriverConfig, metrics::DriverMetrics};
+use protocol::shasta::set_devnet_uzen_override;
 use rpc::client::ClientConfig;
 use tracing::warn;
 use whitelist_preconfirmation_driver::{
@@ -165,6 +166,7 @@ impl Subcommand for WhitelistPreconfirmationDriverSubCommand {
 
     /// Runs the whitelist preconfirmation driver.
     async fn run(&self) -> Result<()> {
+        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_logs()?;
         self.init_metrics()?;
 

--- a/packages/taiko-client-rs/bin/client/src/flags/common.rs
+++ b/packages/taiko-client-rs/bin/client/src/flags/common.rs
@@ -84,6 +84,14 @@ pub struct CommonArgs {
         help = "Address to bind Prometheus metrics server"
     )]
     pub metrics_addr: String,
+    /// Override Uzen fork time for Taiko internal devnet (timestamp).
+    #[clap(
+        long = "devnet-uzen-timestamp",
+        env = "DEVNET_UZEN_TIMESTAMP",
+        default_value_t = 0,
+        help = "Override Uzen fork time for Taiko internal devnet (timestamp). Must match the value passed to alethia-reth's --devnet-uzen-timestamp. Defaults to 0."
+    )]
+    pub devnet_uzen_timestamp: u64,
 }
 
 impl CommonArgs {
@@ -224,6 +232,7 @@ mod tests {
             metrics_enabled: false,
             metrics_port: 9090,
             metrics_addr: "0.0.0.0".to_string(),
+            devnet_uzen_timestamp: 0,
         };
 
         assert!(matches!(args.l1_provider_source(), Err(CliError::InvalidL1EndpointConfig)));
@@ -262,5 +271,33 @@ mod tests {
         let args = CommonArgs::try_parse_from(required_args()).expect("env-backed L1 config");
 
         assert!(matches!(args.l1_provider_source(), Err(CliError::InvalidL1EndpointConfig)));
+    }
+
+    #[test]
+    fn parses_devnet_uzen_timestamp_flag() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let _clear = clear_l1_env();
+        let _clear_dut = EnvGuard::unset("DEVNET_UZEN_TIMESTAMP");
+        let mut argv: Vec<&'static str> = required_args().to_vec();
+        argv.extend(["--l1.http", "http://localhost:8545"]);
+        argv.extend(["--devnet-uzen-timestamp", "12345"]);
+
+        let args =
+            CommonArgs::try_parse_from(argv).expect("devnet uzen timestamp flag should parse");
+
+        assert_eq!(args.devnet_uzen_timestamp, 12345);
+    }
+
+    #[test]
+    fn devnet_uzen_timestamp_defaults_to_zero() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let _clear = clear_l1_env();
+        let _clear_dut = EnvGuard::unset("DEVNET_UZEN_TIMESTAMP");
+        let mut argv: Vec<&'static str> = required_args().to_vec();
+        argv.extend(["--l1.http", "http://localhost:8545"]);
+
+        let args = CommonArgs::try_parse_from(argv).expect("default parse should succeed");
+
+        assert_eq!(args.devnet_uzen_timestamp, 0);
     }
 }

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
@@ -82,9 +82,12 @@ static DEVNET_UZEN_OVERRIDE: OnceLock<u64> = OnceLock::new();
 
 /// Set the devnet Uzen activation timestamp override. Must be called before
 /// any fork-condition lookup runs for the internal devnet. Subsequent calls
-/// after the first are ignored.
+/// after the first are ignored. Logs the applied value on the first
+/// successful set so operators see confirmation at startup.
 pub fn set_devnet_uzen_override(timestamp: u64) {
-    let _ = DEVNET_UZEN_OVERRIDE.set(timestamp);
+    if DEVNET_UZEN_OVERRIDE.set(timestamp).is_ok() {
+        tracing::info!(timestamp, "applied devnet Uzen activation time override");
+    }
 }
 
 /// Taiko chain IDs where the Shasta fork is configured.

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/constants.rs
@@ -1,5 +1,7 @@
 //! Shasta protocol constants and limits.
 
+use std::sync::OnceLock;
+
 use crate::shasta::error::{ForkConfigError, ForkConfigResult};
 use alethia_reth_consensus::eip4396::{MAINNET_MIN_BASE_FEE, MIN_BASE_FEE};
 use alloy_eips::eip4844::BYTES_PER_BLOB;
@@ -71,6 +73,20 @@ pub const UZEN_FORK_HOODI: ForkCondition = ForkCondition::Never;
 /// Uzen fork activation on Taiko Mainnet.
 pub const UZEN_FORK_MAINNET: ForkCondition = ForkCondition::Never;
 
+/// Process-global override for the devnet Uzen activation timestamp.
+///
+/// Set once at startup (typically from a CLI flag mirroring alethia-reth's
+/// `--devnet-uzen-timestamp`) so client and node agree on devnet fork timing.
+/// Only the first call takes effect; subsequent calls are silently ignored.
+static DEVNET_UZEN_OVERRIDE: OnceLock<u64> = OnceLock::new();
+
+/// Set the devnet Uzen activation timestamp override. Must be called before
+/// any fork-condition lookup runs for the internal devnet. Subsequent calls
+/// after the first are ignored.
+pub fn set_devnet_uzen_override(timestamp: u64) {
+    let _ = DEVNET_UZEN_OVERRIDE.set(timestamp);
+}
+
 /// Taiko chain IDs where the Shasta fork is configured.
 pub const TAIKO_DEVNET_CHAIN_ID: u64 = 167_001;
 /// Chain ID for the Taiko Masaya network.
@@ -113,9 +129,18 @@ pub const fn shasta_fork_condition_for_chain(chain_id: u64) -> Option<ForkCondit
 }
 
 /// Returns the configured Uzen fork condition for a given Taiko L2 chain ID.
-pub const fn uzen_fork_condition_for_chain(chain_id: u64) -> Option<ForkCondition> {
+///
+/// For the internal devnet, honors any override installed via
+/// `set_devnet_uzen_override`; falls back to `UZEN_FORK_DEVNET` otherwise.
+pub fn uzen_fork_condition_for_chain(chain_id: u64) -> Option<ForkCondition> {
     match chain_id {
-        TAIKO_DEVNET_CHAIN_ID => Some(UZEN_FORK_DEVNET),
+        TAIKO_DEVNET_CHAIN_ID => Some(
+            DEVNET_UZEN_OVERRIDE
+                .get()
+                .copied()
+                .map(ForkCondition::Timestamp)
+                .unwrap_or(UZEN_FORK_DEVNET),
+        ),
         TAIKO_MASAYA_CHAIN_ID => Some(UZEN_FORK_MASAYA),
         TAIKO_HOODI_CHAIN_ID => Some(UZEN_FORK_HOODI),
         TAIKO_MAINNET_CHAIN_ID => Some(UZEN_FORK_MAINNET),

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
@@ -11,7 +11,9 @@ pub mod payload_helpers;
 #[cfg(feature = "net")]
 pub use anchor::{AnchorTxConstructor, AnchorTxConstructorError, AnchorV4Input};
 pub use blob_coder::BlobCoder;
-pub use constants::{uzen_active_for_chain_timestamp, uzen_fork_timestamp_for_chain};
+pub use constants::{
+    set_devnet_uzen_override, uzen_active_for_chain_timestamp, uzen_fork_timestamp_for_chain,
+};
 pub use error::{ForkConfigError, ForkConfigResult, ProtocolError, Result};
 pub use payload_helpers::{
     PAYLOAD_ID_VERSION_V2, calculate_shasta_difficulty, encode_extra_data, encode_transactions,

--- a/packages/taiko-client-rs/crates/protocol/tests/devnet_uzen_override.rs
+++ b/packages/taiko-client-rs/crates/protocol/tests/devnet_uzen_override.rs
@@ -1,0 +1,48 @@
+//! Verifies that the devnet Uzen timestamp override flows through the
+//! protocol crate's fork-condition lookup. Lives in its own integration
+//! binary because the underlying override is a process-global `OnceLock`.
+
+use alloy_hardforks::ForkCondition;
+use protocol::shasta::{
+    constants::{
+        TAIKO_DEVNET_CHAIN_ID, TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID, TAIKO_MASAYA_CHAIN_ID,
+        uzen_fork_condition_for_chain,
+    },
+    set_devnet_uzen_override, uzen_active_for_chain_timestamp, uzen_fork_timestamp_for_chain,
+};
+
+#[test]
+fn devnet_override_flows_through_fork_lookups() {
+    set_devnet_uzen_override(42);
+
+    assert_eq!(
+        uzen_fork_condition_for_chain(TAIKO_DEVNET_CHAIN_ID),
+        Some(ForkCondition::Timestamp(42)),
+        "devnet should reflect the override"
+    );
+    assert_eq!(uzen_fork_timestamp_for_chain(TAIKO_DEVNET_CHAIN_ID).expect("devnet timestamp"), 42);
+    assert!(
+        !uzen_active_for_chain_timestamp(TAIKO_DEVNET_CHAIN_ID, 41).expect("devnet active"),
+        "devnet should be inactive before override timestamp"
+    );
+    assert!(
+        uzen_active_for_chain_timestamp(TAIKO_DEVNET_CHAIN_ID, 42).expect("devnet active"),
+        "devnet should be active at override timestamp"
+    );
+
+    assert_eq!(
+        uzen_fork_condition_for_chain(TAIKO_MAINNET_CHAIN_ID),
+        Some(ForkCondition::Never),
+        "mainnet must not be affected"
+    );
+    assert_eq!(
+        uzen_fork_condition_for_chain(TAIKO_MASAYA_CHAIN_ID),
+        Some(ForkCondition::Never),
+        "masaya must not be affected"
+    );
+    assert_eq!(
+        uzen_fork_condition_for_chain(TAIKO_HOODI_CHAIN_ID),
+        Some(ForkCondition::Never),
+        "hoodi must not be affected"
+    );
+}

--- a/packages/taiko-client/cmd/flags/common.go
+++ b/packages/taiko-client/cmd/flags/common.go
@@ -139,6 +139,13 @@ var (
 		Value:    12 * time.Second,
 		EnvVars:  []string{"RPC_TIMEOUT"},
 	}
+	TaikoDevnetUzenTime = &cli.Uint64Flag{
+		Name:     "taiko.devnet-uzen-time",
+		Usage:    "Override Uzen fork time for Taiko internal devnet (timestamp). Must match the value passed to taiko-geth's --taiko.devnet-uzen-time. Defaults to 0.",
+		Category: commonCategory,
+		Value:    0,
+		EnvVars:  []string{"TAIKO_DEVNET_UZEN_TIME"},
+	}
 )
 
 // CommonFlags All common flags.
@@ -157,6 +164,7 @@ var CommonFlags = []cli.Flag{
 	BackOffRetryInterval,
 	RPCTimeout,
 	L1PrivateEndpoint,
+	TaikoDevnetUzenTime,
 }
 
 // MergeFlags merges the given flag slices.

--- a/packages/taiko-client/cmd/flags/common.go
+++ b/packages/taiko-client/cmd/flags/common.go
@@ -141,7 +141,7 @@ var (
 	}
 	TaikoDevnetUzenTime = &cli.Uint64Flag{
 		Name:     "taiko.devnet-uzen-time",
-		Usage:    "Override Uzen fork time for Taiko internal devnet (timestamp). Must match the value passed to taiko-geth's --taiko.devnet-uzen-time. Defaults to 0.",
+		Usage:    "Override Uzen fork time for Taiko internal devnet; must match taiko-geth's --taiko.devnet-uzen-time",
 		Category: commonCategory,
 		Value:    0,
 		EnvVars:  []string{"TAIKO_DEVNET_UZEN_TIME"},

--- a/packages/taiko-client/cmd/utils/sub_command.go
+++ b/packages/taiko-client/cmd/utils/sub_command.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 
@@ -24,6 +25,8 @@ type SubcommandApplication interface {
 func SubcommandAction(app SubcommandApplication) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		logger.InitLogger(c)
+
+		applyDevnetUzenTimeOverride(c)
 
 		ctx, ctxClose := context.WithCancel(context.Background())
 		defer ctxClose()
@@ -66,4 +69,18 @@ func SubcommandAction(app SubcommandApplication) cli.ActionFunc {
 
 		return nil
 	}
+}
+
+// applyDevnetUzenTimeOverride mutates the embedded taiko-geth's core.InternalUzenTime
+// package variable from the CLI flag, if and only if the flag was explicitly set.
+// It must run before any chain-config or genesis lookup so downstream consumers
+// observe the overridden Uzen activation timestamp. When the flag is absent this
+// is a no-op (the package var is left untouched, never overwritten with 0).
+func applyDevnetUzenTimeOverride(c *cli.Context) {
+	if !c.IsSet(flags.TaikoDevnetUzenTime.Name) {
+		return
+	}
+	ts := c.Uint64(flags.TaikoDevnetUzenTime.Name)
+	core.InternalUzenTime = ts
+	log.Info("Overriding devnet Uzen activation time", "timestamp", ts)
 }

--- a/packages/taiko-client/cmd/utils/sub_command_test.go
+++ b/packages/taiko-client/cmd/utils/sub_command_test.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"flag"
+	"testing"
+
+	gethcore "github.com/ethereum/go-ethereum/core"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/cmd/flags"
+)
+
+func TestApplyDevnetUzenTimeOverride_SetsGethPackageVar(t *testing.T) {
+	original := gethcore.InternalUzenTime
+	t.Cleanup(func() { gethcore.InternalUzenTime = original })
+
+	app := cli.NewApp()
+	app.Flags = []cli.Flag{flags.TaikoDevnetUzenTime}
+	set := flag.NewFlagSet("test", 0)
+	require.NoError(t, flags.TaikoDevnetUzenTime.Apply(set))
+	require.NoError(t, set.Parse([]string{"--taiko.devnet-uzen-time", "42"}))
+	ctx := cli.NewContext(app, set, nil)
+
+	applyDevnetUzenTimeOverride(ctx)
+
+	require.Equal(t, uint64(42), gethcore.InternalUzenTime)
+}
+
+func TestApplyDevnetUzenTimeOverride_LeavesPackageVarWhenFlagAbsent(t *testing.T) {
+	original := gethcore.InternalUzenTime
+	t.Cleanup(func() { gethcore.InternalUzenTime = original })
+	gethcore.InternalUzenTime = 7
+
+	app := cli.NewApp()
+	app.Flags = []cli.Flag{flags.TaikoDevnetUzenTime}
+	set := flag.NewFlagSet("test", 0)
+	require.NoError(t, flags.TaikoDevnetUzenTime.Apply(set))
+	require.NoError(t, set.Parse([]string{}))
+	ctx := cli.NewContext(app, set, nil)
+
+	applyDevnetUzenTimeOverride(ctx)
+
+	require.Equal(t, uint64(7), gethcore.InternalUzenTime)
+}

--- a/packages/taiko-client/internal/docker/nodes/docker-compose.yml
+++ b/packages/taiko-client/internal/docker/nodes/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - --ws.api
       - admin,debug,eth,net,web3,txpool,miner,taiko
       - --taiko
-      - --taiko.internal-shasta-time
+      - --taiko.devnet-uzen-time
       - "0"
 
   l2_nmc:

--- a/packages/taiko-client/pkg/rpc/engine_uzen_test.go
+++ b/packages/taiko-client/pkg/rpc/engine_uzen_test.go
@@ -1,0 +1,42 @@
+package rpc
+
+import (
+	"math/big"
+	"testing"
+
+	gethcore "github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUzen_DevnetHonorsInternalUzenTimeOverride(t *testing.T) {
+	original := gethcore.InternalUzenTime
+	t.Cleanup(func() { gethcore.InternalUzenTime = original })
+
+	gethcore.InternalUzenTime = 100
+
+	devnetID := params.TaikoInternalNetworkID
+	require.False(t, IsUzen(devnetID, 99), "before override timestamp")
+	require.True(t, IsUzen(devnetID, 100), "at override timestamp")
+	require.True(t, IsUzen(devnetID, 101), "after override timestamp")
+}
+
+func TestIsUzen_NonDevnetUnaffectedByOverride(t *testing.T) {
+	original := gethcore.InternalUzenTime
+	t.Cleanup(func() { gethcore.InternalUzenTime = original })
+
+	gethcore.InternalUzenTime = 100
+
+	mainnetID := params.TaikoMainnetNetworkID
+	require.False(t, IsUzen(mainnetID, 0), "mainnet must remain inactive (MaxUint64)")
+	require.False(t, IsUzen(mainnetID, 100), "mainnet must remain inactive at devnet override timestamp")
+
+	hoodiID := params.TaikoHoodiNetworkID
+	require.False(t, IsUzen(hoodiID, 0))
+	require.False(t, IsUzen(hoodiID, 100))
+}
+
+func TestIsUzen_NilChainID(t *testing.T) {
+	require.False(t, IsUzen(nil, 0))
+	require.False(t, IsUzen((*big.Int)(nil), 12345))
+}


### PR DESCRIPTION
## Summary

Mirrors the node-side flags in [taiko-geth](https://github.com/taikoxyz/taiko-geth) (`--taiko.devnet-uzen-time`) and [alethia-reth](https://github.com/taikoxyz/alethia-reth) (`--devnet-uzen-timestamp`) so both clients correctly identify whether Uzen is active on the **internal devnet** (chain ID `167_001`). Previously, clients used a hardcoded constant of `0`; when an operator launched the node with a non-zero override, the clients silently disagreed with the node about Uzen activation.

Devnet only — mainnet, Hoodi, and Masaya behavior is untouched. Defaults are preserved when the flag is absent.

### Go (`packages/taiko-client`)
- New CLI flag `TaikoDevnetUzenTime` (`--taiko.devnet-uzen-time`, env `TAIKO_DEVNET_UZEN_TIME`, default `0`) in `CommonFlags`.
- `SubcommandAction` applies the override by mutating `core.InternalUzenTime` at startup before any chain config / genesis lookup.
- `IsUzen` already routes through that package var, so the override flows end-to-end with no call-site changes.

### Rust (`packages/taiko-client-rs`)
- New `devnet_uzen_timestamp: u64` field on `CommonArgs` (`--devnet-uzen-timestamp`, env `DEVNET_UZEN_TIMESTAMP`, default `0`).
- Process-global `OnceLock<u64>` + `set_devnet_uzen_override` setter in the `protocol` crate; `uzen_fork_condition_for_chain` honors it on the devnet branch.
- All four subcommands (driver, proposer, preconfirmation-driver, whitelist-preconfirmation-driver) call the setter as the first line of their `run` method.

### Ancillary
- `internal/docker/nodes/docker-compose.yml`: passes the renamed `--taiko.devnet-uzen-time` to the L2 geth service for local devnet testing.

## Test plan
- [x] `go build ./...` in `packages/taiko-client`
- [x] New Go tests pass: `go test ./cmd/utils/ -run TestApplyDevnetUzenTimeOverride -v`
- [x] New Go tests pass: `go test ./pkg/rpc/ -run TestIsUzen_ -v`
- [x] `cargo build --workspace` in `packages/taiko-client-rs`
- [x] New Rust CLI parse tests pass: `cargo test -p taiko-client --bin taiko-client flags::common`
- [x] Rust protocol lib tests pass: `cargo test -p protocol --lib`
- [x] New Rust integration test passes: `cargo test -p protocol --test devnet_uzen_override`
- [ ] Manual smoke test: launch local devnet via `docker-compose` with a non-zero `--taiko.devnet-uzen-time` and confirm client + node agree on Uzen activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)