### PR TITLE
fix(preconfirmation-p2p): activate gossipsub peer scoring

### DIFF
--- a/packages/preconfirmation-p2p/crates/net/src/behaviour.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/behaviour.rs
@@ -139,7 +139,10 @@ impl NetBehaviour {
 /// requires penalty weights to be negative and rejects the whole parameter set otherwise,
 /// so it is applied as `-2.0`. Mesh-delivery penalties (P3/P3b) are not part of the spec
 /// profile and are explicitly disabled; their libp2p defaults would penalize peers on
-/// quiet topics.
+/// quiet topics. The IP-colocation, behaviour, and slow-peer penalties are disabled for
+/// the same reason: their libp2p defaults would graylist healthy peers in small or
+/// co-hosted deployments (e.g. several sidecars behind one NAT), and per ARCHITECTURE.md
+/// colocation/abuse protection relies on connection limits and request rate limiting.
 fn peer_score_settings(
     topics: &(IdentTopic, IdentTopic),
 ) -> (gossipsub::PeerScoreParams, gossipsub::PeerScoreThresholds) {
@@ -175,6 +178,11 @@ fn peer_score_settings(
     let params = PeerScoreParams {
         topics: topic_params,
         app_specific_weight: 1.0,
+        // Non-spec penalty components: disable explicitly instead of inheriting the
+        // libp2p defaults (-5.0 / -10.0 / -0.2), which would penalize healthy peers.
+        ip_colocation_factor_weight: 0.0,
+        behaviour_penalty_weight: 0.0,
+        slow_peer_weight: 0.0,
         decay_interval: Duration::from_secs(10),
         decay_to_zero: 0.1,
         retain_score: Duration::from_secs(3600),
@@ -218,6 +226,20 @@ mod tests {
         let (params, thresholds) = peer_score_settings(&topics);
         params.validate().expect("peer score params must pass gossipsub validation");
         thresholds.validate().expect("peer score thresholds must pass gossipsub validation");
+    }
+
+    #[test]
+    fn peer_score_settings_disable_non_spec_penalties() {
+        let (_, topics, _, _) = behaviour_inputs();
+        let (params, _) = peer_score_settings(&topics);
+        // Not part of the spec §7.1 profile; must not be inherited from libp2p defaults.
+        assert_eq!(params.ip_colocation_factor_weight, 0.0);
+        assert_eq!(params.behaviour_penalty_weight, 0.0);
+        assert_eq!(params.slow_peer_weight, 0.0);
+        for topic_params in params.topics.values() {
+            assert_eq!(topic_params.mesh_message_deliveries_weight, 0.0);
+            assert_eq!(topic_params.mesh_failure_penalty_weight, 0.0);
+        }
     }
 
     #[test]

--- a/packages/preconfirmation-p2p/crates/net/src/behaviour.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/behaviour.rs
@@ -82,41 +82,10 @@ impl NetBehaviour {
             .map_err(|e| anyhow::anyhow!("subscribe raw txlists: {e}"))?;
 
         // Spec §7.1 scoring: enable gossipsub v1.1 scoring with app feedback-like weights.
-        use libp2p::gossipsub::{PeerScoreParams, PeerScoreThresholds, TopicScoreParams};
-        let thresholds = PeerScoreThresholds {
-            gossip_threshold: -1.0,
-            publish_threshold: -2.0,
-            graylist_threshold: -5.0,
-            accept_px_threshold: 0.0,
-            opportunistic_graft_threshold: 0.5,
-        };
-
-        // Build per-topic params aligned with the spec defaults.
-        let mut topic_params = HashMap::new();
-        for topic in [&topics.0, &topics.1] {
-            let p = TopicScoreParams {
-                invalid_message_deliveries_weight: 2.0,
-                invalid_message_deliveries_decay: 0.99,
-                first_message_deliveries_weight: 0.5,
-                first_message_deliveries_decay: 0.999,
-                time_in_mesh_weight: 0.0,
-                time_in_mesh_quantum: Duration::from_secs(1),
-                time_in_mesh_cap: 3600.0,
-                ..Default::default()
-            };
-            topic_params.insert(topic.hash().clone(), p);
-        }
-
-        let params = PeerScoreParams {
-            topics: topic_params,
-            app_specific_weight: 1.0,
-            decay_interval: Duration::from_secs(10),
-            decay_to_zero: 0.1,
-            retain_score: Duration::from_secs(3600),
-            ..Default::default()
-        };
-
-        let _ = gossipsub.with_peer_score(params, thresholds);
+        let (score_params, score_thresholds) = peer_score_settings(&topics);
+        gossipsub
+            .with_peer_score(score_params, score_thresholds)
+            .map_err(|e| anyhow::anyhow!("gossipsub peer score: {e}"))?;
 
         let reqresp_cfg = rr::Config::default()
             .with_request_timeout(cfg.request_timeout)
@@ -160,5 +129,105 @@ impl NetBehaviour {
             block_list,
             conn_limits,
         })
+    }
+}
+
+/// Builds the gossipsub v1.1 peer-score parameters and thresholds for the
+/// preconfirmation topics per spec §7.1.
+///
+/// The spec's `invalidMessageDeliveriesWeight: 2.0` is a penalty magnitude: gossipsub
+/// requires penalty weights to be negative and rejects the whole parameter set otherwise,
+/// so it is applied as `-2.0`. Mesh-delivery penalties (P3/P3b) are not part of the spec
+/// profile and are explicitly disabled; their libp2p defaults would penalize peers on
+/// quiet topics.
+fn peer_score_settings(
+    topics: &(IdentTopic, IdentTopic),
+) -> (gossipsub::PeerScoreParams, gossipsub::PeerScoreThresholds) {
+    use libp2p::gossipsub::{PeerScoreParams, PeerScoreThresholds, TopicScoreParams};
+    let thresholds = PeerScoreThresholds {
+        gossip_threshold: -1.0,
+        publish_threshold: -2.0,
+        graylist_threshold: -5.0,
+        accept_px_threshold: 0.0,
+        opportunistic_graft_threshold: 0.5,
+    };
+
+    // Build per-topic params aligned with the spec defaults.
+    let mut topic_params = HashMap::new();
+    for topic in [&topics.0, &topics.1] {
+        let p = TopicScoreParams {
+            topic_weight: 1.0,
+            invalid_message_deliveries_weight: -2.0,
+            invalid_message_deliveries_decay: 0.99,
+            first_message_deliveries_weight: 0.5,
+            first_message_deliveries_decay: 0.999,
+            first_message_deliveries_cap: 20.0,
+            time_in_mesh_weight: 0.0,
+            time_in_mesh_quantum: Duration::from_secs(1),
+            time_in_mesh_cap: 3600.0,
+            mesh_message_deliveries_weight: 0.0,
+            mesh_failure_penalty_weight: 0.0,
+            ..Default::default()
+        };
+        topic_params.insert(topic.hash().clone(), p);
+    }
+
+    let params = PeerScoreParams {
+        topics: topic_params,
+        app_specific_weight: 1.0,
+        decay_interval: Duration::from_secs(10),
+        decay_to_zero: 0.1,
+        retain_score: Duration::from_secs(3600),
+        ..Default::default()
+    };
+
+    (params, thresholds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::gossipsub::{PeerScoreParams, PeerScoreThresholds};
+
+    /// Builds the inputs needed to construct a `NetBehaviour` in tests.
+    fn behaviour_inputs() -> (
+        libp2p::identity::Keypair,
+        (IdentTopic, IdentTopic),
+        crate::codec::Protocols,
+        crate::config::NetworkConfig,
+    ) {
+        let chain_id = 167_000;
+        (
+            libp2p::identity::Keypair::generate_ed25519(),
+            (
+                IdentTopic::new(preconfirmation_types::topic_preconfirmation_commitments(chain_id)),
+                IdentTopic::new(preconfirmation_types::topic_raw_txlists(chain_id)),
+            ),
+            crate::codec::Protocols {
+                commitments: preconfirmation_types::protocol_get_commitments_by_number(chain_id),
+                raw_txlists: preconfirmation_types::protocol_get_raw_txlist(chain_id),
+                head: preconfirmation_types::protocol_get_head(chain_id),
+            },
+            crate::config::NetworkConfig::default(),
+        )
+    }
+
+    #[test]
+    fn peer_score_settings_satisfy_gossipsub_validation() {
+        let (_, topics, _, _) = behaviour_inputs();
+        let (params, thresholds) = peer_score_settings(&topics);
+        params.validate().expect("peer score params must pass gossipsub validation");
+        thresholds.validate().expect("peer score thresholds must pass gossipsub validation");
+    }
+
+    #[test]
+    fn new_activates_gossipsub_peer_scoring() {
+        let (keypair, topics, protocols, cfg) = behaviour_inputs();
+        let mut behaviour = NetBehaviour::new(keypair, topics, protocols, &cfg).expect("behaviour");
+        // Scoring must already be active, so a second activation attempt is rejected.
+        let second = behaviour
+            .gossipsub
+            .with_peer_score(PeerScoreParams::default(), PeerScoreThresholds::default());
+        assert!(second.is_err(), "peer scoring was not activated during construction");
     }
 }

--- a/packages/preconfirmation-p2p/crates/net/src/driver/mod.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/driver/mod.rs
@@ -80,6 +80,13 @@ pub struct NetworkDriver {
     storage: Arc<dyn PreconfStorage>,
 }
 
+/// Lower bound of the gossipsub app-specific score mirrored from the local reputation
+/// store (spec §7.1 appScore clamp).
+const APP_SCORE_MIN: f64 = -10.0;
+/// Upper bound of the gossipsub app-specific score mirrored from the local reputation
+/// store (spec §7.1 appScore clamp).
+const APP_SCORE_MAX: f64 = 10.0;
+
 /// Builds a `ConnectionGater` instance based on the provided `NetworkConfig`.
 fn build_kona_gater(cfg: &NetworkConfig) -> ConnectionGater {
     let mut gater = ConnectionGater::new(KonaGaterConfig {
@@ -223,6 +230,12 @@ impl NetworkDriver {
     /// Applies a reputation action to a given peer and enforces bans/greylists.
     fn apply_reputation(&mut self, peer: PeerId, action: PeerAction) {
         let ev = self.reputation.apply(peer, action);
+        // Mirror the local reputation into gossipsub's app-specific score (spec §7.1) so
+        // application feedback influences mesh membership and propagation decisions.
+        // `set_application_score` returns false for peers gossipsub no longer tracks;
+        // that is fine for a best-effort mirror.
+        let app_score = ev.new_score.clamp(APP_SCORE_MIN, APP_SCORE_MAX);
+        let _ = self.swarm.behaviour_mut().gossipsub.set_application_score(&ev.peer, app_score);
         if ev.is_banned && !ev.was_banned {
             metrics::inc("p2p_reputation_ban");
             self.swarm.behaviour_mut().block_list.block_peer(ev.peer);

--- a/packages/preconfirmation-p2p/crates/net/src/driver/tests.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/driver/tests.rs
@@ -460,6 +460,57 @@ async fn reqresp_errors_when_no_peer_available() {
     assert_eq!(err.kind, NetworkErrorKind::ReqRespBackpressure);
 }
 
+/// Local reputation changes are mirrored into gossipsub's app-specific score (spec §7.1),
+/// clamped to the spec's appScore bounds.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reputation_mirrors_into_gossipsub_app_score() {
+    let cfg = NetworkConfig { enable_discovery: false, ..Default::default() };
+    let parts1 = build_memory_parts(cfg.chain_id, &cfg);
+    let parts2 = build_memory_parts(cfg.chain_id, &cfg);
+    let lookahead = Arc::new(StaticLookaheadResolver { signer: alloy_primitives::Address::ZERO });
+    let (mut driver1, _handle1) = driver_from_parts(parts1, &cfg, lookahead.clone());
+    let (mut driver2, _handle2) = driver_from_parts(parts2, &cfg, lookahead);
+
+    let peer2_id = *driver2.swarm.local_peer_id();
+    let addr1: Multiaddr = "/memory/1101".parse().unwrap();
+    let mut addr1_full = addr1.clone();
+    addr1_full.push(libp2p::multiaddr::Protocol::P2p(*driver1.swarm.local_peer_id()));
+
+    driver1.swarm.listen_on(addr1).unwrap();
+    driver2.swarm.dial(addr1_full).unwrap();
+    for _ in 0..200 {
+        pump_async(&mut driver1).await;
+        pump_async(&mut driver2).await;
+        if driver1.swarm.is_connected(&peer2_id) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(driver1.swarm.is_connected(&peer2_id), "peers failed to connect");
+
+    // One invalid gossip message applies the spec's -1 app feedback delta.
+    driver1.apply_reputation(peer2_id, PeerAction::GossipInvalid);
+    let score = driver1
+        .swarm
+        .behaviour()
+        .gossipsub
+        .peer_score(&peer2_id)
+        .expect("gossipsub peer scoring must be active");
+    assert!((score + 1.0).abs() < 1e-6, "app score should be -1.0, got {score}");
+
+    // Repeated failures clamp at the spec's appScore floor of -10.
+    for _ in 0..14 {
+        driver1.apply_reputation(peer2_id, PeerAction::GossipInvalid);
+    }
+    let score = driver1
+        .swarm
+        .behaviour()
+        .gossipsub
+        .peer_score(&peer2_id)
+        .expect("gossipsub peer scoring must be active");
+    assert!((score + 10.0).abs() < 1e-6, "app score should clamp at -10.0, got {score}");
+}
+
 #[test]
 fn p2p_config_enable_quic_wiring() {
     let p2p = P2pConfig { enable_quic: false, enable_tcp: true, ..Default::default() };


### PR DESCRIPTION
## Bug

Gossipsub peer scoring has never actually been enabled, so the normative scoring profile in `docs/specification.md` §7.1 (including the drop/prune/graylist thresholds) was dead at runtime:

1. The spec's `invalidMessageDeliveriesWeight: 2.0` was passed to libp2p **as a positive weight**. In gossipsub v1.1, P4 (invalid message deliveries) is a penalty counter and libp2p hard-rejects any positive weight (`"Invalid invalid_message_deliveries_weight; must be negative (or 0 to disable)"`).
2. The failure was invisible because the activation result was discarded: `let _ = gossipsub.with_peer_score(params, thresholds);`

`PeerScoreParams::validate()` recurses into every topic's params, so activation failed for both topics on every node, every time. Peers sending invalid messages faced zero mesh consequences (per-message `Reject` reports still stopped propagation of that one message, but no score ever accrued).

## Fix

- Apply the spec's weight magnitude as `-2.0` and **propagate the `with_peer_score` error** so a misconfiguration fails node construction loudly instead of silently disabling scoring.
- Pin spec §7.1 values explicitly instead of inheriting surprising libp2p defaults that only now would take effect: `topic_weight: 1.0` (libp2p default 0.5), `first_message_deliveries_cap: 20` (libp2p default 2000), and explicitly disable the P3/P3b mesh-delivery penalties — they are not part of the spec profile and their default weights (`-1.0`) would penalize peers on quiet topics.
- Mirror the local reputation store into gossipsub's **app-specific score** on every reputation event, clamped to the spec's `[-10, +10]` appScore bounds. Previously the local store and gossipsub scoring were fully disconnected (`set_application_score` was never called), so `app_specific_weight: 1.0` multiplied a constant 0.
- Extract the parameter construction into `peer_score_settings()` so it is testable against libp2p's own validator.

## Tests (TDD — each watched failing first)

- `behaviour::tests::peer_score_settings_satisfy_gossipsub_validation` — params/thresholds pass libp2p's validators (failed before with the exact rejection above).
- `behaviour::tests::new_activates_gossipsub_peer_scoring` — scoring is active after construction (a second activation attempt must be rejected with "Peer score set twice").
- `driver::tests::reputation_mirrors_into_gossipsub_app_score` — two in-memory peers; one `GossipInvalid` yields app score `-1.0`, repeated failures clamp at the `-10.0` floor.

`cargo nextest run --workspace --all-features`: 47/47 pass. `just clippy` (`-D warnings -D missing_docs -D clippy::missing_docs_in_private_items`) and `just fmt-check` clean.

## Notes / follow-ups (intentionally out of scope)

- The spec text should eventually read `-2.0` for `invalidMessageDeliveriesWeight`; a literal `+2.0` is invalid in every gossipsub implementation.
- §7.1's −4-per-10s failure cap, acceptance cap, "ban below −5 sustained >30s", and the 0.9-per-10s appScore decay cadence are still not implemented in the local reputation store (it uses a 600s halflife and instant bans) — tracked as part of the planned reputation-system cleanup.
- libp2p has no per-topic cap field for the invalid-deliveries counter, so the spec's "cap at −20" is not directly expressible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)