### PR TITLE
fix(taiko-client): delay highestUnsafePayload rollback on L1 reorg

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1213,7 +1213,7 @@ func (s *PreconfBlockAPIServer) handleProposalReorg(ctx context.Context, latestS
 			},
 			header.Time,
 		),
-		PreconfChainReorged: true,
+		PreconfChainReorged: false,
 		LastBlockID:         blockID.ToInt().Uint64(),
 	})
 }

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1213,6 +1213,8 @@ func (s *PreconfBlockAPIServer) handleProposalReorg(ctx context.Context, latestS
 			},
 			header.Time,
 		),
+		// Known proposals do not constitute a real reorg; the inserter will detect
+		// and signal a PreconfChainReorged if the payload actually changes.
 		PreconfChainReorged: false,
 		LastBlockID:         blockID.ToInt().Uint64(),
 	})


### PR DESCRIPTION
We rely on the inserter to determine whether a real `PreconfChainReorged` occurred before rolling back `highestUnsafeL2PayloadBlockID`. Known proposals should not trigger the rollback.
