### PR TITLE
fix(taiko-client): reset head L1 origin in handleProposalReorg

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1137,6 +1137,16 @@ func (s *PreconfBlockAPIServer) handleProposalReorg(ctx context.Context, latestS
 		return
 	}
 
+	if _, err := s.rpc.L2Engine.SetHeadL1Origin(ctx, blockID.ToInt()); err != nil {
+		log.Error(
+			"Failed to reset head L1 origin after proposal reorg",
+			"proposalId", recordedProposal.Id,
+			"blockID", blockID,
+			"err", err,
+		)
+		return
+	}
+
 	header, err := s.rpc.L1.HeaderByHash(ctx, eventLog.BlockHash)
 	if err != nil {
 		log.Error(

--- a/packages/taiko-client/driver/preconf_blocks/util_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/util_test.go
@@ -3,6 +3,7 @@ package preconfblocks
 import (
 	"context"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 )
 
@@ -50,5 +51,36 @@ func (s *PreconfBlockAPIServerTestSuite) TestCheckMessageBlockNumber() {
 		return
 	}
 
+	s.Nil(err)
+}
+
+// TestSetHeadL1OriginUnblocksGuard pins the mechanism handleProposalReorg now relies
+// on: after the head L1 origin is rewound to the canonical block ID, the
+// checkMessageBlockNumber guard accepts an envelope at origin+1 and rejects one
+// at the pinned block ID itself.
+func (s *PreconfBlockAPIServerTestSuite) TestSetHeadL1OriginUnblocksGuard() {
+	ctx := context.Background()
+
+	l2Head, err := s.RPCClient.L2.BlockByNumber(ctx, nil)
+	s.Nil(err)
+
+	pinnedBlockID := l2Head.Number()
+	_, err = s.RPCClient.L2Engine.SetHeadL1Origin(ctx, pinnedBlockID)
+	s.Nil(err)
+
+	headL1Origin, err := s.RPCClient.L2.HeadL1Origin(ctx)
+	s.Nil(err)
+	s.Equal(pinnedBlockID.Uint64(), headL1Origin.BlockID.Uint64())
+
+	atGuard, err := blockToEnvelope(l2Head, nil, nil, nil)
+	s.Nil(err)
+	atGuard.ExecutionPayload.BlockNumber = eth.Uint64Quantity(pinnedBlockID.Uint64())
+	_, err = checkMessageBlockNumber(ctx, s.RPCClient, atGuard)
+	s.NotNil(err)
+
+	above, err := blockToEnvelope(l2Head, nil, nil, nil)
+	s.Nil(err)
+	above.ExecutionPayload.BlockNumber = eth.Uint64Quantity(pinnedBlockID.Uint64() + 1)
+	_, err = checkMessageBlockNumber(ctx, s.RPCClient, above)
 	s.Nil(err)
 }


### PR DESCRIPTION
## Summary

When `handleProposalReorg` (`packages/taiko-client/driver/preconf_blocks/server.go`) detects that the cached latest proposal has been reorged out of the L1 canonical chain, it resets the in-memory `highestUnsafeL2PayloadBlockID` via `recordLatestSeenProposal`, but it does **not** reset the L2 EE's `headL1Origin`. The three downstream guards then reject any new preconf block whose number is `<= headL1Origin.BlockID`, blocking the sequencer until the chain syncer independently rewinds (typically ~10s+ later):

- `driver/preconf_blocks/util.go:147` — used by the `BuildPreconfBlock` API path.
- `driver/preconf_blocks/server.go:829` — missing-parent guard during cache import.
- `driver/chain_syncer/event/blocks_inserter/common.go:684` — preconf insert path.

All three return `"... is less than or equal to the current head L1 origin block ID"`.

## Fix

Inside `handleProposalReorg`, immediately after `LastBlockIDByBatchID` resolves the last canonical L2 block of the recovered proposal and before `recordLatestSeenProposal` runs, call `SetHeadL1Origin(blockID)` on the L2 engine. After this, on-disk `headL1Origin` matches the in-memory `highestUnsafeL2PayloadBlockID` reset, and the next preconf request (or canonical batch from the chain syncer) will reorg the L2 head organically via the engine API's normal `newPayload` + `forkchoiceUpdated` path. No explicit forkchoice update or L2 head rewind is needed in `handleProposalReorg` itself.

Best-effort error handling (log + return) matches every other RPC failure path in the function.

## Test plan

- [x] New unit test `TestSetHeadL1OriginUnblocksGuard` in `driver/preconf_blocks/util_test.go` pins the mechanism: after `SetHeadL1Origin(N)`, `checkMessageBlockNumber` rejects an envelope at block `N` and accepts one at `N+1`.
- [x] `make lint && PACKAGE=./driver/preconf_blocks/... make test` passes locally.
- [ ] Manual devnet verification: trigger an L1 reorg of a Shasta proposal and confirm the preconfer immediately accepts a new `BuildPreconfBlock` request without waiting for the chain syncer to rewind.