### PR TITLE
chore(taiko-client-rs): update alethia reth pin

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=9b561aaf986c6294948163583023ee3aedee3842#9b561aaf986c6294948163583023ee3aedee3842"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6#c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=9b561aaf986c6294948163583023ee3aedee3842#9b561aaf986c6294948163583023ee3aedee3842"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6#c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=9b561aaf986c6294948163583023ee3aedee3842#9b561aaf986c6294948163583023ee3aedee3842"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6#c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=9b561aaf986c6294948163583023ee3aedee3842#9b561aaf986c6294948163583023ee3aedee3842"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6#c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6"
 dependencies = [
  "alloy-primitives",
  "serde",

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=7679835db47b3fbb859dd2c73423256fd42ebff5#7679835db47b3fbb859dd2c73423256fd42ebff5"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=9b561aaf986c6294948163583023ee3aedee3842#9b561aaf986c6294948163583023ee3aedee3842"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=7679835db47b3fbb859dd2c73423256fd42ebff5#7679835db47b3fbb859dd2c73423256fd42ebff5"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=9b561aaf986c6294948163583023ee3aedee3842#9b561aaf986c6294948163583023ee3aedee3842"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=7679835db47b3fbb859dd2c73423256fd42ebff5#7679835db47b3fbb859dd2c73423256fd42ebff5"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=9b561aaf986c6294948163583023ee3aedee3842#9b561aaf986c6294948163583023ee3aedee3842"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=7679835db47b3fbb859dd2c73423256fd42ebff5#7679835db47b3fbb859dd2c73423256fd42ebff5"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=9b561aaf986c6294948163583023ee3aedee3842#9b561aaf986c6294948163583023ee3aedee3842"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3009,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6501,7 +6501,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8604,7 +8604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8662,7 +8662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10583,7 +10583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,12 +81,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "9b561aaf986c6294948163583023ee3aedee3842", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "9b561aaf986c6294948163583023ee3aedee3842", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "9b561aaf986c6294948163583023ee3aedee3842", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6", default-features = false, features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "9b561aaf986c6294948163583023ee3aedee3842" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6" }
 
 # networking
 arc-swap = "1.7"

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,12 +81,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "7679835db47b3fbb859dd2c73423256fd42ebff5", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "7679835db47b3fbb859dd2c73423256fd42ebff5", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "7679835db47b3fbb859dd2c73423256fd42ebff5", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "9b561aaf986c6294948163583023ee3aedee3842", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "9b561aaf986c6294948163583023ee3aedee3842", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "9b561aaf986c6294948163583023ee3aedee3842", default-features = false, features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "7679835db47b3fbb859dd2c73423256fd42ebff5" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "9b561aaf986c6294948163583023ee3aedee3842" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
Why
- Raiko2 needs taiko-client-rs protocol to consume the same alethia-reth revision as the direct raiko2 dependencies.
- The alethia-reth update includes finalized zk gas prefix-stop behavior used by prover witness handling.

How
- Update taiko-client-rs alethia-reth workspace dependency pins to `9b561aaf986c6294948163583023ee3aedee3842`.
- Refresh the taiko-client-rs lockfile.

Tests
- `just fmt-check`
- `cargo check -p protocol --locked`
- `cargo check --workspace --locked`

Depends on
- https://github.com/taikoxyz/alethia-reth/pull/190
