### PR TITLE
refactor(taiko-client-rs): simplify whitelist preconf driver state and API types

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/interface.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/interface.rs
@@ -4,8 +4,7 @@ use async_trait::async_trait;
 use tokio::sync::broadcast;
 
 use super::types::{
-    BuildPreconfBlockRequest, BuildPreconfBlockResponse, EndOfSequencingNotification,
-    WhitelistStatus,
+    ApiStatus, BuildPreconfBlockRequest, BuildPreconfBlockResponse, EndOfSequencingNotification,
 };
 use crate::Result;
 
@@ -22,7 +21,10 @@ pub trait WhitelistApi: Send + Sync {
     ) -> Result<BuildPreconfBlockResponse>;
 
     /// Get the current status of the whitelist preconfirmation driver.
-    async fn get_status(&self) -> Result<WhitelistStatus>;
+    async fn get_status(&self) -> Result<ApiStatus>;
+
+    /// Whether preconfirmation ingress is ready to serve build requests.
+    fn is_sync_ready(&self) -> bool;
 
     /// Subscribe to end-of-sequencing notifications for the REST `/ws` endpoint.
     fn subscribe_end_of_sequencing(&self) -> broadcast::Receiver<EndOfSequencingNotification>;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/handlers.rs
@@ -14,18 +14,7 @@ use super::{
     state::AppState,
     websocket::serve_websocket_notifications,
 };
-use crate::{
-    api::types::{ApiStatus, BuildPreconfBlockApiRequest},
-    metrics::WhitelistPreconfirmationDriverMetrics,
-};
-
-/// REST response payload for successful `/preconfBlocks` requests.
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct BuildPreconfBlockRestResponse {
-    /// Built block header returned by the API.
-    block_header: alloy_rpc_types::Header,
-}
+use crate::{api::types::BuildPreconfBlockRequest, metrics::WhitelistPreconfirmationDriverMetrics};
 
 /// Health endpoint handler.
 pub(super) async fn handle_root() -> Response {
@@ -37,14 +26,7 @@ pub(super) async fn handle_status(State(state): State<AppState>) -> Result<Respo
     let started_at = Instant::now();
     let result = async {
         let status = state.api.get_status().await?;
-        let response = ApiStatus {
-            highest_unsafe_l2_payload_block_id: status.highest_unsafe_l2_payload_block_id,
-            end_of_sequencing_block_hash: status
-                .end_of_sequencing_block_hash
-                .unwrap_or_else(|| alloy_primitives::B256::ZERO.to_string()),
-            can_shutdown: status.can_shutdown,
-        };
-        Ok(json_response(http::StatusCode::OK, &response))
+        Ok(json_response(http::StatusCode::OK, &status))
     }
     .await;
 
@@ -63,25 +45,17 @@ pub(super) async fn handle_preconf_blocks(
 ) -> Result<Response, ApiHttpError> {
     let started_at = Instant::now();
     let result = async {
-        let status = state.api.get_status().await?;
-
-        if !status.sync_ready {
+        if !state.api.is_sync_ready() {
             return Err(ApiHttpError::BadRequest(
                 "event sync is not ready to serve preconfBlocks".to_string(),
             ));
         }
 
         let body = read_request_body(request.into_body(), PRECONF_BLOCKS_BODY_LIMIT_BYTES).await?;
+        let build_request: BuildPreconfBlockRequest = serde_json::from_slice(&body)?;
 
-        let rest_request: BuildPreconfBlockApiRequest = serde_json::from_slice(&body)?;
-
-        let request = rest_request.into_rpc_request().map_err(ApiHttpError::BadRequest)?;
-
-        let response = state.api.build_preconf_block(request).await?;
-        Ok(json_response(
-            http::StatusCode::OK,
-            &BuildPreconfBlockRestResponse { block_header: response.block_header },
-        ))
+        let response = state.api.build_preconf_block(build_request).await?;
+        Ok(json_response(http::StatusCode::OK, &response))
     }
     .await;
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http_utils.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http_utils.rs
@@ -3,11 +3,12 @@
 use std::fmt::Display;
 
 use axum::{
+    Json,
     body::Body,
-    http::{StatusCode, header::CONTENT_TYPE},
-    response::Response,
+    http::StatusCode,
+    response::{IntoResponse, Response},
 };
-use http_body_util::{BodyExt, BodyStream};
+use http_body_util::{BodyExt, LengthLimitError, Limited};
 
 use crate::error::WhitelistPreconfirmationDriverError;
 
@@ -28,13 +29,7 @@ pub(super) fn error_response(status: StatusCode, message: String) -> Response {
 
 /// Build a JSON response from a serializable payload.
 pub(super) fn json_response<T: serde::Serialize>(status: StatusCode, value: &T) -> Response {
-    let bytes = serde_json::to_vec(value)
-        .unwrap_or_else(|_| b"{\"error\":\"serialization failed\"}".to_vec());
-    Response::builder()
-        .status(status)
-        .header(CONTENT_TYPE, "application/json")
-        .body(Body::from(bytes))
-        .expect("valid response")
+    (status, Json(value)).into_response()
 }
 
 /// Map internal driver errors to REST status codes.
@@ -81,28 +76,15 @@ pub(super) async fn read_request_body<B>(
     max_bytes: usize,
 ) -> std::result::Result<Vec<u8>, RequestBodyReadError>
 where
-    B: http_body::Body<Data = bytes::Bytes> + Send + Unpin + 'static,
+    B: http_body::Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<axum::BoxError>,
 {
-    let mut stream = BodyStream::new(body);
-    let mut bytes = Vec::new();
-    while let Some(frame) = stream.frame().await {
-        let data = frame
-            .map_err(|err| {
-                let err: axum::BoxError = err.into();
-                RequestBodyReadError::Read(err.to_string())
-            })?
-            .into_data()
-            .map_err(|_| {
-                RequestBodyReadError::Read("unexpected non-data frame in request body".to_string())
-            })?;
-
-        if bytes.len().saturating_add(data.len()) > max_bytes {
-            return Err(RequestBodyReadError::TooLarge { max_bytes });
+    match Limited::new(body, max_bytes).collect().await {
+        Ok(collected) => Ok(collected.to_bytes().to_vec()),
+        Err(err) if err.is::<LengthLimitError>() => {
+            Err(RequestBodyReadError::TooLarge { max_bytes })
         }
-
-        bytes.extend_from_slice(&data);
+        Err(err) => Err(RequestBodyReadError::Read(err.to_string())),
     }
-    Ok(bytes)
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -16,8 +16,8 @@ use crate::{
     api::{
         WhitelistApi,
         types::{
-            BuildPreconfBlockApiRequest, BuildPreconfBlockRequest, BuildPreconfBlockResponse,
-            EndOfSequencingNotification, ExecutableData, WhitelistStatus,
+            ApiStatus, BuildPreconfBlockRequest, BuildPreconfBlockResponse,
+            EndOfSequencingNotification, ExecutableData,
         },
     },
 };
@@ -35,16 +35,16 @@ impl WhitelistApi for MockApi {
         Ok(BuildPreconfBlockResponse { block_header: Default::default() })
     }
 
-    async fn get_status(&self) -> Result<WhitelistStatus> {
-        Ok(WhitelistStatus {
-            head_l1_origin_block_id: Some(1),
-            highest_unsafe_block_number: 100,
-            peer_id: "test-peer".to_string(),
-            sync_ready: true,
+    async fn get_status(&self) -> Result<ApiStatus> {
+        Ok(ApiStatus {
             highest_unsafe_l2_payload_block_id: 100,
-            end_of_sequencing_block_hash: Some(B256::ZERO.to_string()),
+            end_of_sequencing_block_hash: B256::ZERO.to_string(),
             can_shutdown: true,
         })
+    }
+
+    fn is_sync_ready(&self) -> bool {
+        true
     }
 
     fn subscribe_end_of_sequencing(&self) -> broadcast::Receiver<EndOfSequencingNotification> {
@@ -69,16 +69,16 @@ impl WhitelistApi for SyncReadyApi {
         Ok(BuildPreconfBlockResponse { block_header: Default::default() })
     }
 
-    async fn get_status(&self) -> Result<WhitelistStatus> {
-        Ok(WhitelistStatus {
-            head_l1_origin_block_id: Some(1),
-            highest_unsafe_block_number: 100,
-            peer_id: "test-peer".to_string(),
-            sync_ready: self.sync_ready,
+    async fn get_status(&self) -> Result<ApiStatus> {
+        Ok(ApiStatus {
             highest_unsafe_l2_payload_block_id: 100,
-            end_of_sequencing_block_hash: Some(B256::ZERO.to_string()),
+            end_of_sequencing_block_hash: B256::ZERO.to_string(),
             can_shutdown: true,
         })
+    }
+
+    fn is_sync_ready(&self) -> bool {
+        self.sync_ready
     }
 
     fn subscribe_end_of_sequencing(&self) -> broadcast::Receiver<EndOfSequencingNotification> {
@@ -88,7 +88,7 @@ impl WhitelistApi for SyncReadyApi {
 }
 
 fn sample_preconf_request() -> Vec<u8> {
-    let request = BuildPreconfBlockApiRequest {
+    let request = BuildPreconfBlockRequest {
         executable_data: Some(ExecutableData {
             parent_hash: B256::ZERO,
             fee_recipient: Address::ZERO,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -38,17 +38,21 @@ where
 }
 
 /// Emit the entry log for a preconfirmation block-building request.
-fn log_build_preconf_block_entry(request: &BuildPreconfBlockRequest) {
+fn log_build_preconf_block_entry(
+    data: &ExecutableData,
+    end_of_sequencing: Option<bool>,
+    is_forced_inclusion: Option<bool>,
+) {
     tracing::info!(
-        block_id = request.block_number,
-        coinbase = %request.fee_recipient,
-        timestamp = request.timestamp,
-        gas_limit = request.gas_limit,
-        base_fee_per_gas = request.base_fee_per_gas,
-        extra_data = %alloy_primitives::hex::encode(&request.extra_data),
-        parent_hash = %request.parent_hash,
-        end_of_sequencing = request.end_of_sequencing.unwrap_or(false),
-        is_forced_inclusion = request.is_forced_inclusion.unwrap_or(false),
+        block_id = data.block_number,
+        coinbase = %data.fee_recipient,
+        timestamp = data.timestamp,
+        gas_limit = data.gas_limit,
+        base_fee_per_gas = data.base_fee_per_gas,
+        extra_data = %alloy_primitives::hex::encode(&data.extra_data),
+        parent_hash = %data.parent_hash,
+        end_of_sequencing = end_of_sequencing.unwrap_or(false),
+        is_forced_inclusion = is_forced_inclusion.unwrap_or(false),
         "🏗️ New preconfirmation block building request"
     );
 }
@@ -64,10 +68,19 @@ where
         request: BuildPreconfBlockRequest,
     ) -> Result<BuildPreconfBlockResponse> {
         let started_at = Instant::now();
-        log_build_preconf_block_entry(&request);
         // Record receipt before any validation so even rejected requests
         // mark this pod as the active preconfer for shutdown purposes.
         self.mark_preconf_request_received().await;
+
+        let BuildPreconfBlockRequest { executable_data, end_of_sequencing, is_forced_inclusion } =
+            request;
+        let Some(data) = executable_data else {
+            return Err(WhitelistPreconfirmationDriverError::invalid_payload(
+                "executable data is required",
+            ));
+        };
+        log_build_preconf_block_entry(&data, end_of_sequencing, is_forced_inclusion);
+
         let _build_guard = self.build_preconf_lock.lock().await;
 
         // Guard against building on a genuinely syncing node, but tolerate the false-
@@ -84,19 +97,19 @@ where
             info.current_block < info.highest_block
         {
             return Err(WhitelistPreconfirmationDriverError::Driver(
-                driver::DriverError::EngineSyncing(request.block_number),
+                driver::DriverError::EngineSyncing(data.block_number),
             ));
         }
 
         self.ensure_node_signer_whitelisted()?;
 
-        let prev_randao =
-            self.derive_prev_randao(request.parent_hash, request.block_number).await?;
-        self.validate_request_payload(&request, prev_randao)?;
+        let prev_randao = self.derive_prev_randao(data.parent_hash, data.block_number).await?;
+        self.validate_request_payload(&data, prev_randao)?;
 
         // Insert the preconfirmation payload locally first to
         // obtain the canonical block hash before gossiping.
-        let driver_payload = self.build_driver_payload(&request, prev_randao, [0u8; 65])?;
+        let driver_payload =
+            self.build_driver_payload(&data, is_forced_inclusion, prev_randao, [0u8; 65])?;
         self.event_syncer
             .submit_preconfirmation_payload(PreconfPayload::new(driver_payload))
             .await?;
@@ -104,23 +117,21 @@ where
         let inserted_block = self
             .rpc
             .l2_provider
-            .get_block_by_number(BlockNumberOrTag::Number(request.block_number))
+            .get_block_by_number(BlockNumberOrTag::Number(data.block_number))
             .await
             .map_err(WhitelistPreconfirmationDriverError::provider)?
-            .ok_or(WhitelistPreconfirmationDriverError::MissingInsertedBlock(
-                request.block_number,
-            ))?;
+            .ok_or(WhitelistPreconfirmationDriverError::MissingInsertedBlock(data.block_number))?;
 
-        if inserted_block.header.parent_hash != request.parent_hash {
+        if inserted_block.header.parent_hash != data.parent_hash {
             return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
                 "inserted block parent hash mismatch at block {}: expected {}, got {}",
-                request.block_number, request.parent_hash, inserted_block.header.parent_hash
+                data.block_number, data.parent_hash, inserted_block.header.parent_hash
             )));
         }
-        if inserted_block.header.number != request.block_number {
+        if inserted_block.header.number != data.block_number {
             return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
                 "inserted block number mismatch: expected {}, got {}",
-                request.block_number, inserted_block.header.number
+                data.block_number, inserted_block.header.number
             )));
         }
 
@@ -128,7 +139,7 @@ where
         let block_number = inserted_block.header.number;
         let block_header = inserted_block.header.clone();
         let base_fee_per_gas =
-            inserted_block.header.base_fee_per_gas.unwrap_or(request.base_fee_per_gas);
+            inserted_block.header.base_fee_per_gas.unwrap_or(data.base_fee_per_gas);
         let block_hash_signature =
             self.sign_digest(block_signing_hash(self.chain_id, block_hash.as_slice()))?;
 
@@ -140,7 +151,7 @@ where
                 FixedBytes::<65>::from(block_hash_signature),
             )
             .await?;
-        self.update_highest_unsafe(block_number).await;
+        self.state.set_highest_unsafe(block_number).await;
 
         let execution_payload = ExecutionPayloadV1 {
             parent_hash: inserted_block.header.parent_hash,
@@ -156,12 +167,12 @@ where
             extra_data: inserted_block.header.extra_data.clone(),
             base_fee_per_gas: U256::from(base_fee_per_gas),
             block_hash,
-            transactions: vec![request.transactions.clone()],
+            transactions: vec![data.transactions.clone()],
         };
 
         let envelope = WhitelistExecutionPayloadEnvelope {
-            end_of_sequencing: request.end_of_sequencing,
-            is_forced_inclusion: request.is_forced_inclusion,
+            end_of_sequencing,
+            is_forced_inclusion,
             parent_beacon_block_root: None,
             header_difficulty: (!inserted_block.header.difficulty.is_zero())
                 .then_some(inserted_block.header.difficulty),
@@ -179,25 +190,27 @@ where
             "publishing signed whitelist preconfirmation payload"
         );
 
+        // Cache the envelope locally before publishing so EOS catch-up and
+        // request-topic lookups can serve this block even without peer echo.
+        let envelope = Arc::new(envelope);
+        self.state.insert_recent(envelope.clone()).await;
+
         // Publish to gossipsub.
         self.send_network_command(
-            NetworkCommand::PublishUnsafePayload {
-                signature: wire_signature,
-                envelope: Arc::new(envelope),
-            },
+            NetworkCommand::PublishUnsafePayload { signature: wire_signature, envelope },
             "publish",
         )
         .await?;
 
         // If end-of-sequencing, also publish the EOS request.
-        if request.end_of_sequencing.unwrap_or(false) {
-            let epoch = self.beacon_client.timestamp_to_epoch(request.timestamp).map_err(|e| {
+        if end_of_sequencing.unwrap_or(false) {
+            let epoch = self.beacon_client.timestamp_to_epoch(data.timestamp).map_err(|e| {
                 WhitelistPreconfirmationDriverError::InvalidPayload(format!(
                     "failed to derive epoch from block timestamp {}: {e}",
-                    request.timestamp
+                    data.timestamp
                 ))
             })?;
-            self.cache_state.record_end_of_sequencing(epoch, block_hash).await;
+            self.state.record_end_of_sequencing(epoch, block_hash).await;
             if let Err(err) = self
                 .eos_notification_tx
                 .send(EndOfSequencingNotification { current_epoch: epoch, end_of_sequencing: true })
@@ -223,8 +236,13 @@ where
     }
 
     /// Return runtime status for the whitelist preconfirmation driver.
-    async fn get_status(&self) -> Result<WhitelistStatus> {
+    async fn get_status(&self) -> Result<ApiStatus> {
         self.get_status_snapshot().await
+    }
+
+    /// Whether preconfirmation ingress is ready to serve build requests.
+    fn is_sync_ready(&self) -> bool {
+        self.event_syncer.is_preconf_ingress_ready()
     }
 
     /// Subscribe to end-of-sequencing websocket notifications.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -29,11 +29,11 @@ use crate::{
     api::{
         WhitelistApi,
         types::{
-            BuildPreconfBlockRequest, BuildPreconfBlockResponse, EndOfSequencingNotification,
-            WhitelistStatus,
+            ApiStatus, BuildPreconfBlockRequest, BuildPreconfBlockResponse,
+            EndOfSequencingNotification, ExecutableData,
         },
     },
-    cache::SharedPreconfCacheState,
+    cache::SharedPreconfState,
     codec::{WhitelistExecutionPayloadEnvelope, block_signing_hash, encode_envelope_ssz},
     error::{Result, WhitelistPreconfirmationDriverError},
     importer::validate_execution_payload_for_preconf,
@@ -110,12 +110,8 @@ where
     /// Lock-free shared set of whitelisted sequencer addresses; used to refuse
     /// build requests when this node's own P2P signer has been deregistered on-chain.
     operator_set: SharedOperatorSet,
-    /// Peer ID string.
-    peer_id: String,
-    /// Highest unsafe payload block ID tracked by this node (shared with importer).
-    highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
-    /// Shared cache state used to back `/status` and EOS visibility.
-    cache_state: SharedPreconfCacheState,
+    /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).
+    state: SharedPreconfState,
     /// Broadcast channel for API `/ws` end-of-sequencing notifications.
     eos_notification_tx: broadcast::Sender<EndOfSequencingNotification>,
     /// Wall-clock instant of the most recent `build_preconf_block` invocation,
@@ -141,14 +137,10 @@ where
     pub(crate) beacon_client: Arc<BeaconClient>,
     /// Shared operator set used to gate the build API on the node's own whitelist status.
     pub(crate) operator_set: SharedOperatorSet,
-    /// Shared highest unsafe payload block ID (also updated by importer on P2P import).
-    pub(crate) highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
+    /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).
+    pub(crate) state: SharedPreconfState,
     /// Network command sender for gossip publishing.
     pub(crate) network_command_tx: mpsc::Sender<NetworkCommand>,
-    /// Shared preconfirmation cache state.
-    pub(crate) cache_state: SharedPreconfCacheState,
-    /// Peer ID string.
-    pub(crate) peer_id: String,
 }
 
 impl<P> WhitelistApiService<P>
@@ -164,10 +156,8 @@ where
             signer,
             beacon_client,
             operator_set,
-            highest_unsafe_l2_payload_block_id,
+            state,
             network_command_tx,
-            cache_state,
-            peer_id,
         }: WhitelistApiServiceParams<P>,
     ) -> Self {
         let (eos_notification_tx, _) = broadcast::channel(EOS_NOTIFICATION_CHANNEL_CAPACITY);
@@ -178,9 +168,7 @@ where
             signer,
             beacon_client,
             operator_set,
-            peer_id,
-            highest_unsafe_l2_payload_block_id,
-            cache_state,
+            state,
             eos_notification_tx,
             network_command_tx,
             build_preconf_lock: Mutex::new(()),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
@@ -8,28 +8,29 @@ impl<P> WhitelistApiService<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    /// Build driver payload attributes from the RPC request.
+    /// Build driver payload attributes from the requested executable data.
     pub(super) fn build_driver_payload(
         &self,
-        request: &BuildPreconfBlockRequest,
+        data: &ExecutableData,
+        is_forced_inclusion: Option<bool>,
         prev_randao: B256,
         signature: [u8; 65],
     ) -> Result<TaikoPayloadAttributes> {
-        let tx_list = decompress_tx_list(request.transactions.as_ref())?;
+        let tx_list = decompress_tx_list(data.transactions.as_ref())?;
 
         let block_metadata = TaikoBlockMetadata {
-            beneficiary: request.fee_recipient,
-            gas_limit: request.gas_limit,
-            timestamp: U256::from(request.timestamp),
+            beneficiary: data.fee_recipient,
+            gas_limit: data.gas_limit,
+            timestamp: U256::from(data.timestamp),
             mix_hash: prev_randao,
             tx_list: Some(tx_list.into()),
-            extra_data: request.extra_data.clone(),
+            extra_data: data.extra_data.clone(),
         };
 
         let payload_attributes = EthPayloadAttributes {
-            timestamp: request.timestamp,
+            timestamp: data.timestamp,
             prev_randao,
-            suggested_fee_recipient: request.fee_recipient,
+            suggested_fee_recipient: data.fee_recipient,
             withdrawals: Some(Vec::new()),
             parent_beacon_block_root: None,
             slot_number: None,
@@ -37,21 +38,21 @@ where
 
         let mut payload = TaikoPayloadAttributes {
             payload_attributes,
-            base_fee_per_gas: U256::from(request.base_fee_per_gas),
+            base_fee_per_gas: U256::from(data.base_fee_per_gas),
             block_metadata,
             l1_origin: RpcL1Origin {
-                block_id: U256::from(request.block_number),
+                block_id: U256::from(data.block_number),
                 l2_block_hash: B256::ZERO,
                 l1_block_height: None,
                 l1_block_hash: None,
                 build_payload_args_id: [0u8; 8],
-                is_forced_inclusion: request.is_forced_inclusion.unwrap_or(false),
+                is_forced_inclusion: is_forced_inclusion.unwrap_or(false),
                 signature,
             },
             anchor_transaction: None,
         };
 
-        let payload_id = payload_id_taiko(&request.parent_hash, &payload, PAYLOAD_ID_VERSION_V2);
+        let payload_id = payload_id_taiko(&data.parent_hash, &payload, PAYLOAD_ID_VERSION_V2);
         payload.l1_origin.build_payload_args_id = payload_id_to_bytes(payload_id);
         Ok(payload)
     }
@@ -103,24 +104,24 @@ where
     /// Validate request payload shape before expensive insertion and signing operations.
     pub(super) fn validate_request_payload(
         &self,
-        request: &BuildPreconfBlockRequest,
+        data: &ExecutableData,
         prev_randao: B256,
     ) -> Result<()> {
         let payload = ExecutionPayloadV1 {
-            parent_hash: request.parent_hash,
-            fee_recipient: request.fee_recipient,
+            parent_hash: data.parent_hash,
+            fee_recipient: data.fee_recipient,
             state_root: B256::ZERO,
             receipts_root: B256::ZERO,
             logs_bloom: Bloom::default(),
             prev_randao,
-            block_number: request.block_number,
-            gas_limit: request.gas_limit,
+            block_number: data.block_number,
+            gas_limit: data.gas_limit,
             gas_used: 0,
-            timestamp: request.timestamp,
-            extra_data: request.extra_data.clone(),
-            base_fee_per_gas: U256::from(request.base_fee_per_gas),
+            timestamp: data.timestamp,
+            extra_data: data.extra_data.clone(),
+            base_fee_per_gas: U256::from(data.base_fee_per_gas),
             block_hash: B256::ZERO,
-            transactions: vec![request.transactions.clone()],
+            transactions: vec![data.transactions.clone()],
         };
 
         validate_execution_payload_for_preconf(
@@ -128,10 +129,5 @@ where
             self.chain_id,
             *self.rpc.shasta.anchor.address(),
         )
-    }
-
-    /// Update highest unsafe block tracking on each insertion/reorg point.
-    pub(super) async fn update_highest_unsafe(&self, block_number: u64) {
-        *self.highest_unsafe_l2_payload_block_id.lock().await = block_number;
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -7,9 +7,7 @@ where
     P: Provider + Clone + Send + Sync + 'static,
 {
     /// Build the current status snapshot served by the REST `/status` route.
-    pub(super) async fn get_status_snapshot(&self) -> Result<WhitelistStatus> {
-        let head_l1_origin = self.rpc.head_l1_origin().await?;
-
+    pub(super) async fn get_status_snapshot(&self) -> Result<ApiStatus> {
         // Current L2 execution head, best-effort: a failed read yields `None`, which skips
         // the clamp below and leaves the reported value unchanged.
         let l2_head = self
@@ -29,35 +27,26 @@ where
         // stored counter too low until the next import/build. Clamping only the reported
         // value keeps the counter intact, so the next poll recomputes against a fresh head
         // and self-heals.
-        let highest_unsafe = {
-            let guard = self.highest_unsafe_l2_payload_block_id.lock().await;
-            let reconciled = reconcile_highest_unsafe(*guard, l2_head);
-            if reconciled != *guard {
-                warn!(
-                    tracked = *guard,
-                    head = reconciled,
-                    "highest_unsafe ahead of head; reporting clamped value"
-                );
-            }
-            reconciled
-        };
+        let tracked = self.state.highest_unsafe().await;
+        let highest_unsafe = reconcile_highest_unsafe(tracked, l2_head);
+        if highest_unsafe != tracked {
+            warn!(
+                tracked,
+                head = highest_unsafe,
+                "highest_unsafe ahead of head; reporting clamped value"
+            );
+        }
 
         let current_epoch = self.beacon_client.current_epoch();
         let end_of_sequencing_block_hash = self
-            .cache_state
+            .state
             .end_of_sequencing_for_epoch(current_epoch)
             .await
-            .map(|hash| hash.to_string());
-        // sync_ready reflects ingress readiness, which already includes the confirmed-sync
-        // and scanner-live checks required by the event syncer.
-        let sync_ready = self.event_syncer.is_preconf_ingress_ready();
+            .unwrap_or(B256::ZERO)
+            .to_string();
         let can_shutdown = self.compute_can_shutdown().await;
 
-        Ok(WhitelistStatus {
-            head_l1_origin_block_id: head_l1_origin.as_ref().map(|o| o.block_id.to::<u64>()),
-            highest_unsafe_block_number: highest_unsafe,
-            peer_id: self.peer_id.clone(),
-            sync_ready,
+        Ok(ApiStatus {
             highest_unsafe_l2_payload_block_id: highest_unsafe,
             end_of_sequencing_block_hash,
             can_shutdown,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
@@ -4,44 +4,10 @@ use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types::Header as RpcHeader;
 use serde::{Deserialize, Serialize};
 
-/// Internal request body used by `POST /preconfBlocks`.
+/// Request body for `POST /preconfBlocks`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BuildPreconfBlockRequest {
-    /// Parent block hash.
-    pub parent_hash: B256,
-    /// Fee recipient address.
-    pub fee_recipient: Address,
-    /// Block number.
-    pub block_number: u64,
-    /// Gas limit.
-    pub gas_limit: u64,
-    /// Block timestamp.
-    pub timestamp: u64,
-    /// RLP-encoded then zlib-compressed transaction list.
-    pub transactions: Bytes,
-    /// Extra data for the block header.
-    pub extra_data: Bytes,
-    /// Base fee per gas.
-    pub base_fee_per_gas: u64,
-    /// Whether this is the last preconfirmation block in the epoch.
-    pub end_of_sequencing: Option<bool>,
-    /// Whether this is a forced inclusion block.
-    pub is_forced_inclusion: Option<bool>,
-}
-
-/// Internal response body returned by the build-preconf flow.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BuildPreconfBlockResponse {
-    /// Full block header of the built preconfirmation block.
-    pub block_header: RpcHeader,
-}
-
-/// REST-compatible request body for `POST /preconfBlocks`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BuildPreconfBlockApiRequest {
     /// Nested executable payload fields.
     pub executable_data: Option<ExecutableData>,
     /// Whether this is the last preconfirmation block in the epoch.
@@ -50,7 +16,7 @@ pub struct BuildPreconfBlockApiRequest {
     pub is_forced_inclusion: Option<bool>,
 }
 
-/// REST-compatible nested executable data.
+/// Executable payload fields nested in [`BuildPreconfBlockRequest`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutableData {
@@ -72,33 +38,21 @@ pub struct ExecutableData {
     pub base_fee_per_gas: u64,
 }
 
-impl BuildPreconfBlockApiRequest {
-    /// Convert REST request format into internal RPC request format.
-    pub fn into_rpc_request(self) -> std::result::Result<BuildPreconfBlockRequest, String> {
-        let executable_data =
-            self.executable_data.ok_or_else(|| "executable data is required".to_string())?;
-        Ok(BuildPreconfBlockRequest {
-            parent_hash: executable_data.parent_hash,
-            fee_recipient: executable_data.fee_recipient,
-            block_number: executable_data.block_number,
-            gas_limit: executable_data.gas_limit,
-            timestamp: executable_data.timestamp,
-            transactions: executable_data.transactions,
-            extra_data: executable_data.extra_data,
-            base_fee_per_gas: executable_data.base_fee_per_gas,
-            end_of_sequencing: self.end_of_sequencing,
-            is_forced_inclusion: self.is_forced_inclusion,
-        })
-    }
+/// Response body returned by `POST /preconfBlocks`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildPreconfBlockResponse {
+    /// Full block header of the built preconfirmation block.
+    pub block_header: RpcHeader,
 }
 
-/// REST status response for `GET /status`.
+/// Status response for `GET /status`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiStatus {
     /// Highest unsafe payload block ID tracked by this node.
     pub highest_unsafe_l2_payload_block_id: u64,
-    /// End-of-sequencing block hash for current epoch (if any).
+    /// End-of-sequencing block hash for current epoch (zero hash when unknown).
     pub end_of_sequencing_block_hash: String,
     /// True when SIGTERM is safe — no `build_preconf_block` request has been
     /// received within the last shutdown-block window.
@@ -115,28 +69,6 @@ pub struct EndOfSequencingNotification {
     pub end_of_sequencing: bool,
 }
 
-/// Internal status model used by `GET /status`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WhitelistStatus {
-    /// Head L1 origin block ID, if available.
-    pub head_l1_origin_block_id: Option<u64>,
-    /// Highest unsafe block number on L2.
-    pub highest_unsafe_block_number: u64,
-    /// Local libp2p peer ID.
-    pub peer_id: String,
-    /// Whether preconfirmation ingress is ready.
-    pub sync_ready: bool,
-    /// Highest unsafe payload block ID tracked by this node.
-    pub highest_unsafe_l2_payload_block_id: u64,
-    /// End-of-sequencing block hash for current epoch.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_of_sequencing_block_hash: Option<String>,
-    /// True when SIGTERM is safe — no `build_preconf_block` request has been
-    /// received within the last `SHUTDOWN_BLOCK_WINDOW`.
-    pub can_shutdown: bool,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,19 +76,22 @@ mod tests {
     #[test]
     fn build_preconf_block_request_camel_case() {
         let request = BuildPreconfBlockRequest {
-            parent_hash: B256::ZERO,
-            fee_recipient: Address::ZERO,
-            block_number: 1,
-            gas_limit: 30_000_000,
-            timestamp: 1_735_000_000,
-            transactions: Bytes::from(vec![0x01]),
-            extra_data: Bytes::default(),
-            base_fee_per_gas: 1_000_000_000,
+            executable_data: Some(ExecutableData {
+                parent_hash: B256::ZERO,
+                fee_recipient: Address::ZERO,
+                block_number: 1,
+                gas_limit: 30_000_000,
+                timestamp: 1_735_000_000,
+                transactions: Bytes::from(vec![0x01]),
+                extra_data: Bytes::default(),
+                base_fee_per_gas: 1_000_000_000,
+            }),
             end_of_sequencing: Some(true),
             is_forced_inclusion: None,
         };
 
         let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("executableData"));
         assert!(json.contains("parentHash"));
         assert!(json.contains("feeRecipient"));
         assert!(json.contains("blockNumber"));
@@ -166,28 +101,7 @@ mod tests {
     }
 
     #[test]
-    fn whitelist_status_camel_case() {
-        let status = WhitelistStatus {
-            head_l1_origin_block_id: Some(42),
-            highest_unsafe_block_number: 100,
-            peer_id: "test-peer".to_string(),
-            sync_ready: true,
-            highest_unsafe_l2_payload_block_id: 100,
-            end_of_sequencing_block_hash: Some(B256::ZERO.to_string()),
-            can_shutdown: true,
-        };
-
-        let json = serde_json::to_string(&status).unwrap();
-        assert!(json.contains("headL1OriginBlockId"));
-        assert!(json.contains("highestUnsafeBlockNumber"));
-        assert!(json.contains("syncReady"));
-        assert!(json.contains("highestUnsafeL2PayloadBlockId"));
-        assert!(json.contains("endOfSequencingBlockHash"));
-        assert!(json.contains("canShutdown"));
-    }
-
-    #[test]
-    fn rest_status_serializes_fields() {
+    fn status_serializes_fields_in_camel_case() {
         let status = ApiStatus {
             highest_unsafe_l2_payload_block_id: 1,
             end_of_sequencing_block_hash: B256::ZERO.to_string(),
@@ -203,6 +117,9 @@ mod tests {
                 .expect("missing highest unsafe block id"),
             1
         );
-        assert_eq!(json["canShutdown"].as_bool().expect("missing canShutdown"), true);
+        assert!(
+            json["endOfSequencingBlockHash"].as_str().expect("missing EOS hash").starts_with("0x")
+        );
+        assert!(json["canShutdown"].as_bool().expect("missing canShutdown"));
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -1,4 +1,4 @@
-//! In-memory cache for out-of-order whitelist preconfirmation envelopes.
+//! In-memory caches and shared runtime state for whitelist preconfirmation envelopes.
 
 use std::{
     collections::HashMap,
@@ -10,30 +10,49 @@ use alloy_primitives::B256;
 use hashlink::LinkedHashMap;
 use tokio::sync::Mutex;
 
-use crate::codec::WhitelistExecutionPayloadEnvelope;
+use crate::{
+    codec::WhitelistExecutionPayloadEnvelope, metrics::WhitelistPreconfirmationDriverMetrics,
+};
 
-/// Default maximum number of recently validated envelopes retained for serving responses.
-const DEFAULT_RECENT_ENVELOPE_CAPACITY: usize = 1024;
-/// Default maximum number of pending envelopes retained while waiting for parents.
-const DEFAULT_PENDING_ENVELOPE_CAPACITY: usize = 768;
+/// Maximum number of recently validated envelopes retained for serving responses.
+const RECENT_ENVELOPE_CAPACITY: usize = 1024;
+/// Maximum number of pending envelopes retained while waiting for parents.
+pub(crate) const PENDING_ENVELOPE_CAPACITY: usize = 768;
 /// Maximum number of EOS cache entries retained.
-const DEFAULT_EOS_CACHE_CAPACITY: usize = DEFAULT_PENDING_ENVELOPE_CAPACITY;
+const EOS_CACHE_CAPACITY: usize = PENDING_ENVELOPE_CAPACITY;
 /// Default cooldown, in seconds, between duplicate parent-hash requests.
 const DEFAULT_REQUEST_COOLDOWN_SECS: u64 = 10;
 /// One L1 epoch (32 slots x 12 seconds).
 pub(crate) const L1_EPOCH_DURATION_SECS: u64 = 12 * 32;
 
-/// Shared cache state surfaced through REST status and high-throughput request handlers.
+/// Shared mutable state for the whitelist preconfirmation driver.
+///
+/// Holds everything both the importer (P2P ingestion) and the API service
+/// (REST build/status) need to observe: end-of-sequencing markers, the
+/// recently validated envelopes served to request topics, and the highest
+/// unsafe L2 payload block id.
 #[derive(Debug, Clone)]
-pub(crate) struct SharedPreconfCacheState {
+pub(crate) struct SharedPreconfState {
     /// End-of-sequencing markers tracked per epoch.
     end_of_sequencing_by_epoch: Arc<Mutex<LinkedHashMap<u64, B256>>>,
+    /// Recently validated envelopes retained for serving request-topic responses.
+    recent_envelopes: Arc<Mutex<EnvelopeCache>>,
+    /// Highest unsafe L2 payload block id observed via P2P import or local build.
+    highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
 }
 
-impl SharedPreconfCacheState {
-    /// Create shared cache state with empty epoch mapping.
-    pub(crate) fn new() -> Self {
-        Self { end_of_sequencing_by_epoch: Arc::new(Mutex::new(LinkedHashMap::new())) }
+impl SharedPreconfState {
+    /// Create shared state seeded with the current L2 head block number.
+    pub(crate) fn new(initial_highest_unsafe_l2_payload_block_id: u64) -> Self {
+        Self {
+            end_of_sequencing_by_epoch: Arc::new(Mutex::new(LinkedHashMap::new())),
+            recent_envelopes: Arc::new(Mutex::new(EnvelopeCache::with_capacity(
+                RECENT_ENVELOPE_CAPACITY,
+            ))),
+            highest_unsafe_l2_payload_block_id: Arc::new(Mutex::new(
+                initial_highest_unsafe_l2_payload_block_id,
+            )),
+        }
     }
 
     /// Record an EOS hash for the given epoch with bounded cache size.
@@ -41,7 +60,7 @@ impl SharedPreconfCacheState {
         let mut entries = self.end_of_sequencing_by_epoch.lock().await;
         entries.insert(epoch, block_hash);
 
-        if entries.len() > DEFAULT_EOS_CACHE_CAPACITY {
+        if entries.len() > EOS_CACHE_CAPACITY {
             let _ = entries.pop_front();
         }
     }
@@ -50,9 +69,42 @@ impl SharedPreconfCacheState {
     pub(crate) async fn end_of_sequencing_for_epoch(&self, epoch: u64) -> Option<B256> {
         self.end_of_sequencing_by_epoch.lock().await.get(&epoch).copied()
     }
+
+    /// Insert a validated envelope into the recent cache and refresh its gauge.
+    pub(crate) async fn insert_recent(&self, envelope: Arc<WhitelistExecutionPayloadEnvelope>) {
+        let mut recent = self.recent_envelopes.lock().await;
+        recent.insert(envelope);
+        WhitelistPreconfirmationDriverMetrics::set_cache_recent_count(recent.len());
+    }
+
+    /// Get a recently validated envelope by block hash.
+    pub(crate) async fn get_recent(
+        &self,
+        hash: &B256,
+    ) -> Option<Arc<WhitelistExecutionPayloadEnvelope>> {
+        self.recent_envelopes.lock().await.get(hash).cloned()
+    }
+
+    /// Raise the highest unsafe block id to `block_number` when it is higher.
+    pub(crate) async fn raise_highest_unsafe(&self, block_number: u64) {
+        let mut guard = self.highest_unsafe_l2_payload_block_id.lock().await;
+        *guard = block_number.max(*guard);
+    }
+
+    /// Set the highest unsafe block id unconditionally (local builds may
+    /// legitimately lower it after an L1 reorg).
+    pub(crate) async fn set_highest_unsafe(&self, block_number: u64) {
+        *self.highest_unsafe_l2_payload_block_id.lock().await = block_number;
+    }
+
+    /// Read the highest unsafe block id.
+    pub(crate) async fn highest_unsafe(&self) -> u64 {
+        *self.highest_unsafe_l2_payload_block_id.lock().await
+    }
 }
 
-/// Simple in-memory cache keyed by block hash with bounded capacity.
+/// Bounded in-memory envelope cache keyed by block hash with LRU-style eviction.
+#[derive(Debug)]
 pub(crate) struct EnvelopeCache {
     /// Fast lookup table keyed by payload block hash.
     entries: LinkedHashMap<B256, Arc<WhitelistExecutionPayloadEnvelope>>,
@@ -60,21 +112,14 @@ pub(crate) struct EnvelopeCache {
     capacity: usize,
 }
 
-impl Default for EnvelopeCache {
-    /// Build an envelope cache with the standard pending-capacity default.
-    fn default() -> Self {
-        Self::with_capacity(DEFAULT_PENDING_ENVELOPE_CAPACITY)
-    }
-}
-
 impl EnvelopeCache {
-    /// Construct a pending-envelope cache with a fixed capacity.
+    /// Construct an envelope cache with a fixed capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         let capacity = capacity.max(1);
         Self { entries: LinkedHashMap::with_capacity(capacity), capacity }
     }
 
-    /// Insert or replace a cached envelope.
+    /// Insert or replace a cached envelope, refreshing its recency.
     pub fn insert(&mut self, envelope: Arc<WhitelistExecutionPayloadEnvelope>) {
         let hash = envelope.execution_payload.block_hash;
         self.entries.remove(&hash);
@@ -116,55 +161,6 @@ impl EnvelopeCache {
     }
 
     /// Returns current number of cached envelopes.
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-}
-
-/// Recently seen validated envelopes used for serving request topic responses.
-#[derive(Debug)]
-pub(crate) struct RecentEnvelopeCache {
-    /// Fast lookup table keyed by payload block hash.
-    entries: LinkedHashMap<B256, Arc<WhitelistExecutionPayloadEnvelope>>,
-    /// Maximum number of envelopes to retain.
-    capacity: usize,
-}
-
-impl Default for RecentEnvelopeCache {
-    /// Build a recent cache with the standard bounded-capacity default.
-    fn default() -> Self {
-        Self::with_capacity(DEFAULT_RECENT_ENVELOPE_CAPACITY)
-    }
-}
-
-impl RecentEnvelopeCache {
-    /// Construct a recent-envelope cache with a fixed capacity.
-    pub fn with_capacity(capacity: usize) -> Self {
-        let capacity = capacity.max(1);
-        Self { entries: LinkedHashMap::with_capacity(capacity), capacity }
-    }
-
-    /// Insert or replace a recent envelope.
-    pub fn insert_recent(&mut self, envelope: Arc<WhitelistExecutionPayloadEnvelope>) {
-        let hash = envelope.execution_payload.block_hash;
-        self.entries.remove(&hash);
-        self.entries.insert(hash, envelope);
-        self.evict_oldest();
-    }
-
-    /// Evict oldest entries until capacity is satisfied.
-    fn evict_oldest(&mut self) {
-        while self.entries.len() > self.capacity {
-            let _ = self.entries.pop_front();
-        }
-    }
-
-    /// Get a recent envelope by block hash.
-    pub fn get_recent(&self, hash: &B256) -> Option<Arc<WhitelistExecutionPayloadEnvelope>> {
-        self.entries.get(hash).cloned()
-    }
-
-    /// Returns current number of recent envelopes.
     pub fn len(&self) -> usize {
         self.entries.len()
     }
@@ -249,22 +245,70 @@ mod tests {
     }
 
     #[test]
-    fn recent_cache_gets_by_hash_and_eviction_is_bounded() {
-        let mut recent = RecentEnvelopeCache::with_capacity(2);
-        let h1 = B256::from([0x01u8; 32]);
-        let h2 = B256::from([0x02u8; 32]);
-        let h3 = B256::from([0x03u8; 32]);
+    fn envelope_cache_eviction_is_bounded() {
+        let mut cache = EnvelopeCache::with_capacity(2);
+        let h1 = B256::from([0x10u8; 32]);
+        let h2 = B256::from([0x20u8; 32]);
+        let h3 = B256::from([0x30u8; 32]);
 
-        recent.insert_recent(Arc::new(sample_envelope(h1, 1)));
-        recent.insert_recent(Arc::new(sample_envelope(h2, 2)));
-        assert!(recent.get_recent(&h1).is_some());
-        assert!(recent.get_recent(&h2).is_some());
+        cache.insert(Arc::new(sample_envelope(h1, 1)));
+        cache.insert(Arc::new(sample_envelope(h2, 2)));
+        cache.insert(Arc::new(sample_envelope(h3, 3)));
 
-        recent.insert_recent(Arc::new(sample_envelope(h3, 3)));
-        assert!(recent.get_recent(&h1).is_none());
-        assert!(recent.get_recent(&h2).is_some());
-        assert!(recent.get_recent(&h3).is_some());
-        assert_eq!(recent.len(), 2);
+        let hashes = cache.sorted_hashes_by_block_number();
+        assert_eq!(hashes, vec![h2, h3]);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get(&h1).is_none());
+    }
+
+    #[test]
+    fn envelope_cache_remove_keeps_insertion_order_consistent() {
+        let mut cache = EnvelopeCache::with_capacity(3);
+        let h1 = B256::from([0x40u8; 32]);
+        let h2 = B256::from([0x50u8; 32]);
+        let h3 = B256::from([0x60u8; 32]);
+
+        cache.insert(Arc::new(sample_envelope(h1, 1)));
+        cache.insert(Arc::new(sample_envelope(h2, 2)));
+        cache.insert(Arc::new(sample_envelope(h3, 3)));
+        let removed = cache.remove(&h2);
+        assert!(removed.is_some());
+
+        cache.insert(Arc::new(sample_envelope(B256::from([0x70u8; 32]), 4)));
+        let hashes = cache.sorted_hashes_by_block_number();
+        assert_eq!(hashes, vec![h1, h3, B256::from([0x70u8; 32])]);
+    }
+
+    #[test]
+    fn envelope_cache_sort_tiebreak_is_deterministic() {
+        let mut cache = EnvelopeCache::with_capacity(4);
+        let h1 = B256::from([0x11u8; 32]);
+        let h2 = B256::from([0x22u8; 32]);
+        let h3 = B256::from([0x33u8; 32]);
+
+        cache.insert(Arc::new(sample_envelope(h2, 7)));
+        cache.insert(Arc::new(sample_envelope(h1, 7)));
+        cache.insert(Arc::new(sample_envelope(h3, 8)));
+
+        assert_eq!(cache.sorted_hashes_by_block_number(), vec![h1, h2, h3]);
+    }
+
+    #[test]
+    fn envelope_cache_duplicate_insert_refreshes_recency() {
+        let mut cache = EnvelopeCache::with_capacity(2);
+        let h1 = B256::from([0x44u8; 32]);
+        let h2 = B256::from([0x55u8; 32]);
+        let h3 = B256::from([0x66u8; 32]);
+
+        cache.insert(Arc::new(sample_envelope(h1, 1)));
+        cache.insert(Arc::new(sample_envelope(h2, 2)));
+        cache.insert(Arc::new(sample_envelope(h1, 3)));
+        cache.insert(Arc::new(sample_envelope(h3, 4)));
+
+        assert!(cache.get(&h1).is_some());
+        assert!(cache.get(&h2).is_none());
+        assert!(cache.get(&h3).is_some());
+        assert_eq!(cache.sorted_hashes_by_block_number().len(), 2);
     }
 
     #[test]
@@ -295,69 +339,33 @@ mod tests {
         assert!(throttle.requested_at.contains_key(&h3));
     }
 
-    #[test]
-    fn pending_cache_eviction_is_bounded() {
-        let mut cache = EnvelopeCache::with_capacity(2);
-        let h1 = B256::from([0x10u8; 32]);
-        let h2 = B256::from([0x20u8; 32]);
-        let h3 = B256::from([0x30u8; 32]);
+    #[tokio::test]
+    async fn shared_state_tracks_recent_envelopes_and_eos_markers() {
+        let state = SharedPreconfState::new(7);
+        let hash = B256::from([0x77u8; 32]);
 
-        cache.insert(Arc::new(sample_envelope(h1, 1)));
-        cache.insert(Arc::new(sample_envelope(h2, 2)));
-        cache.insert(Arc::new(sample_envelope(h3, 3)));
+        assert_eq!(state.highest_unsafe().await, 7);
+        assert!(state.get_recent(&hash).await.is_none());
 
-        let hashes = cache.sorted_hashes_by_block_number();
-        assert_eq!(hashes, vec![h2, h3]);
-        assert_eq!(cache.len(), 2);
+        state.insert_recent(Arc::new(sample_envelope(hash, 8))).await;
+        assert!(state.get_recent(&hash).await.is_some());
+
+        state.record_end_of_sequencing(42, hash).await;
+        assert_eq!(state.end_of_sequencing_for_epoch(42).await, Some(hash));
+        assert_eq!(state.end_of_sequencing_for_epoch(43).await, None);
     }
 
-    #[test]
-    fn pending_cache_remove_keeps_insertion_order_consistent() {
-        let mut cache = EnvelopeCache::with_capacity(3);
-        let h1 = B256::from([0x40u8; 32]);
-        let h2 = B256::from([0x50u8; 32]);
-        let h3 = B256::from([0x60u8; 32]);
+    #[tokio::test]
+    async fn shared_state_highest_unsafe_raise_and_set_semantics() {
+        let state = SharedPreconfState::new(10);
 
-        cache.insert(Arc::new(sample_envelope(h1, 1)));
-        cache.insert(Arc::new(sample_envelope(h2, 2)));
-        cache.insert(Arc::new(sample_envelope(h3, 3)));
-        let removed = cache.remove(&h2);
-        assert!(removed.is_some());
+        state.raise_highest_unsafe(5).await;
+        assert_eq!(state.highest_unsafe().await, 10, "raise must never lower the counter");
 
-        cache.insert(Arc::new(sample_envelope(B256::from([0x70u8; 32]), 4)));
-        let hashes = cache.sorted_hashes_by_block_number();
-        assert_eq!(hashes, vec![h1, h3, B256::from([0x70u8; 32])]);
-    }
+        state.raise_highest_unsafe(12).await;
+        assert_eq!(state.highest_unsafe().await, 12);
 
-    #[test]
-    fn pending_cache_sort_tiebreak_is_deterministic() {
-        let mut cache = EnvelopeCache::with_capacity(4);
-        let h1 = B256::from([0x11u8; 32]);
-        let h2 = B256::from([0x22u8; 32]);
-        let h3 = B256::from([0x33u8; 32]);
-
-        cache.insert(Arc::new(sample_envelope(h2, 7)));
-        cache.insert(Arc::new(sample_envelope(h1, 7)));
-        cache.insert(Arc::new(sample_envelope(h3, 8)));
-
-        assert_eq!(cache.sorted_hashes_by_block_number(), vec![h1, h2, h3]);
-    }
-
-    #[test]
-    fn pending_cache_duplicate_insert_refreshes_recency() {
-        let mut cache = EnvelopeCache::with_capacity(2);
-        let h1 = B256::from([0x44u8; 32]);
-        let h2 = B256::from([0x55u8; 32]);
-        let h3 = B256::from([0x66u8; 32]);
-
-        cache.insert(Arc::new(sample_envelope(h1, 1)));
-        cache.insert(Arc::new(sample_envelope(h2, 2)));
-        cache.insert(Arc::new(sample_envelope(h1, 3)));
-        cache.insert(Arc::new(sample_envelope(h3, 4)));
-
-        assert!(cache.get(&h1).is_some());
-        assert!(cache.get(&h2).is_none());
-        assert!(cache.get(&h3).is_some());
-        assert_eq!(cache.sorted_hashes_by_block_number().len(), 2);
+        state.set_highest_unsafe(3).await;
+        assert_eq!(state.highest_unsafe().await, 3, "set may lower after an L1 reorg rebuild");
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/error.rs
@@ -74,11 +74,6 @@ impl WhitelistPreconfirmationDriverError {
         Self::InvalidPayload(message.into())
     }
 
-    /// Build an `InvalidSignature` error from a complete message.
-    pub(crate) fn invalid_signature(message: impl Into<String>) -> Self {
-        Self::InvalidSignature(message.into())
-    }
-
     /// Map an arbitrary provider failure into an RPC provider error variant.
     pub(crate) fn provider(err: impl Display) -> Self {
         Self::Rpc(rpc::RpcClientError::Provider(err.to_string()))

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -29,22 +29,21 @@ where
 
     /// Import as many cached envelopes as possible.
     pub(super) async fn import_from_cache(&mut self) -> Result<()> {
-        let mut cache = std::mem::take(&mut self.cache);
         loop {
             let mut progressed = false;
-            let hashes = cache.sorted_hashes_by_block_number();
+            let hashes = self.cache.sorted_hashes_by_block_number();
 
             for hash in hashes {
-                let Some(entry) = cache.get(&hash) else {
+                let Some(entry) = self.cache.get(&hash).cloned() else {
                     continue;
                 };
                 WhitelistPreconfirmationDriverMetrics::inc_cache_import_attempt();
-                match self.try_import_cached(entry).await {
+                match self.try_import_cached(&entry).await {
                     Ok(true) => {
                         WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
                             "progressed",
                         );
-                        cache.remove(&hash);
+                        self.cache.remove(&hash);
                         progressed = true;
                     }
                     Ok(false) => {
@@ -69,15 +68,14 @@ where
                             error = %err,
                             "dropping cached whitelist preconfirmation payload after invalid import"
                         );
-                        cache.remove(&hash);
+                        self.cache.remove(&hash);
                         progressed = true;
                     }
                     Err(err) => {
                         WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
                             "fatal_error",
                         );
-                        self.cache = cache;
-                        self.update_cache_gauges();
+                        self.update_pending_cache_gauge();
                         return Err(err);
                     }
                 }
@@ -88,8 +86,7 @@ where
             }
         }
 
-        self.cache = cache;
-        self.update_cache_gauges();
+        self.update_pending_cache_gauge();
         Ok(())
     }
 
@@ -171,10 +168,7 @@ where
             "inserted whitelist preconfirmation block"
         );
 
-        if let Some(ref highest) = self.highest_unsafe_l2_payload_block_id {
-            let mut guard = highest.lock().await;
-            *guard = block_number.max(*guard);
-        }
+        self.state.raise_highest_unsafe(block_number).await;
 
         Ok(true)
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -1,4 +1,9 @@
 //! Ingress entrypoints for unsafe payload and response handling.
+//!
+//! Signature authenticity and operator-set membership are enforced at gossip
+//! acceptance time in the network layer's inbound validation
+//! (`network::handler::GossipsubInboundState`) before events are forwarded
+//! here, so these entrypoints perform payload-level validation only.
 
 use std::sync::Arc;
 
@@ -7,10 +12,8 @@ use alloy_provider::Provider;
 use tracing::debug;
 
 use crate::{
-    codec::{
-        DecodedUnsafePayload, WhitelistExecutionPayloadEnvelope, block_signing_hash, recover_signer,
-    },
-    error::{Result, WhitelistPreconfirmationDriverError},
+    codec::{DecodedUnsafePayload, WhitelistExecutionPayloadEnvelope},
+    error::Result,
     metrics::WhitelistPreconfirmationDriverMetrics,
 };
 
@@ -33,8 +36,8 @@ where
         ingress_source: &'static str,
     ) {
         self.cache.insert(envelope.clone());
-        self.recent_cache.insert_recent(envelope.clone());
-        self.update_cache_gauges();
+        self.update_pending_cache_gauge();
+        self.state.insert_recent(envelope.clone()).await;
         self.record_eos_epoch_if_marked(&envelope, ingress_source).await;
     }
 
@@ -63,21 +66,15 @@ where
                 ingress_source,
                 "recording end-of-sequencing envelope for epoch"
             );
-            self.cache_state
-                .record_end_of_sequencing(epoch, envelope.execution_payload.block_hash)
-                .await;
+            self.state.record_end_of_sequencing(epoch, envelope.execution_payload.block_hash).await;
         }
     }
 
-    /// Handle an incoming unsafe payload.
+    /// Handle an incoming unsafe payload from the `preconfBlocks` topic.
     pub(super) async fn handle_unsafe_payload(
         &mut self,
         payload: DecodedUnsafePayload,
     ) -> Result<()> {
-        let prehash = block_signing_hash(self.chain_id, payload.payload_bytes.as_slice());
-        let signer = recover_signer(prehash, &payload.wire_signature)?;
-        self.ensure_signer_allowed(signer)?;
-
         let envelope = normalize_unsafe_payload_envelope(payload.envelope, payload.wire_signature);
         validate_execution_payload_for_preconf(
             &envelope.execution_payload,
@@ -94,30 +91,11 @@ where
         Ok(())
     }
 
-    /// Handle an incoming unsafe response (gossip or direct).
-    ///
-    /// The embedded `envelope.signature` is verified over
-    /// `block_signing_hash(chain_id, block_hash)`. This matches the signing
-    /// domain used by the sequencer when it stores the signature in L1 origin
-    /// (see `rest_handler.rs` — `set_l1_origin_signature`).  It is distinct
-    /// from the gossip *wire* signature on the `preconfBlocks` topic, which
-    /// signs SSZ envelope bytes instead.
+    /// Handle an incoming unsafe response from the `responsePreconfBlocks` topic.
     pub(super) async fn handle_unsafe_response(
         &mut self,
         envelope: WhitelistExecutionPayloadEnvelope,
     ) -> Result<()> {
-        let Some(signature) = envelope.signature else {
-            return Err(WhitelistPreconfirmationDriverError::invalid_signature(
-                "response payload is missing embedded signature",
-            ));
-        };
-
-        // Signing domain: block_signing_hash(chain_id, block_hash).
-        let prehash =
-            block_signing_hash(self.chain_id, envelope.execution_payload.block_hash.as_slice());
-        let signer = recover_signer(prehash, &signature)?;
-        self.ensure_signer_allowed(signer)?;
-
         validate_execution_payload_for_preconf(
             &envelope.execution_payload,
             self.chain_id,
@@ -136,7 +114,7 @@ where
 
     /// Handle a block-hash request from the request topic.
     pub(super) async fn handle_unsafe_request(&mut self, hash: B256) -> Result<()> {
-        let (envelope, result_label) = if let Some(envelope) = self.recent_cache.get_recent(&hash) {
+        let (envelope, result_label) = if let Some(envelope) = self.state.get_recent(&hash).await {
             (envelope, "cache_hit")
         } else if let Some(envelope) = self.build_response_envelope_from_l2(hash).await? {
             (Arc::new(envelope), "l2_hit")
@@ -146,8 +124,7 @@ where
         };
 
         WhitelistPreconfirmationDriverMetrics::inc_response_lookup(result_label);
-        self.recent_cache.insert_recent(envelope.clone());
-        self.update_cache_gauges();
+        self.state.insert_recent(envelope.clone()).await;
         self.publish_unsafe_response(envelope).await;
         Ok(())
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -6,15 +6,14 @@ use alloy_primitives::{Address, B256};
 use alloy_provider::Provider;
 use driver::sync::event::EventSyncer;
 use rpc::{beacon::BeaconClient, client::Client};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use crate::{
-    cache::{EnvelopeCache, RecentEnvelopeCache, RequestThrottle, SharedPreconfCacheState},
+    cache::{EnvelopeCache, PENDING_ENVELOPE_CAPACITY, RequestThrottle, SharedPreconfState},
     error::{Result, WhitelistPreconfirmationDriverError},
     metrics::WhitelistPreconfirmationDriverMetrics,
     network::{NetworkCommand, NetworkEvent},
-    operator_set::SharedOperatorSet,
 };
 
 /// Cache re-import flow for out-of-order envelopes once parents arrive.
@@ -41,21 +40,22 @@ where
     pub(crate) event_syncer: Arc<EventSyncer<P>>,
     /// RPC client used for L1/L2 reads and head-origin updates.
     pub(crate) rpc: Client<P>,
-    /// Shared operator set for signer validation.
-    pub(crate) operator_set: SharedOperatorSet,
     /// Chain id used for preconfirmation signature domain separation.
     pub(crate) chain_id: u64,
     /// Command channel used to publish P2P requests/responses.
     pub(crate) network_command_tx: mpsc::Sender<NetworkCommand>,
-    /// Shared cache state used by status and EOS signaling.
-    pub(crate) cache_state: SharedPreconfCacheState,
+    /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).
+    pub(crate) state: SharedPreconfState,
     /// Beacon client used for EOS epoch validation.
     pub(crate) beacon_client: Arc<BeaconClient>,
-    /// Shared highest unsafe L2 payload block ID (updated on P2P import when REST server enabled).
-    pub(crate) highest_unsafe_l2_payload_block_id: Option<Arc<Mutex<u64>>>,
 }
 
 /// Imports whitelist preconfirmation payloads into the driver after event sync catches up.
+///
+/// Signature authenticity and operator-set membership of inbound gossip are
+/// enforced once, at gossip acceptance time in
+/// [`crate::network`]'s inbound validation state, before events reach this
+/// importer. The importer performs payload-level validation only.
 pub(crate) struct WhitelistPreconfirmationImporter<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
@@ -66,22 +66,16 @@ where
     rpc: Client<P>,
     /// Chain id used for preconfirmation signature domain separation.
     chain_id: u64,
-    /// Shared cache state used by status and EOS signaling.
-    cache_state: SharedPreconfCacheState,
+    /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).
+    state: SharedPreconfState,
     /// Beacon client used for EOS epoch validation.
     beacon_client: Arc<BeaconClient>,
     /// Out-of-order payload cache waiting for parent availability.
     cache: EnvelopeCache,
-    /// Recently accepted envelopes that can be served over response topic requests.
-    recent_cache: RecentEnvelopeCache,
     /// Cooldown gate for repeated missing-parent requests.
     request_throttle: RequestThrottle,
-    /// Lock-free shared set of allowed sequencer addresses, refreshed by background poller.
-    operator_set: SharedOperatorSet,
     /// Command channel used to publish P2P requests/responses.
     network_command_tx: mpsc::Sender<NetworkCommand>,
-    /// Shared highest unsafe L2 payload block ID (updated on P2P import when REST server enabled).
-    highest_unsafe_l2_payload_block_id: Option<Arc<Mutex<u64>>>,
     /// Latched flag indicating event sync has exposed a head L1 origin.
     sync_ready: bool,
     /// Shasta anchor contract address used to validate the first transaction.
@@ -97,12 +91,10 @@ where
         let WhitelistPreconfirmationImporterParams {
             event_syncer,
             rpc,
-            operator_set,
             chain_id,
             network_command_tx,
-            cache_state,
+            state,
             beacon_client,
-            highest_unsafe_l2_payload_block_id,
         } = params;
         let anchor_address = *rpc.shasta.anchor.address();
 
@@ -110,18 +102,15 @@ where
             event_syncer,
             rpc,
             chain_id,
-            cache_state,
+            state,
             beacon_client,
-            cache: EnvelopeCache::default(),
-            recent_cache: RecentEnvelopeCache::default(),
+            cache: EnvelopeCache::with_capacity(PENDING_ENVELOPE_CAPACITY),
             request_throttle: RequestThrottle::default(),
-            operator_set,
             network_command_tx,
-            highest_unsafe_l2_payload_block_id,
             sync_ready: false,
             anchor_address,
         };
-        importer.update_cache_gauges();
+        importer.update_pending_cache_gauge();
         importer
     }
 
@@ -197,7 +186,7 @@ where
     /// Handle an incoming end-of-sequencing request by serving from the recent
     /// cache, falling back to an L2 rebuild, or recording a miss.
     async fn handle_eos_request(&mut self, epoch: u64) -> Result<()> {
-        let Some(hash) = self.cache_state.end_of_sequencing_for_epoch(epoch).await else {
+        let Some(hash) = self.state.end_of_sequencing_for_epoch(epoch).await else {
             WhitelistPreconfirmationDriverMetrics::inc_importer_event(
                 "end_of_sequencing_request",
                 "miss",
@@ -206,7 +195,7 @@ where
         };
 
         // Fast path: envelope still lives in the recent cache.
-        if let Some(envelope) = self.recent_cache.get_recent(&hash) {
+        if let Some(envelope) = self.state.get_recent(&hash).await {
             self.publish_unsafe_response(envelope).await;
             WhitelistPreconfirmationDriverMetrics::inc_importer_event(
                 "end_of_sequencing_request",
@@ -226,25 +215,13 @@ where
 
         envelope.end_of_sequencing = Some(true);
         let envelope = Arc::new(envelope);
-        self.recent_cache.insert_recent(envelope.clone());
-        self.update_cache_gauges();
+        self.state.insert_recent(envelope.clone()).await;
         self.publish_unsafe_response(envelope).await;
         WhitelistPreconfirmationDriverMetrics::inc_importer_event(
             "end_of_sequencing_request",
             "served",
         );
         Ok(())
-    }
-
-    /// Validate that the recovered signer is present in the shared operator set.
-    pub(super) fn ensure_signer_allowed(&self, signer: Address) -> Result<()> {
-        if self.operator_set.load().contains(&signer) {
-            Ok(())
-        } else {
-            Err(WhitelistPreconfirmationDriverError::invalid_signature(format!(
-                "signer {signer} is not a registered operator"
-            )))
-        }
     }
 
     /// Refresh whether sync is ready.
@@ -293,10 +270,9 @@ where
             .map_err(WhitelistPreconfirmationDriverError::provider)
     }
 
-    /// Update cache gauges after cache mutations.
-    pub(super) fn update_cache_gauges(&self) {
+    /// Update the pending-cache gauge after pending-cache mutations.
+    pub(super) fn update_pending_cache_gauge(&self) {
         WhitelistPreconfirmationDriverMetrics::set_cache_pending_count(self.cache.len());
-        WhitelistPreconfirmationDriverMetrics::set_cache_recent_count(self.recent_cache.len());
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -32,7 +32,7 @@ use super::{
 use crate::{
     codec::{
         DecodedUnsafePayload, WhitelistExecutionPayloadEnvelope, decode_envelope_ssz,
-        decode_unsafe_payload_signature, decode_unsafe_response_message, encode_envelope_ssz,
+        decode_unsafe_payload_signature, decode_unsafe_response_message,
         encode_eos_request_message, encode_unsafe_payload_message, encode_unsafe_request_message,
         encode_unsafe_response_message,
     },
@@ -501,7 +501,7 @@ struct NetworkRuntime {
     peer_status_log_interval: Interval,
     /// Inbound validation and dedupe state for gossipsub messages.
     inbound_validation_state: GossipsubInboundState,
-    /// Peer id used by loopback payload events.
+    /// Local peer id used to ignore self-propagated gossip.
     peer_id_for_events: PeerId,
 }
 
@@ -523,7 +523,7 @@ impl NetworkRuntime {
                     None => Ok(false),
                     Some(NetworkCommand::Shutdown) => Ok(false),
                     Some(command) => {
-                        self.handle_command(command).await?;
+                        self.handle_command(command);
                         Ok(true)
                     },
                 }
@@ -548,7 +548,7 @@ impl NetworkRuntime {
     }
 
     /// Execute one outbound network command.
-    async fn handle_command(&mut self, command: NetworkCommand) -> Result<()> {
+    fn handle_command(&mut self, command: NetworkCommand) {
         match command {
             NetworkCommand::PublishUnsafeRequest { hash } => {
                 self.publish_unsafe_request(hash);
@@ -557,15 +557,13 @@ impl NetworkRuntime {
                 self.publish_unsafe_response(envelope);
             }
             NetworkCommand::PublishUnsafePayload { signature, envelope } => {
-                self.publish_unsafe_payload(signature, envelope).await?;
+                self.publish_unsafe_payload(signature, envelope);
             }
             NetworkCommand::PublishEndOfSequencingRequest { epoch } => {
                 self.publish_end_of_sequencing_request(epoch);
             }
             NetworkCommand::Shutdown => unreachable!("handled in run_once"),
         }
-
-        Ok(())
     }
 
     /// Publish a `requestPreconfBlocks` message.
@@ -590,38 +588,19 @@ impl NetworkRuntime {
         );
     }
 
-    /// Publish a `preconfBlocks` message and emit loopback event for local cache/import.
-    async fn publish_unsafe_payload(
+    /// Publish a `preconfBlocks` message.
+    fn publish_unsafe_payload(
         &mut self,
         signature: [u8; 65],
         envelope: Arc<WhitelistExecutionPayloadEnvelope>,
-    ) -> Result<()> {
+    ) {
         let hash = envelope.execution_payload.block_hash;
-
-        // Loop back locally-built payloads so importer caches can serve
-        // follow-up EOS catch-up requests even without peer echo.
-        let payload_bytes = encode_envelope_ssz(&envelope);
-        let local_event = NetworkEvent::UnsafePayload {
-            from: self.peer_id_for_events,
-            payload: DecodedUnsafePayload {
-                wire_signature: signature,
-                payload_bytes,
-                envelope: (*envelope).clone(),
-            },
-        };
-
-        // Loopback first so downstream cache/import logic observes the
-        // payload even when there are no peers to echo it back.
-        forward_event(&self.event_tx, local_event).await?;
-
         self.encode_and_publish(
             encode_unsafe_payload_message(&signature, &envelope),
             self.topics.preconf_blocks.clone(),
             "preconf_blocks",
             &format!("{hash}"),
         );
-
-        Ok(())
     }
 
     /// Publish a `requestEndOfSequencingPreconfBlocks` message.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -8,7 +8,6 @@ use alloy_provider::Provider;
 use driver::DriverConfig;
 use protocol::signer::FixedKSigner;
 use rpc::beacon::BeaconClient;
-use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use crate::{
@@ -17,7 +16,7 @@ use crate::{
         WhitelistApiServer, WhitelistApiServerConfig, WhitelistApiService,
         WhitelistApiServiceParams,
     },
-    cache::{L1_EPOCH_DURATION_SECS, SharedPreconfCacheState},
+    cache::{L1_EPOCH_DURATION_SECS, SharedPreconfState},
     error::WhitelistPreconfirmationDriverError,
     importer::{WhitelistPreconfirmationImporter, WhitelistPreconfirmationImporterParams},
     network::{NetworkCommand, NetworkConfig, WhitelistNetwork},
@@ -81,7 +80,6 @@ impl WhitelistPreconfirmationDriverRunner {
         let network =
             WhitelistNetwork::spawn(chain_id, self.config.p2p_config.clone(), operator_set.clone())
                 .await?;
-        let cache_state = SharedPreconfCacheState::new();
         let beacon_client = Arc::new(
             BeaconClient::new(self.config.driver_config.l1_beacon_endpoint.clone()).await.map_err(
                 |err| WhitelistPreconfirmationDriverError::RestWsServerBeaconInit {
@@ -95,73 +93,67 @@ impl WhitelistPreconfirmationDriverRunner {
             "whitelist preconfirmation p2p subscriber started"
         );
 
-        // Optionally start the REST/WS server when both rpc_listen_addr and p2p_signer_key
-        // are configured. When enabled, create shared state for highestUnsafeL2PayloadBlockID
-        // so the importer can update it on P2P imports.
-        let (mut rest_ws_server, shared_highest_unsafe) =
-            if let (Some(listen_addr), Some(signer_key)) =
-                (self.config.rpc_listen_addr, &self.config.p2p_signer_key)
-            {
-                let signer = FixedKSigner::new(signer_key).map_err(|e| {
-                    WhitelistPreconfirmationDriverError::Signing(format!(
-                        "failed to create P2P signer: {e}"
-                    ))
-                })?;
-                let initial_highest_unsafe_l2_payload_block_id = preconf_ingress_sync
-                    .client()
-                    .l2_provider
-                    .get_block_by_number(BlockNumberOrTag::Latest)
-                    .await
-                    .map_err(WhitelistPreconfirmationDriverError::provider)?
-                    .ok_or_else(|| {
-                        WhitelistPreconfirmationDriverError::provider(
-                            "latest L2 block unavailable during whitelist REST/WS startup",
-                        )
-                    })?
-                    .header
-                    .number;
-                let shared_highest =
-                    Arc::new(Mutex::new(initial_highest_unsafe_l2_payload_block_id));
+        // Seed the shared highest-unsafe counter with the current L2 head.
+        let initial_highest_unsafe_l2_payload_block_id = preconf_ingress_sync
+            .client()
+            .l2_provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await
+            .map_err(WhitelistPreconfirmationDriverError::provider)?
+            .ok_or_else(|| {
+                WhitelistPreconfirmationDriverError::provider(
+                    "latest L2 block unavailable during whitelist driver startup",
+                )
+            })?
+            .header
+            .number;
+        let state = SharedPreconfState::new(initial_highest_unsafe_l2_payload_block_id);
 
-                let handler = Arc::new(WhitelistApiService::new(WhitelistApiServiceParams {
-                    event_syncer: preconf_ingress_sync.event_syncer(),
-                    rpc: preconf_ingress_sync.client().clone(),
-                    chain_id,
-                    signer,
-                    beacon_client: Arc::clone(&beacon_client),
-                    operator_set: operator_set.clone(),
-                    highest_unsafe_l2_payload_block_id: shared_highest.clone(),
-                    network_command_tx: network.command_tx.clone(),
-                    cache_state: cache_state.clone(),
-                    peer_id: network.peer_id.to_string(),
-                }));
-                let server_config = WhitelistApiServerConfig {
-                    listen_addr,
-                    jwt_secret: self.config.rpc_jwt_secret.clone(),
-                    cors_origins: self.config.rpc_cors_origins.clone(),
-                };
-                let server = WhitelistApiServer::start(server_config, handler.clone()).await?;
-                info!(
-                    addr = %server.local_addr(),
-                    http_url = %server.http_url(),
-                    ws_url = %server.ws_url(),
-                    "whitelist preconfirmation REST server started"
-                );
-                (Some(server), Some(shared_highest))
-            } else {
-                (None, None)
+        // Optionally start the REST/WS server when both rpc_listen_addr and p2p_signer_key
+        // are configured.
+        let mut rest_ws_server = if let (Some(listen_addr), Some(signer_key)) =
+            (self.config.rpc_listen_addr, &self.config.p2p_signer_key)
+        {
+            let signer = FixedKSigner::new(signer_key).map_err(|e| {
+                WhitelistPreconfirmationDriverError::Signing(format!(
+                    "failed to create P2P signer: {e}"
+                ))
+            })?;
+            let handler = Arc::new(WhitelistApiService::new(WhitelistApiServiceParams {
+                event_syncer: preconf_ingress_sync.event_syncer(),
+                rpc: preconf_ingress_sync.client().clone(),
+                chain_id,
+                signer,
+                beacon_client: Arc::clone(&beacon_client),
+                operator_set: operator_set.clone(),
+                state: state.clone(),
+                network_command_tx: network.command_tx.clone(),
+            }));
+            let server_config = WhitelistApiServerConfig {
+                listen_addr,
+                jwt_secret: self.config.rpc_jwt_secret.clone(),
+                cors_origins: self.config.rpc_cors_origins.clone(),
             };
+            let server = WhitelistApiServer::start(server_config, handler.clone()).await?;
+            info!(
+                addr = %server.local_addr(),
+                http_url = %server.http_url(),
+                ws_url = %server.ws_url(),
+                "whitelist preconfirmation REST server started"
+            );
+            Some(server)
+        } else {
+            None
+        };
 
         let mut importer =
             WhitelistPreconfirmationImporter::new(WhitelistPreconfirmationImporterParams {
                 event_syncer: preconf_ingress_sync.event_syncer(),
                 rpc: preconf_ingress_sync.client().clone(),
-                operator_set: operator_set.clone(),
                 chain_id,
                 network_command_tx: network.command_tx.clone(),
-                cache_state,
+                state,
                 beacon_client,
-                highest_unsafe_l2_payload_block_id: shared_highest_unsafe,
             });
         let mut sync_ready_interval =
             tokio::time::interval(tokio::time::Duration::from_secs(L1_EPOCH_DURATION_SECS));


### PR DESCRIPTION
## Summary

Phases 3–6 of the whitelist driver simplification plan (follow-up to #21768; net **−213 lines**). All REST wire formats are byte-for-byte unchanged. Verified with clippy (`-D warnings -D missing_docs -D clippy::missing_docs_in_private_items`), 111/111 unit tests, and an independent adversarial review pass over the diff focused on the trust-boundary change.

### Phase 3 — type unification
- **One cache type**: `EnvelopeCache` and `RecentEnvelopeCache` were the same capacity-bounded `LinkedHashMap`; merged into one `EnvelopeCache`.
- **One request type**: the internal flat `BuildPreconfBlockRequest` duplicated all 9 fields of the REST wire type; the wire shape (nested `executableData`) is now the single `BuildPreconfBlockRequest`. The "executable data is required" check moved from the HTTP handler into the service (still 400; message now prefixed `invalid payload format:`).
- **One status type**: internal `WhitelistStatus` carried two fields always set to the same value plus three fields never serialized; merged into the wire `ApiStatus`.
- **`is_sync_ready()` fast path**: `POST /preconfBlocks` previously called `get_status()` — two RPC reads plus a lock — just to read one bool. It now reads `event_syncer.is_preconf_ingress_ready()` directly, and `GET /status` drops its now-unused `head_l1_origin` RPC read.

### Phase 4 — HTTP plumbing
- The hand-rolled body-streaming loop in `http_utils.rs` is now `http_body_util::Limited` + `collect()`; `json_response` uses `axum::Json`. The 413 (too large) vs 422 (read/parse error) mapping is preserved and covered by existing end-to-end tests.

### Phase 5 — validation dedup ⚠️ (trust-boundary change, please review closely)
The importer previously **re-recovered ECDSA signatures and re-checked the operator allowlist** for every inbound payload and response — duplicating, with a second copy of the signing-domain logic, what `GossipsubInboundState` already enforces at gossip acceptance time. The importer-side recovery is removed.

Why this is safe:
- Every `NetworkEvent::UnsafePayload` / `UnsafeResponse` is forwarded **only** from the `Accept` branch of the gossip handler, which recovers the signer (SSZ-bytes domain for payloads, block-hash domain for responses) and checks operator-set membership (`network/handler.rs`).
- `forward_event` / `event_tx` are private to `NetworkRuntime`; with the loopback gone (phase 6) there is no other producer of these events.
- Deep payload validation (anchor transaction, tx-list decode, header difficulty, shape) remains in the importer.

Net effect: one signature recovery per message instead of two, and a single implementation of each signing domain instead of two copies that could drift.

### Phase 6 — state consolidation
- The three separate sharing mechanisms — `SharedPreconfCacheState` (EOS map), the importer-owned recent cache, and an `Option<Arc<Mutex<u64>>>` highest-unsafe counter threaded through two constructors — are now one `SharedPreconfState` shared by the importer and API service.
- **Loopback removed**: locally built blocks were round-tripped through a fake inbound network event so the importer would cache them. The API service now inserts the built envelope into the shared recent cache directly before publishing; EOS catch-up and request-topic serving behavior is unchanged.
- The highest-unsafe counter is now seeded from the L2 head unconditionally at startup (previously only when the REST server was enabled), so `cache_import` drops its `Option` dance.

### Behavior notes (intentional, minor)
- A request with missing `executableData` now counts toward `can_shutdown`'s activity window (receipt is marked before validation); previously it was rejected before marking.
- Locally built blocks no longer transit the pending cache (they were imported-then-dropped as "already inserted" on the next tick — pure overhead).
- The driver now requires the L2 latest-block read at startup even when the REST server is disabled (it already required L2 connectivity to function).

## Test plan

- `cargo nextest run -p whitelist-preconfirmation-driver` — 111/111 pass (new unit tests for `SharedPreconfState` raise/set semantics and recent/EOS tracking)
- `cargo clippy -p whitelist-preconfirmation-driver -p taiko-client --all-features --no-deps -- -D warnings -D missing_docs -D clippy::missing_docs_in_private_items` — clean
- Independent review agent pass over the diff (deadlock check on the new `tokio::Mutex`es, wire-format diff, validation-gating audit) — no findings
- Suggest a devnet run before undrafting to exercise the EOS catch-up and request/response paths end-to-end