### PR TITLE
chore(taiko-client): harden client Docker images

### DIFF
--- a/packages/taiko-client-rs/Dockerfile
+++ b/packages/taiko-client-rs/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93.1 AS build
+FROM rust:1.93.1@sha256:ecbe59a8408895edd02d9ef422504b8501dd9fa1526de27a45b73406d734d659 AS build
 
 WORKDIR /app
 
@@ -18,14 +18,18 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --locked && \
     cp /app/packages/taiko-client-rs/target/release/taiko-client /tmp/taiko-client
 
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 RUN apt-get update && \
-  apt-get install -y jq curl && \
+  apt-get install -y --no-install-recommends jq curl ca-certificates && \
+  groupadd --system --gid 10001 taiko && \
+  useradd --system --uid 10001 --gid taiko --home-dir /nonexistent --shell /usr/sbin/nologin --no-create-home taiko && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-COPY --from=build /tmp/taiko-client ./taiko-client
+COPY --from=build --chown=taiko:taiko /tmp/taiko-client ./taiko-client
+
+USER taiko:taiko
 
 ENTRYPOINT ["./taiko-client"]

--- a/packages/taiko-client/Dockerfile
+++ b/packages/taiko-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
 
 RUN apk update && apk add --no-cache --update gcc musl-dev linux-headers git make build-base
 
@@ -12,12 +12,16 @@ WORKDIR /build/packages/taiko-client
 
 RUN make build
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-RUN apk add --no-cache ca-certificates libstdc++
+RUN apk add --no-cache ca-certificates libstdc++ && \
+  addgroup -S -g 10001 taiko && \
+  adduser -S -D -H -u 10001 -G taiko -h /nonexistent -s /sbin/nologin taiko
 
 COPY --from=builder /build/packages/taiko-client/bin/taiko-client /usr/local/bin/
 
 EXPOSE 6060
+
+USER taiko:taiko
 
 ENTRYPOINT ["taiko-client"]


### PR DESCRIPTION
## Summary
- pin taiko-client and taiko-client-rs Docker base images by digest
- run both final images as a dedicated non-root user
- chown the Rust client binary in the runtime image

## Testing
- docker buildx build --check -f packages/taiko-client/Dockerfile .
- docker buildx build --check -f packages/taiko-client-rs/Dockerfile .
- git diff --check