### PR TITLE
chore(taiko-client-rs,ejector): bump event-scanner to `v1.1.1`

### DIFF
--- a/packages/ejector/Cargo.lock
+++ b/packages/ejector/Cargo.lock
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "ejector"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "alloy",
  "alloy-serde 0.11.1",
@@ -1938,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "event-scanner"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39e57acc785ab3a610f59942684fc790725d6e4b20d7460db34e899dbe93f77"
+checksum = "3ef10bba30394a8cc3b4c7a0038934162d09d2cab4b21e70ad76618546d03d29"
 dependencies = [
  "alloy",
  "futures",

--- a/packages/ejector/Cargo.toml
+++ b/packages/ejector/Cargo.toml
@@ -28,7 +28,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 # web
 axum = "0.7"
 reqwest = { version = "0.12" }
-event-scanner = "1.1.0"
+event-scanner = "1.1.1"
 robust-provider = { version = "1.0.1", features = ["http-subscription"] }
 
 # ethereum

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -3075,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "event-scanner"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39e57acc785ab3a610f59942684fc790725d6e4b20d7460db34e899dbe93f77"
+checksum = "3ef10bba30394a8cc3b4c7a0038934162d09d2cab4b21e70ad76618546d03d29"
 dependencies = [
  "alloy",
  "futures",

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -75,7 +75,7 @@ alloy-sol-types = { version = "1.5.7", default-features = false }
 alloy-transport = { version = "1.8.3", default-features = false }
 alloy-transport-http = { version = "1.8.3", features = ["hyper", "jwt-auth"] }
 base-tx-manager = { git = "https://github.com/base/base", rev = "1f1149cca0748f7ee7c6234f54d0be8dab51579a" }
-event-scanner = "1.1.0"
+event-scanner = "1.1.1"
 jsonrpsee = { version = "0.26", features = ["server"] }
 k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"


### PR DESCRIPTION
## Summary

Bumps the [`event-scanner`](https://crates.io/crates/event-scanner/1.1.1) crate dependency from **1.1.0 → 1.1.1** across the two monorepo packages that depend on it. This is a semver-patch bump — no API changes, no source changes required.

## Changes

- `packages/taiko-client-rs` — workspace `event-scanner` pin → `1.1.1`; `Cargo.lock` updated (event-scanner entry only).
- `packages/ejector` — `event-scanner` pin → `1.1.1`; `Cargo.lock` updated.

The lockfile diffs were kept minimal: incidental `socket2` index-refresh churn from `cargo update` was reverted in taiko-client-rs so only `event-scanner` changes there.

> **Note:** the ejector commit also reconciles ejector's own stale `Cargo.lock` self-version (`0.6.1 → 0.7.0`) to match its already-bumped `Cargo.toml` manifest — a pre-existing lockfile staleness, included so a `--locked` build stays consistent.

## Verification

- **taiko-client-rs:** `cargo check --workspace --locked` ✅ clean (compiles against 1.1.1 with the minimal lock; all 6 event-scanner consumers build).
- **ejector:** `cargo build` ✅ clean; `cargo test` ✅ **54 passed, 0 failed**.
- **taiko-client-rs `just test`** (Docker devnet integration suite): launched locally; left to CI rather than awaited here.