### PR TITLE
fix(relayer): align bridge processing fee estimates

### DIFF
--- a/packages/bridge-ui/__mocks__/$env/static/public.ts
+++ b/packages/bridge-ui/__mocks__/$env/static/public.ts
@@ -9,3 +9,4 @@ export const CONFIGURED_CHAINS = '';
 export const CONFIGURED_CUSTOM_TOKENS = '';
 export const CONFIGURED_RELAYER = '';
 export const PUBLIC_IPFS_GATEWAYS = 'https://ipfs.io/ipfs/';
+export const PUBLIC_FEE_MULTIPLIER = '';

--- a/packages/bridge-ui/src/app.config.ts
+++ b/packages/bridge-ui/src/app.config.ts
@@ -1,6 +1,4 @@
 export const gasLimitConfig = {
-  GAS_RESERVE: 650_000, // based on Bridge.sol
-  ethGasLimit: 100_000,
   erc20NotDeployedGasLimit: 750_000,
   erc20DeployedGasLimit: 500_000,
   erc721NotDeployedGasLimit: 2_400_000,

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/NoneOption.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/NoneOption.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-  import type { Address } from 'viem';
+  import { type Address, parseEther } from 'viem';
 
   import Alert from '$components/Alert/Alert.svelte';
   import FlatAlert from '$components/Alert/FlatAlert.svelte';
-  import { destNetwork, selectedToken } from '$components/Bridge/state';
+  import { destNetwork, enteredAmount, recipientAddress, selectedNFTs, selectedToken } from '$components/Bridge/state';
   import { claimConfig } from '$config';
   import { recommendProcessingFee } from '$libs/fee';
-  import { fetchBalance, type NFT, type Token } from '$libs/token';
+  import { fetchBalance, type NFT, type Token, TokenType } from '$libs/token';
   import { account, connectedSourceChain } from '$stores';
 
   import { getManualClaimHref } from './noneOption';
@@ -19,7 +19,15 @@
   export let headless = false;
   let manualClaimHref: string | null = null;
 
-  async function compute(token: Maybe<Token | NFT>, userAddress?: Address, srcChain?: number, destChain?: number) {
+  async function compute(
+    token: Maybe<Token | NFT>,
+    userAddress?: Address,
+    srcChain?: number,
+    destChain?: number,
+    to?: Address,
+    tokenIds?: number[],
+    amounts?: number[],
+  ) {
     if (!token || !userAddress || !srcChain || !destChain) {
       enoughEth = false;
       return;
@@ -41,11 +49,15 @@
         token,
         destChainId: destChain,
         srcChainId: srcChain,
+        to,
+        tokenIds,
+        amounts,
       });
 
-      if (recommendedAmount <= claimConfig.minimumEthToClaim) {
+      const minimumClaimBalance = parseEther(String(claimConfig.minimumEthToClaim));
+      if (recommendedAmount <= minimumClaimBalance) {
         // should the fee be very small, set it to at least the minimum
-        recommendedAmount = BigInt(claimConfig.minimumEthToClaim);
+        recommendedAmount = minimumClaimBalance;
       }
 
       // Does the user have enough ETH to claim manually on the destination chain?
@@ -60,7 +72,15 @@
     }
   }
 
-  $: compute($selectedToken, $account?.address, $connectedSourceChain?.id, $destNetwork?.id);
+  $: compute(
+    $selectedToken,
+    $account?.address,
+    $connectedSourceChain?.id,
+    $destNetwork?.id,
+    $recipientAddress || $account?.address,
+    $selectedNFTs?.map((nft) => nft.tokenId),
+    $selectedToken?.type === TokenType.ERC1155 ? [Number($enteredAmount)] : undefined,
+  );
   $: manualClaimHref = getManualClaimHref({ selected, enoughEth });
 </script>
 

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/RecommendedFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/RecommendedFee.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
+  import type { Address } from 'viem';
 
-  import { calculatingProcessingFee, destNetwork, selectedToken } from '$components/Bridge/state';
+  import {
+    calculatingProcessingFee,
+    destNetwork,
+    enteredAmount,
+    recipientAddress,
+    selectedNFTs,
+    selectedToken,
+  } from '$components/Bridge/state';
   import { processingFeeComponent } from '$config';
   import { recommendProcessingFee } from '$libs/fee';
-  import type { NFT, Token } from '$libs/token';
+  import { type NFT, type Token, TokenType } from '$libs/token';
+  import { account } from '$stores';
   import { connectedSourceChain } from '$stores/network';
 
   export let amount: bigint;
@@ -12,7 +21,14 @@
 
   let interval: ReturnType<typeof setInterval>;
 
-  async function compute(token: Maybe<Token | NFT>, srcChainId?: number, destChainId?: number) {
+  async function compute(
+    token: Maybe<Token | NFT>,
+    srcChainId?: number,
+    destChainId?: number,
+    to?: Address,
+    tokenIds?: number[],
+    amounts?: number[],
+  ) {
     // Without token nor destination chain we cannot compute this fee
     if (!token || !destChainId) return;
 
@@ -24,6 +40,9 @@
         token,
         destChainId,
         srcChainId,
+        to,
+        tokenIds,
+        amounts,
       });
     } catch (err) {
       console.error(err);
@@ -33,11 +52,25 @@
     }
   }
 
-  $: compute($selectedToken, $connectedSourceChain?.id, $destNetwork?.id);
+  $: compute(
+    $selectedToken,
+    $connectedSourceChain?.id,
+    $destNetwork?.id,
+    $recipientAddress || $account?.address,
+    $selectedNFTs?.map((nft) => nft.tokenId),
+    $selectedToken?.type === TokenType.ERC1155 ? [Number($enteredAmount)] : undefined,
+  );
 
   onMount(() => {
     interval = setInterval(() => {
-      compute($selectedToken, $connectedSourceChain?.id, $destNetwork?.id);
+      compute(
+        $selectedToken,
+        $connectedSourceChain?.id,
+        $destNetwork?.id,
+        $recipientAddress || $account?.address,
+        $selectedNFTs?.map((nft) => nft.tokenId),
+        $selectedToken?.type === TokenType.ERC1155 ? [Number($enteredAmount)] : undefined,
+      );
     }, processingFeeComponent.intervalComputeRecommendedFee);
   });
 

--- a/packages/bridge-ui/src/components/SideNavigation/navigationItems.test.ts
+++ b/packages/bridge-ui/src/components/SideNavigation/navigationItems.test.ts
@@ -1,6 +1,6 @@
 import { sideNavigationTabs } from './navigationItems';
 
-test('includes the relayer tab between bridge and transactions', () => {
+test('includes the manual claim tab between bridge and transactions', () => {
   expect(sideNavigationTabs.map((tab) => tab.href)).toEqual(['/', '/relayer', '/transactions']);
   expect(sideNavigationTabs[1]).toMatchObject({
     href: '/relayer',

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -381,7 +381,7 @@
     "faucet": "Faucet",
     "guide": "Guide",
     "nft": "NFT",
-    "relayer": "Relayer",
+    "relayer": "Manual Claim",
     "swap": "Swap",
     "theme": "Theme",
     "token": "Token",
@@ -444,7 +444,7 @@
   },
   "relayer_component": {
     "address_input_label": "Enter the recipient address",
-    "description": "This component allows you to manually claim any claimable transaction",
+    "description": "Search by recipient address, then claim eligible bridge transactions from any connected wallet with enough ETH.",
     "no_tx_found": "No claimable transactions found",
     "step1": {
       "title": "Step 1: Select the recipient"
@@ -452,7 +452,7 @@
     "step2": {
       "title": "Step 2: Search the transaction you want"
     },
-    "title": "Relayer Component"
+    "title": "Manual Claim"
   },
   "switch_modal": {
     "description": "Your current network is not supported. Please select one of the following chains to proceed:",

--- a/packages/bridge-ui/src/libs/bridge/ERC1155Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC1155Bridge.ts
@@ -2,10 +2,8 @@ import { getPublicClient, simulateContract, writeContract } from '@wagmi/core';
 import { get } from 'svelte/store';
 import { getContract, UserRejectedRequestError } from 'viem';
 
-import { bridgeAbi, erc1155Abi, erc1155VaultAbi } from '$abi';
-import { routingContractsMap } from '$bridgeConfig';
+import { erc1155Abi, erc1155VaultAbi } from '$abi';
 import { destOwnerAddress, gasLimitZero } from '$components/Bridge/state';
-import { gasLimitConfig } from '$config';
 import {
   ApproveError,
   NoApprovalRequiredError,
@@ -20,7 +18,7 @@ import { getLogger } from '$libs/util/logger';
 import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
-import { calculateMessageDataSize } from './calculateMessageDataSize';
+import { estimateMessageGasLimit } from './estimateMessageGasLimit';
 import type { ERC1155BridgeArgs, NFTApproveArgs, NFTBridgeTransferOp, RequireApprovalArgs } from './types';
 
 const log = getLogger('ERC1155Bridge');
@@ -196,28 +194,19 @@ export class ERC1155Bridge extends Bridge {
       address: tokenVaultAddress,
     });
 
-    const { size } = await calculateMessageDataSize({ token: tokenObject, chainId: srcChainId, tokenIds, amounts });
-
-    const client = await getPublicClient(config, { chainId: destChainId });
-    if (!client) throw new Error('Could not get public client');
-
-    const destBridgeAddress = routingContractsMap[destChainId][srcChainId].bridgeAddress;
-    const destBridgeContract = getContract({
-      client,
-      abi: bridgeAbi,
-      address: destBridgeAddress,
-    });
-
-    const minGasLimit = await destBridgeContract.read.getMessageMinGasLimit([BigInt(size)]);
-
     let gasLimit: number;
     if (get(gasLimitZero)) {
       log('Gas limit is set to 0');
       gasLimit = 0;
     } else {
-      gasLimit = !isTokenAlreadyDeployed
-        ? minGasLimit + gasLimitConfig.erc1155NotDeployedGasLimit // Token is not deployed
-        : minGasLimit + gasLimitConfig.erc1155DeployedGasLimit; // Token is deployed
+      gasLimit = await estimateMessageGasLimit({
+        token: tokenObject,
+        srcChainId,
+        destChainId,
+        isTokenAlreadyDeployed,
+        tokenIds,
+        amounts,
+      });
     }
 
     const sendERC1155Args: NFTBridgeTransferOp = {

--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -1,11 +1,9 @@
-import { getPublicClient, readContract, simulateContract, writeContract } from '@wagmi/core';
+import { readContract, simulateContract, writeContract } from '@wagmi/core';
 import { get } from 'svelte/store';
 import { getContract, UserRejectedRequestError } from 'viem';
 
-import { bridgeAbi, erc20Abi, erc20VaultAbi } from '$abi';
-import { routingContractsMap } from '$bridgeConfig';
+import { erc20Abi, erc20VaultAbi } from '$abi';
 import { destOwnerAddress, gasLimitZero } from '$components/Bridge/state';
-import { gasLimitConfig } from '$config';
 import {
   ApproveError,
   BridgePausedError,
@@ -20,7 +18,7 @@ import { getLogger } from '$libs/util/logger';
 import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
-import { calculateMessageDataSize } from './calculateMessageDataSize';
+import { estimateMessageGasLimit } from './estimateMessageGasLimit';
 import type { ApproveArgs, ERC20BridgeArgs, ERC20BridgeTransferOp, RequireAllowanceArgs } from './types';
 
 const log = getLogger('ERC20Bridge');
@@ -47,28 +45,17 @@ export class ERC20Bridge extends Bridge {
       address: tokenVaultAddress,
     });
 
-    const { size } = await calculateMessageDataSize({ token: tokenObject, chainId: srcChainId });
-
-    const client = await getPublicClient(config, { chainId: destChainId });
-    if (!client) throw new Error('Could not get public client');
-
-    const destBridgeAddress = routingContractsMap[destChainId][srcChainId].bridgeAddress;
-    const destBridgeContract = getContract({
-      client,
-      abi: bridgeAbi,
-      address: destBridgeAddress,
-    });
-
-    const minGasLimit = await destBridgeContract.read.getMessageMinGasLimit([BigInt(size)]);
-
     let gasLimit: number;
     if (get(gasLimitZero)) {
       log('Gas limit is set to 0');
       gasLimit = 0;
     } else {
-      gasLimit = !isTokenAlreadyDeployed
-        ? minGasLimit + gasLimitConfig.erc20NotDeployedGasLimit // Token is not deployed
-        : minGasLimit + gasLimitConfig.erc20DeployedGasLimit; // Token is deployed
+      gasLimit = await estimateMessageGasLimit({
+        token: tokenObject,
+        srcChainId,
+        destChainId,
+        isTokenAlreadyDeployed,
+      });
     }
 
     log('Calculated gasLimit for message', gasLimit);

--- a/packages/bridge-ui/src/libs/bridge/ERC721Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC721Bridge.ts
@@ -1,11 +1,9 @@
-import { getPublicClient, getWalletClient, readContract, simulateContract, writeContract } from '@wagmi/core';
+import { getWalletClient, readContract, simulateContract, writeContract } from '@wagmi/core';
 import { get } from 'svelte/store';
 import { getContract, UserRejectedRequestError } from 'viem';
 
-import { bridgeAbi, erc721Abi, erc721VaultAbi } from '$abi';
-import { routingContractsMap } from '$bridgeConfig';
+import { erc721Abi, erc721VaultAbi } from '$abi';
 import { destOwnerAddress, gasLimitZero } from '$components/Bridge/state';
-import { gasLimitConfig } from '$config';
 import {
   ApproveError,
   BridgePausedError,
@@ -22,7 +20,7 @@ import { getLogger } from '$libs/util/logger';
 import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
-import { calculateMessageDataSize } from './calculateMessageDataSize';
+import { estimateMessageGasLimit } from './estimateMessageGasLimit';
 import type { ERC721BridgeArgs, NFTApproveArgs, NFTBridgeTransferOp, RequireApprovalArgs } from './types';
 
 const log = getLogger('ERC721Bridge');
@@ -208,28 +206,18 @@ export class ERC721Bridge extends Bridge {
 
     if (!wallet || !wallet.account) throw new Error('Wallet is not connected');
 
-    const { size } = await calculateMessageDataSize({ token: tokenObject, chainId: srcChainId, tokenIds });
-
-    const client = await getPublicClient(config, { chainId: destChainId });
-    if (!client) throw new Error('Could not get public client');
-
-    const destBridgeAddress = routingContractsMap[destChainId][srcChainId].bridgeAddress;
-    const destBridgeContract = getContract({
-      client,
-      abi: bridgeAbi,
-      address: destBridgeAddress,
-    });
-
-    const minGasLimit = await destBridgeContract.read.getMessageMinGasLimit([BigInt(size)]);
-
     let gasLimit: number;
     if (get(gasLimitZero)) {
       log('Gas limit is set to 0');
       gasLimit = 0;
     } else {
-      gasLimit = !isTokenAlreadyDeployed
-        ? minGasLimit + gasLimitConfig.erc721NotDeployedGasLimit // Token is not deployed
-        : minGasLimit + gasLimitConfig.erc721DeployedGasLimit; // Token is deployed
+      gasLimit = await estimateMessageGasLimit({
+        token: tokenObject,
+        srcChainId,
+        destChainId,
+        isTokenAlreadyDeployed,
+        tokenIds,
+      });
     }
 
     const sendERC721Args: NFTBridgeTransferOp = {

--- a/packages/bridge-ui/src/libs/bridge/ETHBridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ETHBridge.ts
@@ -11,6 +11,7 @@ import { getLogger } from '$libs/util/logger';
 import { config } from '$libs/wagmi';
 
 import { Bridge } from './Bridge';
+import { estimateMessageGasLimit } from './estimateMessageGasLimit';
 import type { ETHBridgeArgs, Message } from './types';
 
 const log = getLogger('bridge:ETHBridge');
@@ -45,9 +46,11 @@ export class ETHBridge extends Bridge {
       log('Gas limit is set to 0');
       gasLimit = 0;
     } else {
-      const minGasLimit = await bridgeContract.read.getMessageMinGasLimit([0n]);
-      log('Min gas limit for message', minGasLimit);
-      gasLimit = minGasLimit + 1;
+      gasLimit = await estimateMessageGasLimit({
+        token: args.tokenObject,
+        srcChainId,
+        destChainId,
+      });
     }
 
     const message: Message = {

--- a/packages/bridge-ui/src/libs/bridge/calculateMessageDataSize.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/calculateMessageDataSize.test.ts
@@ -1,9 +1,18 @@
-import { ETHToken } from '$libs/token';
-import { L1_CHAIN_ID, MOCK_ERC20, MOCK_ERC721, MOCK_ERC1155 } from '$mocks';
+import { type Token, TokenType } from '$libs/token/types';
 
+import { L1_CHAIN_ID } from '../../tests/mocks/chains';
+import { MOCK_ERC20, MOCK_ERC721, MOCK_ERC1155 } from '../../tests/mocks/tokens';
 import { calculateMessageDataSize } from './calculateMessageDataSize';
 
 vi.mock('$customToken');
+
+const ethToken = {
+  name: 'Ether',
+  addresses: { [L1_CHAIN_ID]: '0x0000000000000000000000000000000000000000' },
+  decimals: 18,
+  symbol: 'ETH',
+  type: TokenType.ETH,
+} satisfies Token;
 
 describe('calculateMessageDataSize', () => {
   it('should calculate the message data size for ERC20 correctly', async () => {
@@ -21,7 +30,7 @@ describe('calculateMessageDataSize', () => {
 
   it('should calculate the message data size for ETH correctly', async () => {
     // Given
-    const token = ETHToken;
+    const token = ethToken;
     const chainId = L1_CHAIN_ID;
     const expectedSize = { size: 0 };
 
@@ -46,6 +55,20 @@ describe('calculateMessageDataSize', () => {
 
     // Then
     expect(result).toEqual(expectedSize);
+  });
+
+  it('uses a single placeholder token ID for ERC721 sizing before NFTs are selected', async () => {
+    const token = MOCK_ERC721;
+    const chainId = L1_CHAIN_ID;
+
+    const result = await calculateMessageDataSize({ token, chainId });
+    const explicitSingleNFTResult = await calculateMessageDataSize({
+      token,
+      chainId,
+      tokenIds: [1],
+    });
+
+    expect(result).toEqual(explicitSingleNFTResult);
   });
 
   it('should calculate the message data size for multiple ERC721 correctly', async () => {
@@ -81,5 +104,20 @@ describe('calculateMessageDataSize', () => {
 
     // Then
     expect(result).toEqual(expectedSize);
+  });
+
+  it('uses single placeholder arrays for ERC1155 sizing before NFTs are selected', async () => {
+    const token = MOCK_ERC1155;
+    const chainId = L1_CHAIN_ID;
+
+    const result = await calculateMessageDataSize({ token, chainId });
+    const explicitSingleNFTResult = await calculateMessageDataSize({
+      token,
+      chainId,
+      tokenIds: [1],
+      amounts: [1],
+    });
+
+    expect(result).toEqual(explicitSingleNFTResult);
   });
 });

--- a/packages/bridge-ui/src/libs/bridge/calculateMessageDataSize.ts
+++ b/packages/bridge-ui/src/libs/bridge/calculateMessageDataSize.ts
@@ -1,7 +1,7 @@
 import { encodeAbiParameters, encodeFunctionData, type Hex, zeroAddress } from 'viem';
 
 import { erc20VaultAbi, erc721VaultAbi, erc1155VaultAbi } from '$abi';
-import { type NFT, type Token, TokenType } from '$libs/token';
+import { type NFT, type Token, TokenType } from '$libs/token/types';
 import { getLogger } from '$libs/util/logger';
 
 type CanonicalERC20 = {
@@ -158,7 +158,15 @@ async function encodeData(token: Token | NFT, chainId: number, tokenIds?: number
       },
     ];
 
-    const values = [[cNFT.chainId, cNFT.addr, cNFT.symbol, cNFT.name], zeroAddress, zeroAddress, tokenIds, amounts];
+    const encodedTokenIds = normalizeTokenIds(tokenIds);
+    const encodedAmounts = (amounts?.length ? amounts : encodedTokenIds.map(() => 1)).map(BigInt);
+    const values = [
+      [cNFT.chainId, cNFT.addr, cNFT.symbol, cNFT.name],
+      zeroAddress,
+      zeroAddress,
+      encodedTokenIds,
+      encodedAmounts,
+    ];
 
     const callData = encodeAbiParameters(params, values);
     log('callData', callData);
@@ -204,7 +212,12 @@ async function encodeData(token: Token | NFT, chainId: number, tokenIds?: number
       },
     ];
 
-    const values = [[cNFT.chainId, cNFT.addr, cNFT.symbol, cNFT.name], zeroAddress, zeroAddress, tokenIds?.map(BigInt)];
+    const values = [
+      [cNFT.chainId, cNFT.addr, cNFT.symbol, cNFT.name],
+      zeroAddress,
+      zeroAddress,
+      normalizeTokenIds(tokenIds),
+    ];
 
     const callData = encodeAbiParameters(params, values);
     log('callData', callData);
@@ -220,4 +233,8 @@ async function encodeData(token: Token | NFT, chainId: number, tokenIds?: number
   } else {
     throw new Error('Unsupported token type');
   }
+}
+
+function normalizeTokenIds(tokenIds?: number[]): bigint[] {
+  return (tokenIds?.length ? tokenIds : [0]).map(BigInt);
 }

--- a/packages/bridge-ui/src/libs/bridge/estimateMessageGasLimit.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/estimateMessageGasLimit.test.ts
@@ -1,0 +1,71 @@
+import { getPublicClient } from '@wagmi/core';
+import { getContract } from 'viem';
+
+import { type Token, TokenType } from '$libs/token/types';
+
+import { L1_CHAIN_ID, L2_CHAIN_ID } from '../../tests/mocks/chains';
+import { MOCK_ERC20 } from '../../tests/mocks/tokens';
+import { estimateMessageGasLimit } from './estimateMessageGasLimit';
+
+vi.mock('@wagmi/core');
+vi.mock('$customToken');
+vi.mock('$bridgeConfig');
+vi.mock('$libs/chain', () => ({ chains: [], getConfiguredChainIds: () => [1, 2] }));
+vi.mock('$libs/wagmi', () => ({ config: {} }));
+vi.mock('$libs/wagmi/client', () => ({ config: {} }));
+vi.mock('viem', async () => {
+  const viem = await vi.importActual<typeof import('viem')>('viem');
+  return {
+    ...viem,
+    getContract: vi.fn(),
+  };
+});
+
+const mockContract = {
+  read: {
+    getMessageMinGasLimit: vi.fn(),
+  },
+};
+
+const ethToken = {
+  name: 'Ether',
+  addresses: { [L1_CHAIN_ID]: '0x0000000000000000000000000000000000000000' },
+  decimals: 18,
+  symbol: 'ETH',
+  type: TokenType.ETH,
+} satisfies Token;
+
+describe('estimateMessageGasLimit', () => {
+  beforeEach(() => {
+    vi.mocked(getPublicClient).mockReturnValue({} as ReturnType<typeof getPublicClient>);
+    vi.mocked(getContract).mockReturnValue(mockContract as unknown as ReturnType<typeof getContract>);
+    mockContract.read.getMessageMinGasLimit.mockReset();
+  });
+
+  it('uses the destination bridge minimum for ETH messages', async () => {
+    mockContract.read.getMessageMinGasLimit.mockResolvedValue(806_656);
+
+    const gasLimit = await estimateMessageGasLimit({
+      token: ethToken,
+      srcChainId: L1_CHAIN_ID,
+      destChainId: L2_CHAIN_ID,
+    });
+
+    expect(mockContract.read.getMessageMinGasLimit).toHaveBeenCalledWith([0n]);
+    expect(gasLimit).toBe(806_657);
+  });
+
+  it('uses the same deployed ERC20 message gas limit as the bridge transaction', async () => {
+    mockContract.read.getMessageMinGasLimit.mockResolvedValue(815_360);
+
+    const gasLimit = await estimateMessageGasLimit({
+      token: MOCK_ERC20,
+      srcChainId: L1_CHAIN_ID,
+      destChainId: L2_CHAIN_ID,
+      isTokenAlreadyDeployed: true,
+    });
+
+    expect(mockContract.read.getMessageMinGasLimit).toHaveBeenCalledWith([516n]);
+    expect(gasLimit).toBe(1_315_360);
+  });
+});

--- a/packages/bridge-ui/src/libs/bridge/estimateMessageGasLimit.ts
+++ b/packages/bridge-ui/src/libs/bridge/estimateMessageGasLimit.ts
@@ -1,0 +1,75 @@
+import { getPublicClient } from '@wagmi/core';
+import { getContract } from 'viem';
+
+import { bridgeAbi } from '$abi';
+import { routingContractsMap } from '$bridgeConfig';
+import { gasLimitConfig } from '$config';
+import { type NFT, type Token, TokenType } from '$libs/token/types';
+import { config } from '$libs/wagmi';
+
+import { calculateMessageDataSize } from './calculateMessageDataSize';
+
+type EstimateMessageGasLimitArgs = {
+  token: Token | NFT;
+  srcChainId: number;
+  destChainId: number;
+  isTokenAlreadyDeployed?: boolean;
+  tokenIds?: number[];
+  amounts?: number[];
+};
+
+export async function estimateMessageGasLimit({
+  token,
+  srcChainId,
+  destChainId,
+  isTokenAlreadyDeployed = false,
+  tokenIds,
+  amounts,
+}: EstimateMessageGasLimitArgs): Promise<number> {
+  const { size } = await calculateMessageDataSize({ token, chainId: srcChainId, tokenIds, amounts });
+  const minGasLimit = await getDestinationMessageMinGasLimit({ srcChainId, destChainId, dataSize: size });
+
+  switch (token.type) {
+    case TokenType.ETH:
+      return minGasLimit + 1;
+    case TokenType.ERC20:
+      return (
+        minGasLimit +
+        (isTokenAlreadyDeployed ? gasLimitConfig.erc20DeployedGasLimit : gasLimitConfig.erc20NotDeployedGasLimit)
+      );
+    case TokenType.ERC721:
+      return (
+        minGasLimit +
+        (isTokenAlreadyDeployed ? gasLimitConfig.erc721DeployedGasLimit : gasLimitConfig.erc721NotDeployedGasLimit)
+      );
+    case TokenType.ERC1155:
+      return (
+        minGasLimit +
+        (isTokenAlreadyDeployed ? gasLimitConfig.erc1155DeployedGasLimit : gasLimitConfig.erc1155NotDeployedGasLimit)
+      );
+    default:
+      throw new Error(`Unsupported token type: ${token.type}`);
+  }
+}
+
+async function getDestinationMessageMinGasLimit({
+  srcChainId,
+  destChainId,
+  dataSize,
+}: {
+  srcChainId: number;
+  destChainId: number;
+  dataSize: number;
+}): Promise<number> {
+  const client = getPublicClient(config, { chainId: destChainId });
+  if (!client) throw new Error('Could not get public client');
+
+  const destBridgeAddress = routingContractsMap[destChainId][srcChainId].bridgeAddress;
+  const destBridgeContract = getContract({
+    client,
+    abi: bridgeAbi,
+    address: destBridgeAddress,
+  });
+
+  return Number(await destBridgeContract.read.getMessageMinGasLimit([BigInt(dataSize)]));
+}

--- a/packages/bridge-ui/src/libs/fee/recommendProcessingFee.ts
+++ b/packages/bridge-ui/src/libs/fee/recommendProcessingFee.ts
@@ -1,11 +1,11 @@
 import { getPublicClient } from '@wagmi/core';
-import { formatGwei, parseGwei } from 'viem';
+import { type Address, formatGwei, parseGwei } from 'viem';
 
-import { gasLimitConfig } from '$config';
 import { PUBLIC_FEE_MULTIPLIER } from '$env/static/public';
+import { estimateMessageGasLimit } from '$libs/bridge/estimateMessageGasLimit';
 import { NoCanonicalInfoFoundError } from '$libs/error';
-import { type NFT, type Token, TokenType } from '$libs/token';
 import { getTokenAddresses } from '$libs/token/getTokenAddresses';
+import { type NFT, type Token, TokenType } from '$libs/token/types';
 import { getBaseFee } from '$libs/util/getBaseFee';
 import { getLogger } from '$libs/util/logger';
 import { config } from '$libs/wagmi';
@@ -16,18 +16,22 @@ type RecommendProcessingFeeArgs = {
   token: Token | NFT;
   destChainId: number;
   srcChainId?: number;
+  to?: Address;
+  tokenIds?: number[];
+  amounts?: number[];
 };
 
 export async function recommendProcessingFee({
   token,
   destChainId,
   srcChainId,
+  to,
+  tokenIds,
+  amounts,
 }: RecommendProcessingFeeArgs): Promise<bigint> {
   if (!srcChainId) {
     return 0n;
   }
-
-  let estimatedMsgGaslimit;
 
   const baseFee = await getBaseFee(BigInt(destChainId));
 
@@ -35,25 +39,22 @@ export async function recommendProcessingFee({
 
   if (!destPublicClient) throw new Error('Could not get public client');
 
-  const maxPriorityFee = await destPublicClient.estimateMaxPriorityFeePerGas();
+  let maxPriorityFee = await destPublicClient.estimateMaxPriorityFeePerGas();
   log(`maxPriorityFee: ${formatGwei(maxPriorityFee)} gwei`);
 
-  let gasPrice = await destPublicClient.getGasPrice();
-  log(`gasPrice: ${formatGwei(gasPrice)} gwei`);
-
-  if (gasPrice < parseGwei('0.01')) {
-    log(`gasPrice is less than 0.01 gwei, setting gasPrice to 0.01 gwei`);
-    gasPrice = parseGwei('0.01');
+  if (maxPriorityFee < parseGwei('0.01')) {
+    log(`maxPriorityFee is less than 0.01 gwei, setting maxPriorityFee to 0.01 gwei`);
+    maxPriorityFee = parseGwei('0.01');
   }
 
   if (!baseFee) throw new Error('Unable to get base fee');
   log(`baseFee: ${formatGwei(baseFee)} gwei`);
 
+  let isTokenAlreadyDeployed = false;
+
   if (token.type !== TokenType.ETH) {
     const tokenInfo = await getTokenAddresses({ token, srcChainId, destChainId });
     if (!tokenInfo) throw new NoCanonicalInfoFoundError();
-
-    let isTokenAlreadyDeployed = false;
 
     if (tokenInfo.bridged) {
       const { address } = tokenInfo.bridged;
@@ -61,40 +62,28 @@ export async function recommendProcessingFee({
         isTokenAlreadyDeployed = true;
       }
     }
-    if (token.type === TokenType.ERC20) {
-      if (isTokenAlreadyDeployed) {
-        log(`token ${token.symbol} is already deployed on chain ${destChainId}`);
 
-        estimatedMsgGaslimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc20DeployedGasLimit;
-      } else {
-        log(`token ${token.symbol} is not deployed on chain ${destChainId}`);
-        estimatedMsgGaslimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc20NotDeployedGasLimit;
-      }
-    } else if (token.type === TokenType.ERC721) {
-      if (isTokenAlreadyDeployed) {
-        log(`token ${token.symbol} is already deployed on chain ${destChainId}`);
-        estimatedMsgGaslimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc721DeployedGasLimit;
-      } else {
-        log(`token ${token.symbol} is not deployed on chain ${destChainId}`);
-        estimatedMsgGaslimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc721NotDeployedGasLimit;
-      }
-    } else if (token.type === TokenType.ERC1155) {
-      if (isTokenAlreadyDeployed) {
-        log(`token ${token.symbol} is already deployed on chain ${destChainId}`);
-        estimatedMsgGaslimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc1155DeployedGasLimit;
-      } else {
-        log(`token ${token.symbol} is not deployed on chain ${destChainId}`);
-        estimatedMsgGaslimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc1155NotDeployedGasLimit;
-      }
-    }
-  } else {
-    log(`Fee for ETH bridging`);
-    estimatedMsgGaslimit = gasLimitConfig.GAS_RESERVE;
+    log(`token ${token.symbol} is ${isTokenAlreadyDeployed ? 'already' : 'not'} deployed on chain ${destChainId}`);
   }
-  if (!estimatedMsgGaslimit) throw new Error('Unable to calculate fee');
+
+  const messageGasLimit = await estimateMessageGasLimit({
+    token,
+    srcChainId,
+    destChainId,
+    isTokenAlreadyDeployed,
+    tokenIds,
+    amounts,
+  });
+
+  const relayerGasLimit = await getRelayerGasLimit({
+    token,
+    to,
+    destChainId,
+    messageGasLimit: BigInt(messageGasLimit),
+  });
 
   // Initial fee multiplicator and add fallback
-  const feeMultiplicator: number = parseInt(PUBLIC_FEE_MULTIPLIER) || 1;
+  const feeMultiplier = PUBLIC_FEE_MULTIPLIER || '1';
 
   // if (gasPrice <= parseGwei('0.05')) {
   //   feeMultiplicator = 4;
@@ -109,8 +98,81 @@ export async function recommendProcessingFee({
   //   log(`gasPrice ${formatGwei(gasPrice)} is more than 0.1 gwei, setting feeMultiplicator to 2`);
   // }
 
-  const fee = estimatedMsgGaslimit * Number(gasPrice) * feeMultiplicator;
-  return BigInt(fee);
+  return calculateProcessingFee({
+    relayerGasLimit,
+    baseFee,
+    maxPriorityFeePerGas: maxPriorityFee,
+    feeMultiplier,
+  });
+}
+
+export function calculateProcessingFee({
+  relayerGasLimit,
+  baseFee,
+  maxPriorityFeePerGas,
+  feeMultiplier,
+}: {
+  relayerGasLimit: bigint;
+  baseFee: bigint;
+  maxPriorityFeePerGas: bigint;
+  feeMultiplier: number | string;
+}): bigint {
+  const cost = relayerGasLimit * (baseFee * 2n + maxPriorityFeePerGas);
+  return applyFeeMultiplier(cost, feeMultiplier);
+}
+
+export function applyRelayerGasLimitPadding(messageGasLimit: bigint, isContractRecipient: boolean): bigint {
+  const multiplier = isContractRecipient ? 110n : 105n;
+  return (messageGasLimit * multiplier + 99n) / 100n;
+}
+
+async function getRelayerGasLimit({
+  token,
+  to,
+  destChainId,
+  messageGasLimit,
+}: {
+  token: Token | NFT;
+  to?: Address;
+  destChainId: number;
+  messageGasLimit: bigint;
+}): Promise<bigint> {
+  if (token.type !== TokenType.ETH || !to) {
+    return applyRelayerGasLimitPadding(messageGasLimit, true);
+  }
+
+  try {
+    const destPublicClient = getPublicClient(config, { chainId: destChainId });
+    if (!destPublicClient) throw new Error('Could not get public client');
+
+    const code = await destPublicClient.getBytecode({ address: to });
+    return applyRelayerGasLimitPadding(messageGasLimit, Boolean(code && code !== '0x'));
+  } catch (err) {
+    log('Unable to detect recipient bytecode, using contract recipient gas padding', err);
+    return applyRelayerGasLimitPadding(messageGasLimit, true);
+  }
+}
+
+function applyFeeMultiplier(value: bigint, feeMultiplier: number | string): bigint {
+  const { numerator, denominator } = parseFeeMultiplier(feeMultiplier);
+  return (value * numerator + denominator - 1n) / denominator;
+}
+
+function parseFeeMultiplier(feeMultiplier: number | string): { numerator: bigint; denominator: bigint } {
+  const rawMultiplier = String(feeMultiplier).trim();
+  if (!/^\d+(\.\d+)?$/.test(rawMultiplier)) {
+    return { numerator: 1n, denominator: 1n };
+  }
+
+  const [whole, decimal = ''] = rawMultiplier.split('.');
+  const denominator = 10n ** BigInt(decimal.length);
+  const numerator = BigInt(`${whole}${decimal}`);
+
+  if (numerator < denominator) {
+    return { numerator: 1n, denominator: 1n };
+  }
+
+  return { numerator, denominator };
 }
 
 // function roundWeiTo6DecimalPlaces(wei: bigint): bigint {

--- a/packages/bridge-ui/src/libs/fee/recommendedProcessingFee.test.ts
+++ b/packages/bridge-ui/src/libs/fee/recommendedProcessingFee.test.ts
@@ -1,16 +1,20 @@
 import { getPublicClient } from '@wagmi/core';
-import { parseGwei } from 'viem';
 
-import { gasLimitConfig } from '$config';
-import { ETHToken } from '$libs/token';
+import { estimateMessageGasLimit } from '$libs/bridge/estimateMessageGasLimit';
 import { getTokenAddresses } from '$libs/token/getTokenAddresses';
-import { L1_CHAIN_ID, L2_CHAIN_ID, MOCK_ERC20, MOCK_ERC721, MOCK_ERC1155 } from '$mocks';
+import { type Token, TokenType } from '$libs/token/types';
 
-import { recommendProcessingFee } from './recommendProcessingFee';
+import { L1_CHAIN_ID, L2_CHAIN_ID } from '../../tests/mocks/chains';
+import { MOCK_ERC20, MOCK_ERC721, MOCK_ERC1155 } from '../../tests/mocks/tokens';
+import { applyRelayerGasLimitPadding, calculateProcessingFee, recommendProcessingFee } from './recommendProcessingFee';
 
 vi.mock('@wagmi/core');
+vi.mock('$libs/bridge/estimateMessageGasLimit');
 vi.mock('$customToken');
 vi.mock('$bridgeConfig');
+vi.mock('$libs/chain', () => ({ chains: [], getConfiguredChainIds: () => [1, 2] }));
+vi.mock('$libs/wagmi', () => ({ config: {} }));
+vi.mock('$libs/wagmi/client', () => ({ config: {} }));
 vi.mock('$libs/token/getTokenAddresses');
 
 const mockClient = {
@@ -20,6 +24,14 @@ const mockClient = {
   getGasPrice: vi.fn(),
 };
 
+const ethToken = {
+  name: 'Ether',
+  addresses: { [L1_CHAIN_ID]: '0x0000000000000000000000000000000000000000' },
+  decimals: 18,
+  symbol: 'ETH',
+  type: TokenType.ETH,
+} satisfies Token;
+
 describe('recommendedProcessingFee', () => {
   beforeAll(() => {
     vi.mocked(getPublicClient).mockReturnValue(mockClient);
@@ -27,21 +39,31 @@ describe('recommendedProcessingFee', () => {
     vi.mocked(mockClient.estimateMaxPriorityFeePerGas).mockReturnValue(42n);
   });
 
+  beforeEach(() => {
+    vi.mocked(estimateMessageGasLimit).mockReset();
+  });
+
   describe('ETH fees', () => {
-    it('should calculate the recommended processing fee for ETH when gasPrice is a normal value (0.15 gwei)', async () => {
+    it('should calculate the recommended processing fee for ETH', async () => {
       // Given
-      const token = ETHToken;
+      const token = ethToken;
       const srcChainId = L1_CHAIN_ID;
       const destChainId = L2_CHAIN_ID;
 
-      const gasLimit = gasLimitConfig.GAS_RESERVE;
+      const gasLimit = 806_657;
 
-      const reportedGasPrice = parseGwei('0.15');
+      const baseFee = 11n;
+      const maxPriorityFee = 10_000_000n;
       const feeMultiplicator = 1;
 
-      const expectedFee = gasLimit * Number(reportedGasPrice) * feeMultiplicator;
+      const expectedFee = calculateProcessingFee({
+        relayerGasLimit: applyRelayerGasLimitPadding(BigInt(gasLimit), true),
+        baseFee,
+        maxPriorityFeePerGas: maxPriorityFee,
+        feeMultiplier: feeMultiplicator,
+      });
 
-      vi.mocked(mockClient.getGasPrice).mockReturnValue(reportedGasPrice);
+      vi.mocked(estimateMessageGasLimit).mockResolvedValue(gasLimit);
 
       // When
       const result = await recommendProcessingFee({ token, destChainId, srcChainId });
@@ -58,14 +80,20 @@ describe('recommendedProcessingFee', () => {
       const srcChainId = L1_CHAIN_ID;
       const destChainId = L2_CHAIN_ID;
 
-      const gasLimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc20DeployedGasLimit;
+      const gasLimit = 1_315_360;
 
-      const reportedGasPrice = parseGwei('0.15');
+      const baseFee = 11n;
+      const maxPriorityFee = 10_000_000n;
       const feeMultiplicator = 1;
 
-      const expectedFee = gasLimit * Number(reportedGasPrice) * feeMultiplicator;
+      const expectedFee = calculateProcessingFee({
+        relayerGasLimit: applyRelayerGasLimitPadding(BigInt(gasLimit), true),
+        baseFee,
+        maxPriorityFeePerGas: maxPriorityFee,
+        feeMultiplier: feeMultiplicator,
+      });
 
-      vi.mocked(mockClient.getGasPrice).mockReturnValue(reportedGasPrice);
+      vi.mocked(estimateMessageGasLimit).mockResolvedValue(gasLimit);
       vi.mocked(getTokenAddresses).mockResolvedValue({
         bridged: {
           chainId: L1_CHAIN_ID,
@@ -92,14 +120,20 @@ describe('recommendedProcessingFee', () => {
       const srcChainId = L1_CHAIN_ID;
       const destChainId = L2_CHAIN_ID;
 
-      const gasLimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc721DeployedGasLimit;
+      const gasLimit = 1_915_872;
 
-      const reportedGasPrice = parseGwei('0.12');
+      const baseFee = 11n;
+      const maxPriorityFee = 10_000_000n;
       const feeMultiplicator = 1;
 
-      const expectedFee = gasLimit * Number(reportedGasPrice) * feeMultiplicator;
+      const expectedFee = calculateProcessingFee({
+        relayerGasLimit: applyRelayerGasLimitPadding(BigInt(gasLimit), true),
+        baseFee,
+        maxPriorityFeePerGas: maxPriorityFee,
+        feeMultiplier: feeMultiplicator,
+      });
 
-      vi.mocked(mockClient.getGasPrice).mockReturnValue(reportedGasPrice);
+      vi.mocked(estimateMessageGasLimit).mockResolvedValue(gasLimit);
       vi.mocked(getTokenAddresses).mockResolvedValue({
         bridged: {
           chainId: L1_CHAIN_ID,
@@ -126,14 +160,20 @@ describe('recommendedProcessingFee', () => {
       const srcChainId = L1_CHAIN_ID;
       const destChainId = L2_CHAIN_ID;
 
-      const gasLimit = gasLimitConfig.GAS_RESERVE + gasLimitConfig.erc1155DeployedGasLimit;
+      const gasLimit = 1_919_456;
 
-      const reportedGasPrice = parseGwei('0.12');
+      const baseFee = 11n;
+      const maxPriorityFee = 10_000_000n;
       const feeMultiplicator = 1;
 
-      const expectedFee = gasLimit * Number(reportedGasPrice) * feeMultiplicator;
+      const expectedFee = calculateProcessingFee({
+        relayerGasLimit: applyRelayerGasLimitPadding(BigInt(gasLimit), true),
+        baseFee,
+        maxPriorityFeePerGas: maxPriorityFee,
+        feeMultiplier: feeMultiplicator,
+      });
 
-      vi.mocked(mockClient.getGasPrice).mockReturnValue(reportedGasPrice);
+      vi.mocked(estimateMessageGasLimit).mockResolvedValue(gasLimit);
       vi.mocked(getTokenAddresses).mockResolvedValue({
         bridged: {
           chainId: L1_CHAIN_ID,
@@ -150,6 +190,38 @@ describe('recommendedProcessingFee', () => {
 
       // Then
       expect(result).toBe(BigInt(expectedFee));
+    });
+  });
+
+  describe('reported failing transaction simulation', () => {
+    it('ceil-rounds decimal fee multipliers', () => {
+      const recommendedFee = calculateProcessingFee({
+        relayerGasLimit: 1n,
+        baseFee: 1n,
+        maxPriorityFeePerGas: 0n,
+        feeMultiplier: '1.1',
+      });
+
+      expect(recommendedFee).toBe(3n);
+    });
+
+    it('prices the reported ERC20 deployed message above the old underpriced fee', () => {
+      const reportedMessageGasLimit = 1_315_360n;
+      const reportedProcessingFee = 34_500_000_000_000n;
+      const destChainBaseFee = 8_756_091n;
+      const gasTipCap = 38_434_172n;
+
+      const relayerGasLimit = applyRelayerGasLimitPadding(reportedMessageGasLimit, true);
+      const recommendedFee = calculateProcessingFee({
+        relayerGasLimit,
+        baseFee: destChainBaseFee,
+        maxPriorityFeePerGas: gasTipCap,
+        feeMultiplier: 1,
+      });
+
+      expect(relayerGasLimit).toBe(1_446_896n);
+      expect(recommendedFee).toBe(80_948_555_817_184n);
+      expect(recommendedFee).toBeGreaterThan(reportedProcessingFee);
     });
   });
 });

--- a/packages/bridge-ui/src/routes/relayer/+page.svelte
+++ b/packages/bridge-ui/src/routes/relayer/+page.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <svelte:head>
-  <title>Taiko Bridge | Relayer</title>
+  <title>Taiko Bridge | Manual Claim</title>
 </svelte:head>
 <Page>
   <Relayer />

--- a/packages/relayer/api/api.go
+++ b/packages/relayer/api/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/labstack/echo/v4"
-	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/taikol2"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/http"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils"
@@ -60,18 +59,12 @@ func InitFromConfig(ctx context.Context, api *API, cfg *Config) (err error) {
 		return err
 	}
 
-	taikoL2, err := taikol2.NewTaikoL2(cfg.DestTaikoAddress, destEthClient)
-	if err != nil {
-		return err
-	}
-
 	srv, err := http.NewServer(http.NewServerOpts{
 		EventRepo:               eventRepository,
 		Echo:                    echo.New(),
 		CorsOrigins:             cfg.CORSOrigins,
 		SrcEthClient:            srcEthClient,
 		DestEthClient:           destEthClient,
-		TaikoL2:                 taikoL2,
 		ProcessingFeeMultiplier: cfg.ProcessingFeeMultiplier,
 	})
 	if err != nil {

--- a/packages/relayer/base_fee_errors.go
+++ b/packages/relayer/base_fee_errors.go
@@ -1,0 +1,5 @@
+package relayer
+
+import "errors"
+
+var ErrMissingDestBaseFee = errors.New("destination block missing base fee")

--- a/packages/relayer/fees.go
+++ b/packages/relayer/fees.go
@@ -1,0 +1,11 @@
+package relayer
+
+// PaddedMessageGasLimit returns the relayer gas limit after applying recipient padding.
+func PaddedMessageGasLimit(messageGasLimit uint64, isContractRecipient bool) uint64 {
+	multiplier := uint64(105)
+	if isContractRecipient {
+		multiplier = 110
+	}
+
+	return (messageGasLimit*multiplier + 99) / 100
+}

--- a/packages/relayer/fees_test.go
+++ b/packages/relayer/fees_test.go
@@ -1,0 +1,12 @@
+package relayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPaddedMessageGasLimit(t *testing.T) {
+	assert.Equal(t, uint64(846990), PaddedMessageGasLimit(806657, false))
+	assert.Equal(t, uint64(1446896), PaddedMessageGasLimit(1315360, true))
+}

--- a/packages/relayer/pkg/http/errors.go
+++ b/packages/relayer/pkg/http/errors.go
@@ -11,8 +11,4 @@ var (
 		"ERR_NO_REWARDER",
 		"Rewarder is required",
 	)
-	ErrNoTaikoL2 = errors.Validation.NewWithKeyAndDetail(
-		"ERR_NO_TAIKO_L2",
-		"TaikoL2 is required",
-	)
 )

--- a/packages/relayer/pkg/http/get_recommended_processing_fees.go
+++ b/packages/relayer/pkg/http/get_recommended_processing_fees.go
@@ -2,15 +2,16 @@ package http
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"net/http"
 	"strconv"
 
 	"github.com/cyberhorsey/webutils"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/labstack/echo/v4"
+	"github.com/taikoxyz/taiko-mono/packages/relayer"
 )
 
 type getRecommendedProcessingFeesResponse struct {
@@ -28,13 +29,13 @@ type FeeType uint64
 
 // gas limits
 var (
-	Eth                FeeType = 900000
-	ERC20NotDeployed   FeeType = 1650000
-	ERC20Deployed      FeeType = 1000000
-	ERC721NotDeployed  FeeType = 2500000
-	ERC721Deployed     FeeType = 1500000
-	ERC1155NotDeployed FeeType = 2650000
-	ERC1155Deployed    FeeType = 1850000
+	Eth                FeeType = FeeType(messageMinGasLimit(0) + 1)
+	ERC20NotDeployed   FeeType = FeeType(messageMinGasLimit(516) + 750_000)
+	ERC20Deployed      FeeType = FeeType(messageMinGasLimit(516) + 500_000)
+	ERC721NotDeployed  FeeType = FeeType(messageMinGasLimit(548) + 2_400_000)
+	ERC721Deployed     FeeType = FeeType(messageMinGasLimit(548) + 1_100_000)
+	ERC1155NotDeployed FeeType = FeeType(messageMinGasLimit(772) + 2_600_000)
+	ERC1155Deployed    FeeType = FeeType(messageMinGasLimit(772) + 1_100_000)
 )
 
 var (
@@ -113,16 +114,18 @@ func (srv *Server) GetRecommendedProcessingFees(c echo.Context) error {
 	}
 
 	for _, f := range feeTypes {
+		paddedGasLimit := relayer.PaddedMessageGasLimit(uint64(f), true)
+
 		fees = append(fees, fee{
 			Type:        f.String(),
-			Amount:      srv.getCost(uint64(f), destGasTipCap, destBaseFee, Layer2).String(),
+			Amount:      srv.getCost(paddedGasLimit, destGasTipCap, destBaseFee, Layer2).String(),
 			DestChainID: destChainID.Uint64(),
 			GasLimit:    strconv.Itoa(int(f)),
 		})
 
 		fees = append(fees, fee{
 			Type:        f.String(),
-			Amount:      srv.getCost(uint64(f), srcGasTipCap, srcBaseFee, Layer1).String(),
+			Amount:      srv.getCost(paddedGasLimit, srcGasTipCap, srcBaseFee, Layer1).String(),
 			DestChainID: srcChainID.Uint64(),
 			GasLimit:    strconv.Itoa(int(f)),
 		})
@@ -149,41 +152,58 @@ func (srv *Server) getCost(
 		return cost
 	}
 
-	costRat := new(big.Rat).SetInt(cost)
-
-	multiplierRat := new(big.Rat).SetFloat64(srv.processingFeeMultiplier)
-
-	costRat.Mul(costRat, multiplierRat)
-
-	costAfterMultiplier := new(big.Int).Div(costRat.Num(), costRat.Denom())
-
-	return costAfterMultiplier
+	return mulRatCeil(cost, srv.processingFeeMultiplier)
 }
 
 func (srv *Server) getDestChainBaseFee(ctx context.Context, destLayer layer, chainID *big.Int) (*big.Int, error) {
-	blk, err := srv.srcEthClient.BlockByNumber(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var baseFee *big.Int
-
 	if destLayer == Layer2 {
 		latestL2Block, err := srv.destEthClient.BlockByNumber(ctx, nil)
 		if err != nil {
 			return nil, err
 		}
 
-		bf, err := srv.taikoL2.GetBasefee(&bind.CallOpts{Context: ctx}, blk.NumberU64(), uint32(latestL2Block.GasUsed()))
-		if err != nil {
-			return nil, err
+		if latestL2Block.BaseFee() != nil {
+			return latestL2Block.BaseFee(), nil
 		}
 
-		baseFee = bf.Basefee
-	} else {
-		cfg := params.NetworkIDToChainConfigOrDefault(chainID)
-		baseFee = eip1559.CalcBaseFee(cfg, blk.Header())
+		return nil, relayer.ErrMissingDestBaseFee
 	}
 
-	return baseFee, nil
+	blk, err := srv.srcEthClient.BlockByNumber(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := params.NetworkIDToChainConfigOrDefault(chainID)
+
+	return eip1559.CalcBaseFee(cfg, blk.Header()), nil
+}
+
+func messageMinGasLimit(dataLength uint64) uint64 {
+	return (((dataLength+31)/32)*32+416)*16 + 800_000
+}
+
+func mulRatCeil(value *big.Int, multiplier float64) *big.Int {
+	valueRat := new(big.Rat).SetInt(value)
+	multiplierRat := parseMultiplier(multiplier)
+	valueRat.Mul(valueRat, multiplierRat)
+
+	quotient, remainder := new(big.Int).QuoRem(valueRat.Num(), valueRat.Denom(), new(big.Int))
+	if remainder.Sign() > 0 {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+
+	return quotient
+}
+
+func parseMultiplier(multiplier float64) *big.Rat {
+	if multiplier < 1 || math.IsNaN(multiplier) || math.IsInf(multiplier, 0) {
+		return big.NewRat(1, 1)
+	}
+
+	if rat, ok := new(big.Rat).SetString(strconv.FormatFloat(multiplier, 'f', -1, 64)); ok {
+		return rat
+	}
+
+	return big.NewRat(1, 1)
 }

--- a/packages/relayer/pkg/http/get_recommended_processing_fees_test.go
+++ b/packages/relayer/pkg/http/get_recommended_processing_fees_test.go
@@ -1,18 +1,22 @@
 package http
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/taikoxyz/taiko-mono/packages/relayer"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 )
 
 func TestGetCost_LayerBehaviour(t *testing.T) {
-	srv := &Server{processingFeeMultiplier: 2.5}
+	srv := &Server{processingFeeMultiplier: 1.1}
 
-	gasLimit := uint64(10)
-	gasTipCap := big.NewInt(1)
-	baseFee := big.NewInt(2)
+	gasLimit := uint64(1)
+	gasTipCap := big.NewInt(0)
+	baseFee := big.NewInt(1)
 
 	// Calculate base cost used by both branches: gasLimit * (gasTipCap + baseFee*2).
 	baseCost := new(big.Int).Mul(
@@ -26,11 +30,91 @@ func TestGetCost_LayerBehaviour(t *testing.T) {
 	// For Layer2 we expect raw base cost without processingFeeMultiplier.
 	assert.Equal(t, baseCost, gotLayer2)
 
-	// For Layer1 we expect base cost multiplied by processingFeeMultiplier.
-	costRat := new(big.Rat).SetInt(baseCost)
-	multiplierRat := new(big.Rat).SetFloat64(srv.processingFeeMultiplier)
-	costRat.Mul(costRat, multiplierRat)
-	expectedLayer1 := new(big.Int).Div(costRat.Num(), costRat.Denom())
+	// For Layer1 we expect base cost multiplied by processingFeeMultiplier, rounded up.
+	assert.Equal(t, big.NewInt(3), gotLayer1)
+}
 
-	assert.Equal(t, expectedLayer1, gotLayer1)
+func TestGetCost_CeilsMultiplier(t *testing.T) {
+	srv := &Server{processingFeeMultiplier: 1.1}
+
+	got := srv.getCost(1, big.NewInt(0), big.NewInt(1), Layer1)
+
+	assert.Equal(t, big.NewInt(3), got)
+}
+
+func TestGetCost_UsesExactDecimalMultiplier(t *testing.T) {
+	srv := &Server{processingFeeMultiplier: 1.1}
+
+	got := srv.getCost(10, big.NewInt(0), big.NewInt(1), Layer1)
+
+	assert.Equal(t, big.NewInt(22), got)
+}
+
+func TestGetCost_ClampsInvalidMultiplier(t *testing.T) {
+	srv := &Server{processingFeeMultiplier: 0.5}
+
+	got := srv.getCost(10, big.NewInt(0), big.NewInt(1), Layer1)
+
+	assert.Equal(t, big.NewInt(20), got)
+}
+
+func TestFeeTypeGasLimits(t *testing.T) {
+	assert.Equal(t, uint64(806657), uint64(Eth))
+	assert.Equal(t, uint64(1315360), uint64(ERC20Deployed))
+	assert.Equal(t, uint64(1565360), uint64(ERC20NotDeployed))
+	assert.Equal(t, uint64(1915872), uint64(ERC721Deployed))
+	assert.Equal(t, uint64(3215872), uint64(ERC721NotDeployed))
+	assert.Equal(t, uint64(1919456), uint64(ERC1155Deployed))
+	assert.Equal(t, uint64(3419456), uint64(ERC1155NotDeployed))
+}
+
+func TestGetDestChainBaseFee_Layer2UsesHeaderBaseFee(t *testing.T) {
+	destClient := &blockByNumberClient{EthClient: &mock.EthClient{}, block: blockWithBaseFee(big.NewInt(123))}
+	srcClient := &blockByNumberClient{EthClient: &mock.EthClient{}, block: blockWithBaseFee(big.NewInt(1))}
+	srv := &Server{
+		srcEthClient:  srcClient,
+		destEthClient: destClient,
+	}
+
+	got, err := srv.getDestChainBaseFee(context.Background(), Layer2, mock.MockChainID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewInt(123), got)
+	assert.Equal(t, 1, destClient.blockByNumberCalls)
+	assert.Equal(t, 0, srcClient.blockByNumberCalls)
+}
+
+func TestGetDestChainBaseFee_Layer2MissingBaseFeeFails(t *testing.T) {
+	destClient := &blockByNumberClient{EthClient: &mock.EthClient{}, block: blockWithBaseFee(nil)}
+	srcClient := &blockByNumberClient{EthClient: &mock.EthClient{}, block: blockWithBaseFee(big.NewInt(1))}
+	srv := &Server{
+		srcEthClient:  srcClient,
+		destEthClient: destClient,
+	}
+
+	got, err := srv.getDestChainBaseFee(context.Background(), Layer2, mock.MockChainID)
+
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, relayer.ErrMissingDestBaseFee)
+	assert.Equal(t, 1, destClient.blockByNumberCalls)
+	assert.Equal(t, 0, srcClient.blockByNumberCalls)
+}
+
+type blockByNumberClient struct {
+	*mock.EthClient
+	block              *types.Block
+	blockByNumberCalls int
+}
+
+func (c *blockByNumberClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	c.blockByNumberCalls++
+
+	return c.block, nil
+}
+
+func blockWithBaseFee(baseFee *big.Int) *types.Block {
+	header := *mock.Header
+	header.BaseFee = baseFee
+
+	return types.NewBlockWithHeader(&header)
 }

--- a/packages/relayer/pkg/http/server.go
+++ b/packages/relayer/pkg/http/server.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
-	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/taikol2"
 
 	echo "github.com/labstack/echo/v4"
 )
@@ -50,7 +49,6 @@ type Server struct {
 	destEthClient           ethClient
 	destChainID             *big.Int
 	processingFeeMultiplier float64
-	taikoL2                 *taikol2.TaikoL2
 }
 
 type NewServerOpts struct {
@@ -60,7 +58,6 @@ type NewServerOpts struct {
 	SrcEthClient            ethClient
 	DestEthClient           ethClient
 	ProcessingFeeMultiplier float64
-	TaikoL2                 *taikol2.TaikoL2
 }
 
 func (opts NewServerOpts) Validate() error {
@@ -82,10 +79,6 @@ func (opts NewServerOpts) Validate() error {
 
 	if opts.DestEthClient == nil {
 		return relayer.ErrNoEthClient
-	}
-
-	if opts.TaikoL2 == nil {
-		return ErrNoTaikoL2
 	}
 
 	return nil
@@ -112,7 +105,6 @@ func NewServer(opts NewServerOpts) (*Server, error) {
 		srcEthClient:            opts.SrcEthClient,
 		destEthClient:           opts.DestEthClient,
 		processingFeeMultiplier: opts.ProcessingFeeMultiplier,
-		taikoL2:                 opts.TaikoL2,
 		srcChainID:              srcChainID,
 		destChainID:             destChainID,
 	}

--- a/packages/relayer/pkg/http/server_test.go
+++ b/packages/relayer/pkg/http/server_test.go
@@ -10,7 +10,6 @@ import (
 	echo "github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
-	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/taikol2"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
 )
@@ -43,7 +42,6 @@ func Test_NewServer(t *testing.T) {
 				CorsOrigins:   make([]string, 0),
 				SrcEthClient:  &mock.EthClient{},
 				DestEthClient: &mock.EthClient{},
-				TaikoL2:       &taikol2.TaikoL2{},
 			},
 			nil,
 		},
@@ -66,17 +64,6 @@ func Test_NewServer(t *testing.T) {
 				SrcEthClient: &mock.EthClient{},
 			},
 			relayer.ErrNoEthClient,
-		},
-		{
-			"noTaikoL2",
-			NewServerOpts{
-				Echo:          echo.New(),
-				EventRepo:     &repo.EventRepository{},
-				CorsOrigins:   make([]string, 0),
-				SrcEthClient:  &mock.EthClient{},
-				DestEthClient: &mock.EthClient{},
-			},
-			ErrNoTaikoL2,
 		},
 		{
 			"noEventRepo",

--- a/packages/relayer/processor/is_profitable.go
+++ b/packages/relayer/processor/is_profitable.go
@@ -35,10 +35,10 @@ func (p *Processor) isProfitable(
 		return shouldProcess, errImpossible
 	}
 
-	// if processing fee is higher than baseFee * 2 +gasTipCap +  gasLimit,
+	// If processing fee covers baseFee * 2 + gasTipCap for the padded gas limit,
 	// we should process.
 	estimatedOnchainFee := ((destChainBaseFee * 2) + gasTipCap) * uint64(gasLimit)
-	if fee > estimatedOnchainFee {
+	if fee >= estimatedOnchainFee {
 		shouldProcess = true
 	}
 

--- a/packages/relayer/processor/is_profitable_test.go
+++ b/packages/relayer/processor/is_profitable_test.go
@@ -42,6 +42,16 @@ func Test_isProfitable(t *testing.T) {
 		},
 		{
 			2,
+			"profitableAtEstimatedCost",
+			1200000000600000,
+			600000,
+			1000000000,
+			1,
+			true,
+			nil,
+		},
+		{
+			3,
 			"unprofitable",
 			590000000600000,
 			600000,

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -344,8 +344,6 @@ func (p *Processor) sendProcessMessageCall(
 		return nil, err
 	}
 
-	gasLimit := uint64(float64(event.Message.GasLimit))
-
 	// if destination address is a contract, add padding. check message.to
 	// to see if it is a contract address.
 	code, err := p.destEthClient.CodeAt(ctx, event.Message.To, nil)
@@ -353,11 +351,7 @@ func (p *Processor) sendProcessMessageCall(
 		return nil, err
 	}
 
-	if len(code) != 0 {
-		gasLimit = uint64(float64(gasLimit) * 1.1)
-	} else {
-		gasLimit = uint64(float64(gasLimit) * 1.05)
-	}
+	gasLimit := relayer.PaddedMessageGasLimit(uint64(event.Message.GasLimit), len(code) != 0)
 
 	var estimatedMaxCost uint64
 
@@ -559,7 +553,7 @@ func (p *Processor) saveMessageStatusChangedEvent(
 
 // getBaseFee determines the baseFee on the dest chain
 func (p *Processor) getBaseFee(ctx context.Context) (*big.Int, error) {
-	blk, err := p.destEthClient.BlockByNumber(ctx, nil)
+	destBlock, err := p.destEthClient.BlockByNumber(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -567,15 +561,14 @@ func (p *Processor) getBaseFee(ctx context.Context) (*big.Int, error) {
 	var baseFee *big.Int
 
 	if p.taikoL2 != nil {
-		bf, err := p.taikoL2.GetBasefee(&bind.CallOpts{Context: ctx}, blk.NumberU64(), uint32(blk.GasUsed()))
-		if err != nil {
-			return nil, err
+		if destBlock.BaseFee() != nil {
+			return destBlock.BaseFee(), nil
 		}
 
-		baseFee = bf.Basefee
+		return nil, relayer.ErrMissingDestBaseFee
 	} else {
 		cfg := params.NetworkIDToChainConfigOrDefault(p.destChainId)
-		baseFee = eip1559.CalcBaseFee(cfg, blk.Header())
+		baseFee = eip1559.CalcBaseFee(cfg, destBlock.Header())
 	}
 
 	return baseFee, nil

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/taikol2"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/proof"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
@@ -48,6 +49,31 @@ func Test_sendProcessMessageCall(t *testing.T) {
 		}, []byte{})
 
 	assert.Equal(t, err, errUnprocessable)
+}
+
+func TestGetBaseFee_Layer2UsesHeaderBaseFee(t *testing.T) {
+	p := newTestProcessor(false)
+	p.taikoL2 = &taikol2.TaikoL2{}
+	p.destEthClient = &blockByNumberEthClient{
+		EthClient: &mock.EthClient{},
+		block:     processorBlockWithBaseFee(big.NewInt(123)),
+	}
+
+	got, err := p.getBaseFee(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewInt(123), got)
+}
+
+func TestGetBaseFee_Layer2MissingBaseFeeFails(t *testing.T) {
+	p := newTestProcessor(false)
+	p.taikoL2 = &taikol2.TaikoL2{}
+	p.destEthClient = &blockByNumberEthClient{EthClient: &mock.EthClient{}, block: processorBlockWithBaseFee(nil)}
+
+	got, err := p.getBaseFee(context.Background())
+
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, relayer.ErrMissingDestBaseFee)
 }
 
 func TestSaveMessageStatusChangedEventSkipsLogsWithoutTopics(t *testing.T) {
@@ -213,4 +239,20 @@ func TestGenerateEncodedSignalProofUsesDestChainCheckpoint(t *testing.T) {
 
 	_, err = p.generateEncodedSignalProof(context.Background(), event)
 	assert.Nil(t, err)
+}
+
+type blockByNumberEthClient struct {
+	*mock.EthClient
+	block *types.Block
+}
+
+func (c *blockByNumberEthClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return c.block, nil
+}
+
+func processorBlockWithBaseFee(baseFee *big.Int) *types.Block {
+	header := *mock.Header
+	header.BaseFee = baseFee
+
+	return types.NewBlockWithHeader(&header)
 }


### PR DESCRIPTION
The bridge UI was still pricing claims from a stale reserve/gas-price model while the relayer decides profitability from padded message gas and an EIP-1559 max-fee estimate. This aligns UI estimates, bridge transaction gas limits, and relayer API buckets with `Bridge.getMessageMinGasLimit`, relayer gas padding, and `2 * baseFee + priorityFee` pricing so normal messages are funded enough without requiring an arbitrary extra wei.

The relayer API and processor now read the destination block header base fee and fail explicitly if an L2 RPC cannot provide it, avoiding the production revert path seen on `/recommendedProcessingFees` and the stale generated `getBasefee` binding. Fee multipliers are ceil-rounded, and processor profitability accepts exact break-even fees.

UI copy:
- Rename the `/relayer` navigation/page label to `Manual Claim` so users understand it is the manual claiming fallback, not an internal service page.

Reported L1->L2 tx simulation using the observed production values `baseFee=8,756,091` and `priorityFee=38,434,172`:

| tx | old fee | message gas | relayer gas | new required fee | outcome |
| --- | ---: | ---: | ---: | ---: | --- |
| `0x602137e6...ae479f` | `19,500,000,000,000` | `806,657` | `846,990` | `47,386,002,374,460` | old fee underpriced, new fee passes |
| `0x8380c85f...37fd30e` | `19,500,000,000,000` | `806,657` | `846,990` | `47,386,002,374,460` | old fee underpriced, new fee passes |
| `0xdef49771...90578c` | `34,500,000,000,000` | `1,315,360` | `1,446,896` | `80,948,555,817,184` | old fee underpriced, new fee passes |

Validation:
- `go test ./packages/relayer/pkg/http ./packages/relayer/processor`
- `pnpm --dir packages/bridge-ui exec vitest run src/libs/fee/recommendedProcessingFee.test.ts src/libs/bridge/estimateMessageGasLimit.test.ts --silent`
- `pnpm -C packages/bridge-ui test:unit:debug src/components/SideNavigation/navigationItems.test.ts`
- `pnpm -C packages/bridge-ui svelte:check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core fee/gas-limit estimation in both the Bridge UI and relayer (including profitability checks and API fee buckets), which can impact whether messages get relayed or revert if mispriced. Logic is covered by new/updated unit tests but still affects transaction cost critical paths.
> 
> **Overview**
> Aligns Bridge UI processing-fee estimates with relayer profitability rules by switching to an EIP-1559 style cost model (`relayerGasLimit * (2*baseFee + priorityFee)`) and by incorporating relayer gas-limit padding plus the destination bridge’s `getMessageMinGasLimit`.
> 
> Adds `estimateMessageGasLimit` and updates all bridge transaction builders (ETH/ERC20/ERC721/ERC1155) to derive message gas limits from the destination bridge minimum + token-type overhead, with safer sizing defaults for NFTs when token IDs/amounts aren’t selected yet.
> 
> Updates the relayer API and processor to use the destination block header `BaseFee` (removing the `TaikoL2.GetBasefee` dependency), applies shared gas-limit padding via `PaddedMessageGasLimit`, ceil-rounds fee multipliers, and treats exact break-even fees as profitable.
> 
> Renames `/relayer` UI copy to “Manual Claim” and wires fee calculations to include recipient/NFT details (custom recipient, selected token IDs, ERC1155 amounts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1092fd3d93a08e89fc70f86401adfda32aeafff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

