### PR TITLE
feat(taiko-client-rs): add preconfirmation P2P raw identity flag

### DIFF
--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -106,6 +106,7 @@ libp2p = { version = "0.56.0", features = [
   "ping",
   "identify",
   "noise",
+  "secp256k1",
   "yamux",
   "macros",
   "tokio",

--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -71,7 +71,7 @@ impl WhitelistPreconfirmationDriverSubCommand {
     }
 
     /// Build P2P configuration from command-line arguments.
-    fn build_p2p_config(&self) -> NetworkConfig {
+    fn build_p2p_config(&self) -> Result<NetworkConfig> {
         let pre_dial_peers = self
             .preconf_flags
             .p2p_static_peers
@@ -81,15 +81,16 @@ impl WhitelistPreconfirmationDriverSubCommand {
             })
             .collect();
 
-        NetworkConfig {
+        let mut cfg = NetworkConfig {
             listen_addr: self.preconf_flags.p2p_listen,
             discovery_listen: self.preconf_flags.p2p_discovery_addr,
             enable_discovery: !self.preconf_flags.p2p_disable_discovery,
             bootnodes: self.preconf_flags.p2p_bootnodes.clone(),
             pre_dial_peers,
-            preconfirmation_p2p_priv_raw: self.preconfirmation_p2p_priv_raw.clone(),
             ..Default::default()
-        }
+        };
+        cfg.set_preconfirmation_p2p_priv_raw(self.preconfirmation_p2p_priv_raw.as_deref())?;
+        Ok(cfg)
     }
 
     /// Resolve the whitelist RPC listen address.
@@ -151,7 +152,7 @@ impl Subcommand for WhitelistPreconfirmationDriverSubCommand {
         self.init_metrics()?;
 
         let driver_config = self.build_driver_config()?;
-        let p2p_config = self.build_p2p_config();
+        let p2p_config = self.build_p2p_config()?;
 
         let runner_config = RunnerConfig::new(
             driver_config,

--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -56,6 +56,9 @@ pub struct WhitelistPreconfirmationDriverSubCommand {
     /// Optional hex-encoded private key for P2P block signing.
     #[clap(long = "preconfirmation.p2p-signer-key", env = "PRECONFIRMATION_P2P_SIGNER_KEY")]
     pub preconfirmation_p2p_signer_key: Option<String>,
+    /// Optional raw secp256k1 private key for the local P2P network identity.
+    #[clap(long = "preconfirmation.p2p-priv-raw", env = "PRECONFIRMATION_P2P_PRIV_RAW")]
+    pub preconfirmation_p2p_priv_raw: Option<String>,
 }
 
 impl WhitelistPreconfirmationDriverSubCommand {
@@ -84,6 +87,7 @@ impl WhitelistPreconfirmationDriverSubCommand {
             enable_discovery: !self.preconf_flags.p2p_disable_discovery,
             bootnodes: self.preconf_flags.p2p_bootnodes.clone(),
             pre_dial_peers,
+            preconfirmation_p2p_priv_raw: self.preconfirmation_p2p_priv_raw.clone(),
             ..Default::default()
         }
     }

--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -81,16 +81,17 @@ impl WhitelistPreconfirmationDriverSubCommand {
             })
             .collect();
 
-        let mut cfg = NetworkConfig {
+        Ok(NetworkConfig {
             listen_addr: self.preconf_flags.p2p_listen,
             discovery_listen: self.preconf_flags.p2p_discovery_addr,
             enable_discovery: !self.preconf_flags.p2p_disable_discovery,
             bootnodes: self.preconf_flags.p2p_bootnodes.clone(),
             pre_dial_peers,
+            preconfirmation_p2p_key: NetworkConfig::parse_preconfirmation_p2p_priv_raw(
+                self.preconfirmation_p2p_priv_raw.as_deref(),
+            )?,
             ..Default::default()
-        };
-        cfg.set_preconfirmation_p2p_priv_raw(self.preconfirmation_p2p_priv_raw.as_deref())?;
-        Ok(cfg)
+        })
     }
 
     /// Resolve the whitelist RPC listen address.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::HashSet,
+    fmt,
     net::SocketAddr,
     sync::Arc,
     time::{Duration, Instant},
@@ -122,7 +123,7 @@ pub(crate) struct WhitelistNetwork {
 }
 
 /// Configuration for the whitelist preconfirmation P2P network.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NetworkConfig {
     /// Enable TCP transport.
     pub enable_tcp: bool,
@@ -136,6 +137,25 @@ pub struct NetworkConfig {
     pub enable_discovery: bool,
     /// UDP listen address for discv5 discovery.
     pub discovery_listen: SocketAddr,
+    /// Optional hex-encoded secp256k1 private key for the local P2P network identity.
+    pub preconfirmation_p2p_priv_raw: Option<String>,
+}
+
+impl fmt::Debug for NetworkConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let preconfirmation_p2p_priv_raw =
+            self.preconfirmation_p2p_priv_raw.as_ref().map(|_| "<redacted>");
+
+        f.debug_struct("NetworkConfig")
+            .field("enable_tcp", &self.enable_tcp)
+            .field("listen_addr", &self.listen_addr)
+            .field("bootnodes", &self.bootnodes)
+            .field("pre_dial_peers", &self.pre_dial_peers)
+            .field("enable_discovery", &self.enable_discovery)
+            .field("discovery_listen", &self.discovery_listen)
+            .field("preconfirmation_p2p_priv_raw", &preconfirmation_p2p_priv_raw)
+            .finish()
+    }
 }
 
 impl Default for NetworkConfig {
@@ -147,7 +167,39 @@ impl Default for NetworkConfig {
             pre_dial_peers: Vec::new(),
             enable_discovery: false,
             discovery_listen: SocketAddr::from(([0, 0, 0, 0], 9223)),
+            preconfirmation_p2p_priv_raw: None,
         }
+    }
+}
+
+impl NetworkConfig {
+    /// Build the local libp2p identity key, falling back to an ephemeral key.
+    fn local_key(&self) -> Result<identity::Keypair> {
+        let Some(raw_key) = self.preconfirmation_p2p_priv_raw.as_deref() else {
+            return Ok(identity::Keypair::generate_ed25519());
+        };
+
+        let raw_key = raw_key.strip_prefix("0x").unwrap_or(raw_key);
+        let key_bytes = alloy_primitives::hex::decode(raw_key).map_err(|err| {
+            WhitelistPreconfirmationDriverError::p2p(format!(
+                "invalid preconfirmation.p2p-priv-raw hex: {err}"
+            ))
+        })?;
+        if key_bytes.len() != 32 {
+            return Err(WhitelistPreconfirmationDriverError::p2p(format!(
+                "invalid preconfirmation.p2p-priv-raw key length: expected 32 bytes, got {}",
+                key_bytes.len()
+            )));
+        }
+
+        let secret_key =
+            identity::secp256k1::SecretKey::try_from_bytes(key_bytes).map_err(|err| {
+                WhitelistPreconfirmationDriverError::p2p(format!(
+                    "invalid preconfirmation.p2p-priv-raw key: {err}"
+                ))
+            })?;
+
+        Ok(identity::Keypair::from(identity::secp256k1::Keypair::from(secret_key)))
     }
 }
 
@@ -167,6 +219,7 @@ impl WhitelistNetwork {
         cfg: NetworkConfig,
         operator_set: SharedOperatorSet,
     ) -> Result<Self> {
+        let local_key = cfg.local_key()?;
         let NetworkConfig {
             enable_tcp,
             listen_addr,
@@ -174,12 +227,9 @@ impl WhitelistNetwork {
             pre_dial_peers,
             enable_discovery,
             discovery_listen,
+            preconfirmation_p2p_priv_raw: _,
         } = cfg;
 
-        // Keep the libp2p identity ephemeral until the Rust driver grows an
-        // explicit persisted node-key configuration. This avoids introducing a
-        // second on-disk key path alongside the existing payload signer.
-        let local_key = identity::Keypair::generate_ed25519();
         let local_peer_id = local_key.public().to_peer_id();
 
         let topics = Topics::new(chain_id);
@@ -824,6 +874,8 @@ fn format_peer_ids(peers: &[PeerId]) -> String {
 mod tests {
     use std::net::Ipv4Addr;
 
+    use alloy_primitives::hex;
+
     use super::*;
 
     #[test]
@@ -846,6 +898,78 @@ mod tests {
             Multiaddr::empty().with(Protocol::Ip4(Ipv4Addr::LOCALHOST)).with(Protocol::Tcp(30303));
 
         assert_eq!(peer_id_from_addr(&addr), None);
+    }
+
+    #[test]
+    fn network_config_local_key_uses_raw_secp256k1_private_key() {
+        let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
+        let cfg = NetworkConfig {
+            preconfirmation_p2p_priv_raw: Some(raw_key.to_string()),
+            ..Default::default()
+        };
+
+        let local_key = cfg.local_key().expect("raw key should parse");
+        let expected_key = identity::Keypair::from(identity::secp256k1::Keypair::from(
+            identity::secp256k1::SecretKey::try_from_bytes(
+                hex::decode(raw_key).expect("valid hex"),
+            )
+            .expect("valid secp256k1 key"),
+        ));
+
+        assert_eq!(local_key.public().to_peer_id(), expected_key.public().to_peer_id());
+    }
+
+    #[test]
+    fn network_config_local_key_accepts_hex_prefix() {
+        let raw_key = "0x1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
+        let cfg = NetworkConfig {
+            preconfirmation_p2p_priv_raw: Some(raw_key.to_string()),
+            ..Default::default()
+        };
+
+        cfg.local_key().expect("raw key with prefix should parse");
+    }
+
+    #[test]
+    fn network_config_local_key_rejects_invalid_raw_key() {
+        let cfg = NetworkConfig {
+            preconfirmation_p2p_priv_raw: Some("not-hex".to_string()),
+            ..Default::default()
+        };
+
+        let err = cfg.local_key().expect_err("invalid raw key should fail");
+
+        assert!(
+            matches!(err, WhitelistPreconfirmationDriverError::P2p(message) if message.contains("preconfirmation.p2p-priv-raw"))
+        );
+    }
+
+    #[test]
+    fn network_config_local_key_rejects_wrong_raw_key_length() {
+        let cfg = NetworkConfig {
+            preconfirmation_p2p_priv_raw: Some("01".repeat(31)),
+            ..Default::default()
+        };
+
+        let err = cfg.local_key().expect_err("short raw key should fail");
+
+        assert!(
+            matches!(err, WhitelistPreconfirmationDriverError::P2p(message) if message.contains("expected 32 bytes"))
+        );
+    }
+
+    #[test]
+    fn network_config_debug_redacts_raw_key() {
+        let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
+        let cfg = NetworkConfig {
+            preconfirmation_p2p_priv_raw: Some(raw_key.to_string()),
+            ..Default::default()
+        };
+
+        let debug = format!("{cfg:?}");
+
+        assert!(!debug.contains(raw_key));
+        assert!(debug.contains("<redacted>"));
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -5,7 +5,6 @@
 
 use std::{
     collections::HashSet,
-    fmt,
     net::SocketAddr,
     sync::Arc,
     time::{Duration, Instant},
@@ -125,7 +124,7 @@ pub(crate) struct WhitelistNetwork {
 }
 
 /// Configuration for the whitelist preconfirmation P2P network.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct NetworkConfig {
     /// Enable TCP transport.
     pub enable_tcp: bool,
@@ -141,22 +140,6 @@ pub struct NetworkConfig {
     pub discovery_listen: SocketAddr,
     /// Optional parsed secp256k1 keypair for the local P2P network identity.
     pub preconfirmation_p2p_key: Option<identity::Keypair>,
-}
-
-impl fmt::Debug for NetworkConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let preconfirmation_p2p_key = self.preconfirmation_p2p_key.as_ref().map(|_| "<redacted>");
-
-        f.debug_struct("NetworkConfig")
-            .field("enable_tcp", &self.enable_tcp)
-            .field("listen_addr", &self.listen_addr)
-            .field("bootnodes", &self.bootnodes)
-            .field("pre_dial_peers", &self.pre_dial_peers)
-            .field("enable_discovery", &self.enable_discovery)
-            .field("discovery_listen", &self.discovery_listen)
-            .field("preconfirmation_p2p_key", &preconfirmation_p2p_key)
-            .finish()
-    }
 }
 
 impl Default for NetworkConfig {
@@ -962,7 +945,7 @@ mod tests {
     }
 
     #[test]
-    fn network_config_debug_redacts_raw_key() {
+    fn network_config_debug_does_not_include_raw_key() {
         let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
         let mut cfg = NetworkConfig::default();
         cfg.set_preconfirmation_p2p_priv_raw(Some(raw_key)).expect("raw key should parse");
@@ -970,7 +953,6 @@ mod tests {
         let debug = format!("{cfg:?}");
 
         assert!(!debug.contains(raw_key));
-        assert!(debug.contains("<redacted>"));
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -157,11 +157,11 @@ impl Default for NetworkConfig {
 }
 
 impl NetworkConfig {
-    /// Configure the local P2P network identity from a raw secp256k1 private key.
-    pub fn set_preconfirmation_p2p_priv_raw(&mut self, raw_key: Option<&str>) -> Result<()> {
-        self.preconfirmation_p2p_key =
-            raw_key.map(parse_preconfirmation_p2p_priv_raw).transpose()?;
-        Ok(())
+    /// Parse an optional raw secp256k1 private key for the local P2P network identity.
+    pub fn parse_preconfirmation_p2p_priv_raw(
+        raw_key: Option<&str>,
+    ) -> Result<Option<identity::Keypair>> {
+        raw_key.map(parse_preconfirmation_p2p_priv_raw).transpose()
     }
 
     /// Build the local libp2p identity key, falling back to an ephemeral key.
@@ -894,8 +894,13 @@ mod tests {
     #[test]
     fn network_config_local_key_uses_raw_secp256k1_private_key() {
         let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
-        let mut cfg = NetworkConfig::default();
-        cfg.set_preconfirmation_p2p_priv_raw(Some(raw_key)).expect("raw key should parse");
+        let cfg = NetworkConfig {
+            preconfirmation_p2p_key: NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(
+                raw_key,
+            ))
+            .expect("raw key should parse"),
+            ..Default::default()
+        };
 
         let local_key = cfg.local_key();
         let expected_key = identity::Keypair::from(identity::secp256k1::Keypair::from(
@@ -911,18 +916,13 @@ mod tests {
     #[test]
     fn network_config_local_key_accepts_hex_prefix() {
         let raw_key = "0x1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
-        let mut cfg = NetworkConfig::default();
-
-        cfg.set_preconfirmation_p2p_priv_raw(Some(raw_key))
+        NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(raw_key))
             .expect("raw key with prefix should parse");
     }
 
     #[test]
     fn network_config_local_key_rejects_invalid_raw_key() {
-        let mut cfg = NetworkConfig::default();
-
-        let err = cfg
-            .set_preconfirmation_p2p_priv_raw(Some("not-hex"))
+        let err = NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some("not-hex"))
             .expect_err("invalid raw key should fail");
 
         assert!(
@@ -932,11 +932,9 @@ mod tests {
 
     #[test]
     fn network_config_local_key_rejects_wrong_raw_key_length() {
-        let mut cfg = NetworkConfig::default();
         let raw_key = "01".repeat(31);
 
-        let err = cfg
-            .set_preconfirmation_p2p_priv_raw(Some(&raw_key))
+        let err = NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(&raw_key))
             .expect_err("short raw key should fail");
 
         assert!(
@@ -947,8 +945,13 @@ mod tests {
     #[test]
     fn network_config_debug_does_not_include_raw_key() {
         let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
-        let mut cfg = NetworkConfig::default();
-        cfg.set_preconfirmation_p2p_priv_raw(Some(raw_key)).expect("raw key should parse");
+        let cfg = NetworkConfig {
+            preconfirmation_p2p_key: NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(
+                raw_key,
+            ))
+            .expect("raw key should parse"),
+            ..Default::default()
+        };
 
         let debug = format!("{cfg:?}");
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -194,6 +194,26 @@ fn parse_preconfirmation_p2p_priv_raw(raw_key: &str) -> Result<identity::Keypair
     Ok(identity::Keypair::from(identity::secp256k1::Keypair::from(secret_key)))
 }
 
+/// Build an Ethereum-style enode URL for the local secp256k1 P2P identity.
+fn local_enode_url(
+    local_key: &identity::Keypair,
+    enable_tcp: bool,
+    listen_addr: SocketAddr,
+) -> Option<String> {
+    if !enable_tcp {
+        return None;
+    }
+
+    let secp256k1_key = local_key.clone().try_into_secp256k1().ok()?;
+    let uncompressed_public_key = secp256k1_key.public().to_bytes_uncompressed();
+    Some(format!(
+        "enode://{}@{}:{}",
+        alloy_primitives::hex::encode(&uncompressed_public_key[1..]),
+        listen_addr.ip(),
+        listen_addr.port()
+    ))
+}
+
 /// Address configured for persistent preconfirmation peer dialing.
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ConfiguredPeerAddr {
@@ -222,6 +242,14 @@ impl WhitelistNetwork {
         } = cfg;
 
         let local_peer_id = local_key.public().to_peer_id();
+        let local_enode = local_enode_url(&local_key, enable_tcp, listen_addr);
+        info!(
+            %local_peer_id,
+            local_enode = local_enode.as_deref().unwrap_or("unavailable"),
+            tcp_enabled = enable_tcp,
+            listen_addr = %listen_addr,
+            "whitelist preconfirmation local P2P identity"
+        );
 
         let topics = Topics::new(chain_id);
         let behaviour = build_behaviour(&local_key, &topics)?;
@@ -956,6 +984,34 @@ mod tests {
         let debug = format!("{cfg:?}");
 
         assert!(!debug.contains(raw_key));
+    }
+
+    #[test]
+    fn local_enode_url_uses_secp256k1_public_key() {
+        let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
+        let local_key = NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(raw_key))
+            .expect("raw key should parse")
+            .expect("key should be configured");
+        let listen_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 30303));
+
+        let enode = local_enode_url(&local_key, true, listen_addr).expect("secp key has enode");
+        let public_key = enode
+            .strip_prefix("enode://")
+            .and_then(|rest| rest.split_once('@'))
+            .map(|(public_key, _)| public_key)
+            .expect("enode should include public key");
+
+        assert!(enode.ends_with("@127.0.0.1:30303"));
+        assert_eq!(public_key.len(), 128);
+        assert!(!public_key.starts_with("04"));
+    }
+
+    #[test]
+    fn local_enode_url_is_unavailable_for_non_secp256k1_key() {
+        let local_key = identity::Keypair::generate_ed25519();
+        let listen_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 30303));
+
+        assert_eq!(local_enode_url(&local_key, true, listen_addr), None);
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -44,6 +44,8 @@ use crate::{
 
 /// Interval for retrying configured bootnode/static peer dials.
 const CONFIGURED_PEER_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+/// Expected length of a secp256k1 private key.
+const SECP256K1_PRIVATE_KEY_LEN: usize = 32;
 
 /// Interval for logging current preconfirmation peer connectivity.
 const PEER_STATUS_LOG_INTERVAL: Duration = Duration::from_secs(60);
@@ -137,14 +139,13 @@ pub struct NetworkConfig {
     pub enable_discovery: bool,
     /// UDP listen address for discv5 discovery.
     pub discovery_listen: SocketAddr,
-    /// Optional hex-encoded secp256k1 private key for the local P2P network identity.
-    pub preconfirmation_p2p_priv_raw: Option<String>,
+    /// Optional parsed secp256k1 keypair for the local P2P network identity.
+    pub preconfirmation_p2p_key: Option<identity::Keypair>,
 }
 
 impl fmt::Debug for NetworkConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let preconfirmation_p2p_priv_raw =
-            self.preconfirmation_p2p_priv_raw.as_ref().map(|_| "<redacted>");
+        let preconfirmation_p2p_key = self.preconfirmation_p2p_key.as_ref().map(|_| "<redacted>");
 
         f.debug_struct("NetworkConfig")
             .field("enable_tcp", &self.enable_tcp)
@@ -153,7 +154,7 @@ impl fmt::Debug for NetworkConfig {
             .field("pre_dial_peers", &self.pre_dial_peers)
             .field("enable_discovery", &self.enable_discovery)
             .field("discovery_listen", &self.discovery_listen)
-            .field("preconfirmation_p2p_priv_raw", &preconfirmation_p2p_priv_raw)
+            .field("preconfirmation_p2p_key", &preconfirmation_p2p_key)
             .finish()
     }
 }
@@ -167,40 +168,47 @@ impl Default for NetworkConfig {
             pre_dial_peers: Vec::new(),
             enable_discovery: false,
             discovery_listen: SocketAddr::from(([0, 0, 0, 0], 9223)),
-            preconfirmation_p2p_priv_raw: None,
+            preconfirmation_p2p_key: None,
         }
     }
 }
 
 impl NetworkConfig {
-    /// Build the local libp2p identity key, falling back to an ephemeral key.
-    fn local_key(&self) -> Result<identity::Keypair> {
-        let Some(raw_key) = self.preconfirmation_p2p_priv_raw.as_deref() else {
-            return Ok(identity::Keypair::generate_ed25519());
-        };
-
-        let raw_key = raw_key.strip_prefix("0x").unwrap_or(raw_key);
-        let key_bytes = alloy_primitives::hex::decode(raw_key).map_err(|err| {
-            WhitelistPreconfirmationDriverError::p2p(format!(
-                "invalid preconfirmation.p2p-priv-raw hex: {err}"
-            ))
-        })?;
-        if key_bytes.len() != 32 {
-            return Err(WhitelistPreconfirmationDriverError::p2p(format!(
-                "invalid preconfirmation.p2p-priv-raw key length: expected 32 bytes, got {}",
-                key_bytes.len()
-            )));
-        }
-
-        let secret_key =
-            identity::secp256k1::SecretKey::try_from_bytes(key_bytes).map_err(|err| {
-                WhitelistPreconfirmationDriverError::p2p(format!(
-                    "invalid preconfirmation.p2p-priv-raw key: {err}"
-                ))
-            })?;
-
-        Ok(identity::Keypair::from(identity::secp256k1::Keypair::from(secret_key)))
+    /// Configure the local P2P network identity from a raw secp256k1 private key.
+    pub fn set_preconfirmation_p2p_priv_raw(&mut self, raw_key: Option<&str>) -> Result<()> {
+        self.preconfirmation_p2p_key =
+            raw_key.map(parse_preconfirmation_p2p_priv_raw).transpose()?;
+        Ok(())
     }
+
+    /// Build the local libp2p identity key, falling back to an ephemeral key.
+    fn local_key(&self) -> identity::Keypair {
+        self.preconfirmation_p2p_key.clone().unwrap_or_else(identity::Keypair::generate_ed25519)
+    }
+}
+
+/// Parse a raw secp256k1 private key into a libp2p identity keypair.
+fn parse_preconfirmation_p2p_priv_raw(raw_key: &str) -> Result<identity::Keypair> {
+    let raw_key = raw_key.strip_prefix("0x").unwrap_or(raw_key);
+    let key_bytes = alloy_primitives::hex::decode(raw_key).map_err(|err| {
+        WhitelistPreconfirmationDriverError::p2p(format!(
+            "invalid preconfirmation.p2p-priv-raw hex: {err}"
+        ))
+    })?;
+    if key_bytes.len() != SECP256K1_PRIVATE_KEY_LEN {
+        return Err(WhitelistPreconfirmationDriverError::p2p(format!(
+            "invalid preconfirmation.p2p-priv-raw key length: expected 32 bytes, got {}",
+            key_bytes.len()
+        )));
+    }
+
+    let secret_key = identity::secp256k1::SecretKey::try_from_bytes(key_bytes).map_err(|err| {
+        WhitelistPreconfirmationDriverError::p2p(format!(
+            "invalid preconfirmation.p2p-priv-raw key: {err}"
+        ))
+    })?;
+
+    Ok(identity::Keypair::from(identity::secp256k1::Keypair::from(secret_key)))
 }
 
 /// Address configured for persistent preconfirmation peer dialing.
@@ -219,7 +227,7 @@ impl WhitelistNetwork {
         cfg: NetworkConfig,
         operator_set: SharedOperatorSet,
     ) -> Result<Self> {
-        let local_key = cfg.local_key()?;
+        let local_key = cfg.local_key();
         let NetworkConfig {
             enable_tcp,
             listen_addr,
@@ -227,7 +235,7 @@ impl WhitelistNetwork {
             pre_dial_peers,
             enable_discovery,
             discovery_listen,
-            preconfirmation_p2p_priv_raw: _,
+            preconfirmation_p2p_key: _,
         } = cfg;
 
         let local_peer_id = local_key.public().to_peer_id();
@@ -903,12 +911,10 @@ mod tests {
     #[test]
     fn network_config_local_key_uses_raw_secp256k1_private_key() {
         let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
-        let cfg = NetworkConfig {
-            preconfirmation_p2p_priv_raw: Some(raw_key.to_string()),
-            ..Default::default()
-        };
+        let mut cfg = NetworkConfig::default();
+        cfg.set_preconfirmation_p2p_priv_raw(Some(raw_key)).expect("raw key should parse");
 
-        let local_key = cfg.local_key().expect("raw key should parse");
+        let local_key = cfg.local_key();
         let expected_key = identity::Keypair::from(identity::secp256k1::Keypair::from(
             identity::secp256k1::SecretKey::try_from_bytes(
                 hex::decode(raw_key).expect("valid hex"),
@@ -922,22 +928,19 @@ mod tests {
     #[test]
     fn network_config_local_key_accepts_hex_prefix() {
         let raw_key = "0x1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
-        let cfg = NetworkConfig {
-            preconfirmation_p2p_priv_raw: Some(raw_key.to_string()),
-            ..Default::default()
-        };
+        let mut cfg = NetworkConfig::default();
 
-        cfg.local_key().expect("raw key with prefix should parse");
+        cfg.set_preconfirmation_p2p_priv_raw(Some(raw_key))
+            .expect("raw key with prefix should parse");
     }
 
     #[test]
     fn network_config_local_key_rejects_invalid_raw_key() {
-        let cfg = NetworkConfig {
-            preconfirmation_p2p_priv_raw: Some("not-hex".to_string()),
-            ..Default::default()
-        };
+        let mut cfg = NetworkConfig::default();
 
-        let err = cfg.local_key().expect_err("invalid raw key should fail");
+        let err = cfg
+            .set_preconfirmation_p2p_priv_raw(Some("not-hex"))
+            .expect_err("invalid raw key should fail");
 
         assert!(
             matches!(err, WhitelistPreconfirmationDriverError::P2p(message) if message.contains("preconfirmation.p2p-priv-raw"))
@@ -946,12 +949,12 @@ mod tests {
 
     #[test]
     fn network_config_local_key_rejects_wrong_raw_key_length() {
-        let cfg = NetworkConfig {
-            preconfirmation_p2p_priv_raw: Some("01".repeat(31)),
-            ..Default::default()
-        };
+        let mut cfg = NetworkConfig::default();
+        let raw_key = "01".repeat(31);
 
-        let err = cfg.local_key().expect_err("short raw key should fail");
+        let err = cfg
+            .set_preconfirmation_p2p_priv_raw(Some(&raw_key))
+            .expect_err("short raw key should fail");
 
         assert!(
             matches!(err, WhitelistPreconfirmationDriverError::P2p(message) if message.contains("expected 32 bytes"))
@@ -961,10 +964,8 @@ mod tests {
     #[test]
     fn network_config_debug_redacts_raw_key() {
         let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
-        let cfg = NetworkConfig {
-            preconfirmation_p2p_priv_raw: Some(raw_key.to_string()),
-            ..Default::default()
-        };
+        let mut cfg = NetworkConfig::default();
+        cfg.set_preconfirmation_p2p_priv_raw(Some(raw_key)).expect("raw key should parse");
 
         let debug = format!("{cfg:?}");
 


### PR DESCRIPTION
Closes #21722

## Summary
- add `--preconfirmation.p2p-priv-raw` / `PRECONFIRMATION_P2P_PRIV_RAW` to the Rust whitelist preconfirmation driver
- derive the whitelist preconfirmation libp2p identity from the configured secp256k1 raw key
- redact the raw private key from `NetworkConfig` debug output and validate raw key length before identity construction
- keep the existing ephemeral ed25519 identity fallback when the flag is unset

## Notes
This only changes P2P identity configuration. It does not change event sync, preconfirmation ingress gating, stale-boundary handling, or reorg behavior. WLP-INV-001..009 are unaffected; WLP-INV-010 parity is the relevant invariant.

## Validation
- `just fmt`
- `cargo test -p whitelist-preconfirmation-driver network_config --lib`
- `cargo test -p taiko-client whitelist_preconfirmation_driver`
- `cargo clippy -p whitelist-preconfirmation-driver -p taiko-client --all-features --no-deps -- -D warnings`

Full `just test` was not run locally.