### PR TITLE
chore(taiko-client,taiko-client-rs): bump execution client deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260424023937-810480e7eee6
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260427005750-f636489ae176
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828 h1:8TqBxcCsk7TNvGHjTuStB2waN3KPpTJYeqpk7JY5t+o=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260424023937-810480e7eee6 h1:rc+2vMKowA1L+s0sR/EUX0yWpdwvzxknAEk6TGJX93M=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260424023937-810480e7eee6/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260427005750-f636489ae176 h1:GPFmNZ/hilej0MFO+rwXiVgH5VvSclkoD+MzRmSZW2o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260427005750-f636489ae176/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "0.7.1"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=26010828d12e5b6a7f9cb7588278adef4268167c#26010828d12e5b6a7f9cb7588278adef4268167c"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=d1e831837fddfe6dbf8f7e43a77488316f1458bc#d1e831837fddfe6dbf8f7e43a77488316f1458bc"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.1",
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "0.7.1"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=26010828d12e5b6a7f9cb7588278adef4268167c#26010828d12e5b6a7f9cb7588278adef4268167c"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=d1e831837fddfe6dbf8f7e43a77488316f1458bc#d1e831837fddfe6dbf8f7e43a77488316f1458bc"
 dependencies = [
  "alloy-consensus 2.0.1",
  "alloy-primitives",
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "0.7.1"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=26010828d12e5b6a7f9cb7588278adef4268167c#26010828d12e5b6a7f9cb7588278adef4268167c"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=d1e831837fddfe6dbf8f7e43a77488316f1458bc#d1e831837fddfe6dbf8f7e43a77488316f1458bc"
 dependencies = [
  "alloy-primitives",
  "serde",

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,11 +81,11 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "26010828d12e5b6a7f9cb7588278adef4268167c", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "26010828d12e5b6a7f9cb7588278adef4268167c", features = [
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "d1e831837fddfe6dbf8f7e43a77488316f1458bc", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "d1e831837fddfe6dbf8f7e43a77488316f1458bc", features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "26010828d12e5b6a7f9cb7588278adef4268167c" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "d1e831837fddfe6dbf8f7e43a77488316f1458bc" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary
- Bumps the root Go taiko-geth replacement to taiko branch head f636489ae176d8c9957eb7b1990c6be09969c56e.
- Bumps taiko-client-rs alethia-reth git dependencies to main branch head d1e831837fddfe6dbf8f7e43a77488316f1458bc.
- Refreshes go.sum and Cargo.lock for those dependency pins only.

## Verification
- go test ./packages/taiko-client/... -run '^$'
- cargo test --workspace --no-run --locked