### PR TITLE
chore(taiko-client-rs): update alethia reth pin

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6#c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=26077f125130aa23ab03f376929250d93a21a835#26077f125130aa23ab03f376929250d93a21a835"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6#c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=26077f125130aa23ab03f376929250d93a21a835#26077f125130aa23ab03f376929250d93a21a835"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6#c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=26077f125130aa23ab03f376929250d93a21a835#26077f125130aa23ab03f376929250d93a21a835"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6#c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=26077f125130aa23ab03f376929250d93a21a835#26077f125130aa23ab03f376929250d93a21a835"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3009,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6501,7 +6501,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8604,7 +8604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8662,7 +8662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10583,7 +10583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,12 +81,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "26077f125130aa23ab03f376929250d93a21a835", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "26077f125130aa23ab03f376929250d93a21a835", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "26077f125130aa23ab03f376929250d93a21a835", default-features = false, features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "c242b0dbe0c7bfb739d9e1cdc7afb70a91b255f6" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "26077f125130aa23ab03f376929250d93a21a835" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary

Bumps the `alethia-reth` git pin in `taiko-client-rs` from `c242b0d` → `26077f1` (current tip of [alethia-reth `main`](https://github.com/taikoxyz/alethia-reth)).

The four pinned crates are updated together in the workspace manifest:
- `alethia-reth-chainspec`
- `alethia-reth-consensus`
- `alethia-reth-primitives`
- `alethia-reth-rpc-types`

## What this brings in

A single upstream commit — taikoxyz/alethia-reth#193 — which **reverts** taikoxyz/alethia-reth#190 (_"stop after finalized zk gas target"_). That revert is the current tip of `main`, so the net effect of this bump is rolling back the #190 behavior.

## Verification

- `cargo update -p` for the four alethia-reth packages (Cargo.lock refreshed)
- `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)