### PR TITLE
ci(repo): gate comment triggers and harden self-hosted PR runners

### DIFF
--- a/.github/workflows/eventindexer--test.yml
+++ b/.github/workflows/eventindexer--test.yml
@@ -2,6 +2,8 @@ name: "Eventindexer CI"
 
 permissions:
   contents: read
+  # actions: write is required by styfle/cancel-workflow-action below.
+  actions: write
 
 on:
   push:
@@ -25,10 +27,30 @@ concurrency:
 jobs:
   lint-eventindexer:
     name: lint-eventindexer
-    if: ${{ github.event.pull_request.draft == false && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
-    runs-on: [arc-runner-set]
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.pull_request.draft == false
+          && !startsWith(github.head_ref, 'release-please')
+          && !startsWith(github.head_ref, 'dependabot'))
+    # SECURITY: route fork PRs to a hosted runner where the first step exits 1.
+    # This makes the required check turn red for fork PRs (instead of silently
+    # skipping as success) without ever running PR-controlled code on arc-runner-set.
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request'
+         && github.event.pull_request.head.repo.fork == true)
+        && 'ubuntu-latest' || 'arc-runner-set'
+      }}
     steps:
+      - name: Block fork PR CI on self-hosted runners
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        run: |
+          echo "::error::Fork PR CI on self-hosted runners is disabled for security."
+          echo "::error::A maintainer must move this CI to a hosted-runner job or trigger from a trusted ref."
+          exit 1
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -44,15 +66,34 @@ jobs:
           args: --config=.golangci.yml --timeout=10m
 
   test-eventindexer:
-    runs-on: [arc-runner-set]
-    if: ${{ github.event.pull_request.draft == false && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.pull_request.draft == false
+          && !startsWith(github.head_ref, 'release-please')
+          && !startsWith(github.head_ref, 'dependabot'))
+    # SECURITY: see lint-eventindexer for the dynamic runs-on rationale.
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request'
+         && github.event.pull_request.head.repo.fork == true)
+        && 'ubuntu-latest' || 'arc-runner-set'
+      }}
     steps:
+      - name: Block fork PR CI on self-hosted runners
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        run: |
+          echo "::error::Fork PR CI on self-hosted runners is disabled for security."
+          echo "::error::A maintainer must move this CI to a hosted-runner job or trigger from a trusted ref."
+          exit 1
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.13.1
         with:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/nfts.yml
+++ b/.github/workflows/nfts.yml
@@ -13,11 +13,32 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  # actions: write is required by styfle/cancel-workflow-action below.
+  actions: write
+
 jobs:
   build-nfts-contracts:
-    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
-    runs-on: [arc-runner-set]
+    if: >-
+      github.event.pull_request.draft == false
+      && !startsWith(github.head_ref, 'release-please')
+    # SECURITY: route fork PRs to a hosted runner where the first step exits 1.
+    # The required check turns red for fork PRs (instead of silently skipping
+    # as success) without ever running PR-controlled code on arc-runner-set.
+    runs-on: >-
+      ${{
+        (github.event.pull_request.head.repo.fork == true)
+        && 'ubuntu-latest' || 'arc-runner-set'
+      }}
     steps:
+      - name: Block fork PR CI on self-hosted runners
+        if: github.event.pull_request.head.repo.fork == true
+        run: |
+          echo "::error::Fork PR CI on self-hosted runners is disabled for security."
+          echo "::error::A maintainer must move this CI to a hosted-runner job or trigger from a trusted ref."
+          exit 1
+
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.13.1
         with:
@@ -27,6 +48,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/relayer--test.yml
+++ b/.github/workflows/relayer--test.yml
@@ -2,6 +2,8 @@ name: "Relayer CI"
 
 permissions:
   contents: read
+  # actions: write is required by styfle/cancel-workflow-action below.
+  actions: write
 
 on:
   push:
@@ -25,10 +27,30 @@ concurrency:
 jobs:
   lint-relayer:
     name: lint-relayer
-    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot')}}
-    runs-on: [arc-runner-set]
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.pull_request.draft == false
+          && !startsWith(github.head_ref, 'release-please')
+          && !startsWith(github.head_ref, 'dependabot'))
+    # SECURITY: route fork PRs to a hosted runner where the first step exits 1.
+    # The required check turns red for fork PRs (instead of silently skipping
+    # as success) without ever running PR-controlled code on arc-runner-set.
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request'
+         && github.event.pull_request.head.repo.fork == true)
+        && 'ubuntu-latest' || 'arc-runner-set'
+      }}
     steps:
+      - name: Block fork PR CI on self-hosted runners
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        run: |
+          echo "::error::Fork PR CI on self-hosted runners is disabled for security."
+          echo "::error::A maintainer must move this CI to a hosted-runner job or trigger from a trusted ref."
+          exit 1
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -48,15 +70,34 @@ jobs:
           args: --config=.golangci.yml --timeout=4m
 
   test-relayer:
-    if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
-    runs-on: [arc-runner-set]
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.pull_request.draft == false
+          && !startsWith(github.head_ref, 'release-please')
+          && !startsWith(github.head_ref, 'dependabot'))
+    # SECURITY: see lint-relayer for the dynamic runs-on rationale.
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request'
+         && github.event.pull_request.head.repo.fork == true)
+        && 'ubuntu-latest' || 'arc-runner-set'
+      }}
     steps:
+      - name: Block fork PR CI on self-hosted runners
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        run: |
+          echo "::error::Fork PR CI on self-hosted runners is disabled for security."
+          echo "::error::A maintainer must move this CI to a hosted-runner job or trigger from a trusted ref."
+          exit 1
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.13.1
         with:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/repo--claude.yml
+++ b/.github/workflows/repo--claude.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   claude:
-    if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    # SECURITY: only trusted authors can trigger this secret-bearing job.
+    # Anyone with comment access could otherwise spend the ANTHROPIC_API_KEY
+    # and run a job with contents/pull-requests/issues/id-token write.
+    if: >-
+      github.event_name == 'issue_comment'
+      && contains(github.event.comment.body, '@claude')
+      && github.event.issue.pull_request != null
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -12,10 +12,22 @@ concurrency:
 
 jobs:
   deepseek-review:
-    # Run automatically on non-draft PRs, or when someone comments @deepseek
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@deepseek'))
+    # Run automatically on non-draft PRs from the base repo, or when a trusted
+    # author comments @deepseek (which also covers fork PRs after maintainer review).
+    # SECURITY: both paths are gated so anonymous fork PRs cannot burn
+    # DEEPSEEK_API_KEY budget by opening/synchronizing PRs or spamming comments.
+    if: >-
+      (
+        github.event_name == 'pull_request'
+        && github.event.pull_request.draft == false
+        && github.event.pull_request.head.repo.fork == false
+      )
+      || (
+        github.event_name == 'issue_comment'
+        && contains(github.event.comment.body, '@deepseek')
+        && github.event.issue.pull_request != null
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/repo--typo-check.yml
+++ b/.github/workflows/repo--typo-check.yml
@@ -9,19 +9,44 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check-for-typos:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'option.workflow_on') || github.event.pull_request.draft == false && github.head_ref != 'release-please-*' && !startsWith(github.head_ref, 'dependabot') }}
-    runs-on: [arc-runner-set]
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'option.workflow_on')
+      || (github.event.pull_request.draft == false
+          && github.head_ref != 'release-please-*'
+          && !startsWith(github.head_ref, 'dependabot'))
+    # SECURITY: route fork PRs to a hosted runner where the first step exits 1.
+    # The required check turns red for fork PRs (instead of silently skipping
+    # as success) without ever running PR-controlled code on arc-runner-set.
+    runs-on: >-
+      ${{
+        (github.event.pull_request.head.repo.fork == true)
+        && 'ubuntu-latest' || 'arc-runner-set'
+      }}
 
     steps:
+      - name: Block fork PR CI on self-hosted runners
+        if: github.event.pull_request.head.repo.fork == true
+        run: |
+          echo "::error::Fork PR CI on self-hosted runners is disabled for security."
+          echo "::error::A maintainer must move this CI to a hosted-runner job or trigger from a trusted ref."
+          exit 1
+
       - name: Checkout the repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install wget
         run: sudo apt-get update && sudo apt-get install -y wget
 
       - name: Check for typos
-        uses: crate-ci/typos@master
+        # SECURITY: avoid @master. Pin to a released tag and follow up
+        # with a full commit SHA via Dependabot/Renovate.
+        uses: crate-ci/typos@v1
         with:
           config: ${{github.workspace}}/_typos.toml


### PR DESCRIPTION
## Summary

Addresses high/medium findings from a recent vulnerability scan focused on GitHub Actions security. Three classes of fix:

- **Comment-triggered workflows** — gate `@claude` and `@deepseek` by `author_association` so anonymous users cannot spend `ANTHROPIC_API_KEY` / `DEEPSEEK_API_KEY` or trigger a job with `id-token: write` + repo write scopes. The DeepSeek auto-PR path is also fork-gated (trusted authors can still run it on fork PRs by commenting `@deepseek`).
- **Self-hosted PR runners** — fork PRs are routed to `ubuntu-latest` where the first step exits 1, so the existing required check (`lint-relayer`, `test-relayer`, `lint-eventindexer`, `test-eventindexer`, `build-nfts-contracts`, `check-for-typos`) turns red instead of silently skipping as success. PR-controlled code never reaches `arc-runner-set` on fork PRs.
- **Permissions / token hygiene** — `actions: write` added alongside `contents: read` where `styfle/cancel-workflow-action` runs (closes a pre-existing gap on relayer/eventindexer); `persist-credentials: false` on PR checkouts.

## Files changed

- `.github/workflows/repo--claude.yml`
- `.github/workflows/repo--deepseek-review.yml`
- `.github/workflows/nfts.yml`
- `.github/workflows/relayer--test.yml`
- `.github/workflows/eventindexer--test.yml`
- `.github/workflows/repo--typo-check.yml`

## Out of scope (follow-up PRs)

- `protocol.yml` and `supplementary-contracts.yml` — same fork-PR + auto-commit pattern but require splitting validation (read-only) from auto-commit (trusted, write-scoped). Too large for this PR.
- Pinning all third-party actions to full commit SHAs (mechanical sweep, Dependabot/Renovate).
- Tag-triggered prod/registry workflows: Environments + ancestry checks.
- Hosted-runner CI mirror jobs so fork PRs get green CI without maintainer intervention.

## Test plan

- [ ] Open a draft PR from this branch — confirm `repo--deepseek-review` runs (non-fork, draft=false toggled to ready) and `lint-relayer`/`test-relayer`/`lint-eventindexer`/`test-eventindexer` run on `arc-runner-set` as before.
- [ ] Comment `@claude` on a PR as a non-trusted user — workflow should skip.
- [ ] Comment `@claude` on a PR as a maintainer — workflow should run.
- [ ] Comment `@deepseek` on a PR as a non-trusted user — workflow should skip.
- [ ] Verify a fork PR sees a failed required check (e.g. `lint-relayer`) on `ubuntu-latest` with the explicit `::error::` annotation.
- [ ] Confirm `cancel-workflow-action` no longer 403s in nfts/relayer/eventindexer (i.e. concurrent run cancellation works).