### PR TITLE
ci(repo): improve DeepSeek review by learning from taikoxyz/pico

### DIFF
--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -73,6 +73,14 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
+            // Parse a positive integer from a repo variable, falling back to a
+            // default when unset or non-numeric (e.g. "64k") so a misconfigured
+            // variable can't serialize to null and break every review run.
+            const intFromEnv = (name, fallback) => {
+              const n = parseInt(process.env[name] || '', 10);
+              return Number.isFinite(n) && n > 0 ? n : fallback;
+            };
+
             // Fetch PR details
             const pr = await github.rest.pulls.get({
               owner, repo, pull_number: prNumber
@@ -99,7 +107,7 @@ jobs:
 
             // Truncate diff if too large. deepseek-v4-pro has a large context
             // window, so default high and allow overriding via repo variable.
-            const MAX_DIFF = parseInt(process.env.DEEPSEEK_MAX_DIFF || '2000000', 10);
+            const MAX_DIFF = intFromEnv('DEEPSEEK_MAX_DIFF', 2000000);
             const truncatedDiff = diffText.length > MAX_DIFF
               ? diffText.substring(0, MAX_DIFF) + '\n\n... (diff truncated)'
               : diffText;
@@ -152,7 +160,7 @@ jobs:
             // fully consumed before any visible content is produced, yielding
             // an empty review. Default high (65536) to leave room for output.
             const model = process.env.DEEPSEEK_MODEL || 'deepseek-v4-pro';
-            const maxTokens = parseInt(process.env.DEEPSEEK_MAX_TOKENS || String(8192 * 8), 10);
+            const maxTokens = intFromEnv('DEEPSEEK_MAX_TOKENS', 8192 * 8);
 
             // Call DeepSeek API (OpenAI-compatible endpoint).
             async function requestReview() {

--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -47,40 +47,35 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Get PR number (from comment trigger)
-        if: github.event_name == 'issue_comment'
-        id: pr-from-comment
-        run: |
-          PR_NUMBER=$(gh pr view "${{ github.event.issue.number }}" --json number -q '.number' 2>/dev/null || echo "")
-          if [ -n "$PR_NUMBER" ]; then
-            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          else
-            echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set PR number
+      # For issue_comment events on a PR, github.event.issue.number IS the PR
+      # number (GitHub shares one numbering space for issues and PRs), so no
+      # extra `gh pr view` lookup is needed.
+      - name: Resolve PR number
         id: pr
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
-            echo "number=${{ steps.pr-from-comment.outputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run DeepSeek Code Review
         id: review
         uses: actions/github-script@v8
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
+          DEEPSEEK_MAX_TOKENS: ${{ vars.DEEPSEEK_MAX_TOKENS }}
+          DEEPSEEK_MAX_DIFF: ${{ vars.DEEPSEEK_MAX_DIFF }}
         with:
           script: |
-            const prNumber = '${{ steps.pr.outputs.number }}';
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
             // Fetch PR details
             const pr = await github.rest.pulls.get({
-              owner, repo, pull_number: parseInt(prNumber)
+              owner, repo, pull_number: prNumber
             });
 
             const title = pr.data.title;
@@ -102,8 +97,9 @@ jobs:
               return 'No diff to review.';
             }
 
-            // Truncate diff if too large
-            const MAX_DIFF = 50000;
+            // Truncate diff if too large. deepseek-v4-pro has a large context
+            // window, so default high and allow overriding via repo variable.
+            const MAX_DIFF = parseInt(process.env.DEEPSEEK_MAX_DIFF || '2000000', 10);
             const truncatedDiff = diffText.length > MAX_DIFF
               ? diffText.substring(0, MAX_DIFF) + '\n\n... (diff truncated)'
               : diffText;
@@ -150,48 +146,73 @@ jobs:
 
             Review this PR thoroughly. Be direct - flag only real issues.`;
 
-            // Call DeepSeek API (OpenAI-compatible endpoint)
-            const response = await fetch('https://api.deepseek.com/v1/chat/completions', {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${process.env.DEEPSEEK_API_KEY}`
-              },
-              body: JSON.stringify({
-                model: 'deepseek-v4-pro',
-                messages: [
-                  { role: 'system', content: systemPrompt },
-                  { role: 'user', content: userPrompt }
-                ],
-                max_tokens: 4096,
-                temperature: 0.3
-              })
-            });
+            // Model + token budget are configurable via repo variables.
+            // NOTE: deepseek-v4-pro is a reasoning model — reasoning tokens
+            // count against max_tokens, so a small budget (e.g. 4096) can be
+            // fully consumed before any visible content is produced, yielding
+            // an empty review. Default high (65536) to leave room for output.
+            const model = process.env.DEEPSEEK_MODEL || 'deepseek-v4-pro';
+            const maxTokens = parseInt(process.env.DEEPSEEK_MAX_TOKENS || String(8192 * 8), 10);
 
-            const data = await response.json();
-
-            if (!response.ok) {
-              throw new Error(`DeepSeek API error (${response.status}): ${JSON.stringify(data)}`);
+            // Call DeepSeek API (OpenAI-compatible endpoint).
+            async function requestReview() {
+              const response = await fetch('https://api.deepseek.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': `Bearer ${process.env.DEEPSEEK_API_KEY}`
+                },
+                body: JSON.stringify({
+                  model,
+                  messages: [
+                    { role: 'system', content: systemPrompt },
+                    { role: 'user', content: userPrompt }
+                  ],
+                  max_tokens: maxTokens,
+                  temperature: 0.3
+                })
+              });
+              const data = await response.json();
+              if (!response.ok) {
+                throw new Error(`DeepSeek API error (${response.status}): ${JSON.stringify(data)}`);
+              }
+              const choice = data.choices && data.choices[0];
+              return {
+                reviewText: ((choice && choice.message && choice.message.content) || '').trim(),
+                finishReason: (choice && choice.finish_reason) || 'unknown',
+                usage: data.usage ? JSON.stringify(data.usage) : 'unknown'
+              };
             }
 
-            const reviewText = data.choices[0].message.content;
+            // Empty content usually means the token budget was exhausted by
+            // reasoning or the model id is invalid/aliased. Retry once before
+            // surfacing a diagnostic instead of posting a blank review.
+            let { reviewText, finishReason, usage } = await requestReview();
+            if (!reviewText) {
+              core.warning(
+                `DeepSeek returned no content (model=${model}, finish_reason=${finishReason}, usage=${usage}); retrying once.`
+              );
+              ({ reviewText, finishReason, usage } = await requestReview());
+            }
 
             // Build comment body
             const triggerInfo = context.eventName === 'pull_request'
               ? 'Automatically triggered on PR update'
               : 'Triggered by `@deepseek` comment';
+            const footer = `*${triggerInfo} • model: \`${model}\`*`;
 
-            const commentBody = `## 🐋 DeepSeek Code Review
-
-            ${reviewText}
-
-            ---
-            *${triggerInfo} • [DeepSeek V4](https://deepseek.com)*`;
+            const commentBody = reviewText
+              ? `## 🐋 DeepSeek Code Review\n\n${reviewText}\n\n---\n${footer}`
+              : `## 🐋 DeepSeek Code Review\n\n⚠️ The model returned no review content after a retry `
+                + `(model: \`${model}\`, finish_reason: \`${finishReason}\`, usage: \`${usage}\`). `
+                + `This usually means the configured model id is invalid/aliased or the token budget was `
+                + `exhausted before any visible output. Override via the \`DEEPSEEK_MODEL\` / `
+                + `\`DEEPSEEK_MAX_TOKENS\` repo variables.\n\n---\n${footer}`;
 
             // Check for existing bot comment to update (sticky behavior)
             const comments = await github.rest.issues.listComments({
               owner, repo,
-              issue_number: parseInt(prNumber),
+              issue_number: prNumber,
               per_page: 100
             });
 
@@ -210,12 +231,10 @@ jobs:
             } else {
               await github.rest.issues.createComment({
                 owner, repo,
-                issue_number: parseInt(prNumber),
+                issue_number: prNumber,
                 body: commentBody
               });
               console.log('✅ Posted new review comment');
             }
 
-            return { success: true, reviewLength: reviewText.length };
-        env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+            return { success: !!reviewText, reviewLength: reviewText.length, finishReason };


### PR DESCRIPTION
## Summary

Port the robustness improvements from [`taikoxyz/pico`'s `deepseek-review.yml`](https://github.com/taikoxyz/pico/blob/main/.github/workflows/deepseek-review.yml) to `.github/workflows/repo--deepseek-review.yml`, while **keeping taiko-mono's stricter security model** (fork PRs blocked entirely, `@deepseek` triggers require a trusted `author_association`, `release-please`/`dependabot` branches skipped).

This goes beyond the earlier #21668 (which only added an empty-content *guard*) by fixing the **root cause** of empty reviews.

### Changes
- **Fix empty reviews at the source — raise `max_tokens` 4096 → 65536.** `deepseek-v4-pro` is a reasoning model: reasoning tokens count against `max_tokens`, so the old 4096 budget was often consumed before any visible content was produced, yielding blank reviews. That is the very symptom the prior guard tried to paper over.
- **Make the model and budgets configurable via repo variables** — `DEEPSEEK_MODEL`, `DEEPSEEK_MAX_TOKENS`, `DEEPSEEK_MAX_DIFF` — with sensible defaults, so no code change is needed to swap models or tune limits.
- **Raise the diff cap 50,000 → 2,000,000** so real PRs aren't aggressively truncated before review.
- **Retry once on empty content, then post a diagnostic** comment (model, `finish_reason`, `usage`) explaining the likely cause and how to override, instead of silently skipping.
- **Simplify PR-number resolution** — for `issue_comment` events `github.event.issue.number` already IS the PR number, so the extra `gh pr view` step is removed.
- **Show the model id in the comment footer** for debuggability.

### Kept intentionally
The strict `if:` gating is stricter than pico's gate-on-API-key approach and is preserved to prevent anonymous fork PRs from burning the `DEEPSEEK_API_KEY` budget.

## Validation
- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML valid
- `node --check` on the extracted `github-script` body — JS syntax valid
- Mocked logic test of both paths: success posts the review (1 API call, no warning); empty content retries (2 API calls), logs a `core.warning`, and posts the ⚠️ diagnostic comment

## Test plan
- [ ] Open a non-draft PR from the base repo and confirm DeepSeek posts a non-empty review
- [ ] Comment `@deepseek` as an OWNER/MEMBER/COLLABORATOR and confirm the review is (re-)posted
- [ ] Confirm fork PRs still do not trigger the workflow
- [ ] (Optional) Set `DEEPSEEK_MAX_TOKENS` very low to force an empty response and confirm the diagnostic comment is posted after the retry


---
_Generated by [Claude Code](https://claude.ai/code/session_016PzCrcLv1Uiu5A51AnaRxc)_