### PR TITLE
feat(taiko-client-rs): add preconfirmation entry logs

### DIFF
--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/node_api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/node_api.rs
@@ -11,7 +11,7 @@ use preconfirmation_types::{
 use protocol::codec::ZlibTxListCodec;
 use ssz_rs::Deserialize;
 use tokio::sync::{mpsc, watch};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::{
     Result,
@@ -152,6 +152,8 @@ pub(crate) async fn publish_block_impl(
             metrics::counter!(PreconfirmationClientMetrics::VALIDATION_FAILURES_TOTAL).increment(1);
         })?;
 
+    log_publish_block_entry(&signed_commitment, signer, request.tx_list_hash);
+
     // 4. Validate lookahead.
     let timestamp = uint256_to_u256(&signed_commitment.commitment.preconf.timestamp);
     let slot_info = lookahead_resolver
@@ -235,6 +237,25 @@ pub(crate) async fn publish_block_impl(
     tokio::try_join!(driver_submit, commitment_gossip, txlist_gossip)?;
 
     Ok(PublishBlockResponse { commitment_hash, tx_list_hash: calculated_hash })
+}
+
+/// Emit an entry log for a preconfirmation JSON-RPC block publish request.
+fn log_publish_block_entry(
+    commitment: &SignedCommitment,
+    signer: alloy_primitives::Address,
+    tx_list_hash: B256,
+) {
+    let preconf = &commitment.commitment.preconf;
+    info!(
+        block_id = %uint256_to_u256(&preconf.block_number),
+        signer = %signer,
+        timestamp = %uint256_to_u256(&preconf.timestamp),
+        submission_window_end = %uint256_to_u256(&preconf.submission_window_end),
+        raw_tx_list_hash = %B256::from_slice(preconf.raw_tx_list_hash.as_ref()),
+        request_tx_list_hash = %tx_list_hash,
+        eop = preconf.eop,
+        "🏗️ New preconfirmation block publish request"
+    );
 }
 
 /// Build a NodeStatus by querying peer count and computing sync state.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/event_handler.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/event_handler.rs
@@ -9,7 +9,7 @@ use preconfirmation_types::{
 };
 use protocol::{codec::ZlibTxListCodec, preconfirmation::PreconfSignerResolver};
 use tokio::sync::{broadcast, mpsc::Sender};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     driver_interface::DriverClient,
@@ -194,6 +194,15 @@ where
         metrics::counter!(PreconfirmationClientMetrics::COMMITMENTS_RECEIVED_TOTAL).increment(1);
 
         let current_block = uint256_to_u256(&commitment.commitment.preconf.block_number);
+        let preconf = &commitment.commitment.preconf;
+        info!(
+            block_id = %current_block,
+            timestamp = %uint256_to_u256(&preconf.timestamp),
+            submission_window_end = %uint256_to_u256(&preconf.submission_window_end),
+            raw_tx_list_hash = %B256::from_slice(preconf.raw_tx_list_hash.as_ref()),
+            eop = preconf.eop,
+            "📥 New preconfirmation commitment gossip"
+        );
 
         // If we're behind the event sync tip, drop the commitment.
         if current_block <= self.driver.event_sync_tip().await? {
@@ -286,6 +295,11 @@ where
         metrics::counter!(PreconfirmationClientMetrics::TXLISTS_RECEIVED_TOTAL).increment(1);
 
         let hash = B256::from_slice(txlist.raw_tx_list_hash.as_ref());
+        info!(
+            raw_tx_list_hash = %hash,
+            txlist_bytes = txlist.txlist.as_ref().len(),
+            "📥 New preconfirmation txlist gossip"
+        );
         if let Err(err) = validate_raw_txlist_gossip(&txlist)
             .map_err(|err| PreconfirmationClientError::Validation(err.to_string()))
         {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -37,6 +37,22 @@ where
     }
 }
 
+/// Emit the entry log for a preconfirmation block-building request.
+fn log_build_preconf_block_entry(request: &BuildPreconfBlockRequest) {
+    tracing::info!(
+        block_id = request.block_number,
+        coinbase = %request.fee_recipient,
+        timestamp = request.timestamp,
+        gas_limit = request.gas_limit,
+        base_fee_per_gas = request.base_fee_per_gas,
+        extra_data = %alloy_primitives::hex::encode(&request.extra_data),
+        parent_hash = %request.parent_hash,
+        end_of_sequencing = request.end_of_sequencing.unwrap_or(false),
+        is_forced_inclusion = request.is_forced_inclusion.unwrap_or(false),
+        "🏗️ New preconfirmation block building request"
+    );
+}
+
 #[async_trait]
 impl<P> WhitelistApi for WhitelistApiService<P>
 where
@@ -48,6 +64,7 @@ where
         request: BuildPreconfBlockRequest,
     ) -> Result<BuildPreconfBlockResponse> {
         let started_at = Instant::now();
+        log_build_preconf_block_entry(&request);
         // Record receipt before any validation so even rejected requests
         // mark this pod as the active preconfer for shutdown purposes.
         self.mark_preconf_request_received().await;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -819,6 +819,7 @@ impl NetworkRuntime {
             {
                 Ok((wire_signature, payload_bytes, envelope)) => {
                     let payload = DecodedUnsafePayload { wire_signature, payload_bytes, envelope };
+                    log_inbound_preconf_blocks_entry(from, &payload);
                     let acceptance =
                         self.inbound_validation_state.validate_preconf_blocks(&payload);
 
@@ -849,6 +850,7 @@ impl NetworkRuntime {
         if *topic == self.topics.preconf_response.hash() {
             let (acceptance, inbound_label) = match decode_unsafe_response_message(&message.data) {
                 Ok(envelope) => {
+                    log_inbound_preconf_response_entry(from, &envelope);
                     let acceptance = self.inbound_validation_state.validate_response(&envelope);
                     if matches!(acceptance, gossipsub::MessageAcceptance::Accept) &&
                         let Err(err) = forward_event(
@@ -881,6 +883,12 @@ impl NetworkRuntime {
                 return Ok(());
             };
 
+            info!(
+                peer = %from,
+                requested_block_hash = %hash,
+                "📥 New preconfirmation block request gossip"
+            );
+
             let acceptance = self.inbound_validation_state.validate_request(from, hash, now);
             if matches!(acceptance, gossipsub::MessageAcceptance::Accept) {
                 // Requests are relayed only after inbound dedupe/rate checks pass.
@@ -900,6 +908,12 @@ impl NetworkRuntime {
                 report(acceptance);
                 return Ok(());
             };
+
+            info!(
+                peer = %from,
+                epoch,
+                "📥 New end-of-sequencing preconfirmation request gossip"
+            );
 
             let acceptance = self.inbound_validation_state.validate_eos_request(from, epoch, now);
             if matches!(acceptance, gossipsub::MessageAcceptance::Accept) {
@@ -1140,6 +1154,46 @@ fn record_inbound(topic: &'static str, result: &'static str) {
         "result" => result,
     )
     .increment(1);
+}
+
+/// Emit an entry log for an inbound `preconfBlocks` gossip payload.
+fn log_inbound_preconf_blocks_entry(from: PeerId, payload: &DecodedUnsafePayload) {
+    let execution_payload = &payload.envelope.execution_payload;
+    info!(
+        peer = %from,
+        block_id = execution_payload.block_number,
+        block_hash = %execution_payload.block_hash,
+        coinbase = %execution_payload.fee_recipient,
+        timestamp = execution_payload.timestamp,
+        gas_limit = execution_payload.gas_limit,
+        gas_used = execution_payload.gas_used,
+        base_fee_per_gas = %execution_payload.base_fee_per_gas,
+        extra_data = %alloy_primitives::hex::encode(&execution_payload.extra_data),
+        parent_hash = %execution_payload.parent_hash,
+        end_of_sequencing = payload.envelope.end_of_sequencing.unwrap_or(false),
+        is_forced_inclusion = payload.envelope.is_forced_inclusion.unwrap_or(false),
+        "📥 New preconfirmation block gossip"
+    );
+}
+
+/// Emit an entry log for an inbound `responsePreconfBlocks` gossip payload.
+fn log_inbound_preconf_response_entry(from: PeerId, envelope: &WhitelistExecutionPayloadEnvelope) {
+    let execution_payload = &envelope.execution_payload;
+    info!(
+        peer = %from,
+        block_id = execution_payload.block_number,
+        block_hash = %execution_payload.block_hash,
+        coinbase = %execution_payload.fee_recipient,
+        timestamp = execution_payload.timestamp,
+        gas_limit = execution_payload.gas_limit,
+        gas_used = execution_payload.gas_used,
+        base_fee_per_gas = %execution_payload.base_fee_per_gas,
+        extra_data = %alloy_primitives::hex::encode(&execution_payload.extra_data),
+        parent_hash = %execution_payload.parent_hash,
+        end_of_sequencing = envelope.end_of_sequencing.unwrap_or(false),
+        is_forced_inclusion = envelope.is_forced_inclusion.unwrap_or(false),
+        "📥 New preconfirmation block response gossip"
+    );
 }
 
 /// Forward one decoded event to the importer with backpressure.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -819,21 +819,22 @@ impl NetworkRuntime {
             {
                 Ok((wire_signature, payload_bytes, envelope)) => {
                     let payload = DecodedUnsafePayload { wire_signature, payload_bytes, envelope };
-                    log_inbound_preconf_blocks_entry(from, &payload);
                     let acceptance =
                         self.inbound_validation_state.validate_preconf_blocks(&payload);
 
-                    if matches!(acceptance, gossipsub::MessageAcceptance::Accept) &&
-                        let Err(err) = forward_event(
+                    if matches!(acceptance, gossipsub::MessageAcceptance::Accept) {
+                        log_inbound_preconf_blocks_entry(from, &payload);
+                        if let Err(err) = forward_event(
                             &self.event_tx,
                             NetworkEvent::UnsafePayload { from, payload },
                         )
                         .await
-                    {
-                        // If forwarding to importer fails, reject to avoid silently
-                        // accepting data that local consumers could not process.
-                        report(gossipsub::MessageAcceptance::Reject);
-                        return Err(err);
+                        {
+                            // If forwarding to importer fails, reject to avoid silently
+                            // accepting data that local consumers could not process.
+                            report(gossipsub::MessageAcceptance::Reject);
+                            return Err(err);
+                        }
                     }
 
                     let label = acceptance_label(&acceptance);
@@ -850,17 +851,18 @@ impl NetworkRuntime {
         if *topic == self.topics.preconf_response.hash() {
             let (acceptance, inbound_label) = match decode_unsafe_response_message(&message.data) {
                 Ok(envelope) => {
-                    log_inbound_preconf_response_entry(from, &envelope);
                     let acceptance = self.inbound_validation_state.validate_response(&envelope);
-                    if matches!(acceptance, gossipsub::MessageAcceptance::Accept) &&
-                        let Err(err) = forward_event(
+                    if matches!(acceptance, gossipsub::MessageAcceptance::Accept) {
+                        log_inbound_preconf_response_entry(from, &envelope);
+                        if let Err(err) = forward_event(
                             &self.event_tx,
                             NetworkEvent::UnsafeResponse { from, envelope },
                         )
                         .await
-                    {
-                        report(gossipsub::MessageAcceptance::Reject);
-                        return Err(err);
+                        {
+                            report(gossipsub::MessageAcceptance::Reject);
+                            return Err(err);
+                        }
                     }
 
                     let inbound_label = acceptance_label(&acceptance);
@@ -883,14 +885,13 @@ impl NetworkRuntime {
                 return Ok(());
             };
 
-            info!(
-                peer = %from,
-                requested_block_hash = %hash,
-                "📥 New preconfirmation block request gossip"
-            );
-
             let acceptance = self.inbound_validation_state.validate_request(from, hash, now);
             if matches!(acceptance, gossipsub::MessageAcceptance::Accept) {
+                info!(
+                    peer = %from,
+                    requested_block_hash = %hash,
+                    "📥 New preconfirmation block request gossip"
+                );
                 // Requests are relayed only after inbound dedupe/rate checks pass.
                 forward_event(&self.event_tx, NetworkEvent::UnsafeRequest { from, hash }).await?;
             }
@@ -909,14 +910,13 @@ impl NetworkRuntime {
                 return Ok(());
             };
 
-            info!(
-                peer = %from,
-                epoch,
-                "📥 New end-of-sequencing preconfirmation request gossip"
-            );
-
             let acceptance = self.inbound_validation_state.validate_eos_request(from, epoch, now);
             if matches!(acceptance, gossipsub::MessageAcceptance::Accept) {
+                info!(
+                    peer = %from,
+                    epoch,
+                    "📥 New end-of-sequencing preconfirmation request gossip"
+                );
                 // EOS requests follow the same acceptance gate as preconf requests.
                 forward_event(&self.event_tx, NetworkEvent::EndOfSequencingRequest { from, epoch })
                     .await?;


### PR DESCRIPTION
## Summary

Adds structured entry logs around taiko-client-rs preconfirmation ingress points, following the Go taiko-client preconfirmation block building request log style.

## Changes

- Logs whitelist build_preconf_block requests with block id, coinbase, timestamp, gas limit, base fee, extra data, parent hash, EOS, and forced-inclusion flags.
- Logs whitelist P2P topic ingress for preconfBlocks, responsePreconfBlocks, requestPreconfBlocks, and EOS request gossip.
- Logs legacy preconfirmation-driver JSON-RPC publish requests after signer recovery, before lookahead/stale/driver processing.
- Logs legacy preconfirmation-driver P2P commitment and txlist ingress before stale/validation handling.

## Impact

This improves operator observability for API and P2P interfaces without changing preconfirmation behavior. The WLP ingress gate, stale boundary, event-confirmed reorg protection, and custom-table assumptions are unchanged.

## Validation

- cargo test -p whitelist-preconfirmation-driver build_preconf_block_entry_log_defaults_optional_flags
- cargo test -p preconfirmation-driver test_publish_block_rejects_hash_mismatch
- just fmt
- just clippy-fix

just test was attempted, but Docker was not running locally: Cannot connect to the Docker daemon at unix:///Users/guoyu/.docker/run/docker.sock. The full Docker-backed test was skipped after confirmation because this PR only adds entry logging and does not change behavior.