### PR TITLE
fix(bridge-ui): fall back to 500k gas when ERC20 sendToken estimation fails

### DIFF
--- a/packages/bridge-ui/src/app.config.ts
+++ b/packages/bridge-ui/src/app.config.ts
@@ -3,6 +3,7 @@ export const gasLimitConfig = {
   ethGasLimit: 100_000,
   erc20NotDeployedGasLimit: 750_000,
   erc20DeployedGasLimit: 500_000,
+  erc20SendTokenFallbackGasLimit: 500_000n, // used when eth_estimateGas for sendToken fails
   erc721NotDeployedGasLimit: 2_400_000,
   erc721DeployedGasLimit: 1_100_000,
   erc1155NotDeployedGasLimit: 2_600_000,

--- a/packages/bridge-ui/src/app.config.ts
+++ b/packages/bridge-ui/src/app.config.ts
@@ -3,7 +3,7 @@ export const gasLimitConfig = {
   ethGasLimit: 100_000,
   erc20NotDeployedGasLimit: 750_000,
   erc20DeployedGasLimit: 500_000,
-  erc20SendTokenFallbackGasLimit: 500_000n, // used when eth_estimateGas for sendToken fails
+  erc20SendTokenFallbackGasLimit: 500_000, // used when eth_estimateGas for sendToken fails
   erc721NotDeployedGasLimit: 2_400_000,
   erc721DeployedGasLimit: 1_100_000,
   erc1155NotDeployedGasLimit: 2_600_000,

--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -100,7 +100,7 @@ export class ERC20Bridge extends Bridge {
       return estimatedGas;
     } catch (error) {
       console.error('Failed to estimate gas for sendToken, using fallback', error);
-      return gasLimitConfig.erc20SendTokenFallbackGasLimit;
+      return BigInt(gasLimitConfig.erc20SendTokenFallbackGasLimit);
     }
   }
 

--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -93,6 +93,17 @@ export class ERC20Bridge extends Bridge {
     super(prover);
   }
 
+  private static async _estimateSendTokenGasOrFallback(estimate: () => Promise<bigint>): Promise<bigint> {
+    try {
+      const estimatedGas = await estimate();
+      log('Gas estimated', estimatedGas);
+      return estimatedGas;
+    } catch (error) {
+      console.error('Failed to estimate gas for sendToken, using fallback', error);
+      return gasLimitConfig.erc20SendTokenFallbackGasLimit;
+    }
+  }
+
   async estimateGas(args: ERC20BridgeArgs) {
     isBridgePaused().then((paused) => {
       if (paused) throw new BridgePausedError('Bridge is paused');
@@ -101,18 +112,11 @@ export class ERC20Bridge extends Bridge {
     const { tokenVaultContract, sendERC20Args } = await ERC20Bridge._prepareTransaction(args as ERC20BridgeArgs);
     const { fee } = sendERC20Args;
 
-    const value = fee;
+    log('Estimating gas for sendERC20 call with value', fee);
 
-    log('Estimating gas for sendERC20 call with value', value);
-
-    try {
-      const estimatedGas = await tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value });
-      log('Gas estimated', estimatedGas);
-      return estimatedGas;
-    } catch (error) {
-      console.error('Failed to estimate gas for sendToken, using fallback', error);
-      return 500_000n;
-    }
+    return ERC20Bridge._estimateSendTokenGasOrFallback(() =>
+      tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value: fee }),
+    );
   }
 
   async getAllowance({ amount, tokenAddress, ownerAddress, spenderAddress }: RequireAllowanceArgs) {
@@ -230,13 +234,9 @@ export class ERC20Bridge extends Bridge {
     const { tokenVaultContract, sendERC20Args } = await ERC20Bridge._prepareTransaction(args);
     const { fee } = sendERC20Args;
 
-    let gas: bigint;
-    try {
-      gas = await tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value: fee });
-    } catch (error) {
-      console.error('Failed to estimate gas for sendToken, using fallback', error);
-      gas = 500_000n;
-    }
+    const gas = await ERC20Bridge._estimateSendTokenGasOrFallback(() =>
+      tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value: fee }),
+    );
 
     try {
       const { request } = await simulateContract(config, {

--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -105,11 +105,14 @@ export class ERC20Bridge extends Bridge {
 
     log('Estimating gas for sendERC20 call with value', value);
 
-    const estimatedGas = await tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value });
-
-    log('Gas estimated', estimatedGas);
-
-    return estimatedGas;
+    try {
+      const estimatedGas = await tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value });
+      log('Gas estimated', estimatedGas);
+      return estimatedGas;
+    } catch (error) {
+      console.error('Failed to estimate gas for sendToken, using fallback', error);
+      return 500_000n;
+    }
   }
 
   async getAllowance({ amount, tokenAddress, ownerAddress, spenderAddress }: RequireAllowanceArgs) {

--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -230,6 +230,14 @@ export class ERC20Bridge extends Bridge {
     const { tokenVaultContract, sendERC20Args } = await ERC20Bridge._prepareTransaction(args);
     const { fee } = sendERC20Args;
 
+    let gas: bigint;
+    try {
+      gas = await tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value: fee });
+    } catch (error) {
+      console.error('Failed to estimate gas for sendToken, using fallback', error);
+      gas = 500_000n;
+    }
+
     try {
       const { request } = await simulateContract(config, {
         address: tokenVaultContract.address,
@@ -237,6 +245,7 @@ export class ERC20Bridge extends Bridge {
         functionName: 'sendToken',
         args: [sendERC20Args],
         value: fee,
+        gas,
       });
       log('Simulate contract', request);
 

--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -21,6 +21,7 @@ import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
 import { calculateMessageDataSize } from './calculateMessageDataSize';
+import { estimateSendTokenGasOrFallback } from './estimateSendTokenGas';
 import type { ApproveArgs, ERC20BridgeArgs, ERC20BridgeTransferOp, RequireAllowanceArgs } from './types';
 
 const log = getLogger('ERC20Bridge');
@@ -93,17 +94,6 @@ export class ERC20Bridge extends Bridge {
     super(prover);
   }
 
-  private static async _estimateSendTokenGasOrFallback(estimate: () => Promise<bigint>): Promise<bigint> {
-    try {
-      const estimatedGas = await estimate();
-      log('Gas estimated', estimatedGas);
-      return estimatedGas;
-    } catch (error) {
-      console.error('Failed to estimate gas for sendToken, using fallback', error);
-      return BigInt(gasLimitConfig.erc20SendTokenFallbackGasLimit);
-    }
-  }
-
   async estimateGas(args: ERC20BridgeArgs) {
     isBridgePaused().then((paused) => {
       if (paused) throw new BridgePausedError('Bridge is paused');
@@ -114,7 +104,7 @@ export class ERC20Bridge extends Bridge {
 
     log('Estimating gas for sendERC20 call with value', fee);
 
-    return ERC20Bridge._estimateSendTokenGasOrFallback(() =>
+    return estimateSendTokenGasOrFallback(() =>
       tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value: fee }),
     );
   }
@@ -234,7 +224,7 @@ export class ERC20Bridge extends Bridge {
     const { tokenVaultContract, sendERC20Args } = await ERC20Bridge._prepareTransaction(args);
     const { fee } = sendERC20Args;
 
-    const gas = await ERC20Bridge._estimateSendTokenGasOrFallback(() =>
+    const gas = await estimateSendTokenGasOrFallback(() =>
       tokenVaultContract.estimateGas.sendToken([sendERC20Args], { value: fee }),
     );
 

--- a/packages/bridge-ui/src/libs/bridge/estimateSendTokenGas.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/estimateSendTokenGas.test.ts
@@ -3,14 +3,12 @@ import { gasLimitConfig } from '$config';
 import { estimateSendTokenGasOrFallback } from './estimateSendTokenGas';
 
 describe('estimateSendTokenGasOrFallback', () => {
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    errorSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   it('returns the estimated gas when estimation succeeds', async () => {
@@ -18,7 +16,7 @@ describe('estimateSendTokenGasOrFallback', () => {
     const result = await estimateSendTokenGasOrFallback(async () => estimated);
 
     expect(result).toBe(estimated);
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it('returns the configured fallback gas when estimation rejects', async () => {
@@ -27,7 +25,7 @@ describe('estimateSendTokenGasOrFallback', () => {
     });
 
     expect(result).toBe(BigInt(gasLimitConfig.erc20SendTokenFallbackGasLimit));
-    expect(errorSpy).toHaveBeenCalledWith(
+    expect(console.error).toHaveBeenCalledWith(
       'Failed to estimate gas for sendToken, using fallback',
       expect.any(Error),
     );
@@ -40,7 +38,7 @@ describe('estimateSendTokenGasOrFallback', () => {
     });
 
     expect(result).toBe(BigInt(gasLimitConfig.erc20SendTokenFallbackGasLimit));
-    expect(errorSpy).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalled();
   });
 
   it('coerces the numeric config fallback to a bigint', async () => {

--- a/packages/bridge-ui/src/libs/bridge/estimateSendTokenGas.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/estimateSendTokenGas.test.ts
@@ -1,0 +1,54 @@
+import { gasLimitConfig } from '$config';
+
+import { estimateSendTokenGasOrFallback } from './estimateSendTokenGas';
+
+describe('estimateSendTokenGasOrFallback', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('returns the estimated gas when estimation succeeds', async () => {
+    const estimated = 1_234_567n;
+    const result = await estimateSendTokenGasOrFallback(async () => estimated);
+
+    expect(result).toBe(estimated);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the configured fallback gas when estimation rejects', async () => {
+    const result = await estimateSendTokenGasOrFallback(async () => {
+      throw new Error('RPC rejected eth_estimateGas');
+    });
+
+    expect(result).toBe(BigInt(gasLimitConfig.erc20SendTokenFallbackGasLimit));
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to estimate gas for sendToken, using fallback',
+      expect.any(Error),
+    );
+  });
+
+  it('falls back on non-Error rejections', async () => {
+    const result = await estimateSendTokenGasOrFallback(async () => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'network down';
+    });
+
+    expect(result).toBe(BigInt(gasLimitConfig.erc20SendTokenFallbackGasLimit));
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('coerces the numeric config fallback to a bigint', async () => {
+    const result = await estimateSendTokenGasOrFallback(async () => {
+      throw new Error('fail');
+    });
+
+    expect(typeof result).toBe('bigint');
+    expect(result).toBe(500_000n);
+  });
+});

--- a/packages/bridge-ui/src/libs/bridge/estimateSendTokenGas.ts
+++ b/packages/bridge-ui/src/libs/bridge/estimateSendTokenGas.ts
@@ -1,0 +1,15 @@
+import { gasLimitConfig } from '$config';
+import { getLogger } from '$libs/util/logger';
+
+const log = getLogger('estimateSendTokenGas');
+
+export async function estimateSendTokenGasOrFallback(estimate: () => Promise<bigint>): Promise<bigint> {
+  try {
+    const estimatedGas = await estimate();
+    log('Gas estimated', estimatedGas);
+    return estimatedGas;
+  } catch (error) {
+    console.error('Failed to estimate gas for sendToken, using fallback', error);
+    return BigInt(gasLimitConfig.erc20SendTokenFallbackGasLimit);
+  }
+}


### PR DESCRIPTION
## Summary

- Wrap `ERC20Bridge.estimateGas`'s call to `tokenVaultContract.estimateGas.sendToken` in a try/catch so a failed RPC estimation no longer bubbles up and breaks `estimateCostOfBridging` / the UI cost display.
- On failure, return `500_000n` as a safe default — matches the pattern already used in `Bridge.ts` for `processMessage` (which falls back to `1_300_000n`).

## Test plan

- [x] Bridge an ERC20 (e.g. USDC) from L2 to L1 on a network where gas estimation succeeds — cost display and broadcast behave identically to before.
- [x] Force an estimation failure (e.g. temporarily pointing at an RPC that rejects the call) — UI shows a cost derived from 500k gas instead of throwing.