### PR TITLE
chore(taiko-client): downgrade transition config exchange log to debug

### DIFF
--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -350,7 +350,7 @@ func (d *Driver) exchangeTransitionConfigLoop() {
 				TerminalBlockNumber:     0,
 			})
 			if err != nil {
-				log.Error("Failed to exchange Transition Configuration", "error", err)
+				log.Debug("Failed to exchange Transition Configuration", "error", err)
 			} else {
 				log.Debug("Exchanged transition config", "transitionConfig", tc)
 			}


### PR DESCRIPTION
## Summary
- Downgrades the `exchangeTransitionConfigLoop` failure log from `Error` to `Debug` to reduce noise when the engine API call fails transiently.

## Test plan
- [x] Run driver locally and confirm the message no longer appears at error level.