### PR TITLE
refactor(taiko-client-rs): simplify whitelist preconfirmation driver

### DIFF
--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -156,15 +156,15 @@ impl Subcommand for WhitelistPreconfirmationDriverSubCommand {
         let driver_config = self.build_driver_config()?;
         let p2p_config = self.build_p2p_config()?;
 
-        let runner_config = RunnerConfig::new(
+        let runner_config = RunnerConfig {
             driver_config,
             p2p_config,
-            self.shasta_preconf_whitelist_address,
-            self.resolve_rpc_addr(),
-            self.resolve_rpc_jwt_secret()?,
-            self.resolve_rpc_cors_origins(),
-            self.preconfirmation_p2p_signer_key.clone(),
-        );
+            whitelist_address: self.shasta_preconf_whitelist_address,
+            rpc_listen_addr: self.resolve_rpc_addr(),
+            rpc_jwt_secret: self.resolve_rpc_jwt_secret()?,
+            rpc_cors_origins: self.resolve_rpc_cors_origins(),
+            p2p_signer_key: self.preconfirmation_p2p_signer_key.clone(),
+        };
 
         WhitelistPreconfirmationDriverRunner::new(runner_config).run().await?;
         Ok(())

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/mod.rs
@@ -30,10 +30,6 @@ const PRECONF_BLOCKS_BODY_LIMIT_BYTES: usize = (MAX_COMPRESSED_TX_LIST_BYTES * 2
 pub struct WhitelistApiServerConfig {
     /// Socket address to listen on.
     pub listen_addr: SocketAddr,
-    /// Whether HTTP transport is enabled.
-    pub enable_http: bool,
-    /// Whether WebSocket transport is enabled.
-    pub enable_ws: bool,
     /// Optional shared secret used to validate `Authorization: Bearer <jwt>` on all routes.
     pub jwt_secret: Option<Vec<u8>>,
     /// Optional list of allowed CORS origins.
@@ -41,12 +37,10 @@ pub struct WhitelistApiServerConfig {
 }
 
 impl Default for WhitelistApiServerConfig {
-    /// Build the default server configuration (loopback bind, HTTP+WS enabled, no JWT).
+    /// Build the default server configuration (loopback bind, no JWT).
     fn default() -> Self {
         Self {
             listen_addr: "127.0.0.1:8552".parse().expect("valid default address"),
-            enable_http: true,
-            enable_ws: true,
             jwt_secret: None,
             cors_origins: vec!["*".to_string()],
         }
@@ -72,10 +66,6 @@ impl WhitelistApiServer {
         config: WhitelistApiServerConfig,
         api: Arc<dyn WhitelistApi>,
     ) -> Result<Self> {
-        if !config.enable_http && !config.enable_ws {
-            return Err(WhitelistPreconfirmationDriverError::RestWsServerNoTransportsEnabled);
-        }
-
         let state = state::AppState {
             api: Arc::clone(&api),
             jwt_auth: config
@@ -83,8 +73,7 @@ impl WhitelistApiServer {
                 .as_ref()
                 .map(|secret| Arc::new(auth::JwtAuth::new(secret.as_slice()))),
         };
-        let app =
-            router::build_router(state, &config.cors_origins, config.enable_http, config.enable_ws);
+        let app = router::build_router(state, &config.cors_origins);
 
         let listener = TcpListener::bind(config.listen_addr).await.map_err(|e| {
             WhitelistPreconfirmationDriverError::RestWsServerBind {
@@ -110,8 +99,6 @@ impl WhitelistApiServer {
 
         info!(
             addr = %addr,
-            enable_http = config.enable_http,
-            enable_ws = config.enable_ws,
             jwt_enabled = config.jwt_secret.is_some(),
             cors_origins = ?config.cors_origins,
             http_url = %format!("http://{addr}"),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/router.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/router.rs
@@ -20,7 +20,7 @@ use super::{
     state::AppState,
 };
 
-/// Construct the server router with optional HTTP and WebSocket route groups.
+/// Construct the server router with public probe routes and protected REST/WS routes.
 ///
 /// `/`, `/healthz`, and `/status` are served without JWT authentication so
 /// that lightweight Kubernetes liveness/readiness probes (which cannot

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/router.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/router.rs
@@ -26,34 +26,21 @@ use super::{
 /// that lightweight Kubernetes liveness/readiness probes (which cannot
 /// generate HMAC-SHA256 bearer tokens) can reach them. `/preconfBlocks` and
 /// `/ws` remain JWT-protected when `jwt_secret` is configured.
-pub(super) fn build_router(
-    state: AppState,
-    cors_origins: &[String],
-    enable_http: bool,
-    enable_ws: bool,
-) -> Router {
+pub(super) fn build_router(state: AppState, cors_origins: &[String]) -> Router {
     let cors_layer = build_cors_layer(cors_origins);
 
-    let mut public_router = Router::new();
-    let mut protected_router = Router::new();
-
-    if enable_http {
-        public_router = public_router
-            .route("/", get(handle_root))
-            .route("/healthz", get(handle_root))
-            .route("/status", get(handle_status));
-        protected_router = protected_router.route("/preconfBlocks", post(handle_preconf_blocks));
-    }
-
-    if enable_ws {
-        protected_router = protected_router.route("/ws", get(handle_websocket_upgrade));
-    }
+    let public_router = Router::new()
+        .route("/", get(handle_root))
+        .route("/healthz", get(handle_root))
+        .route("/status", get(handle_status));
 
     // Place the not-found fallback inside the protected router so the auth
     // middleware wraps it: when a JWT secret is configured, unknown paths
     // must still return 401 rather than leaking their non-existence as 404
     // to unauthenticated probers.
-    let protected_router = protected_router
+    let protected_router = Router::new()
+        .route("/preconfBlocks", post(handle_preconf_blocks))
+        .route("/ws", get(handle_websocket_upgrade))
         .fallback(handle_not_found)
         .layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -20,7 +20,6 @@ use crate::{
             EndOfSequencingNotification, ExecutableData, WhitelistStatus,
         },
     },
-    error::WhitelistPreconfirmationDriverError,
 };
 use alloy_primitives::{Address, B256, Bytes as RpcBytes};
 use async_trait::async_trait;
@@ -106,11 +105,9 @@ fn sample_preconf_request() -> Vec<u8> {
     serde_json::to_vec(&request).expect("sample preconf request should serialize")
 }
 
-fn test_config(enable_http: bool, enable_ws: bool) -> WhitelistApiServerConfig {
+fn test_config() -> WhitelistApiServerConfig {
     WhitelistApiServerConfig {
         listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
-        enable_http,
-        enable_ws,
         jwt_secret: None,
         cors_origins: vec!["*".to_string()],
     }
@@ -118,18 +115,16 @@ fn test_config(enable_http: bool, enable_ws: bool) -> WhitelistApiServerConfig {
 
 /// Start a server configured with a JWT secret so probe-route auth-skip
 /// behavior and protected-route enforcement can be exercised.
-async fn start_jwt_server(enable_http: bool, enable_ws: bool) -> WhitelistApiServer {
-    let config = WhitelistApiServerConfig {
-        jwt_secret: Some(b"test-secret".to_vec()),
-        ..test_config(enable_http, enable_ws)
-    };
+async fn start_jwt_server() -> WhitelistApiServer {
+    let config =
+        WhitelistApiServerConfig { jwt_secret: Some(b"test-secret".to_vec()), ..test_config() };
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
     WhitelistApiServer::start(config, api).await.expect("server should start")
 }
 
 #[tokio::test]
 async fn server_start_stop() {
-    let config = test_config(true, true);
+    let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
 
     let server = WhitelistApiServer::start(config, api).await.expect("server should start");
@@ -140,23 +135,10 @@ async fn server_start_stop() {
     server.stop().await;
 }
 
-#[tokio::test]
-async fn server_start_fails_when_no_transports_enabled() {
-    let config = test_config(false, false);
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-
-    let err = WhitelistApiServer::start(config, api)
-        .await
-        .expect_err("server must fail when both transports are disabled");
-    assert!(matches!(err, WhitelistPreconfirmationDriverError::RestWsServerNoTransportsEnabled));
-}
-
 #[test]
 fn default_config() {
     let config = WhitelistApiServerConfig::default();
     assert_eq!(config.listen_addr.port(), 8552);
-    assert!(config.enable_http);
-    assert!(config.enable_ws);
     assert!(config.jwt_secret.is_none());
     assert_eq!(config.cors_origins, vec!["*".to_string()]);
 }
@@ -164,9 +146,8 @@ fn default_config() {
 #[tokio::test]
 async fn cors_layer_allows_configured_origin() {
     let config = WhitelistApiServerConfig {
-        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
         cors_origins: vec!["https://example.com".to_string()],
-        ..test_config(true, true)
+        ..test_config()
     };
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
 
@@ -194,9 +175,8 @@ async fn cors_layer_allows_configured_origin() {
 async fn preconf_blocks_is_rejected_when_not_sync_ready() {
     let build_preconf_calls = Arc::new(AtomicUsize::new(0));
     let config = WhitelistApiServerConfig {
-        listen_addr: "127.0.0.1:0".parse().expect("valid loopback address"),
         cors_origins: vec!["https://example.com".to_string()],
-        ..test_config(true, false)
+        ..test_config()
     };
     let api = SyncReadyApi { build_preconf_calls: build_preconf_calls.clone(), sync_ready: false };
     let server =
@@ -243,7 +223,7 @@ fn jwt_auth_rejects_missing_header() {
 
 #[tokio::test]
 async fn jwt_auth_is_required_when_secret_configured() {
-    let server = start_jwt_server(true, false).await;
+    let server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .post(format!("{}/preconfBlocks", server.http_url()))
@@ -259,7 +239,7 @@ async fn jwt_auth_is_required_when_secret_configured() {
 
 #[tokio::test]
 async fn websocket_route_rejects_non_upgrade_requests() {
-    let config = test_config(false, true);
+    let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
     let server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
@@ -274,40 +254,8 @@ async fn websocket_route_rejects_non_upgrade_requests() {
 }
 
 #[tokio::test]
-async fn ws_route_is_not_served_when_ws_transport_is_disabled() {
-    let config = test_config(true, false);
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
-
-    let response = reqwest::Client::new()
-        .get(format!("{}/ws", server.http_url()))
-        .send()
-        .await
-        .expect("request should succeed");
-    assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
-
-    server.stop().await;
-}
-
-#[tokio::test]
-async fn http_routes_are_not_served_when_http_transport_is_disabled() {
-    let config = test_config(false, true);
-    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
-
-    let response = reqwest::Client::new()
-        .get(format!("{}/status", server.http_url()))
-        .send()
-        .await
-        .expect("request should succeed");
-    assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
-
-    server.stop().await;
-}
-
-#[tokio::test]
 async fn preconf_blocks_enforces_body_limit() {
-    let config = test_config(true, false);
+    let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
     let server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
@@ -331,7 +279,7 @@ async fn preconf_blocks_enforces_body_limit() {
 
 #[tokio::test]
 async fn preconf_blocks_rejects_invalid_json() {
-    let config = test_config(true, false);
+    let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
     let server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
@@ -356,7 +304,7 @@ async fn preconf_blocks_rejects_invalid_json() {
 
 #[tokio::test]
 async fn get_status_returns_can_shutdown_field_in_camel_case() {
-    let config = test_config(true, false);
+    let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
     let server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
@@ -378,7 +326,7 @@ async fn get_status_returns_can_shutdown_field_in_camel_case() {
 
 #[tokio::test]
 async fn status_path_skips_jwt_when_secret_configured() {
-    let server = start_jwt_server(true, false).await;
+    let server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/status", server.http_url()))
@@ -396,7 +344,7 @@ async fn status_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn healthz_path_skips_jwt_when_secret_configured() {
-    let server = start_jwt_server(true, false).await;
+    let server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/healthz", server.http_url()))
@@ -410,7 +358,7 @@ async fn healthz_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn root_path_skips_jwt_when_secret_configured() {
-    let server = start_jwt_server(true, false).await;
+    let server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/", server.http_url()))
@@ -424,7 +372,7 @@ async fn root_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn preconf_blocks_still_requires_jwt_when_configured() {
-    let server = start_jwt_server(true, false).await;
+    let server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .post(format!("{}/preconfBlocks", server.http_url()))
@@ -444,7 +392,7 @@ async fn preconf_blocks_still_requires_jwt_when_configured() {
 
 #[tokio::test]
 async fn ws_still_requires_jwt_when_configured() {
-    let server = start_jwt_server(true, true).await;
+    let server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/ws", server.http_url()))
@@ -462,7 +410,7 @@ async fn ws_still_requires_jwt_when_configured() {
 
 #[tokio::test]
 async fn unknown_path_requires_jwt_when_secret_configured() {
-    let server = start_jwt_server(true, false).await;
+    let server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/this-route-does-not-exist", server.http_url()))
@@ -480,7 +428,7 @@ async fn unknown_path_requires_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn unknown_path_returns_not_found_when_no_jwt_secret() {
-    let config = test_config(true, false);
+    let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
     let server = WhitelistApiServer::start(config, api).await.expect("server should start");
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/error.rs
@@ -45,9 +45,6 @@ pub enum WhitelistPreconfirmationDriverError {
         /// Underlying local-address error description.
         reason: String,
     },
-    /// Invalid transport configuration for the whitelist REST/WS server.
-    #[error("whitelist REST/WS server requires at least one transport to be enabled")]
-    RestWsServerNoTransportsEnabled,
     /// Failed to initialize the beacon client used by the whitelist REST/WS handler.
     #[error("failed to initialize beacon client for whitelist REST/WS: {reason}")]
     RestWsServerBeaconInit {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -19,7 +19,7 @@ where
 {
     /// Attempt to import cached envelopes if sync is ready.
     pub(crate) async fn maybe_import_from_cache(&mut self) -> Result<()> {
-        let _ = self.refresh_sync_ready().await?;
+        self.refresh_sync_ready().await?;
         if !self.sync_ready || self.cache.is_empty() {
             return Ok(());
         }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -141,19 +141,14 @@ where
         } else if let Some(envelope) = self.build_response_envelope_from_l2(hash).await? {
             (Arc::new(envelope), "l2_hit")
         } else {
-            record_response_lookup("not_found");
+            WhitelistPreconfirmationDriverMetrics::inc_response_lookup("not_found");
             return Ok(());
         };
 
-        record_response_lookup(result_label);
+        WhitelistPreconfirmationDriverMetrics::inc_response_lookup(result_label);
         self.recent_cache.insert_recent(envelope.clone());
         self.update_cache_gauges();
         self.publish_unsafe_response(envelope).await;
         Ok(())
     }
-}
-
-/// Increment the response-lookup counter with the given result label.
-fn record_response_lookup(result: &'static str) {
-    WhitelistPreconfirmationDriverMetrics::inc_response_lookup(result);
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -131,17 +131,29 @@ where
             NetworkEvent::UnsafePayload { from, payload } => {
                 if let Err(err) = self.handle_unsafe_payload(payload).await {
                     warn!(peer = %from, error = %err, "dropping invalid whitelist preconfirmation payload");
-                    record_importer_event("unsafe_payload", "dropped");
+                    WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                        "unsafe_payload",
+                        "dropped",
+                    );
                 } else {
-                    record_importer_event("unsafe_payload", "accepted");
+                    WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                        "unsafe_payload",
+                        "accepted",
+                    );
                 }
             }
             NetworkEvent::UnsafeResponse { from, envelope } => {
                 if let Err(err) = self.handle_unsafe_response(envelope).await {
                     warn!(peer = %from, error = %err, "dropping invalid whitelist preconfirmation response");
-                    record_importer_event("unsafe_response", "dropped");
+                    WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                        "unsafe_response",
+                        "dropped",
+                    );
                 } else {
-                    record_importer_event("unsafe_response", "accepted");
+                    WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                        "unsafe_response",
+                        "accepted",
+                    );
                 }
             }
             NetworkEvent::UnsafeRequest { from, hash } => {
@@ -152,9 +164,15 @@ where
                         error = %err,
                         "failed to handle whitelist preconfirmation request"
                     );
-                    record_importer_event("unsafe_request", "error");
+                    WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                        "unsafe_request",
+                        "error",
+                    );
                 } else {
-                    record_importer_event("unsafe_request", "handled");
+                    WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                        "unsafe_request",
+                        "handled",
+                    );
                 }
             }
             NetworkEvent::EndOfSequencingRequest { from, epoch } => {
@@ -165,7 +183,10 @@ where
                         error = %err,
                         "failed to handle whitelist preconfirmation end-of-sequencing request"
                     );
-                    record_importer_event("end_of_sequencing_request", "error");
+                    WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                        "end_of_sequencing_request",
+                        "error",
+                    );
                 }
             }
         }
@@ -177,20 +198,29 @@ where
     /// cache, falling back to an L2 rebuild, or recording a miss.
     async fn handle_eos_request(&mut self, epoch: u64) -> Result<()> {
         let Some(hash) = self.cache_state.end_of_sequencing_for_epoch(epoch).await else {
-            record_importer_event("end_of_sequencing_request", "miss");
+            WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                "end_of_sequencing_request",
+                "miss",
+            );
             return Ok(());
         };
 
         // Fast path: envelope still lives in the recent cache.
         if let Some(envelope) = self.recent_cache.get_recent(&hash) {
             self.publish_unsafe_response(envelope).await;
-            record_importer_event("end_of_sequencing_request", "served");
+            WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                "end_of_sequencing_request",
+                "served",
+            );
             return Ok(());
         }
 
         // Slow path: rebuild from local L2 state.
         let Some(mut envelope) = self.build_response_envelope_from_l2(hash).await? else {
-            record_importer_event("end_of_sequencing_request", "miss");
+            WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+                "end_of_sequencing_request",
+                "miss",
+            );
             return Ok(());
         };
 
@@ -199,7 +229,10 @@ where
         self.recent_cache.insert_recent(envelope.clone());
         self.update_cache_gauges();
         self.publish_unsafe_response(envelope).await;
-        record_importer_event("end_of_sequencing_request", "served");
+        WhitelistPreconfirmationDriverMetrics::inc_importer_event(
+            "end_of_sequencing_request",
+            "served",
+        );
         Ok(())
     }
 
@@ -220,18 +253,16 @@ where
     /// when no real proposal exists yet (`nextProposalId == 1`). Core state is read lazily,
     /// only while the origin pointer is absent. During beacon-sync custom-table gaps
     /// (`nextProposalId > 1`, origin unwritten) this stays fail-closed (WLP-INV-002).
-    pub(super) async fn refresh_sync_ready(&mut self) -> Result<bool> {
+    pub(super) async fn refresh_sync_ready(&mut self) -> Result<()> {
         let head_written = self.head_l1_origin_block_id().await?.is_some();
         let next_proposal_id =
             if head_written { None } else { Some(self.next_proposal_id().await?) };
         let ready = should_enable_preconf_imports(head_written, next_proposal_id);
-        let became_ready = sync_ready_transition(self.sync_ready, ready);
-        if became_ready {
-            WhitelistPreconfirmationDriverMetrics::inc_sync_ready_transition();
+        if sync_ready_transition(self.sync_ready, ready) {
             info!("event sync ready; enabling whitelist preconfirmation imports");
         }
         self.sync_ready = ready;
-        Ok(became_ready)
+        Ok(())
     }
 
     /// Get the block ID of the head L1 origin.
@@ -267,11 +298,6 @@ where
         WhitelistPreconfirmationDriverMetrics::set_cache_pending_count(self.cache.len());
         WhitelistPreconfirmationDriverMetrics::set_cache_recent_count(self.recent_cache.len());
     }
-}
-
-/// Record one importer event outcome for the given event type and result.
-fn record_importer_event(event_type: &'static str, result: &'static str) {
-    WhitelistPreconfirmationDriverMetrics::inc_importer_event(event_type, result);
 }
 
 /// Returns true only when sync readiness transitions from disabled to enabled.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -241,7 +241,7 @@ fn validate_payload_rejects_oversized_compressed_transactions_list() {
     assert!(matches!(
         err,
         WhitelistPreconfirmationDriverError::InvalidPayload(msg)
-            if msg.contains("compressed transactions size exceeds")
+            if msg.contains("compressed txlist exceeds max size")
     ));
 }
 
@@ -374,7 +374,7 @@ fn validate_payload_rejects_invalid_zlib_transactions_bytes() {
     assert!(matches!(
         err,
         WhitelistPreconfirmationDriverError::InvalidPayload(msg)
-            if msg.contains("invalid zlib bytes for transactions")
+            if msg.contains("zlib decode failed")
     ));
 }
 
@@ -392,7 +392,7 @@ fn validate_payload_rejects_invalid_rlp_transactions_bytes() {
     assert!(matches!(
         err,
         WhitelistPreconfirmationDriverError::InvalidPayload(msg)
-            if msg.contains("invalid RLP bytes for transactions")
+            if msg.contains("rlp decode failed")
     ));
 }
 
@@ -412,7 +412,7 @@ fn validate_payload_rejects_oversized_decompressed_transactions_bytes() {
     assert!(matches!(
         err,
         WhitelistPreconfirmationDriverError::InvalidPayload(msg)
-            if msg.contains("decompressed transactions size exceeds")
+            if msg.contains("decompressed txlist exceeds max size")
     ));
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
@@ -8,10 +8,7 @@ use alloy_consensus::{
 };
 use alloy_eips::Decodable2718;
 use alloy_primitives::Address;
-use protocol::{
-    codec::{TxListCodecError, ZlibTxListCodec},
-    shasta::unzen_active_for_chain_timestamp,
-};
+use protocol::{codec::ZlibTxListCodec, shasta::unzen_active_for_chain_timestamp};
 use thiserror::Error;
 
 use crate::{
@@ -107,46 +104,16 @@ pub(crate) fn validate_execution_payload_for_preconf(
     }
 
     let compressed_tx_list = &payload.transactions[0];
-    if compressed_tx_list.len() > MAX_COMPRESSED_TX_LIST_BYTES {
-        return Err(WhitelistPreconfirmationDriverError::invalid_payload(
-            "compressed transactions size exceeds max blob data size".to_string(),
-        ));
-    }
-
     let txs = ZlibTxListCodec::new_with_limits(
         MAX_COMPRESSED_TX_LIST_BYTES,
         MAX_DECOMPRESSED_TX_LIST_BYTES,
     )
     .decode(compressed_tx_list)
-    .map_err(|err| match err {
-        TxListCodecError::ZlibDecode(reason) => {
-            WhitelistPreconfirmationDriverError::invalid_payload_with_context(
-                "invalid zlib bytes for transactions",
-                reason,
-            )
-        }
-        TxListCodecError::RlpDecode(reason) => {
-            WhitelistPreconfirmationDriverError::invalid_payload_with_context(
-                "invalid RLP bytes for transactions",
-                reason,
-            )
-        }
-        TxListCodecError::CompressedTooLarge { .. } => {
-            WhitelistPreconfirmationDriverError::invalid_payload(
-                "compressed transactions size exceeds max blob data size".to_string(),
-            )
-        }
-        TxListCodecError::DecompressedTooLarge { .. } => {
-            WhitelistPreconfirmationDriverError::invalid_payload(
-                "decompressed transactions size exceeds max tx list size".to_string(),
-            )
-        }
-        TxListCodecError::ZlibEncode(reason) | TxListCodecError::ZlibFinish(reason) => {
-            WhitelistPreconfirmationDriverError::invalid_payload_with_context(
-                "invalid transactions list bytes",
-                reason,
-            )
-        }
+    .map_err(|err| {
+        WhitelistPreconfirmationDriverError::invalid_payload_with_context(
+            "invalid transactions list bytes",
+            err,
+        )
     })?;
 
     if txs.is_empty() {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/metrics.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/metrics.rs
@@ -8,145 +8,132 @@ const DURATION_SECONDS_BUCKETS: &[f64] =
     &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0];
 
 /// Process-wide whitelist preconfirmation metrics registered with Prometheus.
-static METRICS: Lazy<WhitelistPreconfirmationMetricHandles> =
-    Lazy::new(WhitelistPreconfirmationMetricHandles::register);
+static METRICS: Lazy<Metrics> = Lazy::new(Metrics::register);
 
 /// Typed handles for whitelist preconfirmation metric families.
-struct WhitelistPreconfirmationMetricHandles {
-    /// Counters without labels.
-    counters: Vec<(&'static str, IntCounter)>,
-    /// Counters grouped by stable label dimensions.
-    counter_vecs: Vec<(&'static str, IntCounterVec)>,
-    /// Gauges without labels.
-    gauges: Vec<(&'static str, Gauge)>,
-    /// Histograms without labels.
-    histograms: Vec<(&'static str, Histogram)>,
+struct Metrics {
+    /// Inbound network messages by topic and decode result.
+    network_inbound_messages: IntCounterVec,
+    /// Outbound publish command outcomes by topic.
+    network_outbound_publish: IntCounterVec,
+    /// Dial attempts by source and result.
+    network_dial_attempts: IntCounterVec,
+    /// Failures forwarding network events to the importer.
+    network_forward_failures: IntCounter,
+    /// Importer event handling outcomes by event type and result.
+    importer_events: IntCounterVec,
+    /// Whitelist contract lookup failures.
+    whitelist_lookup_failures: IntCounter,
+    /// Unsafe request lookup outcomes.
+    response_lookups: IntCounterVec,
+    /// Cache import attempts.
+    cache_import_attempts: IntCounter,
+    /// Cache import results.
+    cache_import_results: IntCounterVec,
+    /// Driver submission outcomes.
+    driver_submit: IntCounterVec,
+    /// Duration for the driver submission path.
+    driver_submit_duration: Histogram,
+    /// Parent request outcomes.
+    parent_requests: IntCounterVec,
     /// RPC request counter grouped by method.
-    rpc_requests_total: IntCounterVec,
+    rpc_requests: IntCounterVec,
     /// RPC error counter grouped by method.
-    rpc_errors_total: IntCounterVec,
+    rpc_errors: IntCounterVec,
     /// RPC duration histogram grouped by method.
-    rpc_duration_seconds: HistogramVec,
+    rpc_duration: HistogramVec,
+    /// Duration for `build_preconf_block` RPC calls.
+    build_preconf_block_duration: Histogram,
+    /// Pending cache size.
+    cache_pending: Gauge,
+    /// Recent cache size.
+    cache_recent: Gauge,
 }
 
-impl WhitelistPreconfirmationMetricHandles {
+impl Metrics {
     /// Register every whitelist preconfirmation collector with the default registry.
     fn register() -> Self {
         Self {
-            counters: vec![
-                counter(
-                    WhitelistPreconfirmationDriverMetrics::RUNNER_START_TOTAL,
-                    "Runner start count",
-                ),
-                counter(
-                    WhitelistPreconfirmationDriverMetrics::SYNC_READY_TRANSITIONS_TOTAL,
-                    "Number of sync-ready state transitions",
-                ),
-                counter(
-                    WhitelistPreconfirmationDriverMetrics::NETWORK_FORWARD_FAILURES_TOTAL,
-                    "Failures forwarding network events to importer",
-                ),
-                counter(
-                    WhitelistPreconfirmationDriverMetrics::WHITELIST_LOOKUP_FAILURES_TOTAL,
-                    "Whitelist contract lookup failures",
-                ),
-                counter(
-                    WhitelistPreconfirmationDriverMetrics::CACHE_IMPORT_ATTEMPTS_TOTAL,
-                    "Cache import attempts",
-                ),
-            ],
-            counter_vecs: vec![
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::RUNNER_EXIT_TOTAL,
-                    "Runner exits grouped by reason",
-                    &["reason"],
-                ),
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::NETWORK_INBOUND_MESSAGES_TOTAL,
-                    "Inbound network messages by topic and decode result",
-                    &["topic", "result"],
-                ),
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::NETWORK_OUTBOUND_PUBLISH_TOTAL,
-                    "Outbound publish command outcomes by topic",
-                    &["topic", "result"],
-                ),
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::NETWORK_DIAL_ATTEMPTS_TOTAL,
-                    "Dial attempts by source and result",
-                    &["source", "result"],
-                ),
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
-                    "Importer event handling outcomes",
-                    &["event_type", "result"],
-                ),
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::RESPONSE_LOOKUPS_TOTAL,
-                    "Unsafe request lookup outcomes",
-                    &["result"],
-                ),
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::CACHE_IMPORT_RESULTS_TOTAL,
-                    "Cache import results",
-                    &["result"],
-                ),
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::DRIVER_SUBMIT_TOTAL,
-                    "Driver submission outcomes",
-                    &["result"],
-                ),
-                counter_vec(
-                    WhitelistPreconfirmationDriverMetrics::PARENT_REQUESTS_TOTAL,
-                    "Parent request outcomes",
-                    &["result"],
-                ),
-            ],
-            gauges: vec![
-                gauge(
-                    WhitelistPreconfirmationDriverMetrics::CACHE_PENDING_COUNT,
-                    "Pending cache size",
-                ),
-                gauge(
-                    WhitelistPreconfirmationDriverMetrics::CACHE_RECENT_COUNT,
-                    "Recent cache size",
-                ),
-            ],
-            histograms: vec![
-                histogram(
-                    WhitelistPreconfirmationDriverMetrics::EVENT_SYNC_WAIT_DURATION_SECONDS,
-                    "Time spent waiting for preconfirmation ingress readiness",
-                    DURATION_SECONDS_BUCKETS,
-                ),
-                histogram(
-                    WhitelistPreconfirmationDriverMetrics::DRIVER_SUBMIT_DURATION_SECONDS,
-                    "Duration for driver submission path",
-                    DURATION_SECONDS_BUCKETS,
-                ),
-                histogram(
-                    WhitelistPreconfirmationDriverMetrics::BUILD_PRECONF_BLOCK_DURATION_SECONDS,
-                    "Duration for build_preconf_block RPC calls",
-                    DURATION_SECONDS_BUCKETS,
-                ),
-            ],
-            rpc_requests_total: counter_vec(
-                WhitelistPreconfirmationDriverMetrics::RPC_REQUESTS_TOTAL,
+            network_inbound_messages: counter_vec(
+                "whitelist_preconf_driver_network_inbound_messages_total",
+                "Inbound network messages by topic and decode result",
+                &["topic", "result"],
+            ),
+            network_outbound_publish: counter_vec(
+                "whitelist_preconf_driver_network_outbound_publish_total",
+                "Outbound publish command outcomes by topic",
+                &["topic", "result"],
+            ),
+            network_dial_attempts: counter_vec(
+                "whitelist_preconf_driver_network_dial_attempts_total",
+                "Dial attempts by source and result",
+                &["source", "result"],
+            ),
+            network_forward_failures: counter(
+                "whitelist_preconf_driver_network_forward_failures_total",
+                "Failures forwarding network events to importer",
+            ),
+            importer_events: counter_vec(
+                "whitelist_preconf_driver_importer_events_total",
+                "Importer event handling outcomes",
+                &["event_type", "result"],
+            ),
+            whitelist_lookup_failures: counter(
+                "whitelist_preconf_driver_whitelist_lookup_failures_total",
+                "Whitelist contract lookup failures",
+            ),
+            response_lookups: counter_vec(
+                "whitelist_preconf_driver_response_lookups_total",
+                "Unsafe request lookup outcomes",
+                &["result"],
+            ),
+            cache_import_attempts: counter(
+                "whitelist_preconf_driver_cache_import_attempts_total",
+                "Cache import attempts",
+            ),
+            cache_import_results: counter_vec(
+                "whitelist_preconf_driver_cache_import_results_total",
+                "Cache import results",
+                &["result"],
+            ),
+            driver_submit: counter_vec(
+                "whitelist_preconf_driver_driver_submit_total",
+                "Driver submission outcomes",
+                &["result"],
+            ),
+            driver_submit_duration: histogram(
+                "whitelist_preconf_driver_driver_submit_duration_seconds",
+                "Duration for driver submission path",
+            ),
+            parent_requests: counter_vec(
+                "whitelist_preconf_driver_parent_requests_total",
+                "Parent request outcomes",
+                &["result"],
+            ),
+            rpc_requests: counter_vec(
+                "whitelist_preconf_driver_rpc_requests_total",
                 "Total whitelist RPC requests by method",
                 &["method"],
-            )
-            .1,
-            rpc_errors_total: counter_vec(
-                WhitelistPreconfirmationDriverMetrics::RPC_ERRORS_TOTAL,
+            ),
+            rpc_errors: counter_vec(
+                "whitelist_preconf_driver_rpc_errors_total",
                 "Total whitelist RPC errors by method",
                 &["method"],
-            )
-            .1,
-            rpc_duration_seconds: histogram_vec(
-                WhitelistPreconfirmationDriverMetrics::RPC_DURATION_SECONDS,
+            ),
+            rpc_duration: histogram_vec(
+                "whitelist_preconf_driver_rpc_duration_seconds",
                 "Whitelist RPC request duration by method",
                 &["method"],
-                DURATION_SECONDS_BUCKETS,
             ),
+            build_preconf_block_duration: histogram(
+                "whitelist_preconf_driver_build_preconf_block_duration_seconds",
+                "Duration for build_preconf_block RPC calls",
+            ),
+            cache_pending: gauge(
+                "whitelist_preconf_driver_cache_pending_count",
+                "Pending cache size",
+            ),
+            cache_recent: gauge("whitelist_preconf_driver_cache_recent_count", "Recent cache size"),
         }
     }
 }
@@ -155,302 +142,142 @@ impl WhitelistPreconfirmationMetricHandles {
 pub struct WhitelistPreconfirmationDriverMetrics;
 
 impl WhitelistPreconfirmationDriverMetrics {
-    // Runner lifecycle metrics
-    /// Counter tracking runner starts.
-    pub const RUNNER_START_TOTAL: &'static str = "whitelist_preconf_driver_runner_start_total";
-    /// Counter tracking runner exits by reason.
-    pub const RUNNER_EXIT_TOTAL: &'static str = "whitelist_preconf_driver_runner_exit_total";
-    /// Histogram tracking how long we wait for event-sync ingress readiness.
-    pub const EVENT_SYNC_WAIT_DURATION_SECONDS: &'static str =
-        "whitelist_preconf_driver_event_sync_wait_duration_seconds";
-    /// Counter tracking sync-ready transitions.
-    pub const SYNC_READY_TRANSITIONS_TOTAL: &'static str =
-        "whitelist_preconf_driver_sync_ready_transitions_total";
-    // Network metrics
-    /// Counter tracking inbound gossip/request messages by topic and decode status.
-    pub const NETWORK_INBOUND_MESSAGES_TOTAL: &'static str =
-        "whitelist_preconf_driver_network_inbound_messages_total";
-    /// Counter tracking outbound publish commands by topic and result.
-    pub const NETWORK_OUTBOUND_PUBLISH_TOTAL: &'static str =
-        "whitelist_preconf_driver_network_outbound_publish_total";
-    /// Counter tracking dial attempts by source and result.
-    pub const NETWORK_DIAL_ATTEMPTS_TOTAL: &'static str =
-        "whitelist_preconf_driver_network_dial_attempts_total";
-    /// Counter tracking event-forward failures into importer queue.
-    pub const NETWORK_FORWARD_FAILURES_TOTAL: &'static str =
-        "whitelist_preconf_driver_network_forward_failures_total";
-
-    // Importer metrics
-    /// Counter tracking importer event handling by event type and result.
-    pub const IMPORTER_EVENTS_TOTAL: &'static str =
-        "whitelist_preconf_driver_importer_events_total";
-    /// Counter tracking whitelist contract lookup failures.
-    pub const WHITELIST_LOOKUP_FAILURES_TOTAL: &'static str =
-        "whitelist_preconf_driver_whitelist_lookup_failures_total";
-    /// Counter tracking request-response lookup outcomes.
-    pub const RESPONSE_LOOKUPS_TOTAL: &'static str =
-        "whitelist_preconf_driver_response_lookups_total";
-    /// Counter tracking cache import attempts.
-    pub const CACHE_IMPORT_ATTEMPTS_TOTAL: &'static str =
-        "whitelist_preconf_driver_cache_import_attempts_total";
-    /// Counter tracking cache import outcomes.
-    pub const CACHE_IMPORT_RESULTS_TOTAL: &'static str =
-        "whitelist_preconf_driver_cache_import_results_total";
-    /// Counter tracking driver submit outcomes.
-    pub const DRIVER_SUBMIT_TOTAL: &'static str = "whitelist_preconf_driver_driver_submit_total";
-    /// Histogram tracking duration of driver submission path.
-    pub const DRIVER_SUBMIT_DURATION_SECONDS: &'static str =
-        "whitelist_preconf_driver_driver_submit_duration_seconds";
-    /// Counter tracking parent request outcomes (issued/throttled).
-    pub const PARENT_REQUESTS_TOTAL: &'static str =
-        "whitelist_preconf_driver_parent_requests_total";
-
-    // RPC metrics
-    /// Counter tracking total RPC requests by method.
-    pub const RPC_REQUESTS_TOTAL: &'static str = "whitelist_preconf_driver_rpc_requests_total";
-    /// Counter tracking total RPC errors by method.
-    pub const RPC_ERRORS_TOTAL: &'static str = "whitelist_preconf_driver_rpc_errors_total";
-    /// Histogram tracking RPC request duration by method.
-    pub const RPC_DURATION_SECONDS: &'static str = "whitelist_preconf_driver_rpc_duration_seconds";
-    /// Histogram tracking build_preconf_block request duration.
-    pub const BUILD_PRECONF_BLOCK_DURATION_SECONDS: &'static str =
-        "whitelist_preconf_driver_build_preconf_block_duration_seconds";
-
-    // Cache gauges
-    /// Gauge tracking pending cache size.
-    pub const CACHE_PENDING_COUNT: &'static str = "whitelist_preconf_driver_cache_pending_count";
-    /// Gauge tracking recent cache size.
-    pub const CACHE_RECENT_COUNT: &'static str = "whitelist_preconf_driver_cache_recent_count";
-
     /// Register metric collectors with the process-wide Prometheus registry.
     pub fn init() {
         Lazy::force(&METRICS);
     }
 
-    /// Return a scalar counter by its exported metric name.
-    pub(crate) fn counter(name: &'static str) -> IntCounter {
-        find(&METRICS.counters, name)
-    }
-
-    /// Return a labelled counter family by its exported metric name.
-    pub(crate) fn counter_vec(name: &'static str) -> IntCounterVec {
-        find(&METRICS.counter_vecs, name)
-    }
-
-    /// Return a scalar gauge by its exported metric name.
-    pub(crate) fn gauge(name: &'static str) -> Gauge {
-        find(&METRICS.gauges, name)
-    }
-
-    /// Return a scalar histogram by its exported metric name.
-    pub(crate) fn histogram(name: &'static str) -> Histogram {
-        find(&METRICS.histograms, name)
-    }
-
     /// Record one REST RPC request outcome.
     pub(crate) fn record_rpc(method: &str, failed: bool, duration_secs: f64) {
-        METRICS.rpc_duration_seconds.with_label_values(&[method]).observe(duration_secs);
-        METRICS.rpc_requests_total.with_label_values(&[method]).inc();
+        METRICS.rpc_duration.with_label_values(&[method]).observe(duration_secs);
+        METRICS.rpc_requests.with_label_values(&[method]).inc();
         if failed {
-            METRICS.rpc_errors_total.with_label_values(&[method]).inc();
+            METRICS.rpc_errors.with_label_values(&[method]).inc();
         }
-    }
-
-    /// Increment the runner start counter.
-    pub(crate) fn inc_runner_start() {
-        Self::counter(Self::RUNNER_START_TOTAL).inc();
-    }
-
-    /// Increment a runner exit counter for the given reason.
-    pub(crate) fn inc_runner_exit(reason: &str) {
-        Self::counter_vec(Self::RUNNER_EXIT_TOTAL).with_label_values(&[reason]).inc();
-    }
-
-    /// Observe time spent waiting for event-sync readiness.
-    pub(crate) fn observe_event_sync_wait_duration(duration_secs: f64) {
-        Self::histogram(Self::EVENT_SYNC_WAIT_DURATION_SECONDS).observe(duration_secs);
-    }
-
-    /// Increment the sync-ready transition counter.
-    pub(crate) fn inc_sync_ready_transition() {
-        Self::counter(Self::SYNC_READY_TRANSITIONS_TOTAL).inc();
     }
 
     /// Increment an inbound network message counter.
     pub(crate) fn inc_network_inbound_message(topic: &str, result: &str) {
-        Self::counter_vec(Self::NETWORK_INBOUND_MESSAGES_TOTAL)
-            .with_label_values(&[topic, result])
-            .inc();
+        METRICS.network_inbound_messages.with_label_values(&[topic, result]).inc();
     }
 
     /// Increment an outbound network publish counter.
     pub(crate) fn inc_network_outbound_publish(topic: &str, result: &str) {
-        Self::counter_vec(Self::NETWORK_OUTBOUND_PUBLISH_TOTAL)
-            .with_label_values(&[topic, result])
-            .inc();
+        METRICS.network_outbound_publish.with_label_values(&[topic, result]).inc();
     }
 
     /// Increment a network dial attempt counter.
     pub(crate) fn inc_network_dial_attempt(source: &str, result: &str) {
-        Self::counter_vec(Self::NETWORK_DIAL_ATTEMPTS_TOTAL)
-            .with_label_values(&[source, result])
-            .inc();
+        METRICS.network_dial_attempts.with_label_values(&[source, result]).inc();
     }
 
     /// Increment the network forward failure counter.
     pub(crate) fn inc_network_forward_failure() {
-        Self::counter(Self::NETWORK_FORWARD_FAILURES_TOTAL).inc();
+        METRICS.network_forward_failures.inc();
     }
 
     /// Increment an importer event counter.
     pub(crate) fn inc_importer_event(event_type: &str, result: &str) {
-        Self::counter_vec(Self::IMPORTER_EVENTS_TOTAL)
-            .with_label_values(&[event_type, result])
-            .inc();
+        METRICS.importer_events.with_label_values(&[event_type, result]).inc();
     }
 
     /// Increment the whitelist lookup failure counter.
     pub(crate) fn inc_whitelist_lookup_failure() {
-        Self::counter(Self::WHITELIST_LOOKUP_FAILURES_TOTAL).inc();
+        METRICS.whitelist_lookup_failures.inc();
     }
 
     /// Increment a response lookup counter.
     pub(crate) fn inc_response_lookup(result: &str) {
-        Self::counter_vec(Self::RESPONSE_LOOKUPS_TOTAL).with_label_values(&[result]).inc();
+        METRICS.response_lookups.with_label_values(&[result]).inc();
     }
 
     /// Increment the cache import attempt counter.
     pub(crate) fn inc_cache_import_attempt() {
-        Self::counter(Self::CACHE_IMPORT_ATTEMPTS_TOTAL).inc();
+        METRICS.cache_import_attempts.inc();
     }
 
     /// Increment a cache import result counter.
     pub(crate) fn inc_cache_import_result(result: &str) {
-        Self::counter_vec(Self::CACHE_IMPORT_RESULTS_TOTAL).with_label_values(&[result]).inc();
+        METRICS.cache_import_results.with_label_values(&[result]).inc();
     }
 
     /// Increment a driver submission result counter.
     pub(crate) fn inc_driver_submit(result: &str) {
-        Self::counter_vec(Self::DRIVER_SUBMIT_TOTAL).with_label_values(&[result]).inc();
+        METRICS.driver_submit.with_label_values(&[result]).inc();
     }
 
     /// Observe driver submission duration.
     pub(crate) fn observe_driver_submit_duration(duration_secs: f64) {
-        Self::histogram(Self::DRIVER_SUBMIT_DURATION_SECONDS).observe(duration_secs);
+        METRICS.driver_submit_duration.observe(duration_secs);
     }
 
     /// Increment a parent request counter.
     pub(crate) fn inc_parent_request(result: &str) {
-        Self::counter_vec(Self::PARENT_REQUESTS_TOTAL).with_label_values(&[result]).inc();
+        METRICS.parent_requests.with_label_values(&[result]).inc();
     }
 
     /// Observe build_preconf_block duration.
     pub(crate) fn observe_build_preconf_block_duration(duration_secs: f64) {
-        Self::histogram(Self::BUILD_PRECONF_BLOCK_DURATION_SECONDS).observe(duration_secs);
+        METRICS.build_preconf_block_duration.observe(duration_secs);
     }
 
     /// Set the pending cache gauge.
     pub(crate) fn set_cache_pending_count(count: usize) {
-        Self::gauge(Self::CACHE_PENDING_COUNT).set(count as f64);
+        METRICS.cache_pending.set(count as f64);
     }
 
     /// Set the recent cache gauge.
     pub(crate) fn set_cache_recent_count(count: usize) {
-        Self::gauge(Self::CACHE_RECENT_COUNT).set(count as f64);
+        METRICS.cache_recent.set(count as f64);
     }
 }
 
-/// Register a scalar counter and return it with its exported name.
-fn counter(name: &'static str, help: &'static str) -> (&'static str, IntCounter) {
+/// Register a scalar counter with the default registry.
+fn counter(name: &str, help: &str) -> IntCounter {
     let metric = IntCounter::new(name, help).expect("valid counter definition");
     prometheus::register(Box::new(metric.clone())).expect("counter registration must succeed");
-    (name, metric)
+    metric
 }
 
-/// Register a labelled counter family and return it with its exported name.
-fn counter_vec(
-    name: &'static str,
-    help: &'static str,
-    labels: &'static [&'static str],
-) -> (&'static str, IntCounterVec) {
+/// Register a labelled counter family with the default registry.
+fn counter_vec(name: &str, help: &str, labels: &[&str]) -> IntCounterVec {
     let metric =
         IntCounterVec::new(Opts::new(name, help), labels).expect("valid counter definition");
     prometheus::register(Box::new(metric.clone())).expect("counter registration must succeed");
-    (name, metric)
+    metric
 }
 
-/// Register a scalar gauge and return it with its exported name.
-fn gauge(name: &'static str, help: &'static str) -> (&'static str, Gauge) {
+/// Register a scalar gauge with the default registry.
+fn gauge(name: &str, help: &str) -> Gauge {
     let metric = Gauge::new(name, help).expect("valid gauge definition");
     prometheus::register(Box::new(metric.clone())).expect("gauge registration must succeed");
-    (name, metric)
+    metric
 }
 
-/// Register a scalar histogram and return it with its exported name.
-fn histogram(name: &'static str, help: &'static str, buckets: &[f64]) -> (&'static str, Histogram) {
-    let metric = Histogram::with_opts(HistogramOpts::new(name, help).buckets(buckets.to_vec()))
-        .expect("valid histogram definition");
-    prometheus::register(Box::new(metric.clone())).expect("histogram registration must succeed");
-    (name, metric)
-}
-
-/// Register a labelled histogram family and return it.
-fn histogram_vec(
-    name: &'static str,
-    help: &'static str,
-    labels: &'static [&'static str],
-    buckets: &[f64],
-) -> HistogramVec {
-    let metric =
-        HistogramVec::new(HistogramOpts::new(name, help).buckets(buckets.to_vec()), labels)
-            .expect("valid histogram definition");
+/// Register a scalar duration histogram with the default registry.
+fn histogram(name: &str, help: &str) -> Histogram {
+    let metric = Histogram::with_opts(
+        HistogramOpts::new(name, help).buckets(DURATION_SECONDS_BUCKETS.to_vec()),
+    )
+    .expect("valid histogram definition");
     prometheus::register(Box::new(metric.clone())).expect("histogram registration must succeed");
     metric
 }
 
-/// Clone a registered collector by its exported metric name.
-fn find<T: Clone>(metrics: &[(&'static str, T)], name: &'static str) -> T {
-    metrics
-        .iter()
-        .find(|(metric_name, _)| *metric_name == name)
-        .expect("registered metric")
-        .1
-        .clone()
+/// Register a labelled duration histogram family with the default registry.
+fn histogram_vec(name: &str, help: &str, labels: &[&str]) -> HistogramVec {
+    let metric = HistogramVec::new(
+        HistogramOpts::new(name, help).buckets(DURATION_SECONDS_BUCKETS.to_vec()),
+        labels,
+    )
+    .expect("valid histogram definition");
+    prometheus::register(Box::new(metric.clone())).expect("histogram registration must succeed");
+    metric
 }
 
 #[cfg(test)]
 mod tests {
     use super::WhitelistPreconfirmationDriverMetrics;
-
-    #[test]
-    fn metric_constants_have_expected_prefix() {
-        let names = [
-            WhitelistPreconfirmationDriverMetrics::RUNNER_START_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::RUNNER_EXIT_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::EVENT_SYNC_WAIT_DURATION_SECONDS,
-            WhitelistPreconfirmationDriverMetrics::SYNC_READY_TRANSITIONS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::NETWORK_INBOUND_MESSAGES_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::NETWORK_OUTBOUND_PUBLISH_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::NETWORK_DIAL_ATTEMPTS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::NETWORK_FORWARD_FAILURES_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::IMPORTER_EVENTS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::WHITELIST_LOOKUP_FAILURES_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::RESPONSE_LOOKUPS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::CACHE_IMPORT_ATTEMPTS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::CACHE_IMPORT_RESULTS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::DRIVER_SUBMIT_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::DRIVER_SUBMIT_DURATION_SECONDS,
-            WhitelistPreconfirmationDriverMetrics::PARENT_REQUESTS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::RPC_REQUESTS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::RPC_ERRORS_TOTAL,
-            WhitelistPreconfirmationDriverMetrics::RPC_DURATION_SECONDS,
-            WhitelistPreconfirmationDriverMetrics::BUILD_PRECONF_BLOCK_DURATION_SECONDS,
-            WhitelistPreconfirmationDriverMetrics::CACHE_PENDING_COUNT,
-            WhitelistPreconfirmationDriverMetrics::CACHE_RECENT_COUNT,
-        ];
-
-        assert!(names.into_iter().all(|name| name.starts_with("whitelist_preconf_driver_")));
-    }
 
     #[test]
     fn init_does_not_panic() {
@@ -465,10 +292,9 @@ mod tests {
         let family = families
             .iter()
             .find(|family| {
-                family.get_name() ==
-                    WhitelistPreconfirmationDriverMetrics::EVENT_SYNC_WAIT_DURATION_SECONDS
+                family.get_name() == "whitelist_preconf_driver_driver_submit_duration_seconds"
             })
-            .expect("event-sync wait duration histogram should be exported");
+            .expect("driver submit duration histogram should be exported");
         let metric = family.get_metric().first().expect("duration histogram should have a metric");
 
         assert!(
@@ -490,9 +316,7 @@ mod tests {
         let families = prometheus::gather();
         let requests = families
             .iter()
-            .find(|family| {
-                family.get_name() == WhitelistPreconfirmationDriverMetrics::RPC_REQUESTS_TOTAL
-            })
+            .find(|family| family.get_name() == "whitelist_preconf_driver_rpc_requests_total")
             .expect("RPC request counter should be exported");
         let request_metric = requests
             .get_metric()

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -383,7 +383,10 @@ fn dial_configured_peer(
     reason: &'static str,
 ) {
     if connected_configured_addrs.contains(&peer.addr) {
-        record_dial_attempt(peer.source, "skipped_connected_addr");
+        WhitelistPreconfirmationDriverMetrics::inc_network_dial_attempt(
+            peer.source,
+            "skipped_connected_addr",
+        );
         debug!(addr = %peer.addr, source = peer.source, reason, "configured peer address already connected");
         return;
     }
@@ -391,7 +394,10 @@ fn dial_configured_peer(
     if let Some(peer_id) = peer_id_from_addr(&peer.addr) &&
         swarm.is_connected(&peer_id)
     {
-        record_dial_attempt(peer.source, "skipped_connected");
+        WhitelistPreconfirmationDriverMetrics::inc_network_dial_attempt(
+            peer.source,
+            "skipped_connected",
+        );
         debug!(addr = %peer.addr, source = peer.source, %peer_id, reason, "configured peer already connected");
         return;
     }
@@ -421,20 +427,15 @@ fn dial_addr(
     reason: &'static str,
 ) {
     if let Err(err) = swarm.dial(addr.clone()) {
-        record_dial_attempt(source, "failed");
+        WhitelistPreconfirmationDriverMetrics::inc_network_dial_attempt(source, "failed");
         if matches!(err, DialError::DialPeerConditionFalse(_)) {
             debug!(%addr, source, reason, error = %err, "configured peer dial skipped by swarm");
         } else {
             warn!(%addr, source, reason, error = %err, "failed to dial address");
         }
     } else {
-        record_dial_attempt(source, "ok");
+        WhitelistPreconfirmationDriverMetrics::inc_network_dial_attempt(source, "ok");
     }
-}
-
-/// Record one configured or discovered dial attempt.
-fn record_dial_attempt(source: &str, result: &'static str) {
-    WhitelistPreconfirmationDriverMetrics::inc_network_dial_attempt(source, result);
 }
 
 /// Dial configured static peers and bootnode multiaddrs, returning them for retries.
@@ -648,7 +649,10 @@ impl NetworkRuntime {
                 self.publish_to_gossipsub(topic, payload, topic_label, context);
             }
             Err(err) => {
-                record_publish(topic_label, "encode_failed");
+                WhitelistPreconfirmationDriverMetrics::inc_network_outbound_publish(
+                    topic_label,
+                    "encode_failed",
+                );
                 warn!(
                     context,
                     error = %err,
@@ -667,14 +671,20 @@ impl NetworkRuntime {
         context: &str,
     ) {
         if let Err(err) = self.swarm.behaviour_mut().gossipsub.publish(topic, payload) {
-            record_publish(topic_label, "publish_failed");
+            WhitelistPreconfirmationDriverMetrics::inc_network_outbound_publish(
+                topic_label,
+                "publish_failed",
+            );
             warn!(
                 context,
                 error = %err,
                 "failed to publish whitelist preconfirmation message"
             );
         } else {
-            record_publish(topic_label, "published");
+            WhitelistPreconfirmationDriverMetrics::inc_network_outbound_publish(
+                topic_label,
+                "published",
+            );
         }
     }
 
@@ -788,7 +798,7 @@ impl NetworkRuntime {
         let from = propagation_source;
         let now = Instant::now();
 
-        if is_local_gossip_source(self.peer_id_for_events, from) {
+        if from == self.peer_id_for_events {
             debug!(peer = %from, topic = %topic, "ignoring self-propagated whitelist preconfirmation gossip");
             let _ = self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
                 &message_id,
@@ -838,7 +848,10 @@ impl NetworkRuntime {
                 Err(_) => (gossipsub::MessageAcceptance::Reject, "decode_failed"),
             };
 
-            record_inbound("preconf_blocks", inbound_label);
+            WhitelistPreconfirmationDriverMetrics::inc_network_inbound_message(
+                "preconf_blocks",
+                inbound_label,
+            );
             report(acceptance);
             return Ok(());
         }
@@ -866,7 +879,10 @@ impl NetworkRuntime {
                 Err(_) => (gossipsub::MessageAcceptance::Reject, "decode_failed"),
             };
 
-            record_inbound("response_preconf_blocks", inbound_label);
+            WhitelistPreconfirmationDriverMetrics::inc_network_inbound_message(
+                "response_preconf_blocks",
+                inbound_label,
+            );
             report(acceptance);
             return Ok(());
         }
@@ -875,7 +891,10 @@ impl NetworkRuntime {
             let Some(hash) = decode_request_hash_exact(&message.data) else {
                 let (acceptance, inbound_label) =
                     (gossipsub::MessageAcceptance::Reject, "decode_failed");
-                record_inbound("request_preconf_blocks", inbound_label);
+                WhitelistPreconfirmationDriverMetrics::inc_network_inbound_message(
+                    "request_preconf_blocks",
+                    inbound_label,
+                );
                 report(acceptance);
                 return Ok(());
             };
@@ -891,7 +910,10 @@ impl NetworkRuntime {
                 forward_event(&self.event_tx, NetworkEvent::UnsafeRequest { from, hash }).await?;
             }
 
-            record_inbound("request_preconf_blocks", acceptance_label(&acceptance));
+            WhitelistPreconfirmationDriverMetrics::inc_network_inbound_message(
+                "request_preconf_blocks",
+                acceptance_label(&acceptance),
+            );
             report(acceptance);
             return Ok(());
         }
@@ -900,7 +922,10 @@ impl NetworkRuntime {
             let Some(epoch) = decode_eos_epoch_exact(&message.data) else {
                 let (acceptance, inbound_label) =
                     (gossipsub::MessageAcceptance::Reject, "decode_failed");
-                record_inbound("request_eos_preconf_blocks", inbound_label);
+                WhitelistPreconfirmationDriverMetrics::inc_network_inbound_message(
+                    "request_eos_preconf_blocks",
+                    inbound_label,
+                );
                 report(acceptance);
                 return Ok(());
             };
@@ -917,7 +942,10 @@ impl NetworkRuntime {
                     .await?;
             }
 
-            record_inbound("request_eos_preconf_blocks", acceptance_label(&acceptance));
+            WhitelistPreconfirmationDriverMetrics::inc_network_inbound_message(
+                "request_eos_preconf_blocks",
+                acceptance_label(&acceptance),
+            );
             report(acceptance);
         }
 
@@ -928,11 +956,6 @@ impl NetworkRuntime {
 /// Format peer ids into a compact comma-separated log value.
 fn format_peer_ids(peers: &[PeerId]) -> String {
     peers.iter().map(ToString::to_string).collect::<Vec<_>>().join(",")
-}
-
-/// Return whether an inbound gossip event was propagated by the local libp2p peer.
-fn is_local_gossip_source(peer_id: PeerId, from: PeerId) -> bool {
-    peer_id == from
 }
 
 #[cfg(test)]
@@ -1112,14 +1135,6 @@ mod tests {
 
         assert_eq!(advertised_enode_url(&local_key, true, listen_addr, None, None), None);
     }
-    #[test]
-    fn local_gossip_source_is_identified() {
-        let local_peer = PeerId::random();
-        let remote_peer = PeerId::random();
-
-        assert!(is_local_gossip_source(local_peer, local_peer));
-        assert!(!is_local_gossip_source(local_peer, remote_peer));
-    }
 }
 
 /// Convert a gossipsub message acceptance decision into a metrics label.
@@ -1129,16 +1144,6 @@ fn acceptance_label(acceptance: &gossipsub::MessageAcceptance) -> &'static str {
         gossipsub::MessageAcceptance::Ignore => "ignored",
         gossipsub::MessageAcceptance::Reject => "rejected",
     }
-}
-
-/// Record one outbound publish lifecycle outcome for the given network topic label.
-fn record_publish(topic: &'static str, result: &'static str) {
-    WhitelistPreconfirmationDriverMetrics::inc_network_outbound_publish(topic, result);
-}
-
-/// Record one inbound message result for the given network topic label.
-fn record_inbound(topic: &'static str, result: &'static str) {
-    WhitelistPreconfirmationDriverMetrics::inc_network_inbound_message(topic, result);
 }
 
 /// Emit an entry log for an inbound `preconfBlocks` gossip payload.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/preconf_ingress_sync.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/preconf_ingress_sync.rs
@@ -80,12 +80,12 @@ where
 {
     tokio::select! {
         ready = ready => ready.map_err(map_driver_error::<WhitelistPreconfirmationDriverError>),
-        result = event_syncer_handle => map_event_syncer_exit_for_ingress(result),
+        result = event_syncer_handle => map_event_syncer_exit(result),
     }
 }
 
-/// Convert event syncer task termination into ingress-readiness errors.
-fn map_event_syncer_exit_for_ingress(result: EventSyncJoinResult) -> WhitelistResult<()> {
+/// Convert event syncer task termination into driver errors.
+pub(crate) fn map_event_syncer_exit(result: EventSyncJoinResult) -> WhitelistResult<()> {
     match result {
         Ok(Ok(())) => Err(WhitelistPreconfirmationDriverError::EventSyncerExited),
         Ok(Err(err)) => Err(map_driver_error(err)),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -1,11 +1,11 @@
 //! Whitelist preconfirmation runner orchestration.
 
-use std::{net::SocketAddr, sync::Arc, time::Instant};
+use std::{net::SocketAddr, sync::Arc};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::Address;
 use alloy_provider::Provider;
-use driver::{DriverConfig, map_driver_error};
+use driver::DriverConfig;
 use protocol::signer::FixedKSigner;
 use rpc::beacon::BeaconClient;
 use tokio::sync::Mutex;
@@ -20,10 +20,9 @@ use crate::{
     cache::{L1_EPOCH_DURATION_SECS, SharedPreconfCacheState},
     error::WhitelistPreconfirmationDriverError,
     importer::{WhitelistPreconfirmationImporter, WhitelistPreconfirmationImporterParams},
-    metrics::WhitelistPreconfirmationDriverMetrics,
     network::{NetworkCommand, NetworkConfig, WhitelistNetwork},
     operator_set::OperatorSetPoller,
-    preconf_ingress_sync::{EventSyncJoinResult, PreconfIngressSync},
+    preconf_ingress_sync::{PreconfIngressSync, map_event_syncer_exit},
 };
 
 /// Configuration for the whitelist preconfirmation runner.
@@ -45,29 +44,6 @@ pub struct RunnerConfig {
     pub p2p_signer_key: Option<String>,
 }
 
-impl RunnerConfig {
-    /// Build runner configuration.
-    pub fn new(
-        driver_config: DriverConfig,
-        p2p_config: NetworkConfig,
-        whitelist_address: Address,
-        rpc_listen_addr: Option<SocketAddr>,
-        rpc_jwt_secret: Option<Vec<u8>>,
-        rpc_cors_origins: Vec<String>,
-        p2p_signer_key: Option<String>,
-    ) -> Self {
-        Self {
-            driver_config,
-            p2p_config,
-            whitelist_address,
-            rpc_listen_addr,
-            rpc_jwt_secret,
-            rpc_cors_origins,
-            p2p_signer_key,
-        }
-    }
-}
-
 /// Runs event sync plus whitelist preconfirmation message ingestion.
 pub struct WhitelistPreconfirmationDriverRunner {
     /// Static runtime configuration for the network and importer.
@@ -82,8 +58,6 @@ impl WhitelistPreconfirmationDriverRunner {
 
     /// Run until either event syncer or whitelist network exits.
     pub async fn run(self) -> Result<()> {
-        WhitelistPreconfirmationDriverMetrics::inc_runner_start();
-
         let mut preconf_ingress_sync =
             PreconfIngressSync::start(&self.config.driver_config).await?;
         let chain_id = preconf_ingress_sync.client().chain_id;
@@ -94,11 +68,7 @@ impl WhitelistPreconfirmationDriverRunner {
             "starting whitelist preconfirmation driver"
         );
 
-        let wait_start = Instant::now();
         preconf_ingress_sync.wait_preconf_ingress_ready().await?;
-        WhitelistPreconfirmationDriverMetrics::observe_event_sync_wait_duration(
-            wait_start.elapsed().as_secs_f64(),
-        );
 
         let operator_poller = OperatorSetPoller::new(
             self.config.whitelist_address,
@@ -169,7 +139,6 @@ impl WhitelistPreconfirmationDriverRunner {
                     listen_addr,
                     jwt_secret: self.config.rpc_jwt_secret.clone(),
                     cors_origins: self.config.rpc_cors_origins.clone(),
-                    ..Default::default()
                 };
                 let server = WhitelistApiServer::start(server_config, handler.clone()).await?;
                 info!(
@@ -207,36 +176,29 @@ impl WhitelistPreconfirmationDriverRunner {
         loop {
             tokio::select! {
                 result = &mut node_handle => {
-                    return finish_runner(
-                        event_syncer_handle,
-                        &mut rest_ws_server,
-                        map_node_exit_for_runner(result),
-                    )
-                    .await;
+                    stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                    return match result {
+                        Ok(Ok(())) => Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
+                            "whitelist preconfirmation network exited unexpectedly".to_string(),
+                        )),
+                        Ok(Err(err)) => Err(err),
+                        Err(err) => Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
+                            err.to_string(),
+                        )),
+                    };
                 }
                 result = &mut event_syncer_handle => {
                     let _ = command_tx.send(NetworkCommand::Shutdown).await;
                     node_handle.abort();
-                    return finish_runner(
-                        event_syncer_handle,
-                        &mut rest_ws_server,
-                        map_event_syncer_exit_for_runner(result),
-                    )
-                    .await;
+                    stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                    return map_event_syncer_exit(result);
                 }
                 maybe_event = event_rx.recv() => {
                     let Some(event) = maybe_event else {
-                        return finish_runner(
-                            event_syncer_handle,
-                            &mut rest_ws_server,
-                            (
-                                "network_event_channel_closed",
-                                Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
-                                "whitelist preconfirmation event channel closed".to_string(),
-                            )),
-                            ),
-                        )
-                        .await;
+                        stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                        return Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
+                            "whitelist preconfirmation event channel closed".to_string(),
+                        ));
                     };
 
                     if let Err(err) = importer.handle_event(event).await {
@@ -268,62 +230,4 @@ async fn stop_sidecars<T>(
     if let Some(server) = rest_ws_server.take() {
         server.stop().await;
     }
-}
-
-/// Tuple describing the runner exit reason and result.
-type RunnerExit = (&'static str, Result<()>);
-
-/// Stop sidecars and return the unified runner exit result.
-async fn finish_runner<T>(
-    event_syncer_handle: &mut tokio::task::JoinHandle<T>,
-    rest_ws_server: &mut Option<WhitelistApiServer>,
-    (reason, result): RunnerExit,
-) -> Result<()> {
-    stop_sidecars(event_syncer_handle, rest_ws_server).await;
-    record_runner_exit(reason, result)
-}
-
-/// Convert a node task result into a standardized runner exit reason.
-fn map_node_exit_for_runner(
-    result: std::result::Result<
-        std::result::Result<(), WhitelistPreconfirmationDriverError>,
-        tokio::task::JoinError,
-    >,
-) -> (&'static str, Result<()>) {
-    match result {
-        Ok(Ok(())) => (
-            "node_exit_unexpected",
-            Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
-                "whitelist preconfirmation network exited unexpectedly".to_string(),
-            )),
-        ),
-        Ok(Err(err)) => ("node_error", Err(err)),
-        Err(err) => (
-            "node_join_error",
-            Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(err.to_string())),
-        ),
-    }
-}
-
-/// Convert an event-syncer result into a standardized runner exit reason.
-fn map_event_syncer_exit_for_runner(result: EventSyncJoinResult) -> (&'static str, Result<()>) {
-    match result {
-        Ok(Ok(())) => {
-            ("event_syncer_exit", Err(WhitelistPreconfirmationDriverError::EventSyncerExited))
-        }
-        Ok(Err(err)) => (
-            "event_syncer_error",
-            Err(map_driver_error::<WhitelistPreconfirmationDriverError>(err)),
-        ),
-        Err(err) => (
-            "event_syncer_join_error",
-            Err(WhitelistPreconfirmationDriverError::EventSyncerFailed(err.to_string())),
-        ),
-    }
-}
-
-/// Record exit reason and return the final result.
-fn record_runner_exit(reason: &'static str, result: Result<()>) -> Result<()> {
-    WhitelistPreconfirmationDriverMetrics::inc_runner_exit(reason);
-    result
 }


### PR DESCRIPTION
## Summary

Phases 1–2 of an overdesign cleanup of `whitelist-preconfirmation-driver` (net **−360 lines**, no functional behavior change apart from removing four unused metrics). Follow-up phases (type unification, HTTP plumbing via axum built-ins, validation dedup, shared-state consolidation) will come as separate PRs.

### Metrics registry rewrite (`metrics.rs`: 510 → ~330 lines)
- Replaced the name-keyed registry (`Vec<(&str, Metric)>` + linear `find()` scan + clone on **every** metric increment) with a plain struct of typed handles accessed directly through one `Lazy`.
- All surviving metric names, labels, and bucket layouts are unchanged.

### ⚠️ Pruned metrics (only intentional observable change)
Removed four once-per-process runner lifecycle metrics that are effectively never scraped (incremented once at startup or immediately before process exit):
- `whitelist_preconf_driver_runner_start_total`
- `whitelist_preconf_driver_runner_exit_total`
- `whitelist_preconf_driver_event_sync_wait_duration_seconds`
- `whitelist_preconf_driver_sync_ready_transitions_total`

No dashboards/configs in this repo reference them (the similarly named `preconf_client_event_sync_wait_duration_seconds` belongs to the sibling crate and is untouched).

### Runner exit ceremony inlined (`runner.rs`: 329 → 260 lines)
- Deleted `RunnerExit` tuple type, `finish_runner`, `map_node_exit_for_runner`, `map_event_syncer_exit_for_runner`, `record_runner_exit` — they existed to label the now-removed exit counter. Exit handling is now a plain `match` per select arm.
- The event-syncer exit mapping now reuses `map_event_syncer_exit` from `preconf_ingress_sync` instead of a duplicate copy.
- Dropped the `RunnerConfig::new` 7-positional-arg constructor; the CLI builds the config with a struct literal.

### Dead configurability removed
- `WhitelistApiServerConfig::enable_http` / `enable_ws` were never `false` outside tests (the runner always used `..Default::default()`); removed them, the conditional router construction, and the unreachable `RestWsServerNoTransportsEnabled` error variant.

### Error-mapping verbosity
- Collapsed the six-arm `TxListCodecError` → `InvalidPayload` match into one `invalid_payload_with_context` (the codec's `Display` messages are already descriptive; REST error strings change slightly, e.g. `invalid zlib bytes for transactions: …` → `invalid transactions list bytes: zlib decode failed: …`).
- Dropped the compressed-size pre-check that duplicated the codec's own `CompressedTooLarge` enforcement.

### One-line wrapper functions inlined
`record_publish` / `record_inbound` / `record_dial_attempt` / `record_importer_event` / `record_response_lookup` / `is_local_gossip_source` — each wrapped a single already-one-line call.

## Test plan

- `cargo nextest run -p whitelist-preconfirmation-driver` — 111/111 pass
- `cargo clippy -p whitelist-preconfirmation-driver -p taiko-client --all-features --no-deps -- -D warnings -D missing_docs -D clippy::missing_docs_in_private_items` — clean
- `cargo +nightly-2025-09-27 fmt` — applied