### PR TITLE
docs(protocol): recalibrate zk gas multipliers (SP1 v6.1.0 + risc0 v3.0.5)

### DIFF
--- a/packages/protocol/docs/zk_gas_spec.md
+++ b/packages/protocol/docs/zk_gas_spec.md
@@ -37,10 +37,11 @@ Example rows:
 
 ```text
 Operation              Multiplier
-modexp (precompile)    1363
-point_evaluation       398
-blake2f                243
-mulmod (opcode)        152
+modexp (precompile)    923
+point_evaluation       859
+bls12_pairing          365
+blake2f                166
+mulmod (opcode)        113
 ...
 ```
 
@@ -231,23 +232,23 @@ Indexed by the low byte of the precompile address. Sorted by multiplier descendi
 
 | Precompile | Address | Multiplier |
 | --- | --- | ---: |
-| modexp | 0x05 | 1363 |
-| point_evaluation | 0x0a | 398 |
-| blake2f | 0x09 | 243 |
-| bls12_map_fp_to_g1 | 0x12 | 159 |
-| bls12_pairing | 0x11 | 134 |
-| bls12_g1add | 0x0b | 112 |
-| bls12_map_fp2_to_g2 | 0x13 | 112 |
-| bls12_g2add | 0x0e | 111 |
-| bn128_mul | 0x07 | 87 |
-| bn128_pairing | 0x08 | 82 |
-| ecrecover | 0x01 | 81 |
-| bls12_g1msm | 0x0c | 52 |
-| bls12_g2msm | 0x0f | 39 |
-| bn128_add | 0x06 | 38 |
+| modexp | 0x05 | 923 |
+| point_evaluation | 0x0a | 859 |
+| bls12_pairing | 0x11 | 365 |
+| bls12_map_fp_to_g1 | 0x12 | 246 |
+| bls12_g2add | 0x0e | 230 |
+| bls12_map_fp2_to_g2 | 0x13 | 208 |
+| bls12_g1add | 0x0b | 201 |
+| blake2f | 0x09 | 166 |
+| bls12_g1msm | 0x0c | 93 |
+| bls12_g2msm | 0x0f | 71 |
+| bn128_mul | 0x07 | 58 |
+| bn128_pairing | 0x08 | 54 |
+| ecrecover | 0x01 | 47 |
+| bn128_add | 0x06 | 19 |
 | sha256 | 0x02 | 10 |
-| ripemd160 | 0x03 | 3 |
-| identity | 0x04 | 2 |
+| identity | 0x04 | 6 |
+| ripemd160 | 0x03 | 4 |
 
 ### Opcode Multipliers
 
@@ -255,155 +256,155 @@ Indexed by opcode byte. Sorted by multiplier descending.
 
 | Opcode | Byte | Multiplier |
 | --- | --- | ---: |
-| mulmod | 0x09 | 152 |
-| div | 0x04 | 110 |
-| mod | 0x06 | 95 |
-| sdiv | 0x05 | 93 |
-| selfbalance | 0x47 | 85 |
-| keccak256 | 0x20 | 85 |
-| addmod | 0x08 | 71 |
-| eq | 0x14 | 35 |
-| exp | 0x0a | 33 |
-| smod | 0x07 | 29 |
-| sar | 0x1d | 29 |
-| prevrandao | 0x44 | 28 |
-| call | 0xf1 | 25 |
-| callcode | 0xf2 | 24 |
-| staticcall | 0xfa | 24 |
-| mstore | 0x52 | 22 |
-| address | 0x30 | 22 |
+| mulmod | 0x09 | 113 |
+| sdiv | 0x05 | 78 |
+| div | 0x04 | 76 |
+| mod | 0x06 | 66 |
+| addmod | 0x08 | 52 |
+| selfbalance | 0x47 | 52 |
+| prevrandao | 0x44 | 42 |
+| eq | 0x14 | 36 |
+| swap15 | 0x9e | 36 |
+| swap6 | 0x95 | 34 |
+| swap11 | 0x9a | 33 |
+| swap5 | 0x94 | 33 |
+| swap12 | 0x9b | 32 |
+| swap3 | 0x92 | 32 |
+| swap9 | 0x98 | 32 |
+| keccak256 | 0x20 | 31 |
+| swap1 | 0x90 | 31 |
+| swap10 | 0x99 | 31 |
+| swap13 | 0x9c | 31 |
+| swap14 | 0x9d | 31 |
+| swap16 | 0x9f | 31 |
+| swap4 | 0x93 | 31 |
+| swap7 | 0x96 | 31 |
+| swap2 | 0x91 | 30 |
+| swap8 | 0x97 | 30 |
+| mstore | 0x52 | 29 |
+| push30 | 0x7d | 29 |
+| push29 | 0x7c | 28 |
+| smod | 0x07 | 28 |
+| push24 | 0x77 | 24 |
+| push26 | 0x79 | 24 |
+| shl | 0x1b | 24 |
+| staticcall | 0xfa | 23 |
+| calldataload | 0x35 | 22 |
+| push23 | 0x76 | 22 |
+| push25 | 0x78 | 22 |
+| shr | 0x1c | 22 |
+| sub | 0x03 | 22 |
+| exp | 0x0a | 21 |
 | origin | 0x32 | 21 |
-| caller | 0x33 | 21 |
-| mul | 0x02 | 21 |
-| delegatecall | 0xf4 | 21 |
-| coinbase | 0x41 | 21 |
-| signextend | 0x0b | 21 |
-| shl | 0x1b | 20 |
-| calldataload | 0x35 | 20 |
-| mload | 0x51 | 20 |
-| swap4 | 0x93 | 19 |
-| swap13 | 0x9c | 19 |
-| shr | 0x1c | 19 |
-| swap12 | 0x9b | 19 |
-| swap11 | 0x9a | 18 |
-| swap3 | 0x92 | 18 |
-| swap14 | 0x9d | 18 |
-| swap9 | 0x98 | 18 |
-| swap2 | 0x91 | 18 |
-| push31 | 0x7e | 18 |
-| swap16 | 0x9f | 18 |
-| swap15 | 0x9e | 17 |
-| push29 | 0x7c | 17 |
+| push15 | 0x6e | 21 |
+| sar | 0x1d | 21 |
+| call | 0xf1 | 20 |
+| callcode | 0xf2 | 20 |
+| jumpdest | 0x5b | 20 |
+| or | 0x17 | 20 |
+| push17 | 0x70 | 20 |
+| push19 | 0x72 | 20 |
+| push20 | 0x73 | 20 |
+| slt | 0x12 | 20 |
+| add | 0x01 | 19 |
+| address | 0x30 | 19 |
+| and | 0x16 | 19 |
+| gt | 0x11 | 19 |
+| lt | 0x10 | 19 |
+| mul | 0x02 | 19 |
+| push32 | 0x7f | 19 |
+| sgt | 0x13 | 19 |
+| caller | 0x33 | 18 |
+| coinbase | 0x41 | 18 |
+| mload | 0x51 | 18 |
+| push18 | 0x71 | 18 |
+| push21 | 0x74 | 18 |
+| xor | 0x18 | 18 |
+| byte | 0x1a | 17 |
+| delegatecall | 0xf4 | 17 |
+| push14 | 0x6d | 17 |
 | push28 | 0x7b | 17 |
-| swap7 | 0x96 | 17 |
-| swap6 | 0x95 | 17 |
-| swap10 | 0x99 | 17 |
-| push32 | 0x7f | 17 |
-| swap1 | 0x90 | 16 |
-| push24 | 0x77 | 16 |
-| swap5 | 0x94 | 16 |
-| push22 | 0x75 | 16 |
-| swap8 | 0x97 | 15 |
-| push27 | 0x7a | 15 |
+| signextend | 0x0b | 17 |
+| iszero | 0x15 | 16 |
+| push27 | 0x7a | 16 |
+| push31 | 0x7e | 16 |
 | blobbasefee | 0x4a | 15 |
-| gasprice | 0x3a | 14 |
-| push26 | 0x79 | 14 |
-| slt | 0x12 | 14 |
-| push21 | 0x74 | 14 |
-| sgt | 0x13 | 14 |
-| sub | 0x03 | 13 |
-| callvalue | 0x34 | 13 |
-| push25 | 0x78 | 13 |
-| push17 | 0x70 | 13 |
-| push20 | 0x73 | 13 |
-| codecopy | 0x39 | 13 |
-| sstore | 0x55 | 13 |
-| push14 | 0x6d | 12 |
-| calldatacopy | 0x37 | 12 |
-| push30 | 0x7d | 12 |
-| push23 | 0x76 | 12 |
-| pc | 0x58 | 12 |
-| add | 0x01 | 12 |
-| push19 | 0x72 | 11 |
-| gas | 0x5a | 11 |
-| timestamp | 0x42 | 11 |
-| basefee | 0x48 | 11 |
-| number | 0x43 | 11 |
-| push18 | 0x71 | 11 |
-| calldatasize | 0x36 | 11 |
-| push16 | 0x6f | 11 |
-| codesize | 0x38 | 11 |
+| gasprice | 0x3a | 15 |
+| not | 0x19 | 15 |
+| push12 | 0x6b | 15 |
+| push13 | 0x6c | 15 |
+| push8 | 0x67 | 15 |
+| basefee | 0x48 | 14 |
+| push22 | 0x75 | 14 |
+| blobhash | 0x49 | 13 |
+| calldatacopy | 0x37 | 13 |
+| calldatasize | 0x36 | 13 |
+| gaslimit | 0x45 | 13 |
+| msize | 0x59 | 13 |
+| pc | 0x58 | 13 |
+| push0 | 0x5f | 13 |
+| push16 | 0x6f | 13 |
+| push9 | 0x68 | 13 |
+| codecopy | 0x39 | 12 |
+| number | 0x43 | 12 |
+| push10 | 0x69 | 12 |
+| push11 | 0x6a | 12 |
+| push6 | 0x65 | 12 |
+| returndatasize | 0x3d | 12 |
+| callvalue | 0x34 | 11 |
 | chainid | 0x46 | 11 |
-| lt | 0x10 | 11 |
-| gaslimit | 0x45 | 11 |
-| msize | 0x59 | 11 |
-| returndatasize | 0x3d | 10 |
-| push0 | 0x5f | 10 |
-| push15 | 0x6e | 10 |
-| gt | 0x11 | 10 |
-| push10 | 0x69 | 10 |
-| blobhash | 0x49 | 10 |
-| push12 | 0x6b | 9 |
-| push9 | 0x68 | 9 |
-| or | 0x17 | 9 |
-| mstore8 | 0x53 | 9 |
-| byte | 0x1a | 9 |
-| xor | 0x18 | 9 |
-| jumpdest | 0x5b | 9 |
-| returndatacopy | 0x3e | 9 |
-| push11 | 0x6a | 8 |
-| and | 0x16 | 8 |
-| dup12 | 0x8b | 8 |
+| codesize | 0x38 | 11 |
+| dup5 | 0x84 | 11 |
+| gas | 0x5a | 11 |
+| dup1 | 0x80 | 10 |
+| dup10 | 0x89 | 10 |
+| dup11 | 0x8a | 10 |
+| dup16 | 0x8f | 10 |
+| dup4 | 0x83 | 10 |
+| dup8 | 0x87 | 10 |
+| mstore8 | 0x53 | 10 |
+| pop | 0x50 | 10 |
+| push4 | 0x63 | 10 |
+| push7 | 0x66 | 10 |
+| returndatacopy | 0x3e | 10 |
+| timestamp | 0x42 | 10 |
+| dup12 | 0x8b | 9 |
+| dup13 | 0x8c | 9 |
+| dup3 | 0x82 | 9 |
+| dup9 | 0x88 | 9 |
+| push1 | 0x60 | 9 |
+| push3 | 0x62 | 9 |
+| push5 | 0x64 | 9 |
+| dup14 | 0x8d | 8 |
 | dup15 | 0x8e | 8 |
-| push6 | 0x65 | 8 |
-| push4 | 0x63 | 8 |
-| iszero | 0x15 | 8 |
-| extcodehash | 0x3f | 8 |
-| push13 | 0x6c | 7 |
-| push7 | 0x66 | 7 |
-| blockhash | 0x40 | 7 |
-| dup9 | 0x88 | 7 |
-| push8 | 0x67 | 7 |
-| dup14 | 0x8d | 7 |
-| log1 | 0xa1 | 7 |
-| log0 | 0xa0 | 6 |
-| not | 0x19 | 6 |
-| dup16 | 0x8f | 6 |
-| dup5 | 0x84 | 6 |
-| push3 | 0x62 | 6 |
-| dup6 | 0x85 | 6 |
-| dup8 | 0x87 | 6 |
-| extcodesize | 0x3b | 6 |
-| balance | 0x31 | 6 |
-| dup1 | 0x80 | 6 |
-| dup3 | 0x82 | 6 |
-| tstore | 0x5d | 6 |
-| dup13 | 0x8c | 6 |
-| dup11 | 0x8a | 6 |
-| extcodecopy | 0x3c | 6 |
-| dup4 | 0x83 | 6 |
-| push5 | 0x64 | 6 |
-| pop | 0x50 | 5 |
-| sload | 0x54 | 5 |
-| mcopy | 0x5e | 5 |
-| push1 | 0x60 | 5 |
-| dup10 | 0x89 | 5 |
-| push2 | 0x61 | 5 |
-| dup7 | 0x86 | 5 |
-| log3 | 0xa3 | 5 |
-| dup2 | 0x81 | 5 |
-| log4 | 0xa4 | 5 |
+| dup2 | 0x81 | 8 |
+| dup6 | 0x85 | 8 |
+| dup7 | 0x86 | 8 |
+| push2 | 0x61 | 8 |
+| extcodehash | 0x3f | 7 |
+| blockhash | 0x40 | 6 |
 | jumpi | 0x57 | 5 |
-| log2 | 0xa2 | 4 |
-| jump | 0x56 | 3 |
-| tload | 0x5c | 1 |
+| sstore | 0x55 | 5 |
+| tstore | 0x5d | 5 |
+| balance | 0x31 | 4 |
+| extcodecopy | 0x3c | 4 |
+| extcodesize | 0x3b | 4 |
+| jump | 0x56 | 4 |
+| mcopy | 0x5e | 4 |
+| log0 | 0xa0 | 3 |
+| log1 | 0xa1 | 3 |
+| sload | 0x54 | 3 |
+| log2 | 0xa2 | 2 |
+| log3 | 0xa3 | 2 |
+| log4 | 0xa4 | 2 |
 | create | 0xf0 | 1 |
 | create2 | 0xf5 | 1 |
-| stop | 0x00 | 0 |
+| tload | 0x5c | 1 |
+| invalid | 0xfe | 0 |
 | return | 0xf3 | 0 |
 | revert | 0xfd | 0 |
 | selfdestruct | 0xff | 0 |
-| invalid | 0xfe | 0 |
+| stop | 0x00 | 0 |
 
 Terminal opcodes (`stop`, `return`, `revert`, `selfdestruct`, `invalid`) have multiplier `0` — execution ends at these opcodes so no further zk gas cost is incurred.
 
@@ -417,14 +418,14 @@ The initial value of 100M is a placeholder derived from the following model:
 
 The table below shows how the per-block limit scales with proving deadline, assuming 384 blocks per proposal. Values in the EVM Gas columns show the equivalent conventional gas budget if every opcode in the block were of that single type.
 
-| Proving Deadline | Total ZK Budget | ZK_GAS_LIMIT (÷384) | EVM Gas (modexp@1363×) | EVM Gas (keccak256@85×) | EVM Gas (add@12×) | EVM Gas (push1@5×) |
+| Proving Deadline | Total ZK Budget | ZK_GAS_LIMIT (÷384) | EVM Gas (modexp@923×) | EVM Gas (keccak256@31×) | EVM Gas (add@19×) | EVM Gas (push1@9×) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 2 hours | 7.2B | 18.75M | 13.8K | 220.6K | 1.56M | 3.61M |
-| 4 hours | 14.4B | 37.5M | 27.5K | 441.2K | 3.13M | 7.23M |
-| 6 hours | 21.6B | 56.25M | 41.3K | 661.8K | 4.69M | 10.84M |
-| 8 hours | 28.8B | 75M | 55K | 882.4K | 6.25M | 14.45M |
-| 12 hours | 43.2B | 112.5M | 82.5K | 1.32M | 9.38M | 21.68M |
-| 24 hours | 86.4B | 225M | 165.1K | 2.65M | 18.75M | 43.35M |
+| 2 hours | 7.2B | 18.75M | 20.3K | 604.8K | 986.8K | 2.08M |
+| 4 hours | 14.4B | 37.5M | 40.6K | 1.21M | 1.97M | 4.17M |
+| 6 hours | 21.6B | 56.25M | 60.9K | 1.81M | 2.96M | 6.25M |
+| 8 hours | 28.8B | 75M | 81.3K | 2.42M | 3.95M | 8.33M |
+| 12 hours | 43.2B | 112.5M | 121.9K | 3.63M | 5.92M | 12.50M |
+| 24 hours | 86.4B | 225M | 243.8K | 7.26M | 11.84M | 25.00M |
 
 **This value is a placeholder and will almost certainly change.** Factors that will influence the final value include: number of GPUs available, prover software improvements and target proving deadline chosen for production.
 


### PR DESCRIPTION
## Summary

Recalibrate every opcode and precompile multiplier from a fresh marginal regression on **SP1 v6.1.0** and **risc0 v3.0.5**.

New formula:

```
multiplier = max(SP1_µs_per_gas,  risc0_µs_per_gas / 6)
```

The `/6` matches a 1h SP1 / 6h risc0 deadline budget so neither prover is starved regardless of which one a network operator picks.

**No per-op overhead constant needed.** The slope-based multipliers already absorb the cost of the metering hook itself, so adding a fixed `ZK_GAS_METERING_OVERHEAD` on top would double-count it. This PR keeps the spec as `raw_gas * multiplier` with no extra term.

## Validation — stress test before/after

Six stress workloads, each calibrated to ~100M zk-gas/block under its respective spec, proven on SP1 + risc0.

<img width="1306" height="634" alt="image" src="https://github.com/user-attachments/assets/aaa579a8-1ed0-4e7d-973c-4ccf116e97e8" />
<img width="1317" height="634" alt="image" src="https://github.com/user-attachments/assets/1f82bced-9c0f-45bf-b2eb-508ff7107412" />

Bars look taller, but each "after" block now packs **1.4× to 7× more EVM gas** under the same 100M zk-gas budget. The metric that matters is **prove-time spread at constant zk-gas budget**:

| prover | spread before | spread after |
|---|---:|---:|
| SP1   | 5.2× | **2.0×** |
| risc0 | 4.9× | **2.0×** |

A 100M zk-gas block now proves in roughly the same wall-clock regardless of which opcode dominates — which is the whole point of the recalibration.

## Notable multiplier changes (selected)

| op | current | new |
|---|---:|---:|
| modexp | 1363 | 923 |
| point_evaluation | 398 | 859 |
| bls12_pairing | 134 | 365 |
| blake2f | 243 | 166 |
| mulmod | 152 | 113 |
| keccak256 | 85 | 31 |
| add | 12 | 19 |

Full table in `Appendix B`. `Appendix C` budget projections recomputed against the new multipliers.
