### PR TITLE
docs(protocol): add p256verify (RIP-7212) multiplier

### DIFF
--- a/packages/protocol/docs/zk_gas_spec.md
+++ b/packages/protocol/docs/zk_gas_spec.md
@@ -240,6 +240,7 @@ Indexed by the low byte of the precompile address. Sorted by multiplier descendi
 | bls12_map_fp2_to_g2 | 0x13 | 208 |
 | bls12_g1add | 0x0b | 201 |
 | blake2f | 0x09 | 166 |
+| p256verify | 0x100 | 163 |
 | bls12_g1msm | 0x0c | 93 |
 | bls12_g2msm | 0x0f | 71 |
 | bn128_mul | 0x07 | 58 |


### PR DESCRIPTION
Adds `p256verify` (RIP-7212, address `0x100`) to the precompile multiplier table with value **163**.

We missed this in the initial calibration sweep because RIP-7212 hadn't been added to the alethia-reth precompile set at the time of the benchmark.

Multiplier derived from SP1 marginal cycle measurement (~100k cycles/call, ~4× ecrecover) extrapolated via ecrecover's measured µs/cycle ratio formula `max(SP1, risc0/6)`.