### PR TITLE
chore(taiko-client,taiko-client-rs): bump taiko-geth and alethia-reth to latest

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -7,6 +7,8 @@ on:
       - "taiko-alethia-client-v*"
     paths:
       - "packages/taiko-client/**"
+      - "go.mod"
+      - "go.sum"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260525003749-96923758c5e4
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260604021651-56bdb63a6212
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828 h1:8TqBxcCsk7TNvGHjTuStB2waN3KPpTJYeqpk7JY5t+o=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260525003749-96923758c5e4 h1:O00TxTkhdECyaj54y5b3atzD29MeZ4JQy4gIOs/Y6H0=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260525003749-96923758c5e4/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260604021651-56bdb63a6212 h1:yH7SJ9hS7gQVIk+wWSvlwbSNv7UeyndwQ8vN0NruCYU=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260604021651-56bdb63a6212/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9#04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=abc9833208ccf5b9ea5271016ef316d78c000a82#abc9833208ccf5b9ea5271016ef316d78c000a82"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9#04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=abc9833208ccf5b9ea5271016ef316d78c000a82#abc9833208ccf5b9ea5271016ef316d78c000a82"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9#04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=abc9833208ccf5b9ea5271016ef316d78c000a82#abc9833208ccf5b9ea5271016ef316d78c000a82"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9#04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=abc9833208ccf5b9ea5271016ef316d78c000a82#abc9833208ccf5b9ea5271016ef316d78c000a82"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3009,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6501,7 +6501,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8604,7 +8604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8662,7 +8662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10583,7 +10583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,12 +81,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "abc9833208ccf5b9ea5271016ef316d78c000a82", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "abc9833208ccf5b9ea5271016ef316d78c000a82", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "abc9833208ccf5b9ea5271016ef316d78c000a82", default-features = false, features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "04d232ccadb6800dc5d2ed8eec982f32e7d0c6e9" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "abc9833208ccf5b9ea5271016ef316d78c000a82" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary

Bumps the two pinned Taiko execution-layer forks to the tip of their default
development branches, and fixes CI so a root `go.mod`/`go.sum` change triggers
the taiko-client Docker image build.

- **taiko-geth** (`go.mod` `replace` directive): `96923758c5e4` → `56bdb63a6212`
  (`v1.18.1-0.20260604021651-56bdb63a6212`, `taiko` branch HEAD — "correct Unzen
  BLS12 precompile addresses and add CLZ opcode" taikoxyz/taiko-geth#567).
- **alethia-reth** (4 crates in `packages/taiko-client-rs/Cargo.toml`):
  `04d232cc` → `abc9833208` (`main` HEAD — "apply canonical BLS12 addresses +
  CLZ opcode" taikoxyz/alethia-reth#203).
- **CI** (`taiko-client--docker.yml`): add `go.mod`/`go.sum` to the push path
  filter. The taiko-client Go module is rooted at the repo root, so dependency
  bumps touch only root `go.mod`/`go.sum` and would otherwise not match the
  existing `packages/taiko-client/**` filter — meaning the image would not
  rebuild on merge. This mirrors the PR path filter already in
  `taiko-client--test.yml`.

## Verification (build-only)

- `CGO_ENABLED=1 go build ./packages/taiko-client/...` → passes.
- `cargo check --workspace` (in `packages/taiko-client-rs`) → passes.

Tests were not run as part of this bump. The only `go build ./...` failure is a
pre-existing, unrelated `packages/fork-diff` `go:embed page.gohtml` issue
(generated template absent in a plain checkout); it fails identically without
this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
