### PR TITLE
chore(taiko-client-rs): update alethia reth pin

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=6e17536f31e7f3d8fcb76e391210c72e64bfbc13#6e17536f31e7f3d8fcb76e391210c72e64bfbc13"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=e4e09ecdaf93729654c472bf4db5cef7b62f447c#e4e09ecdaf93729654c472bf4db5cef7b62f447c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=6e17536f31e7f3d8fcb76e391210c72e64bfbc13#6e17536f31e7f3d8fcb76e391210c72e64bfbc13"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=e4e09ecdaf93729654c472bf4db5cef7b62f447c#e4e09ecdaf93729654c472bf4db5cef7b62f447c"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=6e17536f31e7f3d8fcb76e391210c72e64bfbc13#6e17536f31e7f3d8fcb76e391210c72e64bfbc13"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=e4e09ecdaf93729654c472bf4db5cef7b62f447c#e4e09ecdaf93729654c472bf4db5cef7b62f447c"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=6e17536f31e7f3d8fcb76e391210c72e64bfbc13#6e17536f31e7f3d8fcb76e391210c72e64bfbc13"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=e4e09ecdaf93729654c472bf4db5cef7b62f447c#e4e09ecdaf93729654c472bf4db5cef7b62f447c"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3009,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6501,7 +6501,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8604,7 +8604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8662,7 +8662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10583,7 +10583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,12 +81,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "6e17536f31e7f3d8fcb76e391210c72e64bfbc13", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "6e17536f31e7f3d8fcb76e391210c72e64bfbc13", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "6e17536f31e7f3d8fcb76e391210c72e64bfbc13", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "e4e09ecdaf93729654c472bf4db5cef7b62f447c", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "e4e09ecdaf93729654c472bf4db5cef7b62f447c", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "e4e09ecdaf93729654c472bf4db5cef7b62f447c", default-features = false, features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "6e17536f31e7f3d8fcb76e391210c72e64bfbc13" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "e4e09ecdaf93729654c472bf4db5cef7b62f447c" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary
- Bump the `alethia-reth-*` git dependencies (`chainspec`, `consensus`, `primitives`, `rpc-types`) from `6e17536` to the latest `main` (`e4e09ec`) in `packages/taiko-client-rs/Cargo.toml`.
- Update `Cargo.lock` accordingly (transitive `windows-sys` versions unified by re-resolution; macOS-irrelevant).

## Test plan
- [x] `cargo build --workspace` compiles clean (no breaking changes from the bump)
- [x] `just fmt` — no changes
- [x] `just clippy-fix` — clean, no warnings
- [ ] `just test` integration suite (left to CI; local run skipped)