### PR TITLE
ci(repo): harden DeepSeek review against empty responses

### DIFF
--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -45,26 +45,13 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Get PR number (from comment trigger)
-        if: github.event_name == 'issue_comment'
-        id: pr-from-comment
-        run: |
-          PR_NUMBER=$(gh pr view "${{ github.event.issue.number }}" --json number -q '.number' 2>/dev/null || echo "")
-          if [ -n "$PR_NUMBER" ]; then
-            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          else
-            echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set PR number
+      - name: Resolve PR number
         id: pr
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
-            echo "number=${{ steps.pr-from-comment.outputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run DeepSeek Code Review
@@ -172,7 +159,18 @@ jobs:
               throw new Error(`DeepSeek API error (${response.status}): ${JSON.stringify(data)}`);
             }
 
-            const reviewText = data.choices[0].message.content;
+            const choice = data.choices && data.choices[0];
+            const reviewText = (choice && choice.message && choice.message.content || '').trim();
+            const finishReason = choice && choice.finish_reason;
+
+            if (!reviewText) {
+              const usage = data.usage ? JSON.stringify(data.usage) : 'unknown';
+              core.warning(
+                `DeepSeek returned no review content (finish_reason=${finishReason || 'unknown'}, usage=${usage}). ` +
+                `Skipping comment to avoid posting an empty review.`
+              );
+              return { success: false, reason: 'empty-content', finishReason };
+            }
 
             // Build comment body
             const triggerInfo = context.eventName === 'pull_request'


### PR DESCRIPTION
## Summary

Port two improvements from [`taikoxyz/pico`'s `deepseek-review.yml`](https://github.com/taikoxyz/pico/blob/main/.github/workflows/deepseek-review.yml) to the existing `.github/workflows/repo--deepseek-review.yml`:

- **Empty-content guard**: If DeepSeek returns no review text (e.g., when `max_tokens` is consumed entirely by reasoning tokens, or the API returns an unusable choice), the workflow now emits a `core.warning` with `finish_reason` and `usage` and skips posting instead of publishing a blank "🐋 DeepSeek Code Review" comment.
- **Simpler PR-number resolution**: For `issue_comment` events on a PR, `github.event.issue.number` is already the PR number — GitHub uses the same numbering space for issues and PRs. The redundant `gh pr view` shell step has been removed.

The strict security model (block fork PRs entirely, require trusted commenter author_association for `@deepseek` triggers) is intentionally **kept** — it's stricter than pico's gate-on-API-key approach and prevents anonymous fork PRs from burning the `DEEPSEEK_API_KEY` budget.

## Test plan

- [ ] Open a non-draft PR from the base repo and confirm DeepSeek posts a review
- [ ] Force an empty/zero-length DeepSeek response (simulate by tightening `max_tokens`) and confirm the workflow logs a warning and does **not** post a blank comment
- [ ] Comment `@deepseek` on a PR as an OWNER/MEMBER/COLLABORATOR and confirm the review is (re-)posted
- [ ] Confirm fork PRs still do not trigger the workflow


---
_Generated by [Claude Code](https://claude.ai/code/session_018uZEEtEgdjod9ciGQxwFkQ)_