### PR TITLE
feat(taiko-client): support HTTP polling fallback in driver

### DIFF
--- a/packages/taiko-client/cmd/flags/common.go
+++ b/packages/taiko-client/cmd/flags/common.go
@@ -17,14 +17,20 @@ var (
 	txmgrCategory    = "TX_MANAGER"
 )
 
-// Required flags used by all client software.
+// Shared flags used by all client software.
 var (
 	L1WSEndpoint = &cli.StringFlag{
 		Name:     "l1.ws",
 		Usage:    "Websocket RPC endpoint of a L1 ethereum node",
-		Required: true,
 		Category: commonCategory,
 		EnvVars:  []string{"L1_WS"},
+	}
+	// L1HTTPEndpoint is the optional L1 HTTP RPC endpoint used by commands that support HTTP fallback.
+	L1HTTPEndpoint = &cli.StringFlag{
+		Name:     "l1.http",
+		Usage:    "HTTP RPC endpoint of a L1 ethereum node",
+		Category: commonCategory,
+		EnvVars:  []string{"L1_HTTP"},
 	}
 	L1PrivateEndpoint = &cli.StringFlag{
 		Name:     "l1.private",
@@ -35,7 +41,6 @@ var (
 	L2WSEndpoint = &cli.StringFlag{
 		Name:     "l2.ws",
 		Usage:    "Websocket RPC endpoint of a L2 taiko-geth execution engine",
-		Required: true,
 		Category: commonCategory,
 		EnvVars:  []string{"L2_WS"},
 	}
@@ -48,7 +53,6 @@ var (
 	L2HTTPEndpoint = &cli.StringFlag{
 		Name:     "l2.http",
 		Usage:    "HTTP RPC endpoint of a L2 taiko-geth execution engine",
-		Required: true,
 		Category: commonCategory,
 		EnvVars:  []string{"L2_HTTP"},
 	}
@@ -150,8 +154,9 @@ var (
 
 // CommonFlags All common flags.
 var CommonFlags = []cli.Flag{
-	// Required
+	// Endpoints
 	L1WSEndpoint,
+	// Required
 	InboxAddress,
 	TaikoAnchorAddress,
 	// Optional

--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -69,8 +69,10 @@ var (
 
 // DriverFlags All driver flags.
 var DriverFlags = MergeFlags(CommonFlags, []cli.Flag{
+	L1HTTPEndpoint,
 	L1BeaconEndpoint,
 	L2WSEndpoint,
+	L2HTTPEndpoint,
 	L2AuthEndpoint,
 	JWTSecret,
 	P2PSync,

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	p2pFlags "github.com/ethereum-optimism/optimism/op-node/flags"
@@ -23,18 +24,30 @@ import (
 
 // Config contains the configurations to initialize a Taiko driver.
 type Config struct {
+	// ClientConfig contains the selected RPC endpoints and protocol addresses.
 	*rpc.ClientConfig
-	P2PSync                       bool
-	P2PSyncTimeout                time.Duration
-	RetryInterval                 time.Duration
-	BlobServerEndpoint            *url.URL
-	PreconfBlockServerPort        uint64
-	PreconfBlockServerJWTSecret   []byte
+	// P2PSync enables checkpoint sync from another L2 execution engine.
+	P2PSync bool
+	// P2PSyncTimeout limits how long checkpoint sync can run without progress.
+	P2PSyncTimeout time.Duration
+	// RetryInterval is the backoff retry interval used by the driver.
+	RetryInterval time.Duration
+	// BlobServerEndpoint is the endpoint used to fetch blob sidecars.
+	BlobServerEndpoint *url.URL
+	// PreconfBlockServerPort is the HTTP port for the preconfirmation block server.
+	PreconfBlockServerPort uint64
+	// PreconfBlockServerJWTSecret is the JWT secret for the preconfirmation block server.
+	PreconfBlockServerJWTSecret []byte
+	// PreconfBlockServerCORSOrigins contains allowed CORS origins for the preconfirmation block server.
 	PreconfBlockServerCORSOrigins string
-	HandoverSkipSlots             uint64
-	P2PConfigs                    *p2p.Config
-	P2PSignerConfigs              p2p.SignerSetup
-	PreconfOperatorAddress        common.Address
+	// HandoverSkipSlots is the number of slots reserved for preconfirmation handover.
+	HandoverSkipSlots uint64
+	// P2PConfigs contains the driver's P2P networking configuration.
+	P2PConfigs *p2p.Config
+	// P2PSignerConfigs contains the signing configuration for P2P messages.
+	P2PSignerConfigs p2p.SignerSetup
+	// PreconfOperatorAddress is the address derived from the preconfirmation P2P key.
+	PreconfOperatorAddress common.Address
 }
 
 // NewConfigFromCliContext creates a new config instance from
@@ -52,6 +65,11 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 
 	if p2pSync && len(l2CheckPoint) == 0 {
 		return nil, errors.New("empty L2 check point URL")
+	}
+
+	l1Endpoint, l2Endpoint, err := resolveDriverRPCEndpoints(c)
+	if err != nil {
+		return nil, err
 	}
 
 	var beaconEndpoint string
@@ -84,9 +102,9 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	// Check P2P network flags and create the P2P configurations.
 	var (
 		clientConfig = &rpc.ClientConfig{
-			L1Endpoint:         c.String(flags.L1WSEndpoint.Name),
+			L1Endpoint:         l1Endpoint,
 			L1BeaconEndpoint:   beaconEndpoint,
-			L2Endpoint:         c.String(flags.L2WSEndpoint.Name),
+			L2Endpoint:         l2Endpoint,
 			L2CheckPoint:       l2CheckPoint,
 			InboxAddress:       common.HexToAddress(c.String(flags.InboxAddress.Name)),
 			TaikoAnchorAddress: common.HexToAddress(c.String(flags.TaikoAnchorAddress.Name)),
@@ -141,4 +159,35 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		P2PSignerConfigs:              signerConfigs,
 		PreconfOperatorAddress:        preconfOperatorAddress,
 	}, nil
+}
+
+// resolveDriverRPCEndpoints selects driver L1/L2 endpoints with WS preferred over HTTP.
+func resolveDriverRPCEndpoints(c *cli.Context) (string, string, error) {
+	l1Endpoint := firstNonEmpty(
+		c.String(flags.L1WSEndpoint.Name),
+		c.String(flags.L1HTTPEndpoint.Name),
+	)
+	if l1Endpoint == "" {
+		return "", "", errors.New("empty L1 RPC endpoint")
+	}
+
+	l2Endpoint := firstNonEmpty(
+		c.String(flags.L2WSEndpoint.Name),
+		c.String(flags.L2HTTPEndpoint.Name),
+	)
+	if l2Endpoint == "" {
+		return "", "", errors.New("empty L2 RPC endpoint")
+	}
+
+	return l1Endpoint, l2Endpoint, nil
+}
+
+// firstNonEmpty returns the first non-empty value after trimming whitespace.
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }

--- a/packages/taiko-client/driver/config_test.go
+++ b/packages/taiko-client/driver/config_test.go
@@ -18,8 +18,10 @@ import (
 
 var (
 	l1Endpoint       = os.Getenv("L1_WS")
+	l1HTTPEndpoint   = os.Getenv("L1_HTTP")
 	l1BeaconEndpoint = os.Getenv("L1_HTTP")
 	l2Endpoint       = os.Getenv("L2_WS")
+	l2HTTPEndpoint   = os.Getenv("L2_HTTP")
 	l2CheckPoint     = os.Getenv("L2_HTTP")
 	l2EngineEndpoint = os.Getenv("L2_AUTH")
 	inbox            = os.Getenv("INBOX")
@@ -51,8 +53,10 @@ func (s *DriverTestSuite) TestNewConfigFromCliContext() {
 	s.Nil(app.Run([]string{
 		"TestNewConfigFromCliContext",
 		"--" + flags.L1WSEndpoint.Name, l1Endpoint,
+		"--" + flags.L1HTTPEndpoint.Name, l1HTTPEndpoint,
 		"--" + flags.L1BeaconEndpoint.Name, l1BeaconEndpoint,
 		"--" + flags.L2WSEndpoint.Name, l2Endpoint,
+		"--" + flags.L2HTTPEndpoint.Name, l2HTTPEndpoint,
 		"--" + flags.L2AuthEndpoint.Name, l2EngineEndpoint,
 		"--" + flags.InboxAddress.Name, inbox,
 		"--" + flags.TaikoAnchorAddress.Name, taikoAnchor,
@@ -68,10 +72,85 @@ func (s *DriverTestSuite) TestNewConfigFromCliContext() {
 	}))
 }
 
+func (s *DriverTestSuite) TestNewConfigFromCliContextHTTPFallback() {
+	app := s.SetupApp()
+
+	app.Action = func(ctx *cli.Context) error {
+		c, err := NewConfigFromCliContext(ctx)
+		s.Nil(err)
+		s.Equal(l1HTTPEndpoint, c.L1Endpoint)
+		s.Equal(l2HTTPEndpoint, c.L2Endpoint)
+
+		return err
+	}
+
+	s.Nil(app.Run([]string{
+		"TestNewConfigFromCliContextHTTPFallback",
+		"--" + flags.L1WSEndpoint.Name, " ",
+		"--" + flags.L1HTTPEndpoint.Name, l1HTTPEndpoint,
+		"--" + flags.L1BeaconEndpoint.Name, l1BeaconEndpoint,
+		"--" + flags.L2WSEndpoint.Name, " ",
+		"--" + flags.L2HTTPEndpoint.Name, l2HTTPEndpoint,
+		"--" + flags.L2AuthEndpoint.Name, l2EngineEndpoint,
+		"--" + flags.InboxAddress.Name, inbox,
+		"--" + flags.TaikoAnchorAddress.Name, taikoAnchor,
+		"--" + flags.JWTSecret.Name, os.Getenv("JWT_SECRET"),
+		"--" + p2pFlags.P2PPrivPathName, os.Getenv("JWT_SECRET"),
+		"--" + p2pFlags.DiscoveryPathName, "memory",
+		"--" + p2pFlags.PeerstorePathName, "memory",
+	}))
+}
+
+func (s *DriverTestSuite) TestResolveDriverRPCEndpointsTrimsAndFallsBack() {
+	app := s.SetupEndpointResolverApp()
+
+	app.Action = func(ctx *cli.Context) error {
+		l1Endpoint, l2Endpoint, err := resolveDriverRPCEndpoints(ctx)
+		s.Nil(err)
+		s.Equal("ws://l1", l1Endpoint)
+		s.Equal("http://l2", l2Endpoint)
+
+		return err
+	}
+
+	s.Nil(app.Run([]string{
+		"TestResolveDriverRPCEndpointsTrimsAndFallsBack",
+		"--" + flags.L1WSEndpoint.Name, " ws://l1 ",
+		"--" + flags.L1HTTPEndpoint.Name, " http://l1 ",
+		"--" + flags.L2WSEndpoint.Name, " ",
+		"--" + flags.L2HTTPEndpoint.Name, " http://l2 ",
+	}))
+}
+
+func (s *DriverTestSuite) TestResolveDriverRPCEndpointsEmptyL1Endpoint() {
+	app := s.SetupEndpointResolverApp()
+	s.ErrorContains(app.Run([]string{
+		"TestResolveDriverRPCEndpointsEmptyL1Endpoint",
+		"--" + flags.L1WSEndpoint.Name, " ",
+		"--" + flags.L1HTTPEndpoint.Name, " ",
+		"--" + flags.L2WSEndpoint.Name, "ws://l2",
+	}), "empty L1 RPC endpoint")
+}
+
+func (s *DriverTestSuite) TestResolveDriverRPCEndpointsEmptyL2Endpoint() {
+	app := s.SetupEndpointResolverApp()
+	s.ErrorContains(app.Run([]string{
+		"TestResolveDriverRPCEndpointsEmptyL2Endpoint",
+		"--" + flags.L1WSEndpoint.Name, "ws://l1",
+		"--" + flags.L2WSEndpoint.Name, " ",
+		"--" + flags.L2HTTPEndpoint.Name, " ",
+	}), "empty L2 RPC endpoint")
+}
+
 func (s *DriverTestSuite) TestNewConfigFromCliContextJWTError() {
 	app := s.SetupApp()
 	s.ErrorContains(app.Run([]string{
 		"TestNewConfigFromCliContext",
+		"--" + flags.L1WSEndpoint.Name, l1Endpoint,
+		"--" + flags.L2WSEndpoint.Name, l2Endpoint,
+		"--" + flags.L2AuthEndpoint.Name, l2EngineEndpoint,
+		"--" + flags.InboxAddress.Name, inbox,
+		"--" + flags.TaikoAnchorAddress.Name, taikoAnchor,
 		"--" + flags.JWTSecret.Name, "wrongsecretfile.txt",
 	}), "invalid JWT secret file")
 }
@@ -80,6 +159,9 @@ func (s *DriverTestSuite) TestNewConfigFromCliContextEmptyL2CheckPoint() {
 	app := s.SetupApp()
 	s.ErrorContains(app.Run([]string{
 		"TestNewConfigFromCliContext",
+		"--" + flags.L2AuthEndpoint.Name, l2EngineEndpoint,
+		"--" + flags.InboxAddress.Name, inbox,
+		"--" + flags.TaikoAnchorAddress.Name, taikoAnchor,
 		"--" + flags.JWTSecret.Name, os.Getenv("JWT_SECRET"),
 		"--" + flags.P2PSync.Name,
 		"--" + flags.L2WSEndpoint.Name, "",
@@ -88,22 +170,24 @@ func (s *DriverTestSuite) TestNewConfigFromCliContextEmptyL2CheckPoint() {
 
 func (s *DriverTestSuite) SetupApp() *cli.App {
 	app := cli.NewApp()
-	app.Flags = flags.MergeFlags([]cli.Flag{
-		&cli.StringFlag{Name: flags.L1WSEndpoint.Name},
-		&cli.StringFlag{Name: flags.L1BeaconEndpoint.Name},
-		&cli.StringFlag{Name: flags.L2WSEndpoint.Name},
-		&cli.StringFlag{Name: flags.L2AuthEndpoint.Name},
-		&cli.StringFlag{Name: flags.InboxAddress.Name},
-		&cli.StringFlag{Name: flags.TaikoAnchorAddress.Name},
-		&cli.Uint64Flag{Name: flags.PreconfHandoverSkipSlots.Name, Value: 8},
-		&cli.StringFlag{Name: flags.JWTSecret.Name},
-		&cli.BoolFlag{Name: flags.P2PSync.Name},
-		&cli.DurationFlag{Name: flags.P2PSyncTimeout.Name},
-		&cli.DurationFlag{Name: flags.RPCTimeout.Name},
-		&cli.StringFlag{Name: flags.CheckPointSyncURL.Name},
-	}, p2pFlags.P2PFlags("PRECONFIRMATION"))
+	app.Flags = flags.DriverFlags
 	app.Action = func(ctx *cli.Context) error {
 		_, err := NewConfigFromCliContext(ctx)
+		return err
+	}
+	return app
+}
+
+func (s *DriverTestSuite) SetupEndpointResolverApp() *cli.App {
+	app := cli.NewApp()
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{Name: flags.L1WSEndpoint.Name},
+		&cli.StringFlag{Name: flags.L1HTTPEndpoint.Name},
+		&cli.StringFlag{Name: flags.L2WSEndpoint.Name},
+		&cli.StringFlag{Name: flags.L2HTTPEndpoint.Name},
+	}
+	app.Action = func(ctx *cli.Context) error {
+		_, _, err := resolveDriverRPCEndpoints(ctx)
 		return err
 	}
 	return app
@@ -137,8 +221,10 @@ func (s *DriverTestSuite) defaultCliP2PConfigs() (*p2p.Config, p2p.SignerSetup) 
 	s.Nil(app.Run([]string{
 		"GetDefaultP2PConfig",
 		"--" + flags.L1WSEndpoint.Name, l1Endpoint,
+		"--" + flags.L1HTTPEndpoint.Name, l1HTTPEndpoint,
 		"--" + flags.L1BeaconEndpoint.Name, l1BeaconEndpoint,
 		"--" + flags.L2WSEndpoint.Name, l2Endpoint,
+		"--" + flags.L2HTTPEndpoint.Name, l2HTTPEndpoint,
 		"--" + flags.L2AuthEndpoint.Name, l2EngineEndpoint,
 		"--" + flags.InboxAddress.Name, inbox,
 		"--" + flags.TaikoAnchorAddress.Name, taikoAnchor,

--- a/packages/taiko-client/driver/state/head_tracker.go
+++ b/packages/taiko-client/driver/state/head_tracker.go
@@ -1,0 +1,165 @@
+package state
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+
+	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
+)
+
+const defaultHeadPollingInterval = 3 * time.Second
+
+// headTracker keeps the cached L1/L2 heads fresh for the driver state.
+type headTracker interface {
+	// Start runs the tracker until the context is done or Close is called.
+	Start(context.Context)
+	// Close stops the tracker and releases any owned subscriptions.
+	Close()
+}
+
+// newHeadTracker chooses the subscription or polling backend for the selected RPC endpoints.
+func newHeadTracker(s *State) headTracker {
+	if s.rpc.UseSubscriptions {
+		return &subscriptionHeadTracker{s: s, closeCh: make(chan struct{})}
+	}
+
+	return &pollingHeadTracker{s: s, closeCh: make(chan struct{})}
+}
+
+// subscriptionHeadTracker updates heads from websocket subscriptions.
+type subscriptionHeadTracker struct {
+	// s is the driver state updated by subscription events.
+	s *State
+	// closeCh signals Start to exit.
+	closeCh chan struct{}
+	// close makes Close idempotent.
+	close sync.Once
+	// mu guards subs while Close may run concurrently with Start.
+	mu sync.Mutex
+	// subs contains all active websocket subscriptions owned by the tracker.
+	subs []event.Subscription
+}
+
+// Start subscribes to L1/L2 heads and Shasta proof events.
+func (t *subscriptionHeadTracker) Start(ctx context.Context) {
+	var (
+		// Channels for subscriptions.
+		l1HeadCh = make(chan *types.Header, 10)
+		l2HeadCh = make(chan *types.Header, 10)
+		provedCh = make(chan *shastaBindings.ShastaInboxClientProved, 10)
+
+		// Subscriptions.
+		l1HeadSub         = rpc.SubscribeChainHead(t.s.rpc.L1, l1HeadCh)
+		l2HeadSub         = rpc.SubscribeChainHead(t.s.rpc.L2, l2HeadCh)
+		l2ProvedShastaSub = rpc.SubscribeProved(t.s.rpc.ShastaClients.Inbox, provedCh)
+	)
+
+	t.mu.Lock()
+	t.subs = []event.Subscription{l1HeadSub, l2HeadSub, l2ProvedShastaSub}
+	t.mu.Unlock()
+	defer t.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.closeCh:
+			return
+		case e := <-provedCh:
+			coreState, err := t.s.rpc.GetCoreState(&bind.CallOpts{Context: ctx})
+			if err != nil {
+				log.Error("Failed to get core state", "err", err)
+				continue
+			}
+			header, err := t.s.rpc.L2.HeaderByHash(ctx, coreState.LastFinalizedBlockHash)
+			if err != nil {
+				log.Error("Failed to get finalized block header", "err", err)
+				continue
+			}
+			log.Info(
+				"📈 Proposals proven and verified",
+				"firstProposalID", e.FirstNewProposalId,
+				"lastProposalID", e.LastProposalId,
+				"checkpointNumber", header.Number,
+				"checkpointHash", common.Hash(coreState.LastFinalizedBlockHash),
+			)
+		case newHead := <-l1HeadCh:
+			t.s.updateL1HeadIfChanged(newHead)
+		case newHead := <-l2HeadCh:
+			t.s.setL2Head(newHead)
+		}
+	}
+}
+
+// Close stops all active subscriptions and unblocks Start.
+func (t *subscriptionHeadTracker) Close() {
+	t.close.Do(func() {
+		close(t.closeCh)
+	})
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, sub := range t.subs {
+		sub.Unsubscribe()
+	}
+	t.subs = nil
+}
+
+// pollingHeadTracker updates heads by periodically polling latest headers.
+type pollingHeadTracker struct {
+	// s is the driver state updated by polling results.
+	s *State
+	// closeCh signals Start to exit.
+	closeCh chan struct{}
+	// close makes Close idempotent.
+	close sync.Once
+}
+
+// Start polls latest L1/L2 heads until the context is done or Close is called.
+func (t *pollingHeadTracker) Start(ctx context.Context) {
+	ticker := time.NewTicker(defaultHeadPollingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.closeCh:
+			return
+		case <-ticker.C:
+			t.poll(ctx)
+		}
+	}
+}
+
+// Close unblocks Start and stops future polling.
+func (t *pollingHeadTracker) Close() {
+	t.close.Do(func() {
+		close(t.closeCh)
+	})
+}
+
+// poll fetches latest L1/L2 heads once and applies changed values to state.
+func (t *pollingHeadTracker) poll(ctx context.Context) {
+	l1Head, err := t.s.rpc.L1.HeaderByNumber(ctx, nil)
+	if err != nil {
+		log.Warn("Failed to poll L1 head", "err", err)
+	} else {
+		t.s.updateL1HeadIfChanged(l1Head)
+	}
+
+	l2Head, err := t.s.rpc.L2.HeaderByNumber(ctx, nil)
+	if err != nil {
+		log.Warn("Failed to poll L2 head", "err", err)
+	} else {
+		t.s.updateL2HeadIfChanged(l2Head)
+	}
+}

--- a/packages/taiko-client/driver/state/state.go
+++ b/packages/taiko-client/driver/state/state.go
@@ -7,32 +7,35 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 
-	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/metrics"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
 // State contains all states which will be used by driver.
 type State struct {
-	// Feeds
-	l1HeadsFeed event.Feed // L1 new heads notification feed
+	// l1HeadsFeed broadcasts changed L1 heads to sync consumers.
+	l1HeadsFeed event.Feed
 
-	l1Head    atomic.Value // Latest known L1 head
-	l2Head    atomic.Value // Current L2 execution engine's local chain head
-	l1Current atomic.Value // Current L1 block sync cursor
+	// l1Head stores the latest known L1 head.
+	l1Head atomic.Value
+	// l2Head stores the current L2 execution engine's local chain head.
+	l2Head atomic.Value
+	// l1Current stores the current L1 block sync cursor.
+	l1Current atomic.Value
 
-	// Constants
+	// GenesisL1Height is the L1 activation height for the current inbox.
 	GenesisL1Height *big.Int
 
-	// RPC clients
+	// rpc contains the L1/L2 RPC clients used by the state.
 	rpc *rpc.Client
 
+	// headTracker updates cached L1/L2 heads from subscriptions or polling.
+	headTracker headTracker
+	// wg waits for the tracker event loop to exit.
 	wg sync.WaitGroup
 }
 
@@ -44,6 +47,8 @@ func New(ctx context.Context, rpc *rpc.Client) (*State, error) {
 		return nil, fmt.Errorf("failed to initialize driver state: %w", err)
 	}
 
+	s.headTracker = newHeadTracker(s)
+	s.wg.Add(1)
 	go s.eventLoop(ctx)
 
 	return s, nil
@@ -51,6 +56,9 @@ func New(ctx context.Context, rpc *rpc.Client) (*State, error) {
 
 // Close closes all inner subscriptions.
 func (s *State) Close() {
+	if s.headTracker != nil {
+		s.headTracker.Close()
+	}
 	s.wg.Wait()
 }
 
@@ -88,60 +96,12 @@ func (s *State) init(ctx context.Context) error {
 	return nil
 }
 
-// eventLoop initializes and starts all subscriptions and callbacks in the given state instance.
+// eventLoop starts the configured head tracker in the given state instance.
 func (s *State) eventLoop(ctx context.Context) {
-	s.wg.Add(1)
 	defer s.wg.Done()
 
-	var (
-		// Channels for subscriptions.
-		l1HeadCh   = make(chan *types.Header, 10)
-		l2HeadCh   = make(chan *types.Header, 10)
-		proposedCh = make(chan *shastaBindings.ShastaInboxClientProposed, 10)
-		provedCh   = make(chan *shastaBindings.ShastaInboxClientProved, 10)
-
-		// Subscriptions.
-		l1HeadSub           = rpc.SubscribeChainHead(s.rpc.L1, l1HeadCh)
-		l2HeadSub           = rpc.SubscribeChainHead(s.rpc.L2, l2HeadCh)
-		l2ProposedShastaSub = rpc.SubscribeProposed(s.rpc.ShastaClients.Inbox, proposedCh)
-		l2ProvedShastaSub   = rpc.SubscribeProved(s.rpc.ShastaClients.Inbox, provedCh)
-	)
-
-	defer func() {
-		l1HeadSub.Unsubscribe()
-		l2HeadSub.Unsubscribe()
-		l2ProposedShastaSub.Unsubscribe()
-		l2ProvedShastaSub.Unsubscribe()
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case e := <-provedCh:
-			coreState, err := s.rpc.GetCoreState(&bind.CallOpts{Context: ctx})
-			if err != nil {
-				log.Error("Failed to get core state", "err", err)
-				continue
-			}
-			header, err := s.rpc.L2.HeaderByHash(ctx, coreState.LastFinalizedBlockHash)
-			if err != nil {
-				log.Error("Failed to get finalized block header", "err", err)
-				continue
-			}
-			log.Info(
-				"📈 Proposals proven and verified",
-				"firstProposalID", e.FirstNewProposalId,
-				"lastProposalID", e.LastProposalId,
-				"checkpointNumber", header.Number,
-				"checkpointHash", common.Hash(coreState.LastFinalizedBlockHash),
-			)
-		case newHead := <-l1HeadCh:
-			s.setL1Head(newHead)
-			s.l1HeadsFeed.Send(newHead)
-		case newHead := <-l2HeadCh:
-			s.setL2Head(newHead)
-		}
+	if s.headTracker != nil {
+		s.headTracker.Start(ctx)
 	}
 }
 
@@ -156,6 +116,22 @@ func (s *State) setL1Head(l1Head *types.Header) {
 	metrics.DriverL1HeadHeightGauge.Set(float64(l1Head.Number.Int64()))
 
 	s.l1Head.Store(l1Head)
+}
+
+// updateL1HeadIfChanged updates and broadcasts an L1 head only when it changed.
+func (s *State) updateL1HeadIfChanged(l1Head *types.Header) bool {
+	if l1Head == nil {
+		s.setL1Head(l1Head)
+		return false
+	}
+
+	if sameHeader(s.GetL1Head(), l1Head) {
+		return false
+	}
+
+	s.setL1Head(l1Head)
+	s.l1HeadsFeed.Send(l1Head)
+	return true
 }
 
 // GetL1Head reads the L1 head concurrent safely.
@@ -182,6 +158,21 @@ func (s *State) setL2Head(l2Head *types.Header) {
 	s.l2Head.Store(l2Head)
 }
 
+// updateL2HeadIfChanged updates the cached L2 head only when it changed.
+func (s *State) updateL2HeadIfChanged(l2Head *types.Header) bool {
+	if l2Head == nil {
+		s.setL2Head(l2Head)
+		return false
+	}
+
+	if sameHeader(s.GetL2Head(), l2Head) {
+		return false
+	}
+
+	s.setL2Head(l2Head)
+	return true
+}
+
 // GetL2Head reads the L2 head concurrent safely.
 func (s *State) GetL2Head() *types.Header {
 	return s.l2Head.Load().(*types.Header)
@@ -203,4 +194,17 @@ func (s *State) initGenesisHeight(ctx context.Context) error {
 
 	s.GenesisL1Height = genesisHeight
 	return nil
+}
+
+// sameHeader reports whether two headers identify the same block.
+func sameHeader(a, b *types.Header) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	if a.Number == nil || b.Number == nil {
+		return a.Number == b.Number && a.Hash() == b.Hash()
+	}
+
+	return a.Number.Cmp(b.Number) == 0 && a.Hash() == b.Hash()
 }

--- a/packages/taiko-client/driver/state/state_test.go
+++ b/packages/taiko-client/driver/state/state_test.go
@@ -6,11 +6,13 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
 type DriverStateTestSuite struct {
@@ -32,6 +34,9 @@ func (s *DriverStateTestSuite) TearDownTest() {
 	defer s.ClientTestSuite.TearDownTest()
 	if s.ctx.Err() == nil {
 		s.cancel()
+	}
+	if s.s != nil {
+		s.s.Close()
 	}
 }
 
@@ -58,6 +63,116 @@ func (s *DriverStateTestSuite) TestSubL1HeadsFeed() {
 	s.NotNil(s.s.SubL1HeadsFeed(make(chan *types.Header)))
 }
 
+func (s *DriverStateTestSuite) TestUpdateL1HeadIfChanged() {
+	s.cancel()
+	s.s.Close()
+
+	head := testHeader(100, "a")
+	s.s.setL1Head(head)
+	l1HeadCh := make(chan *types.Header, 1)
+	sub := s.s.SubL1HeadsFeed(l1HeadCh)
+	defer sub.Unsubscribe()
+
+	s.False(s.s.updateL1HeadIfChanged(types.CopyHeader(head)))
+	s.Equal(head.Hash(), s.s.GetL1Head().Hash())
+	assertNoHeader(s.T(), l1HeadCh)
+
+	changedHead := testHeader(101, "b")
+	s.True(s.s.updateL1HeadIfChanged(changedHead))
+	s.Equal(changedHead.Hash(), s.s.GetL1Head().Hash())
+	assertHeader(s.T(), l1HeadCh, changedHead)
+
+	s.False(s.s.updateL1HeadIfChanged(types.CopyHeader(changedHead)))
+	s.Equal(changedHead.Hash(), s.s.GetL1Head().Hash())
+	assertNoHeader(s.T(), l1HeadCh)
+
+	s.False(s.s.updateL1HeadIfChanged(nil))
+	s.Equal(changedHead.Hash(), s.s.GetL1Head().Hash())
+	assertNoHeader(s.T(), l1HeadCh)
+}
+
+func (s *DriverStateTestSuite) TestUpdateL2HeadIfChanged() {
+	s.cancel()
+	s.s.Close()
+
+	head := testHeader(200, "a")
+	s.s.setL2Head(head)
+
+	s.False(s.s.updateL2HeadIfChanged(types.CopyHeader(head)))
+	s.Equal(head.Hash(), s.s.GetL2Head().Hash())
+
+	changedHead := testHeader(201, "b")
+	s.True(s.s.updateL2HeadIfChanged(changedHead))
+	s.Equal(changedHead.Hash(), s.s.GetL2Head().Hash())
+
+	s.False(s.s.updateL2HeadIfChanged(nil))
+	s.Equal(changedHead.Hash(), s.s.GetL2Head().Hash())
+}
+
+func (s *DriverStateTestSuite) TestPollingHeadTrackerPollUpdatesAndDedupes() {
+	s.cancel()
+	s.s.Close()
+
+	ctx := context.Background()
+	l1Head, err := s.RPCClient.L1.HeaderByNumber(ctx, nil)
+	s.Nil(err)
+	l2Head, err := s.RPCClient.L2.HeaderByNumber(ctx, nil)
+	s.Nil(err)
+
+	staleL1Head := testHeader(l1Head.Number.Uint64()+1000, "stale-l1")
+	staleL2Head := testHeader(l2Head.Number.Uint64()+1000, "stale-l2")
+	s.s.setL1Head(staleL1Head)
+	s.s.setL2Head(staleL2Head)
+
+	l1HeadCh := make(chan *types.Header, 1)
+	sub := s.s.SubL1HeadsFeed(l1HeadCh)
+	defer sub.Unsubscribe()
+
+	tracker := &pollingHeadTracker{s: s.s, closeCh: make(chan struct{})}
+	tracker.poll(ctx)
+
+	s.NotEqual(staleL1Head.Hash(), s.s.GetL1Head().Hash())
+	s.NotEqual(staleL2Head.Hash(), s.s.GetL2Head().Hash())
+	assertHeader(s.T(), l1HeadCh, s.s.GetL1Head())
+
+	polledL1Head := types.CopyHeader(s.s.GetL1Head())
+	polledL2Head := types.CopyHeader(s.s.GetL2Head())
+	tracker.poll(ctx)
+
+	s.True(sameHeader(polledL1Head, s.s.GetL1Head()))
+	s.True(sameHeader(polledL2Head, s.s.GetL2Head()))
+	assertNoHeader(s.T(), l1HeadCh)
+}
+
+func (s *DriverStateTestSuite) TestPollingHeadTrackerRecoversAfterPollError() {
+	s.cancel()
+	s.s.Close()
+
+	ctx := context.Background()
+	l1Head, err := s.RPCClient.L1.HeaderByNumber(ctx, nil)
+	s.Nil(err)
+	l2Head, err := s.RPCClient.L2.HeaderByNumber(ctx, nil)
+	s.Nil(err)
+
+	staleL1Head := testHeader(l1Head.Number.Uint64()+1000, "stale-l1")
+	staleL2Head := testHeader(l2Head.Number.Uint64()+1000, "stale-l2")
+	s.s.setL1Head(staleL1Head)
+	s.s.setL2Head(staleL2Head)
+
+	tracker := &pollingHeadTracker{s: s.s, closeCh: make(chan struct{})}
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	tracker.poll(canceledCtx)
+
+	s.Equal(staleL1Head.Hash(), s.s.GetL1Head().Hash())
+	s.Equal(staleL2Head.Hash(), s.s.GetL2Head().Hash())
+
+	tracker.poll(ctx)
+
+	s.NotEqual(staleL1Head.Hash(), s.s.GetL1Head().Hash())
+	s.NotEqual(staleL2Head.Hash(), s.s.GetL2Head().Hash())
+}
+
 func (s *DriverStateTestSuite) TestNewDriverContextErr() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -75,6 +190,91 @@ func (s *DriverStateTestSuite) TestDriverInitContextErr() {
 
 func TestDriverStateTestSuite(t *testing.T) {
 	suite.Run(t, new(DriverStateTestSuite))
+}
+
+func TestNewHeadTracker(t *testing.T) {
+	subscriptionState := &State{rpc: &rpc.Client{UseSubscriptions: true}}
+	if _, ok := newHeadTracker(subscriptionState).(*subscriptionHeadTracker); !ok {
+		t.Fatal("expected subscription head tracker")
+	}
+
+	pollingState := &State{rpc: &rpc.Client{UseSubscriptions: false}}
+	if _, ok := newHeadTracker(pollingState).(*pollingHeadTracker); !ok {
+		t.Fatal("expected polling head tracker")
+	}
+}
+
+func TestPollingHeadTrackerStartStopsOnCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	tracker := &pollingHeadTracker{closeCh: make(chan struct{})}
+	go func() {
+		tracker.Start(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("polling head tracker did not stop after context cancellation")
+	}
+}
+
+func TestSameHeader(t *testing.T) {
+	head := testHeader(100, "a")
+
+	tests := []struct {
+		name string
+		a    *types.Header
+		b    *types.Header
+		want bool
+	}{
+		{name: "both nil", want: true},
+		{name: "left nil", b: head},
+		{name: "right nil", a: head},
+		{name: "same number and hash", a: head, b: types.CopyHeader(head), want: true},
+		{name: "different number", a: head, b: testHeader(101, "a")},
+		{name: "different hash", a: head, b: testHeader(100, "b")},
+		{name: "both nil numbers and same hash", a: &types.Header{}, b: &types.Header{}, want: true},
+		{name: "one nil number", a: &types.Header{}, b: testHeader(0, "")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameHeader(tt.a, tt.b); got != tt.want {
+				t.Fatalf("sameHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func testHeader(number uint64, extra string) *types.Header {
+	return &types.Header{Number: new(big.Int).SetUint64(number), Extra: []byte(extra)}
+}
+
+func assertHeader(t *testing.T, ch <-chan *types.Header, want *types.Header) {
+	t.Helper()
+
+	select {
+	case got := <-ch:
+		if !sameHeader(got, want) {
+			t.Fatalf("got header %v, want %v", got.Hash(), want.Hash())
+		}
+	default:
+		t.Fatal("expected L1 head feed event")
+	}
+}
+
+func assertNoHeader(t *testing.T, ch <-chan *types.Header) {
+	t.Helper()
+
+	select {
+	case got := <-ch:
+		t.Fatalf("unexpected L1 head feed event: %v", got.Hash())
+	default:
+	}
 }
 
 // RandUint64 returns a random uint64 number.

--- a/packages/taiko-client/pkg/rpc/client.go
+++ b/packages/taiko-client/pkg/rpc/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"net/url"
 	"os"
 	"time"
 
@@ -19,42 +20,60 @@ const (
 	DefaultRpcTimeout = 1 * time.Minute
 )
 
-// ShastaClients contains all smart contract clients for ShastaClients fork.
+// ShastaClients contains all smart contract clients for the Shasta fork.
 type ShastaClients struct {
-	Inbox            *shastaBindings.ShastaInboxClient
-	Anchor           *shastaBindings.ShastaAnchor
-	ComposeVerifier  *shastaBindings.ComposeVerifier
+	// Inbox is the Shasta inbox contract client.
+	Inbox *shastaBindings.ShastaInboxClient
+	// Anchor is the Shasta anchor contract client.
+	Anchor *shastaBindings.ShastaAnchor
+	// ComposeVerifier is the compose verifier contract client.
+	ComposeVerifier *shastaBindings.ComposeVerifier
+	// PreconfWhitelist is the optional preconfirmation whitelist contract client.
 	PreconfWhitelist *shastaBindings.PreconfWhitelist
-	InboxAddress     common.Address
+	// InboxAddress is the Shasta inbox contract address.
+	InboxAddress common.Address
 }
 
 // Client contains all L1/L2 RPC clients that a driver needs.
 type Client struct {
-	// Geth ethclient clients
-	L1           *EthClient
-	L2           *EthClient
+	// L1 is the selected L1 execution RPC client.
+	L1 *EthClient
+	// L2 is the selected L2 execution RPC client.
+	L2 *EthClient
+	// L2CheckPoint is an optional checkpoint L2 execution RPC client.
 	L2CheckPoint *EthClient
-	// Geth Engine API clients
+	// L2Engine is the optional authenticated L2 Engine API client.
 	L2Engine *EngineClient
-	// Beacon clients
+	// L1Beacon is the optional L1 beacon client.
 	L1Beacon *BeaconClient
-	// Protocol contract clients
+	// ShastaClients contains protocol contract clients for Shasta.
 	ShastaClients *ShastaClients
+	// UseSubscriptions indicates whether both selected L1/L2 endpoints support subscriptions.
+	UseSubscriptions bool
 }
 
 // ClientConfig contains all configs which will be used to initializing an
 // RPC client. If not providing L2EngineEndpoint or JwtSecret, then the L2Engine client
 // won't be initialized.
 type ClientConfig struct {
-	L1Endpoint         string
-	L2Endpoint         string
-	L1BeaconEndpoint   string
-	L2CheckPoint       string
-	InboxAddress       common.Address
+	// L1Endpoint is the selected L1 execution RPC endpoint.
+	L1Endpoint string
+	// L2Endpoint is the selected L2 execution RPC endpoint.
+	L2Endpoint string
+	// L1BeaconEndpoint is the optional L1 beacon HTTP endpoint.
+	L1BeaconEndpoint string
+	// L2CheckPoint is the optional checkpoint L2 execution RPC endpoint.
+	L2CheckPoint string
+	// InboxAddress is the Shasta inbox contract address.
+	InboxAddress common.Address
+	// TaikoAnchorAddress is the L2 Taiko anchor contract address.
 	TaikoAnchorAddress common.Address
-	L2EngineEndpoint   string
-	JwtSecret          string
-	Timeout            time.Duration
+	// L2EngineEndpoint is the optional authenticated L2 Engine API endpoint.
+	L2EngineEndpoint string
+	// JwtSecret is the optional JWT secret used for authenticated Engine API calls.
+	JwtSecret string
+	// Timeout is the per-request RPC timeout.
+	Timeout time.Duration
 }
 
 // NewClient initializes all RPC clients used by Taiko client software.
@@ -115,11 +134,12 @@ func NewClient(ctx context.Context, cfg *ClientConfig) (*Client, error) {
 	}
 
 	c := &Client{
-		L1:           l1Client,
-		L1Beacon:     l1BeaconClient,
-		L2:           l2Client,
-		L2CheckPoint: l2CheckPoint,
-		L2Engine:     l2AuthClient,
+		L1:               l1Client,
+		L1Beacon:         l1BeaconClient,
+		L2:               l2Client,
+		L2CheckPoint:     l2CheckPoint,
+		L2Engine:         l2AuthClient,
+		UseSubscriptions: isWebSocketEndpoint(cfg.L1Endpoint) && isWebSocketEndpoint(cfg.L2Endpoint),
 	}
 
 	ctxWithTimeout, cancel := CtxWithTimeoutOrDefault(ctx, DefaultRpcTimeout)
@@ -129,6 +149,21 @@ func NewClient(ctx context.Context, cfg *ClientConfig) (*Client, error) {
 	}
 
 	return c, nil
+}
+
+// isWebSocketEndpoint reports whether the endpoint scheme supports websocket subscriptions.
+func isWebSocketEndpoint(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	switch parsed.Scheme {
+	case "ws", "wss":
+		return true
+	default:
+		return false
+	}
 }
 
 // initShastaClients initializes all smart contract clients.

--- a/packages/taiko-client/pkg/rpc/client_test.go
+++ b/packages/taiko-client/pkg/rpc/client_test.go
@@ -39,6 +39,51 @@ func TestNewClientShastaOnlyConfig(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestIsWebSocketEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		expected bool
+	}{
+		{
+			name:     "ws",
+			endpoint: "ws://localhost:8546",
+			expected: true,
+		},
+		{
+			name:     "wss",
+			endpoint: "wss://rpc.example.com",
+			expected: true,
+		},
+		{
+			name:     "http",
+			endpoint: "http://localhost:8545",
+			expected: false,
+		},
+		{
+			name:     "https",
+			endpoint: "https://rpc.example.com",
+			expected: false,
+		},
+		{
+			name:     "empty",
+			endpoint: "",
+			expected: false,
+		},
+		{
+			name:     "malformed",
+			endpoint: "://missing-scheme",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isWebSocketEndpoint(tt.endpoint))
+		})
+	}
+}
+
 func newTestClientWithTimeout(t *testing.T) *Client {
 	jwtSecret, err := jwt.ParseSecretFromFile(os.Getenv("JWT_SECRET"))
 	require.Nil(t, err)

--- a/packages/taiko-client/proposer/config.go
+++ b/packages/taiko-client/proposer/config.go
@@ -3,6 +3,7 @@ package proposer
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -64,10 +65,19 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		)
 	}
 
+	l1Endpoint, err := requiredEndpoint(c, flags.L1WSEndpoint.Name)
+	if err != nil {
+		return nil, err
+	}
+	l2Endpoint, err := requiredEndpoint(c, flags.L2WSEndpoint.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Config{
 		ClientConfig: &rpc.ClientConfig{
-			L1Endpoint:         c.String(flags.L1WSEndpoint.Name),
-			L2Endpoint:         c.String(flags.L2WSEndpoint.Name),
+			L1Endpoint:         l1Endpoint,
+			L2Endpoint:         l2Endpoint,
 			InboxAddress:       common.HexToAddress(c.String(flags.InboxAddress.Name)),
 			TaikoAnchorAddress: common.HexToAddress(c.String(flags.TaikoAnchorAddress.Name)),
 			L2EngineEndpoint:   c.String(flags.L2AuthEndpoint.Name),
@@ -83,7 +93,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		AllowZeroTipInterval:    c.Uint64(flags.AllowZeroTipInterval.Name),
 		ProposeBatchTxGasLimit:  c.Uint64(flags.TxGasLimit.Name),
 		TxmgrConfigs: pkgFlags.InitTxmgrConfigsFromCli(
-			c.String(flags.L1WSEndpoint.Name),
+			l1Endpoint,
 			l1ProposerPrivKey,
 			c,
 		),
@@ -93,4 +103,13 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			c,
 		),
 	}, nil
+}
+
+// requiredEndpoint returns a trimmed required endpoint value from the CLI context.
+func requiredEndpoint(c *cli.Context, name string) (string, error) {
+	endpoint := strings.TrimSpace(c.String(name))
+	if endpoint == "" {
+		return "", fmt.Errorf("empty %s endpoint", name)
+	}
+	return endpoint, nil
 }

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -90,11 +90,24 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	}
 	log.Info("Local proposer addresses", "addresses", localProposerAddresses)
 
+	l1WsEndpoint, err := requiredEndpoint(c, flags.L1WSEndpoint.Name)
+	if err != nil {
+		return nil, err
+	}
+	l2WsEndpoint, err := requiredEndpoint(c, flags.L2WSEndpoint.Name)
+	if err != nil {
+		return nil, err
+	}
+	l2HttpEndpoint, err := requiredEndpoint(c, flags.L2HTTPEndpoint.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Config{
-		L1WsEndpoint:             c.String(flags.L1WSEndpoint.Name),
+		L1WsEndpoint:             l1WsEndpoint,
 		L1BeaconEndpoint:         c.String(flags.L1BeaconEndpoint.Name),
-		L2WsEndpoint:             c.String(flags.L2WSEndpoint.Name),
-		L2HttpEndpoint:           c.String(flags.L2HTTPEndpoint.Name),
+		L2WsEndpoint:             l2WsEndpoint,
+		L2HttpEndpoint:           l2HttpEndpoint,
 		L2EngineEndpoint:         c.String(flags.L2AuthEndpoint.Name),
 		JwtSecret:                string(jwtSecret),
 		InboxAddress:             common.HexToAddress(c.String(flags.InboxAddress.Name)),
@@ -114,7 +127,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		ProveBatchesGasLimit:     c.Uint64(flags.TxGasLimit.Name),
 		LocalProposerAddresses:   localProposerAddresses,
 		BlockConfirmations:       c.Uint64(flags.BlockConfirmations.Name),
-		TxmgrConfigs:             pkgFlags.InitTxmgrConfigsFromCli(c.String(flags.L1WSEndpoint.Name), l1ProverPrivKey, c),
+		TxmgrConfigs:             pkgFlags.InitTxmgrConfigsFromCli(l1WsEndpoint, l1ProverPrivKey, c),
 		PrivateTxmgrConfigs: pkgFlags.InitTxmgrConfigsFromCli(
 			c.String(flags.L1PrivateEndpoint.Name),
 			l1ProverPrivKey,
@@ -125,4 +138,13 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		ForceBatchProvingInterval: c.Duration(flags.ForceBatchProvingInterval.Name),
 		ProofPollingInterval:      c.Duration(flags.ProofPollingInterval.Name),
 	}, nil
+}
+
+// requiredEndpoint returns a trimmed required endpoint value from the CLI context.
+func requiredEndpoint(c *cli.Context, name string) (string, error) {
+	endpoint := strings.TrimSpace(c.String(name))
+	if endpoint == "" {
+		return "", fmt.Errorf("empty %s endpoint", name)
+	}
+	return endpoint, nil
 }


### PR DESCRIPTION
## Summary
- Make driver L1/L2 WS flags optional and resolve selected RPC endpoints as WS first, then HTTP fallback.
- Track whether selected endpoints support subscriptions and use a polling head tracker for HTTP-only driver mode.
- Add coverage for endpoint fallback, endpoint scheme classification, and head update behavior.

## Tests
- PACKAGE=driver/... make test
- PACKAGE=pkg/rpc make test
- make lint
