### PR TITLE
fix(relayer): harden message handling and config validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PACKAGE=eventindexer
 
-FROM golang:1.26.0 AS builder
+FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
 
 ARG PACKAGE
 
@@ -18,7 +18,7 @@ WORKDIR /taiko-mono/packages/${PACKAGE}
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /taiko-mono/packages/${PACKAGE}/bin/${PACKAGE} /taiko-mono/packages/${PACKAGE}/cmd/main.go
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 ARG PACKAGE
 ENV PACKAGE=${PACKAGE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PACKAGE=eventindexer
 
-FROM golang:1.26.0
+FROM golang:1.26.0 AS builder
 
 ARG PACKAGE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /taiko-mono/packages/${PACKAGE}
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /taiko-mono/packages/${PACKAGE}/bin/${PACKAGE} /taiko-mono/packages/${PACKAGE}/cmd/main.go
 
-FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+FROM alpine:latest
 
 ARG PACKAGE
 ENV PACKAGE=${PACKAGE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PACKAGE=eventindexer
 
-FROM golang:1.26.0@sha256:fb612b7831d53a89cbc0aaa7855b69ad7b0caf603715860cf538df854d047b84 AS builder
+FROM golang:1.26.0
 
 ARG PACKAGE
 

--- a/packages/relayer/bridge/config.go
+++ b/packages/relayer/bridge/config.go
@@ -52,10 +52,20 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		return nil, errors.New("invalid bridgeMessageValue")
 	}
 
+	srcBridgeAddress, err := parseRequiredAddress(c.String(flags.SrcBridgeAddress.Name), "srcBridgeAddress")
+	if err != nil {
+		return nil, err
+	}
+
+	destBridgeAddress, err := parseRequiredAddress(c.String(flags.DestBridgeAddress.Name), "destBridgeAddress")
+	if err != nil {
+		return nil, err
+	}
+
 	return &Config{
 		BridgePrivateKey:     bridgePrivateKey,
-		DestBridgeAddress:    common.HexToAddress(c.String(flags.DestBridgeAddress.Name)),
-		SrcBridgeAddress:     common.HexToAddress(c.String(flags.SrcBridgeAddress.Name)),
+		DestBridgeAddress:    destBridgeAddress,
+		SrcBridgeAddress:     srcBridgeAddress,
 		SrcRPCUrl:            c.String(flags.SrcRPCUrl.Name),
 		DestRPCUrl:           c.String(flags.DestRPCUrl.Name),
 		Confirmations:        c.Uint64(flags.Confirmations.Name),
@@ -66,4 +76,17 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		ETHClientTimeout:     c.Uint64(flags.ETHClientTimeout.Name),
 		BridgeMessageValue:   bridgeMessageValue,
 	}, nil
+}
+
+func parseRequiredAddress(value string, name string) (common.Address, error) {
+	if !common.IsHexAddress(value) {
+		return common.Address{}, fmt.Errorf("invalid %s", name)
+	}
+
+	address := common.HexToAddress(value)
+	if address == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("invalid %s: zero address", name)
+	}
+
+	return address, nil
 }

--- a/packages/relayer/bridge/config_test.go
+++ b/packages/relayer/bridge/config_test.go
@@ -1,0 +1,38 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/cmd/flags"
+	"github.com/urfave/cli/v2"
+)
+
+func TestNewConfigFromCliContextRejectsInvalidBridgeAddress(t *testing.T) {
+	app := cli.NewApp()
+	app.Flags = flags.BridgeFlags
+	app.Action = func(ctx *cli.Context) error {
+		_, err := NewConfigFromCliContext(ctx)
+		return err
+	}
+
+	err := app.Run([]string{
+		"TestNewConfigFromCliContextRejectsInvalidBridgeAddress",
+		"--" + flags.BridgePrivateKey.Name, "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f",
+		"--" + flags.BridgeMessageValue.Name, "1",
+		"--" + flags.SrcBridgeAddress.Name, "0x123",
+		"--" + flags.DestBridgeAddress.Name, "0x63FaC9201494f0bd17B9892B9fae4d52fe3BD377",
+		"--" + flags.DatabaseUsername.Name, "dbuser",
+		"--" + flags.DatabasePassword.Name, "dbpass",
+		"--" + flags.DatabaseHost.Name, "dbhost",
+		"--" + flags.DatabaseName.Name, "dbname",
+		"--" + flags.SrcRPCUrl.Name, "srcRpcUrl",
+		"--" + flags.DestRPCUrl.Name, "destRpcUrl",
+		"--" + flags.QueueUsername.Name, "queueuser",
+		"--" + flags.QueuePassword.Name, "queuepass",
+		"--" + flags.QueueHost.Name, "queuehost",
+		"--" + flags.QueuePort.Name, "5555",
+	})
+
+	assert.ErrorContains(t, err, "invalid srcBridgeAddress")
+}

--- a/packages/relayer/pkg/db/db.go
+++ b/packages/relayer/pkg/db/db.go
@@ -49,6 +49,10 @@ type DBConnectionOpts struct {
 	OpenFunc        func(dsn string) (DB, error)
 }
 
+func ConnMaxLifetimeFromSeconds(seconds uint64) time.Duration {
+	return time.Duration(seconds) * time.Second
+}
+
 func OpenDBConnection(opts DBConnectionOpts) (DB, error) {
 	dsn := ""
 	if opts.Password == "" {
@@ -87,7 +91,7 @@ func OpenDBConnection(opts DBConnectionOpts) (DB, error) {
 	sqlDB.SetMaxIdleConns(int(opts.MaxIdleConns))
 
 	// SetConnMaxLifetime sets the maximum amount of time a connection may be reused.
-	sqlDB.SetConnMaxLifetime(time.Duration(opts.MaxConnLifetime))
+	sqlDB.SetConnMaxLifetime(ConnMaxLifetimeFromSeconds(opts.MaxConnLifetime))
 
 	return db, nil
 }

--- a/packages/relayer/pkg/db/db_test.go
+++ b/packages/relayer/pkg/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
@@ -11,4 +12,8 @@ func Test_DB(t *testing.T) {
 	d := New(&gorm.DB{})
 
 	assert.Equal(t, &gorm.DB{}, d.GormDB())
+}
+
+func TestConnMaxLifetimeFromSeconds(t *testing.T) {
+	assert.Equal(t, 30*time.Second, ConnMaxLifetimeFromSeconds(30))
 }

--- a/packages/relayer/pkg/http/errors.go
+++ b/packages/relayer/pkg/http/errors.go
@@ -11,4 +11,8 @@ var (
 		"ERR_NO_REWARDER",
 		"Rewarder is required",
 	)
+	ErrNoTaikoL2 = errors.Validation.NewWithKeyAndDetail(
+		"ERR_NO_TAIKO_L2",
+		"TaikoL2 is required",
+	)
 )

--- a/packages/relayer/pkg/http/server.go
+++ b/packages/relayer/pkg/http/server.go
@@ -84,6 +84,10 @@ func (opts NewServerOpts) Validate() error {
 		return relayer.ErrNoEthClient
 	}
 
+	if opts.TaikoL2 == nil {
+		return ErrNoTaikoL2
+	}
+
 	return nil
 }
 

--- a/packages/relayer/pkg/http/server_test.go
+++ b/packages/relayer/pkg/http/server_test.go
@@ -10,6 +10,7 @@ import (
 	echo "github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/taikol2"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
 )
@@ -42,6 +43,7 @@ func Test_NewServer(t *testing.T) {
 				CorsOrigins:   make([]string, 0),
 				SrcEthClient:  &mock.EthClient{},
 				DestEthClient: &mock.EthClient{},
+				TaikoL2:       &taikol2.TaikoL2{},
 			},
 			nil,
 		},
@@ -64,6 +66,17 @@ func Test_NewServer(t *testing.T) {
 				SrcEthClient: &mock.EthClient{},
 			},
 			relayer.ErrNoEthClient,
+		},
+		{
+			"noTaikoL2",
+			NewServerOpts{
+				Echo:          echo.New(),
+				EventRepo:     &repo.EventRepository{},
+				CorsOrigins:   make([]string, 0),
+				SrcEthClient:  &mock.EthClient{},
+				DestEthClient: &mock.EthClient{},
+			},
+			ErrNoTaikoL2,
 		},
 		{
 			"noEventRepo",

--- a/packages/relayer/pkg/utils/gas.go
+++ b/packages/relayer/pkg/utils/gas.go
@@ -40,6 +40,7 @@ func SetGasTipOrPrice(ctx context.Context, auth *bind.TransactOpts, ethClient et
 	if err != nil {
 		if IsMaxPriorityFeePerGasNotFoundError(err) {
 			auth.GasTipCap = FallbackGasTipCap
+			return nil
 		} else {
 			gasPrice, err := ethClient.SuggestGasPrice(context.Background())
 			if err != nil {
@@ -47,6 +48,7 @@ func SetGasTipOrPrice(ctx context.Context, auth *bind.TransactOpts, ethClient et
 			}
 
 			auth.GasPrice = gasPrice
+			return nil
 		}
 	}
 

--- a/packages/relayer/pkg/utils/gas.go
+++ b/packages/relayer/pkg/utils/gas.go
@@ -40,16 +40,18 @@ func SetGasTipOrPrice(ctx context.Context, auth *bind.TransactOpts, ethClient et
 	if err != nil {
 		if IsMaxPriorityFeePerGasNotFoundError(err) {
 			auth.GasTipCap = FallbackGasTipCap
-			return nil
-		} else {
-			gasPrice, err := ethClient.SuggestGasPrice(context.Background())
-			if err != nil {
-				return errors.Wrap(err, "w.destBridge.SuggestGasPrice")
-			}
 
-			auth.GasPrice = gasPrice
 			return nil
 		}
+
+		gasPrice, err := ethClient.SuggestGasPrice(context.Background())
+		if err != nil {
+			return errors.Wrap(err, "w.destBridge.SuggestGasPrice")
+		}
+
+		auth.GasPrice = gasPrice
+
+		return nil
 	}
 
 	auth.GasTipCap = gasTipCap

--- a/packages/relayer/pkg/utils/gas_test.go
+++ b/packages/relayer/pkg/utils/gas_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 	"gotest.tools/assert"
+	"math/big"
 )
 
 func Test_IsMaxPriorityFeePerGasNotFoundError(t *testing.T) {
@@ -30,4 +31,22 @@ func Test_SetGasTipOrPrice(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Equal(t, auth.GasTipCap.Uint64(), uint64(100))
+}
+
+type maxPriorityFeeUnsupportedClient struct {
+	mock.EthClient
+}
+
+func (c *maxPriorityFeeUnsupportedClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	return nil, ErrMaxPriorityFeePerGasNotFound
+}
+
+func Test_SetGasTipOrPriceKeepsFallbackGasTip(t *testing.T) {
+	auth := &bind.TransactOpts{}
+
+	err := SetGasTipOrPrice(context.Background(), auth, &maxPriorityFeeUnsupportedClient{})
+
+	assert.NilError(t, err)
+	assert.Equal(t, auth.GasTipCap, FallbackGasTipCap)
+	assert.Equal(t, auth.GasPrice, (*big.Int)(nil))
 }

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -519,6 +519,10 @@ func (p *Processor) saveMessageStatusChangedEvent(
 	m := make(map[string]interface{})
 
 	for _, log := range receipt.Logs {
+		if len(log.Topics) == 0 {
+			continue
+		}
+
 		topic := log.Topics[0]
 		if topic == bridgeAbi.Events["MessageStatusChanged"].ID {
 			err = bridgeAbi.UnpackIntoMap(m, "MessageStatusChanged", log.Data)

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -50,6 +50,33 @@ func Test_sendProcessMessageCall(t *testing.T) {
 	assert.Equal(t, err, errUnprocessable)
 }
 
+func TestSaveMessageStatusChangedEventSkipsLogsWithoutTopics(t *testing.T) {
+	p := newTestProcessor(false)
+
+	err := p.saveMessageStatusChangedEvent(
+		context.Background(),
+		&types.Receipt{
+			TxHash: relayer.ZeroHash,
+			Logs: []*types.Log{
+				{},
+			},
+		},
+		&bridge.BridgeMessageSent{
+			Message: bridge.IBridgeMessage{
+				SrcChainId:  mock.MockChainID.Uint64(),
+				DestChainId: mock.MockChainID.Uint64(),
+				SrcOwner:    common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+			},
+			MsgHash: relayer.ZeroHash,
+			Raw: types.Log{
+				BlockNumber: 1,
+			},
+		},
+	)
+
+	assert.Nil(t, err)
+}
+
 func Test_ProcessMessage_messageUnprocessable(t *testing.T) {
 	p := newTestProcessor(true)
 	body := &queue.QueueMessageSentBody{

--- a/packages/relayer/processor/process_single.go
+++ b/packages/relayer/processor/process_single.go
@@ -29,6 +29,10 @@ func (p *Processor) processSingle(ctx context.Context) error {
 	}
 
 	for _, log := range receipt.Logs {
+		if len(log.Topics) == 0 {
+			continue
+		}
+
 		topic := log.Topics[0]
 
 		if topic == bridgeAbi.Events["MessageSent"].ID {

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -410,6 +410,7 @@ func (p *Processor) eventLoop(ctx context.Context) {
 				defer func() {
 					if r := recover(); r != nil {
 						slog.Error("panic processing message", "panic", r)
+
 						if err := p.queue.Nack(ctx, m, false); err != nil {
 							slog.Error("Err nacking panicked message", "err", err.Error())
 						}
@@ -418,7 +419,6 @@ func (p *Processor) eventLoop(ctx context.Context) {
 
 				shouldRequeue, timesRetried, err := p.processMessage(ctx, m)
 				p.handleProcessMessageResult(ctx, m, shouldRequeue, timesRetried, err)
-
 			}(msg)
 		}
 	}
@@ -441,11 +441,13 @@ func (p *Processor) handleProcessMessageResult(
 			p.handleUnprofitableMessage(ctx, m, timesRetried)
 		case isTransientProcessMessageError(err):
 			slog.Error("process message failed", "err", err.Error())
+
 			if err := p.queue.Nack(ctx, m, true); err != nil {
 				slog.Error("Err nacking message", "err", err.Error())
 			}
 		default:
 			slog.Error("process message failed", "err", err.Error())
+
 			if err := p.queue.Nack(ctx, m, shouldRequeue); err != nil {
 				slog.Error("Err nacking message", "err", err.Error())
 			}
@@ -473,19 +475,24 @@ func (p *Processor) handleUnprofitableMessage(ctx context.Context, m queue.Messa
 	msgBody := &queue.QueueMessageSentBody{}
 	if err := json.Unmarshal(m.Body, msgBody); err != nil {
 		slog.Error("error decoding unprofitable message", "error", err)
+
 		if err := p.queue.Nack(ctx, m, false); err != nil {
 			slog.Error("Err nacking message", "err", err.Error())
 		}
+
 		return
 	}
 
 	msgBody.TimesRetried = nextRetries
+
 	body, err := json.Marshal(msgBody)
 	if err != nil {
 		slog.Error("error encoding unprofitable message", "error", err)
+
 		if err := p.queue.Nack(ctx, m, false); err != nil {
 			slog.Error("Err nacking message", "err", err.Error())
 		}
+
 		return
 	}
 
@@ -497,9 +504,11 @@ func (p *Processor) handleUnprofitableMessage(ctx context.Context, m queue.Messa
 		p.cfg.UnprofitableMessageQueueExpiration,
 	); err != nil {
 		slog.Error("error publishing to unprofitable queue", "error", err)
+
 		if err := p.queue.Nack(ctx, m, true); err != nil {
 			slog.Error("Err nacking message", "err", err.Error())
 		}
+
 		return
 	}
 

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -406,69 +407,111 @@ func (p *Processor) eventLoop(ctx context.Context) {
 			return
 		case msg := <-p.msgCh:
 			go func(m queue.Message) {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("panic processing message", "panic", r)
+						if err := p.queue.Nack(ctx, m, false); err != nil {
+							slog.Error("Err nacking panicked message", "err", err.Error())
+						}
+					}
+				}()
+
 				shouldRequeue, timesRetried, err := p.processMessage(ctx, m)
+				p.handleProcessMessageResult(ctx, m, shouldRequeue, timesRetried, err)
 
-				if err != nil {
-					switch {
-					case errors.Is(err, errUnprocessable):
-						if err := p.queue.Ack(ctx, m); err != nil {
-							slog.Error("Err acking message", "err", err.Error())
-						}
-					case errors.Is(err, relayer.ErrUnprofitable):
-						slog.Info("publishing to unprofitable queue")
-
-						headers := make(map[string]interface{}, 0)
-
-						headers["retries"] = int64(timesRetried + 1)
-
-						if err := p.queue.Publish(
-							ctx,
-							fmt.Sprintf("%v-unprofitable", p.queueName()),
-							m.Body,
-							headers,
-							p.cfg.UnprofitableMessageQueueExpiration,
-						); err != nil {
-							slog.Error("error publishing to unprofitable queue", "error", err)
-						}
-
-						// after publishing successfully, we can acknowledge this message to remove it
-						// from our main queue.
-						if err := p.queue.Ack(ctx, m); err != nil {
-							slog.Error("Err acking message", "err", err.Error())
-						}
-					case errors.Is(err, context.Canceled) ||
-						strings.Contains(err.Error(), "timeout") ||
-						strings.Contains(err.Error(), "i/o") ||
-						strings.Contains(err.Error(), "connect") ||
-						strings.Contains(err.Error(), "failed to get tx into the mempool"):
-						// we want to do nothing, just log, and the message will be re-picked up
-						// by another consumer. no need to nack or ack.
-						slog.Error("process message failed", "err", err.Error())
-					default:
-						slog.Error("process message failed", "err", err.Error())
-
-						// we want to negatively acknowledge the message and requeue it if we
-						// encountered an error, but the message is processable.
-						if err := p.queue.Nack(ctx, m, shouldRequeue); err != nil {
-							slog.Error("Err nacking message", "err", err.Error())
-						}
-					}
-
-					return
-				}
-
-				if shouldRequeue {
-					// we want to negatively acknowledge the message and let the broker requeue it
-					if err := p.queue.Nack(ctx, m, true); err != nil {
-						slog.Error("Err nacking message", "err", err.Error())
-					}
-				} else {
-					// otherwise if no error, we can acknowledge it successfully.
-					if err := p.queue.Ack(ctx, m); err != nil {
-						slog.Error("Err acking message", "err", err.Error())
-					}
-				}
 			}(msg)
 		}
 	}
+}
+
+func (p *Processor) handleProcessMessageResult(
+	ctx context.Context,
+	m queue.Message,
+	shouldRequeue bool,
+	timesRetried uint64,
+	err error,
+) {
+	if err != nil {
+		switch {
+		case errors.Is(err, errUnprocessable):
+			if err := p.queue.Ack(ctx, m); err != nil {
+				slog.Error("Err acking message", "err", err.Error())
+			}
+		case errors.Is(err, relayer.ErrUnprofitable):
+			p.handleUnprofitableMessage(ctx, m, timesRetried)
+		case isTransientProcessMessageError(err):
+			slog.Error("process message failed", "err", err.Error())
+			if err := p.queue.Nack(ctx, m, true); err != nil {
+				slog.Error("Err nacking message", "err", err.Error())
+			}
+		default:
+			slog.Error("process message failed", "err", err.Error())
+			if err := p.queue.Nack(ctx, m, shouldRequeue); err != nil {
+				slog.Error("Err nacking message", "err", err.Error())
+			}
+		}
+
+		return
+	}
+
+	if shouldRequeue {
+		if err := p.queue.Nack(ctx, m, true); err != nil {
+			slog.Error("Err nacking message", "err", err.Error())
+		}
+	} else if err := p.queue.Ack(ctx, m); err != nil {
+		slog.Error("Err acking message", "err", err.Error())
+	}
+}
+
+func (p *Processor) handleUnprofitableMessage(ctx context.Context, m queue.Message, timesRetried uint64) {
+	slog.Info("publishing to unprofitable queue")
+
+	headers := make(map[string]interface{}, 0)
+	nextRetries := timesRetried + 1
+	headers["retries"] = int64(nextRetries)
+
+	msgBody := &queue.QueueMessageSentBody{}
+	if err := json.Unmarshal(m.Body, msgBody); err != nil {
+		slog.Error("error decoding unprofitable message", "error", err)
+		if err := p.queue.Nack(ctx, m, false); err != nil {
+			slog.Error("Err nacking message", "err", err.Error())
+		}
+		return
+	}
+
+	msgBody.TimesRetried = nextRetries
+	body, err := json.Marshal(msgBody)
+	if err != nil {
+		slog.Error("error encoding unprofitable message", "error", err)
+		if err := p.queue.Nack(ctx, m, false); err != nil {
+			slog.Error("Err nacking message", "err", err.Error())
+		}
+		return
+	}
+
+	if err := p.queue.Publish(
+		ctx,
+		fmt.Sprintf("%v-unprofitable", p.queueName()),
+		body,
+		headers,
+		p.cfg.UnprofitableMessageQueueExpiration,
+	); err != nil {
+		slog.Error("error publishing to unprofitable queue", "error", err)
+		if err := p.queue.Nack(ctx, m, true); err != nil {
+			slog.Error("Err nacking message", "err", err.Error())
+		}
+		return
+	}
+
+	if err := p.queue.Ack(ctx, m); err != nil {
+		slog.Error("Err acking message", "err", err.Error())
+	}
+}
+
+func isTransientProcessMessageError(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		strings.Contains(err.Error(), "timeout") ||
+		strings.Contains(err.Error(), "i/o") ||
+		strings.Contains(err.Error(), "connect") ||
+		strings.Contains(err.Error(), "failed to get tx into the mempool")
 }

--- a/packages/relayer/processor/processor_test.go
+++ b/packages/relayer/processor/processor_test.go
@@ -1,12 +1,20 @@
 package processor
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/proof"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
 )
 
 var dummyEcdsaKey = "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f"
@@ -46,4 +54,83 @@ func newTestProcessor(profitableOnly bool) *Processor {
 		destQuotaManager:   &mock.QuotaManager{},
 		processingTxHashes: make(map[common.Hash]bool, 0),
 	}
+}
+
+type recordingQueue struct {
+	publishErr     error
+	publishedBody  []byte
+	publishedQueue string
+	acked          int
+	nacked         int
+	requeued       bool
+}
+
+func (q *recordingQueue) Start(ctx context.Context, queueName string) error { return nil }
+func (q *recordingQueue) Close(ctx context.Context)                         {}
+func (q *recordingQueue) Notify(ctx context.Context, wg *sync.WaitGroup) error {
+	return nil
+}
+func (q *recordingQueue) Subscribe(ctx context.Context, msgs chan<- queue.Message, wg *sync.WaitGroup) error {
+	return nil
+}
+func (q *recordingQueue) Publish(
+	ctx context.Context,
+	queueName string,
+	msg []byte,
+	headers map[string]interface{},
+	expiration *string,
+) error {
+	q.publishedQueue = queueName
+	q.publishedBody = msg
+	return q.publishErr
+}
+func (q *recordingQueue) Ack(ctx context.Context, msg queue.Message) error {
+	q.acked++
+	return nil
+}
+func (q *recordingQueue) Nack(ctx context.Context, msg queue.Message, requeue bool) error {
+	q.nacked++
+	q.requeued = requeue
+	return nil
+}
+
+func TestHandleProcessMessageResultNacksWhenUnprofitableRepublishFails(t *testing.T) {
+	q := &recordingQueue{publishErr: errors.New("publish failed")}
+	p := newTestProcessor(false)
+	p.queue = q
+
+	p.handleProcessMessageResult(context.Background(), queue.Message{Body: []byte(`{}`)}, false, 2, relayer.ErrUnprofitable)
+
+	assert.Equal(t, 0, q.acked)
+	assert.Equal(t, 1, q.nacked)
+	assert.True(t, q.requeued)
+}
+
+func TestHandleProcessMessageResultNacksTransientErrors(t *testing.T) {
+	q := &recordingQueue{}
+	p := newTestProcessor(false)
+	p.queue = q
+
+	p.handleProcessMessageResult(context.Background(), queue.Message{Body: []byte(`{}`)}, false, 0, errors.New("i/o timeout"))
+
+	assert.Equal(t, 0, q.acked)
+	assert.Equal(t, 1, q.nacked)
+	assert.True(t, q.requeued)
+}
+
+func TestHandleProcessMessageResultPersistsUnprofitableRetryCount(t *testing.T) {
+	q := &recordingQueue{}
+	p := newTestProcessor(false)
+	p.queue = q
+
+	body, err := json.Marshal(queue.QueueMessageSentBody{TimesRetried: 2})
+	assert.NoError(t, err)
+
+	p.handleProcessMessageResult(context.Background(), queue.Message{Body: body}, false, 2, relayer.ErrUnprofitable)
+
+	var published queue.QueueMessageSentBody
+	assert.NoError(t, json.Unmarshal(q.publishedBody, &published))
+	assert.Equal(t, uint64(3), published.TimesRetried)
+	assert.Equal(t, 1, q.acked)
+	assert.Equal(t, 0, q.nacked)
 }

--- a/packages/relayer/processor/processor_test.go
+++ b/packages/relayer/processor/processor_test.go
@@ -82,6 +82,7 @@ func (q *recordingQueue) Publish(
 ) error {
 	q.publishedQueue = queueName
 	q.publishedBody = msg
+
 	return q.publishErr
 }
 func (q *recordingQueue) Ack(ctx context.Context, msg queue.Message) error {
@@ -91,6 +92,7 @@ func (q *recordingQueue) Ack(ctx context.Context, msg queue.Message) error {
 func (q *recordingQueue) Nack(ctx context.Context, msg queue.Message, requeue bool) error {
 	q.nacked++
 	q.requeued = requeue
+
 	return nil
 }
 
@@ -99,7 +101,13 @@ func TestHandleProcessMessageResultNacksWhenUnprofitableRepublishFails(t *testin
 	p := newTestProcessor(false)
 	p.queue = q
 
-	p.handleProcessMessageResult(context.Background(), queue.Message{Body: []byte(`{}`)}, false, 2, relayer.ErrUnprofitable)
+	p.handleProcessMessageResult(
+		context.Background(),
+		queue.Message{Body: []byte(`{}`)},
+		false,
+		2,
+		relayer.ErrUnprofitable,
+	)
 
 	assert.Equal(t, 0, q.acked)
 	assert.Equal(t, 1, q.nacked)
@@ -111,7 +119,13 @@ func TestHandleProcessMessageResultNacksTransientErrors(t *testing.T) {
 	p := newTestProcessor(false)
 	p.queue = q
 
-	p.handleProcessMessageResult(context.Background(), queue.Message{Body: []byte(`{}`)}, false, 0, errors.New("i/o timeout"))
+	p.handleProcessMessageResult(
+		context.Background(),
+		queue.Message{Body: []byte(`{}`)},
+		false,
+		0,
+		errors.New("i/o timeout"),
+	)
 
 	assert.Equal(t, 0, q.acked)
 	assert.Equal(t, 1, q.nacked)
@@ -126,9 +140,16 @@ func TestHandleProcessMessageResultPersistsUnprofitableRetryCount(t *testing.T) 
 	body, err := json.Marshal(queue.QueueMessageSentBody{TimesRetried: 2})
 	assert.NoError(t, err)
 
-	p.handleProcessMessageResult(context.Background(), queue.Message{Body: body}, false, 2, relayer.ErrUnprofitable)
+	p.handleProcessMessageResult(
+		context.Background(),
+		queue.Message{Body: body},
+		false,
+		2,
+		relayer.ErrUnprofitable,
+	)
 
 	var published queue.QueueMessageSentBody
+
 	assert.NoError(t, json.Unmarshal(q.publishedBody, &published))
 	assert.Equal(t, uint64(3), published.TimesRetried)
 	assert.Equal(t, 1, q.acked)

--- a/packages/relayer/watchdog/watchdog.go
+++ b/packages/relayer/watchdog/watchdog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -277,7 +278,7 @@ func (w *Watchdog) eventLoop(ctx context.Context) {
 				if err != nil {
 					slog.Error("err checking message", "err", err.Error())
 
-					if err := w.queue.Nack(ctx, msg, true); err != nil {
+					if err := w.queue.Nack(ctx, msg, shouldRequeueCheckMessageError(err)); err != nil {
 						slog.Error("Err nacking message", "err", err.Error())
 					}
 				} else {
@@ -377,6 +378,16 @@ func (w *Watchdog) checkMessage(ctx context.Context, msg queue.Message) error {
 	relayer.BridgePaused.Inc()
 
 	return nil
+}
+
+func shouldRequeueCheckMessageError(err error) bool {
+	var syntaxErr *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+	if stderrors.As(err, &syntaxErr) || stderrors.As(err, &typeErr) {
+		return false
+	}
+
+	return true
 }
 
 func (w *Watchdog) pauseBridge(

--- a/packages/relayer/watchdog/watchdog.go
+++ b/packages/relayer/watchdog/watchdog.go
@@ -382,7 +382,9 @@ func (w *Watchdog) checkMessage(ctx context.Context, msg queue.Message) error {
 
 func shouldRequeueCheckMessageError(err error) bool {
 	var syntaxErr *json.SyntaxError
+
 	var typeErr *json.UnmarshalTypeError
+
 	if stderrors.As(err, &syntaxErr) || stderrors.As(err, &typeErr) {
 		return false
 	}

--- a/packages/relayer/watchdog/watchdog_test.go
+++ b/packages/relayer/watchdog/watchdog_test.go
@@ -27,6 +27,7 @@ func Test_queueName(t *testing.T) {
 
 func TestShouldRequeueCheckMessageErrorReturnsFalseForMalformedJSON(t *testing.T) {
 	var syntaxErr *json.SyntaxError
+
 	err := json.Unmarshal([]byte("{"), &struct{}{})
 	assert.True(t, errors.As(err, &syntaxErr))
 

--- a/packages/relayer/watchdog/watchdog_test.go
+++ b/packages/relayer/watchdog/watchdog_test.go
@@ -1,9 +1,12 @@
 package watchdog
 
 import (
+	"encoding/json"
+	"errors"
 	"math/big"
 	"testing"
 
+	cybererrors "github.com/cyberhorsey/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,4 +23,12 @@ func Test_queueName(t *testing.T) {
 	}
 
 	assert.Equal(t, "1-2-MessageProcessed-queue", w.queueName())
+}
+
+func TestShouldRequeueCheckMessageErrorReturnsFalseForMalformedJSON(t *testing.T) {
+	var syntaxErr *json.SyntaxError
+	err := json.Unmarshal([]byte("{"), &struct{}{})
+	assert.True(t, errors.As(err, &syntaxErr))
+
+	assert.False(t, shouldRequeueCheckMessageError(cybererrors.Wrap(err, "json.Unmarshal")))
 }


### PR DESCRIPTION
## Summary

This PR hardens the relayer Go services against several reliability and configuration issues found during review.

The processor now recovers from per-message panics, skips receipt logs that have no topics before reading `Topics[0]`, persists unprofitable retry counts in the queue message body, and avoids acknowledging original deliveries when retry publication fails. Transient processing errors are now explicitly nacked with requeue so RabbitMQ does not leave them stuck as unacked deliveries.

The watchdog now treats malformed queue payloads as permanent failures instead of requeueing them forever. The bridge CLI validates required bridge addresses before binding contracts. The shared DB helper now interprets `db.connMaxLifetime` as seconds, matching the flag documentation, and the relayer HTTP server validates that `TaikoL2` is present before registering routes that dereference it. Gas tip fallback handling now returns after setting fallback values so they are not overwritten with nil.

The shared Go service Dockerfile also pins the `golang:1.26.0` and `alpine:latest` base images to immutable manifest digests.

## Tests

```bash
go test -count=1 ./packages/relayer/pkg/utils ./packages/relayer/pkg/db ./packages/relayer/processor ./packages/relayer/watchdog ./packages/relayer/pkg/http ./packages/relayer/bridge
```

```bash
go test -count=1 $(go list ./packages/relayer/... | grep -v /pkg/repo)
```

I also ran:

```bash
go test -count=1 ./packages/relayer/...
```

That full command only failed in `packages/relayer/pkg/repo` because the local environment lacks rootless Docker for testcontainers (`rootless Docker not found`).
