### PR TITLE
fix(taiko-client-rs): skip stale finalized hint for current proposal

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -96,8 +96,11 @@ fn build_bundle_meta(
     event: &ProposedEventContext,
     last_finalized_proposal_id: Option<u64>,
 ) -> BundleMeta {
+    let proposal_id = event.event.id.to::<u64>();
+    let last_finalized_proposal_id = last_finalized_proposal_id.filter(|id| *id < proposal_id);
+
     BundleMeta {
-        proposal_id: event.event.id.to::<u64>(),
+        proposal_id,
         last_finalized_proposal_id,
         proposal_timestamp: event.l1_timestamp,
         l1_block_number: event.l1_block_number,


### PR DESCRIPTION
## Summary
- Sync the finalized proposal hint guard from taikoxyz/taiko-mono#21693 into taiko-client-rs.
- Only keep `last_finalized_proposal_id` for a proposal bundle when it is strictly behind the current proposal id.

## Why
When inbox core state reports a finalized proposal id equal to or ahead of the proposal currently being derived, the driver should not use it as the finalized forkchoice hint for that proposal. This matches the Go client fix and avoids advancing finalized based on a proposal that is not behind the derivation target.

## Validation
- `just fmt` passed.
- `just clippy-fix` was started but not completed locally because it spent a long time compiling native dependencies (`librocksdb-sys` / `openssl-sys`) and was stopped before publishing this draft.
