### PR TITLE
chore(taiko-client-rs): rename difficulty to mixHash after Uzen

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types::Transaction as RpcTransaction;
 use alloy_rpc_types_engine::{PayloadAttributes as EthPayloadAttributes, PayloadId};
 use metrics::counter;
 use protocol::shasta::{
-    PAYLOAD_ID_VERSION_V2, calculate_shasta_difficulty, encode_extra_data, encode_transactions,
+    PAYLOAD_ID_VERSION_V2, calculate_shasta_mix_hash, encode_extra_data, encode_transactions,
     manifest::{BlockManifest, DerivationSourceManifest},
     payload_id_to_bytes, uzen_active_for_chain_timestamp,
 };
@@ -78,8 +78,8 @@ struct PayloadContext<'a> {
     meta: &'a BundleMeta,
     /// Base fee target for the upcoming block.
     block_base_fee: u64,
-    /// Difficulty used when sealing the block.
-    difficulty: B256,
+    /// Mix hash used when sealing the block.
+    mix_hash: B256,
     /// Height of the block being built.
     block_number: u64,
     /// Hash of the parent block used for payload ID derivation.
@@ -441,8 +441,8 @@ where
             "processing manifest block"
         );
         let block_base_fee = state.compute_block_base_fee()?;
-        let parent_difficulty = B256::from(state.header.difficulty.to_be_bytes::<32>());
-        let difficulty = calculate_shasta_difficulty(parent_difficulty, block_number);
+        let parent_mix_hash = B256::from(state.header.difficulty.to_be_bytes::<32>());
+        let mix_hash = calculate_shasta_mix_hash(parent_mix_hash, block_number);
 
         let anchor_inputs = AnchorTxInputs { block, block_number, block_base_fee };
 
@@ -458,7 +458,7 @@ where
             proposal_id = meta.proposal_id,
             block_number,
             block_base_fee,
-            difficulty = ?difficulty,
+            mix_hash = ?mix_hash,
             transaction_count_with_anchor = transactions.len(),
             parent_hash = ?parent_hash,
             "calculated block parameters"
@@ -470,7 +470,7 @@ where
                 block,
                 meta,
                 block_base_fee,
-                difficulty,
+                mix_hash,
                 block_number,
                 parent_hash,
                 position,
@@ -498,7 +498,7 @@ where
             block,
             meta,
             block_base_fee,
-            difficulty,
+            mix_hash,
             block_number,
             parent_hash,
             position,
@@ -516,14 +516,14 @@ where
             beneficiary: block.coinbase,
             gas_limit,
             timestamp: U256::from(block.timestamp),
-            mix_hash: difficulty,
+            mix_hash,
             tx_list: Some(tx_list),
             extra_data,
         };
 
         let payload_attributes = EthPayloadAttributes {
             timestamp: block.timestamp,
-            prev_randao: difficulty,
+            prev_randao: mix_hash,
             suggested_fee_recipient: block.coinbase,
             withdrawals: Some(Vec::new()),
             parent_beacon_block_root: None,

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/payload.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/driver_interface/payload.rs
@@ -18,7 +18,7 @@ use preconfirmation_types::uint256_to_u256;
 use super::{PreconfirmationInput, traits::BlockHeaderProvider};
 use crate::{Result, error::DriverApiError};
 use protocol::shasta::{
-    PAYLOAD_ID_VERSION_V2, calculate_shasta_difficulty, encode_extra_data, encode_tx_list,
+    PAYLOAD_ID_VERSION_V2, calculate_shasta_mix_hash, encode_extra_data, encode_tx_list,
     payload_id_to_bytes,
 };
 
@@ -93,7 +93,7 @@ pub async fn build_taiko_payload_attributes(
     let fee_recipient = Address::from_slice(preconf.coinbase.as_ref());
     let parent_block_number = block_number.saturating_sub(1);
     let parent_header = l2_provider.header_by_number(parent_block_number).await?;
-    let mix_hash = calculate_shasta_difficulty(
+    let mix_hash = calculate_shasta_mix_hash(
         B256::from(parent_header.inner.difficulty.to_be_bytes::<32>()),
         block_number,
     );
@@ -232,8 +232,8 @@ mod tests {
         )
         .await
         .expect("payload");
-        let parent_difficulty = B256::from(parent_header.inner.difficulty.to_be_bytes::<32>());
-        let expected_mix_hash = calculate_shasta_difficulty(parent_difficulty, 5);
+        let parent_mix_hash = B256::from(parent_header.inner.difficulty.to_be_bytes::<32>());
+        let expected_mix_hash = calculate_shasta_mix_hash(parent_mix_hash, 5);
         let transactions = vec![Bytes::from(vec![0x01, 0x02])];
         let tx_list = encode_tx_list(&transactions);
         let extra_data = encode_extra_data(basefee_sharing_pctg, 7); // proposal_id = 7

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/tests/preconf_e2e.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/tests/preconf_e2e.rs
@@ -20,7 +20,7 @@ use preconfirmation_driver::{DriverClient, PreconfirmationClient, Preconfirmatio
 use preconfirmation_net::{InMemoryStorage, LocalValidationAdapter, P2pNode};
 use preconfirmation_types::{SignedCommitment, uint256_to_u256};
 use protocol::shasta::{
-    calculate_shasta_difficulty, encode_extra_data, uzen_active_for_chain_timestamp,
+    calculate_shasta_mix_hash, encode_extra_data, uzen_active_for_chain_timestamp,
 };
 use rpc::client::{Client, ClientConfig};
 use serial_test::serial;
@@ -63,7 +63,7 @@ where
     let parent_block = fetch_block_by_number(provider, block_number.saturating_sub(1)).await?;
     let parent_header = &parent_block.header.inner;
 
-    let expected_mix_hash = calculate_shasta_difficulty(
+    let expected_mix_hash = calculate_shasta_mix_hash(
         B256::from(parent_header.difficulty.to_be_bytes::<32>()),
         block_number,
     );

--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -26,7 +26,7 @@ use alloy_rpc_types_engine::{
 use base_tx_manager::TxManagerError;
 use metrics::{counter, gauge, histogram};
 use protocol::shasta::{
-    AnchorTxConstructor, AnchorV4Input, calculate_shasta_difficulty,
+    AnchorTxConstructor, AnchorV4Input, calculate_shasta_mix_hash,
     constants::{MIN_BLOCK_GAS_LIMIT, PROPOSAL_MAX_BLOB_BYTES, min_base_fee_for_chain},
     encode_extra_data,
 };
@@ -362,8 +362,8 @@ impl Proposer {
             )
             .await?;
 
-        // Calculate mix hash (difficulty).
-        let mix_hash = calculate_shasta_difficulty(parent.header.inner.mix_hash, block_number);
+        // Calculate mix hash.
+        let mix_hash = calculate_shasta_mix_hash(parent.header.inner.mix_hash, block_number);
 
         let payload_attributes = TaikoPayloadAttributes {
             payload_attributes: EthPayloadAttributes {

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
@@ -16,6 +16,6 @@ pub use constants::{
 };
 pub use error::{ForkConfigError, ForkConfigResult, ProtocolError, Result};
 pub use payload_helpers::{
-    PAYLOAD_ID_VERSION_V2, calculate_shasta_difficulty, encode_extra_data, encode_transactions,
+    PAYLOAD_ID_VERSION_V2, calculate_shasta_mix_hash, encode_extra_data, encode_transactions,
     encode_tx_list, payload_id_to_bytes,
 };

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/payload_helpers.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/payload_helpers.rs
@@ -14,17 +14,17 @@ use alloy_rpc_types_engine::PayloadId;
 pub const PAYLOAD_ID_VERSION_V2: u8 = 2;
 
 sol! {
-    struct ShastaDifficultyInput {
-        bytes32 parentDifficulty;
+    struct ShastaMixHashInput {
+        bytes32 parentMixHash;
         uint256 blockNumber;
     }
 }
 
-/// Calculate the Shasta difficulty for a new block based on the parent difficulty (randao digest)
+/// Calculate the Shasta mix hash for a new block based on the parent mix hash (randao digest)
 /// and block number.
-pub fn calculate_shasta_difficulty(parent_difficulty: B256, block_number: u64) -> B256 {
-    let params = ShastaDifficultyInput {
-        parentDifficulty: parent_difficulty,
+pub fn calculate_shasta_mix_hash(parent_mix_hash: B256, block_number: u64) -> B256 {
+    let params = ShastaMixHashInput {
+        parentMixHash: parent_mix_hash,
         blockNumber: U256::from(block_number),
     };
     B256::from(keccak256(params.abi_encode()))

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use driver::{PreconfPayload, sync::event::EventSyncer};
 use metrics::histogram;
 use protocol::{
-    shasta::{PAYLOAD_ID_VERSION_V2, calculate_shasta_difficulty, payload_id_to_bytes},
+    shasta::{PAYLOAD_ID_VERSION_V2, calculate_shasta_mix_hash, payload_id_to_bytes},
     signer::FixedKSigner,
 };
 use rpc::{beacon::BeaconClient, client::Client};

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
@@ -95,8 +95,8 @@ where
             )));
         }
 
-        let parent_difficulty = B256::from(parent.header.difficulty.to_be_bytes::<32>());
-        Ok(calculate_shasta_difficulty(parent_difficulty, block_number))
+        let parent_mix_hash = B256::from(parent.header.difficulty.to_be_bytes::<32>());
+        Ok(calculate_shasta_mix_hash(parent_mix_hash, block_number))
     }
 
     /// Validate request payload shape before expensive insertion and signing operations.


### PR DESCRIPTION
ref: https://github.com/taikoxyz/taiko-mono/pull/21563

## Summary
- Mirrors the Go client rename (`8b4a629969`) in the Rust client
- Renames `calculate_shasta_difficulty` → `calculate_shasta_mix_hash` and the sol! ABI struct `ShastaDifficultyInput` → `ShastaMixHashInput`
- Updates all call sites, local variables, and comments across 8 files

## Test plan
- [x] `just fmt` passes
- [x] `just clippy-fix` passes with zero warnings
- [x] `just test` — all 362 tests pass