### PR TITLE
chore(repo): let fork PRs pass the typos check

### DIFF
--- a/.github/workflows/repo--typo-check.yml
+++ b/.github/workflows/repo--typo-check.yml
@@ -19,9 +19,9 @@ jobs:
       || (github.event.pull_request.draft == false
           && github.head_ref != 'release-please-*'
           && !startsWith(github.head_ref, 'dependabot'))
-    # SECURITY: route fork PRs to a hosted runner where the first step exits 1.
-    # The required check turns red for fork PRs (instead of silently skipping
-    # as success) without ever running PR-controlled code on arc-runner-set.
+    # SECURITY: route fork PRs to a hosted runner so PR-controlled code never
+    # executes on arc-runner-set. The typo check itself (crate-ci/typos, pinned)
+    # is safe to run against fork contents on ubuntu-latest.
     runs-on: >-
       ${{
         (github.event.pull_request.head.repo.fork == true)
@@ -29,13 +29,6 @@ jobs:
       }}
 
     steps:
-      - name: Block fork PR CI on self-hosted runners
-        if: github.event.pull_request.head.repo.fork == true
-        run: |
-          echo "::error::Fork PR CI on self-hosted runners is disabled for security."
-          echo "::error::A maintainer must move this CI to a hosted-runner job or trigger from a trusted ref."
-          exit 1
-
       - name: Checkout the repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

The `check-for-typos` job in `.github/workflows/repo--typo-check.yml` is a required check that turns red on every fork PR — see the failure on [PR #21670](https://github.com/taikoxyz/taiko-mono/pull/21670) ([run 26164247791](https://github.com/taikoxyz/taiko-mono/actions/runs/26164247791/job/76964504725?pr=21670)).

The job already routes fork PRs to `ubuntu-latest` so PR-controlled code never executes on `arc-runner-set`. On top of that, the first step did `exit 1` whenever the PR came from a fork — which means fork PRs could never pass the check regardless of typos.

This PR removes the redundant block step. The runner split is the real security boundary; `crate-ci/typos` is pinned to `v1` and is safe to run against fork contents on a hosted runner.

## Test plan

- [ ] Confirm the workflow still runs (and can fail on real typos) for non-fork PRs on `arc-runner-set`.
- [ ] Confirm the workflow runs on `ubuntu-latest` for a fork PR (e.g. re-run [PR #21670](https://github.com/taikoxyz/taiko-mono/pull/21670) after this lands) and now passes when there are no typos.