### PR TITLE
chore(taiko-client,taiko-client-rs): bump Hoodi Unzen execution deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260513112312-9d62780bfc85
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260515033657-f23532c7cbdc
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 

--- a/go.sum
+++ b/go.sum
@@ -891,6 +891,8 @@ github.com/taikoxyz/taiko-geth v1.18.1-0.20260508015755-6c6a4df06d46 h1:vSQnXZ6c
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260508015755-6c6a4df06d46/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260513112312-9d62780bfc85 h1:w2ZkiQRMvN9yGEnmBNy+CbItQ9rr4gIi+gNbB7wtCDQ=
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260513112312-9d62780bfc85/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260515033657-f23532c7cbdc h1:jHgmGs7MCj10TpQKN7y9bcqop19wBqBwvYkCxxDaxXY=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260515033657-f23532c7cbdc/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=faee735b7386cbdf93839bc070cc693b590408f2#faee735b7386cbdf93839bc070cc693b590408f2"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=2213eabe288a267764160ba64eb86864930bc258#2213eabe288a267764160ba64eb86864930bc258"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=faee735b7386cbdf93839bc070cc693b590408f2#faee735b7386cbdf93839bc070cc693b590408f2"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=2213eabe288a267764160ba64eb86864930bc258#2213eabe288a267764160ba64eb86864930bc258"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=faee735b7386cbdf93839bc070cc693b590408f2#faee735b7386cbdf93839bc070cc693b590408f2"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=2213eabe288a267764160ba64eb86864930bc258#2213eabe288a267764160ba64eb86864930bc258"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -2987,7 +2987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3774,7 +3774,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -6438,7 +6438,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6476,9 +6476,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8581,7 +8581,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8639,7 +8639,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9485,7 +9485,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10560,7 +10560,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -2987,7 +2987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3774,7 +3774,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -6438,7 +6438,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6476,9 +6476,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8581,7 +8581,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8639,7 +8639,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9485,7 +9485,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10560,7 +10560,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,11 +81,11 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "faee735b7386cbdf93839bc070cc693b590408f2", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "faee735b7386cbdf93839bc070cc693b590408f2", default-features = false, features = [
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "2213eabe288a267764160ba64eb86864930bc258", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "2213eabe288a267764160ba64eb86864930bc258", default-features = false, features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "faee735b7386cbdf93839bc070cc693b590408f2" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "2213eabe288a267764160ba64eb86864930bc258" }
 
 # networking
 arc-swap = "1.7"

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -189,7 +189,6 @@ func (d *Driver) Start() error {
 
 		go d.preconfBlockServer.LatestSeenProposalEventLoop(d.ctx)
 	}
-
 	if d.p2pNode != nil && d.p2pNode.Dv5Udp() != nil {
 		log.Info("Start P2P discovery process")
 


### PR DESCRIPTION
## Summary
- bump the root taiko-geth replace to `f23532c7cbdc3345749f9b8bdf9f63d256b388e1` (`v1.18.1-0.20260515033657-f23532c7cbdc`)
- bump the taiko-client-rs Alethia-Reth git deps to `2213eabe288a267764160ba64eb86864930bc258`
- refresh `go.sum` and `packages/taiko-client-rs/Cargo.lock`

## Validation
- `go test ./packages/taiko-client/... -run '^$'`
- `cargo check --workspace --all-features --exclude bindings --exclude test-harness` was started, then stopped per request before completion