### PR TITLE
feat(taiko-client,taiko-client-rs): carry Uzen `header.difficulty` on preconfirmation gossip wire

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -306,6 +306,6 @@ require (
 
 replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260413072358-e33be202c76f
 
-replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f
+replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 
 replace github.com/uber/jaeger-client-go => github.com/uber/jaeger-client-go v2.25.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -881,8 +881,8 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
-github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f h1:7lZFtV7wip0wmcTquvmtSH5LRp1djzSiDkOeGpIuEN4=
-github.com/taikoxyz/optimism v0.0.0-20251229030244-37aa83d15a8f/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
+github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828 h1:8TqBxcCsk7TNvGHjTuStB2waN3KPpTJYeqpk7JY5t+o=
+github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260413072358-e33be202c76f h1:DgX9ViGUV0OAGC6Bb6uSYTp+D3zm2dlVRcoKf7g4iYo=
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260413072358-e33be202c76f/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -137,6 +137,8 @@ where
             end_of_sequencing: request.end_of_sequencing,
             is_forced_inclusion: request.is_forced_inclusion,
             parent_beacon_block_root: None,
+            header_difficulty: (!inserted_block.header.difficulty.is_zero())
+                .then_some(inserted_block.header.difficulty),
             execution_payload,
             signature: Some(block_hash_signature),
         };

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -227,6 +227,7 @@ mod tests {
             end_of_sequencing: None,
             is_forced_inclusion: None,
             parent_beacon_block_root: None,
+            header_difficulty: Some(U256::from(1_000_000u64)),
             execution_payload: ExecutionPayloadV1 {
                 parent_hash: B256::from([0x10u8; 32]),
                 fee_recipient: Address::from([0x11u8; 20]),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
@@ -32,6 +32,10 @@ pub(crate) struct WhitelistExecutionPayloadEnvelope {
     pub is_forced_inclusion: Option<bool>,
     /// Optional parent beacon block root.
     pub parent_beacon_block_root: Option<B256>,
+    /// Optional hash-relevant header difficulty for post-Uzen blocks.
+    /// When `Some`, the encoder emits a 32-byte big-endian slot after
+    /// `parent_beacon_block_root` and sets `flags0 & 0x02`.
+    pub header_difficulty: Option<U256>,
     /// Execution payload.
     pub execution_payload: ExecutionPayloadV1,
     /// Optional embedded signature.
@@ -156,15 +160,23 @@ pub(crate) fn encode_unsafe_request_message(hash: B256) -> Vec<u8> {
 
 /// Encode Taiko whitelist preconfirmation SSZ envelope bytes.
 pub(crate) fn encode_envelope_ssz(envelope: &WhitelistExecutionPayloadEnvelope) -> Vec<u8> {
+    let has_header_difficulty = envelope.header_difficulty.map(|v| !v.is_zero()).unwrap_or(false);
+    let header_difficulty_len = if has_header_difficulty { 32 } else { 0 };
     let sig_len = if envelope.signature.is_some() { SIGNATURE_LEN } else { 0 };
     let mut out = Vec::with_capacity(
-        ENVELOPE_HEADER_LEN + envelope.execution_payload.as_ssz_bytes().len() + sig_len,
+        ENVELOPE_HEADER_LEN +
+            header_difficulty_len +
+            envelope.execution_payload.as_ssz_bytes().len() +
+            sig_len,
     );
 
     let mut flags0 = 0u8;
     let mut flags1 = 0u8;
     if envelope.end_of_sequencing.unwrap_or(false) {
         flags0 |= 0x01;
+    }
+    if has_header_difficulty {
+        flags0 |= 0x02;
     }
     if envelope.is_forced_inclusion.unwrap_or(false) {
         flags1 |= 0x01;
@@ -179,6 +191,11 @@ pub(crate) fn encode_envelope_ssz(envelope: &WhitelistExecutionPayloadEnvelope) 
         out.extend_from_slice(root.as_slice());
     } else {
         out.extend_from_slice(&[0u8; 32]);
+    }
+
+    if has_header_difficulty {
+        let v = envelope.header_difficulty.expect("has_header_difficulty implies Some");
+        out.extend_from_slice(&v.to_be_bytes::<32>());
     }
 
     out.extend_from_slice(envelope.execution_payload.as_ssz_bytes().as_slice());
@@ -215,22 +232,34 @@ pub(crate) fn decode_envelope_ssz(bytes: &[u8]) -> Result<WhitelistExecutionPayl
     let flags1 = bytes[1];
 
     let end_of_sequencing = (flags0 & 0x01 != 0).then_some(true);
+    let has_header_difficulty = flags0 & 0x02 != 0;
     let is_forced_inclusion = (flags1 & 0x01 != 0).then_some(true);
     let has_signature = flags1 & 0x02 != 0;
 
     let root = &bytes[2..ENVELOPE_HEADER_LEN];
     let parent_beacon_block_root = root.iter().any(|&b| b != 0).then(|| B256::from_slice(root));
 
+    let header_difficulty_len = if has_header_difficulty { 32 } else { 0 };
     let signature_len = if has_signature { SIGNATURE_LEN } else { 0 };
-    if bytes.len() < ENVELOPE_HEADER_LEN + signature_len {
+    let min_len = ENVELOPE_HEADER_LEN + header_difficulty_len + signature_len;
+    if bytes.len() < min_len {
         return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
             "envelope missing payload data: {}",
             bytes.len()
         )));
     }
 
+    let mut cursor = ENVELOPE_HEADER_LEN;
+    let header_difficulty = if has_header_difficulty {
+        let slot = &bytes[cursor..cursor + 32];
+        cursor += 32;
+        Some(U256::from_be_slice(slot))
+    } else {
+        None
+    };
+
     let payload_end = bytes.len() - signature_len;
-    let payload_bytes = &bytes[ENVELOPE_HEADER_LEN..payload_end];
+    let payload_bytes = &bytes[cursor..payload_end];
     let execution_payload = ExecutionPayloadV1::from_ssz_bytes(payload_bytes).map_err(|err| {
         WhitelistPreconfirmationDriverError::InvalidPayload(format!(
             "invalid execution payload SSZ: {err:?}"
@@ -247,6 +276,7 @@ pub(crate) fn decode_envelope_ssz(bytes: &[u8]) -> Result<WhitelistExecutionPayl
         end_of_sequencing,
         is_forced_inclusion,
         parent_beacon_block_root,
+        header_difficulty,
         execution_payload,
         signature,
     })
@@ -300,6 +330,7 @@ mod tests {
             end_of_sequencing: Some(true),
             is_forced_inclusion: Some(true),
             parent_beacon_block_root: Some(B256::from([0xabu8; 32])),
+            header_difficulty: Some(U256::from(0x12345678u64)),
             execution_payload: ExecutionPayloadV1 {
                 parent_hash: B256::from([0x01u8; 32]),
                 fee_recipient: Address::from([0x11u8; 20]),
@@ -339,6 +370,7 @@ mod tests {
         assert_eq!(decoded.end_of_sequencing, envelope.end_of_sequencing);
         assert_eq!(decoded.is_forced_inclusion, envelope.is_forced_inclusion);
         assert_eq!(decoded.parent_beacon_block_root, envelope.parent_beacon_block_root);
+        assert_eq!(decoded.header_difficulty, envelope.header_difficulty);
         assert_eq!(decoded.execution_payload.block_hash, envelope.execution_payload.block_hash);
         assert_eq!(decoded.execution_payload.block_number, envelope.execution_payload.block_number);
         assert_eq!(decoded.signature, envelope.signature);
@@ -375,6 +407,7 @@ mod tests {
         assert_eq!(decoded_envelope.end_of_sequencing, envelope.end_of_sequencing);
         assert_eq!(decoded_envelope.is_forced_inclusion, envelope.is_forced_inclusion);
         assert_eq!(decoded_envelope.parent_beacon_block_root, envelope.parent_beacon_block_root);
+        assert_eq!(decoded_envelope.header_difficulty, envelope.header_difficulty);
         assert_eq!(
             decoded_envelope.execution_payload.block_hash,
             envelope.execution_payload.block_hash

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -16,7 +16,10 @@ use crate::{
 
 use super::{
     WhitelistPreconfirmationImporter,
-    validation::{normalize_unsafe_payload_envelope, validate_execution_payload_for_preconf},
+    validation::{
+        normalize_unsafe_payload_envelope, validate_envelope_header_difficulty,
+        validate_execution_payload_for_preconf,
+    },
 };
 
 impl<P> WhitelistPreconfirmationImporter<P>
@@ -81,6 +84,11 @@ where
             self.chain_id,
             self.anchor_address,
         )?;
+        validate_envelope_header_difficulty(
+            self.chain_id,
+            envelope.execution_payload.timestamp,
+            envelope.header_difficulty,
+        )?;
         self.ingest_validated_envelope(Arc::new(envelope), "payload").await;
 
         Ok(())
@@ -114,6 +122,11 @@ where
             &envelope.execution_payload,
             self.chain_id,
             self.anchor_address,
+        )?;
+        validate_envelope_header_difficulty(
+            self.chain_id,
+            envelope.execution_payload.timestamp,
+            envelope.header_difficulty,
         )?;
 
         self.ingest_validated_envelope(Arc::new(envelope), "response").await;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/response.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/response.rs
@@ -101,6 +101,11 @@ where
             // in the envelope (see rest_handler.rs), and the SSZ wire format
             // encodes None as 32 zero bytes which is the expected default.
             parent_beacon_block_root: None,
+            // Carry Uzen header.difficulty (= block_zk_gas_used) so receivers
+            // can reconstruct the sender's block hash. Left `None` for Shasta
+            // blocks whose difficulty is zero.
+            header_difficulty: (!block.header.difficulty.is_zero())
+                .then_some(block.header.difficulty),
             execution_payload: alloy_rpc_types_engine::ExecutionPayloadV1 {
                 parent_hash: block.header.parent_hash,
                 fee_recipient: block.header.beneficiary,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -31,6 +31,7 @@ fn sample_execution_payload_with_transactions(
         end_of_sequencing: None,
         is_forced_inclusion: None,
         parent_beacon_block_root: None,
+        header_difficulty: Some(U256::from(1_000_000u64)),
         execution_payload: ExecutionPayloadV1 {
             parent_hash: B256::from([0x10u8; 32]),
             fee_recipient: Address::from([0x11u8; 20]),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
@@ -13,7 +13,6 @@ use protocol::{
     shasta::uzen_active_for_chain_timestamp,
 };
 use thiserror::Error;
-use tracing::warn;
 
 use crate::{
     codec::{
@@ -242,18 +241,12 @@ pub(crate) fn validate_envelope_header_difficulty(
     timestamp: u64,
     header_difficulty: Option<alloy_primitives::U256>,
 ) -> Result<()> {
-    let uzen = match uzen_active_for_chain_timestamp(chain_id, timestamp) {
-        Ok(active) => active,
-        Err(err) => {
-            warn!(
-                chain_id,
-                timestamp,
-                error = %err,
-                "uzen fork lookup failed; treating envelope as pre-Uzen",
-            );
-            false
-        }
-    };
+    let uzen = uzen_active_for_chain_timestamp(chain_id, timestamp).map_err(|err| {
+        WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+            &format!("uzen fork lookup failed for chain {chain_id} at timestamp {timestamp}"),
+            err,
+        )
+    })?;
     let present = header_difficulty.map(|v| !v.is_zero()).unwrap_or(false);
 
     match (uzen, present) {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
@@ -8,8 +8,12 @@ use alloy_consensus::{
 };
 use alloy_eips::Decodable2718;
 use alloy_primitives::Address;
-use protocol::codec::{TxListCodecError, ZlibTxListCodec};
+use protocol::{
+    codec::{TxListCodecError, ZlibTxListCodec},
+    shasta::uzen_active_for_chain_timestamp,
+};
 use thiserror::Error;
+use tracing::warn;
 
 use crate::{
     codec::{
@@ -226,4 +230,39 @@ pub(super) fn normalize_unsafe_payload_envelope(
         envelope.signature = Some(wire_signature);
     }
     envelope
+}
+
+/// Reject envelopes whose `header_difficulty` presence contradicts the Uzen
+/// status at the payload timestamp.
+///
+/// - Uzen active + `None` or zero                → error
+/// - Uzen inactive + `Some(non_zero)`            → error
+pub(crate) fn validate_envelope_header_difficulty(
+    chain_id: u64,
+    timestamp: u64,
+    header_difficulty: Option<alloy_primitives::U256>,
+) -> Result<()> {
+    let uzen = match uzen_active_for_chain_timestamp(chain_id, timestamp) {
+        Ok(active) => active,
+        Err(err) => {
+            warn!(
+                chain_id,
+                timestamp,
+                error = %err,
+                "uzen fork lookup failed; treating envelope as pre-Uzen",
+            );
+            false
+        }
+    };
+    let present = header_difficulty.map(|v| !v.is_zero()).unwrap_or(false);
+
+    match (uzen, present) {
+        (true, false) => Err(WhitelistPreconfirmationDriverError::invalid_payload(format!(
+            "uzen active at timestamp {timestamp} but envelope is missing header difficulty",
+        ))),
+        (false, true) => Err(WhitelistPreconfirmationDriverError::invalid_payload(format!(
+            "uzen inactive at timestamp {timestamp} but envelope carries non-zero header difficulty",
+        ))),
+        _ => Ok(()),
+    }
 }

--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/common.go
@@ -195,6 +195,7 @@ func createExecutionPayloads(
 		"gasLimit", payload.GasLimit,
 		"gasUsed", payload.GasUsed,
 		"timestamp", payload.Timestamp,
+		"headerDifficulty", payload.HeaderDifficultyOrZero(),
 		"withdrawalsHash", payload.WithdrawalsHash,
 	)
 
@@ -667,6 +668,7 @@ func InsertPreconfBlockFromEnvelope(
 		"parentHash", envelope.Payload.ParentHash,
 		"timestamp", envelope.Payload.Timestamp,
 		"feeRecipient", envelope.Payload.FeeRecipient,
+		"headerDifficulty", envelope.HeaderDifficulty,
 		"signature", common.Bytes2Hex(signature[:]),
 	)
 

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -572,7 +572,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2Payload() {
 	s.Nil(s.d.preconfBlockServer.OnUnsafeL2Payload(
 		context.Background(),
 		peer.ID(testutils.RandomBytes(32)),
-		&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload},
+		&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload, HeaderDifficulty: l2Head1.Difficulty},
 	))
 
 	l2Head2, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
@@ -617,7 +617,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithInvalidPayload() {
 	s.Nil(s.d.preconfBlockServer.OnUnsafeL2Payload(
 		context.Background(),
 		peer.ID(testutils.RandomBytes(32)),
-		&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload},
+		&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload, HeaderDifficulty: l2Head1.Difficulty},
 	))
 
 	l2Head2, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
@@ -742,7 +742,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 		s.Nil(s.d.preconfBlockServer.OnUnsafeL2Payload(
 			context.Background(),
 			peer.ID(testutils.RandomBytes(32)),
-			&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload},
+			&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload, HeaderDifficulty: block.Difficulty()},
 		))
 	}
 
@@ -777,6 +777,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 				BlockHash:   forkA[len(forkA)-1].Hash(),
 				ParentHash:  forkA[len(forkA)-1].ParentHash(),
 			},
+			HeaderDifficulty: forkA[len(forkA)-1].Difficulty(),
 		},
 		&rawdb.L1Origin{BlockID: headL1Origin.BlockID, L2BlockHash: testutils.RandomHash()},
 	)
@@ -791,6 +792,7 @@ func (s *DriverTestSuite) TestGossipMessagesRandomReorgs() {
 				BlockHash:   forkB[len(forkB)-1].Hash(),
 				ParentHash:  forkB[len(forkB)-1].ParentHash(),
 			},
+			HeaderDifficulty: forkB[len(forkB)-1].Difficulty(),
 		},
 		&rawdb.L1Origin{BlockID: headL1Origin.BlockID, L2BlockHash: testutils.RandomHash()},
 	)
@@ -868,6 +870,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 			Transactions:  []eth.Data{b},
 			Withdrawals:   &types.Withdrawals{},
 		},
+		HeaderDifficulty: l2Head1.Difficulty(),
 	})
 
 	// Randomly gossip preconfirmation messages with missing ancients
@@ -908,7 +911,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 				BaseFeePerGas: eth.Uint256Quantity(*baseFee),
 				Transactions:  []eth.Data{b},
 				Withdrawals:   &types.Withdrawals{},
-			}},
+			}, HeaderDifficulty: block.Difficulty()},
 		))
 
 		if gossipRandom {
@@ -928,7 +931,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 					BaseFeePerGas: eth.Uint256Quantity(*baseFee),
 					Transactions:  []eth.Data{b},
 					Withdrawals:   &types.Withdrawals{},
-				}},
+				}, HeaderDifficulty: block.Difficulty()},
 			))
 
 			s.Nil(s.d.preconfBlockServer.OnUnsafeL2Payload(
@@ -946,7 +949,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 					BaseFeePerGas: eth.Uint256Quantity(*baseFee),
 					Transactions:  []eth.Data{b},
 					Withdrawals:   &types.Withdrawals{},
-				}},
+				}, HeaderDifficulty: block.Difficulty()},
 			))
 		}
 	}
@@ -991,6 +994,7 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 			Transactions:  []eth.Data{b},
 			Withdrawals:   &types.Withdrawals{},
 		},
+		HeaderDifficulty: block.Difficulty(),
 	})
 
 	block = getBlock(l2Head1.Number().Uint64() + 2)
@@ -1050,6 +1054,7 @@ func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
 				Transactions:  []eth.Data{b},
 				Withdrawals:   &types.Withdrawals{},
 			},
+			HeaderDifficulty: block.Difficulty(),
 		})
 	}
 

--- a/packages/taiko-client/driver/preconf_blocks/cache_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/cache_test.go
@@ -39,7 +39,8 @@ func (s *CacheTestSuite) TestOrphanBlockDetectionWithoutGetBlockByHash() {
 			ParentHash:   genesis,
 			Transactions: []eth.Data{testutils.RandomBytes(100)},
 		},
-		Signature: &[65]byte{},
+		Signature:        &[65]byte{},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(1, env1)
 
@@ -51,7 +52,8 @@ func (s *CacheTestSuite) TestOrphanBlockDetectionWithoutGetBlockByHash() {
 			ParentHash:   block1Hash,
 			Transactions: []eth.Data{testutils.RandomBytes(100)},
 		},
-		Signature: &[65]byte{},
+		Signature:        &[65]byte{},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(2, env2A)
 
@@ -63,7 +65,8 @@ func (s *CacheTestSuite) TestOrphanBlockDetectionWithoutGetBlockByHash() {
 			ParentHash:   block1Hash,
 			Transactions: []eth.Data{testutils.RandomBytes(100)},
 		},
-		Signature: &[65]byte{1, 2, 3},
+		Signature:        &[65]byte{1, 2, 3},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(2, env2B)
 
@@ -101,6 +104,7 @@ func (s *CacheTestSuite) TestL1OriginUpdateUsingCachedData() {
 		},
 		Signature:         &[65]byte{5, 6, 7, 8},
 		IsForcedInclusion: true,
+		HeaderDifficulty:  common.Big1,
 	}
 	cache.put(parentBlockNum, parentEnv)
 
@@ -139,7 +143,8 @@ func (s *CacheTestSuite) TestEnvelopeCachingFlow() {
 			ParentHash:   parentHash,
 			Transactions: []eth.Data{testutils.RandomBytes(100)},
 		},
-		Signature: &[65]byte{1},
+		Signature:        &[65]byte{1},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(blockNum, env1)
 	s.True(cache.hasExact(blockNum, blockHash))
@@ -154,7 +159,8 @@ func (s *CacheTestSuite) TestEnvelopeCachingFlow() {
 			ParentHash:   blockHash,
 			Transactions: []eth.Data{testutils.RandomBytes(100)},
 		},
-		Signature: &[65]byte{2},
+		Signature:        &[65]byte{2},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(blockNum2, env2)
 	s.True(cache.hasExact(blockNum2, blockHash2))
@@ -169,7 +175,8 @@ func (s *CacheTestSuite) TestEnvelopeCachingFlow() {
 			ParentHash:   blockHash2,
 			Transactions: []eth.Data{testutils.RandomBytes(100)},
 		},
-		Signature: &[65]byte{3},
+		Signature:        &[65]byte{3},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(blockNum3, env3)
 	s.True(cache.hasExact(blockNum3, blockHash3))
@@ -203,7 +210,8 @@ func (s *CacheTestSuite) TestCachedParentForOrphanHandling() {
 			Timestamp:    eth.Uint64Quantity(1000),
 			PrevRandao:   eth.Bytes32(testutils.RandomHash()),
 		},
-		Signature: &[65]byte{10, 11, 12},
+		Signature:        &[65]byte{10, 11, 12},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(parentBlockNum, parentEnvA)
 
@@ -218,7 +226,8 @@ func (s *CacheTestSuite) TestCachedParentForOrphanHandling() {
 			Timestamp:    eth.Uint64Quantity(1001),
 			PrevRandao:   eth.Bytes32(testutils.RandomHash()),
 		},
-		Signature: &[65]byte{20, 21, 22},
+		Signature:        &[65]byte{20, 21, 22},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(parentBlockNum, parentEnvB)
 
@@ -259,7 +268,8 @@ func (s *CacheTestSuite) TestDuplicateCachingPrevention() {
 			BlockHash:   blockHash,
 			ParentHash:  testutils.RandomHash(),
 		},
-		Signature: &[65]byte{1, 2, 3},
+		Signature:        &[65]byte{1, 2, 3},
+		HeaderDifficulty: common.Big1,
 	}
 
 	// First insertion
@@ -276,7 +286,8 @@ func (s *CacheTestSuite) TestDuplicateCachingPrevention() {
 			BlockHash:   blockHash, // Same hash
 			ParentHash:  testutils.RandomHash(),
 		},
-		Signature: &[65]byte{1, 2, 3},
+		Signature:        &[65]byte{1, 2, 3},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(blockNum, env2)
 

--- a/packages/taiko-client/driver/preconf_blocks/queue_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/preconf"
@@ -19,6 +20,7 @@ func (s *PreconfBlockAPIServerTestSuite) TestCacheGet() {
 			BlockNumber: eth.Uint64Quantity(uint64(testutils.RandomPort())),
 			BlockHash:   testutils.RandomHash(),
 		},
+		HeaderDifficulty: common.Big1,
 	}
 	cache.put(uint64(payload.Payload.BlockNumber), payload)
 	payloadCached := cache.get(uint64(payload.Payload.BlockNumber), payload.Payload.BlockHash)
@@ -33,6 +35,7 @@ func (s *PreconfBlockAPIServerTestSuite) TestCacheGetLongestChildren() {
 			BlockNumber: eth.Uint64Quantity(uint64(testutils.RandomPort())),
 			BlockHash:   testutils.RandomHash(),
 		},
+		HeaderDifficulty: common.Big1,
 	}
 
 	createFork := func(currentPayload *preconf.Envelope, len int) []*preconf.Envelope {
@@ -45,6 +48,7 @@ func (s *PreconfBlockAPIServerTestSuite) TestCacheGetLongestChildren() {
 					BlockHash:   testutils.RandomHash(),
 					ParentHash:  parent.Payload.BlockHash,
 				},
+				HeaderDifficulty: common.Big1,
 			}
 			payloads[i] = payload
 			parent = payload

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -284,6 +284,7 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 		"gasUsed", uint64(msg.ExecutionPayload.GasUsed),
 		"endOfSequencing", msg.EndOfSequencing != nil && *msg.EndOfSequencing,
 		"isForcedInclusion", msg.IsForcedInclusion != nil && *msg.IsForcedInclusion,
+		"headerDifficulty", msg.HeaderDifficulty,
 		"signature", common.Bytes2Hex(signature[:]),
 	)
 	metrics.DriverPreconfEnvelopeCounter.Inc()
@@ -970,6 +971,7 @@ func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context
 		ExecutionPayload:  latestPayload.Payload,
 		Signature:         latestPayload.Signature,
 		IsForcedInclusion: &latestPayload.IsForcedInclusion,
+		HeaderDifficulty:  latestPayload.HeaderDifficulty,
 	})
 }
 
@@ -1322,6 +1324,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 			Payload:           msg.ExecutionPayload,
 			Signature:         msg.Signature,
 			IsForcedInclusion: msg.IsForcedInclusion != nil && *msg.IsForcedInclusion,
+			HeaderDifficulty:  msg.HeaderDifficulty,
 		}, headL1Origin); err != nil {
 			log.Info(
 				"Unable to find all the missing ancients from the cache, cache the current payload",
@@ -1375,6 +1378,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 				Payload:           msg.ExecutionPayload,
 				Signature:         msg.Signature,
 				IsForcedInclusion: msg.IsForcedInclusion != nil && *msg.IsForcedInclusion,
+				HeaderDifficulty:  msg.HeaderDifficulty,
 			},
 		},
 		false,
@@ -1407,6 +1411,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 		Payload:           msg.ExecutionPayload,
 		Signature:         msg.Signature,
 		IsForcedInclusion: msg.IsForcedInclusion != nil && *msg.IsForcedInclusion,
+		HeaderDifficulty:  msg.HeaderDifficulty,
 	}); err != nil {
 		return false, fmt.Errorf("failed to try importing child blocks from cache: %w", err)
 	}
@@ -1453,6 +1458,7 @@ func (s *PreconfBlockAPIServer) tryPutEnvelopeIntoCache(msg *eth.ExecutionPayloa
 		Payload:           msg.ExecutionPayload,
 		Signature:         msg.Signature,
 		IsForcedInclusion: msg.IsForcedInclusion != nil && *msg.IsForcedInclusion,
+		HeaderDifficulty:  msg.HeaderDifficulty,
 	})
 }
 

--- a/packages/taiko-client/driver/preconf_blocks/util.go
+++ b/packages/taiko-client/driver/preconf_blocks/util.go
@@ -42,6 +42,7 @@ func executionPayloadEnvelope(
 	endOfSequencing *bool,
 	isForcedInclusion *bool,
 	signature *[65]byte,
+	headerDifficulty *big.Int,
 ) (*eth.ExecutionPayloadEnvelope, error) {
 	// If the base fee is too large to fit in a uint256, we should return an error instead of silently truncating it.
 	var u256 uint256.Int
@@ -49,7 +50,7 @@ func executionPayloadEnvelope(
 		return nil, fmt.Errorf("failed to convert base fee to uint256: %v", overflow)
 	}
 
-	return &eth.ExecutionPayloadEnvelope{
+	envelope := &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{
 			BaseFeePerGas: eth.Uint256Quantity(u256),
 			ParentHash:    parentHash,
@@ -66,7 +67,11 @@ func executionPayloadEnvelope(
 		EndOfSequencing:   endOfSequencing,
 		IsForcedInclusion: isForcedInclusion,
 		Signature:         signature,
-	}, nil
+	}
+	if headerDifficulty != nil && headerDifficulty.Cmp(common.Big0) > 0 {
+		envelope.HeaderDifficulty = new(big.Int).Set(headerDifficulty)
+	}
+	return envelope, nil
 }
 
 // blockToEnvelope converts a block to an ExecutionPayloadEnvelope.
@@ -96,6 +101,7 @@ func blockToEnvelope(
 		endOfSequencing,
 		isForcedInclusion,
 		signature,
+		block.Difficulty(),
 	)
 }
 
@@ -122,6 +128,7 @@ func headerToEnvelope(
 		endOfSequencing,
 		isForcedInclusion,
 		signature,
+		header.Difficulty,
 	)
 }
 

--- a/packages/taiko-client/driver/preconf_blocks/util_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/util_test.go
@@ -13,6 +13,7 @@ func (s *PreconfBlockAPIServerTestSuite) TestBlockToEnvelope() {
 	s.Nil(err)
 	s.Nil(e.EndOfSequencing)
 	s.Equal(l2Head.Hash(), e.ExecutionPayload.BlockHash)
+	s.Equal(l2Head.Difficulty(), e.HeaderDifficulty)
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestBlockToEnvelopeMarkers() {
@@ -27,6 +28,7 @@ func (s *PreconfBlockAPIServerTestSuite) TestBlockToEnvelopeMarkers() {
 	s.Equal(endOfSequencing, *e.EndOfSequencing)
 	s.Equal(signature, *e.Signature)
 	s.Equal(l2Head.Hash(), e.ExecutionPayload.BlockHash)
+	s.Equal(l2Head.Difficulty(), e.HeaderDifficulty)
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestCheckMessageBlockNumber() {

--- a/packages/taiko-client/pkg/preconf/payload.go
+++ b/packages/taiko-client/pkg/preconf/payload.go
@@ -1,9 +1,30 @@
 package preconf
 
-import "github.com/ethereum-optimism/optimism/op-service/eth"
+import (
+	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// Envelope is the decoded, validated form of a preconfirmation gossip message
+// used inside the driver. It is decoupled from `eth.ExecutionPayloadEnvelope`
+// so ingest code can carry only the fields the driver consumes.
 type Envelope struct {
-	Payload           *eth.ExecutionPayload
+	// Payload is the execution payload carried by the preconfirmation message.
+	Payload *eth.ExecutionPayload
+	// IsForcedInclusion signals that the block was sequenced via the
+	// forced-inclusion path rather than the regular preconfirmation flow.
 	IsForcedInclusion bool
-	Signature         *[65]byte
+	// Signature is the 65-byte secp256k1 signature covering the gossip
+	// envelope bytes; nil when the envelope is synthesized locally (not
+	// gossiped) or when the message is loaded from cache without signature
+	// preservation.
+	Signature *[65]byte
+	// HeaderDifficulty is the Uzen-era `header.Difficulty` (= block zk gas
+	// used) carried on the wire so receivers can reconstruct the sender's
+	// block hash. Nil on Shasta-era messages, where `header.Difficulty` is
+	// always zero. Copied straight off the decoded gossip envelope without
+	// recomputation (see pkg/preconf/validation.go for the fork-gated
+	// presence check).
+	HeaderDifficulty *big.Int
 }


### PR DESCRIPTION
## Summary

- Thread Uzen `header.Difficulty` (= `block_zk_gas_used`, a non-zero `U256` post-Uzen) through the preconfirmation gossip envelope end-to-end so receivers can reconstruct the sender's block hash.
- Match the wire format shipped in [taikoxyz/optimism#40](https://github.com/taikoxyz/optimism/pull/40): `flags0 & 0x02` gates a 32-byte slot after `parent_beacon_block_root`. Shasta envelopes remain byte-identical on the wire.
- Go side: `preconf.Envelope.HeaderDifficulty`, propagated through `util.go`/`server.go` ingest + cache sites.
- Rust side: `WhitelistExecutionPayloadEnvelope` SSZ codec extended; `validate_envelope_header_difficulty` runs post-decode on both `handle_unsafe_payload` and `handle_unsafe_response`; the REST `build_preconf_block` path and `build_response_envelope_from_l2` populate the field from the engine-stamped `block.header.difficulty` so loopback ingest and remote peers pass validation.
- `go.mod` pin bumped to the `taikoxyz/optimism` rev that ships the wire-format change.

Both clients continue to let the local engine's deterministic zk-gas recompute produce the authoritative `header.Difficulty` for block-hash construction; the gossiped field serves cross-client integrity (shared spec / flag semantics) and the Rust fork × presence validator.

## Test plan

- [x] `cd packages/taiko-client && make test PACKAGE="driver/..."` — all driver sub-packages PASS
- [x] `cd packages/taiko-client-rs && just test` — 362/362 PASS
- [x] Devnet interop: Go ↔ Rust preconf gossip handshake on Uzen-from-genesis devnet