### PR TITLE
chore(taiko-client,taiko-client-rs): bump execution client dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260515033657-f23532c7cbdc
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260525003749-96923758c5e4
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 

--- a/go.sum
+++ b/go.sum
@@ -893,6 +893,8 @@ github.com/taikoxyz/taiko-geth v1.18.1-0.20260513112312-9d62780bfc85 h1:w2ZkiQRM
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260513112312-9d62780bfc85/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260515033657-f23532c7cbdc h1:jHgmGs7MCj10TpQKN7y9bcqop19wBqBwvYkCxxDaxXY=
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260515033657-f23532c7cbdc/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260525003749-96923758c5e4 h1:O00TxTkhdECyaj54y5b3atzD29MeZ4JQy4gIOs/Y6H0=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260525003749-96923758c5e4/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/go.sum
+++ b/go.sum
@@ -883,16 +883,6 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828 h1:8TqBxcCsk7TNvGHjTuStB2waN3KPpTJYeqpk7JY5t+o=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260427005750-f636489ae176 h1:GPFmNZ/hilej0MFO+rwXiVgH5VvSclkoD+MzRmSZW2o=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260427005750-f636489ae176/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260506145046-5ec860d6684e h1:RlHWmvZORt+cgll6Hzl6u6FKY6rYO4SO2yqoy7TJuuE=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260506145046-5ec860d6684e/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260508015755-6c6a4df06d46 h1:vSQnXZ6c1lDytiOtkuyTMDlYclNRiRYyFD39Wv9e06g=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260508015755-6c6a4df06d46/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260513112312-9d62780bfc85 h1:w2ZkiQRMvN9yGEnmBNy+CbItQ9rr4gIi+gNbB7wtCDQ=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260513112312-9d62780bfc85/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260515033657-f23532c7cbdc h1:jHgmGs7MCj10TpQKN7y9bcqop19wBqBwvYkCxxDaxXY=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260515033657-f23532c7cbdc/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260525003749-96923758c5e4 h1:O00TxTkhdECyaj54y5b3atzD29MeZ4JQy4gIOs/Y6H0=
 github.com/taikoxyz/taiko-geth v1.18.1-0.20260525003749-96923758c5e4/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=e4e09ecdaf93729654c472bf4db5cef7b62f447c#e4e09ecdaf93729654c472bf4db5cef7b62f447c"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=7679835db47b3fbb859dd2c73423256fd42ebff5#7679835db47b3fbb859dd2c73423256fd42ebff5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=e4e09ecdaf93729654c472bf4db5cef7b62f447c#e4e09ecdaf93729654c472bf4db5cef7b62f447c"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=7679835db47b3fbb859dd2c73423256fd42ebff5#7679835db47b3fbb859dd2c73423256fd42ebff5"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=e4e09ecdaf93729654c472bf4db5cef7b62f447c#e4e09ecdaf93729654c472bf4db5cef7b62f447c"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=7679835db47b3fbb859dd2c73423256fd42ebff5#7679835db47b3fbb859dd2c73423256fd42ebff5"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=e4e09ecdaf93729654c472bf4db5cef7b62f447c#e4e09ecdaf93729654c472bf4db5cef7b62f447c"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=7679835db47b3fbb859dd2c73423256fd42ebff5#7679835db47b3fbb859dd2c73423256fd42ebff5"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3009,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6501,7 +6501,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8604,7 +8604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8662,7 +8662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10583,7 +10583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,12 +81,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "e4e09ecdaf93729654c472bf4db5cef7b62f447c", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "e4e09ecdaf93729654c472bf4db5cef7b62f447c", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "e4e09ecdaf93729654c472bf4db5cef7b62f447c", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "7679835db47b3fbb859dd2c73423256fd42ebff5", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "7679835db47b3fbb859dd2c73423256fd42ebff5", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "7679835db47b3fbb859dd2c73423256fd42ebff5", default-features = false, features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "e4e09ecdaf93729654c472bf4db5cef7b62f447c" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "7679835db47b3fbb859dd2c73423256fd42ebff5" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary

- bump taiko-geth replacement to the latest `taiko` branch
- bump aligned Alethia-Reth Rust deps to the latest `main` branch
- refresh Go checksums and Rust lockfile

## Dependency Targets

- taiko-geth: `v1.18.1-0.20260515033657-f23532c7cbdc` -> `v1.18.1-0.20260525003749-96923758c5e4` (`96923758c5e43e51eecde8617a7bd70cfa9163d8`)
- alethia-reth: `e4e09ecdaf93729654c472bf4db5cef7b62f447c` -> `7679835db47b3fbb859dd2c73423256fd42ebff5`

## Verification

- `cd packages/taiko-client-rs && cargo metadata --locked --format-version 1 --no-deps`
- `cd packages/taiko-client-rs && cargo check --workspace --all-features --locked`
- `git diff --check`

Go tests were not used as a gate per request.
