### PR TITLE
feat(taiko-client-rs): advertise whitelist p2p enode address

### DIFF
--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -1,6 +1,6 @@
 //! Whitelist preconfirmation driver subcommand.
 
-use std::path::PathBuf;
+use std::{net::SocketAddr, path::PathBuf};
 
 use alloy_primitives::Address;
 use async_trait::async_trait;
@@ -32,6 +32,9 @@ pub struct WhitelistPreconfirmationDriverSubCommand {
     /// Preconfirmation-specific CLI arguments.
     #[command(flatten)]
     pub preconf_flags: PreconfirmationArgs,
+    /// Externally dialable TCP address advertised in the local whitelist P2P enode URL.
+    #[clap(long = "p2p.advertise.addr", env = "P2P_ADVERTISE_ADDR")]
+    pub p2p_advertise_addr: Option<SocketAddr>,
     /// Shasta preconfirmation whitelist contract address.
     #[clap(long = "shasta.preconf-whitelist", env = "SHASTA_PRECONF_WHITELIST", required = true)]
     pub shasta_preconf_whitelist_address: Address,
@@ -83,6 +86,7 @@ impl WhitelistPreconfirmationDriverSubCommand {
 
         Ok(NetworkConfig {
             listen_addr: self.preconf_flags.p2p_listen,
+            advertise_addr: self.p2p_advertise_addr,
             discovery_listen: self.preconf_flags.p2p_discovery_addr,
             enable_discovery: !self.preconf_flags.p2p_disable_discovery,
             bootnodes: self.preconf_flags.p2p_bootnodes.clone(),

--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -1,6 +1,6 @@
 //! Whitelist preconfirmation driver subcommand.
 
-use std::{net::SocketAddr, path::PathBuf};
+use std::path::PathBuf;
 
 use alloy_primitives::Address;
 use async_trait::async_trait;
@@ -32,9 +32,6 @@ pub struct WhitelistPreconfirmationDriverSubCommand {
     /// Preconfirmation-specific CLI arguments.
     #[command(flatten)]
     pub preconf_flags: PreconfirmationArgs,
-    /// Externally dialable TCP address advertised in the local whitelist P2P enode URL.
-    #[clap(long = "p2p.advertise.addr", env = "P2P_ADVERTISE_ADDR")]
-    pub p2p_advertise_addr: Option<SocketAddr>,
     /// Shasta preconfirmation whitelist contract address.
     #[clap(long = "shasta.preconf-whitelist", env = "SHASTA_PRECONF_WHITELIST", required = true)]
     pub shasta_preconf_whitelist_address: Address,
@@ -86,7 +83,7 @@ impl WhitelistPreconfirmationDriverSubCommand {
 
         Ok(NetworkConfig {
             listen_addr: self.preconf_flags.p2p_listen,
-            advertise_addr: self.p2p_advertise_addr,
+            advertise_addr: self.preconf_flags.p2p_advertise_addr,
             discovery_listen: self.preconf_flags.p2p_discovery_addr,
             enable_discovery: !self.preconf_flags.p2p_disable_discovery,
             bootnodes: self.preconf_flags.p2p_bootnodes.clone(),

--- a/packages/taiko-client-rs/bin/client/src/flags/preconfirmation.rs
+++ b/packages/taiko-client-rs/bin/client/src/flags/preconfirmation.rs
@@ -31,7 +31,35 @@ pub struct PreconfirmationArgs {
     #[clap(long = "p2p.disable-discovery", env = "P2P_DISABLE_DISCOVERY", default_value = "false")]
     pub p2p_disable_discovery: bool,
 
+    /// Externally dialable TCP address advertised in the local P2P node record.
+    #[clap(long = "p2p.advertise.addr", env = "P2P_ADVERTISE_ADDR")]
+    pub p2p_advertise_addr: Option<SocketAddr>,
+
     /// Optional address for user-facing preconfirmation RPC server.
     #[clap(long = "preconf.rpc.addr", env = "PRECONF_RPC_ADDR")]
     pub preconf_rpc_addr: Option<SocketAddr>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use clap::Parser;
+
+    use super::PreconfirmationArgs;
+
+    #[test]
+    fn parses_p2p_advertise_addr() {
+        let args = PreconfirmationArgs::try_parse_from([
+            "test",
+            "--p2p.advertise.addr",
+            "127.0.0.1:30303",
+        ])
+        .expect("p2p advertise addr should parse");
+
+        assert_eq!(
+            args.p2p_advertise_addr,
+            Some("127.0.0.1:30303".parse::<SocketAddr>().expect("socket addr"))
+        );
+    }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -101,8 +101,8 @@ where
     /// Lock-free shared set of whitelisted sequencer addresses; used to refuse
     /// build requests when this node's own P2P signer has been deregistered on-chain.
     operator_set: SharedOperatorSet,
-    /// Local peer ID string.
-    local_peer_id: String,
+    /// Peer ID string.
+    peer_id: String,
     /// Highest unsafe payload block ID tracked by this node (shared with importer).
     highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
     /// Shared cache state used to back `/status` and EOS visibility.
@@ -138,8 +138,8 @@ where
     pub(crate) network_command_tx: mpsc::Sender<NetworkCommand>,
     /// Shared preconfirmation cache state.
     pub(crate) cache_state: SharedPreconfCacheState,
-    /// Local peer ID string.
-    pub(crate) local_peer_id: String,
+    /// Peer ID string.
+    pub(crate) peer_id: String,
 }
 
 impl<P> WhitelistApiService<P>
@@ -158,7 +158,7 @@ where
             highest_unsafe_l2_payload_block_id,
             network_command_tx,
             cache_state,
-            local_peer_id,
+            peer_id,
         }: WhitelistApiServiceParams<P>,
     ) -> Self {
         let (eos_notification_tx, _) = broadcast::channel(EOS_NOTIFICATION_CHANNEL_CAPACITY);
@@ -169,7 +169,7 @@ where
             signer,
             beacon_client,
             operator_set,
-            local_peer_id,
+            peer_id,
             highest_unsafe_l2_payload_block_id,
             cache_state,
             eos_notification_tx,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -24,7 +24,7 @@ where
         Ok(WhitelistStatus {
             head_l1_origin_block_id: head_l1_origin.as_ref().map(|o| o.block_id.to::<u64>()),
             highest_unsafe_block_number: highest_unsafe,
-            peer_id: self.local_peer_id.clone(),
+            peer_id: self.peer_id.clone(),
             sync_ready,
             highest_unsafe_l2_payload_block_id: highest_unsafe,
             end_of_sequencing_block_hash,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -213,10 +213,9 @@ fn advertised_enode_url(
     let uncompressed_public_key = secp256k1_key.public().to_bytes_uncompressed();
     let advertised_addr = advertise_addr.unwrap_or(listen_addr);
     let mut enode = format!(
-        "enode://{}@{}:{}",
+        "enode://{}@{}",
         alloy_primitives::hex::encode(&uncompressed_public_key[1..]),
-        advertised_addr.ip(),
-        advertised_addr.port()
+        enode_endpoint(advertised_addr)
     );
     if let Some(discovery_listen) =
         discovery_listen.filter(|addr| addr.port() != advertised_addr.port())
@@ -224,6 +223,14 @@ fn advertised_enode_url(
         enode.push_str(&format!("?discport={}", discovery_listen.port()));
     }
     Some(enode)
+}
+
+/// Format the endpoint component of an enode URL.
+fn enode_endpoint(addr: SocketAddr) -> String {
+    match addr {
+        SocketAddr::V4(addr) => addr.to_string(),
+        SocketAddr::V6(addr) => format!("[{}]:{}", addr.ip(), addr.port()),
+    }
 }
 
 /// Address configured for persistent preconfirmation peer dialing.
@@ -921,7 +928,7 @@ fn is_local_gossip_source(peer_id: PeerId, from: PeerId) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
     use alloy_primitives::hex;
 
@@ -1050,6 +1057,21 @@ mod tests {
             .expect("secp key has enode");
 
         assert!(enode.ends_with("@203.0.113.10:30303"));
+    }
+
+    #[test]
+    fn advertised_enode_url_brackets_ipv6_advertise_addr() {
+        let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
+        let local_key = NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(raw_key))
+            .expect("raw key should parse")
+            .expect("key should be configured");
+        let listen_addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, 30303));
+        let advertise_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 30303));
+
+        let enode = advertised_enode_url(&local_key, true, listen_addr, Some(advertise_addr), None)
+            .expect("secp key has enode");
+
+        assert!(enode.ends_with("@[::1]:30303"));
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -113,8 +113,8 @@ pub(crate) enum NetworkCommand {
 
 /// Handle to the running whitelist network.
 pub(crate) struct WhitelistNetwork {
-    /// Local peer id.
-    pub(crate) local_peer_id: PeerId,
+    /// Peer id for this network instance.
+    pub(crate) peer_id: PeerId,
     /// Inbound event stream.
     pub(crate) event_rx: mpsc::Receiver<NetworkEvent>,
     /// Outbound command sender.
@@ -130,6 +130,8 @@ pub struct NetworkConfig {
     pub enable_tcp: bool,
     /// TCP listen address.
     pub listen_addr: SocketAddr,
+    /// Optional externally dialable TCP address advertised in the local enode URL.
+    pub advertise_addr: Option<SocketAddr>,
     /// Bootnodes as ENR or multiaddr strings.
     pub bootnodes: Vec<String>,
     /// Static peers to dial on startup.
@@ -147,6 +149,7 @@ impl Default for NetworkConfig {
         Self {
             enable_tcp: true,
             listen_addr: SocketAddr::from(([0, 0, 0, 0], 9222)),
+            advertise_addr: None,
             bootnodes: Vec::new(),
             pre_dial_peers: Vec::new(),
             enable_discovery: false,
@@ -194,11 +197,13 @@ fn parse_preconfirmation_p2p_priv_raw(raw_key: &str) -> Result<identity::Keypair
     Ok(identity::Keypair::from(identity::secp256k1::Keypair::from(secret_key)))
 }
 
-/// Build an Ethereum-style enode URL for the local secp256k1 P2P identity.
-fn local_enode_url(
+/// Build the Ethereum-style enode URL advertised for the secp256k1 P2P identity.
+fn advertised_enode_url(
     local_key: &identity::Keypair,
     enable_tcp: bool,
     listen_addr: SocketAddr,
+    advertise_addr: Option<SocketAddr>,
+    discovery_listen: Option<SocketAddr>,
 ) -> Option<String> {
     if !enable_tcp {
         return None;
@@ -206,12 +211,19 @@ fn local_enode_url(
 
     let secp256k1_key = local_key.clone().try_into_secp256k1().ok()?;
     let uncompressed_public_key = secp256k1_key.public().to_bytes_uncompressed();
-    Some(format!(
+    let advertised_addr = advertise_addr.unwrap_or(listen_addr);
+    let mut enode = format!(
         "enode://{}@{}:{}",
         alloy_primitives::hex::encode(&uncompressed_public_key[1..]),
-        listen_addr.ip(),
-        listen_addr.port()
-    ))
+        advertised_addr.ip(),
+        advertised_addr.port()
+    );
+    if let Some(discovery_listen) =
+        discovery_listen.filter(|addr| addr.port() != advertised_addr.port())
+    {
+        enode.push_str(&format!("?discport={}", discovery_listen.port()));
+    }
+    Some(enode)
 }
 
 /// Address configured for persistent preconfirmation peer dialing.
@@ -234,6 +246,7 @@ impl WhitelistNetwork {
         let NetworkConfig {
             enable_tcp,
             listen_addr,
+            advertise_addr,
             bootnodes,
             pre_dial_peers,
             enable_discovery,
@@ -241,19 +254,26 @@ impl WhitelistNetwork {
             preconfirmation_p2p_key: _,
         } = cfg;
 
-        let local_peer_id = local_key.public().to_peer_id();
-        let local_enode = local_enode_url(&local_key, enable_tcp, listen_addr);
+        let peer_id = local_key.public().to_peer_id();
+        let advertised_enode = advertised_enode_url(
+            &local_key,
+            enable_tcp,
+            listen_addr,
+            advertise_addr,
+            enable_discovery.then_some(discovery_listen),
+        );
         info!(
-            %local_peer_id,
-            local_enode = local_enode.as_deref().unwrap_or("unavailable"),
+            %peer_id,
+            advertised_enode = advertised_enode.as_deref().unwrap_or("unavailable"),
             tcp_enabled = enable_tcp,
             listen_addr = %listen_addr,
+            advertise_addr = advertise_addr.map(|addr| addr.to_string()).as_deref().unwrap_or("unset"),
             "whitelist preconfirmation local P2P identity"
         );
 
         let topics = Topics::new(chain_id);
         let behaviour = build_behaviour(&local_key, &topics)?;
-        let mut swarm = build_swarm(&local_key, local_peer_id, behaviour)?;
+        let mut swarm = build_swarm(&local_key, peer_id, behaviour)?;
         configure_listen_addr(&mut swarm, enable_tcp, listen_addr)?;
 
         let bootnodes = classify_bootnodes(bootnodes);
@@ -279,19 +299,19 @@ impl WhitelistNetwork {
             peer_retry_interval: delayed_interval(CONFIGURED_PEER_RETRY_INTERVAL),
             peer_status_log_interval: delayed_interval(PEER_STATUS_LOG_INTERVAL),
             inbound_validation_state,
-            local_peer_id_for_events: local_peer_id,
+            peer_id_for_events: peer_id,
         };
 
         let handle = tokio::spawn(async move { runtime.run().await });
 
-        Ok(Self { local_peer_id, event_rx, command_tx, handle })
+        Ok(Self { peer_id, event_rx, command_tx, handle })
     }
 }
 
 /// Build a libp2p swarm with DNS-over-TCP transport, noise auth, and yamux multiplexing.
 fn build_swarm(
     local_key: &identity::Keypair,
-    local_peer_id: PeerId,
+    peer_id: PeerId,
     behaviour: TaikoBehaviour,
 ) -> Result<Swarm<TaikoBehaviour>> {
     let noise_config =
@@ -305,12 +325,7 @@ fn build_swarm(
         .multiplex(yamux::Config::default())
         .boxed();
 
-    Ok(Swarm::new(
-        transport,
-        behaviour,
-        local_peer_id,
-        libp2p::swarm::Config::with_tokio_executor(),
-    ))
+    Ok(Swarm::new(transport, behaviour, peer_id, libp2p::swarm::Config::with_tokio_executor()))
 }
 
 /// Configure the TCP listen address when TCP serving is enabled.
@@ -483,8 +498,8 @@ struct NetworkRuntime {
     peer_status_log_interval: Interval,
     /// Inbound validation and dedupe state for gossipsub messages.
     inbound_validation_state: GossipsubInboundState,
-    /// Local peer id used by loopback payload events.
-    local_peer_id_for_events: PeerId,
+    /// Peer id used by loopback payload events.
+    peer_id_for_events: PeerId,
 }
 
 impl NetworkRuntime {
@@ -584,7 +599,7 @@ impl NetworkRuntime {
         // follow-up EOS catch-up requests even without peer echo.
         let payload_bytes = encode_envelope_ssz(&envelope);
         let local_event = NetworkEvent::UnsafePayload {
-            from: self.local_peer_id_for_events,
+            from: self.peer_id_for_events,
             payload: DecodedUnsafePayload {
                 wire_signature: signature,
                 payload_bytes,
@@ -771,7 +786,7 @@ impl NetworkRuntime {
         let from = propagation_source;
         let now = Instant::now();
 
-        if is_local_gossip_source(self.local_peer_id_for_events, from) {
+        if is_local_gossip_source(self.peer_id_for_events, from) {
             debug!(peer = %from, topic = %topic, "ignoring self-propagated whitelist preconfirmation gossip");
             let _ = self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
                 &message_id,
@@ -900,8 +915,8 @@ fn format_peer_ids(peers: &[PeerId]) -> String {
 }
 
 /// Return whether an inbound gossip event was propagated by the local libp2p peer.
-fn is_local_gossip_source(local_peer_id: PeerId, from: PeerId) -> bool {
-    local_peer_id == from
+fn is_local_gossip_source(peer_id: PeerId, from: PeerId) -> bool {
+    peer_id == from
 }
 
 #[cfg(test)]
@@ -1002,14 +1017,15 @@ mod tests {
     }
 
     #[test]
-    fn local_enode_url_uses_secp256k1_public_key() {
+    fn advertised_enode_url_uses_secp256k1_public_key() {
         let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
         let local_key = NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(raw_key))
             .expect("raw key should parse")
             .expect("key should be configured");
         let listen_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 30303));
 
-        let enode = local_enode_url(&local_key, true, listen_addr).expect("secp key has enode");
+        let enode = advertised_enode_url(&local_key, true, listen_addr, None, None)
+            .expect("secp key has enode");
         let public_key = enode
             .strip_prefix("enode://")
             .and_then(|rest| rest.split_once('@'))
@@ -1022,11 +1038,48 @@ mod tests {
     }
 
     #[test]
-    fn local_enode_url_is_unavailable_for_non_secp256k1_key() {
+    fn advertised_enode_url_uses_advertise_addr_when_configured() {
+        let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
+        let local_key = NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(raw_key))
+            .expect("raw key should parse")
+            .expect("key should be configured");
+        let listen_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 30303));
+        let advertise_addr = SocketAddr::from(([203, 0, 113, 10], 30303));
+
+        let enode = advertised_enode_url(&local_key, true, listen_addr, Some(advertise_addr), None)
+            .expect("secp key has enode");
+
+        assert!(enode.ends_with("@203.0.113.10:30303"));
+    }
+
+    #[test]
+    fn advertised_enode_url_appends_discovery_port_when_different_from_tcp_port() {
+        let raw_key = "1875af8dad47674dd6897fb7bcdc1ba872144914082e02dace98dcf2ba16aa8d";
+        let local_key = NetworkConfig::parse_preconfirmation_p2p_priv_raw(Some(raw_key))
+            .expect("raw key should parse")
+            .expect("key should be configured");
+        let listen_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 4001));
+        let advertise_addr = SocketAddr::from(([34, 41, 203, 88], 4001));
+        let discovery_listen = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 30304));
+
+        let enode = advertised_enode_url(
+            &local_key,
+            true,
+            listen_addr,
+            Some(advertise_addr),
+            Some(discovery_listen),
+        )
+        .expect("secp key has enode");
+
+        assert!(enode.ends_with("@34.41.203.88:4001?discport=30304"));
+    }
+
+    #[test]
+    fn advertised_enode_url_is_unavailable_for_non_secp256k1_key() {
         let local_key = identity::Keypair::generate_ed25519();
         let listen_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 30303));
 
-        assert_eq!(local_enode_url(&local_key, true, listen_addr), None);
+        assert_eq!(advertised_enode_url(&local_key, true, listen_addr, None, None), None);
     }
     #[test]
     fn local_gossip_source_is_identified() {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -121,7 +121,7 @@ impl WhitelistPreconfirmationDriverRunner {
             )?,
         );
         info!(
-            peer_id = %network.local_peer_id,
+            peer_id = %network.peer_id,
             chain_id,
             "whitelist preconfirmation p2p subscriber started"
         );
@@ -164,7 +164,7 @@ impl WhitelistPreconfirmationDriverRunner {
                     highest_unsafe_l2_payload_block_id: shared_highest.clone(),
                     network_command_tx: network.command_tx.clone(),
                     cache_state: cache_state.clone(),
-                    local_peer_id: network.local_peer_id.to_string(),
+                    peer_id: network.peer_id.to_string(),
                 }));
                 let server_config = WhitelistApiServerConfig {
                     listen_addr,


### PR DESCRIPTION
## Summary
- Add `--p2p.advertise.addr` / `P2P_ADVERTISE_ADDR` for the whitelist preconfirmation driver.
- Use the advertised TCP address when rendering the whitelist P2P enode, while keeping the bind address unchanged.
- Append `?discport=...` when discovery is enabled and its UDP port differs from the advertised TCP port; clean up related peer/enode naming.

## Impact
Operators can bind P2P on `0.0.0.0` while publishing a dialable external enode such as `enode://...@34.41.203.88:4001?discport=30304`.

## Validation
- `just fmt`
- `cargo test -p whitelist-preconfirmation-driver advertised_enode_url`
- `cargo check -p whitelist-preconfirmation-driver`
- `cargo clippy -p whitelist-preconfirmation-driver -p taiko-client --all-features --no-deps -- -D warnings`

Full `just test` was not run locally because it starts the Docker-backed integration stack.