### PR TITLE
fix(taiko-client-rs): call `set_devnet_uzen_override` after `init_logs`

### DIFF
--- a/packages/taiko-client-rs/bin/client/src/commands/driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/driver.rs
@@ -72,8 +72,8 @@ impl Subcommand for DriverSubCommand {
 
     /// Run the driver.
     async fn run(&self) -> Result<()> {
-        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_logs()?;
+        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_metrics()?;
 
         let cfg = self.build_config()?;

--- a/packages/taiko-client-rs/bin/client/src/commands/preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/preconfirmation_driver.rs
@@ -108,8 +108,8 @@ impl Subcommand for PreconfirmationDriverSubCommand {
 
     /// Runs the preconfirmation driver with embedded P2P client.
     async fn run(&self) -> Result<()> {
-        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_logs()?;
+        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_metrics()?;
 
         let driver_config = self.build_driver_config()?;

--- a/packages/taiko-client-rs/bin/client/src/commands/proposer.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/proposer.rs
@@ -78,8 +78,8 @@ impl Subcommand for ProposerSubCommand {
 
     /// Execute the proposer subcommand flow.
     async fn run(&self) -> Result<()> {
-        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_logs()?;
+        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_metrics()?;
 
         let cfg = self.build_config()?;

--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -166,8 +166,8 @@ impl Subcommand for WhitelistPreconfirmationDriverSubCommand {
 
     /// Runs the whitelist preconfirmation driver.
     async fn run(&self) -> Result<()> {
-        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_logs()?;
+        set_devnet_uzen_override(self.common_flags.devnet_uzen_timestamp);
         self.init_metrics()?;
 
         let driver_config = self.build_driver_config()?;


### PR DESCRIPTION
## Summary

Follow-up to #21566. The setter was running before the tracing subscriber was attached, so the `tracing::info!` emitted on the first successful `OnceLock` set was silently dropped. On a real devnet restart no override-confirmation line appeared in the logs.

Swap the order in all four subcommand `run` methods so `init_logs` runs first, then the setter — the log now reaches stdout. Still well before any fork-condition lookup (those occur inside the driver sync pipeline, after `build_config` + `Driver::new().await`).

## Test plan

- [x] `cargo build -p taiko-client --bin taiko-client` clean
- [ ] Smoke test: restart `l2-node-reth` driver with `--devnet-uzen-timestamp=N` and confirm a log line like `applied devnet Uzen activation time override timestamp=N` appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)