### PR TITLE
feat(taiko-client-rs): expose canShutdown on whitelist preconf /status

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/handlers.rs
@@ -35,6 +35,7 @@ pub(super) async fn handle_status(State(state): State<AppState>) -> Result<Respo
         end_of_sequencing_block_hash: status
             .end_of_sequencing_block_hash
             .unwrap_or_else(|| alloy_primitives::B256::ZERO.to_string()),
+        can_shutdown: status.can_shutdown,
     };
     Ok(json_response(http::StatusCode::OK, &response))
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/router.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/router.rs
@@ -49,14 +49,15 @@ pub(super) fn build_router(
         protected_router = protected_router.route("/ws", get(handle_websocket_upgrade));
     }
 
-    let protected_router =
-        protected_router.layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
-
-    public_router
-        .merge(protected_router)
+    // Place the not-found fallback inside the protected router so the auth
+    // middleware wraps it: when a JWT secret is configured, unknown paths
+    // must still return 401 rather than leaking their non-existence as 404
+    // to unauthenticated probers.
+    let protected_router = protected_router
         .fallback(handle_not_found)
-        .layer(cors_layer)
-        .with_state(state)
+        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
+
+    public_router.merge(protected_router).layer(cors_layer).with_state(state)
 }
 
 /// Build CORS middleware from configured allowed origins.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/router.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/router.rs
@@ -21,6 +21,11 @@ use super::{
 };
 
 /// Construct the server router with optional HTTP and WebSocket route groups.
+///
+/// `/`, `/healthz`, and `/status` are served without JWT authentication so
+/// that lightweight Kubernetes liveness/readiness probes (which cannot
+/// generate HMAC-SHA256 bearer tokens) can reach them. `/preconfBlocks` and
+/// `/ws` remain JWT-protected when `jwt_secret` is configured.
 pub(super) fn build_router(
     state: AppState,
     cors_origins: &[String],
@@ -28,24 +33,30 @@ pub(super) fn build_router(
     enable_ws: bool,
 ) -> Router {
     let cors_layer = build_cors_layer(cors_origins);
-    let mut router = Router::new();
+
+    let mut public_router = Router::new();
+    let mut protected_router = Router::new();
 
     if enable_http {
-        router = router
+        public_router = public_router
             .route("/", get(handle_root))
             .route("/healthz", get(handle_root))
-            .route("/status", get(handle_status))
-            .route("/preconfBlocks", post(handle_preconf_blocks));
+            .route("/status", get(handle_status));
+        protected_router = protected_router.route("/preconfBlocks", post(handle_preconf_blocks));
     }
 
     if enable_ws {
-        router = router.route("/ws", get(handle_websocket_upgrade));
+        protected_router = protected_router.route("/ws", get(handle_websocket_upgrade));
     }
 
-    router = router
+    let protected_router =
+        protected_router.layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
+
+    public_router
+        .merge(protected_router)
         .fallback(handle_not_found)
-        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
-    router.layer(cors_layer).with_state(state)
+        .layer(cors_layer)
+        .with_state(state)
 }
 
 /// Build CORS middleware from configured allowed origins.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -116,6 +116,17 @@ fn test_config(enable_http: bool, enable_ws: bool) -> WhitelistApiServerConfig {
     }
 }
 
+/// Start a server configured with a JWT secret so probe-route auth-skip
+/// behavior and protected-route enforcement can be exercised.
+async fn start_jwt_server(enable_http: bool, enable_ws: bool) -> WhitelistApiServer {
+    let config = WhitelistApiServerConfig {
+        jwt_secret: Some(b"test-secret".to_vec()),
+        ..test_config(enable_http, enable_ws)
+    };
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    WhitelistApiServer::start(config, api).await.expect("server should start")
+}
+
 #[tokio::test]
 async fn server_start_stop() {
     let config = test_config(true, true);
@@ -232,13 +243,7 @@ fn jwt_auth_rejects_missing_header() {
 
 #[tokio::test]
 async fn jwt_auth_is_required_when_secret_configured() {
-    let config = WhitelistApiServerConfig {
-        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
-        jwt_secret: Some(b"test-secret".to_vec()),
-        ..test_config(true, false)
-    };
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let server = start_jwt_server(true, false).await;
 
     let response = reqwest::Client::new()
         .post(format!("{}/preconfBlocks", server.http_url()))
@@ -373,13 +378,7 @@ async fn get_status_returns_can_shutdown_field_in_camel_case() {
 
 #[tokio::test]
 async fn status_path_skips_jwt_when_secret_configured() {
-    let config = WhitelistApiServerConfig {
-        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
-        jwt_secret: Some(b"test-secret".to_vec()),
-        ..test_config(true, false)
-    };
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let server = start_jwt_server(true, false).await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/status", server.http_url()))
@@ -397,13 +396,7 @@ async fn status_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn healthz_path_skips_jwt_when_secret_configured() {
-    let config = WhitelistApiServerConfig {
-        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
-        jwt_secret: Some(b"test-secret".to_vec()),
-        ..test_config(true, false)
-    };
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let server = start_jwt_server(true, false).await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/healthz", server.http_url()))
@@ -417,13 +410,7 @@ async fn healthz_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn root_path_skips_jwt_when_secret_configured() {
-    let config = WhitelistApiServerConfig {
-        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
-        jwt_secret: Some(b"test-secret".to_vec()),
-        ..test_config(true, false)
-    };
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let server = start_jwt_server(true, false).await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/", server.http_url()))
@@ -437,13 +424,7 @@ async fn root_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn preconf_blocks_still_requires_jwt_when_configured() {
-    let config = WhitelistApiServerConfig {
-        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
-        jwt_secret: Some(b"test-secret".to_vec()),
-        ..test_config(true, false)
-    };
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let server = start_jwt_server(true, false).await;
 
     let response = reqwest::Client::new()
         .post(format!("{}/preconfBlocks", server.http_url()))
@@ -463,13 +444,7 @@ async fn preconf_blocks_still_requires_jwt_when_configured() {
 
 #[tokio::test]
 async fn ws_still_requires_jwt_when_configured() {
-    let config = WhitelistApiServerConfig {
-        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
-        jwt_secret: Some(b"test-secret".to_vec()),
-        ..test_config(true, true)
-    };
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let server = start_jwt_server(true, true).await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/ws", server.http_url()))

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -241,7 +241,9 @@ async fn jwt_auth_is_required_when_secret_configured() {
     let server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
     let response = reqwest::Client::new()
-        .get(format!("{}/status", server.http_url()))
+        .post(format!("{}/preconfBlocks", server.http_url()))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(sample_preconf_request())
         .send()
         .await
         .expect("request should succeed");
@@ -364,6 +366,120 @@ async fn get_status_returns_can_shutdown_field_in_camel_case() {
         payload.get("canShutdown").and_then(serde_json::Value::as_bool),
         Some(true),
         "GET /status response must serialize canShutdown as a camelCase boolean field; got {payload:?}"
+    );
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn status_path_skips_jwt_when_secret_configured() {
+    let config = WhitelistApiServerConfig {
+        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
+        jwt_secret: Some(b"test-secret".to_vec()),
+        ..test_config(true, false)
+    };
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/status", server.http_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "GET /status must succeed without auth so that busybox k8s probes can hit it"
+    );
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn healthz_path_skips_jwt_when_secret_configured() {
+    let config = WhitelistApiServerConfig {
+        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
+        jwt_secret: Some(b"test-secret".to_vec()),
+        ..test_config(true, false)
+    };
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/healthz", server.http_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn root_path_skips_jwt_when_secret_configured() {
+    let config = WhitelistApiServerConfig {
+        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
+        jwt_secret: Some(b"test-secret".to_vec()),
+        ..test_config(true, false)
+    };
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/", server.http_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn preconf_blocks_still_requires_jwt_when_configured() {
+    let config = WhitelistApiServerConfig {
+        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
+        jwt_secret: Some(b"test-secret".to_vec()),
+        ..test_config(true, false)
+    };
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/preconfBlocks", server.http_url()))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(sample_preconf_request())
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "POST /preconfBlocks must remain JWT-protected"
+    );
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ws_still_requires_jwt_when_configured() {
+    let config = WhitelistApiServerConfig {
+        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
+        jwt_secret: Some(b"test-secret".to_vec()),
+        ..test_config(true, true)
+    };
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/ws", server.http_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "GET /ws upgrades must remain JWT-protected"
     );
 
     server.stop().await;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -44,6 +44,7 @@ impl WhitelistApi for MockApi {
             sync_ready: true,
             highest_unsafe_l2_payload_block_id: 100,
             end_of_sequencing_block_hash: Some(B256::ZERO.to_string()),
+            can_shutdown: true,
         })
     }
 
@@ -77,6 +78,7 @@ impl WhitelistApi for SyncReadyApi {
             sync_ready: self.sync_ready,
             highest_unsafe_l2_payload_block_id: 100,
             end_of_sequencing_block_hash: Some(B256::ZERO.to_string()),
+            can_shutdown: true,
         })
     }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -346,3 +346,25 @@ async fn preconf_blocks_rejects_invalid_json() {
 
     server.stop().await;
 }
+
+#[tokio::test]
+async fn get_status_returns_can_shutdown_field_in_camel_case() {
+    let config = test_config(true, false);
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/status", server.http_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body expected");
+    assert_eq!(
+        payload.get("canShutdown").and_then(serde_json::Value::as_bool),
+        Some(true),
+        "GET /status response must serialize canShutdown as a camelCase boolean field; got {payload:?}"
+    );
+
+    server.stop().await;
+}

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -459,3 +459,37 @@ async fn ws_still_requires_jwt_when_configured() {
 
     server.stop().await;
 }
+
+#[tokio::test]
+async fn unknown_path_requires_jwt_when_secret_configured() {
+    let server = start_jwt_server(true, false).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/this-route-does-not-exist", server.http_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "unknown paths must stay JWT-gated to avoid widening unauthenticated route probing"
+    );
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn unknown_path_returns_not_found_when_no_jwt_secret() {
+    let config = test_config(true, false);
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/this-route-does-not-exist", server.http_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.stop().await;
+}

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -48,6 +48,9 @@ where
         request: BuildPreconfBlockRequest,
     ) -> Result<BuildPreconfBlockResponse> {
         let started_at = Instant::now();
+        // Record receipt before any validation so even rejected requests
+        // mark this pod as the active preconfer for shutdown purposes.
+        self.mark_preconf_request_received().await;
         let _build_guard = self.build_preconf_lock.lock().await;
 
         // Guard against building on a genuinely syncing node, but tolerate the false-

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -109,6 +109,10 @@ where
     cache_state: SharedPreconfCacheState,
     /// Broadcast channel for API `/ws` end-of-sequencing notifications.
     eos_notification_tx: broadcast::Sender<EndOfSequencingNotification>,
+    /// Wall-clock instant of the most recent `build_preconf_block` invocation,
+    /// regardless of the request's outcome. `None` until the first request
+    /// arrives. Read by `/status` to compute `can_shutdown`.
+    last_preconf_request_at: Mutex<Option<Instant>>,
 }
 
 /// Dependency bundle for constructing `WhitelistApiService`.
@@ -171,6 +175,25 @@ where
             eos_notification_tx,
             network_command_tx,
             build_preconf_lock: Mutex::new(()),
+            last_preconf_request_at: Mutex::new(None),
         }
+    }
+}
+
+impl<P> WhitelistApiService<P>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    /// Record that a `build_preconf_block` request has been received.
+    /// Called at the top of the request handler so that even rejected
+    /// requests count toward shutdown-safety.
+    pub(super) async fn mark_preconf_request_received(&self) {
+        *self.last_preconf_request_at.lock().await = Some(Instant::now());
+    }
+
+    /// Returns `true` when no `build_preconf_block` request has been received
+    /// within the last `SHUTDOWN_BLOCK_WINDOW`.
+    pub(super) async fn compute_can_shutdown(&self) -> bool {
+        can_shutdown_for(*self.last_preconf_request_at.lock().await)
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -178,12 +178,7 @@ where
             last_preconf_request_at: Mutex::new(None),
         }
     }
-}
 
-impl<P> WhitelistApiService<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
     /// Record that a `build_preconf_block` request has been received.
     /// Called at the top of the request handler so that even rejected
     /// requests count toward shutdown-safety.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -1,6 +1,9 @@
 //! Whitelist preconfirmation API service implementation.
 
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use alethia_reth_primitives::payload::{
     attributes::{RpcL1Origin, TaikoBlockMetadata, TaikoPayloadAttributes},
@@ -48,6 +51,33 @@ mod tests;
 
 /// Maximum number of pending EOS notifications retained for `/ws` subscribers.
 const EOS_NOTIFICATION_CHANNEL_CAPACITY: usize = 128;
+
+/// Number of L1 slots in the preconfer hand-over window. Doubled relative to
+/// the Go client's default `handover_slots = 4` because the Rust whitelist
+/// driver lacks lookahead-aware logic and must rely on a coarser time-based
+/// heuristic. See PR #21648 for the Go counterpart.
+const HAND_OVER_WINDOW_SLOTS: u64 = 8;
+
+/// L1 slot duration in seconds (Ethereum mainnet).
+const SECONDS_PER_SLOT: u64 = 12;
+
+/// Duration during which a recently received `build_preconf_block` request
+/// blocks pod shutdown. Computed as `1.5 × HAND_OVER_WINDOW_SLOTS ×
+/// SECONDS_PER_SLOT`, expressed as integer math (`× 3 / 2`) so the result is
+/// `const`-evaluable. Equals 144 s.
+const SHUTDOWN_BLOCK_WINDOW: Duration =
+    Duration::from_secs(HAND_OVER_WINDOW_SLOTS * SECONDS_PER_SLOT * 3 / 2);
+
+/// Pure helper deciding whether the pod is safe to shut down given the time
+/// of the most recent `build_preconf_block` invocation. Returns `true` when
+/// no invocation has been recorded or when the elapsed time meets or exceeds
+/// `SHUTDOWN_BLOCK_WINDOW`.
+fn can_shutdown_for(last_preconf_request: Option<Instant>) -> bool {
+    match last_preconf_request {
+        None => true,
+        Some(at) => at.elapsed() >= SHUTDOWN_BLOCK_WINDOW,
+    }
+}
 
 /// Implements whitelist preconfirmation API business logic.
 pub(crate) struct WhitelistApiService<P>

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -19,6 +19,7 @@ where
         // sync_ready reflects ingress readiness, which already includes the confirmed-sync
         // and scanner-live checks required by the event syncer.
         let sync_ready = self.event_syncer.is_preconf_ingress_ready();
+        let can_shutdown = self.compute_can_shutdown().await;
 
         Ok(WhitelistStatus {
             head_l1_origin_block_id: head_l1_origin.as_ref().map(|o| o.block_id.to::<u64>()),
@@ -27,6 +28,7 @@ where
             sync_ready,
             highest_unsafe_l2_payload_block_id: highest_unsafe,
             end_of_sequencing_block_hash,
+            can_shutdown,
         })
     }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -1,8 +1,12 @@
-use std::io::Write;
+use std::{
+    io::Write,
+    time::{Duration, Instant},
+};
 
 use flate2::{Compression, write::ZlibEncoder};
 
 use crate::{
+    api::service::{SHUTDOWN_BLOCK_WINDOW, can_shutdown_for},
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, decompress_tx_list},
     error::WhitelistPreconfirmationDriverError,
 };
@@ -44,10 +48,6 @@ fn decompress_tx_list_accepts_non_empty_payload_within_limits() {
     let decoded = decompress_tx_list(&compressed).expect("valid payload should decode");
     assert_eq!(decoded, expected);
 }
-
-use std::time::{Duration, Instant};
-
-use crate::api::service::{SHUTDOWN_BLOCK_WINDOW, can_shutdown_for};
 
 #[test]
 fn can_shutdown_returns_true_when_no_request_received() {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -44,3 +44,38 @@ fn decompress_tx_list_accepts_non_empty_payload_within_limits() {
     let decoded = decompress_tx_list(&compressed).expect("valid payload should decode");
     assert_eq!(decoded, expected);
 }
+
+use std::time::{Duration, Instant};
+
+use crate::api::service::{SHUTDOWN_BLOCK_WINDOW, can_shutdown_for};
+
+#[test]
+fn can_shutdown_returns_true_when_no_request_received() {
+    assert!(can_shutdown_for(None));
+}
+
+#[test]
+fn can_shutdown_returns_false_for_request_just_now() {
+    assert!(!can_shutdown_for(Some(Instant::now())));
+}
+
+#[test]
+fn can_shutdown_returns_true_after_full_window_has_elapsed() {
+    let well_past = Instant::now()
+        .checked_sub(SHUTDOWN_BLOCK_WINDOW + Duration::from_secs(1))
+        .expect("test platform must support subtracting from Instant::now");
+    assert!(can_shutdown_for(Some(well_past)));
+}
+
+#[test]
+fn can_shutdown_returns_false_just_before_window_boundary() {
+    let almost = Instant::now()
+        .checked_sub(SHUTDOWN_BLOCK_WINDOW - Duration::from_secs(1))
+        .expect("test platform must support subtracting from Instant::now");
+    assert!(!can_shutdown_for(Some(almost)));
+}
+
+#[test]
+fn shutdown_block_window_is_one_hundred_forty_four_seconds() {
+    assert_eq!(SHUTDOWN_BLOCK_WINDOW, Duration::from_secs(144));
+}

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
@@ -100,6 +100,9 @@ pub struct ApiStatus {
     pub highest_unsafe_l2_payload_block_id: u64,
     /// End-of-sequencing block hash for current epoch (if any).
     pub end_of_sequencing_block_hash: String,
+    /// True when SIGTERM is safe — no `build_preconf_block` request has been
+    /// received within the last shutdown-block window.
+    pub can_shutdown: bool,
 }
 
 /// `/ws` push notification payload.
@@ -188,6 +191,7 @@ mod tests {
         let status = ApiStatus {
             highest_unsafe_l2_payload_block_id: 1,
             end_of_sequencing_block_hash: B256::ZERO.to_string(),
+            can_shutdown: true,
         };
 
         let json =
@@ -199,5 +203,6 @@ mod tests {
                 .expect("missing highest unsafe block id"),
             1
         );
+        assert_eq!(json["canShutdown"].as_bool().expect("missing canShutdown"), true);
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
@@ -129,6 +129,9 @@ pub struct WhitelistStatus {
     /// End-of-sequencing block hash for current epoch.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_of_sequencing_block_hash: Option<String>,
+    /// True when SIGTERM is safe — no `build_preconf_block` request has been
+    /// received within the last `SHUTDOWN_BLOCK_WINDOW`.
+    pub can_shutdown: bool,
 }
 
 #[cfg(test)]
@@ -168,6 +171,7 @@ mod tests {
             sync_ready: true,
             highest_unsafe_l2_payload_block_id: 100,
             end_of_sequencing_block_hash: Some(B256::ZERO.to_string()),
+            can_shutdown: true,
         };
 
         let json = serde_json::to_string(&status).unwrap();
@@ -176,6 +180,7 @@ mod tests {
         assert!(json.contains("syncReady"));
         assert!(json.contains("highestUnsafeL2PayloadBlockId"));
         assert!(json.contains("endOfSequencingBlockHash"));
+        assert!(json.contains("canShutdown"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Mirrors [#21648](https://github.com/taikoxyz/taiko-mono/pull/21648) for the Rust whitelist preconfirmation driver. Adds a `canShutdown` boolean to `GET /status` so that Kubernetes `lifecycle.preStop` hooks can avoid recycling preconfer pods mid-window.

The Rust whitelist driver does not track lookahead operators, so the heuristic is simpler than the Go counterpart: `canShutdown` is `true` iff no `POST /preconfBlocks` request has been received within the last `1.5 × 8 slots × 12 s = 144 s`. A pod that has never received a request reports `true` (uninitialized = safe).

## Changes

- `WhitelistApiService` tracks `last_preconf_request_at: Mutex<Option<Instant>>`, stamped at the top of `build_preconf_block` so that even rejected requests block shutdown.
- `WhitelistStatus` and the REST `ApiStatus` gain `can_shutdown` (serialized as `canShutdown`).
- `/`, `/healthz`, `/status` are now JWT-skipped via a router split (public group + protected group); `/preconfBlocks` and `/ws` remain JWT-protected. Required because busybox `wget` (the k8s probe environment) can't forge HMAC-SHA256 bearer tokens.
- New unit tests: `can_shutdown_for` boundary cases; HTTP tests for the `canShutdown` JSON field, JWT-skip on probe paths, and JWT enforcement on protected paths.

## Test plan

- [x] `just fmt` — clean
- [x] `just clippy` — clean (strict gate, includes `-D missing_docs -D clippy::missing_docs_in_private_items`)
- [x] `cargo test -p whitelist-preconfirmation-driver --lib` — 89 passed, 0 failed
- [ ] Full `just test` (Dockerized e2e) — runs in CI
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)