### PR TITLE
fix(taiko-client-rs): defer whitelist preconf driver timeouts instead of crashing

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -260,7 +260,10 @@ fn should_drop_cached_driver_error(err: &driver::DriverError) -> bool {
 /// Returns true when a driver error is expected to recover after sync catches up.
 fn should_defer_cached_driver_error(err: &driver::DriverError) -> bool {
     match err {
-        driver::DriverError::EngineSyncing(_) | driver::DriverError::BlockNotFound(_) => true,
+        driver::DriverError::EngineSyncing(_) |
+        driver::DriverError::BlockNotFound(_) |
+        driver::DriverError::PreconfEnqueueTimeout { .. } |
+        driver::DriverError::PreconfResponseTimeout { .. } => true,
         driver::DriverError::PreconfInjectionFailed { source, .. } => matches!(
             source,
             driver::sync::error::EngineSubmissionError::EngineSyncing(_) |

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -167,13 +167,23 @@ fn propagates_cached_import_errors_for_non_payload_failures() {
 }
 
 #[test]
-fn propagates_cached_import_errors_for_driver_queue_timeouts() {
+fn defers_cached_import_errors_for_preconf_enqueue_timeout() {
     let err =
         WhitelistPreconfirmationDriverError::Driver(driver::DriverError::PreconfEnqueueTimeout {
             waited: Duration::from_secs(1),
         });
     assert!(!should_drop_cached_import_error(&err));
-    assert!(!should_defer_cached_import_error(&err));
+    assert!(should_defer_cached_import_error(&err));
+}
+
+#[test]
+fn defers_cached_import_errors_for_preconf_response_timeout() {
+    let err =
+        WhitelistPreconfirmationDriverError::Driver(driver::DriverError::PreconfResponseTimeout {
+            waited: Duration::from_secs(12),
+        });
+    assert!(!should_drop_cached_import_error(&err));
+    assert!(should_defer_cached_import_error(&err));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- The whitelist preconfirmation cache importer treated `DriverError::PreconfResponseTimeout` / `PreconfEnqueueTimeout` as fatal, so a single slow reth engine response (>12 s) crashed `l2-node-reth-0`.
- Classify both timeout variants as deferrable in `should_defer_cached_driver_error` so the envelope stays in the cache and is retried on the next sync tick.
- Flip the existing enqueue-timeout test from "propagate" to "defer" and add a matching response-timeout test.

## Context

Mainnet `l2-node-reth-0` pods were crashing every ~25-30 min with:

```
ERROR driver::sync::event: preconfirmation response timed out block_number=5542497 timeout_ms=12000
Error: WhitelistPreconfirmation(Driver(PreconfResponseTimeout { waited: 12s }))
```

The timeouts correlate with transient reth stalls (e.g. beacon "no consensus updates received for 121s" a few minutes prior). These got more frequent after the HTTP event scanner polling change (`da35f604ec`), but the crash itself is an error-classification gap: `PreconfResponseTimeout` is transient and recoverable, not fatal.

The non-whitelist preconfirmation path already handles this via `submit_preconfirmation_payload_with_retry` in `crates/preconfirmation-driver/src/driver_interface/event_syncer_client.rs`. The whitelist importer calls `event_syncer.submit_preconfirmation_payload` directly without any retry, so the classifier is the only line of defense.

## Test plan

- [x] `cargo test -p whitelist-preconfirmation-driver --lib` — 78 tests pass, including the two updated/new classifier tests.
- [ ] Deploy to mainnet and confirm no more `PreconfResponseTimeout` crash loops over a 24h window.