### PR TITLE
chore(taiko-client,taiko-client-rs): bump taiko-geth and alethia-reth to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260604021651-56bdb63a6212
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260604073822-312ef681a061
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828 h1:8TqBxcCsk7TNvGHjTuStB2waN3KPpTJYeqpk7JY5t+o=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260604021651-56bdb63a6212 h1:yH7SJ9hS7gQVIk+wWSvlwbSNv7UeyndwQ8vN0NruCYU=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260604021651-56bdb63a6212/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260604073822-312ef681a061 h1:/GaNesPRo7ed8zHAUC6NNXEisBKaY/A9GSrfj1+xfdE=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260604073822-312ef681a061/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=abc9833208ccf5b9ea5271016ef316d78c000a82#abc9833208ccf5b9ea5271016ef316d78c000a82"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=ec1650bfc5925af4f763795cfeb7872f9e85813b#ec1650bfc5925af4f763795cfeb7872f9e85813b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=abc9833208ccf5b9ea5271016ef316d78c000a82#abc9833208ccf5b9ea5271016ef316d78c000a82"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=ec1650bfc5925af4f763795cfeb7872f9e85813b#ec1650bfc5925af4f763795cfeb7872f9e85813b"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=abc9833208ccf5b9ea5271016ef316d78c000a82#abc9833208ccf5b9ea5271016ef316d78c000a82"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=ec1650bfc5925af4f763795cfeb7872f9e85813b#ec1650bfc5925af4f763795cfeb7872f9e85813b"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=abc9833208ccf5b9ea5271016ef316d78c000a82#abc9833208ccf5b9ea5271016ef316d78c000a82"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=ec1650bfc5925af4f763795cfeb7872f9e85813b#ec1650bfc5925af4f763795cfeb7872f9e85813b"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3009,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6501,7 +6501,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8604,7 +8604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8662,7 +8662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10583,7 +10583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -81,12 +81,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "abc9833208ccf5b9ea5271016ef316d78c000a82", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "abc9833208ccf5b9ea5271016ef316d78c000a82", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "abc9833208ccf5b9ea5271016ef316d78c000a82", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "ec1650bfc5925af4f763795cfeb7872f9e85813b", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "ec1650bfc5925af4f763795cfeb7872f9e85813b", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "ec1650bfc5925af4f763795cfeb7872f9e85813b", default-features = false, features = [
   "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "abc9833208ccf5b9ea5271016ef316d78c000a82" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "ec1650bfc5925af4f763795cfeb7872f9e85813b" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary

Bumps the two pinned Taiko execution-layer forks to the tip of their default
development branches. Both pick up the same follow-up change — lowering the
default Unzen modexp zk-gas multiplier to 154.

- **taiko-geth** (`go.mod` `replace` directive): `56bdb63a6212` → `312ef681a061`
  (`v1.18.1-0.20260604073822-312ef681a061`, `taiko` branch HEAD — "lower default
  Unzen modexp zk-gas multiplier to 154" taikoxyz/taiko-geth#568).
- **alethia-reth** (4 crates in `packages/taiko-client-rs/Cargo.toml`):
  `abc9833208` → `ec1650bfc592` (`main` HEAD — "lower modexp zk-gas multiplier
  to 154" taikoxyz/alethia-reth#204).

No CI change needed — the `go.mod`/`go.sum` Docker-trigger path filter already
landed in the previous bump PR.

## Verification (build-only)

- `CGO_ENABLED=1 go build ./packages/taiko-client/...` → passes.
- `cargo check --workspace` (in `packages/taiko-client-rs`) → passes.

Tests were not run as part of this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
