### PR TITLE
fix(taiko-client-rs): ignore self preconfirmation gossip

### DIFF
--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/client.rs
@@ -135,6 +135,7 @@ where
 
         self.handle = handle;
         self.handler.set_command_tx(self.handle.command_sender());
+        self.handler.set_local_peer_id(self.handle.local_peer_id());
         self.node_handle = tokio::spawn(async move {
             node.run().await.map_err(|err| PreconfirmationClientError::Network(err.to_string()))
         });
@@ -269,15 +270,18 @@ where
         info!(event_sync_tip = %event_sync_tip, "driver event sync complete, starting preconfirmation client");
 
         // Build the event handler for gossip processing.
-        let handler = EventHandler::new(EventHandlerParams {
-            store: store.clone(),
-            codec: codec.clone(),
-            driver: driver.clone(),
-            expected_slasher: config.expected_slasher.clone(),
-            event_tx: event_tx.clone(),
-            command_tx: handle.command_sender(),
-            lookahead_resolver: Arc::clone(&config.lookahead_resolver),
-        });
+        let handler = EventHandler::new_with_local_peer_id(
+            EventHandlerParams {
+                store: store.clone(),
+                codec: codec.clone(),
+                driver: driver.clone(),
+                expected_slasher: config.expected_slasher.clone(),
+                event_tx: event_tx.clone(),
+                command_tx: handle.command_sender(),
+                lookahead_resolver: Arc::clone(&config.lookahead_resolver),
+            },
+            handle.local_peer_id(),
+        );
 
         // Spawn the P2P node loop before running catch-up.
         // Convert anyhow::Result from P2pNode::run() to our crate's Result type.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/event_handler.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/event_handler.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use alloy_primitives::{B256, U256};
-use preconfirmation_net::{NetworkCommand, NetworkEvent};
+use preconfirmation_net::{NetworkCommand, NetworkEvent, PeerId};
 use preconfirmation_types::{
     Bytes20, RawTxListGossip, SignedCommitment, uint256_to_u256, validate_raw_txlist_gossip,
 };
@@ -55,6 +55,8 @@ where
     pub(super) command_tx: Sender<NetworkCommand>,
     /// Lookahead resolver for signer and window validation.
     pub(super) lookahead_resolver: Arc<dyn PreconfSignerResolver + Send + Sync>,
+    /// Local libp2p peer ID used to ignore looped-back gossip messages.
+    pub(super) local_peer_id: Option<PeerId>,
 }
 
 /// Construction parameters for an [`EventHandler`].
@@ -93,12 +95,33 @@ where
             command_tx,
             lookahead_resolver,
         } = params;
-        Self { store, codec, driver, expected_slasher, event_tx, command_tx, lookahead_resolver }
+        Self {
+            store,
+            codec,
+            driver,
+            expected_slasher,
+            event_tx,
+            command_tx,
+            lookahead_resolver,
+            local_peer_id: None,
+        }
+    }
+
+    /// Create a new event handler that ignores gossip propagated by the local peer.
+    pub fn new_with_local_peer_id(params: EventHandlerParams<D>, local_peer_id: PeerId) -> Self {
+        let mut handler = Self::new(params);
+        handler.local_peer_id = Some(local_peer_id);
+        handler
     }
 
     /// Update the command tx used to notify the P2P node.
     pub(crate) fn set_command_tx(&mut self, command_tx: Sender<NetworkCommand>) {
         self.command_tx = command_tx;
+    }
+
+    /// Update the local peer ID used to suppress looped-back gossip.
+    pub(crate) fn set_local_peer_id(&mut self, local_peer_id: PeerId) {
+        self.local_peer_id = Some(local_peer_id);
     }
 
     /// Handle a network event.
@@ -110,10 +133,18 @@ where
             NetworkEvent::PeerDisconnected(peer_id) => {
                 self.handle_peer_disconnected(peer_id.to_string());
             }
-            NetworkEvent::GossipSignedCommitment { from: _, msg } => {
+            NetworkEvent::GossipSignedCommitment { from, msg } => {
+                if self.is_local_peer(from) {
+                    debug!(peer = %from, "ignoring self-propagated commitment gossip");
+                    return Ok(());
+                }
                 self.handle_commitment(*msg).await?;
             }
-            NetworkEvent::GossipRawTxList { from: _, msg } => {
+            NetworkEvent::GossipRawTxList { from, msg } => {
+                if self.is_local_peer(from) {
+                    debug!(peer = %from, "ignoring self-propagated raw txlist gossip");
+                    return Ok(());
+                }
                 self.handle_txlist(*msg).await?;
             }
             NetworkEvent::InboundCommitmentsRequest { from } => {
@@ -137,6 +168,11 @@ where
             }
         }
         Ok(())
+    }
+
+    /// Return whether a network event came from the local libp2p peer.
+    fn is_local_peer(&self, peer_id: PeerId) -> bool {
+        self.local_peer_id.is_some_and(|local_peer_id| local_peer_id == peer_id)
     }
 
     /// Emit a peer-connected event to subscribers.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/mod.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/mod.rs
@@ -20,7 +20,7 @@ mod tests {
 
     use alloy_primitives::{Address, B256, U256};
     use async_trait::async_trait;
-    use preconfirmation_net::PreconfStorage;
+    use preconfirmation_net::{NetworkEvent, PeerId, PreconfStorage};
     use protocol::{
         codec::ZlibTxListCodec,
         preconfirmation::{PreconfSignerResolver, PreconfSlotInfo},
@@ -238,6 +238,90 @@ mod tests {
         handler.handle_commitment(commitment).await.expect("genesis processed");
         assert!(store.latest_commitment().is_some());
         assert_eq!(driver.submissions(), 1);
+    }
+
+    #[tokio::test]
+    async fn self_gossiped_commitment_is_ignored() {
+        let store = Arc::new(InMemoryCommitmentStore::new());
+        let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
+        let driver = Arc::new(TestDriver::new());
+        let (event_tx, _event_rx) = broadcast::channel(16);
+        let (command_tx, _command_rx) = mpsc::channel(8);
+
+        let sk = SecretKey::from_slice(&[3u8; 32]).expect("secret key");
+        let signer = public_key_to_address(&PublicKey::from_secret_key(&Secp256k1::new(), &sk));
+        let lookahead_resolver =
+            Arc::new(MatchingResolver { signer, submission_window_end: U256::from(200u64) });
+        let local_peer_id = PeerId::random();
+
+        let handler = EventHandler::new_with_local_peer_id(
+            EventHandlerParams {
+                store: store.clone(),
+                codec,
+                driver: driver.clone(),
+                expected_slasher: None,
+                event_tx,
+                command_tx,
+                lookahead_resolver,
+            },
+            local_peer_id,
+        );
+
+        let parent_hash = Bytes32::try_from(vec![0u8; 32]).expect("parent hash");
+        let commitment = build_signed_commitment(&sk, 1, parent_hash, 100, 200);
+
+        handler
+            .handle_event(NetworkEvent::GossipSignedCommitment {
+                from: local_peer_id,
+                msg: Box::new(commitment),
+            })
+            .await
+            .expect("self gossip ignored");
+
+        assert!(store.latest_commitment().is_none());
+        assert_eq!(driver.submissions(), 0);
+    }
+
+    #[tokio::test]
+    async fn self_gossiped_txlist_is_ignored() {
+        let store = Arc::new(InMemoryCommitmentStore::new());
+        let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
+        let driver = Arc::new(TestDriver::new());
+        let lookahead_resolver = Arc::new(MockResolver);
+        let (event_tx, _event_rx) = broadcast::channel(16);
+        let (command_tx, _command_rx) = mpsc::channel(8);
+        let local_peer_id = PeerId::random();
+
+        let handler = EventHandler::new_with_local_peer_id(
+            EventHandlerParams {
+                store: store.clone(),
+                codec,
+                driver,
+                expected_slasher: None,
+                event_tx,
+                command_tx,
+                lookahead_resolver,
+            },
+            local_peer_id,
+        );
+
+        let txlist_bytes = TxListBytes::try_from(vec![0xAB; 3]).expect("txlist bytes");
+        let txlist_hash = keccak256_bytes(txlist_bytes.as_ref());
+        let raw_tx_list_hash =
+            Bytes32::try_from(txlist_hash.as_slice().to_vec()).expect("txlist hash");
+        let gossip =
+            RawTxListGossip { raw_tx_list_hash: raw_tx_list_hash.clone(), txlist: txlist_bytes };
+        let hash = B256::from_slice(gossip.raw_tx_list_hash.as_ref());
+
+        handler
+            .handle_event(NetworkEvent::GossipRawTxList {
+                from: local_peer_id,
+                msg: Box::new(gossip),
+            })
+            .await
+            .expect("self txlist gossip ignored");
+
+        assert!(CommitmentStore::get_txlist(store.as_ref(), &hash).is_none());
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -702,6 +702,16 @@ impl NetworkRuntime {
         let from = propagation_source;
         let now = Instant::now();
 
+        if is_local_gossip_source(self.local_peer_id_for_events, from) {
+            debug!(peer = %from, topic = %topic, "ignoring self-propagated whitelist preconfirmation gossip");
+            let _ = self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
+                &message_id,
+                &from,
+                gossipsub::MessageAcceptance::Ignore,
+            );
+            return Ok(());
+        }
+
         let mut report = |acceptance: gossipsub::MessageAcceptance| {
             // Explicitly report every decision so mesh scoring remains aligned with local
             // validation.
@@ -820,6 +830,11 @@ fn format_peer_ids(peers: &[PeerId]) -> String {
     peers.iter().map(ToString::to_string).collect::<Vec<_>>().join(",")
 }
 
+/// Return whether an inbound gossip event was propagated by the local libp2p peer.
+fn is_local_gossip_source(local_peer_id: PeerId, from: PeerId) -> bool {
+    local_peer_id == from
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
@@ -846,6 +861,15 @@ mod tests {
             Multiaddr::empty().with(Protocol::Ip4(Ipv4Addr::LOCALHOST)).with(Protocol::Tcp(30303));
 
         assert_eq!(peer_id_from_addr(&addr), None);
+    }
+
+    #[test]
+    fn local_gossip_source_is_identified() {
+        let local_peer = PeerId::random();
+        let remote_peer = PeerId::random();
+
+        assert!(is_local_gossip_source(local_peer, local_peer));
+        assert!(!is_local_gossip_source(local_peer, remote_peer));
     }
 }
 


### PR DESCRIPTION
## Summary

- Ignore preconfirmation gossip events whose source peer is the local libp2p peer in `preconfirmation-driver`.
- Apply the same self-gossip suppression to `whitelist-preconfirmation-driver` gossipsub ingress.
- Wire the local peer ID into the preconfirmation event handler at startup and after P2P rebuilds.
- Add unit coverage for self-gossiped signed commitments, raw txlists, and whitelist self-source detection.

## Why

This mirrors the taiko-client behavior that drops messages originating from the current P2P node. It prevents taiko-client-rs from processing commitment, txlist, or whitelist preconfirmation gossip that loops back from itself.

## Validation

- `just fmt`
- `cargo test -p preconfirmation-driver --lib self_gossiped`
- `cargo test -p whitelist-preconfirmation-driver --lib network::runtime::tests`