### PR TITLE
chore(taiko-client-rs): validate blob server KZG data

### DIFF
--- a/packages/taiko-client-rs/crates/rpc/Cargo.toml
+++ b/packages/taiko-client-rs/crates/rpc/Cargo.toml
@@ -17,7 +17,7 @@ tower = { workspace = true }
 
 # ethereum
 alloy = { workspace = true }
-alloy-eips = { workspace = true }
+alloy-eips = { workspace = true, features = ["kzg"] }
 alloy-primitives = { workspace = true, default-features = false }
 alloy-provider = { workspace = true, features = ["ws"] }
 alloy-rpc-types = { workspace = true }
@@ -42,3 +42,6 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+
+[dev-dependencies]
+hyper = { workspace = true, features = ["server"] }

--- a/packages/taiko-client-rs/crates/rpc/src/blob.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/blob.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use alloy::primitives::{B256, hex};
-use alloy_eips::eip4844::{Blob, Bytes48, VERSIONED_HASH_VERSION_KZG};
+use alloy_eips::eip4844::{
+    Blob, Bytes48, VERSIONED_HASH_VERSION_KZG, c_kzg, env_settings::EnvKzgSettings,
+};
 use alloy_rpc_types::BlobTransactionSidecar;
 use once_cell::sync::OnceCell;
 use reqwest::Client as HttpClient;
@@ -175,22 +177,11 @@ impl BlobDataSource {
                 response.json().await.map_err(|err| BlobDataError::Parse(err.to_string()))?;
 
             let blob = parse_blob(&payload.data)?;
-            let commitment = parse_bytes48(&payload.commitment)?;
+            let commitment = compute_blob_commitment(&blob)?;
             let proof =
                 payload.proof.as_deref().map(parse_bytes48).transpose()?.unwrap_or_default();
 
             let versioned_hash = versioned_hash_from_commitment(&commitment);
-            if let Ok(reported_hash) = payload.versioned_hash.parse::<B256>() &&
-                reported_hash != versioned_hash
-            {
-                warn!(
-                    ?hash,
-                    reported = ?reported_hash,
-                    derived = ?versioned_hash,
-                    "blob server reported mismatched versioned hash"
-                );
-                return Err(BlobDataError::Parse("blob hash mismatch from blob server".into()));
-            }
             if versioned_hash != *hash {
                 warn!(
                 ?hash,
@@ -198,6 +189,27 @@ impl BlobDataSource {
                 "blob server returned mismatched blob hash"
                 );
                 return Err(BlobDataError::Parse("blob hash mismatch from blob server".into()));
+            }
+
+            if let Ok(reported_commitment) = parse_bytes48(&payload.commitment)
+                && reported_commitment != commitment
+            {
+                debug!(
+                    ?hash,
+                    reported = ?reported_commitment,
+                    computed = ?commitment,
+                    "blob server reported mismatched KZG commitment metadata"
+                );
+            }
+            if let Ok(reported_hash) = payload.versioned_hash.parse::<B256>()
+                && reported_hash != versioned_hash
+            {
+                debug!(
+                    ?hash,
+                    reported = ?reported_hash,
+                    computed = ?versioned_hash,
+                    "blob server reported mismatched versioned hash metadata"
+                );
             }
 
             blobs.push(BlobTransactionSidecar {
@@ -264,6 +276,18 @@ pub(crate) fn parse_bytes48(value: &str) -> Result<Bytes48, BlobDataError> {
         .map_err(|_| BlobDataError::Parse("invalid 48-byte value".into()))
 }
 
+/// Computes the KZG commitment for a blob using the default Ethereum trusted setup.
+fn compute_blob_commitment(blob: &Blob) -> Result<Bytes48, BlobDataError> {
+    let kzg_blob = c_kzg::Blob::from_bytes(blob.as_slice())
+        .map_err(|err| BlobDataError::Other(anyhow::anyhow!(err.to_string())))?;
+    let commitment = EnvKzgSettings::Default
+        .get()
+        .blob_to_kzg_commitment(&kzg_blob)
+        .map_err(|err| BlobDataError::Other(anyhow::anyhow!(err.to_string())))?;
+
+    Ok(Bytes48::from_slice(commitment.to_bytes().as_ref()))
+}
+
 /// Computes the versioned hash from a KZG commitment.
 fn versioned_hash_from_commitment(commitment: &Bytes48) -> B256 {
     let mut hash: [u8; 32] = Sha256::digest(commitment.as_slice()).into();
@@ -273,7 +297,80 @@ fn versioned_hash_from_commitment(commitment: &Bytes48) -> B256 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use alloy_eips::eip4844::env_settings::EnvKzgSettings;
+    use http_body_util::Full;
+    use hyper::{
+        StatusCode, body::Bytes as HyperBytes, header::CONTENT_TYPE,
+        server::conn::http1::Builder as Http1Builder, service::service_fn,
+    };
+    use tokio::{net::TcpListener, select, spawn, sync::Notify, task::JoinHandle};
+
+    struct TestBlobServer {
+        endpoint: Url,
+        shutdown: Arc<Notify>,
+        handle: JoinHandle<()>,
+    }
+
+    impl TestBlobServer {
+        async fn start(body: String) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("test server should bind an ephemeral port");
+            let addr = listener.local_addr().expect("listener address should be available");
+            let endpoint =
+                Url::parse(&format!("http://{addr}")).expect("test endpoint URL should parse");
+
+            let shutdown = Arc::new(Notify::new());
+            let cancel = shutdown.clone();
+            let body = Arc::new(body);
+
+            let handle = spawn(async move {
+                loop {
+                    select! {
+                        _ = cancel.notified() => break,
+                        accept_result = listener.accept() => {
+                            let Ok((stream, _)) = accept_result else { continue };
+                            let body = body.clone();
+                            spawn(async move {
+                                let io = hyper_util::rt::TokioIo::new(stream);
+                                let service = service_fn(move |_| {
+                                    let body = body.clone();
+                                    async move {
+                                        Ok::<_, hyper::Error>(
+                                            hyper::Response::builder()
+                                                .status(StatusCode::OK)
+                                                .header(CONTENT_TYPE, "application/json")
+                                                .body(Full::new(HyperBytes::from(
+                                                    body.as_bytes().to_vec(),
+                                                )))
+                                                .expect("test response should build"),
+                                        )
+                                    }
+                                });
+                                let _ = Http1Builder::new().serve_connection(io, service).await;
+                            });
+                        }
+                    }
+                }
+            });
+
+            Self { endpoint, shutdown, handle }
+        }
+
+        fn endpoint(&self) -> Url {
+            self.endpoint.clone()
+        }
+    }
+
+    impl Drop for TestBlobServer {
+        fn drop(&mut self) {
+            self.shutdown.notify_waiters();
+            self.handle.abort();
+        }
+    }
 
     #[test]
     fn display_blob_sidecar() {
@@ -286,5 +383,62 @@ mod tests {
         assert_eq!(sidecar.blobs.len(), 1);
         assert!(sidecar.commitments.is_empty());
         assert!(sidecar.proofs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn blob_server_rejects_blob_bytes_that_do_not_match_commitment_metadata() {
+        let zero_sidecar = sidecar_for_blob(Blob::ZERO);
+        let zero_commitment = zero_sidecar.commitments[0];
+        let zero_hash = versioned_hash_from_commitment(&zero_commitment);
+        let body = blob_server_body(&Blob::repeat_byte(0x11), &zero_commitment, zero_hash);
+        let server = TestBlobServer::start(body).await;
+        let source = BlobDataSource::new(None, Some(server.endpoint()), true)
+            .await
+            .expect("blob source should be constructed");
+
+        let result = source.get_blobs(0, &[zero_hash]).await;
+        assert!(
+            matches!(result, Err(BlobDataError::Parse(_))),
+            "expected parse error for blob bytes that do not match metadata, got {result:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn blob_server_accepts_valid_blob_even_if_commitment_metadata_is_wrong() {
+        let zero_sidecar = sidecar_for_blob(Blob::ZERO);
+        let zero_hash = versioned_hash_from_commitment(&zero_sidecar.commitments[0]);
+        let wrong_commitment = Bytes48::repeat_byte(0x42);
+        let body = blob_server_body(&Blob::ZERO, &wrong_commitment, zero_hash);
+        let server = TestBlobServer::start(body).await;
+        let source = BlobDataSource::new(None, Some(server.endpoint()), true)
+            .await
+            .expect("blob source should be constructed");
+
+        let sidecars = source
+            .get_blobs(0, &[zero_hash])
+            .await
+            .expect("valid blob data should be accepted despite wrong metadata");
+
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0].blobs, vec![Blob::ZERO]);
+        assert_eq!(sidecars[0].commitments, vec![zero_sidecar.commitments[0]]);
+        assert_eq!(sidecars[0].proofs, vec![Bytes48::default()]);
+    }
+
+    fn sidecar_for_blob(blob: Blob) -> BlobTransactionSidecar {
+        BlobTransactionSidecar::try_from_blobs_with_settings(
+            vec![blob],
+            EnvKzgSettings::Default.get(),
+        )
+        .expect("test blob should produce a KZG sidecar")
+    }
+
+    fn blob_server_body(blob: &Blob, commitment: &Bytes48, versioned_hash: B256) -> String {
+        serde_json::json!({
+            "versionedHash": versioned_hash.to_string(),
+            "commitment": format!("0x{}", hex::encode(commitment.as_slice())),
+            "data": format!("0x{}", hex::encode(blob.as_slice())),
+        })
+        .to_string()
     }
 }

--- a/packages/taiko-client-rs/crates/rpc/src/blob.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/blob.rs
@@ -191,8 +191,8 @@ impl BlobDataSource {
                 return Err(BlobDataError::Parse("blob hash mismatch from blob server".into()));
             }
 
-            if let Ok(reported_commitment) = parse_bytes48(&payload.commitment)
-                && reported_commitment != commitment
+            if let Ok(reported_commitment) = parse_bytes48(&payload.commitment) &&
+                reported_commitment != commitment
             {
                 debug!(
                     ?hash,
@@ -201,8 +201,8 @@ impl BlobDataSource {
                     "blob server reported mismatched KZG commitment metadata"
                 );
             }
-            if let Ok(reported_hash) = payload.versioned_hash.parse::<B256>()
-                && reported_hash != versioned_hash
+            if let Ok(reported_hash) = payload.versioned_hash.parse::<B256>() &&
+                reported_hash != versioned_hash
             {
                 debug!(
                     ?hash,


### PR DESCRIPTION
## Summary

- validate blob-server fallback responses by recomputing the KZG commitment from returned blob bytes
- return sidecars with the computed commitment instead of trusting blob-server commitment metadata
- add regression coverage for mismatched blob bytes and bad metadata with valid blob bytes

## Validation

- `cargo test -p rpc blob_server -- --nocapture`
- `cargo test -p rpc display_blob_sidecar -- --nocapture`
- `cargo check -p rpc`
- `cargo fmt --package rpc --check`
- `cargo clippy -p rpc --all-features --no-deps -- -D warnings`
- `git diff --check`
