### PR TITLE
chore(taiko-client): harden preconf and blob fallback inputs

### DIFF
--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -80,6 +80,9 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			return nil, fmt.Errorf("invalid JWT secret file: %w", err)
 		}
 	}
+	if c.Uint64(flags.PreconfBlockServerPort.Name) > 0 && len(preconfBlockServerJWTSecret) == 0 {
+		return nil, errors.New("preconfirmation.jwtSecret is required when preconfirmation.serverPort is enabled")
+	}
 
 	// Check P2P network flags and create the P2P configurations.
 	var (

--- a/packages/taiko-client/driver/config_test.go
+++ b/packages/taiko-client/driver/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -86,6 +87,20 @@ func (s *DriverTestSuite) TestNewConfigFromCliContextEmptyL2CheckPoint() {
 	}), "empty L2 check point URL")
 }
 
+func (s *DriverTestSuite) TestNewConfigFromCliContextPreconfServerRequiresJWTSecret() {
+	jwtFile := s.T().TempDir() + "/jwt.hex"
+	s.Require().NoError(os.WriteFile(jwtFile, []byte(strings.Repeat("11", 32)), 0o600))
+
+	app := s.SetupApp()
+
+	s.ErrorContains(app.Run([]string{
+		"TestNewConfigFromCliContextPreconfServerRequiresJWTSecret",
+		"--" + flags.JWTSecret.Name, jwtFile,
+		"--" + flags.L1BeaconEndpoint.Name, "http://localhost:5052",
+		"--" + flags.PreconfBlockServerPort.Name, "9871",
+	}), "preconfirmation.jwtSecret is required when preconfirmation.serverPort is enabled")
+}
+
 func (s *DriverTestSuite) SetupApp() *cli.App {
 	app := cli.NewApp()
 	app.Flags = flags.MergeFlags([]cli.Flag{
@@ -96,6 +111,8 @@ func (s *DriverTestSuite) SetupApp() *cli.App {
 		&cli.StringFlag{Name: flags.InboxAddress.Name},
 		&cli.StringFlag{Name: flags.TaikoAnchorAddress.Name},
 		&cli.Uint64Flag{Name: flags.PreconfHandoverSkipSlots.Name, Value: 8},
+		&cli.Uint64Flag{Name: flags.PreconfBlockServerPort.Name},
+		&cli.StringFlag{Name: flags.PreconfBlockServerJWTSecret.Name},
 		&cli.StringFlag{Name: flags.JWTSecret.Name},
 		&cli.BoolFlag{Name: flags.P2PSync.Name},
 		&cli.DurationFlag{Name: flags.P2PSyncTimeout.Name},

--- a/packages/taiko-client/pkg/rpc/blob_datasource.go
+++ b/packages/taiko-client/pkg/rpc/blob_datasource.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/go-resty/resty/v2"
@@ -56,20 +58,32 @@ func NewBlobDataSource(
 
 // UnmarshalJSON overwrites to parse data based on different json keys
 func (p *BlobServerResponse) UnmarshalJSON(data []byte) error {
-	var tempMap map[string]interface{}
-	if err := json.Unmarshal(data, &tempMap); err != nil {
+	var response struct {
+		Commitment          string `json:"commitment"`
+		Data                string `json:"data"`
+		VersionedHash       string `json:"versionedHash"`
+		VersionedHashLegacy string `json:"versioned_hash"`
+	}
+	if err := json.Unmarshal(data, &response); err != nil {
 		return err
 	}
 
-	// Parsing data based on different keys
-	if versionedHash, ok := tempMap["versionedHash"]; ok {
-		p.VersionedHash = versionedHash.(string)
-	} else if versionedHash, ok := tempMap["versioned_hash"]; ok {
-		p.VersionedHash = versionedHash.(string)
+	p.VersionedHash = response.VersionedHash
+	if p.VersionedHash == "" {
+		p.VersionedHash = response.VersionedHashLegacy
 	}
+	p.Commitment = response.Commitment
+	p.Data = response.Data
 
-	p.Commitment = tempMap["commitment"].(string)
-	p.Data = tempMap["data"].(string)
+	if p.VersionedHash == "" {
+		return errors.New("missing versioned hash in blob server response")
+	}
+	if p.Commitment == "" {
+		return errors.New("missing commitment in blob server response")
+	}
+	if p.Data == "" {
+		return errors.New("missing data in blob server response")
+	}
 
 	return nil
 }
@@ -129,10 +143,11 @@ func (ds *BlobDataSource) GetSidecars(
 		}
 		allSidecars = make([]*structs.Sidecar, len(blobs.Data))
 		for index, value := range blobs.Data {
-			allSidecars[index] = &structs.Sidecar{
-				KzgCommitment: value.KzgCommitment,
-				Blob:          value.Blob,
+			sidecar, err := sidecarFromBlobServer(value, blobHashes[index])
+			if err != nil {
+				return nil, err
 			}
+			allSidecars[index] = sidecar
 		}
 	}
 	for _, blobHash := range blobHashes {
@@ -157,6 +172,45 @@ func (ds *BlobDataSource) GetSidecars(
 		return nil, fmt.Errorf("blob sidecar count mismatch: expected %d, got %d", len(blobHashes), len(sidecars))
 	}
 	return sidecars, nil
+}
+
+// sidecarFromBlobServer rebuilds the sidecar from blob bytes and verifies it
+// against the requested versioned hash instead of trusting blob-server metadata.
+func sidecarFromBlobServer(blobData *BlobData, expectedHash common.Hash) (*structs.Sidecar, error) {
+	if blobData == nil {
+		return nil, errors.New("nil blob data from blob server")
+	}
+
+	blobHex := blobData.Blob
+	if !strings.HasPrefix(blobHex, "0x") {
+		blobHex = "0x" + blobHex
+	}
+
+	blobBytes, err := hexutil.Decode(blobHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid blob bytes from blob server: %w", err)
+	}
+	if len(blobBytes) != eth.BlobSize {
+		return nil, fmt.Errorf("invalid blob length from blob server: expected %d, got %d", eth.BlobSize, len(blobBytes))
+	}
+
+	var blob eth.Blob
+	copy(blob[:], blobBytes)
+
+	commitment, err := blob.ComputeKZGCommitment()
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute KZG commitment from blob server data: %w", err)
+	}
+
+	blobHash := kzg4844.CalcBlobHashV1(sha256.New(), &commitment)
+	if blobHash != expectedHash {
+		return nil, fmt.Errorf("blob server returned blob with versioned hash %s, expected %s", blobHash, expectedHash)
+	}
+
+	return &structs.Sidecar{
+		KzgCommitment: common.Bytes2Hex(commitment[:]),
+		Blob:          blob.String(),
+	}, nil
 }
 
 // getBlobFromServer get blob data from server path `/blob` or `/blobs`.

--- a/packages/taiko-client/pkg/rpc/blob_datasource_test.go
+++ b/packages/taiko-client/pkg/rpc/blob_datasource_test.go
@@ -1,0 +1,76 @@
+package rpc
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlobServerResponseUnmarshalRejectsMalformedFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "missing fields",
+			body: `{}`,
+		},
+		{
+			name: "wrong field types",
+			body: `{"versionedHash":123,"commitment":456,"data":789}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var response BlobServerResponse
+			require.NotPanics(t, func() {
+				require.Error(t, json.Unmarshal([]byte(tt.body), &response))
+			})
+		})
+	}
+}
+
+func TestBlobServerFallbackRejectsBlobDataNotMatchingRequestedHash(t *testing.T) {
+	_, goodCommitment, goodHash := testBlobWithCommitment(t, []byte("expected derivation data"))
+	badBlob, _, _ := testBlobWithCommitment(t, []byte("different derivation data"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/blobs/"+goodHash.String(), r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(BlobServerResponse{
+			VersionedHash: goodHash.String(),
+			Commitment:    common.Bytes2Hex(goodCommitment[:]),
+			Data:          badBlob.String(),
+		}))
+	}))
+	defer server.Close()
+
+	endpoint, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ds := NewBlobDataSource(context.Background(), &Client{}, endpoint)
+	_, err = ds.GetSidecars(context.Background(), 0, []common.Hash{goodHash})
+	require.ErrorContains(t, err, "blob server returned blob with versioned hash")
+}
+
+func testBlobWithCommitment(t *testing.T, data []byte) (*opeth.Blob, kzg4844.Commitment, common.Hash) {
+	t.Helper()
+
+	var blob opeth.Blob
+	require.NoError(t, blob.FromData(opeth.Data(data)))
+
+	commitment, err := blob.ComputeKZGCommitment()
+	require.NoError(t, err)
+
+	return &blob, commitment, kzg4844.CalcBlobHashV1(sha256.New(), &commitment)
+}


### PR DESCRIPTION
## Summary
- require preconfirmation.jwtSecret whenever preconfirmation.serverPort is enabled
- make blob server JSON parsing return validation errors instead of panics
- recompute KZG commitment/versioned hash from blob-server fallback bytes before accepting sidecars

## Testing
- pnpm install
- make lint && PACKAGE=pkg/rpc make test && PACKAGE=driver make test
- git diff --check