### PR TITLE
fix(relayer): crash on RabbitMQ subscription retry exhaustion instead of zombieing

### DIFF
--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -374,7 +375,8 @@ func (p *Processor) Start() error {
 
 			return nil
 		}, bo); err != nil {
-			slog.Error("rabbitmq subscribe backoff retry error", "err", err.Error())
+			slog.Error("rabbitmq subscribe backoff retry error, exiting so container restarts", "err", err.Error())
+			os.Exit(1)
 		}
 	}()
 

--- a/packages/relayer/watchdog/watchdog.go
+++ b/packages/relayer/watchdog/watchdog.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"os"
 	"sync"
 	"time"
 
@@ -239,7 +240,8 @@ func (w *Watchdog) Start() error {
 
 			return nil
 		}, bo); err != nil {
-			slog.Error("rabbitmq subscribe backoff retry error", "err", err.Error())
+			slog.Error("rabbitmq subscribe backoff retry error, exiting so container restarts", "err", err.Error())
+			os.Exit(1)
 		}
 	}()
 


### PR DESCRIPTION
## Root Cause

When the RabbitMQ pod restarts (e.g. rescheduling), the relayer processor receives a `CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'` notification. It then enters a backoff retry loop (default: 5 retries × 12s interval = ~60s window).

If RabbitMQ is still unavailable during the entire retry window (e.g. slow reschedule with `FailedScheduling` due to insufficient resources), the backoff retries are exhausted. Currently, the goroutine just logs the error and exits silently, leaving the processor in a **zombie state**: health checks pass (metrics endpoint on `:6061` is independent), but no messages are being processed.

## What This Fix Does

After the backoff retries are exhausted, calls `os.Exit(1)` instead of silently continuing. This causes Kubernetes to restart the container, which re-establishes the RabbitMQ connection on startup — the standard "crash and let the orchestrator restart" pattern for containerized services.

Applied to both `processor/processor.go` and `watchdog/watchdog.go` which had the identical bug.

## Evidence

From the `relayer-processor-l2-to-l1` pod on mainnet:

```
06:56:41 INFO connected to rabbitmq
06:59:15 ERROR rabbitmq notify close connection err="Exception (320) Reason: \"CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'\""
06:59:27 → 07:00:17: 5 retry attempts, all failing with "dial tcp 34.118.228.95:5672: connect: connection refused"
07:00:17 ERROR rabbitmq subscribe backoff retry error err="dial tcp 34.118.228.95:5672: connect: connection refused"
(no more logs — processor is zombie)
```

RabbitMQ pod (`rabbitmq-0`) was rescheduled due to resource constraints and came back healthy at ~06:59:47, but the processor had already exhausted retries by 07:00:17.

## Verification

- Reviewed backoff config: default 5 retries at 12s interval (flags `BACKOFF_MAX_RETRIES`, `BACKOFF_RETRY_INTERVAL`)
- No override in k8s-configs `values/l2-to-l1_relayer_processor.yaml`
- Confirmed pod in zombie state: no logs after 07:00:17 while pod shows Ready=True

## Slack thread

Alert: Relayer Processor Connection Instantiation Error on `relayer-processor-l2-to-l1.mainnet:6061`