### PR TITLE
fix: correct grammar in code comments

### DIFF
--- a/packages/eventindexer/indexer/index_erc20_transfers.go
+++ b/packages/eventindexer/indexer/index_erc20_transfers.go
@@ -174,7 +174,7 @@ func (i *Indexer) saveERC20Transfer(ctx context.Context, chainID *big.Int, vLog 
 	if pk == 0 {
 		symbol, err := getERC20Symbol(ctx, i.ethClient, vLog.Address.Hex())
 		if err != nil {
-			// some erc20 dont have symbol method properly,
+			// some erc20 don't have symbol method properly,
 			// returns `invalid opcode`.
 			if strings.Contains(err.Error(), "invalid opcode") {
 				symbol = "ERC20"

--- a/packages/relayer/indexer/handle_message_processed_event.go
+++ b/packages/relayer/indexer/handle_message_processed_event.go
@@ -25,7 +25,7 @@ func (i *Indexer) handleMessageProcessedEvent(
 
 	message := event.Message
 
-	// if the destination doesn't match our source chain, we dont want to handle this event.
+	// if the destination doesn't match our source chain, we don't want to handle this event.
 	if new(big.Int).SetUint64(message.DestChainId).Cmp(i.srcChainId) != 0 {
 		slog.Info("skipping event, wrong chainID",
 			"messageDestChainID",

--- a/packages/relayer/indexer/handle_message_sent_event.go
+++ b/packages/relayer/indexer/handle_message_sent_event.go
@@ -22,7 +22,7 @@ func (i *Indexer) handleMessageSentEvent(
 	event *bridge.BridgeMessageSent,
 	waitForConfirmations bool,
 ) error {
-	// if the destinatio chain doesn't match, we dont process it in this indexer.
+	// if the destinatio chain doesn't match, we don't process it in this indexer.
 	if new(big.Int).SetUint64(event.Message.DestChainId).Cmp(i.destChainId) != 0 {
 		return nil
 	}
@@ -41,7 +41,7 @@ func (i *Indexer) handleMessageSentEvent(
 		return nil
 	}
 
-	// we should never see an empty msgHash, but if we do, we dont process.
+	// we should never see an empty msgHash, but if we do, we don't process.
 	if event.MsgHash == relayer.ZeroHash {
 		slog.Warn("Zero msgHash found. This is unexpected. Returning early")
 		return nil

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -399,7 +399,7 @@ func (i *Indexer) filter(ctx context.Context) error {
 				relayer.MessageSentEventsAfterRetryErrorCount.Inc()
 			}
 
-			// we dont want to watch for message status changed events
+			// we don't want to watch for message status changed events
 			// when crawling past blocks on a loop. but otherwise,
 			// we want to index all three event types when indexing MessageSent events,
 			// since they are related.

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -469,7 +469,7 @@ func (d *Driver) cacheLookaheadLoop() {
 		}
 
 		lookahead := d.preconfBlockServer.GetLookahead()
-		// We dont need to update the lookahead on every slot, we just need to make sure we do it
+		// We don't need to update the lookahead on every slot, we just need to make sure we do it
 		// once per epoch, since we push the next operator as the current range when we check.
 		// so, this means we should use a reliable slot past 0 where the operator has no possible
 		// way to change. mid-epooch works, so we use slot 16.
@@ -574,7 +574,7 @@ func (d *Driver) cacheLookaheadLoop() {
 		return nil
 	}
 
-	// Run once initially, so we dont have to wait for ticker.
+	// Run once initially, so we don't have to wait for ticker.
 	if err := cacheLookahead(d.rpc.L1Beacon.CurrentEpoch(), d.rpc.L1Beacon.CurrentSlot()); err != nil {
 		log.Warn("Failed to cache initial lookahead", "error", err)
 	}

--- a/packages/taiko-client/driver/preconf_blocks/util.go
+++ b/packages/taiko-client/driver/preconf_blocks/util.go
@@ -156,7 +156,7 @@ func checkMessageBlockNumber(
 }
 
 // deterministicJitter returns a deterministic jitter based on the peer ID and block hash,
-// such that we dont immediately reply to messages.
+// such that we don't immediately reply to messages.
 func deterministicJitter(self peer.ID, h common.Hash, max time.Duration) time.Duration {
 	b := append([]byte(self), h.Bytes()...)
 	sum := sha256.Sum256(b)

--- a/packages/taiko-client/pkg/rpc/engine.go
+++ b/packages/taiko-client/pkg/rpc/engine.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// EngineClient represents a RPC client connecting to an Ethereum Engine API
+// EngineClient represents an RPC client connecting to an Ethereum Engine API
 // endpoint.
 // ref: https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md
 type EngineClient struct {


### PR DESCRIPTION
## Description
Fixed grammar errors in Go code comments for better readability.

⚠️ **Note:** These are comment-only changes. No functional code is modified. This is a minor documentation improvement to the repository.

## Changes
- Fixed `dont` → `don't` in multiple files
- Fixed `a RPC` → `an RPC` in engine.go
- Improves code documentation clarity

## Files Modified
- packages/eventindexer/indexer/index_erc20_transfers.go
- packages/relayer/indexer/handle_message_processed_event.go
- packages/relayer/indexer/handle_message_sent_event.go
- packages/relayer/indexer/indexer.go
- packages/taiko-client/driver/driver.go
- packages/taiko-client/driver/preconf_blocks/util.go
- packages/taiko-client/pkg/rpc/engine.go

## Impact
- No functional changes to code logic
- No API or behavior changes
- Documentation readability improvement only