### PR TITLE
fix(taiko-client): allow preconf ingress before first proposal

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -128,15 +129,26 @@ func (s *L2ChainSyncer) Sync() error {
 		return err
 	}
 
-	// After beacon sync, only enable preconf imports once head L1 origin has been written by the first
-	// successful event sync. This avoids importing cached forks before the L1 origin base exists.
+	// After beacon sync, enable preconf imports once event sync has established a safe base:
+	// either head L1 origin has been written, or no proposal has been created yet.
+	// This avoids importing cached forks before the L1 origin base exists for non-genesis chains.
 	if s.preconfBlockServer != nil && s.postBeaconSyncPending {
 		headL1Origin, err := s.rpc.L2.HeadL1Origin(s.ctx)
 		if err != nil && err.Error() != ethereum.NotFound.Error() {
 			return fmt.Errorf("failed to fetch head L1 origin after event sync: %w", err)
 		}
-		if headL1Origin != nil {
-			log.Info("Head L1 origin written after event sync, enable preconf imports")
+		headL1OriginWritten := headL1Origin != nil
+		var nextProposalID *big.Int
+		if !headL1OriginWritten {
+			coreState, err := s.rpc.GetCoreState(&bind.CallOpts{Context: s.ctx})
+			if err != nil {
+				return fmt.Errorf("failed to fetch core state after event sync: %w", err)
+			}
+			nextProposalID = coreState.NextProposalId
+		}
+
+		if shouldEnablePreconfImports(headL1OriginWritten, nextProposalID) {
+			log.Info("Event sync ready, enable preconf imports")
 			s.preconfBlockServer.SetSyncReady(true)
 			if err := s.preconfBlockServer.ImportPendingBlocksFromCache(s.ctx); err != nil {
 				log.Warn("Failed to import pending preconfirmation blocks from cache, skip the import", "error", err)
@@ -147,6 +159,11 @@ func (s *L2ChainSyncer) Sync() error {
 		}
 	}
 	return nil
+}
+
+// shouldEnablePreconfImports reports whether preconf imports can open after beacon sync.
+func shouldEnablePreconfImports(headL1OriginWritten bool, nextProposalID *big.Int) bool {
+	return headL1OriginWritten || (nextProposalID != nil && nextProposalID.Cmp(common.Big1) <= 0)
 }
 
 // SetUpEventSync resets the L1Current cursor to the latest L2 execution engine's chain head.

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -106,6 +106,48 @@ func (s *ChainSyncerTestSuite) TestSync() {
 	s.Nil(s.s.Sync())
 }
 
+func TestShouldEnablePreconfImportsAfterEventSync(t *testing.T) {
+	tests := []struct {
+		name                string
+		headL1OriginWritten bool
+		nextProposalID      *big.Int
+		expected            bool
+	}{
+		{
+			name:                "ready when head L1 origin exists",
+			headL1OriginWritten: true,
+			nextProposalID:      common.Big2,
+			expected:            true,
+		},
+		{
+			name:                "ready before first proposal",
+			headL1OriginWritten: false,
+			nextProposalID:      common.Big1,
+			expected:            true,
+		},
+		{
+			name:                "not ready without head L1 origin after proposals exist",
+			headL1OriginWritten: false,
+			nextProposalID:      common.Big2,
+			expected:            false,
+		},
+		{
+			name:                "not ready without any signal",
+			headL1OriginWritten: false,
+			nextProposalID:      nil,
+			expected:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldEnablePreconfImports(tt.headL1OriginWritten, tt.nextProposalID); got != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
 func (s *ChainSyncerTestSuite) TestAheadOfProtocolVerifiedHead() {
 	s.True(s.s.AheadOfHeadToSync(0))
 }


### PR DESCRIPTION
## Summary

- Align Go `taiko-client` post-beacon-sync preconf readiness so imports can open when the current head-L1-origin condition is met or when core state still has no proposal (`nextProposalId <= 1`).
- Keep the existing ready path unchanged: if `head_l1_origin` is already written, preconf imports open without requiring the new core-state check.
- Add a pure unit test for the readiness decision.

## Why

Before the first proposal exists, there is no event-confirmed proposal range to validate. Requiring `head_l1_origin` in that state can keep preconfirmation imports closed even though the contract core state indicates `nextProposalId <= 1`.

## Validation

- `go test ./driver/chain_syncer -run TestShouldEnablePreconfImportsAfterEventSync`

Notes:
- `go test ./driver/chain_syncer` was attempted, but the existing integration suite requires local L1/L2 env and failed during setup with empty env/private-key parsing before running those suite tests.