### PR TITLE
test(taiko-client-rs): make ShastaEnv teardown tolerant of lost L1 snapshots

### DIFF
--- a/packages/taiko-client-rs/crates/test-harness/src/shasta/env.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/shasta/env.rs
@@ -10,7 +10,7 @@ use rpc::{
     client::{Client, ClientConfig, connect_provider_with_timeout},
 };
 use test_context::AsyncTestContext;
-use tracing::info;
+use tracing::{info, warn};
 
 use super::helpers::{
     RpcClient, create_snapshot, ensure_preconf_whitelist_active, reset_head_l1_origin,
@@ -161,8 +161,11 @@ impl ShastaEnv {
         })
     }
 
-    /// Explicit async teardown to revert the L1 snapshot.
-    pub async fn shutdown(self) -> Result<()> {
+    /// Explicit async teardown to revert the L1 snapshot. Returns whether Anvil actually
+    /// rolled back; a `false` result means the snapshot id was already gone (e.g. the L1
+    /// container restarted mid-run), which is non-fatal because each `setup` resets L2 state
+    /// and takes a fresh snapshot.
+    pub async fn shutdown(self) -> Result<bool> {
         revert_snapshot(&self.cleanup_provider, &self.snapshot_id).await
     }
 }
@@ -175,9 +178,20 @@ impl AsyncTestContext for ShastaEnv {
             .unwrap_or_else(|err| panic!("failed to load ShastaEnv: {err:#}"))
     }
 
-    /// Teardown the ShastaEnv after each test.
+    /// Teardown the ShastaEnv after each test. A missing snapshot is logged but not fatal:
+    /// the next `setup` reinitialises state from scratch, so masking body-level successes
+    /// with a teardown panic only adds flakiness without protecting subsequent tests.
     async fn teardown(self) {
-        self.shutdown().await.unwrap_or_else(|err| panic!("ShastaEnv teardown failed: {err:?}"));
+        let snapshot_id = self.snapshot_id.clone();
+        match self.shutdown().await {
+            Ok(true) => {}
+            Ok(false) => warn!(
+                %snapshot_id,
+                "evm_revert returned false during ShastaEnv teardown; L1 snapshot was likely \
+                 invalidated (e.g. anvil restart). Continuing since setup re-establishes state."
+            ),
+            Err(err) => panic!("ShastaEnv teardown failed: {err:?}"),
+        }
     }
 }
 

--- a/packages/taiko-client-rs/crates/test-harness/src/shasta/helpers.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/shasta/helpers.rs
@@ -91,14 +91,15 @@ pub async fn reset_head_l1_origin(client: &RpcClient) -> Result<()> {
     Ok(())
 }
 
-/// Revert the L1 snapshot.
-pub async fn revert_snapshot(provider: &RootProvider, snapshot_id: &str) -> Result<()> {
+/// Revert the L1 snapshot. Returns `true` when Anvil actually rolled back, `false` when the
+/// snapshot id was already invalidated (e.g. the L1 container restarted or a prior revert
+/// consumed it). Callers decide whether a missing snapshot is fatal.
+pub async fn revert_snapshot(provider: &RootProvider, snapshot_id: &str) -> Result<bool> {
     let reverted = provider
         .raw_request::<_, bool>(Cow::Borrowed("evm_revert"), (&snapshot_id,))
         .await
         .context("reverting L1 snapshot")?;
-    ensure!(reverted, "evm_revert returned false");
-    Ok(())
+    Ok(reverted)
 }
 
 /// Create a new L1 snapshot to reuse across a single test run.


### PR DESCRIPTION
## Summary
- `ShastaEnv::teardown` currently panics with \`evm_revert returned false\` when Anvil no longer has the snapshot id. This has surfaced as an occasional \`just test\` failure (e.g. \`known_canonical_fast_path\` failing while the test body itself passed).
- The most plausible trigger is the L1 \`anvil\` container restarting mid-run (\`docker-compose.test.yaml\` sets \`restart: unless-stopped\`); the accompanying \"block 1 missing; skipping L2 head reset\" warning seen in the failing log is consistent with L2 also being back at genesis, i.e. container restart rather than snapshot-id misuse on our side.
- \`ShastaEnv::load_from_env\` already does \`reset_to_base_block\` + \`reset_head_l1_origin\` + a fresh \`create_snapshot\` on every setup, so a missing snapshot during the prior teardown does not poison the next test.
- \`revert_snapshot\` now returns \`Result<bool>\` (true = rolled back, false = snapshot already invalidated) and \`teardown\` only \`warn!\`s on \`Ok(false)\`. Real RPC errors still panic so genuine bugs aren't masked.

## Test plan
- [x] \`cargo check -p test-harness --all-features\`
- [x] \`cargo clippy -p test-harness --all-features --no-deps -- -D warnings\`
- [x] \`just test\` (all 362 tests pass; re-ran multiple times)