### PR TITLE
chore(taiko-client-rs): keep host features out of no-default build

### DIFF
--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -48,7 +48,7 @@ hyper-util = { version = "0.1", features = ["client", "http1", "tokio"] }
 tower = { version = "0.5", features = ["timeout", "util"] }
 
 # ethereum
-alloy = "1.4.3"
+alloy = { version = "1.4.3", default-features = false }
 alloy-consensus = { version = "1.4.3", default-features = false, features = [
   "serde",
 ] }
@@ -82,7 +82,7 @@ robust-provider = "1.0.1"
 
 # taiko
 alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "d1e831837fddfe6dbf8f7e43a77488316f1458bc", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "d1e831837fddfe6dbf8f7e43a77488316f1458bc", features = [
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "d1e831837fddfe6dbf8f7e43a77488316f1458bc", default-features = false, features = [
   "serde",
 ] }
 alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "d1e831837fddfe6dbf8f7e43a77488316f1458bc" }

--- a/packages/taiko-client-rs/crates/driver/Cargo.toml
+++ b/packages/taiko-client-rs/crates/driver/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 
 [dependencies]
 alethia-reth-consensus = { workspace = true }
-alethia-reth-primitives = { workspace = true }
+alethia-reth-primitives = { workspace = true, features = ["net"] }
 alloy = { workspace = true }
 alloy-consensus = { workspace = true }
 alloy-eips = { workspace = true }

--- a/packages/taiko-client-rs/crates/protocol/Cargo.toml
+++ b/packages/taiko-client-rs/crates/protocol/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 [features]
 default = ["net"]
 net = [
+    "alloy/default",
+    "bindings",
     "tokio",
     "tokio-retry",
     "tokio-stream",
@@ -27,7 +29,7 @@ tokio-stream = { workspace = true, optional = true }
 tracing = { workspace = true }
 
 # ethereum
-alloy = { workspace = true }
+alloy = { workspace = true, features = ["std", "signers", "sol-types"] }
 alloy-consensus = { workspace = true }
 alloy-contract = { workspace = true }
 alloy-eips = { workspace = true }
@@ -50,7 +52,7 @@ k256 = { workspace = true }
 # taiko
 alethia-reth-consensus = { workspace = true }
 alethia-reth-primitives = { workspace = true }
-bindings = { path = "../bindings" }
+bindings = { path = "../bindings", optional = true }
 
 # types
 anyhow = { workspace = true }

--- a/packages/taiko-client-rs/crates/rpc/Cargo.toml
+++ b/packages/taiko-client-rs/crates/rpc/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { workspace = true, features = ["sync"] }
 url = { workspace = true }
 
 # taiko
-alethia-reth-primitives = { workspace = true }
+alethia-reth-primitives = { workspace = true, features = ["net"] }
 alethia-reth-rpc-types = { workspace = true }
 bindings = { path = "../bindings" }
 event-scanner = { workspace = true }

--- a/packages/taiko-client-rs/crates/test-harness/Cargo.toml
+++ b/packages/taiko-client-rs/crates/test-harness/Cargo.toml
@@ -18,7 +18,7 @@ preconfirmation = [
 
 [dependencies]
 alethia-reth-consensus = { workspace = true }
-alethia-reth-primitives = { workspace = true }
+alethia-reth-primitives = { workspace = true, features = ["net"] }
 alloy = { workspace = true }
 alloy-consensus = { workspace = true }
 alloy-eips = { workspace = true }


### PR DESCRIPTION
Why
- Allow taiko-client-rs protocol to compile with default features disabled for guest consumers.
- Keep host-only network/provider dependencies behind explicit feature selections.

How
- Disable default features on the workspace alloy and alethia-reth-primitives dependencies.
- Re-enable host capabilities through protocol net and host crates that require alethia-reth net types.
- Make generated bindings an optional protocol dependency used by net paths.

Tests
- cargo check -p protocol --no-default-features --locked
- cargo check -p protocol --locked
- cargo check --workspace --locked