### PR TITLE
chore(taiko-client-rs): gate signer behind net feature

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/Cargo.toml
+++ b/packages/taiko-client-rs/crates/protocol/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 default = ["net"]
 net = [
     "alloy/default",
+    "alloy/signers",
     "bindings",
     "tokio",
     "tokio-retry",
@@ -29,7 +30,7 @@ tokio-stream = { workspace = true, optional = true }
 tracing = { workspace = true }
 
 # ethereum
-alloy = { workspace = true, features = ["std", "signers", "sol-types"] }
+alloy = { workspace = true, default-features = false, features = ["std", "sol-types"] }
 alloy-consensus = { workspace = true }
 alloy-contract = { workspace = true }
 alloy-eips = { workspace = true }

--- a/packages/taiko-client-rs/crates/protocol/src/lib.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/lib.rs
@@ -9,10 +9,12 @@ pub mod codec;
 pub mod preconfirmation;
 /// Shasta-specific protocol types, constants, and builders.
 pub mod shasta;
-/// Deterministic signer used by protocol flows.
+/// Deterministic signer used by network protocol flows.
+#[cfg(feature = "net")]
 pub mod signer;
 /// Provider/event-scanner subscription source abstraction.
 #[cfg(feature = "net")]
 pub mod subscription_source;
 
+#[cfg(feature = "net")]
 pub use signer::{FixedKSigner, FixedKSignerError};


### PR DESCRIPTION
Why
- Keep protocol no-default builds free of host-only signing code for zkVM guests.
- Fix SP1 guest builds that do not expose k256 ProjectivePoint::GENERATOR through sp1-lib.

How
- Gate protocol::signer exports behind the net feature.
- Move alloy/signers activation into the net feature while keeping base alloy no-default.

Tests
- cargo check -p protocol --no-default-features --locked
- cargo check -p protocol --locked
- cargo check --workspace --locked