### PR TITLE
chore(taiko-client,taiko-client-rs): bump execution client dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260604073822-312ef681a061
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260612002551-3ea282a772c1
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828 h1:8TqBxcCsk7TNvGHjTuStB2waN3KPpTJYeqpk7JY5t+o=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260604073822-312ef681a061 h1:/GaNesPRo7ed8zHAUC6NNXEisBKaY/A9GSrfj1+xfdE=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260604073822-312ef681a061/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260612002551-3ea282a772c1 h1:VcG4e46RCUqMACQfAFNv6PUYzVZgjcDdH4g+FBks9/M=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260612002551-3ea282a772c1/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -67,8 +67,8 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-chainspec"
-version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=ec1650bfc5925af4f763795cfeb7872f9e85813b#ec1650bfc5925af4f763795cfeb7872f9e85813b"
+version = "1.2.0"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=1ed7c19d1f9652c5fed96185f4ab8f930e812dd3#1ed7c19d1f9652c5fed96185f4ab8f930e812dd3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -89,8 +89,8 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-consensus"
-version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=ec1650bfc5925af4f763795cfeb7872f9e85813b#ec1650bfc5925af4f763795cfeb7872f9e85813b"
+version = "1.2.0"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=1ed7c19d1f9652c5fed96185f4ab8f930e812dd3#1ed7c19d1f9652c5fed96185f4ab8f930e812dd3"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -101,8 +101,8 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-primitives"
-version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=ec1650bfc5925af4f763795cfeb7872f9e85813b#ec1650bfc5925af4f763795cfeb7872f9e85813b"
+version = "1.2.0"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=1ed7c19d1f9652c5fed96185f4ab8f930e812dd3#1ed7c19d1f9652c5fed96185f4ab8f930e812dd3"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -125,8 +125,8 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-rpc-types"
-version = "1.1.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=ec1650bfc5925af4f763795cfeb7872f9e85813b#ec1650bfc5925af4f763795cfeb7872f9e85813b"
+version = "1.2.0"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=1ed7c19d1f9652c5fed96185f4ab8f930e812dd3#1ed7c19d1f9652c5fed96185f4ab8f930e812dd3"
 dependencies = [
  "alloy-primitives",
  "serde",

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -77,12 +77,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "ec1650bfc5925af4f763795cfeb7872f9e85813b", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "ec1650bfc5925af4f763795cfeb7872f9e85813b", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "ec1650bfc5925af4f763795cfeb7872f9e85813b", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "1ed7c19d1f9652c5fed96185f4ab8f930e812dd3", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "1ed7c19d1f9652c5fed96185f4ab8f930e812dd3", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "1ed7c19d1f9652c5fed96185f4ab8f930e812dd3", default-features = false, features = [
     "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "ec1650bfc5925af4f763795cfeb7872f9e85813b" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "1ed7c19d1f9652c5fed96185f4ab8f930e812dd3" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary

- Bump the Go `github.com/ethereum/go-ethereum` replacement to `github.com/taikoxyz/taiko-geth` from the latest `taiko` branch head.
- Bump Rust `alethia-reth-*` workspace dependencies to the latest `main` branch head and update `Cargo.lock` source pins.

## Updated Revisions

- `taiko-geth`: `3ea282a772c10a066c9cbc897fdc6d1e66e35e62` (`v1.18.1-0.20260612002551-3ea282a772c1`)
- `alethia-reth`: `1ed7c19d1f9652c5fed96185f4ab8f930e812dd3` (`1.2.0`)

## Validation

- `go list -m -mod=readonly -json github.com/ethereum/go-ethereum`
- `cargo metadata --locked --manifest-path packages/taiko-client-rs/Cargo.toml --no-deps --format-version 1`

Full package test suites were not run before opening this draft PR.