### PR TITLE
docs(protocol): add ZK_GAS_METERING_OVERHEAD to zk gas spec

### DIFF
--- a/packages/protocol/docs/zk_gas_spec.md
+++ b/packages/protocol/docs/zk_gas_spec.md
@@ -10,10 +10,13 @@ Cap proving time per block with a protocol constant `BLOCK_ZK_GAS_LIMIT`
 | --- | --- | --- |
 | `BLOCK_ZK_GAS_LIMIT` | 100,000,000 | Maximum zk gas allowed per block. See [Appendix C](#appendix-c-block_zk_gas_limit-rationale) for rationale. |
 | `TX_INTRINSIC_ZK_GAS` | 243,000 | Fixed zk gas charged once per transaction, primarily covering sender ecrecovery cost. |
+| `ZK_GAS_METERING_OVERHEAD` | 90 | Fixed zk gas charged once per opcode execution and once per precompile call, covering the prover cost of the zk-gas metering hook itself. |
 
 ## Core Idea
 
 `zk gas` is a weighted gas metric — the gas consumed by each opcode and precompile is scaled by a proving-cost multiplier.
+
+Each opcode execution and each precompile call also pays a flat `ZK_GAS_METERING_OVERHEAD` on top of its `gas × multiplier`.
 
 Each block transaction also pays `TX_INTRINSIC_ZK_GAS` before opcode or precompile metering begins.
 
@@ -53,6 +56,7 @@ Definitions:
 - `child_frame_created`: true only when a spawn opcode creates a child EVM execution frame.
 - `precompile_invoked`: true when a CALL-family opcode (`CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`) resolves to an active precompile and executes it.
 - `tx_intrinsic_zk_gas`: transaction-level zk gas charged once per transaction, equal to `TX_INTRINSIC_ZK_GAS`.
+- `zk_gas_metering_overhead`: zk gas charged once per invocation of the zk gas metering hook (i.e. once per opcode execution and once per precompile call), equal to `ZK_GAS_METERING_OVERHEAD`.
 - `opcode_multiplier[opcode]`: per-opcode proving-cost multiplier. All valid opcodes are listed in [Appendix B](#appendix-b-full-zk-multipliers). Unlisted opcodes default to `max(uint16)` (fail-safe).
 - `precompile_multiplier[addr]`: per-precompile proving-cost multiplier, indexed by the low byte of the precompile address. All active precompiles are listed in [Appendix B](#appendix-b-full-zk-multipliers). Unlisted precompiles default to `max(uint16)` (fail-safe).
 - Multiplier values are listed in [Appendix B](#appendix-b-full-zk-multipliers).
@@ -67,6 +71,9 @@ Definitions:
 
 # --- Transaction-level constants ---
 TX_INTRINSIC_ZK_GAS = 243_000
+
+# --- Metering overhead ---
+ZK_GAS_METERING_OVERHEAD = 90
 
 # --- Spawn estimation constants ---
 SPAWN_ESTIMATE = {
@@ -89,7 +96,7 @@ def on_opcode(opcode: uint8, step_gas: uint64, child_frame_created: bool, precom
     else:
         raw_gas: uint64 = step_gas
 
-    tx_zk_gas_used += raw_gas * opcode_multiplier[opcode]
+    tx_zk_gas_used += raw_gas * opcode_multiplier[opcode] + ZK_GAS_METERING_OVERHEAD
 
     if block_zk_gas_used + tx_zk_gas_used > BLOCK_ZK_GAS_LIMIT:
         halt_execution()  # stop immediately, do not execute further opcodes
@@ -98,7 +105,7 @@ def on_opcode(opcode: uint8, step_gas: uint64, child_frame_created: bool, precom
 # --- Precompile hook (called when a CALL-family opcode resolves to a precompile) ---
 
 def on_precompile(precompile_address: uint8, gas_used: uint64):
-    tx_zk_gas_used += gas_used * precompile_multiplier[precompile_address]
+    tx_zk_gas_used += gas_used * precompile_multiplier[precompile_address] + ZK_GAS_METERING_OVERHEAD
 
     if block_zk_gas_used + tx_zk_gas_used > BLOCK_ZK_GAS_LIMIT:
         halt_execution()
@@ -139,7 +146,7 @@ Precompile detection is implementation-defined (e.g. checking the active precomp
 When a CALL-family opcode targets a precompile address:
 
 - The CALL-family opcode itself is metered via `on_opcode` with `precompile_invoked = True` and uses `SPAWN_ESTIMATE[opcode]` as raw gas (not `step_gas`). This covers only opcode-side spawn overhead.
-- `precompile_zk = precompile_gas_used * precompile_multiplier[low_byte]`
+- `precompile_zk = precompile_gas_used * precompile_multiplier[low_byte] + ZK_GAS_METERING_OVERHEAD`
 - `precompile_gas_used` is the gas charged by the precompile's own gas schedule (`base_cost + data_cost`), excluding the CALL-family opcode's own costs (cold account access, memory expansion, value transfer stipend). This is the value deducted from the calling frame's gas counter when the precompile runs.
 - The charge is applied after the precompile executes, since gas cost is only known after execution. Since precompiles are atomic (no child opcodes), the block limit check fires before any subsequent opcode.
 


### PR DESCRIPTION
## Problem

Some of our stress tests had disproportionately long proving times relative to their nominal zk-gas budget. At the same 100M zk-gas budget, `stressAdd` (spamming `add` in a tight loop) was 5-10 times slower than other workloads (e.g., `stressBlake2f`).

We traced this to the proving cost of the zk-gas check hook itself: the per-opcode metering work has its own, non-trivial proving cost that the current zk-gas formula doesn't account for. To confirm, we ported Unzen alethia-reth (with zk gas checks) to my [marginal zk gas benchmarks](https://ethresear.ch/t/measuring-per-opcode-proving-time/23955) and compared it to stock reth. Alethia-reth is consistently slower, with a noticeably steeper proving-time slope:

<img width="540" height="348" alt="image" src="https://github.com/user-attachments/assets/55e24b25-09d8-4bb5-a283-a1a8ccd4e294" />

The gap is even more dramatic for some opcodes like `jumpdest`:

<img width="541" height="348" alt="image" src="https://github.com/user-attachments/assets/5750c721-7571-446c-b827-89dfb73da576" />

The fix is to add a flat per-opcode overhead to the zk-gas charge so the formula accounts for the hook's own proving cost.

## Solution

Added a flat `ZK_GAS_METERING_OVERHEAD = 90` to every opcode and precompile zk-gas charge, on top of the existing `gas × multiplier`. Updated `packages/protocol/docs/zk_gas_spec.md` to reflect the new constant and apply it in both `on_opcode` and `on_precompile`.

## Result

The proving time spread across stress workloads improved a lot. The image below shows proving time for different stress workloads at the same 100M ZK gas budget — red bars are before recalibration, green bars are after. Before, `stressAdd` was disproportionately slow; after, it's much more in line with other workloads.

<img width="913" height="372" alt="image" src="https://github.com/user-attachments/assets/bff14a01-262c-49ca-998c-62e351b43ece" />

## Why +90 zk-gas per opcode?

Per Taiko's zk-gas spec, **1 zk-gas ≈ 1 µs of prove time** (the spec multipliers were derived from per-opcode prove-time slopes in µs per EVM-gas). Adding zk-gas for the `ZkGasInspector` hook is therefore just "add the extra µs of prove time the hook causes per opcode".

We measured that directly. Running the SP1 marginal benchmark twice — once with upstream `reth-evm-ethereum::EthEvmConfig` (no hook) and once with `alethia-reth-block::TaikoEvmConfig` (with the `ZkGasInspector`) — and diffing per-opcode prove-time slopes yields:

| stat (simple opcodes, n=22) | Δ µs / op |
| --- | --- |
| mean | 87.5 |
| median | 76.5 |
| stdev | 36 |

→ rounded: **+90 zk-gas / opcode**.

Cross-check: Masaya's production stressAdd cost is 293 G PGU; the upstream marginal benchmark predicts 88 G. The 205 G gap, divided across 3.75 M opcodes × 408 blocks = 1.53 G opcodes, comes to **134 PGU per opcode** — consistent with the +135 SP1 cycles per opcode the marginal regression also produced, and corresponds to roughly the same ~90 zk-gas-equivalent. Two independent paths to the same number.

## Impact per opcode/precompile

`+90` is meaningful in relative terms for the cheapest opcodes (10× for `jumpdest`, 7× for `pop`/`push1`/`mcopy`) and rounding noise for expensive opcodes and most precompiles. Full table sorted by % increase descending; precompiles marked `(p)`. Variable-gas precompiles shown at a representative single-block/single-pair/single-word case.

| Op | step/typ gas | mult | base | +90 | % increase |
| --- | ---: | ---: | ---: | ---: | ---: |
| jumpdest | 1 | 9 | 9 | 99 | 1000% |
| pop | 2 | 5 | 10 | 100 | 900% |
| mcopy, push1, push2, dup2, dup7, dup10 | 3 | 5 | 15 | 105 | 600% |
| not, push3, push5, dup1, dup3, dup4, dup5, dup6, dup8, dup11, dup13, dup16 | 3 | 6 | 18 | 108 | 500% |
| returndatasize, push0 | 2 | 10 | 20 | 110 | 450% |
| push7, push8, push13, dup9, dup14 | 3 | 7 | 21 | 111 | 429% |
| codesize, calldatasize, chainid, gas, gaslimit, msize, number, basefee, timestamp | 2 | 11 | 22 | 112 | 409% |
| and, iszero, push4, push6, push11, dup12, dup15 | 3 | 8 | 24 | 114 | 375% |
| pc | 2 | 12 | 24 | 114 | 375% |
| jump | 8 | 3 | 24 | 114 | 375% |
| callvalue | 2 | 13 | 26 | 116 | 346% |
| or, xor, byte, mstore8, push9, push12, returndatacopy | 3 | 9 | 27 | 117 | 333% |
| gasprice | 2 | 14 | 28 | 118 | 321% |
| gt, blobhash, push10, push15 | 3 | 10 | 30 | 120 | 300% |
| blobbasefee | 2 | 15 | 30 | 120 | 300% |
| lt, push16, push18, push19 | 3 | 11 | 33 | 123 | 273% |
| add, calldatacopy, push14, push23, push30 | 3 | 12 | 36 | 126 | 250% |
| *identity (p)* | 18 | 2 | 36 | 126 | 250% |
| sub, codecopy, push17, push20, push25 | 3 | 13 | 39 | 129 | 231% |
| slt, sgt, push21, push26 | 3 | 14 | 42 | 132 | 214% |
| origin, caller, coinbase | 2 | 21 | 42 | 132 | 214% |
| address | 2 | 22 | 44 | 134 | 205% |
| swap8, push27 | 3 | 15 | 45 | 135 | 200% |
| swap1, swap5, push22, push24 | 3 | 16 | 48 | 138 | 188% |
| jumpi | 10 | 5 | 50 | 140 | 180% |
| swap6, swap7, swap10, swap15, push28, push29, push32 | 3 | 17 | 51 | 141 | 176% |
| swap2, swap3, swap9, swap11, swap14, swap16, push31 | 3 | 18 | 54 | 144 | 167% |
| prevrandao | 2 | 28 | 56 | 146 | 161% |
| shr, swap4, swap12, swap13 | 3 | 19 | 57 | 147 | 158% |
| shl, calldataload, mload | 3 | 20 | 60 | 150 | 150% |
| mstore | 3 | 22 | 66 | 156 | 136% |
| sar | 3 | 29 | 87 | 177 | 103% |
| tload | 100 | 1 | 100 | 190 | 90.0% |
| mul, signextend | 5 | 21 | 105 | 195 | 85.7% |
| eq | 3 | 35 | 105 | 195 | 85.7% |
| blockhash | 20 | 7 | 140 | 230 | 64.3% |
| smod | 5 | 29 | 145 | 235 | 62.1% |
| exp | 10 | 33 | 330 | 420 | 27.3% |
| selfbalance | 5 | 85 | 425 | 515 | 21.2% |
| sdiv | 5 | 93 | 465 | 555 | 19.4% |
| mod | 5 | 95 | 475 | 565 | 19.0% |
| sload | 100 | 5 | 500 | 590 | 18.0% |
| div | 5 | 110 | 550 | 640 | 16.4% |
| addmod | 8 | 71 | 568 | 658 | 15.8% |
| balance, extcodesize, extcodecopy, tstore | 100 | 6 | 600 | 690 | 15.0% |
| *sha256 (p, 1 word)* | 72 | 10 | 720 | 810 | 12.5% |
| extcodehash | 100 | 8 | 800 | 890 | 11.3% |
| mulmod | 8 | 152 | 1,216 | 1,306 | 7.40% |
| sstore (warm-noop) | 100 | 13 | 1,300 | 1,390 | 6.92% |
| *ripemd160 (p, 1 word)* | 720 | 3 | 2,160 | 2,250 | 4.17% |
| log0 | 375 | 6 | 2,250 | 2,340 | 4.00% |
| keccak256 | 30 | 85 | 2,550 | 2,640 | 3.53% |
| *blake2f (p, 12 rounds)* | 12 | 243 | 2,916 | 3,006 | 3.09% |
| log2 | 1,125 | 4 | 4,500 | 4,590 | 2.00% |
| log1 | 750 | 7 | 5,250 | 5,340 | 1.71% |
| *bn128_add (p)* | 150 | 38 | 5,700 | 5,790 | 1.58% |
| log3 | 1,500 | 5 | 7,500 | 7,590 | 1.20% |
| log4 | 1,875 | 5 | 9,375 | 9,465 | 0.96% |
| create | 37,000 | 1 | 37,000 | 37,090 | 0.243% |
| *bls12_g1add (p)* | 375 | 112 | 42,000 | 42,090 | 0.214% |
| create2 | 44,500 | 1 | 44,500 | 44,590 | 0.202% |
| *bls12_g2add (p)* | 600 | 111 | 66,600 | 66,690 | 0.135% |
| delegatecall | 3,500 | 21 | 73,500 | 73,590 | 0.122% |
| staticcall | 3,500 | 24 | 84,000 | 84,090 | 0.107% |
| *ecrecover (p)* | 3,000 | 81 | 243,000 | 243,090 | 0.037% |
| callcode | 12,500 | 24 | 300,000 | 300,090 | 0.030% |
| call | 12,500 | 25 | 312,500 | 312,590 | 0.029% |
| *bn128_mul (p)* | 6,000 | 87 | 522,000 | 522,090 | 0.017% |
| *bls12_g1msm (p, 1 pt)* | 12,000 | 52 | 624,000 | 624,090 | 0.014% |
| *bls12_map_fp_to_g1 (p)* | 5,500 | 159 | 874,500 | 874,590 | 0.010% |
| *bls12_g2msm (p, 1 pt)* | 22,500 | 39 | 877,500 | 877,590 | 0.010% |
| *modexp (p, variable)* | ≥1,000 | 1,363 | ≥1.36M | +90 | ≤0.007% |
| *bls12_map_fp2_to_g2 (p)* | 23,800 | 112 | 2.67M | +90 | 0.003% |
| *bn128_pairing (p, 1 pair)* | 79,000 | 82 | 6.48M | +90 | 0.001% |
| *bls12_pairing (p, 1 pair)* | 70,300 | 134 | 9.42M | +90 | ~0.001% |
| *point_evaluation (p)* | 50,000 | 398 | 19.9M | +90 | 0.0005% |


## Open question

Is the flat `+90` constant acceptable for Taiko going forward, or should we push to reduce the hook overhead itself (e.g. by simplifying the inspector implementation)?