### PR TITLE
fix(protocol): harden preconf slashing checks

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/impl/LookaheadStore.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/LookaheadStore.sol
@@ -438,6 +438,7 @@ contract LookaheadStore is ILookaheadStore, IProposerChecker, Blacklist, Essenti
         require(isLookaheadRequired(), LookaheadNotRequired());
 
         unchecked {
+            uint256 nextEpochEnd = _nextEpochTimestamp + LibPreconfConstants.SECONDS_IN_EPOCH;
             // Set this value to the last slot timestamp of the previous epoch
             uint256 prevSlotTimestamp = _nextEpochTimestamp - LibPreconfConstants.SECONDS_IN_SLOT;
 
@@ -446,17 +447,17 @@ contract LookaheadStore is ILookaheadStore, IProposerChecker, Blacklist, Essenti
 
             for (uint256 i; i < _lookaheadSlots.length; ++i) {
                 LookaheadSlot memory lookaheadSlot = _lookaheadSlots[i];
+                uint256 slotTimestamp = lookaheadSlot.timestamp;
 
+                require(slotTimestamp >= _nextEpochTimestamp, InvalidLookaheadEpoch());
+                require(slotTimestamp > prevSlotTimestamp, SlotTimestampIsNotIncrementing());
                 require(
-                    lookaheadSlot.timestamp > prevSlotTimestamp, SlotTimestampIsNotIncrementing()
-                );
-                require(
-                    (lookaheadSlot.timestamp - _nextEpochTimestamp)
-                            % LibPreconfConstants.SECONDS_IN_SLOT == 0,
+                    (slotTimestamp - _nextEpochTimestamp) % LibPreconfConstants.SECONDS_IN_SLOT
+                        == 0,
                     InvalidSlotTimestamp()
                 );
 
-                prevSlotTimestamp = lookaheadSlot.timestamp;
+                prevSlotTimestamp = slotTimestamp;
 
                 // Validate the operator in the lookahead payload with the current epoch as
                 // reference
@@ -478,10 +479,7 @@ contract LookaheadStore is ILookaheadStore, IProposerChecker, Blacklist, Essenti
             }
 
             // Validate that the last slot timestamp is within the next epoch
-            require(
-                prevSlotTimestamp < _nextEpochTimestamp + LibPreconfConstants.SECONDS_IN_EPOCH,
-                InvalidLookaheadEpoch()
-            );
+            require(prevSlotTimestamp < nextEpochEnd, InvalidLookaheadEpoch());
         }
 
         // Hash the lookahead slots and update the lookahead hash for next epoch

--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasherL1.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfSlasherL1.sol
@@ -17,11 +17,18 @@ import { IPreconfSlasher } from "src/shared/preconf/IPreconfSlasher.sol";
 contract PreconfSlasherL1 is IPreconfSlasherL1 {
     address public immutable urc;
     address public immutable preconfSlasherL2;
+    uint64 public immutable preconfSlasherL2ChainId;
     address public immutable bridge;
 
-    constructor(address _urc, address _preconfSlasherL2, address _bridge) {
+    constructor(
+        address _urc,
+        address _preconfSlasherL2,
+        uint64 _preconfSlasherL2ChainId,
+        address _bridge
+    ) {
         urc = _urc;
         preconfSlasherL2 = _preconfSlasherL2;
+        preconfSlasherL2ChainId = _preconfSlasherL2ChainId;
         bridge = _bridge;
     }
 
@@ -68,9 +75,14 @@ contract PreconfSlasherL1 is IPreconfSlasherL1 {
     /// @inheritdoc IMessageInvocable
     /// @dev Invoked by the L2 preconf slasher
     function onMessageInvocation(bytes calldata _data) external payable {
+        require(msg.sender == bridge, CallerIsNotBridge());
+
         // Verify that the sender on the L2 side is the preconf slasher contract
         IBridge.Context memory ctx = IBridge(bridge).context();
-        require(ctx.from == preconfSlasherL2, CallerIsNotPreconfSlasherL2());
+        require(
+            ctx.srcChainId == preconfSlasherL2ChainId && ctx.from == preconfSlasherL2,
+            CallerIsNotPreconfSlasherL2()
+        );
 
         (
             IPreconfSlasher.Fault fault,
@@ -95,6 +107,7 @@ contract PreconfSlasherL1 is IPreconfSlasherL1 {
     // Errors
     // ---------------------------------------------------------------
 
+    error CallerIsNotBridge();
     error CallerIsNotPreconfSlasherL2();
     error ChallengerIsNotSelf();
     error InvalidCommitmentType();

--- a/packages/protocol/test/layer1/preconf/PreconfSlasherL1.t.sol
+++ b/packages/protocol/test/layer1/preconf/PreconfSlasherL1.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { ISlasher } from "@eth-fabric/urc/ISlasher.sol";
+import { PreconfSlasherL1 } from "src/layer1/preconf/impl/PreconfSlasherL1.sol";
+import { UnifiedSlasher } from "src/layer1/preconf/impl/UnifiedSlasher.sol";
+import { LibPreconfConstants } from "src/layer1/preconf/libs/LibPreconfConstants.sol";
+import { Bridge } from "src/shared/bridge/Bridge.sol";
+import { IBridge, IMessageInvocable } from "src/shared/bridge/IBridge.sol";
+import { IPreconfSlasher } from "src/shared/preconf/IPreconfSlasher.sol";
+import { SignalService } from "src/shared/signal/SignalService.sol";
+import { CommonTest } from "test/shared/CommonTest.sol";
+
+contract RecordingURC {
+    uint256 public slashCalls;
+    bytes32 public lastRegistrationRoot;
+
+    function slashCommitment(
+        bytes32 _registrationRoot,
+        ISlasher.SignedCommitment calldata,
+        bytes calldata
+    )
+        external
+        returns (uint256)
+    {
+        slashCalls++;
+        lastRegistrationRoot = _registrationRoot;
+        return 1 ether;
+    }
+}
+
+contract PreconfSlasherL1Test is CommonTest {
+    bytes internal constant FAKE_PROOF = "";
+    uint64 internal constant ATTACKER_CHAIN_ID = 9_999_999;
+
+    RecordingURC internal urc;
+    SignalService internal signalService;
+    Bridge internal l1Bridge;
+    PreconfSlasherL1 internal preconfSlasherL1;
+    UnifiedSlasher internal unifiedSlasher;
+
+    address internal preconfSlasherL2 = makeAddr("preconfSlasherL2");
+
+    function setUpOnEthereum() internal override {
+        signalService = deploySignalServiceWithoutProof(
+            address(this), address(uint160(uint256(keccak256("remote signal service")))), deployer
+        );
+        l1Bridge = deployBridge(address(new Bridge(address(resolver), address(signalService))));
+        vm.deal(address(l1Bridge), 100 ether);
+
+        resolver.registerAddress(
+            ATTACKER_CHAIN_ID, "bridge", address(uint160(uint256(keccak256("attacker bridge"))))
+        );
+
+        urc = new RecordingURC();
+        preconfSlasherL1 =
+            new PreconfSlasherL1(address(urc), preconfSlasherL2, taikoChainId, address(l1Bridge));
+        unifiedSlasher = new UnifiedSlasher(
+            address(preconfSlasherL1), makeAddr("lookaheadSlasher"), address(urc)
+        );
+    }
+
+    function setUpOnTaiko() internal override {
+        register("bridge", address(uint160(uint256(keccak256("taiko bridge")))));
+    }
+
+    function test_onMessageInvocation_rejectsDirectCalls() external {
+        vm.expectRevert(PreconfSlasherL1.CallerIsNotBridge.selector);
+        unifiedSlasher.onMessageInvocation(_slashingData(keccak256("direct")));
+    }
+
+    function test_onMessageInvocation_acceptsExpectedL2SenderAndChain() external {
+        bytes32 registrationRoot = keccak256("victim operator");
+
+        vm.prank(Alice);
+        (IBridge.Status status, IBridge.StatusReason reason) =
+            l1Bridge.processMessage(_message(uint64(taikoChainId), registrationRoot), FAKE_PROOF);
+
+        assertEq(uint8(status), uint8(IBridge.Status.DONE));
+        assertEq(uint8(reason), uint8(IBridge.StatusReason.INVOCATION_OK));
+        assertEq(urc.slashCalls(), 1);
+        assertEq(urc.lastRegistrationRoot(), registrationRoot);
+    }
+
+    function test_onMessageInvocation_rejectsWrongSourceChain() external {
+        bytes32 registrationRoot = keccak256("victim operator");
+
+        vm.prank(Alice);
+        (IBridge.Status status, IBridge.StatusReason reason) =
+            l1Bridge.processMessage(_message(ATTACKER_CHAIN_ID, registrationRoot), FAKE_PROOF);
+
+        assertEq(uint8(status), uint8(IBridge.Status.RETRIABLE));
+        assertEq(uint8(reason), uint8(IBridge.StatusReason.INVOCATION_FAILED));
+        assertEq(urc.slashCalls(), 0);
+    }
+
+    function _message(
+        uint64 _srcChainId,
+        bytes32 _registrationRoot
+    )
+        private
+        view
+        returns (IBridge.Message memory)
+    {
+        return IBridge.Message({
+            id: 0,
+            fee: 0,
+            gasLimit: 0,
+            from: preconfSlasherL2,
+            srcChainId: _srcChainId,
+            srcOwner: preconfSlasherL2,
+            destChainId: ethereumChainId,
+            destOwner: Alice,
+            to: address(unifiedSlasher),
+            value: 0,
+            data: abi.encodeCall(
+                IMessageInvocable.onMessageInvocation, (_slashingData(_registrationRoot))
+            )
+        });
+    }
+
+    function _slashingData(bytes32 _registrationRoot) private view returns (bytes memory) {
+        return abi.encode(
+            IPreconfSlasher.Fault.InvalidEOP,
+            _registrationRoot,
+            ISlasher.SignedCommitment({
+                commitment: ISlasher.Commitment({
+                    commitmentType: LibPreconfConstants.PRECONF_COMMITMENT_TYPE,
+                    payload: abi.encode(_preconfirmation()),
+                    slasher: address(unifiedSlasher)
+                }),
+                signature: hex"1234"
+            })
+        );
+    }
+
+    function _preconfirmation() private pure returns (IPreconfSlasher.Preconfirmation memory) {
+        return IPreconfSlasher.Preconfirmation({
+            eop: false,
+            blockNumber: 1,
+            anchorBlockNumber: 1,
+            parentRawTxListHash: bytes32(0),
+            rawTxListHash: bytes32(0),
+            parentSubmissionWindowEnd: 1,
+            submissionWindowEnd: 2
+        });
+    }
+}

--- a/packages/protocol/test/layer1/preconf/lookahead-store/LookaheadStore.t.sol
+++ b/packages/protocol/test/layer1/preconf/lookahead-store/LookaheadStore.t.sol
@@ -113,6 +113,20 @@ contract TestLookaheadStore is CommonTest {
         lookaheadStore.updateLookahead(nextEpochTimestamp, slots);
     }
 
+    function test_updateLookahead_RevertWhen_PreEpochSlotTimestamp() external {
+        _warpAfterEpochStart();
+        bytes32 registrationRoot = keccak256("operator");
+        address committer = makeAddr("committer");
+        _setupOperator(registrationRoot, committer, 1);
+
+        uint256 nextEpochTimestamp = _nextEpochTimestamp();
+        ILookaheadStore.LookaheadSlot[] memory slots = new ILookaheadStore.LookaheadSlot[](1);
+        slots[0] = _buildSlot(nextEpochTimestamp - 4, registrationRoot, committer, 0);
+
+        vm.expectRevert(LookaheadStore.InvalidLookaheadEpoch.selector);
+        lookaheadStore.updateLookahead(nextEpochTimestamp, slots);
+    }
+
     function test_updateLookahead_RevertWhen_InvalidValidatorLeafIndex() external {
         _warpAfterEpochStart();
         bytes32 registrationRoot = keccak256("operator");


### PR DESCRIPTION
## Summary

Hardens the L1 preconfirmation slasher bridge entrypoint so it only accepts calls from the configured bridge and the expected L2 slasher chain/address pair. Also bounds next-epoch lookahead slot timestamps before unchecked slot arithmetic so pre-epoch timestamps cannot be persisted.

## Test plan

- `FOUNDRY_PROFILE=layer1 forge test --match-path 'test/layer1/preconf/PreconfSlasherL1.t.sol'`
- `FOUNDRY_PROFILE=layer1 forge test --match-path 'test/layer1/preconf/lookahead-store/LookaheadStore.t.sol'`
- `pnpm compile`
- `pnpm test`
- `FOUNDRY_PROFILE=layer1 forge fmt --check contracts/layer1/preconf/impl/PreconfSlasherL1.sol contracts/layer1/preconf/impl/LookaheadStore.sol test/layer1/preconf/PreconfSlasherL1.t.sol test/layer1/preconf/lookahead-store/LookaheadStore.t.sol`
- `pnpm solhint contracts/layer1/preconf/impl/PreconfSlasherL1.sol contracts/layer1/preconf/impl/LookaheadStore.sol`
