### PR TITLE
chore(repo): tighten DeepSeek review section headers

### DIFF
--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -105,16 +105,16 @@ jobs:
 
             Provide a CONCISE code review in the following format. Skip sections that don't apply:
 
-            ## 🔴 Critical Issues
+            ### 🔴 Critical Issues
             Issues that could lead to security vulnerabilities, fund loss, or chain halts.
 
-            ## 🟡 Warnings
+            ### 🟡 Warnings
             Logic errors, edge cases, or potential bugs that should be addressed.
 
-            ## 🔵 Suggestions
+            ### 🔵 Suggestions
             Performance improvements, style/convention fixes, better error handling.
 
-            ## ✅ What Looks Good
+            ### 🟢 What Looks Good
             No need to comment on things that are already clear or don't need review.
 
             ### Review Guidelines


### PR DESCRIPTION
## Summary
- Demote DeepSeek review group headings from `##` to `###` so the section titles render smaller in the PR comment
- Swap `✅` for `🟢` on "What Looks Good" so all four group markers (🔴 🟡 🔵 🟢) are same-shape, same-size colored dots

## Test plan
- [ ] Trigger the workflow on a draft PR (or via `@deepseek` comment) and confirm the rendered review uses `###` group headings with the four colored-dot markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)