### PR TITLE
ci(taiko-client-rs): restore rust cache after toolchain setup

### DIFF
--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -56,17 +56,19 @@ jobs:
           cc --version
           echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> "$GITHUB_ENV"
 
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-09-27
           components: clippy, rustfmt
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          workspaces: |
+            packages/taiko-client-rs -> target
 
       - name: Setup just
         uses: extractions/setup-just@v3
@@ -182,17 +184,19 @@ jobs:
           $SUDO chmod +x /usr/local/bin/docker-compose
           docker-compose version
 
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-09-27
           components: clippy, rustfmt
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          workspaces: |
+            packages/taiko-client-rs -> target
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
## Summary

- install the Rust toolchain before `Swatinem/rust-cache@v2` in the `taiko-client-rs` lint and test jobs
- scope both Rust cache steps to `packages/taiko-client-rs -> target`
- keep ARC runner labels, timeouts, and lint/test commands unchanged

## Why

The referenced CI run showed `Swatinem/rust-cache@v2` running before any Rust toolchain was available, so the cache setup logged `Command failed: rustc -vV`. `cargo clippy` then cold-fetched and checked a large Rust dependency graph until the 10-minute lint job was canceled.

Installing the toolchain first gives rust-cache a usable `rustc` for keying and restore, while keeping the change conservative and limited to the existing workflow.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/taiko-client-rs--test.yml"); puts "yaml ok"'`
- `git diff --check origin/main..HEAD -- .github/workflows/taiko-client-rs--test.yml`
- reviewed `origin/main..HEAD`: tracked diff is only `.github/workflows/taiko-client-rs--test.yml`
- spec, quality, and final branch reviews found no issues

## Notes

This PR changes only the workflow file. The existing workflow path filter only matches `packages/taiko-client-rs/**`, so the updated workflow may not self-trigger on this PR unless CI is run through another trigger.
