### PR TITLE
fix(taiko-client-rs): keep release lockfile current

### DIFF
--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -12,14 +12,29 @@ on:
     paths:
       - "packages/taiko-client-rs/**"
       - "!**/*.md"
-    branches-ignore:
-      - release-please--branches--**
 
 concurrency:
   group: taiko-client-rs-test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  lockfile:
+    if: ${{ github.event.pull_request.draft == false }}
+    name: Lockfile
+    runs-on: [arc-runner-set]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.1
+
+      - name: Check Cargo.lock
+        working-directory: packages/taiko-client-rs
+        run: cargo fetch --locked
+
   lint:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
     name: Lint

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "bindings"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy",
  "serde",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "driver"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alethia-reth-consensus",
  "alethia-reth-primitives",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "preconfirmation-driver"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alethia-reth-consensus",
  "alethia-reth-primitives",
@@ -6256,7 +6256,7 @@ dependencies = [
 
 [[package]]
 name = "proposer"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alethia-reth-consensus",
  "alethia-reth-primitives",
@@ -6315,7 +6315,7 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protocol"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-consensus",
@@ -8408,7 +8408,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rpc"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alethia-reth-primitives",
  "alethia-reth-rpc-types",
@@ -9397,7 +9397,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "taiko-client"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus 1.8.3",
  "alloy-primitives",
@@ -9467,7 +9467,7 @@ dependencies = [
 
 [[package]]
 name = "test-harness"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alethia-reth-consensus",
  "alethia-reth-primitives",
@@ -10446,7 +10446,7 @@ dependencies = [
 
 [[package]]
 name = "whitelist-preconfirmation-driver"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alethia-reth-consensus",
  "alethia-reth-primitives",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -111,7 +111,47 @@
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?((@.name == \"taiko-client\" || @.name == \"bindings\" || @.name == \"driver\" || @.name == \"preconfirmation-driver\" || @.name == \"whitelist-preconfirmation-driver\" || @.name == \"proposer\" || @.name == \"protocol\" || @.name == \"rpc\" || @.name == \"test-harness\") && !@.source)].version"
+          "jsonpath": "$.package[?(@.name == \"taiko-client\" && !@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name == \"bindings\" && !@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name == \"driver\" && !@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name == \"preconfirmation-driver\" && !@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name == \"whitelist-preconfirmation-driver\" && !@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name == \"proposer\" && !@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name == \"protocol\" && !@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name == \"rpc\" && !@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name == \"test-harness\" && !@.source)].version"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Fix the taiko-client-rs release lockfile mismatch that broke the Docker image workflow after release-please PR #20392.

## Root cause

PR #20392 bumped `packages/taiko-client-rs/Cargo.toml` and `packages/taiko-client-rs/crates/bindings/Cargo.toml` to `2.1.0`, but `packages/taiko-client-rs/Cargo.lock` still had local workspace packages at `2.0.0`. The Docker build uses `cargo build --release --locked`, so it failed when Cargo tried to update the lockfile.

The existing release-please config attempted to update all taiko-client-rs local lockfile packages with one compound JSONPath. In practice, the release PR did not include `Cargo.lock`, and taiko-client-rs PR CI skipped release-please branches, so the mismatch was not caught before merge.

## Changes

- Update taiko-client-rs local workspace package entries in `Cargo.lock` from `2.0.0` to `2.1.0`.
- Split the release-please `Cargo.lock` `extra-files` JSONPath into one entry per local package, so future release PRs can update each package version explicitly.
- Let the taiko-client-rs PR workflow run on release-please branches, but only add a lightweight `cargo fetch --locked` lockfile job there. Existing heavy lint/test jobs still skip release-please branches.

## Validation

- Reproduced the old state with `cargo fetch --locked` and confirmed it fails with the same lockfile error.
- `cargo fetch --locked`
- `jq empty release-please-config.json`
- YAML parse for `.github/workflows/taiko-client-rs--test.yml`
- `git diff --check`