### PR TITLE
fix(eventindexer): harden combine-bridged-events pipeline

### DIFF
--- a/packages/tools/bridged-token-scanner/combine-bridged-events.js
+++ b/packages/tools/bridged-token-scanner/combine-bridged-events.js
@@ -97,11 +97,14 @@ async function collectChunkFilesByVault(rootDir) {
     // Deduplicate by txHash + logIndex (canonical EVM event key)
     const unique = new Map();
     for (const r of merged) {
-      if (!r.txHash || r.logIndex == null) {
+      if (!r.txHash) {
         console.warn("⚠️ Skipping malformed record", r);
         continue;
       }
-      const key = `${r.txHash}-${r.logIndex}`;
+      const key =
+        r.logIndex != null
+          ? `${r.txHash}-${r.logIndex}`
+          : `${r.txHash}-${r.vaultType}-${r.bridgedToken}`;
       if (unique.has(key)) {
         console.warn(`⚠️ Duplicate detected: ${key}`);
         continue;

--- a/packages/tools/bridged-token-scanner/combine-bridged-events.js
+++ b/packages/tools/bridged-token-scanner/combine-bridged-events.js
@@ -10,9 +10,19 @@ const outputDir = "combined";
 const vaultTypes = ["ERC20", "ERC721", "ERC1155"];
 
 const csvHeaders = [
-  "network", "chainId", "blockNumber", "txHash", "vaultType", "event",
-  "srcChainId", "canonicalToken", "bridgedToken", "symbol", "name", "decimals",
-  "contractOwner"
+  "network",
+  "chainId",
+  "blockNumber",
+  "txHash",
+  "vaultType",
+  "event",
+  "srcChainId",
+  "canonicalToken",
+  "bridgedToken",
+  "symbol",
+  "name",
+  "decimals",
+  "contractOwner",
 ];
 
 const OWNABLE_ABI = ["function owner() view returns (address)"];
@@ -21,7 +31,8 @@ async function fetchOwner(provider, address) {
   try {
     const contract = new ethers.Contract(address, OWNABLE_ABI, provider);
     return await contract.owner();
-  } catch {
+  } catch (err) {
+    console.warn(`⚠️ Failed to fetch owner for ${address}: ${err.message}`);
     return "";
   }
 }
@@ -29,19 +40,25 @@ async function fetchOwner(provider, address) {
 async function collectChunkFilesByVault(rootDir) {
   const fileMap = {}; // key: `${network}:::${vaultType}`
 
-  const networks = await fs.readdir(rootDir);
-  for (const network of networks) {
-    const vaultDirs = await fs.readdir(path.join(rootDir, network));
+  const networkDirs = await fs.readdir(rootDir);
+  for (const networkDir of networkDirs) {
+    const vaultDirs = await fs.readdir(path.join(rootDir, networkDir));
     for (const vaultDir of vaultDirs) {
       for (const vaultType of vaultTypes) {
         if (vaultDir === `BridgedTokenDeployed_${vaultType}`) {
-          const fullDir = path.join(rootDir, network, vaultDir);
+          const fullDir = path.join(rootDir, networkDir, vaultDir);
           try {
             const files = await fs.readdir(fullDir);
-            const chunkFiles = files.filter(f => f.startsWith("chunk_") && f.endsWith(".json"));
-            const key = `${network}:::${vaultType}`;
-            fileMap[key] = chunkFiles.map(f => path.join(fullDir, f));
-          } catch {}
+            const chunkFiles = files.filter(
+              (f) => f.startsWith("chunk_") && f.endsWith(".json"),
+            );
+            const key = `${networkDir}:::${vaultType}`;
+            fileMap[key] = chunkFiles.map((f) => path.join(fullDir, f));
+          } catch (err) {
+            console.warn(
+              `⚠️ Failed to read directory ${fullDir}: ${err.message}`,
+            );
+          }
         }
       }
     }
@@ -56,8 +73,15 @@ async function collectChunkFilesByVault(rootDir) {
 
   for (const [key, files] of Object.entries(fileMap)) {
     const [network, vaultType] = key.split(":::");
-    const matchedNet = networks.find(n => n.name.replaceAll(" ", "_") === network);
-    const provider = new ethers.JsonRpcProvider(matchedNet?.rpcUrl);
+    const matchedNet = networks.find(
+      (n) => n.name.replaceAll(" ", "_") === network,
+    );
+    if (!matchedNet?.rpcUrl) {
+      console.error(`❌ Missing RPC URL for network: ${network}`);
+      continue;
+    }
+
+    const provider = new ethers.JsonRpcProvider(matchedNet.rpcUrl);
     const merged = [];
 
     for (const file of files) {
@@ -70,16 +94,28 @@ async function collectChunkFilesByVault(rootDir) {
       }
     }
 
-    // Deduplicate by txHash + vaultType
+    // Deduplicate by txHash + logIndex (canonical EVM event key)
     const unique = new Map();
     for (const r of merged) {
-      unique.set(`${r.txHash}-${r.vaultType}`, r);
+      if (!r.txHash || r.logIndex == null) {
+        console.warn("⚠️ Skipping malformed record", r);
+        continue;
+      }
+      const key = `${r.txHash}-${r.logIndex}`;
+      if (unique.has(key)) {
+        console.warn(`⚠️ Duplicate detected: ${key}`);
+        continue;
+      }
+      unique.set(key, r);
     }
+
     const deduped = Array.from(unique.values());
 
     // Fetch owners for unique bridgedToken addresses
     const ownerCache = {};
-    const uniqueAddresses = [...new Set(deduped.map(e => e.bridgedToken))];
+    const uniqueAddresses = [
+      ...new Set(deduped.map((e) => e.bridgedToken).filter(Boolean)),
+    ];
     for (const addr of uniqueAddresses) {
       ownerCache[addr] = await fetchOwner(provider, addr);
     }
@@ -96,6 +132,8 @@ async function collectChunkFilesByVault(rootDir) {
     await fs.writeFile(jsonFile, JSON.stringify(deduped, null, 2), "utf8");
     await saveCSV(csvFile, deduped, csvHeaders);
 
-    console.log(`✅ Combined ${files.length} chunks into ${deduped.length} records for ${network} ${vaultType}`);
+    console.log(
+      `✅ Combined ${files.length} chunks into ${deduped.length} records for ${network} ${vaultType}`,
+    );
   }
 })();


### PR DESCRIPTION
Fixed a critical bug where events from the same transaction were silently dropped during deduplication (was using txHash+vaultType, now txHash+logIndex). Also added guards for malformed records, missing RPC URLs, invalid bridgedToken addresses, and replaced all silent failures with proper logging.