### PR TITLE
refactor(taiko-client,taiko-client-rs): swap preconf whitelist check from coinbase to node P2P signer

### DIFF
--- a/.github/workflows/taiko-client--test.yml
+++ b/.github/workflows/taiko-client--test.yml
@@ -16,7 +16,7 @@ on:
       - release-please--branches--**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: taiko-client-test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -16,7 +16,7 @@ on:
       - release-please--branches--**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: taiko-client-rs-test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -6,17 +6,6 @@ impl<P> WhitelistApiService<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    /// Validate that the fee recipient is a registered operator.
-    fn ensure_fee_recipient_allowed(&self, fee_recipient: alloy_primitives::Address) -> Result<()> {
-        if self.operator_set.load().contains(&fee_recipient) {
-            Ok(())
-        } else {
-            Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                "fee recipient {fee_recipient} is not a registered operator"
-            )))
-        }
-    }
-
     /// Send one network command and map channel failures into a consistent P2P error.
     async fn send_network_command(
         &self,
@@ -61,8 +50,6 @@ where
                 driver::DriverError::EngineSyncing(request.block_number),
             ));
         }
-
-        self.ensure_fee_recipient_allowed(request.fee_recipient)?;
 
         let prev_randao =
             self.derive_prev_randao(request.parent_hash, request.block_number).await?;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -6,6 +6,23 @@ impl<P> WhitelistApiService<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
+    /// Reject build requests when this node's own P2P signer is not a registered
+    /// operator in the on-chain whitelist.
+    ///
+    /// Peers only accept gossip from whitelisted operators, so if our signer has been
+    /// deregistered any block we build would be dropped on arrival. Failing fast here
+    /// avoids building blocks that can never be gossiped.
+    fn ensure_node_signer_whitelisted(&self) -> Result<()> {
+        let signer = self.signer.address();
+        if self.operator_set.load().contains(&signer) {
+            Ok(())
+        } else {
+            Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
+                "node P2P signer {signer} is not a registered operator"
+            )))
+        }
+    }
+
     /// Send one network command and map channel failures into a consistent P2P error.
     async fn send_network_command(
         &self,
@@ -50,6 +67,8 @@ where
                 driver::DriverError::EngineSyncing(request.block_number),
             ));
         }
+
+        self.ensure_node_signer_whitelisted()?;
 
         let prev_randao =
             self.derive_prev_randao(request.parent_hash, request.block_number).await?;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -35,6 +35,7 @@ use crate::{
     error::{Result, WhitelistPreconfirmationDriverError},
     importer::validate_execution_payload_for_preconf,
     network::NetworkCommand,
+    operator_set::SharedOperatorSet,
 };
 
 mod handlers;
@@ -66,6 +67,9 @@ where
     network_command_tx: mpsc::Sender<NetworkCommand>,
     /// Serializes build requests to avoid concurrent insertion/signing races.
     build_preconf_lock: Mutex<()>,
+    /// Lock-free shared set of whitelisted sequencer addresses; used to refuse
+    /// build requests when this node's own P2P signer has been deregistered on-chain.
+    operator_set: SharedOperatorSet,
     /// Local peer ID string.
     local_peer_id: String,
     /// Highest unsafe payload block ID tracked by this node (shared with importer).
@@ -91,6 +95,8 @@ where
     pub(crate) signer: FixedKSigner,
     /// Beacon client used for epoch calculations.
     pub(crate) beacon_client: Arc<BeaconClient>,
+    /// Shared operator set used to gate the build API on the node's own whitelist status.
+    pub(crate) operator_set: SharedOperatorSet,
     /// Shared highest unsafe payload block ID (also updated by importer on P2P import).
     pub(crate) highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
     /// Network command sender for gossip publishing.
@@ -113,6 +119,7 @@ where
             chain_id,
             signer,
             beacon_client,
+            operator_set,
             highest_unsafe_l2_payload_block_id,
             network_command_tx,
             cache_state,
@@ -126,6 +133,7 @@ where
             chain_id,
             signer,
             beacon_client,
+            operator_set,
             local_peer_id,
             highest_unsafe_l2_payload_block_id,
             cache_state,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -66,8 +66,6 @@ where
     network_command_tx: mpsc::Sender<NetworkCommand>,
     /// Serializes build requests to avoid concurrent insertion/signing races.
     build_preconf_lock: Mutex<()>,
-    /// Lock-free shared set of allowed sequencer addresses, refreshed by background poller.
-    operator_set: crate::operator_set::SharedOperatorSet,
     /// Local peer ID string.
     local_peer_id: String,
     /// Highest unsafe payload block ID tracked by this node (shared with importer).
@@ -93,8 +91,6 @@ where
     pub(crate) signer: FixedKSigner,
     /// Beacon client used for epoch calculations.
     pub(crate) beacon_client: Arc<BeaconClient>,
-    /// Shared operator set for fee-recipient validation.
-    pub(crate) operator_set: crate::operator_set::SharedOperatorSet,
     /// Shared highest unsafe payload block ID (also updated by importer on P2P import).
     pub(crate) highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
     /// Network command sender for gossip publishing.
@@ -117,7 +113,6 @@ where
             chain_id,
             signer,
             beacon_client,
-            operator_set,
             highest_unsafe_l2_payload_block_id,
             network_command_tx,
             cache_state,
@@ -131,7 +126,6 @@ where
             chain_id,
             signer,
             beacon_client,
-            operator_set,
             local_peer_id,
             highest_unsafe_l2_payload_block_id,
             cache_state,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -160,7 +160,6 @@ impl WhitelistPreconfirmationDriverRunner {
                     chain_id,
                     signer,
                     beacon_client: Arc::clone(&beacon_client),
-                    operator_set: operator_set.clone(),
                     highest_unsafe_l2_payload_block_id: shared_highest.clone(),
                     network_command_tx: network.command_tx.clone(),
                     cache_state: cache_state.clone(),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -160,6 +160,7 @@ impl WhitelistPreconfirmationDriverRunner {
                     chain_id,
                     signer,
                     beacon_client: Arc::clone(&beacon_client),
+                    operator_set: operator_set.clone(),
                     highest_unsafe_l2_payload_block_id: shared_highest.clone(),
                     network_command_tx: network.command_tx.clone(),
                     cache_state: cache_state.clone(),

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -390,7 +390,7 @@ func (d *Driver) cacheLookaheadLoop() {
 			return
 		}
 
-		isSequencer := d.preconfBlockServer.CheckLookaheadHandover(d.PreconfOperatorAddress, slot) == nil
+		isSequencer := d.preconfBlockServer.CheckLookaheadHandover(slot) == nil
 
 		if isSequencer && !wasSequencer {
 			log.Info("Lookahead transitioning to sequencing for operator", "epoch", epoch, "slot", slot)

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -157,9 +157,10 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 		"isForcedInclusion", isForcedInclusion,
 	)
 
-	// Check if the fee recipient the current operator or the next operator if its in handover window.
+	// Check that the current L1 slot falls inside this operator's sequencing window
+	// (current or next, covering the handover window).
 	if s.rpc.L1Beacon != nil {
-		if err := s.CheckLookaheadHandover(reqBody.ExecutableData.FeeRecipient, s.rpc.L1Beacon.CurrentSlot()); err != nil {
+		if err := s.CheckLookaheadHandover(s.rpc.L1Beacon.CurrentSlot()); err != nil {
 			return s.returnError(c, http.StatusBadRequest, err)
 		}
 	}

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -41,9 +41,8 @@ import (
 )
 
 var (
-	errInvalidCurrOperator = errors.New("invalid operator: expected current operator in handover window")
-	errInvalidNextOperator = errors.New("invalid operator: expected next operator in handover window")
-	wsUpgrader             = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	errSlotOutsideSequencingWindow = errors.New("slot outside current and next operator sequencing windows")
+	wsUpgrader                     = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 )
 
 const requestSyncMargin = uint64(128) // Margin for requesting sync, to avoid requesting very old blocks.
@@ -1021,10 +1020,9 @@ func (s *PreconfBlockAPIServer) GetLookahead() *Lookahead {
 	return s.lookahead
 }
 
-// CheckLookaheadHandover returns nil if feeRecipient is allowed to build at slot globalSlot (absolute L1 slot).
-// and checks the handover window to see if we need to request the end of sequencing
-// block.
-func (s *PreconfBlockAPIServer) CheckLookaheadHandover(feeRecipient common.Address, globalSlot uint64) error {
+// CheckLookaheadHandover returns nil if globalSlot (absolute L1 slot) falls inside
+// this operator's current or next scheduled sequencing window.
+func (s *PreconfBlockAPIServer) CheckLookaheadHandover(globalSlot uint64) error {
 	s.lookaheadMutex.Lock()
 	defer s.lookaheadMutex.Unlock()
 
@@ -1033,21 +1031,18 @@ func (s *PreconfBlockAPIServer) CheckLookaheadHandover(feeRecipient common.Addre
 		return nil
 	}
 
-	// Check if the fee recipient is the current operator.
 	for _, r := range s.lookahead.CurrRanges {
 		if globalSlot >= r.Start && globalSlot < r.End {
 			return nil
 		}
 	}
 
-	// Check if the fee recipient is the next operator.
 	for _, r := range s.lookahead.NextRanges {
 		if globalSlot >= r.Start && globalSlot < r.End {
 			return nil
 		}
 	}
 
-	// If not in any range, we returns an error.
 	log.Debug(
 		"Slot out of sequencing window",
 		"slot", globalSlot,
@@ -1055,11 +1050,7 @@ func (s *PreconfBlockAPIServer) CheckLookaheadHandover(feeRecipient common.Addre
 		"nextRanges", s.lookahead.NextRanges,
 	)
 
-	if feeRecipient == s.lookahead.CurrOperator {
-		return errInvalidCurrOperator
-	}
-
-	return errInvalidNextOperator
+	return errSlotOutsideSequencingWindow
 }
 
 // PutPayloadsCache puts the given payload into the payload cache queue, should ONLY be used in testing.

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -59,32 +59,20 @@ func (s *PreconfBlockAPIServerTestSuite) TestCheckLookaheadHandover() {
 	}
 
 	tests := []struct {
-		name         string
-		globalSlot   uint64
-		feeRecipient common.Address
-		wantErr      error
+		name       string
+		globalSlot uint64
+		wantErr    error
 	}{
-		// Inside CurrRanges, before handover point
-		{name: "curr allowed early slot", globalSlot: 10, feeRecipient: curr, wantErr: nil},
-
-		// Inside CurrRanges, at handover threshold
-		{name: "next allowed at handover slot", globalSlot: 28, feeRecipient: next, wantErr: nil},
-
-		// Inside CurrRanges, after threshold
-		{name: "next allowed after handover", globalSlot: 30, feeRecipient: next, wantErr: nil},
+		// Inside CurrRanges
+		{name: "curr range early slot", globalSlot: 10, wantErr: nil},
+		{name: "curr range at handover slot", globalSlot: 28, wantErr: nil},
+		{name: "curr range after handover", globalSlot: 30, wantErr: nil},
 
 		// Inside NextRanges (next epoch)
-		{name: "next allowed next epoch", globalSlot: 33, feeRecipient: next, wantErr: nil},
+		{name: "next range next epoch", globalSlot: 33, wantErr: nil},
 
-		// Slot outside all ranges (invalid)
-		{
-			name:         "random address wrong",
-			globalSlot:   70,
-			feeRecipient: common.HexToAddress("0xCCC0000000000000000000000000000000000000"),
-			wantErr:      errInvalidNextOperator,
-		},
-		{name: "curr wrong outside", globalSlot: 70, feeRecipient: curr, wantErr: errInvalidCurrOperator},
-		{name: "next wrong outside", globalSlot: 70, feeRecipient: next, wantErr: errInvalidNextOperator},
+		// Slot outside all ranges
+		{name: "outside all ranges", globalSlot: 70, wantErr: errSlotOutsideSequencingWindow},
 	}
 
 	for _, tt := range tests {
@@ -94,7 +82,7 @@ func (s *PreconfBlockAPIServerTestSuite) TestCheckLookaheadHandover() {
 				SlotsPerEpoch: 32,
 			}
 
-			s.Equal(tt.wantErr, s.s.CheckLookaheadHandover(tt.feeRecipient, tt.globalSlot))
+			s.Equal(tt.wantErr, s.s.CheckLookaheadHandover(tt.globalSlot))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- **Rust `whitelist-preconfirmation-driver`** — replace the coinbase-in-whitelist check on `build_preconf_block` with a node-P2P-signer-in-whitelist check. The API now rejects a request iff this node's own `FixedKSigner::address()` is absent from the on-chain `PreconfWhitelist` operator set (polled by `OperatorSetPoller`). The block's `fee_recipient` is no longer validated against the whitelist.
- **Go `driver/preconf_blocks`** — no behavioral change. `CheckLookaheadHandover` already rejects a non-whitelisted node implicitly (its lookahead ranges are empty). While we're in the file, drop the unused `feeRecipient` parameter (only used to pick between two diagnostic error strings) and collapse `errInvalidCurrOperator` / `errInvalidNextOperator` into a single `errSlotOutsideSequencingWindow`.
- **CI** — isolate the `taiko-client` and `taiko-client-rs` test workflow concurrency groups so a PR touching both packages doesn't make them cancel each other.

## Why the swap is correct

**Checking the block's coinbase was the wrong invariant.** Protocol-side, the derivation pipeline does not require coinbase to equal any operator/proposer address. Per-block `BlockManifest.coinbase` is preserved end-to-end in the normal proposal path:

**Go (`taiko-client`):**
- `bindings/manifest/manifest.go:40-52` — `BlockManifest.Coinbase` is per-block.
- `driver/chain_syncer/event/derivation/source_fetcher.go:231-274` — `ValidateMetadata` checks only timestamps, anchor block numbers, and gas limits. No coinbase check.
- `ApplyInheritedMetadata` (source_fetcher.go:452) rewrites `Coinbase = event.Proposer` only for forced-inclusion segments or when `ValidateMetadata` fails and a one-block default payload is substituted (syncer.go:328-358).
- Otherwise payload construction at `blocks_inserter/common.go:538` threads `SuggestedFeeRecipient: blockInfo.Coinbase` per block.

**Rust (`taiko-client-rs`):**
- `crates/protocol/src/shasta/manifest.rs:23-35` — same structure, `BlockManifest.coinbase` per block.
- `crates/driver/src/derivation/pipeline/shasta/validation.rs:68-94` — `validate_source_manifest` only validates timestamps / anchor numbers / gas limits.
- `apply_inherited_metadata` (validation.rs:238) runs only for forced-inclusion or default-manifest segments (payload.rs:306). Otherwise payload.rs:516/527 threads per-block `coinbase` into both `beneficiary` and `suggested_fee_recipient`.

So a single proposal can legitimately contain blocks with different coinbases produced by different whitelisted sequencers — the derivation pipeline accepts them as-is. Gating on coinbase at the preconf API would wrongly reject blocks a proposer could otherwise bundle in.

## Why we still need *some* check

The node's own **P2P signer** is the right thing to gate on. Peers already verify gossip signatures against the whitelist on the inbound side:

- **Rust inbound:** `importer::ensure_signer_allowed` (`importer/mod.rs:207-215`) and `network::handler` (line 338) check the recovered gossip signer against the full `operator_set`.
- **Go inbound:** the Optimism P2P layer calls `GossipRuntimeConfig.P2PSequencerAddress()` (`server.go:977-988`) / `PreconfGossipRuntimeConfig.P2PSequencerAddresses()` (line 990-1005), which return the current (and next) scheduled operator from the `PreconfWhitelist` contract / lookahead.

If our own signer has been deregistered, peers will drop anything we gossip. The new outbound guard in Rust (`ensure_node_signer_whitelisted`) fails fast with 400 so we never build a block we can't gossip. Go gets the same guarantee implicitly via `CheckLookaheadHandover` (an unregistered node has no lookahead ranges).

## Test plan

- [x] `cargo check -p whitelist-preconfirmation-driver`
- [x] `TEST_CRATE=whitelist-preconfirmation-driver just test` (all tests pass, 78/78 baseline)
- [x] `PACKAGE=./driver/preconf_blocks/... make test` (all subtests incl. updated `TestCheckLookaheadHandover` pass)
- [x] CI green on both `taiko-client` and `taiko-client-rs` test workflows (and verify both run to completion now that concurrency groups are distinct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)