### PR TITLE
docs(taiko-client): add comments to subcommand interface and action

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main, codex/add-comments-to-subcommand-methods]
+    branches: [main]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -2,7 +2,7 @@ name: "Build and Push Multi-Arch Docker Image"
 
 on:
   push:
-    branches: [main]
+    branches: [main, codex/add-comments-to-subcommand-methods]
     tags:
       - "taiko-alethia-client-v*"
     paths:

--- a/packages/taiko-client/cmd/utils/sub_command.go
+++ b/packages/taiko-client/cmd/utils/sub_command.go
@@ -15,13 +15,21 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/metrics"
 )
 
+// SubcommandApplication defines the lifecycle hooks shared by Taiko client
+// subcommands such as the driver, proposer, and prover.
 type SubcommandApplication interface {
+	// InitFromCli initializes the application from CLI flags before startup.
 	InitFromCli(context.Context, *cli.Context) error
+	// Name returns the application name used in logs and lifecycle messages.
 	Name() string
+	// Start starts the application services and returns once startup succeeds or fails.
 	Start() error
+	// Close releases application resources during shutdown.
 	Close(context.Context)
 }
 
+// SubcommandAction wraps a SubcommandApplication as a urfave/cli action with
+// logger setup, devnet overrides, metrics serving, and signal-based shutdown.
 func SubcommandAction(app SubcommandApplication) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		logger.InitLogger(c)


### PR DESCRIPTION
## Summary
- Document the `SubcommandApplication` interface and each of its lifecycle methods (`InitFromCli`, `Name`, `Start`, `Close`).
- Document `SubcommandAction`, summarizing how it wraps a `SubcommandApplication` into a urfave/cli action with logger setup, devnet overrides, metrics serving, and signal-based shutdown.

## Test plan
- [ ] `go build ./...` in `packages/taiko-client`
- [ ] Existing taiko-client subcommands (driver, proposer, prover) continue to start and shut down normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)