### PR TITLE
chore(taiko-client): bump taiko-geth dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260612002551-3ea282a772c1
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260612022329-f003739ec4e7
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828 h1:8TqBxcCsk7TNvGHjTuStB2waN3KPpTJYeqpk7JY5t+o=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260612002551-3ea282a772c1 h1:VcG4e46RCUqMACQfAFNv6PUYzVZgjcDdH4g+FBks9/M=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260612002551-3ea282a772c1/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260612022329-f003739ec4e7 h1:uMcjRtbbTqiZv+tRFu3OU4yixTLsY2ntJq35+rw6Y+A=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260612022329-f003739ec4e7/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=


### PR DESCRIPTION
## Summary

- Bump the Go `github.com/ethereum/go-ethereum` replacement to the latest `github.com/taikoxyz/taiko-geth` `taiko` branch head.
- Update the matching `go.sum` checksums.

## Updated Revision

- `taiko-geth`: `f003739ec4e7babc3e2606021165cec814d2c000` (`v1.18.1-0.20260612022329-f003739ec4e7`)

## Validation

- `go list -m -mod=readonly -json github.com/ethereum/go-ethereum`

Full package test suites were not run before opening this draft PR.