### PR TITLE
fix(taiko-client-rs): report execution head in /status when unsafe counter lags it

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -71,14 +71,18 @@ fn can_shutdown_for(last_preconf_request: Option<Instant>) -> bool {
     }
 }
 
-/// Clamp `tracked` down to `head`; never raise it, and leave it unchanged when `head`
-/// is `None`.
+/// Report `head` whenever it is known; fall back to `tracked` when it is `None`.
 ///
-/// The tracked value only ever moves up, so after the head moves backward (e.g. an L1
-/// reorg) it can be left above the head. Lowering it restores `tracked <= head` while
-/// still preserving a value that legitimately trails the head.
+/// The tracked value only moves on preconfirmation imports and local builds, so it can
+/// drift from the head in both directions: an L1 reorg rewinds the head below the
+/// counter, while canonical L1 derivation with no gossip traffic advances the head past
+/// it. Every canonical block was inserted by this driver, so the head is always an
+/// honest answer — and the Catalyst sidecar's sync gate requires the reported value to
+/// equal the execution head exactly before it starts (or resumes) preconfirming. A
+/// permanently lagging report would wedge the operator in a restart loop that only a
+/// driver restart clears.
 fn reconcile_highest_unsafe(tracked: u64, head: Option<u64>) -> u64 {
-    head.map_or(tracked, |h| tracked.min(h))
+    head.unwrap_or(tracked)
 }
 
 /// Implements whitelist preconfirmation API business logic.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -9,7 +9,7 @@ where
     /// Build the current status snapshot served by the REST `/status` route.
     pub(super) async fn get_status_snapshot(&self) -> Result<ApiStatus> {
         // Current L2 execution head, best-effort: a failed read yields `None`, which skips
-        // the clamp below and leaves the reported value unchanged.
+        // the reconciliation below and reports the tracked counter unchanged.
         let l2_head = self
             .rpc
             .l2_provider
@@ -19,22 +19,26 @@ where
             .flatten()
             .map(|block| block.header.number);
 
-        // The counter only moves up (on import/build), so after the head moves backward
-        // (e.g. an L1 reorg) it can be left above the head. Report it clamped to the head.
+        // The counter only moves on imports/builds, so it can drift from the head in both
+        // directions: an L1 reorg rewinds the head below it, and canonical L1 derivation
+        // with no gossip traffic advances the head past it. Report the head in both cases —
+        // canonical blocks were inserted by this driver too, and the Catalyst sync gate
+        // only opens when the reported value equals the execution head exactly.
         //
-        // Report only — do NOT write the clamp back. `l2_head` is read without the lock, so
-        // it can already be stale; persisting `min(counter, stale_head)` would pin the
-        // stored counter too low until the next import/build. Clamping only the reported
-        // value keeps the counter intact, so the next poll recomputes against a fresh head
-        // and self-heals.
+        // Report only — do NOT write the reconciled value back. `l2_head` is read without
+        // the lock, so it can already be stale; persisting it could pin the stored counter
+        // wrong until the next import/build. Reconciling only the reported value keeps the
+        // counter intact, so the next poll recomputes against a fresh head and self-heals.
         let tracked = self.state.highest_unsafe().await;
         let highest_unsafe = reconcile_highest_unsafe(tracked, l2_head);
-        if highest_unsafe != tracked {
+        if highest_unsafe < tracked {
             warn!(
                 tracked,
                 head = highest_unsafe,
                 "highest_unsafe ahead of head; reporting clamped value"
             );
+        } else if highest_unsafe > tracked {
+            debug!(tracked, head = highest_unsafe, "highest_unsafe behind head; reporting head");
         }
 
         let current_epoch = self.beacon_client.current_epoch();

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -82,7 +82,7 @@ fn shutdown_block_window_is_one_hundred_forty_four_seconds() {
 
 #[test]
 fn reconcile_clamps_down_when_counter_exceeds_reth_head() {
-    // The L1-reorg wedge: counter stuck above reth's rewound head -> clamp to head.
+    // The L1-reorg wedge: counter stuck above reth's rewound head -> report the head.
     assert_eq!(reconcile_highest_unsafe(5_811_227, Some(5_811_208)), 5_811_208);
 }
 
@@ -93,9 +93,12 @@ fn reconcile_keeps_counter_when_equal_to_reth_head() {
 }
 
 #[test]
-fn reconcile_keeps_counter_when_below_reth_head() {
-    // Legitimate catch-up state (reth ahead via L1 derivation); must NOT be raised.
-    assert_eq!(reconcile_highest_unsafe(5_811_208, Some(5_811_227)), 5_811_208);
+fn reconcile_reports_head_when_counter_below_reth_head() {
+    // The catch-up wedge: reth advanced via canonical L1 derivation while no gossip was
+    // flowing, so the counter was never raised. Catalyst's sync gate requires the
+    // reported value to equal the head exactly; a lagging report blocks preconfirmation
+    // (and triggers Catalyst self-restarts) until a driver restart re-seeds the counter.
+    assert_eq!(reconcile_highest_unsafe(5_811_208, Some(5_811_227)), 5_811_227);
 }
 
 #[test]


### PR DESCRIPTION
## The bug

The whitelist driver's `highest_unsafe` counter only moves on three events: a local `POST /preconfBlocks` build (`set`), a P2P envelope import (`raise`), and the startup re-seed from the EE head. Canonical L1 derivation advances the execution head **without** touching the counter, and the `/status` reconciliation only handled the counter-**above**-head direction (the L1-reorg case).

So whenever the head advances via derivation with no gossip flowing — post-checkpoint-sync backfill, or the first operator coming online after a sequencing outage — `/status.highestUnsafeL2PayloadBlockId` permanently lags the EE head.

Catalyst's sync gate (`is_block_height_synced_between_taiko_geth_and_the_driver`) requires the reported value to **exactly equal** the EE `latest` head (or be 0). A lagging value means: Catalyst never starts preconfirming, its cancel counter trips after ~96 heartbeats (~3.2 min), and it self-restarts in a loop — which never resolves, because restarting Catalyst doesn't re-seed the driver's counter, and with no preconfirmations flowing nothing ever raises it. Only a *driver* restart clears the wedge.

The Go driver doesn't have this problem: it advances its counter to the canonical tip on every derived proposal (`recordLatestSeenProposal`).

## The fix

`reconcile_highest_unsafe` now reports the execution head whenever it is readable, in **both** drift directions. This is always an honest answer — every canonical block was inserted by this driver too. The reorg (above-head) direction keeps its `warn`; the catch-up (below-head) direction logs at `debug` since it's a normal transient state polled every ~2s.

The report-only design is unchanged: the stored counter is never written back (the head is read without the state lock and may be stale; the next poll self-heals), and import/build semantics (`raise`/`set`) are untouched — `/status` is the only reader of the counter.

## Notes

- Found during the Go-driver-retirement readiness review (driver-sync-gate behavior through catch-up/recovery); this turns that verification item into a fix.
- Unit tests updated: the previous `reconcile_keeps_counter_when_below_reth_head` test pinned the wedge behavior as intended; it now asserts the head is reported.
- `cargo test -p whitelist-preconfirmation-driver --lib` (105 passed), crate-scoped clippy with CI flags, and `just fmt-check` are green.