### PR TITLE
fix(taiko-client-rs): fix rs preconf ingress after L1 reorg

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -6,7 +6,7 @@ const FINALIZED_BLOCK_NOT_FOUND: &str = "finalized block not found";
 use std::{
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -105,6 +105,11 @@ fn should_probe_confirmed_sync(
 /// payloads.
 fn close_preconf_ingress_for_reorg(preconf_ingress_ready: &AtomicBool) -> bool {
     preconf_ingress_ready.swap(false, Ordering::AcqRel)
+}
+
+/// Publish that post-reorg head-L1-origin reset completed and unsafe state should be rebuilt.
+fn record_preconf_reorg_state_reset(preconf_reorg_generation: &AtomicU64) -> u64 {
+    preconf_reorg_generation.fetch_add(1, Ordering::AcqRel) + 1
 }
 
 /// Resolve whether confirmed-sync readiness should open ingress.
@@ -241,6 +246,8 @@ where
     preconf_ingress_ready: Arc<AtomicBool>,
     /// Notifier signaled when strict ingress gating is satisfied and the loop becomes ready.
     preconf_ingress_notify: Arc<Notify>,
+    /// Monotonic counter bumped whenever an event-scanner reorg invalidates unsafe preconf state.
+    preconf_reorg_generation: Arc<AtomicU64>,
 }
 
 /// Maximum number of buffered preconfirmation payloads before backpressure applies.
@@ -740,6 +747,7 @@ where
             preconf_rx: Mutex::new(preconf_rx),
             preconf_ingress_ready: Arc::new(AtomicBool::new(false)),
             preconf_ingress_notify: Arc::new(Notify::new()),
+            preconf_reorg_generation: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -805,6 +813,11 @@ where
     /// This mirrors the internal readiness signal used by the strict ingress gate.
     pub fn is_preconf_ingress_ready(&self) -> bool {
         self.preconf_ingress_ready.load(Ordering::Acquire)
+    }
+
+    /// Returns the current event-scanner reorg generation for preconfirmation consumers.
+    pub fn preconf_reorg_generation(&self) -> u64 {
+        self.preconf_reorg_generation.load(Ordering::Acquire)
     }
 
     /// Submit a preconfirmation payload and await the processing result.
@@ -1345,6 +1358,15 @@ where
                                             REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT.as_millis() as u64,
                                         "timed out resetting head_l1_origin after reorg"
                                     );
+                                } else {
+                                    let preconf_reorg_generation = record_preconf_reorg_state_reset(
+                                        &self.preconf_reorg_generation,
+                                    );
+                                    info!(
+                                        common_ancestor,
+                                        preconf_reorg_generation,
+                                        "published preconfirmation reorg state reset"
+                                    );
                                 }
                             }
                             Notification::NoPastLogsFound => {}
@@ -1547,6 +1569,7 @@ mod tests {
             preconf_rx: Mutex::new(Some(preconf_rx)),
             preconf_ingress_ready: Arc::new(AtomicBool::new(false)),
             preconf_ingress_notify: Arc::new(Notify::new()),
+            preconf_reorg_generation: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -1976,6 +1999,16 @@ mod tests {
 
         assert!(!ingress_ready.load(Ordering::Acquire));
         assert!(should_probe_confirmed_sync(true, true, false, true));
+    }
+
+    #[test]
+    fn preconf_reorg_generation_publishes_completed_state_reset() {
+        let reorg_generation = AtomicU64::new(0);
+
+        let generation = record_preconf_reorg_state_reset(&reorg_generation);
+
+        assert_eq!(generation, 1);
+        assert_eq!(reorg_generation.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -517,11 +517,10 @@ where
     }
 
     /// Best-effort reset of `head_l1_origin` to the latest canonical proposal's last L2 block at
-    /// the stable post-reorg boundary. If the L2 EE's confirmed boundary is left ahead of the
-    /// post-reorg canonical chain, preconf and chain-syncer guards reject incoming blocks until
-    /// the chain syncer rewinds. Lowering it here unblocks them immediately. All failures are
-    /// non-fatal: log and return.
-    async fn reset_head_l1_origin_after_reorg(&self, common_ancestor: u64) {
+    /// the stable post-reorg boundary.
+    ///
+    /// Returns `true` only when the confirmed boundary was successfully reset.
+    async fn reset_head_l1_origin_after_reorg(&self, common_ancestor: u64) -> bool {
         let core_state = match self
             .rpc
             .shasta
@@ -534,7 +533,7 @@ where
             Ok(core_state) => core_state,
             Err(err) => {
                 warn!(common_ancestor, %err, "failed to read core state for head_l1_origin reset");
-                return;
+                return false;
             }
         };
 
@@ -544,7 +543,7 @@ where
                 common_ancestor,
                 next_proposal_id, "skipping head_l1_origin reset at genesis boundary"
             );
-            return;
+            return false;
         }
         let proposal_id = next_proposal_id - 1;
 
@@ -556,7 +555,7 @@ where
                         common_ancestor,
                         proposal_id, "missing batch mapping; skipping head_l1_origin reset"
                     );
-                    return;
+                    return false;
                 }
                 Err(err) => {
                     warn!(
@@ -565,24 +564,30 @@ where
                         ?err,
                         "failed to read batch mapping; skipping head_l1_origin reset"
                     );
-                    return;
+                    return false;
                 }
             };
 
         match self.rpc.set_head_l1_origin(block_id).await {
-            Ok(_) => info!(
-                common_ancestor,
-                proposal_id,
-                %block_id,
-                "reset head_l1_origin after reorg"
-            ),
-            Err(err) => warn!(
-                common_ancestor,
-                proposal_id,
-                %block_id,
-                ?err,
-                "failed to reset head_l1_origin after reorg"
-            ),
+            Ok(_) => {
+                info!(
+                    common_ancestor,
+                    proposal_id,
+                    %block_id,
+                    "reset head_l1_origin after reorg"
+                );
+                true
+            }
+            Err(err) => {
+                warn!(
+                    common_ancestor,
+                    proposal_id,
+                    %block_id,
+                    ?err,
+                    "failed to reset head_l1_origin after reorg"
+                );
+                false
+            }
         }
     }
 
@@ -1345,28 +1350,38 @@ where
                                         "closing preconfirmation ingress after event scanner reorg"
                                     );
                                 }
-                                if timeout(
+                                match timeout(
                                     REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT,
                                     self.reset_head_l1_origin_after_reorg(common_ancestor),
                                 )
                                 .await
-                                .is_err()
                                 {
-                                    warn!(
-                                        common_ancestor,
-                                        timeout_ms =
-                                            REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT.as_millis() as u64,
-                                        "timed out resetting head_l1_origin after reorg"
-                                    );
-                                } else {
-                                    let preconf_reorg_generation = record_preconf_reorg_state_reset(
-                                        &self.preconf_reorg_generation,
-                                    );
-                                    info!(
-                                        common_ancestor,
-                                        preconf_reorg_generation,
-                                        "published preconfirmation reorg state reset"
-                                    );
+                                    Ok(true) => {
+                                        let preconf_reorg_generation =
+                                            record_preconf_reorg_state_reset(
+                                                &self.preconf_reorg_generation,
+                                            );
+                                        info!(
+                                            common_ancestor,
+                                            preconf_reorg_generation,
+                                            "published preconfirmation reorg state reset"
+                                        );
+                                    }
+                                    Ok(false) => {
+                                        warn!(
+                                            common_ancestor,
+                                            "skipping preconfirmation reorg state reset publish"
+                                        );
+                                    }
+                                    Err(_) => {
+                                        warn!(
+                                            common_ancestor,
+                                            timeout_ms = REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT
+                                                .as_millis()
+                                                as u64,
+                                            "timed out resetting head_l1_origin after reorg"
+                                        );
+                                    }
                                 }
                             }
                             Notification::NoPastLogsFound => {}
@@ -2038,8 +2053,9 @@ mod tests {
         l2_auth_asserter.push_success(&Some(U256::from(7_777u64))); // last_certain_block_id_by_batch_id
         l2_auth_asserter.push_success(&Some(U256::from(7_777u64))); // set_head_l1_origin
 
-        syncer.reset_head_l1_origin_after_reorg(1_234).await;
+        let reset = syncer.reset_head_l1_origin_after_reorg(1_234).await;
 
+        assert!(reset);
         assert!(l1_asserter.read_q().is_empty());
         assert!(l2_auth_asserter.read_q().is_empty());
     }
@@ -2058,9 +2074,10 @@ mod tests {
         l1_asserter.push_success(&encoded_core_state);
         l2_auth_asserter.push_success(&Option::<U256>::None);
 
-        syncer.reset_head_l1_origin_after_reorg(1_234).await;
+        let reset = syncer.reset_head_l1_origin_after_reorg(1_234).await;
 
         // No set_head_l1_origin call should be queued: missing mapping is a best-effort skip.
+        assert!(!reset);
         assert!(l1_asserter.read_q().is_empty());
         assert!(l2_auth_asserter.read_q().is_empty());
     }

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -584,7 +584,7 @@ where
                 common_ancestor,
                 next_proposal_id, "skipping head_l1_origin reset at genesis boundary"
             );
-            return false;
+            return true;
         }
         let proposal_id = next_proposal_id - 1;
 
@@ -2122,6 +2122,27 @@ mod tests {
 
         assert_eq!(generation, 1);
         assert_eq!(reorg_generation.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn complete_preconf_reorg_reset_publishes_generation_at_genesis_boundary() {
+        let l1_asserter = Asserter::new();
+        let l2_auth_asserter = Asserter::new();
+        let syncer = EventSyncer {
+            rpc: mock_client_with_asserters(l1_asserter.clone(), l2_auth_asserter.clone()),
+            preconf_reorg_reset_pending: Arc::new(AtomicBool::new(true)),
+            ..build_syncer().await
+        };
+
+        let core_state = sample_core_state(1);
+        let encoded_core_state = Bytes::from(getCoreStateCall::abi_encode_returns(&core_state));
+        l1_asserter.push_success(&encoded_core_state);
+
+        assert!(syncer.complete_preconf_reorg_reset(1_234).await);
+        assert!(!syncer.preconf_reorg_reset_pending.load(Ordering::Acquire));
+        assert_eq!(syncer.preconf_reorg_generation.load(Ordering::Acquire), 1);
+        assert!(l1_asserter.read_q().is_empty());
+        assert!(l2_auth_asserter.read_q().is_empty());
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -107,6 +107,15 @@ fn close_preconf_ingress_for_reorg(preconf_ingress_ready: &AtomicBool) -> bool {
     preconf_ingress_ready.swap(false, Ordering::AcqRel)
 }
 
+/// Mark post-reorg reset pending and close preconfirmation ingress before serialization waits.
+fn begin_preconf_reorg_reset(
+    preconf_ingress_ready: &AtomicBool,
+    preconf_reorg_reset_pending: &AtomicBool,
+) -> bool {
+    preconf_reorg_reset_pending.store(true, Ordering::Release);
+    close_preconf_ingress_for_reorg(preconf_ingress_ready)
+}
+
 /// Returns whether an already-queued preconfirmation job may still enter the engine.
 fn preconf_ingress_accepts_queued_job(preconf_ingress_ready: &AtomicBool) -> bool {
     preconf_ingress_ready.load(Ordering::Acquire)
@@ -1411,13 +1420,16 @@ where
                                 scanner_live = true;
                             }
                             Notification::ReorgDetected { common_ancestor } => {
+                                pending_reorg_common_ancestor = Some(common_ancestor);
+                                let ingress_was_ready = begin_preconf_reorg_reset(
+                                    &self.preconf_ingress_ready,
+                                    &self.preconf_reorg_reset_pending,
+                                );
                                 // Serialize reorg closure with preconfirmation production so a
                                 // queued job cannot pass the router gate after reorg handling
                                 // starts.
                                 let _router_guard = router.lock().await;
-                                pending_reorg_common_ancestor = Some(common_ancestor);
-                                self.preconf_reorg_reset_pending.store(true, Ordering::Release);
-                                if close_preconf_ingress_for_reorg(&self.preconf_ingress_ready) {
+                                if ingress_was_ready {
                                     info!(
                                         common_ancestor,
                                         "closing preconfirmation ingress after event scanner reorg"
@@ -2075,6 +2087,17 @@ mod tests {
 
         assert!(!ingress_ready.load(Ordering::Acquire));
         assert!(should_probe_confirmed_sync(true, true, false, true));
+    }
+
+    #[test]
+    fn event_reorg_marks_reset_pending_before_serialization() {
+        let ingress_ready = AtomicBool::new(true);
+        let reset_pending = AtomicBool::new(false);
+
+        begin_preconf_reorg_reset(&ingress_ready, &reset_pending);
+
+        assert!(!ingress_ready.load(Ordering::Acquire));
+        assert!(reset_pending.load(Ordering::Acquire));
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -98,6 +98,15 @@ fn should_probe_confirmed_sync(
     preconfirmation_enabled && scanner_live && (!preconf_ingress_spawned || !preconf_ingress_ready)
 }
 
+/// Close preconfirmation ingress after an event-scanner reorg notification.
+///
+/// Reorgs invalidate the confirmed-boundary assumptions that opened ingress. Closing here forces
+/// the scanner loop to run the strict confirmed-sync probe again before accepting more unsafe
+/// payloads.
+fn close_preconf_ingress_for_reorg(preconf_ingress_ready: &AtomicBool) -> bool {
+    preconf_ingress_ready.swap(false, Ordering::AcqRel)
+}
+
 /// Resolve whether confirmed-sync readiness should open ingress.
 fn resolve_confirmed_sync_ready(confirmed_sync_snapshot: ConfirmedSyncSnapshot) -> bool {
     confirmed_sync_snapshot.is_ready()
@@ -1317,6 +1326,12 @@ where
                                 scanner_live = true;
                             }
                             Notification::ReorgDetected { common_ancestor } => {
+                                if close_preconf_ingress_for_reorg(&self.preconf_ingress_ready) {
+                                    info!(
+                                        common_ancestor,
+                                        "closing preconfirmation ingress after event scanner reorg"
+                                    );
+                                }
                                 if timeout(
                                     REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT,
                                     self.reset_head_l1_origin_after_reorg(common_ancestor),
@@ -1951,6 +1966,16 @@ mod tests {
         assert!(should_probe_confirmed_sync(true, false, false, true));
         assert!(!should_probe_confirmed_sync(true, false, false, false));
         assert!(!should_probe_confirmed_sync(false, true, false, true));
+    }
+
+    #[test]
+    fn event_reorg_closes_preconf_ingress_until_confirmed_sync_reprobe() {
+        let ingress_ready = AtomicBool::new(true);
+
+        close_preconf_ingress_for_reorg(&ingress_ready);
+
+        assert!(!ingress_ready.load(Ordering::Acquire));
+        assert!(should_probe_confirmed_sync(true, true, false, true));
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -107,9 +107,19 @@ fn close_preconf_ingress_for_reorg(preconf_ingress_ready: &AtomicBool) -> bool {
     preconf_ingress_ready.swap(false, Ordering::AcqRel)
 }
 
+/// Returns whether an already-queued preconfirmation job may still enter the engine.
+fn preconf_ingress_accepts_queued_job(preconf_ingress_ready: &AtomicBool) -> bool {
+    preconf_ingress_ready.load(Ordering::Acquire)
+}
+
 /// Publish that post-reorg head-L1-origin reset completed and unsafe state should be rebuilt.
 fn record_preconf_reorg_state_reset(preconf_reorg_generation: &AtomicU64) -> u64 {
     preconf_reorg_generation.fetch_add(1, Ordering::AcqRel) + 1
+}
+
+/// Resolve whether a successful confirmed-sync probe may open preconfirmation ingress.
+fn should_open_preconf_ingress(confirmed_sync_ready: bool, reorg_reset_pending: bool) -> bool {
+    confirmed_sync_ready && !reorg_reset_pending
 }
 
 /// Resolve whether confirmed-sync readiness should open ingress.
@@ -246,6 +256,8 @@ where
     preconf_ingress_ready: Arc<AtomicBool>,
     /// Notifier signaled when strict ingress gating is satisfied and the loop becomes ready.
     preconf_ingress_notify: Arc<Notify>,
+    /// Whether a reorg reset must complete before preconfirmation ingress can re-open.
+    preconf_reorg_reset_pending: Arc<AtomicBool>,
     /// Monotonic counter bumped whenever an event-scanner reorg invalidates unsafe preconf state.
     preconf_reorg_generation: Arc<AtomicU64>,
 }
@@ -386,6 +398,16 @@ where
                 gauge!(DriverMetrics::PRECONF_QUEUE_DEPTH).set(rx.len() as f64);
                 let start = Instant::now();
                 let block_number = job.payload.block_number();
+                if !preconf_ingress_accepts_queued_job(&ready_flag) {
+                    warn!(
+                        block_number,
+                        "rejecting queued preconfirmation payload while ingress is closed"
+                    );
+                    let _ = job.respond_to.send(Err(DriverError::PreconfIngressNotReady));
+                    gauge!(DriverMetrics::PRECONF_QUEUE_DEPTH).set(rx.len() as f64);
+                    continue;
+                }
+
                 match preconfirmation_payload_is_materialized(&rpc, job.payload.as_ref()).await {
                     Ok(true) => {
                         debug!(
@@ -410,6 +432,16 @@ where
                 }
 
                 let router_guard = router.lock().await;
+                if !preconf_ingress_accepts_queued_job(&ready_flag) {
+                    warn!(
+                        block_number,
+                        "rejecting queued preconfirmation payload after ingress closed"
+                    );
+                    let _ = job.respond_to.send(Err(DriverError::PreconfIngressNotReady));
+                    gauge!(DriverMetrics::PRECONF_QUEUE_DEPTH).set(rx.len() as f64);
+                    continue;
+                }
+
                 // Re-check after acquiring router lock so event-sync updates cannot race this
                 // preconfirmation submission.
                 // On genesis chains head_l1_origin is not yet written; default to 0 so
@@ -591,6 +623,39 @@ where
         }
     }
 
+    /// Try to complete the post-reorg reset and publish the preconfirmation rebuild signal.
+    async fn complete_preconf_reorg_reset(&self, common_ancestor: u64) -> bool {
+        match timeout(
+            REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT,
+            self.reset_head_l1_origin_after_reorg(common_ancestor),
+        )
+        .await
+        {
+            Ok(true) => {
+                let preconf_reorg_generation =
+                    record_preconf_reorg_state_reset(&self.preconf_reorg_generation);
+                self.preconf_reorg_reset_pending.store(false, Ordering::Release);
+                info!(
+                    common_ancestor,
+                    preconf_reorg_generation, "published preconfirmation reorg state reset"
+                );
+                true
+            }
+            Ok(false) => {
+                warn!(common_ancestor, "skipping preconfirmation reorg state reset publish");
+                false
+            }
+            Err(_) => {
+                warn!(
+                    common_ancestor,
+                    timeout_ms = REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT.as_millis() as u64,
+                    "timed out resetting head_l1_origin after reorg"
+                );
+                false
+            }
+        }
+    }
+
     /// Process a batch of proposal logs from the event scanner.
     async fn process_log_batch(
         &self,
@@ -752,6 +817,7 @@ where
             preconf_rx: Mutex::new(preconf_rx),
             preconf_ingress_ready: Arc::new(AtomicBool::new(false)),
             preconf_ingress_notify: Arc::new(Notify::new()),
+            preconf_reorg_reset_pending: Arc::new(AtomicBool::new(false)),
             preconf_reorg_generation: Arc::new(AtomicU64::new(0)),
         })
     }
@@ -1264,6 +1330,7 @@ where
         let mut preconf_ingress_spawned = false;
         let mut scanner_live = false;
         let mut scanner_started_once = false;
+        let mut pending_reorg_common_ancestor = None;
 
         loop {
             if !preconf_ingress_spawned {
@@ -1344,44 +1411,20 @@ where
                                 scanner_live = true;
                             }
                             Notification::ReorgDetected { common_ancestor } => {
+                                // Serialize reorg closure with preconfirmation production so a
+                                // queued job cannot pass the router gate after reorg handling
+                                // starts.
+                                let _router_guard = router.lock().await;
+                                pending_reorg_common_ancestor = Some(common_ancestor);
+                                self.preconf_reorg_reset_pending.store(true, Ordering::Release);
                                 if close_preconf_ingress_for_reorg(&self.preconf_ingress_ready) {
                                     info!(
                                         common_ancestor,
                                         "closing preconfirmation ingress after event scanner reorg"
                                     );
                                 }
-                                match timeout(
-                                    REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT,
-                                    self.reset_head_l1_origin_after_reorg(common_ancestor),
-                                )
-                                .await
-                                {
-                                    Ok(true) => {
-                                        let preconf_reorg_generation =
-                                            record_preconf_reorg_state_reset(
-                                                &self.preconf_reorg_generation,
-                                            );
-                                        info!(
-                                            common_ancestor,
-                                            preconf_reorg_generation,
-                                            "published preconfirmation reorg state reset"
-                                        );
-                                    }
-                                    Ok(false) => {
-                                        warn!(
-                                            common_ancestor,
-                                            "skipping preconfirmation reorg state reset publish"
-                                        );
-                                    }
-                                    Err(_) => {
-                                        warn!(
-                                            common_ancestor,
-                                            timeout_ms = REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT
-                                                .as_millis()
-                                                as u64,
-                                            "timed out resetting head_l1_origin after reorg"
-                                        );
-                                    }
+                                if self.complete_preconf_reorg_reset(common_ancestor).await {
+                                    pending_reorg_common_ancestor = None;
                                 }
                             }
                             Notification::NoPastLogsFound => {}
@@ -1411,7 +1454,19 @@ where
                         continue;
                     }
                     let confirmed_sync_ready = resolve_confirmed_sync_probe(confirmed_sync_probe);
-                    if confirmed_sync_ready {
+                    let reorg_reset_pending =
+                        self.preconf_reorg_reset_pending.load(Ordering::Acquire);
+                    if confirmed_sync_ready &&
+                        reorg_reset_pending &&
+                        let Some(common_ancestor) = pending_reorg_common_ancestor &&
+                        self.complete_preconf_reorg_reset(common_ancestor).await
+                    {
+                        pending_reorg_common_ancestor = None;
+                    }
+
+                    let reorg_reset_pending =
+                        self.preconf_reorg_reset_pending.load(Ordering::Acquire);
+                    if should_open_preconf_ingress(confirmed_sync_ready, reorg_reset_pending) {
                         let rx = self
                             .preconf_rx
                             .lock()
@@ -1430,6 +1485,11 @@ where
                             info!("re-opened preconfirmation ingress after scanner reconnect");
                             self.preconf_ingress_notify.notify_waiters();
                         }
+                    } else if confirmed_sync_ready {
+                        warn!(
+                            "confirmed-sync probe passed but preconfirmation ingress remains \
+                             closed until reorg reset completes"
+                        );
                     }
                 }
             }
@@ -1584,6 +1644,7 @@ mod tests {
             preconf_rx: Mutex::new(Some(preconf_rx)),
             preconf_ingress_ready: Arc::new(AtomicBool::new(false)),
             preconf_ingress_notify: Arc::new(Notify::new()),
+            preconf_reorg_reset_pending: Arc::new(AtomicBool::new(false)),
             preconf_reorg_generation: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -2014,6 +2075,20 @@ mod tests {
 
         assert!(!ingress_ready.load(Ordering::Acquire));
         assert!(should_probe_confirmed_sync(true, true, false, true));
+    }
+
+    #[test]
+    fn queued_preconf_job_is_rejected_when_ingress_closes_after_enqueue() {
+        let ingress_ready = AtomicBool::new(false);
+
+        assert!(!preconf_ingress_accepts_queued_job(&ingress_ready));
+    }
+
+    #[test]
+    fn confirmed_sync_probe_does_not_open_ingress_while_reorg_reset_is_pending() {
+        assert!(!should_open_preconf_ingress(true, true));
+        assert!(should_open_preconf_ingress(true, false));
+        assert!(!should_open_preconf_ingress(false, false));
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -131,6 +131,14 @@ fn should_open_preconf_ingress(confirmed_sync_ready: bool, reorg_reset_pending: 
     confirmed_sync_ready && !reorg_reset_pending
 }
 
+/// Return the common ancestor whose pending post-reorg reset should be retried.
+fn pending_preconf_reorg_reset_common_ancestor(
+    reorg_reset_pending: bool,
+    pending_common_ancestor: Option<u64>,
+) -> Option<u64> {
+    reorg_reset_pending.then_some(pending_common_ancestor).flatten()
+}
+
 /// Resolve whether confirmed-sync readiness should open ingress.
 fn resolve_confirmed_sync_ready(confirmed_sync_snapshot: ConfirmedSyncSnapshot) -> bool {
     confirmed_sync_snapshot.is_ready()
@@ -1455,6 +1463,14 @@ where
                     self.preconf_ingress_ready.load(Ordering::Acquire),
                     scanner_live,
                 ) {
+                    if let Some(common_ancestor) = pending_preconf_reorg_reset_common_ancestor(
+                        self.preconf_reorg_reset_pending.load(Ordering::Acquire),
+                        pending_reorg_common_ancestor,
+                    ) && self.complete_preconf_reorg_reset(common_ancestor).await
+                    {
+                        pending_reorg_common_ancestor = None;
+                    }
+
                     let confirmed_sync_probe = self.confirmed_sync_snapshot().await;
                     if let Err(err) = &confirmed_sync_probe {
                         counter!(DriverMetrics::EVENT_CONFIRMED_SYNC_PROBE_ERRORS_TOTAL)
@@ -1466,16 +1482,6 @@ where
                         continue;
                     }
                     let confirmed_sync_ready = resolve_confirmed_sync_probe(confirmed_sync_probe);
-                    let reorg_reset_pending =
-                        self.preconf_reorg_reset_pending.load(Ordering::Acquire);
-                    if confirmed_sync_ready &&
-                        reorg_reset_pending &&
-                        let Some(common_ancestor) = pending_reorg_common_ancestor &&
-                        self.complete_preconf_reorg_reset(common_ancestor).await
-                    {
-                        pending_reorg_common_ancestor = None;
-                    }
-
                     let reorg_reset_pending =
                         self.preconf_reorg_reset_pending.load(Ordering::Acquire);
                     if should_open_preconf_ingress(confirmed_sync_ready, reorg_reset_pending) {
@@ -2112,6 +2118,13 @@ mod tests {
         assert!(!should_open_preconf_ingress(true, true));
         assert!(should_open_preconf_ingress(true, false));
         assert!(!should_open_preconf_ingress(false, false));
+    }
+
+    #[test]
+    fn pending_reorg_reset_retries_before_confirmed_sync_can_reopen_ingress() {
+        assert_eq!(pending_preconf_reorg_reset_common_ancestor(true, Some(42)), Some(42));
+        assert_eq!(pending_preconf_reorg_reset_common_ancestor(false, Some(42)), None);
+        assert_eq!(pending_preconf_reorg_reset_common_ancestor(true, None), None);
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -52,6 +52,7 @@ where
         // mark this pod as the active preconfer for shutdown purposes.
         self.mark_preconf_request_received().await;
         let _build_guard = self.build_preconf_lock.lock().await;
+        self.reconcile_preconf_reorg_state().await?;
 
         // Guard against building on a genuinely syncing node, but tolerate the false-
         // positive that taiko-geth emits on genesis chains (currentBlock == highestBlock

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -1,7 +1,10 @@
 //! Whitelist preconfirmation API service implementation.
 
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -24,7 +27,7 @@ use protocol::{
 };
 use rpc::{beacon::BeaconClient, client::Client};
 use tokio::sync::{Mutex, broadcast, mpsc};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     api::{
@@ -107,6 +110,8 @@ where
     highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
     /// Shared cache state used to back `/status` and EOS visibility.
     cache_state: SharedPreconfCacheState,
+    /// Last event-scanner reorg generation reflected in API-visible unsafe state.
+    observed_preconf_reorg_generation: AtomicU64,
     /// Broadcast channel for API `/ws` end-of-sequencing notifications.
     eos_notification_tx: broadcast::Sender<EndOfSequencingNotification>,
     /// Wall-clock instant of the most recent `build_preconf_block` invocation,
@@ -162,6 +167,7 @@ where
         }: WhitelistApiServiceParams<P>,
     ) -> Self {
         let (eos_notification_tx, _) = broadcast::channel(EOS_NOTIFICATION_CHANNEL_CAPACITY);
+        let observed_preconf_reorg_generation = event_syncer.preconf_reorg_generation();
         Self {
             event_syncer,
             rpc,
@@ -172,6 +178,7 @@ where
             local_peer_id,
             highest_unsafe_l2_payload_block_id,
             cache_state,
+            observed_preconf_reorg_generation: AtomicU64::new(observed_preconf_reorg_generation),
             eos_notification_tx,
             network_command_tx,
             build_preconf_lock: Mutex::new(()),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
@@ -134,4 +134,32 @@ where
     pub(super) async fn update_highest_unsafe(&self, block_number: u64) {
         *self.highest_unsafe_l2_payload_block_id.lock().await = block_number;
     }
+
+    /// Reconcile API-visible unsafe state after event sync publishes a completed reorg reset.
+    pub(super) async fn reconcile_preconf_reorg_state(&self) -> Result<()> {
+        let current_generation = self.event_syncer.preconf_reorg_generation();
+        let observed_generation = self.observed_preconf_reorg_generation.load(Ordering::Acquire);
+        if current_generation == observed_generation {
+            return Ok(());
+        }
+
+        let Some(boundary) = self.rpc.head_l1_origin().await?.map(|head| head.block_id.to::<u64>())
+        else {
+            warn!(
+                preconf_reorg_generation = current_generation,
+                "skipping whitelist API unsafe-state reset until head l1 origin is available"
+            );
+            return Ok(());
+        };
+
+        self.update_highest_unsafe(boundary).await;
+        self.cache_state.clear().await;
+        self.observed_preconf_reorg_generation.store(current_generation, Ordering::Release);
+        info!(
+            preconf_reorg_generation = current_generation,
+            head_l1_origin_block_id = boundary,
+            "reset whitelist API unsafe state after event scanner reorg"
+        );
+        Ok(())
+    }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -8,6 +8,8 @@ where
 {
     /// Build the current status snapshot served by the REST `/status` route.
     pub(super) async fn get_status_snapshot(&self) -> Result<WhitelistStatus> {
+        self.reconcile_preconf_reorg_state().await?;
+
         let head_l1_origin = self.rpc.head_l1_origin().await?;
         let highest_unsafe = *self.highest_unsafe_l2_payload_block_id.lock().await;
         let current_epoch = self.beacon_client.current_epoch();

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -50,6 +50,11 @@ impl SharedPreconfCacheState {
     pub(crate) async fn end_of_sequencing_for_epoch(&self, epoch: u64) -> Option<B256> {
         self.end_of_sequencing_by_epoch.lock().await.get(&epoch).copied()
     }
+
+    /// Clear all shared cache state after the unsafe preconfirmation branch is invalidated.
+    pub(crate) async fn clear(&self) {
+        self.end_of_sequencing_by_epoch.lock().await.clear();
+    }
 }
 
 /// Simple in-memory cache keyed by block hash with bounded capacity.
@@ -92,6 +97,11 @@ impl EnvelopeCache {
     /// Remove a cached envelope by block hash.
     pub fn remove(&mut self, hash: &B256) -> Option<Arc<WhitelistExecutionPayloadEnvelope>> {
         self.entries.remove(hash)
+    }
+
+    /// Clear all pending envelopes.
+    pub fn clear(&mut self) {
+        self.entries.clear();
     }
 
     /// Returns all cached envelope hashes sorted by block number and hash.
@@ -162,6 +172,11 @@ impl RecentEnvelopeCache {
     /// Get a recent envelope by block hash.
     pub fn get_recent(&self, hash: &B256) -> Option<Arc<WhitelistExecutionPayloadEnvelope>> {
         self.entries.get(hash).cloned()
+    }
+
+    /// Clear all recently accepted envelopes.
+    pub fn clear(&mut self) {
+        self.entries.clear();
     }
 
     /// Returns current number of recent envelopes.
@@ -268,6 +283,21 @@ mod tests {
     }
 
     #[test]
+    fn recent_cache_clear_removes_all_entries() {
+        let mut recent = RecentEnvelopeCache::with_capacity(2);
+        let h1 = B256::from([0x01u8; 32]);
+        let h2 = B256::from([0x02u8; 32]);
+
+        recent.insert_recent(Arc::new(sample_envelope(h1, 1)));
+        recent.insert_recent(Arc::new(sample_envelope(h2, 2)));
+        recent.clear();
+
+        assert!(recent.get_recent(&h1).is_none());
+        assert!(recent.get_recent(&h2).is_none());
+        assert_eq!(recent.len(), 0);
+    }
+
+    #[test]
     fn request_throttle_applies_cooldown_per_hash() {
         let mut throttle = RequestThrottle::new(Duration::from_secs(10));
         let hash = B256::from([0xaau8; 32]);
@@ -309,6 +339,31 @@ mod tests {
         let hashes = cache.sorted_hashes_by_block_number();
         assert_eq!(hashes, vec![h2, h3]);
         assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn pending_cache_clear_removes_all_entries() {
+        let mut cache = EnvelopeCache::with_capacity(2);
+        let h1 = B256::from([0x10u8; 32]);
+        let h2 = B256::from([0x20u8; 32]);
+
+        cache.insert(Arc::new(sample_envelope(h1, 1)));
+        cache.insert(Arc::new(sample_envelope(h2, 2)));
+        cache.clear();
+
+        assert!(cache.get(&h1).is_none());
+        assert!(cache.get(&h2).is_none());
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn shared_preconf_cache_state_clear_removes_eos_entries() {
+        let state = SharedPreconfCacheState::new();
+        state.record_end_of_sequencing(7, B256::from([0x07u8; 32])).await;
+
+        state.clear().await;
+
+        assert_eq!(state.end_of_sequencing_for_epoch(7).await, None);
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -255,6 +255,7 @@ where
         Ok(true)
     }
 
+    /// Publish or throttle a request for a missing parent payload.
     async fn request_missing_parent(
         &mut self,
         parent_hash: alloy_primitives::B256,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -175,7 +175,7 @@ where
         }
 
         if self.block_hash_by_number(block_number).await? == Some(block_hash) {
-            record_materialized_preconf_block(
+            let can_remove = record_materialized_preconf_cache_hit(
                 &mut self.preconf_import_cursor,
                 self.highest_unsafe_l2_payload_block_id.as_ref(),
                 block_number,
@@ -184,9 +184,10 @@ where
             debug!(
                 block_number,
                 block_hash = %block_hash,
-                "dropping already-inserted whitelist preconfirmation payload"
+                can_remove,
+                "handling already-inserted whitelist preconfirmation payload"
             );
-            return Ok(true);
+            return Ok(can_remove);
         }
 
         let parent_hash = payload.parent_hash;
@@ -337,6 +338,20 @@ pub(super) async fn record_materialized_preconf_block(
     true
 }
 
+/// Record a materialized cache hit and return whether the cached entry can be removed.
+pub(super) async fn record_materialized_preconf_cache_hit(
+    cursor: &mut Option<u64>,
+    highest: Option<&Arc<Mutex<u64>>>,
+    block_number: u64,
+) -> bool {
+    let original_cursor = *cursor;
+    if record_materialized_preconf_block(cursor, highest, block_number).await {
+        return true;
+    }
+
+    original_cursor.is_some_and(|cursor| block_number <= cursor)
+}
+
 /// Apply a resolved post-reorg boundary to importer-local unsafe state.
 pub(super) async fn apply_preconf_reorg_boundary(
     observed_generation: &mut u64,
@@ -420,7 +435,8 @@ mod tests {
     use super::{
         advance_preconf_import_cursor, apply_preconf_reorg_boundary,
         preconf_reorg_cursor_allows_block, record_materialized_preconf_block,
-        set_highest_unsafe_block_id, should_defer_cached_driver_error,
+        record_materialized_preconf_cache_hit, set_highest_unsafe_block_id,
+        should_defer_cached_driver_error,
     };
 
     #[test]
@@ -478,6 +494,35 @@ mod tests {
         assert!(!advanced);
         assert_eq!(cursor, Some(100));
         assert_eq!(*highest.lock().await, 100);
+    }
+
+    #[tokio::test]
+    async fn materialized_later_block_is_retained_until_reorg_cursor_can_record_it() {
+        let highest = Arc::new(Mutex::new(100));
+        let mut cursor = Some(100);
+
+        let can_remove =
+            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 102).await;
+
+        assert!(!can_remove);
+        assert_eq!(cursor, Some(100));
+        assert_eq!(*highest.lock().await, 100);
+    }
+
+    #[tokio::test]
+    async fn materialized_recorded_or_old_block_can_be_removed_from_cache() {
+        let highest = Arc::new(Mutex::new(100));
+        let mut cursor = Some(100);
+
+        let next_can_remove =
+            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 101).await;
+        let old_can_remove =
+            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 100).await;
+
+        assert!(next_can_remove);
+        assert!(old_can_remove);
+        assert_eq!(cursor, Some(101));
+        assert_eq!(*highest.lock().await, 101);
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -375,9 +375,26 @@ where
     if original_cursor.is_none() {
         return Ok(record_materialized_preconf_block(cursor, highest, block_number).await);
     }
+    if original_cursor.is_some_and(|cursor| block_number <= cursor) {
+        return Ok(true);
+    }
+    if !highest_allows_materialized_cursor_advance(highest, block_number).await {
+        return Ok(false);
+    }
 
     advance_materialized_preconf_cursor(cursor, highest, block_number, is_materialized).await?;
     Ok(cursor.is_some_and(|cursor| block_number <= cursor))
+}
+
+/// Returns true when shared unsafe state confirms this materialized block is from this rebuild.
+pub(super) async fn highest_allows_materialized_cursor_advance(
+    highest: Option<&Arc<Mutex<u64>>>,
+    block_number: u64,
+) -> bool {
+    let Some(highest) = highest else {
+        return false;
+    };
+    *highest.lock().await >= block_number
 }
 
 /// Advance an active reorg cursor across locally materialized contiguous blocks.
@@ -538,6 +555,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn materialized_cache_hit_does_not_advance_active_cursor_past_highest_unsafe() {
+        let highest = Arc::new(Mutex::new(100));
+        let mut cursor = Some(100);
+
+        let can_remove =
+            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 101, |_| async {
+                Ok(true)
+            })
+            .await
+            .unwrap();
+
+        assert!(!can_remove);
+        assert_eq!(cursor, Some(100));
+        assert_eq!(*highest.lock().await, 100);
+    }
+
+    #[tokio::test]
     async fn materialized_cache_hit_without_reorg_cursor_does_not_lower_highest_unsafe() {
         let highest = Arc::new(Mutex::new(150));
         let mut cursor = None;
@@ -587,7 +621,7 @@ mod tests {
 
     #[tokio::test]
     async fn materialized_cache_hit_advances_across_local_contiguous_blocks() {
-        let highest = Arc::new(Mutex::new(100));
+        let highest = Arc::new(Mutex::new(102));
         let mut cursor = Some(100);
 
         let can_remove = record_materialized_preconf_cache_hit(
@@ -606,7 +640,7 @@ mod tests {
 
     #[tokio::test]
     async fn materialized_recorded_or_old_block_can_be_removed_from_cache() {
-        let highest = Arc::new(Mutex::new(100));
+        let highest = Arc::new(Mutex::new(101));
         let mut cursor = Some(100);
 
         let next_can_remove =

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -386,13 +386,14 @@ where
     Ok(cursor.is_some_and(|cursor| block_number <= cursor))
 }
 
-/// Returns true when shared unsafe state confirms this materialized block is from this rebuild.
+/// Returns true when shared unsafe state, if present, confirms this materialized block is from this
+/// rebuild.
 pub(super) async fn highest_allows_materialized_cursor_advance(
     highest: Option<&Arc<Mutex<u64>>>,
     block_number: u64,
 ) -> bool {
     let Some(highest) = highest else {
-        return false;
+        return true;
     };
     *highest.lock().await >= block_number
 }
@@ -636,6 +637,21 @@ mod tests {
         assert!(can_remove);
         assert_eq!(cursor, Some(102));
         assert_eq!(*highest.lock().await, 102);
+    }
+
+    #[tokio::test]
+    async fn materialized_cache_hit_advances_without_shared_highest_state() {
+        let mut cursor = Some(100);
+
+        let can_remove =
+            record_materialized_preconf_cache_hit(&mut cursor, None, 102, |number| async move {
+                Ok(matches!(number, 101 | 102))
+            })
+            .await
+            .unwrap();
+
+        assert!(can_remove);
+        assert_eq!(cursor, Some(102));
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -249,6 +249,7 @@ fn should_defer_cached_driver_error(err: &driver::DriverError) -> bool {
     match err {
         driver::DriverError::EngineSyncing(_) |
         driver::DriverError::BlockNotFound(_) |
+        driver::DriverError::PreconfIngressNotReady |
         driver::DriverError::PreconfEnqueueTimeout { .. } |
         driver::DriverError::PreconfResponseTimeout { .. } => true,
         driver::DriverError::PreconfInjectionFailed { source, .. } => matches!(
@@ -259,5 +260,17 @@ fn should_defer_cached_driver_error(err: &driver::DriverError) -> bool {
                 driver::sync::error::EngineSubmissionError::MissingInsertedBlock(_)
         ),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use driver::DriverError;
+
+    use super::should_defer_cached_driver_error;
+
+    #[test]
+    fn preconf_ingress_not_ready_defers_cached_import() {
+        assert!(should_defer_cached_driver_error(&DriverError::PreconfIngressNotReady));
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -1,8 +1,9 @@
 //! Cache re-import flow for out-of-order envelopes once parents arrive.
 
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 
 use driver::PreconfPayload;
+use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -19,6 +20,8 @@ where
 {
     /// Attempt to import cached envelopes if sync is ready.
     pub(crate) async fn maybe_import_from_cache(&mut self) -> Result<()> {
+        self.reconcile_preconf_reorg_state().await?;
+
         let _ = self.refresh_sync_ready().await?;
         if !self.sync_ready || self.cache.is_empty() {
             return Ok(());
@@ -108,6 +111,42 @@ where
         Ok(())
     }
 
+    /// Reconcile importer-local unsafe state after the event scanner reports an L1 reorg.
+    pub(super) async fn reconcile_preconf_reorg_state(&mut self) -> Result<()> {
+        let current_generation = self.event_syncer.preconf_reorg_generation();
+        if current_generation == self.observed_preconf_reorg_generation {
+            return Ok(());
+        }
+
+        self.observed_preconf_reorg_generation = current_generation;
+        self.cache.clear();
+        self.recent_cache.clear();
+        self.cache_state.clear().await;
+
+        let Some(boundary) = self.head_l1_origin_block_id().await? else {
+            self.preconf_import_cursor = None;
+            self.sync_ready = false;
+            self.update_cache_gauges();
+            warn!(
+                preconf_reorg_generation = current_generation,
+                "cleared whitelist preconfirmation caches after reorg without head l1 origin"
+            );
+            return Ok(());
+        };
+
+        self.preconf_import_cursor = Some(boundary);
+        if let Some(ref highest) = self.highest_unsafe_l2_payload_block_id {
+            set_highest_unsafe_block_id(highest, boundary).await;
+        }
+        self.update_cache_gauges();
+        info!(
+            preconf_reorg_generation = current_generation,
+            head_l1_origin_block_id = boundary,
+            "reset whitelist preconfirmation unsafe state after event scanner reorg"
+        );
+        Ok(())
+    }
+
     /// Try to import one cached envelope.
     async fn try_import_cached(
         &mut self,
@@ -141,33 +180,35 @@ where
             return Ok(true);
         }
 
+        let parent_hash = payload.parent_hash;
+        let parent_number = block_number.saturating_sub(1);
         if block_number == 0 {
             return Ok(true);
         }
 
-        let parent_hash = payload.parent_hash;
-        let parent_number = block_number.saturating_sub(1);
-        if self.block_hash_by_number(parent_number).await? != Some(parent_hash) {
-            if self.request_throttle.should_request(parent_hash, Instant::now()) {
-                metrics::counter!(
-                    WhitelistPreconfirmationDriverMetrics::PARENT_REQUESTS_TOTAL,
-                    "result" => "issued",
-                )
-                .increment(1);
-                self.publish_unsafe_request(parent_hash).await;
-            } else {
-                metrics::counter!(
-                    WhitelistPreconfirmationDriverMetrics::PARENT_REQUESTS_TOTAL,
-                    "result" => "throttled",
-                )
-                .increment(1);
+        if !preconf_reorg_cursor_allows_block(self.preconf_import_cursor, block_number) {
+            if self.preconf_import_cursor.is_some_and(|cursor| block_number <= cursor) {
                 debug!(
                     block_number,
                     block_hash = %block_hash,
-                    parent_hash = %parent_hash,
-                    "suppressed duplicate whitelist preconfirmation parent request due to cooldown"
+                    preconf_import_cursor = ?self.preconf_import_cursor,
+                    "dropping cached whitelist preconfirmation payload at or before reorg cursor"
                 );
+                return Ok(true);
             }
+
+            self.request_missing_parent(parent_hash, block_number, block_hash).await;
+            debug!(
+                block_number,
+                block_hash = %block_hash,
+                preconf_import_cursor = ?self.preconf_import_cursor,
+                "deferring cached whitelist preconfirmation payload until reorg cursor advances"
+            );
+            return Ok(false);
+        }
+
+        if self.block_hash_by_number(parent_number).await? != Some(parent_hash) {
+            self.request_missing_parent(parent_hash, block_number, block_hash).await;
             return Ok(false);
         }
 
@@ -203,12 +244,70 @@ where
         );
 
         if let Some(ref highest) = self.highest_unsafe_l2_payload_block_id {
-            let mut guard = highest.lock().await;
-            *guard = block_number.max(*guard);
+            if self.preconf_import_cursor.is_some() {
+                set_highest_unsafe_block_id(highest, block_number).await;
+            } else {
+                advance_highest_unsafe_block_id(highest, block_number).await;
+            }
         }
+        advance_preconf_import_cursor(&mut self.preconf_import_cursor, block_number);
 
         Ok(true)
     }
+
+    async fn request_missing_parent(
+        &mut self,
+        parent_hash: alloy_primitives::B256,
+        block_number: u64,
+        block_hash: alloy_primitives::B256,
+    ) {
+        if self.request_throttle.should_request(parent_hash, Instant::now()) {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::PARENT_REQUESTS_TOTAL,
+                "result" => "issued",
+            )
+            .increment(1);
+            self.publish_unsafe_request(parent_hash).await;
+        } else {
+            metrics::counter!(
+                WhitelistPreconfirmationDriverMetrics::PARENT_REQUESTS_TOTAL,
+                "result" => "throttled",
+            )
+            .increment(1);
+            debug!(
+                block_number,
+                block_hash = %block_hash,
+                parent_hash = %parent_hash,
+                "suppressed duplicate whitelist preconfirmation parent request due to cooldown"
+            );
+        }
+    }
+}
+
+/// Returns true when the reorg import cursor permits importing `block_number`.
+pub(super) fn preconf_reorg_cursor_allows_block(cursor: Option<u64>, block_number: u64) -> bool {
+    match cursor {
+        Some(cursor) => block_number == cursor.saturating_add(1),
+        None => true,
+    }
+}
+
+/// Advance the reorg import cursor after a successful unsafe payload import.
+pub(super) fn advance_preconf_import_cursor(cursor: &mut Option<u64>, block_number: u64) {
+    if cursor.is_some() {
+        *cursor = Some(block_number);
+    }
+}
+
+/// Set the shared highest unsafe block ID, allowing reorg resets to move it backward.
+pub(super) async fn set_highest_unsafe_block_id(highest: &Arc<Mutex<u64>>, block_number: u64) {
+    *highest.lock().await = block_number;
+}
+
+/// Advance the shared highest unsafe block ID without moving it backward.
+pub(super) async fn advance_highest_unsafe_block_id(highest: &Arc<Mutex<u64>>, block_number: u64) {
+    let mut guard = highest.lock().await;
+    *guard = block_number.max(*guard);
 }
 
 /// Returns true when a cached-envelope import error should be logged and dropped.
@@ -265,12 +364,46 @@ fn should_defer_cached_driver_error(err: &driver::DriverError) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use driver::DriverError;
+    use std::sync::Arc;
 
-    use super::should_defer_cached_driver_error;
+    use driver::DriverError;
+    use tokio::sync::Mutex;
+
+    use super::{
+        advance_preconf_import_cursor, preconf_reorg_cursor_allows_block,
+        set_highest_unsafe_block_id, should_defer_cached_driver_error,
+    };
 
     #[test]
     fn preconf_ingress_not_ready_defers_cached_import() {
         assert!(should_defer_cached_driver_error(&DriverError::PreconfIngressNotReady));
+    }
+
+    #[test]
+    fn preconf_reorg_cursor_requires_contiguous_block_after_boundary() {
+        assert!(preconf_reorg_cursor_allows_block(None, 102));
+        assert!(preconf_reorg_cursor_allows_block(Some(100), 101));
+        assert!(!preconf_reorg_cursor_allows_block(Some(100), 102));
+        assert!(!preconf_reorg_cursor_allows_block(Some(100), 100));
+    }
+
+    #[test]
+    fn preconf_reorg_cursor_advances_only_when_active() {
+        let mut inactive = None;
+        advance_preconf_import_cursor(&mut inactive, 101);
+        assert_eq!(inactive, None);
+
+        let mut active = Some(100);
+        advance_preconf_import_cursor(&mut active, 101);
+        assert_eq!(active, Some(101));
+    }
+
+    #[tokio::test]
+    async fn highest_unsafe_block_id_can_move_backward_after_reorg() {
+        let highest = Arc::new(Mutex::new(150));
+
+        set_highest_unsafe_block_id(&highest, 100).await;
+
+        assert_eq!(*highest.lock().await, 100);
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -1,7 +1,8 @@
 //! Cache re-import flow for out-of-order envelopes once parents arrive.
 
-use std::{sync::Arc, time::Instant};
+use std::{future::Future, sync::Arc, time::Instant};
 
+use alloy_provider::Provider;
 use driver::PreconfPayload;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
@@ -175,12 +176,29 @@ where
         }
 
         if self.block_hash_by_number(block_number).await? == Some(block_hash) {
+            let l2_provider = self.rpc.l2_provider.clone();
             let can_remove = record_materialized_preconf_cache_hit(
                 &mut self.preconf_import_cursor,
                 self.highest_unsafe_l2_payload_block_id.as_ref(),
                 block_number,
+                move |materialized_block_number| {
+                    let l2_provider = l2_provider.clone();
+                    async move {
+                        if materialized_block_number == block_number {
+                            return Ok(true);
+                        }
+
+                        l2_provider
+                            .get_block_by_number(alloy_eips::BlockNumberOrTag::Number(
+                                materialized_block_number,
+                            ))
+                            .await
+                            .map(|block| block.is_some())
+                            .map_err(WhitelistPreconfirmationDriverError::provider)
+                    }
+                },
             )
-            .await;
+            .await?;
             debug!(
                 block_number,
                 block_hash = %block_hash,
@@ -332,24 +350,59 @@ pub(super) async fn record_materialized_preconf_block(
     }
 
     if let Some(highest) = highest {
-        set_highest_unsafe_block_id(highest, block_number).await;
+        if cursor.is_some() {
+            set_highest_unsafe_block_id(highest, block_number).await;
+        } else {
+            advance_highest_unsafe_block_id(highest, block_number).await;
+        }
     }
     advance_preconf_import_cursor(cursor, block_number);
     true
 }
 
 /// Record a materialized cache hit and return whether the cached entry can be removed.
-pub(super) async fn record_materialized_preconf_cache_hit(
+pub(super) async fn record_materialized_preconf_cache_hit<F, Fut>(
     cursor: &mut Option<u64>,
     highest: Option<&Arc<Mutex<u64>>>,
     block_number: u64,
-) -> bool {
+    is_materialized: F,
+) -> Result<bool>
+where
+    F: FnMut(u64) -> Fut,
+    Fut: Future<Output = Result<bool>>,
+{
     let original_cursor = *cursor;
-    if record_materialized_preconf_block(cursor, highest, block_number).await {
-        return true;
+    if original_cursor.is_none() {
+        return Ok(record_materialized_preconf_block(cursor, highest, block_number).await);
     }
 
-    original_cursor.is_some_and(|cursor| block_number <= cursor)
+    advance_materialized_preconf_cursor(cursor, highest, block_number, is_materialized).await?;
+    Ok(cursor.is_some_and(|cursor| block_number <= cursor))
+}
+
+/// Advance an active reorg cursor across locally materialized contiguous blocks.
+pub(super) async fn advance_materialized_preconf_cursor<F, Fut>(
+    cursor: &mut Option<u64>,
+    highest: Option<&Arc<Mutex<u64>>>,
+    target_block_number: u64,
+    mut is_materialized: F,
+) -> Result<()>
+where
+    F: FnMut(u64) -> Fut,
+    Fut: Future<Output = Result<bool>>,
+{
+    while let Some(next_block_number) = cursor.and_then(|cursor| cursor.checked_add(1)) {
+        if next_block_number > target_block_number {
+            break;
+        }
+        if !is_materialized(next_block_number).await? {
+            break;
+        }
+
+        let advanced = record_materialized_preconf_block(cursor, highest, next_block_number).await;
+        debug_assert!(advanced, "contiguous materialized cursor advance must succeed");
+    }
+    Ok(())
 }
 
 /// Apply a resolved post-reorg boundary to importer-local unsafe state.
@@ -485,6 +538,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn materialized_cache_hit_without_reorg_cursor_does_not_lower_highest_unsafe() {
+        let highest = Arc::new(Mutex::new(150));
+        let mut cursor = None;
+
+        let can_remove =
+            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 120, |_| async {
+                Ok(true)
+            })
+            .await
+            .unwrap();
+
+        assert!(can_remove);
+        assert_eq!(cursor, None);
+        assert_eq!(*highest.lock().await, 150);
+    }
+
+    #[tokio::test]
     async fn materialized_later_block_does_not_skip_active_reorg_cursor() {
         let highest = Arc::new(Mutex::new(100));
         let mut cursor = Some(100);
@@ -501,12 +571,37 @@ mod tests {
         let highest = Arc::new(Mutex::new(100));
         let mut cursor = Some(100);
 
-        let can_remove =
-            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 102).await;
+        let can_remove = record_materialized_preconf_cache_hit(
+            &mut cursor,
+            Some(&highest),
+            102,
+            |number| async move { Ok(number == 102) },
+        )
+        .await
+        .unwrap();
 
         assert!(!can_remove);
         assert_eq!(cursor, Some(100));
         assert_eq!(*highest.lock().await, 100);
+    }
+
+    #[tokio::test]
+    async fn materialized_cache_hit_advances_across_local_contiguous_blocks() {
+        let highest = Arc::new(Mutex::new(100));
+        let mut cursor = Some(100);
+
+        let can_remove = record_materialized_preconf_cache_hit(
+            &mut cursor,
+            Some(&highest),
+            102,
+            |number| async move { Ok(matches!(number, 101 | 102)) },
+        )
+        .await
+        .unwrap();
+
+        assert!(can_remove);
+        assert_eq!(cursor, Some(102));
+        assert_eq!(*highest.lock().await, 102);
     }
 
     #[tokio::test]
@@ -515,9 +610,17 @@ mod tests {
         let mut cursor = Some(100);
 
         let next_can_remove =
-            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 101).await;
+            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 101, |_| async {
+                Ok(true)
+            })
+            .await
+            .unwrap();
         let old_can_remove =
-            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 100).await;
+            record_materialized_preconf_cache_hit(&mut cursor, Some(&highest), 100, |_| async {
+                Ok(true)
+            })
+            .await
+            .unwrap();
 
         assert!(next_can_remove);
         assert!(old_can_remove);

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -118,13 +118,20 @@ where
             return Ok(());
         }
 
-        self.observed_preconf_reorg_generation = current_generation;
         self.cache.clear();
         self.recent_cache.clear();
         self.cache_state.clear().await;
 
-        let Some(boundary) = self.head_l1_origin_block_id().await? else {
-            self.preconf_import_cursor = None;
+        let boundary = self.head_l1_origin_block_id().await?;
+        if !apply_preconf_reorg_boundary(
+            &mut self.observed_preconf_reorg_generation,
+            &mut self.preconf_import_cursor,
+            self.highest_unsafe_l2_payload_block_id.as_ref(),
+            current_generation,
+            boundary,
+        )
+        .await
+        {
             self.sync_ready = false;
             self.update_cache_gauges();
             warn!(
@@ -134,14 +141,10 @@ where
             return Ok(());
         };
 
-        self.preconf_import_cursor = Some(boundary);
-        if let Some(ref highest) = self.highest_unsafe_l2_payload_block_id {
-            set_highest_unsafe_block_id(highest, boundary).await;
-        }
         self.update_cache_gauges();
         info!(
             preconf_reorg_generation = current_generation,
-            head_l1_origin_block_id = boundary,
+            head_l1_origin_block_id = boundary.expect("applied reorg boundary must exist"),
             "reset whitelist preconfirmation unsafe state after event scanner reorg"
         );
         Ok(())
@@ -334,6 +337,27 @@ pub(super) async fn record_materialized_preconf_block(
     true
 }
 
+/// Apply a resolved post-reorg boundary to importer-local unsafe state.
+pub(super) async fn apply_preconf_reorg_boundary(
+    observed_generation: &mut u64,
+    cursor: &mut Option<u64>,
+    highest: Option<&Arc<Mutex<u64>>>,
+    current_generation: u64,
+    boundary: Option<u64>,
+) -> bool {
+    let Some(boundary) = boundary else {
+        *cursor = None;
+        return false;
+    };
+
+    *cursor = Some(boundary);
+    if let Some(highest) = highest {
+        set_highest_unsafe_block_id(highest, boundary).await;
+    }
+    *observed_generation = current_generation;
+    true
+}
+
 /// Returns true when a cached-envelope import error should be logged and dropped.
 pub(super) fn should_drop_cached_import_error(err: &WhitelistPreconfirmationDriverError) -> bool {
     match err {
@@ -394,9 +418,9 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::{
-        advance_preconf_import_cursor, preconf_reorg_cursor_allows_block,
-        record_materialized_preconf_block, set_highest_unsafe_block_id,
-        should_defer_cached_driver_error,
+        advance_preconf_import_cursor, apply_preconf_reorg_boundary,
+        preconf_reorg_cursor_allows_block, record_materialized_preconf_block,
+        set_highest_unsafe_block_id, should_defer_cached_driver_error,
     };
 
     #[test]
@@ -452,6 +476,48 @@ mod tests {
         let advanced = record_materialized_preconf_block(&mut cursor, Some(&highest), 102).await;
 
         assert!(!advanced);
+        assert_eq!(cursor, Some(100));
+        assert_eq!(*highest.lock().await, 100);
+    }
+
+    #[tokio::test]
+    async fn missing_reorg_boundary_does_not_mark_generation_observed() {
+        let highest = Arc::new(Mutex::new(150));
+        let mut observed_generation = 1;
+        let mut cursor = Some(150);
+
+        let applied = apply_preconf_reorg_boundary(
+            &mut observed_generation,
+            &mut cursor,
+            Some(&highest),
+            2,
+            None,
+        )
+        .await;
+
+        assert!(!applied);
+        assert_eq!(observed_generation, 1);
+        assert_eq!(cursor, None);
+        assert_eq!(*highest.lock().await, 150);
+    }
+
+    #[tokio::test]
+    async fn resolved_reorg_boundary_marks_generation_observed() {
+        let highest = Arc::new(Mutex::new(150));
+        let mut observed_generation = 1;
+        let mut cursor = Some(150);
+
+        let applied = apply_preconf_reorg_boundary(
+            &mut observed_generation,
+            &mut cursor,
+            Some(&highest),
+            2,
+            Some(100),
+        )
+        .await;
+
+        assert!(applied);
+        assert_eq!(observed_generation, 2);
         assert_eq!(cursor, Some(100));
         assert_eq!(*highest.lock().await, 100);
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -172,6 +172,12 @@ where
         }
 
         if self.block_hash_by_number(block_number).await? == Some(block_hash) {
+            record_materialized_preconf_block(
+                &mut self.preconf_import_cursor,
+                self.highest_unsafe_l2_payload_block_id.as_ref(),
+                block_number,
+            )
+            .await;
             debug!(
                 block_number,
                 block_hash = %block_hash,
@@ -311,6 +317,23 @@ pub(super) async fn advance_highest_unsafe_block_id(highest: &Arc<Mutex<u64>>, b
     *guard = block_number.max(*guard);
 }
 
+/// Record an already-materialized block when it is the next block required by a reorg cursor.
+pub(super) async fn record_materialized_preconf_block(
+    cursor: &mut Option<u64>,
+    highest: Option<&Arc<Mutex<u64>>>,
+    block_number: u64,
+) -> bool {
+    if !preconf_reorg_cursor_allows_block(*cursor, block_number) {
+        return false;
+    }
+
+    if let Some(highest) = highest {
+        set_highest_unsafe_block_id(highest, block_number).await;
+    }
+    advance_preconf_import_cursor(cursor, block_number);
+    true
+}
+
 /// Returns true when a cached-envelope import error should be logged and dropped.
 pub(super) fn should_drop_cached_import_error(err: &WhitelistPreconfirmationDriverError) -> bool {
     match err {
@@ -372,7 +395,8 @@ mod tests {
 
     use super::{
         advance_preconf_import_cursor, preconf_reorg_cursor_allows_block,
-        set_highest_unsafe_block_id, should_defer_cached_driver_error,
+        record_materialized_preconf_block, set_highest_unsafe_block_id,
+        should_defer_cached_driver_error,
     };
 
     #[test]
@@ -405,6 +429,30 @@ mod tests {
 
         set_highest_unsafe_block_id(&highest, 100).await;
 
+        assert_eq!(*highest.lock().await, 100);
+    }
+
+    #[tokio::test]
+    async fn materialized_next_block_advances_active_reorg_cursor() {
+        let highest = Arc::new(Mutex::new(100));
+        let mut cursor = Some(100);
+
+        let advanced = record_materialized_preconf_block(&mut cursor, Some(&highest), 101).await;
+
+        assert!(advanced);
+        assert_eq!(cursor, Some(101));
+        assert_eq!(*highest.lock().await, 101);
+    }
+
+    #[tokio::test]
+    async fn materialized_later_block_does_not_skip_active_reorg_cursor() {
+        let highest = Arc::new(Mutex::new(100));
+        let mut cursor = Some(100);
+
+        let advanced = record_materialized_preconf_block(&mut cursor, Some(&highest), 102).await;
+
+        assert!(!advanced);
+        assert_eq!(cursor, Some(100));
         assert_eq!(*highest.lock().await, 100);
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -82,6 +82,10 @@ where
     network_command_tx: mpsc::Sender<NetworkCommand>,
     /// Shared highest unsafe L2 payload block ID (updated on P2P import when REST server enabled).
     highest_unsafe_l2_payload_block_id: Option<Arc<Mutex<u64>>>,
+    /// Last event-scanner reorg generation reflected in importer-local unsafe state.
+    observed_preconf_reorg_generation: u64,
+    /// Required next unsafe import base after an event-scanner reorg reset.
+    preconf_import_cursor: Option<u64>,
     /// Latched flag indicating event sync has exposed a head L1 origin.
     sync_ready: bool,
     /// Shasta anchor contract address used to validate the first transaction.
@@ -106,6 +110,7 @@ where
         } = params;
         let anchor_address = *rpc.shasta.anchor.address();
 
+        let observed_preconf_reorg_generation = event_syncer.preconf_reorg_generation();
         let importer = Self {
             event_syncer,
             rpc,
@@ -118,6 +123,8 @@ where
             operator_set,
             network_command_tx,
             highest_unsafe_l2_payload_block_id,
+            observed_preconf_reorg_generation,
+            preconf_import_cursor: None,
             sync_ready: false,
             anchor_address,
         };
@@ -127,6 +134,8 @@ where
 
     /// Handle one network event.
     pub(crate) async fn handle_event(&mut self, event: NetworkEvent) -> Result<()> {
+        self.reconcile_preconf_reorg_state().await?;
+
         match event {
             NetworkEvent::UnsafePayload { from, payload } => {
                 if let Err(err) = self.handle_unsafe_payload(payload).await {


### PR DESCRIPTION
## Summary

- Close Rust preconfirmation ingress when the event scanner reports an L1 reorg, and only publish a preconfirmation reorg generation after `head_l1_origin` has been reset to the event-confirmed canonical boundary.
- Reset whitelist preconfirmation unsafe state on that generation change: clear pending/recent/EOS caches, move shared `highest_unsafe_l2_payload_block_id` back to `head_l1_origin.block_id`, and rebuild imports from that boundary.
- Require cached whitelist payload imports after reorg to be contiguous from the reset boundary (`boundary + 1`, then next block), while still validating parent hash before submitting to the driver.
- Reconcile REST API/status/build-visible unsafe state against the same reorg generation so API consumers do not continue seeing the old unsafe tip.
- Treat `PreconfIngressNotReady` as a deferred whitelist cache import error instead of a fatal cache import error.

## Root Cause

Masaya logs showed both Go driver and Rust driver accepted the same bad preconfirmation branch around L2 block `4927664`. The Go driver then observed the L1 reorg, reset its proposal/L1 cursor, and moved its highest unsafe preconfirmation block state back to the latest event-confirmed canonical boundary before rebuilding unsafe payload imports.

The Rust driver only reset `head_l1_origin`; it did not fully reset/rebuild whitelist preconfirmation state. That left cached/recent unsafe payload state and the shared highest unsafe block number pointing at the old branch, so later payloads could continue from a stale unsafe branch after the canonical event boundary changed.

That violates the split flow captured by `WLP-INV-009`: event-driven reorg handling and preconf branch handling are distinct, and both must participate. It also risks `WLP-INV-003` / `WLP-INV-004` if stale unsafe payloads remain usable across the event-confirmed boundary.

## Impact

After this change, an event-scanner reorg closes preconfirmation ingress immediately. Once `head_l1_origin` is reset successfully, the driver publishes a monotonic preconfirmation reorg generation. Whitelist importer/API paths use that generation to clear unsafe preconf caches, reset EOS visibility, move `highest_unsafe_l2_payload_block_id` back to the current event-confirmed boundary, and only accept subsequent cached payloads that rebuild a contiguous unsafe chain above that boundary.

This mirrors the Go driver behavior more closely: unsafe preconfirmation state can move backward on L1 reorg, and subsequent unsafe payloads must be based on the event-confirmed canonical boundary rather than the old branch.

## Invariants

- `WLP-INV-002`: ingress remains fail-closed until scanner-live plus strict confirmed-sync readiness re-open it.
- `WLP-INV-003`: cached preconf payloads at or below `head_l1_origin` are dropped as stale.
- `WLP-INV-004`: reorg recovery never permits parent recovery/imports below the event-confirmed boundary.
- `WLP-INV-009`: event-side reorg reset and preconf-side unsafe branch rebuild both run after an L1 reorg.

## Validation

Passed:

- `just fmt`
- `git diff --check`
- `cargo test -p driver --lib`
- `cargo test -p whitelist-preconfirmation-driver --lib`
- `cargo check -p driver -p whitelist-preconfirmation-driver --all-targets`

Earlier attempted but blocked by existing generated binding warnings:

- `cargo clippy -p driver -p whitelist-preconfirmation-driver --all-targets -- -D warnings`

The clippy run fails in generated files under `crates/bindings/src` with existing `#[automatically_derived]` and unused generated alias warnings promoted by `-D warnings`; those files are generated and intentionally not edited in this PR.