### PR TITLE
test(taiko-client-rs): bound preconfirmation E2E waits to fail fast on hangs

### DIFF
--- a/packages/taiko-client-rs/crates/preconfirmation-driver/tests/preconf_e2e.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/tests/preconf_e2e.rs
@@ -35,7 +35,13 @@ use test_harness::{
     },
     verify_anchor_block, wait_for_block_or_loop_error,
 };
-use tokio::{spawn, sync::oneshot};
+use tokio::{spawn, sync::oneshot, time::timeout};
+
+/// Upper bound on the unbounded setup waits in this test (ingress readiness,
+/// sync/catch-up, peer connection). Without these bounds a missed signal blocks
+/// the test until the job-level timeout while discarding its captured logs;
+/// wrapping each wait converts a hang into a fast, named failure.
+const SETUP_WAIT_TIMEOUT: Duration = Duration::from_secs(90);
 
 // ============================================================================
 // Block Validation Helper (test-specific)
@@ -245,9 +251,14 @@ async fn p2p_preconfirmation_produces_block(env: &mut ShastaEnv) -> Result<()> {
         async move { syncer.run().await }
     });
 
-    event_syncer
-        .wait_preconf_ingress_ready()
+    timeout(SETUP_WAIT_TIMEOUT, event_syncer.wait_preconf_ingress_ready())
         .await
+        .map_err(|_| {
+            anyhow!(
+                "timed out after {}s waiting for preconfirmation ingress to become ready",
+                SETUP_WAIT_TIMEOUT.as_secs()
+            )
+        })?
         .map_err(|err| anyhow!("preconfirmation ingress unavailable: {err}"))?;
 
     // Set up driver client with logging wrapper.
@@ -294,7 +305,13 @@ async fn p2p_preconfirmation_produces_block(env: &mut ShastaEnv) -> Result<()> {
     let internal_client = PreconfirmationClient::new(int_cfg, driver_client)?;
     let mut events = internal_client.subscribe();
 
-    let mut event_loop = internal_client.sync_and_catchup().await?;
+    let mut event_loop =
+        timeout(SETUP_WAIT_TIMEOUT, internal_client.sync_and_catchup()).await.map_err(|_| {
+            anyhow!(
+                "timed out after {}s waiting for preconfirmation sync/catch-up",
+                SETUP_WAIT_TIMEOUT.as_secs()
+            )
+        })??;
     let (event_loop_tx, mut event_loop_rx) = oneshot::channel::<anyhow::Result<()>>();
     let event_loop_handle = spawn(async move {
         let _ = event_loop_tx.send(event_loop.run().await.map_err(Into::into));
@@ -302,7 +319,7 @@ async fn p2p_preconfirmation_produces_block(env: &mut ShastaEnv) -> Result<()> {
 
     // Wait for peer connection.
     wait_for_peer_connected(&mut events).await;
-    ext_handle.wait_for_peer_connected().await?;
+    ext_handle.wait_for_peer_connected_with_timeout(Some(SETUP_WAIT_TIMEOUT)).await?;
 
     // Build anchor + test transfers using helper.
     let PreconfTxList { raw_tx_bytes, transfers } = build_preconf_txlist(

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/driver.rs
@@ -25,6 +25,7 @@ use rpc::client::{Client, ClientConfig};
 use tokio::{
     sync::{Mutex, Notify},
     task::JoinHandle,
+    time::timeout,
 };
 use tracing::{info, warn};
 
@@ -32,6 +33,13 @@ use crate::{BeaconStubServer, ShastaEnv, fetch_block_by_number};
 
 /// Fast event-sync poll interval used by the harness to keep E2E waits responsive.
 const HARNESS_WAIT_EVENT_SYNC_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Upper bound on how long the harness waits for preconfirmation ingress to become
+/// ready before failing the test. Ingress readiness depends on the event scanner
+/// switching to live and a confirmed-sync probe passing; if either signal is
+/// missed the underlying wait is unbounded, so this bound converts that hang into
+/// a fast, named failure.
+const HARNESS_INGRESS_READY_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// A mock driver client that records submissions for test verification.
 ///
@@ -334,7 +342,14 @@ impl RealDriverSetup {
             }
         });
 
-        event_syncer.wait_preconf_ingress_ready().await?;
+        timeout(HARNESS_INGRESS_READY_TIMEOUT, event_syncer.wait_preconf_ingress_ready())
+            .await
+            .map_err(|_| {
+            anyhow::anyhow!(
+                "timed out after {}s waiting for preconfirmation ingress to become ready",
+                HARNESS_INGRESS_READY_TIMEOUT.as_secs()
+            )
+        })??;
 
         let l2_provider = rpc_client.l2_provider.clone();
         let embedded_client =

--- a/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/events.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/preconfirmation/events.rs
@@ -5,9 +5,26 @@
 //! - [`wait_for_commitment_and_txlist`]: Waits for both commitment and txlist.
 //! - [`wait_for_commitments_and_txlists`]: Waits for multiple commitments/txlists.
 //! - [`wait_for_synced`]: Waits for the synced event.
+//!
+//! Every waiter is bounded by [`EVENT_WAIT_TIMEOUT`]. Without a bound, a missed
+//! event (for example a gossip message dropped before the gossipsub mesh forms)
+//! would block the test until the CI job-level timeout while discarding the
+//! test's captured logs. Failing fast with a descriptive panic turns an opaque
+//! multi-minute hang into an immediately diagnosable test failure that names the
+//! event that never arrived.
+
+use std::time::Duration;
 
 use preconfirmation_driver::subscription::PreconfirmationEvent;
-use tokio::sync::broadcast;
+use tokio::{sync::broadcast, time::timeout};
+
+/// Maximum time any single event-wait helper blocks before failing the test.
+///
+/// Healthy waits resolve within seconds; this bound only trips on a genuinely
+/// missed event. It is kept below the nextest `terminate-after` budget so the
+/// descriptive panic below fires (and is reported) before nextest hard-kills the
+/// process.
+const EVENT_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 // ============================================================================
 // Peer Connection Events
@@ -16,7 +33,7 @@ use tokio::sync::broadcast;
 /// Waits for a peer connection event.
 ///
 /// Blocks until `PreconfirmationEvent::PeerConnected` is received.
-/// Panics if the event stream closes unexpectedly.
+/// Panics if the event stream closes unexpectedly or [`EVENT_WAIT_TIMEOUT`] elapses.
 ///
 /// # Example
 ///
@@ -26,12 +43,18 @@ use tokio::sync::broadcast;
 /// // Peer is now connected, safe to publish gossip
 /// ```
 pub async fn wait_for_peer_connected(events: &mut broadcast::Receiver<PreconfirmationEvent>) {
-    loop {
-        match events.recv().await {
-            Ok(PreconfirmationEvent::PeerConnected(_)) => return,
-            Ok(_) => continue,
-            Err(err) => panic!("preconfirmation event stream closed: {err}"),
+    let wait = async {
+        loop {
+            match events.recv().await {
+                Ok(PreconfirmationEvent::PeerConnected(_)) => return,
+                Ok(_) => continue,
+                Err(err) => panic!("preconfirmation event stream closed: {err}"),
+            }
         }
+    };
+
+    if timeout(EVENT_WAIT_TIMEOUT, wait).await.is_err() {
+        panic!("timed out after {}s waiting for PeerConnected event", EVENT_WAIT_TIMEOUT.as_secs());
     }
 }
 
@@ -43,6 +66,10 @@ pub async fn wait_for_peer_connected(events: &mut broadcast::Receiver<Preconfirm
 ///
 /// Blocks until both `NewCommitment` and `NewTxList` events have been seen.
 /// The events may arrive in any order.
+///
+/// Panics if the event stream closes unexpectedly or [`EVENT_WAIT_TIMEOUT`]
+/// elapses; the timeout message reports which of the two events was still
+/// outstanding.
 ///
 /// # Example
 ///
@@ -57,13 +84,23 @@ pub async fn wait_for_commitment_and_txlist(
     let mut saw_commitment = false;
     let mut saw_txlist = false;
 
-    while !(saw_commitment && saw_txlist) {
-        match events.recv().await {
-            Ok(PreconfirmationEvent::NewCommitment(_)) => saw_commitment = true,
-            Ok(PreconfirmationEvent::NewTxList(_)) => saw_txlist = true,
-            Ok(_) => continue,
-            Err(err) => panic!("preconfirmation event stream closed: {err}"),
+    let wait = async {
+        while !(saw_commitment && saw_txlist) {
+            match events.recv().await {
+                Ok(PreconfirmationEvent::NewCommitment(_)) => saw_commitment = true,
+                Ok(PreconfirmationEvent::NewTxList(_)) => saw_txlist = true,
+                Ok(_) => continue,
+                Err(err) => panic!("preconfirmation event stream closed: {err}"),
+            }
         }
+    };
+
+    if timeout(EVENT_WAIT_TIMEOUT, wait).await.is_err() {
+        panic!(
+            "timed out after {}s waiting for commitment+txlist gossip \
+             (saw_commitment={saw_commitment}, saw_txlist={saw_txlist})",
+            EVENT_WAIT_TIMEOUT.as_secs()
+        );
     }
 }
 
@@ -71,6 +108,9 @@ pub async fn wait_for_commitment_and_txlist(
 ///
 /// Blocks until at least `commitment_count` commitments and `txlist_count`
 /// transaction lists have been received.
+///
+/// Panics if the event stream closes unexpectedly or [`EVENT_WAIT_TIMEOUT`]
+/// elapses; the timeout message reports the received-vs-expected counts.
 ///
 /// # Arguments
 ///
@@ -92,13 +132,24 @@ pub async fn wait_for_commitments_and_txlists(
     let mut commitments_received = 0;
     let mut txlists_received = 0;
 
-    while commitments_received < commitment_count || txlists_received < txlist_count {
-        match events.recv().await {
-            Ok(PreconfirmationEvent::NewCommitment(_)) => commitments_received += 1,
-            Ok(PreconfirmationEvent::NewTxList(_)) => txlists_received += 1,
-            Ok(_) => continue,
-            Err(err) => panic!("preconfirmation event stream closed: {err}"),
+    let wait = async {
+        while commitments_received < commitment_count || txlists_received < txlist_count {
+            match events.recv().await {
+                Ok(PreconfirmationEvent::NewCommitment(_)) => commitments_received += 1,
+                Ok(PreconfirmationEvent::NewTxList(_)) => txlists_received += 1,
+                Ok(_) => continue,
+                Err(err) => panic!("preconfirmation event stream closed: {err}"),
+            }
         }
+    };
+
+    if timeout(EVENT_WAIT_TIMEOUT, wait).await.is_err() {
+        panic!(
+            "timed out after {}s waiting for {commitment_count} commitments and \
+             {txlist_count} txlists (received {commitments_received} commitments, \
+             {txlists_received} txlists)",
+            EVENT_WAIT_TIMEOUT.as_secs()
+        );
     }
 }
 
@@ -111,6 +162,8 @@ pub async fn wait_for_commitments_and_txlists(
 /// Blocks until `PreconfirmationEvent::Synced` is received, indicating
 /// the preconfirmation client has caught up with the network.
 ///
+/// Panics if the event stream closes unexpectedly or [`EVENT_WAIT_TIMEOUT`] elapses.
+///
 /// # Example
 ///
 /// ```ignore
@@ -119,11 +172,17 @@ pub async fn wait_for_commitments_and_txlists(
 /// // Client is now synced and ready to process new commitments
 /// ```
 pub async fn wait_for_synced(events: &mut broadcast::Receiver<PreconfirmationEvent>) {
-    loop {
-        match events.recv().await {
-            Ok(PreconfirmationEvent::Synced) => return,
-            Ok(_) => continue,
-            Err(err) => panic!("preconfirmation event stream closed: {err}"),
+    let wait = async {
+        loop {
+            match events.recv().await {
+                Ok(PreconfirmationEvent::Synced) => return,
+                Ok(_) => continue,
+                Err(err) => panic!("preconfirmation event stream closed: {err}"),
+            }
         }
+    };
+
+    if timeout(EVENT_WAIT_TIMEOUT, wait).await.is_err() {
+        panic!("timed out after {}s waiting for Synced event", EVENT_WAIT_TIMEOUT.as_secs());
     }
 }

--- a/packages/taiko-client-rs/nextest.toml
+++ b/packages/taiko-client-rs/nextest.toml
@@ -1,6 +1,16 @@
 nextest-version = "0.9.104"
 
 [profile.default]
+# Fail-fast safety net for hung tests. The preconfirmation E2E tests are built
+# from chains of async waits; if any signal is missed (e.g. a gossip message
+# dropped before the gossipsub mesh forms, or ingress readiness that never
+# fires) the test would otherwise block until the job-level timeout (~10+ min),
+# printing only SLOW markers and discarding the test's captured logs. Killing
+# the test after `period * terminate-after` reports it as a TIMEOUT failure and
+# surfaces its captured output so the stuck wait is immediately diagnosable.
+# Legitimate integration tests finish well under a minute (the longest bounded
+# wait is the 30s block-production poll), so 180s leaves ample headroom.
+slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.default.overrides]]
 # All integration test binaries (targets from any `tests/` dir) are serialized


### PR DESCRIPTION
## Problem

`preconfirmation-driver::preconf_e2e p2p_preconfirmation_produces_block` intermittently **hangs in CI** (observed `SLOW [>1020s]` in [run 26750190045](https://github.com/taikoxyz/taiko-mono/actions/runs/26750190045/job/78835886161)) until the job-level timeout kills the runner.

Root-cause analysis: the test isn't *failing* — it's deadlock-hanging on an unbounded `await`. The only bounded wait is the 30s block-production poll; everything before it (peer connection, gossip delivery via `wait_for_commitment_and_txlist`, `wait_preconf_ingress_ready`, `sync_and_catchup`) loops on `recv().await` with **no timeout**. Two race-prone signals can be missed under CI scheduling pressure:

- **Gossip publish drop** — `gossipsub.publish()` returns `InsufficientPeers` if it runs before the subscriber's topic subscription has propagated. The external node only bumps a metric + emits an error to *its own* event channel (which the test no longer reads), so a dropped commitment is invisible and the gossip wait blocks forever.
- **Ingress readiness** — the confirmed-sync probe only re-runs on new event-scanner stream messages; if it isn't ready at the instant `SwitchingToLive` fires on a quiescent devnet, ingress never opens and `wait_preconf_ingress_ready` blocks forever.

Worse: nextest has no `terminate-after`, so the hung test is never killed — it just prints SLOW markers, and because nextest buffers per-test output and only flushes on completion, **killing the test discards all its captured logs**, leaving zero diagnostics. The near-identical `p2p_integration` test passed in the same run, confirming this is a latent race, not a regression. (This PR's parent — an `event-scanner` 1.1.0→1.1.1 patch bump — is coincidental.)

## This PR (fail-fast + diagnosable; does **not** yet fix the race)

1. **nextest `slow-timeout` terminate-after** (`period = 60s`, `terminate-after = 3`) — universal safety net: a hung test is killed and reported as a TIMEOUT failure with its captured output within ~3 min instead of stalling the job ~10+ min.
2. **Named timeouts on the wait helpers** — `wait_for_peer_connected` / `wait_for_commitment_and_txlist` / `wait_for_commitments_and_txlists` / `wait_for_synced` (shared across all P2P tests), plus the direct `wait_preconf_ingress_ready`, `sync_and_catchup`, and ext-node peer waits. Each now fails with a message naming exactly which signal never arrived (e.g. `saw_commitment=true, saw_txlist=false`).

Together these turn an opaque multi-minute hang into a fast, self-describing failure — which will pinpoint the exact stuck wait on the next occurrence so the underlying race can be fixed.

## Follow-up

Source fix for the race (periodic ingress re-probe / bounded retry; robust test gossip publish that waits for mesh readiness or surfaces `InsufficientPeers`) — to be done once the named timeouts confirm which wait is the culprit.

## Verification

- `cargo check` (test-harness + preconfirmation-driver tests) ✅
- `cargo +nightly-2025-09-27 fmt --check` (workspace) ✅
- `cargo clippy` (test-harness + preconfirmation-driver, incl. tests) ✅
- nextest config parses (`cargo nextest list --config-file nextest.toml`) ✅
- Full E2E run requires the Docker harness (not run locally).