### PR TITLE
fix(preconfirmation-p2p,taiko-client-rs): spec-compliance follow-ups from the P2P rescan

### DIFF
--- a/packages/preconfirmation-p2p/crates/net/src/config.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/config.rs
@@ -195,9 +195,12 @@ impl Default for NetworkConfig {
             gossipsub_heartbeat: *kona_gossip::GOSSIP_HEARTBEAT,
             request_timeout: Duration::from_secs(10),
             enable_discovery: true,
-            reputation_greylist: -5.0,
-            reputation_ban: -10.0,
-            reputation_halflife: Duration::from_secs(600),
+            // Spec §7.1 enforcement thresholds: prune (greylist) below -2, ban below -5
+            // sustained >30s. The 66s halflife matches the spec's ~0.9-per-10s decay
+            // (0.5^(10/66) ≈ 0.9).
+            reputation_greylist: -2.0,
+            reputation_ban: -5.0,
+            reputation_halflife: Duration::from_secs(66),
             request_window: Duration::from_secs(10),
             max_requests_per_window: 8,
             max_reqresp_concurrent_streams: 100,

--- a/packages/preconfirmation-p2p/crates/net/src/driver/tests.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/driver/tests.rs
@@ -498,7 +498,7 @@ async fn reputation_mirrors_into_gossipsub_app_score() {
         .expect("gossipsub peer scoring must be active");
     assert!((score + 1.0).abs() < 1e-6, "app score should be -1.0, got {score}");
 
-    // Repeated failures clamp at the spec's appScore floor of -10.
+    // Rapid-fire failures within one 10s window cap at the spec's -4 failure budget.
     for _ in 0..14 {
         driver1.apply_reputation(peer2_id, PeerAction::GossipInvalid);
     }
@@ -508,7 +508,7 @@ async fn reputation_mirrors_into_gossipsub_app_score() {
         .gossipsub
         .peer_score(&peer2_id)
         .expect("gossipsub peer scoring must be active");
-    assert!((score + 10.0).abs() < 1e-6, "app score should clamp at -10.0, got {score}");
+    assert!((score + 4.0).abs() < 1e-3, "app score should cap at -4.0 per window, got {score}");
 }
 
 #[test]

--- a/packages/preconfirmation-p2p/crates/net/src/reputation.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/reputation.rs
@@ -42,6 +42,17 @@ const DEFAULT_BAN_THRESHOLD: PeerScore = -5.0; // spec ban threshold
 const DEFAULT_GREYLIST_THRESHOLD: PeerScore = -2.0; // spec prune/grey threshold
 /// Reputation delta applied on successful responses.
 const SUCCESS_REWARD: PeerScore = 0.05; // acceptance delta
+/// Maximum failure penalty accumulated per window (spec §7.1: cap -4 per 10s per peer).
+const FAILURE_CAP_PER_WINDOW: PeerScore = 4.0;
+/// Rolling window over which failure penalties are capped (spec §7.1).
+const FAILURE_CAP_WINDOW: Duration = Duration::from_secs(10);
+/// Lower appScore clamp bound (spec §7.1: appScore clamp [-10, +10]).
+const SCORE_MIN: PeerScore = -10.0;
+/// Upper appScore clamp bound (spec §7.1: appScore clamp [-10, +10]).
+const SCORE_MAX: PeerScore = 10.0;
+/// Duration a score must remain at/below the ban threshold before a hard ban
+/// (spec §7.1: ban below -5 sustained >30s).
+const BAN_SUSTAIN: Duration = Duration::from_secs(30);
 
 /// Represents the current reputation score of a peer.
 #[derive(Debug, Clone)]
@@ -50,12 +61,25 @@ pub struct PeerReputation {
     score: PeerScore,
     /// The last `Instant` at which the score was updated. Used for decay calculation.
     last_updated: Instant,
+    /// Start of the current failure-cap window (spec §7.1).
+    window_start: Instant,
+    /// Failure penalty accumulated within the current window.
+    window_penalty: PeerScore,
+    /// Earliest instant since which the score has continuously been at/below the ban
+    /// threshold; `None` while above it.
+    below_ban_since: Option<Instant>,
 }
 
 impl PeerReputation {
     /// Creates a new `PeerReputation` with a default score of 0.0.
     pub fn new(now: Instant) -> Self {
-        Self { score: 0.0, last_updated: now }
+        Self {
+            score: 0.0,
+            last_updated: now,
+            window_start: now,
+            window_penalty: 0.0,
+            below_ban_since: None,
+        }
     }
 
     /// Returns the current score of the peer.
@@ -128,18 +152,42 @@ impl PeerReputationStore {
 
     /// Applies a `PeerAction` to a peer, updating its score and ban/greylist status.
     pub fn apply(&mut self, peer: PeerId, action: PeerAction) -> ReputationEvent {
-        let now = Instant::now();
+        self.apply_at(peer, action, Instant::now())
+    }
+
+    /// Applies a `PeerAction` at an explicit instant (spec §7.1 semantics).
+    ///
+    /// - Failure penalties are capped at -4 accumulated per 10s window per peer.
+    /// - Scores are clamped to the [-10, +10] appScore bounds.
+    /// - A hard ban requires the score to stay at/below the ban threshold for >30s.
+    fn apply_at(&mut self, peer: PeerId, action: PeerAction, now: Instant) -> ReputationEvent {
         let was_banned = self.banned.contains(&peer);
         let was_grey = self.greylisted.contains(&peer);
         let entry = self.scores.entry(peer).or_insert_with(|| PeerReputation::new(now));
-        // Split borrows: compute new score then update.
         // Decay ensures older infractions fade so recent behavior dominates decisions.
-        let mut score = entry.score;
-        score = Self::decayed(score, entry.last_updated, now, self.cfg.halflife);
-        score += action_delta(action, &self.weights);
+        let mut score = Self::decayed(entry.score, entry.last_updated, now, self.cfg.halflife);
+        let mut delta = action_delta(action, &self.weights);
+        if delta < 0.0 {
+            if now.saturating_duration_since(entry.window_start) >= FAILURE_CAP_WINDOW {
+                entry.window_start = now;
+                entry.window_penalty = 0.0;
+            }
+            let allowed = (FAILURE_CAP_PER_WINDOW - entry.window_penalty).max(0.0);
+            delta = delta.max(-allowed);
+            entry.window_penalty -= delta;
+        }
+        score = (score + delta).clamp(SCORE_MIN, SCORE_MAX);
         entry.score = score;
         entry.last_updated = now;
-        self.update_lists(peer, score);
+        // Track how long the score has continuously breached the ban threshold.
+        let ban_eligible = if score <= self.cfg.ban_threshold {
+            let since = *entry.below_ban_since.get_or_insert(now);
+            now.saturating_duration_since(since) > BAN_SUSTAIN
+        } else {
+            entry.below_ban_since = None;
+            false
+        };
+        self.update_lists(peer, score, ban_eligible);
         let is_banned = self.banned.contains(&peer);
         let is_greylisted = self.greylisted.contains(&peer);
         ReputationEvent {
@@ -168,9 +216,12 @@ impl PeerReputationStore {
         score * (-lambda * dt).exp()
     }
 
-    /// Updates banned/greylisted sets based on the peer's score.
-    fn update_lists(&mut self, peer: PeerId, score: PeerScore) {
-        if score <= self.cfg.ban_threshold {
+    /// Updates banned/greylisted sets based on the peer's score and ban eligibility.
+    ///
+    /// `ban_eligible` is true only when the score has stayed at/below the ban threshold
+    /// for the sustained period required by spec §7.1.
+    fn update_lists(&mut self, peer: PeerId, score: PeerScore, ban_eligible: bool) {
+        if ban_eligible {
             // Ban takes precedence: ensure greylist entry is cleared to avoid conflicting states.
             self.banned.insert(peer);
             self.greylisted.remove(&peer);
@@ -312,23 +363,109 @@ mod tests {
         ReputationConfig {
             greylist_threshold: DEFAULT_GREYLIST_THRESHOLD,
             ban_threshold: DEFAULT_BAN_THRESHOLD,
-            halflife: Duration::from_secs(600),
+            halflife: Duration::from_secs(66),
         }
     }
 
-    /// Repeated errors eventually ban a peer.
+    /// Negative deltas accumulate to at most -4 within a single 10s window (spec §7.1).
     #[test]
-    fn peer_store_reaches_ban_threshold() {
+    fn failure_cap_limits_negative_delta_per_window() {
         let mut store = PeerReputationStore::new(cfg());
         let peer = PeerId::random();
-        for _ in 0..20 {
-            let ev = store.apply(peer, PeerAction::ReqRespError);
-            if ev.is_banned {
-                assert!(store.is_banned(&peer));
-                return;
-            }
+        let now = Instant::now();
+        let mut last: PeerScore = 0.0;
+        for _ in 0..10 {
+            last = store.apply_at(peer, PeerAction::GossipInvalid, now).new_score;
         }
-        panic!("peer was not banned after repeated errors");
+        assert!((last + 4.0).abs() < 1e-9, "expected window cap at -4, got {last}");
+    }
+
+    /// The failure window resets after 10s, allowing further (capped) penalties.
+    #[test]
+    fn failure_cap_resets_after_window() {
+        let mut store = PeerReputationStore::new(cfg());
+        let peer = PeerId::random();
+        let t0 = Instant::now();
+        for _ in 0..10 {
+            store.apply_at(peer, PeerAction::GossipInvalid, t0);
+        }
+        let t1 = t0 + Duration::from_secs(11);
+        let mut last: PeerScore = 0.0;
+        for _ in 0..10 {
+            last = store.apply_at(peer, PeerAction::GossipInvalid, t1).new_score;
+        }
+        assert!(last < -7.0, "expected a second window of penalties, got {last}");
+    }
+
+    /// Scores clamp at the spec's appScore bounds of [-10, +10] (spec §7.1).
+    #[test]
+    fn scores_clamp_at_spec_bounds() {
+        let mut store = PeerReputationStore::new(cfg());
+        let peer = PeerId::random();
+        let mut now = Instant::now();
+        let mut last: PeerScore = 0.0;
+        for _ in 0..4 {
+            for _ in 0..10 {
+                last = store.apply_at(peer, PeerAction::GossipInvalid, now).new_score;
+            }
+            now += Duration::from_secs(11);
+        }
+        assert!((last + 10.0).abs() < 1e-9, "expected clamp at -10, got {last}");
+
+        let mut positive: PeerScore = 0.0;
+        let good = PeerId::random();
+        for _ in 0..300 {
+            positive = store.apply_at(good, PeerAction::GossipValid, now).new_score;
+        }
+        assert!(positive <= 10.0, "expected clamp at +10, got {positive}");
+    }
+
+    /// A ban requires the score to stay at or below the ban threshold for >30s (spec §7.1).
+    #[test]
+    fn ban_requires_sustained_breach() {
+        let mut store = PeerReputationStore::new(cfg());
+        let peer = PeerId::random();
+        let t0 = Instant::now();
+        // Two saturated windows push the score below the -5 ban threshold.
+        for _ in 0..10 {
+            store.apply_at(peer, PeerAction::GossipInvalid, t0);
+        }
+        let t1 = t0 + Duration::from_secs(11);
+        let mut ev = store.apply_at(peer, PeerAction::GossipInvalid, t1);
+        for _ in 0..9 {
+            ev = store.apply_at(peer, PeerAction::GossipInvalid, t1);
+        }
+        assert!(ev.new_score <= DEFAULT_BAN_THRESHOLD, "setup must breach the ban threshold");
+        assert!(!ev.is_banned, "breach must not ban before the sustain period");
+        assert!(!store.is_banned(&peer));
+
+        // Still below the threshold 31s later: the sustained breach bans the peer.
+        let t2 = t1 + Duration::from_secs(31);
+        let ev = store.apply_at(peer, PeerAction::GossipInvalid, t2);
+        assert!(ev.is_banned, "sustained breach (>30s) must ban; score {}", ev.new_score);
+        assert!(store.is_banned(&peer));
+    }
+
+    /// Healing above the ban threshold resets the sustained-breach timer.
+    #[test]
+    fn ban_timer_resets_when_score_heals() {
+        let mut store = PeerReputationStore::new(cfg());
+        let peer = PeerId::random();
+        let t0 = Instant::now();
+        for _ in 0..10 {
+            store.apply_at(peer, PeerAction::GossipInvalid, t0);
+        }
+        let t1 = t0 + Duration::from_secs(11);
+        for _ in 0..10 {
+            store.apply_at(peer, PeerAction::GossipInvalid, t1);
+        }
+
+        // Long quiet period: decay heals the score above the ban threshold.
+        let t2 = t1 + Duration::from_secs(120);
+        let ev = store.apply_at(peer, PeerAction::GossipValid, t2);
+        assert!(ev.new_score > DEFAULT_BAN_THRESHOLD, "decay should heal, got {}", ev.new_score);
+        assert!(!ev.is_banned, "healed peer must not be banned despite >30s since first breach");
+        assert!(!store.is_banned(&peer));
     }
 
     /// Fresh peers are not banned before any actions are applied.

--- a/packages/preconfirmation-p2p/crates/net/src/validation.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/validation.rs
@@ -16,9 +16,9 @@ use alloy_primitives::Address;
 use libp2p::PeerId;
 
 use preconfirmation_types::{
-    Bytes20, GetCommitmentsByNumberResponse, GetRawTxListResponse, RawTxListGossip,
+    Bytes20, DOMAIN_PRECONF, GetCommitmentsByNumberResponse, GetRawTxListResponse, RawTxListGossip,
     SignedCommitment, Uint256, validate_commitments_response, validate_preconfirmation_basic,
-    validate_raw_txlist_gossip, validate_raw_txlist_response, verify_signed_commitment,
+    validate_raw_txlist_gossip, validate_raw_txlist_response, verify_signed_commitment_with_domain,
 };
 
 /// Resolver that can validate commitments against an external lookahead schedule.
@@ -72,12 +72,20 @@ pub trait ValidationAdapter: Send + Sync {
 pub struct LocalValidationAdapter {
     /// Optional slasher address to enforce on inbound commitments.
     expected_slasher: Option<Bytes20>,
+    /// Signing domain used for commitment signature recovery (spec §4.1/§8).
+    domain: [u8; 32],
 }
 
 impl LocalValidationAdapter {
-    /// Construct a local validator that optionally enforces a specific slasher address.
+    /// Construct a local validator that optionally enforces a specific slasher address,
+    /// using the default `DOMAIN_PRECONF` signing domain.
     pub fn new(expected_slasher: Option<Bytes20>) -> Self {
-        Self { expected_slasher }
+        Self::with_domain(expected_slasher, DOMAIN_PRECONF)
+    }
+
+    /// Construct a local validator with an explicit chain-configured signing domain.
+    pub fn with_domain(expected_slasher: Option<Bytes20>, domain: [u8; 32]) -> Self {
+        Self { expected_slasher, domain }
     }
 
     /// Validate slasher address and basic preconfirmation invariants.
@@ -100,7 +108,7 @@ impl ValidationAdapter for LocalValidationAdapter {
         _from: &PeerId,
         msg: &SignedCommitment,
     ) -> Result<(), String> {
-        verify_signed_commitment(msg).map_err(|e| e.to_string())?;
+        verify_signed_commitment_with_domain(msg, &self.domain).map_err(|e| e.to_string())?;
         self.validate_commitment_fields(msg)
     }
 
@@ -154,9 +162,19 @@ pub struct LookaheadValidationAdapter {
 }
 
 impl LookaheadValidationAdapter {
-    /// Construct a lookahead validator wrapping the local validator and an external resolver.
+    /// Construct a lookahead validator wrapping the local validator and an external resolver,
+    /// using the default `DOMAIN_PRECONF` signing domain.
     pub fn new(expected_slasher: Option<Bytes20>, resolver: Arc<dyn LookaheadResolver>) -> Self {
-        Self { local: LocalValidationAdapter::new(expected_slasher), resolver }
+        Self::with_domain(expected_slasher, resolver, DOMAIN_PRECONF)
+    }
+
+    /// Construct a lookahead validator with an explicit chain-configured signing domain.
+    pub fn with_domain(
+        expected_slasher: Option<Bytes20>,
+        resolver: Arc<dyn LookaheadResolver>,
+        domain: [u8; 32],
+    ) -> Self {
+        Self { local: LocalValidationAdapter::with_domain(expected_slasher, domain), resolver }
     }
 }
 
@@ -167,7 +185,8 @@ impl ValidationAdapter for LookaheadValidationAdapter {
         _from: &PeerId,
         msg: &SignedCommitment,
     ) -> Result<(), String> {
-        let recovered = verify_signed_commitment(msg).map_err(|e| e.to_string())?;
+        let recovered = verify_signed_commitment_with_domain(msg, &self.local.domain)
+            .map_err(|e| e.to_string())?;
         self.local.validate_commitment_fields(msg)?;
         let slot_end = &msg.commitment.preconf.submission_window_end;
         let expected_signer = self.resolver.signer_for_timestamp(slot_end)?;
@@ -270,6 +289,37 @@ mod tests {
         let wrong = Vector::try_from(vec![8u8; 20]).unwrap();
         let msg = sample_signed_commitment(wrong);
         assert!(adapter.validate_gossip_commitment(&PeerId::random(), &msg).is_err());
+    }
+
+    /// A custom-domain commitment is rejected by the default adapter and accepted by a
+    /// domain-aware adapter (spec §4.1/§8 chain-configurable `DOMAIN_PRECONF`).
+    #[test]
+    fn custom_signing_domain_enforced() {
+        let domain = *b"CUSTOM_PRECONF_DOMAIN_FOR_TESTS!";
+        let slasher: Bytes20 = Vector::try_from(vec![7u8; 20]).unwrap();
+        let mut msg = sample_signed_commitment(slasher.clone());
+        let sk = SecretKey::from_slice(&[9u8; 32]).unwrap();
+        msg.signature =
+            preconfirmation_types::sign_commitment_with_domain(&msg.commitment, &sk, &domain)
+                .unwrap();
+
+        // The local adapter accepts under the matching domain (recovery succeeds).
+        let domain_adapter = LocalValidationAdapter::with_domain(Some(slasher), domain);
+        assert!(domain_adapter.validate_gossip_commitment(&PeerId::random(), &msg).is_ok());
+
+        // The lookahead adapter binds the recovered signer, making a domain mismatch
+        // observable: under the default domain the recovered signer cannot match.
+        let signer = preconfirmation_types::public_key_to_address(
+            &secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &sk),
+        );
+        let resolver = Arc::new(AcceptResolver {
+            signer,
+            slot_end: msg.commitment.preconf.submission_window_end.clone(),
+        });
+        let default_lookahead = LookaheadValidationAdapter::new(None, resolver.clone());
+        assert!(default_lookahead.validate_gossip_commitment(&PeerId::random(), &msg).is_err());
+        let domain_lookahead = LookaheadValidationAdapter::with_domain(None, resolver, domain);
+        assert!(domain_lookahead.validate_gossip_commitment(&PeerId::random(), &msg).is_ok());
     }
 
     /// Resolver that always returns a configured signer and slot end.

--- a/packages/preconfirmation-p2p/crates/types/src/crypto.rs
+++ b/packages/preconfirmation-p2p/crates/types/src/crypto.rs
@@ -50,11 +50,23 @@ pub fn keccak256_ssz_with_domain<T: SimpleSerialize>(
 }
 
 /// Sign the SSZ-serialized commitment with a secp256k1 key, returning a 65-byte (r,s,v) signature.
+///
+/// Uses the default `DOMAIN_PRECONF` separator; deployments with a chain-specific domain
+/// should use [`sign_commitment_with_domain`].
 pub fn sign_commitment(
     commitment: &PreconfCommitment,
     sk: &SecretKey,
 ) -> Result<Bytes65, CryptoError> {
-    let msg_hash = keccak256_ssz(commitment)?;
+    sign_commitment_with_domain(commitment, sk, &crate::constants::DOMAIN_PRECONF)
+}
+
+/// Sign the SSZ-serialized commitment with an explicit 32-byte signing domain (spec §4.1).
+pub fn sign_commitment_with_domain(
+    commitment: &PreconfCommitment,
+    sk: &SecretKey,
+    domain: &[u8; 32],
+) -> Result<Bytes65, CryptoError> {
+    let msg_hash = keccak256_ssz_with_domain(commitment, domain)?;
     let msg =
         Message::from_digest_slice(msg_hash.as_slice()).map_err(CryptoError::SignatureFormat)?;
     let sig = Secp256k1::new().sign_ecdsa_recoverable(&msg, sk);
@@ -67,11 +79,24 @@ pub fn sign_commitment(
 }
 
 /// Recover the signer address from a signature over SSZ(commitment).
+///
+/// Uses the default `DOMAIN_PRECONF` separator; deployments with a chain-specific domain
+/// should use [`recover_signer_with_domain`].
 pub fn recover_signer(
     commitment: &PreconfCommitment,
     signature: &Bytes65,
 ) -> Result<Address, CryptoError> {
-    let msg_hash = keccak256_ssz(commitment)?;
+    recover_signer_with_domain(commitment, signature, &crate::constants::DOMAIN_PRECONF)
+}
+
+/// Recover the signer address from a signature using an explicit 32-byte signing domain
+/// (spec §4.1).
+pub fn recover_signer_with_domain(
+    commitment: &PreconfCommitment,
+    signature: &Bytes65,
+    domain: &[u8; 32],
+) -> Result<Address, CryptoError> {
+    let msg_hash = keccak256_ssz_with_domain(commitment, domain)?;
     let msg =
         Message::from_digest_slice(msg_hash.as_slice()).map_err(CryptoError::SignatureFormat)?;
     let rec_id =
@@ -85,8 +110,20 @@ pub fn recover_signer(
 }
 
 /// Verify a `SignedCommitment`, returning the recovered address on success.
+///
+/// Uses the default `DOMAIN_PRECONF` separator; deployments with a chain-specific domain
+/// should use [`verify_signed_commitment_with_domain`].
 pub fn verify_signed_commitment(signed: &SignedCommitment) -> Result<Address, CryptoError> {
     recover_signer(&signed.commitment, &signed.signature)
+}
+
+/// Verify a `SignedCommitment` under an explicit 32-byte signing domain (spec §4.1),
+/// returning the recovered address on success.
+pub fn verify_signed_commitment_with_domain(
+    signed: &SignedCommitment,
+    domain: &[u8; 32],
+) -> Result<Address, CryptoError> {
+    recover_signer_with_domain(&signed.commitment, &signed.signature, domain)
 }
 
 /// Convert a secp256k1 public key into an Ethereum address (last 20 bytes of keccak256(pubkey)).
@@ -144,6 +181,49 @@ mod tests {
         let pk = PublicKey::from_secret_key(&Secp256k1::new(), &sk);
         let expected = public_key_to_address(&pk);
         assert_eq!(recovered, expected);
+    }
+
+    /// Signing and recovery agree when both sides use the same custom domain.
+    #[test]
+    fn custom_domain_sign_and_recover_roundtrip() {
+        let commitment = sample_commitment();
+        let sk = SecretKey::from_slice(&[42u8; 32]).unwrap();
+        let domain = *b"CUSTOM_PRECONF_DOMAIN_FOR_TESTS!";
+        let sig = sign_commitment_with_domain(&commitment, &sk, &domain).unwrap();
+        let recovered = recover_signer_with_domain(&commitment, &sig, &domain).unwrap();
+        let pk = PublicKey::from_secret_key(&Secp256k1::new(), &sk);
+        assert_eq!(recovered, public_key_to_address(&pk));
+
+        let signed = SignedCommitment { commitment, signature: sig };
+        let verified = verify_signed_commitment_with_domain(&signed, &domain).unwrap();
+        assert_eq!(verified, public_key_to_address(&pk));
+    }
+
+    /// Recovery under a different domain must not yield the signer's address.
+    #[test]
+    fn mismatched_domain_recovers_different_signer() {
+        let commitment = sample_commitment();
+        let sk = SecretKey::from_slice(&[42u8; 32]).unwrap();
+        let domain = *b"CUSTOM_PRECONF_DOMAIN_FOR_TESTS!";
+        let sig = sign_commitment_with_domain(&commitment, &sk, &domain).unwrap();
+        let pk = PublicKey::from_secret_key(&Secp256k1::new(), &sk);
+        let signer = public_key_to_address(&pk);
+
+        // Recovering with the default domain must not attribute the signature to the signer.
+        let recovered = recover_signer(&commitment, &sig);
+        assert!(recovered.is_err() || recovered.unwrap() != signer);
+    }
+
+    /// The default-domain helpers stay byte-identical to the explicit-domain variants.
+    #[test]
+    fn default_domain_helpers_match_explicit_variants() {
+        let commitment = sample_commitment();
+        let sk = SecretKey::from_slice(&[42u8; 32]).unwrap();
+        let default_sig = sign_commitment(&commitment, &sk).unwrap();
+        let explicit_sig =
+            sign_commitment_with_domain(&commitment, &sk, &crate::constants::DOMAIN_PRECONF)
+                .unwrap();
+        assert_eq!(default_sig, explicit_sig);
     }
 
     /// Verifying a signed commitment recovers the signer used to create it.

--- a/packages/preconfirmation-p2p/crates/types/src/types.rs
+++ b/packages/preconfirmation-p2p/crates/types/src/types.rs
@@ -32,7 +32,7 @@ pub struct Preconfirmation {
     /// End Of Preconfirmation window flag for the preconfirmation,
     /// indicating if this is the final preconfirmation in a sequence.
     pub eop: bool,
-    /// L1 block number referenced by the preconfirmation.
+    /// L2 block number being preconfirmed (spec §3.1).
     pub block_number: Uint256,
     /// Timestamp for the preconfirmation window.
     pub timestamp: Uint256,

--- a/packages/preconfirmation-p2p/docs/specification.md
+++ b/packages/preconfirmation-p2p/docs/specification.md
@@ -21,11 +21,11 @@ Scope: This spec covers preconfirmation metadata and raw transaction list (txlis
 Sidecars MUST publish and subscribe to the following live gossip topics:
 
 1. `/taiko/<chainID>/0/preconfirmationCommitments`
-    - Payload: raw SSZ-encoded `SignedCommitment` (no snappy compression).
-    - Purpose: live, authoritative preconfirmation metadata feed.
+   - Payload: raw SSZ-encoded `SignedCommitment` (no snappy compression).
+   - Purpose: live, authoritative preconfirmation metadata feed.
 2. `/taiko/<chainID>/0/rawTxLists`
-    - Payload: `RawTxListGossip` (see §3.4) — includes `rawTxListHash`, and compressed `txlist` bytes.
-    - Purpose: live distribution of raw txlists referenced by commitments.
+   - Payload: `RawTxListGossip` (see §3.4) — includes `rawTxListHash`, and compressed `txlist` bytes.
+   - Purpose: live distribution of raw txlists referenced by commitments.
 
 Sidecars SHOULD deprecate the following legacy topics when operating in permissionless mode (MUST NOT publish to them):
 
@@ -34,7 +34,7 @@ Sidecars SHOULD deprecate the following legacy topics when operating in permissi
 - `/taiko/<chainID>/0/requestPreconfBlocks`
 - `/taiko/<chainID>/0/requestEndOfSequencingPreconfBlocks`
 
-Note: The `preconfirmationCommitments` topic previously existed for compatibility; in permissionless mode it is the primary live feed of preconfirmation metadata. Deterministic catch‑up of commitments and txlists is provided via req/resp protocols in §11–§12 (not via PubSub request/response topics).
+Note: The `preconfirmationCommitments` topic previously existed for compatibility; in permissionless mode it is the primary live feed of preconfirmation metadata. Deterministic catch‑up of commitments and txlists is provided via req/resp protocols in §10–§11 (not via PubSub request/response topics).
 
 ## 3. Message Types and SSZ Encodings
 
@@ -84,6 +84,7 @@ SignedCommitment := container {
 ```
 
 Encoding rules:
+
 - `SignedCommitment` is SSZ‑encoded (bool → 1 byte; LE32 encoding for `uint256`; hashes/addresses/signature copied as raw bytes). The signature is NOT part of the signing preimage.
 - On the wire, `SignedCommitment` MUST be sent as raw SSZ bytes (no additional compression or envelope).
 
@@ -99,6 +100,7 @@ RawTxListGossip := container {
 ```
 
 Rules:
+
 - Receivers MUST verify `keccak256(txlist) == rawTxListHash` before storing.
 - The message does not require a signature; authenticity is derived from the content hash and subsequent commitment verification.
 - Implementations SHOULD cap the maximum `txlist` size per chain config.
@@ -130,19 +132,21 @@ MUST REJECT if any of the following hold:
 - `c.slasherAddress != PRECONFER_SLASHER_ADDRESS`.
 - `p.submissionWindowEnd` does not equal the expected slot end timestamp according to the local schedule.
 - Parent consistency fails:
-    - `p.parentPreconfirmationHash` does not equal the local canonical head’s `PreconfirmationHash`.
+  - `p.parentPreconfirmationHash` does not equal the local canonical head’s `PreconfirmationHash`.
 - Block parameter validation fails:
-    - `p.blockNumber` does not follow the local canonical head (e.g., not parent.blockNumber + 1).
-    - `p.timestamp`, `p.gasLimit`, `p.coinbase`, `p.proverAuth`, or `p.proposalId` violate the chain’s derivation rules (e.g., timestamp drift bounds, gas limit progression, correct coinbase/prover authorization per lookahead/URC configuration).
+  - `p.blockNumber` does not follow the local canonical head (e.g., not parent.blockNumber + 1).
+  - `p.timestamp`, `p.gasLimit`, `p.coinbase`, `p.proverAuth`, or `p.proposalId` violate the chain’s derivation rules (e.g., timestamp drift bounds, gas limit progression, correct coinbase/prover authorization per lookahead/URC configuration).
 
 Missing parents:
 
 - If the referenced parent commitment is not yet known locally (e.g., commitments 101–102 arrive before 100), implementations SHOULD buffer the child as pending and MUST NOT reject or penalize it until the parent is available. Once the parent is known, only reject if the expected parent hash does not match; otherwise continue validation.
 
 EOP-only handling:
+
 - If `p.eop == true` and the local sidecar does not expect a transaction list for this slot (`rawTxListHash == 0x00`), the sidecar MUST treat this as a handoff signal (advance the expected preconfer to the next committer per schedule). Any further non-EOP preconfs by the same committer for the same window SHOULD be considered misbehavior (basis for slashing evidence; outside this P2P scope).
 
 Client execution checks (out of P2P):
+
 - Before executing the L2 block, the client MUST ensure that `keccak256(txlist) == p.rawTxListHash`.
 
 ## 6. Sidecar Behavior
@@ -150,6 +154,7 @@ Client execution checks (out of P2P):
 ### 6.1 Publishing
 
 The elected preconfer for each L2 slot SHOULD:
+
 - Publish the `RawTxListGossip` on `/taiko/<chainID>/0/rawTxLists` (for non‑EOP slots), and
 - Publish the `SignedCommitment` on `/taiko/<chainID>/0/preconfirmationCommitments` before `submissionWindowEnd`.
 
@@ -162,18 +167,19 @@ Ordering: Sidecars MAY publish the txlist first (or concurrently) and the commit
 Upon receiving a `SignedCommitment`:
 
 1. Validate per section 5.
-    - If the local lookahead schedule for `p.submissionWindowEnd` is not yet available (e.g., still syncing the lookahead), implementations MAY buffer the commitment as “pending schedule”; during this phase they SHOULD only enforce hash‑chain linkage via `parentPreconfirmationHash` and defer all other validation until the schedule is known (or drop per local policy). No on‑chain lookups are required in
-    the hot path.
-2. If valid and `eop=false`, the client SHOULD look up the txlist by `p.rawTxListHash` in its local cache (populated by `/rawTxLists`) or via §12, verify the hash, reconstruct the L2 block (anchorTx from `p.anchorBlockNumber` + txlist) using the committed block parameters (`timestamp`, `gasLimit`, `coinbase`, `proverAuth`, `proposalId`), execute, and advance local L2 head.
+   - If the local lookahead schedule for `p.submissionWindowEnd` is not yet available (e.g., still syncing the lookahead), implementations MAY buffer the commitment as “pending schedule”; during this phase they SHOULD only enforce hash‑chain linkage via `parentPreconfirmationHash` and defer all other validation until the schedule is known (or drop per local policy). No on‑chain lookups are required in
+     the hot path.
+2. If valid and `eop=false`, the client SHOULD look up the txlist by `p.rawTxListHash` in its local cache (populated by `/rawTxLists`) or via §11, verify the hash, reconstruct the L2 block (anchorTx from `p.anchorBlockNumber` + txlist) using the committed block parameters (`timestamp`, `gasLimit`, `coinbase`, `proverAuth`, `proposalId`), execute, and advance local L2 head.
 3. If valid and `eop=true` and:
-    1.  **`rawTxListHash != 0x0`, d**o the same execution flow as in step (2), **and then** update local schedule state to reflect handoff to the next committer.
 
-    2. **`rawTxListHash == 0x00`**, no execution is required. Update local schedule state to reflect handoff to the next committer for subsequent slots.
+   1. **`rawTxListHash != 0x0`, d**o the same execution flow as in step (2), **and then** update local schedule state to reflect handoff to the next committer.
 
+   2. **`rawTxListHash == 0x00`**, no execution is required. Update local schedule state to reflect handoff to the next committer for subsequent slots.
 
 Startup and catch‑up:
-- After beacon‑syncing the L2 execution engine to the latest on‑chain tip, sidecars SHOULD synchronize missing preconfirmation metadata via the req/resp commitment sync (§11), then subscribe for live updates on `/preconfirmationCommitments`.
-- If the sidecar lacks required txlists for validated commitments (e.g., due to downtime and no local cache), it SHOULD fetch the missing txlists by hash using the req/resp rawTxList retrieval (§12) or an equivalent non‑P2P path.
+
+- After beacon‑syncing the L2 execution engine to the latest on‑chain tip, sidecars SHOULD synchronize missing preconfirmation metadata via the req/resp commitment sync (§10), then subscribe for live updates on `/preconfirmationCommitments`.
+- If the sidecar lacks required txlists for validated commitments (e.g., due to downtime and no local cache), it SHOULD fetch the missing txlists by hash using the req/resp rawTxList retrieval (§11) or an equivalent non‑P2P path.
 
 ### 6.3 Reorgs
 
@@ -184,7 +190,7 @@ On L1 reorgs affecting any `anchorBlockNumber` in the executed range, implementa
 - Message formats: raw SSZ `SignedCommitment` (commitments) and `RawTxListGossip` (txlists).
 - Message identification: Implementations SHOULD select a stable message ID function (e.g., hash of topic + payload) suitable for deduplication.
 - Rate limiting: Implementations SHOULD enforce per‑peer rate limiting and short duplicate windows to limit spam.
-- Deduplication: Implementations SHOULD deduplicate commitments per `(slot, signer)` and per `(blockNumber, rawTxListHash)`; txlists per `rawTxListHash`.
+- Deduplication: Implementations SHOULD deduplicate commitments per `blockNumber` (the latest validated commitment for a block supersedes earlier ones) and txlists per `rawTxListHash`. Wire-level duplicates are additionally suppressed by the gossipsub message-id cache.
 - Size caps: Implementations MUST enforce a maximum txlist size and discard oversized `RawTxListGossip` messages.
 - Self‑messages: Implementations MUST ignore messages originating from the local sidecar.
 - Peer scoring: Implementations MUST integrate gossipsub peer scoring feedback to penalize peers whose messages fail validation (e.g., wrong signer for the slot), to reduce repeated spam from misbehaving peers.
@@ -196,10 +202,10 @@ The following scoring profile is normative for all preconfirmation topics unless
 - Enable gossipsub v1.1 scoring with application feedback.
 - App feedback MUST apply a negative delta on validation failure (bad signature, wrong slot signer, hash mismatch, oversized txlist) and a small positive delta on acceptance/forward; defaults: ‑1 per failure (cap ‑4 per 10s per peer), +0.05 per acceptance (with a cap).
 - Parameters (defaults to be exposed/configurable but supported):
-    - decay: ~0.9 per 10s tick; `appScore` clamp: [‑10, +10]; `topicWeight` : 1.0.
-    - `invalidMessageDeliveriesWeight`: 2.0 (dominant); `invalidMessageDeliveriesDecay`: 0.99; cap at ‑20 (networks MAY remove the cap entirely to accelerate eviction).
-    - `firstMessageDeliveriesWeight`: 0.5; `firstMessageDeliveriesDecay`: 0.999; cap at 20.
-    - `timeInMeshQuantum`: 1s; `timeInMeshCap`: 3600s.
+  - decay: ~0.9 per 10s tick; `appScore` clamp: [‑10, +10]; `topicWeight` : 1.0.
+  - `invalidMessageDeliveriesWeight`: ‑2.0 (a negative penalty weight, dominant; gossipsub implementations reject positive penalty weights); `invalidMessageDeliveriesDecay`: 0.99; cap at ‑20 where the implementation supports a cap (networks MAY remove the cap entirely to accelerate eviction).
+  - `firstMessageDeliveriesWeight`: 0.5; `firstMessageDeliveriesDecay`: 0.999; cap at 20.
+  - `timeInMeshQuantum`: 1s; `timeInMeshCap`: 3600s.
 - Enforcement MUST drop peers below score ‑1, prune below ‑2, and ban (disconnect + ignore) below ‑5 sustained >30s (or stricter).
 - Implementations MUST NOT penalize buffered commitments awaiting lookahead availability; only score once validation can definitively succeed/fail.
 
@@ -227,7 +233,18 @@ All requests are libp2p stream-based req/resp methods (eth-like). Suggested prot
 
 ### 10.2 Messages (SSZ)
 
-GetHead (no request body):
+GetHead (request):
+
+```
+GetHeadRequest := container {
+  reserved: List[uint8, 0]            # empty placeholder; carries no data
+}
+```
+
+The request carries no information; the empty `reserved` list exists so the request is a
+well-formed SSZ container on the wire (serializing to a single 4-byte offset).
+
+GetHead (response):
 
 ```
 PreconfHead := container {
@@ -254,6 +271,7 @@ GetCommitmentsByNumberResponse := container {
 ```
 
 Constraints:
+
 - Responders MUST cap `maxCount` and the total response bytes.
 - Receivers MUST validate each `SignedCommitment` per §5.
 
@@ -266,11 +284,13 @@ Constraints:
 ### 10.3 Behavior
 
 Requester (catch‑up):
+
 - After beacon‑sync, call `get_head` to discover peer preconf head P.
 - If `P > local_onchain_tip`, page `get_commitments_by_number{ start = local_onchain_tip+1, maxCount = CAP }` until caught up.
 - For each commitment, validate (§5); for any missing txlist, retrieve by hash via §11; then reconstruct and execute.
 
 Responder:
+
 - Rate‑limit per peer; deduplicate repeated requests; respond with ordered commitments up to limits.
 
 ### 10.4 DoS and Limits
@@ -306,8 +326,12 @@ GetRawTxListResponse := container {
 ```
 
 Constraints:
+
 - Responders MUST ensure `keccak256(txlist) == rawTxListHash` before serving.
 - Responders SHOULD cap the maximum response size per chain config (e.g., `BlockMaxTxListBytes`).
+- Not found: when the responder does not hold the requested txlist, it MUST respond with the
+  echoed `rawTxListHash` and an empty `txlist`. Requesters MUST treat an empty `txlist` as
+  not-found (and MUST NOT penalize the responder for it).
 
 ### 11.2.1 Transport Framing and Encoding
 
@@ -318,10 +342,12 @@ Constraints:
 ### 11.3 Behavior
 
 Requester:
+
 - For each validated commitment lacking a local txlist, call `get_raw_txlist{ rawTxListHash }`.
 - Verify `keccak256(txlist) == rawTxListHash`, store by hash, reconstruct and execute using `anchorBlockNumber` from the related commitment.
 
 Responder:
+
 - Serve available txlists keyed by hash; rate‑limit and deduplicate per peer/hash.
 
 ### 11.4 DoS and Limits

--- a/packages/taiko-client-rs/bin/client/src/commands/preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/preconfirmation_driver.rs
@@ -96,6 +96,13 @@ impl Subcommand for PreconfirmationDriverSubCommand {
             runner_config =
                 runner_config.with_rpc(Some(PreconfRpcServerConfig { listen_addr: rpc_addr }));
         }
+        if let Some(domain) = self
+            .preconf_flags
+            .parse_signing_domain()
+            .map_err(preconfirmation_driver::PreconfirmationClientError::Config)?
+        {
+            runner_config = runner_config.with_signing_domain(domain);
+        }
 
         PreconfirmationDriverRunner::new(runner_config).run().await?;
         Ok(())

--- a/packages/taiko-client-rs/bin/client/src/flags/preconfirmation.rs
+++ b/packages/taiko-client-rs/bin/client/src/flags/preconfirmation.rs
@@ -38,6 +38,30 @@ pub struct PreconfirmationArgs {
     /// Optional address for user-facing preconfirmation RPC server.
     #[clap(long = "preconf.rpc.addr", env = "PRECONF_RPC_ADDR")]
     pub preconf_rpc_addr: Option<SocketAddr>,
+
+    /// Chain-configured 32-byte preconfirmation signing domain as hex (64 hex chars,
+    /// optional 0x prefix). Defaults to the protocol's built-in `DOMAIN_PRECONF`.
+    #[clap(long = "preconf.signing-domain", env = "PRECONF_SIGNING_DOMAIN")]
+    pub preconf_signing_domain: Option<String>,
+}
+
+impl PreconfirmationArgs {
+    /// Parse the optional signing-domain flag into a 32-byte array.
+    ///
+    /// Returns `None` when the flag is unset and an error when the value is not exactly
+    /// 32 bytes of hex.
+    pub fn parse_signing_domain(&self) -> Result<Option<[u8; 32]>, String> {
+        let Some(raw) = self.preconf_signing_domain.as_deref() else {
+            return Ok(None);
+        };
+        let stripped = raw.strip_prefix("0x").unwrap_or(raw);
+        let bytes = alloy_primitives::hex::decode(stripped)
+            .map_err(|err| format!("invalid preconf.signing-domain hex: {err}"))?;
+        let domain: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| "preconf.signing-domain must be exactly 32 bytes".to_string())?;
+        Ok(Some(domain))
+    }
 }
 
 #[cfg(test)]
@@ -47,6 +71,30 @@ mod tests {
     use clap::Parser;
 
     use super::PreconfirmationArgs;
+
+    #[test]
+    fn parses_signing_domain_hex() {
+        let domain_hex = "0x".to_string() + &"ab".repeat(32);
+        let args =
+            PreconfirmationArgs::try_parse_from(["test", "--preconf.signing-domain", &domain_hex])
+                .expect("signing domain should parse");
+        let parsed = args.parse_signing_domain().expect("valid domain");
+        assert_eq!(parsed, Some([0xab; 32]));
+    }
+
+    #[test]
+    fn rejects_wrong_length_signing_domain() {
+        let args =
+            PreconfirmationArgs::try_parse_from(["test", "--preconf.signing-domain", "0xabcd"])
+                .expect("flag parses as string");
+        assert!(args.parse_signing_domain().is_err());
+    }
+
+    #[test]
+    fn unset_signing_domain_is_none() {
+        let args = PreconfirmationArgs::try_parse_from(["test"]).expect("no flags");
+        assert_eq!(args.parse_signing_domain().expect("ok"), None);
+    }
 
     #[test]
     fn parses_p2p_advertise_addr() {

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/client.rs
@@ -124,9 +124,11 @@ where
         let store: Arc<dyn CommitmentStore> = store;
         // Build the txlist codec using the protocol constant.
         let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
-        // Build the network validator.
-        let validator: Box<dyn ValidationAdapter> =
-            Box::new(LocalValidationAdapter::new(config.expected_slasher.clone()));
+        // Build the network validator with the chain-configured signing domain.
+        let validator: Box<dyn ValidationAdapter> = Box::new(LocalValidationAdapter::with_domain(
+            config.expected_slasher.clone(),
+            config.signing_domain,
+        ));
         // Create the P2P handle and node.
         let (handle, node) = P2pNode::new_with_validator_and_storage(
             config.p2p.clone(),
@@ -201,7 +203,8 @@ where
                 lookahead_resolver: Arc::clone(&config.lookahead_resolver),
             },
             handle.local_peer_id(),
-        );
+        )
+        .with_signing_domain(config.signing_domain);
 
         // Spawn the P2P node loop before running catch-up.
         // Convert anyhow::Result from P2pNode::run() to our crate's Result type.

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/config.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/config.rs
@@ -9,7 +9,7 @@ use std::{
 use alloy_primitives::Address;
 use alloy_provider::Provider;
 use preconfirmation_net::P2pConfig;
-use preconfirmation_types::Bytes20;
+use preconfirmation_types::{Bytes20, DOMAIN_PRECONF};
 use protocol::preconfirmation::{LookaheadResolver, PreconfSignerResolver};
 
 use crate::Result;
@@ -34,6 +34,8 @@ pub struct PreconfirmationClientConfig {
     pub lookahead_resolver: Arc<dyn PreconfSignerResolver + Send + Sync>,
     /// Maximum number of commitments/txlists retained in memory.
     pub retention_limit: usize,
+    /// Chain-configured 32-byte signing domain for commitment signatures (spec §4.1/§8).
+    pub signing_domain: [u8; 32],
 }
 
 impl Debug for PreconfirmationClientConfig {
@@ -47,6 +49,7 @@ impl Debug for PreconfirmationClientConfig {
             .field("txlist_fetch_concurrency", &self.txlist_fetch_concurrency)
             .field("lookahead_resolver", &"<PreconfSignerResolver>")
             .field("retention_limit", &self.retention_limit)
+            .field("signing_domain", &alloy_primitives::hex::encode(self.signing_domain))
             .finish()
     }
 }
@@ -66,6 +69,7 @@ impl PreconfirmationClientConfig {
             txlist_fetch_concurrency: None,
             lookahead_resolver,
             retention_limit: DEFAULT_RETENTION_LIMIT,
+            signing_domain: DOMAIN_PRECONF,
         })
     }
 
@@ -82,6 +86,7 @@ impl PreconfirmationClientConfig {
             txlist_fetch_concurrency: None,
             lookahead_resolver,
             retention_limit: DEFAULT_RETENTION_LIMIT,
+            signing_domain: DOMAIN_PRECONF,
         }
     }
 
@@ -130,6 +135,7 @@ mod tests {
             txlist_fetch_concurrency: None,
             lookahead_resolver: Arc::new(MockLookaheadResolver::new(Address::ZERO, U256::ZERO)),
             retention_limit,
+            signing_domain: preconfirmation_types::DOMAIN_PRECONF,
         }
     }
 

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/api_helpers.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/api_helpers.rs
@@ -56,6 +56,7 @@ pub(crate) async fn publish_block_impl(
     codec: &ZlibTxListCodec,
     expected_slasher: Option<&Bytes20>,
     lookahead_resolver: &(dyn protocol::preconfirmation::PreconfSignerResolver + Send + Sync),
+    signing_domain: &[u8; 32],
     request: PublishBlockRequest,
 ) -> Result<PublishBlockResponse> {
     // 1. SSZ-decode the commitment.
@@ -96,10 +97,11 @@ pub(crate) async fn publish_block_impl(
     }
 
     // 3. Validate commitment signature + recover signer.
-    let signer = validate_commitment_with_signer(&signed_commitment, expected_slasher)
-        .inspect_err(|_| {
-            record_validation_failure();
-        })?;
+    let signer =
+        validate_commitment_with_signer(&signed_commitment, expected_slasher, signing_domain)
+            .inspect_err(|_| {
+                record_validation_failure();
+            })?;
 
     log_publish_block_entry(&signed_commitment, signer, request.tx_list_hash);
 
@@ -253,6 +255,7 @@ mod tests {
             &codec,
             None,
             &MockLookaheadResolver::default(),
+            &preconfirmation_types::DOMAIN_PRECONF,
             request,
         )
         .await;
@@ -289,6 +292,7 @@ mod tests {
             &codec,
             None,
             &MockLookaheadResolver::default(),
+            &preconfirmation_types::DOMAIN_PRECONF,
             request,
         )
         .await;

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/runner_api.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/rpc/runner_api.rs
@@ -32,21 +32,45 @@ pub(crate) struct RunnerRpcApiImpl<I: InboxReader> {
     codec: Arc<ZlibTxListCodec>,
     /// Expected slasher address for commitment validation.
     expected_slasher: Option<Bytes20>,
+    /// Chain-configured 32-byte signing domain for commitment signatures (spec §4.1/§8).
+    signing_domain: [u8; 32],
     /// Local peer ID string used in status responses.
     local_peer_id: String,
 }
 
+/// Construction parameters for [`RunnerRpcApiImpl`].
+pub(crate) struct RunnerRpcApiParams<I: InboxReader> {
+    /// Channel used to send P2P/network commands.
+    pub command_tx: mpsc::Sender<NetworkCommand>,
+    /// Driver client used for tip queries and preconfirmation submission.
+    pub driver: Arc<dyn DriverClient>,
+    /// Inbox reader used to determine sync status.
+    pub inbox_reader: I,
+    /// Lookahead resolver for slot info by timestamp.
+    pub lookahead_resolver: Arc<dyn protocol::preconfirmation::PreconfSignerResolver + Send + Sync>,
+    /// Txlist codec for decompression.
+    pub codec: Arc<ZlibTxListCodec>,
+    /// Expected slasher address for commitment validation.
+    pub expected_slasher: Option<Bytes20>,
+    /// Chain-configured 32-byte signing domain for commitment signatures (spec §4.1/§8).
+    pub signing_domain: [u8; 32],
+    /// Local peer ID string used in status responses.
+    pub local_peer_id: String,
+}
+
 impl<I: InboxReader> RunnerRpcApiImpl<I> {
     /// Create a new runner RPC API instance.
-    pub(crate) fn new(
-        command_tx: mpsc::Sender<NetworkCommand>,
-        driver: Arc<dyn DriverClient>,
-        inbox_reader: I,
-        lookahead_resolver: Arc<dyn protocol::preconfirmation::PreconfSignerResolver + Send + Sync>,
-        codec: Arc<ZlibTxListCodec>,
-        expected_slasher: Option<Bytes20>,
-        local_peer_id: String,
-    ) -> Self {
+    pub(crate) fn new(params: RunnerRpcApiParams<I>) -> Self {
+        let RunnerRpcApiParams {
+            command_tx,
+            driver,
+            inbox_reader,
+            lookahead_resolver,
+            codec,
+            expected_slasher,
+            signing_domain,
+            local_peer_id,
+        } = params;
         Self {
             command_tx,
             driver,
@@ -54,6 +78,7 @@ impl<I: InboxReader> RunnerRpcApiImpl<I> {
             lookahead_resolver,
             codec,
             expected_slasher,
+            signing_domain,
             local_peer_id,
         }
     }
@@ -68,6 +93,7 @@ impl<I: InboxReader + 'static> PreconfRpcApi for RunnerRpcApiImpl<I> {
             &self.codec,
             self.expected_slasher.as_ref(),
             self.lookahead_resolver.as_ref(),
+            &self.signing_domain,
             request,
         )
         .await
@@ -122,15 +148,16 @@ mod tests {
         let driver = Arc::new(StubDriver::with_preconf_tip(U256::from(100)));
         let inbox_reader = MockInboxReader::new(43, Some(88), Some(88));
 
-        let api = RunnerRpcApiImpl::new(
+        let api = RunnerRpcApiImpl::new(super::RunnerRpcApiParams {
             command_tx,
             driver,
             inbox_reader,
-            Arc::new(MockLookaheadResolver::default()),
-            Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES)),
-            None,
-            "test-peer".to_string(),
-        );
+            lookahead_resolver: Arc::new(MockLookaheadResolver::default()),
+            codec: Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES)),
+            expected_slasher: None,
+            signing_domain: preconfirmation_types::DOMAIN_PRECONF,
+            local_peer_id: "test-peer".to_string(),
+        });
 
         let status = api.get_status().await.unwrap();
         assert_eq!(status.event_sync_tip, Some(U256::from(88)));
@@ -146,15 +173,16 @@ mod tests {
         let (command_tx, mut command_rx) = mpsc::channel(8);
         tokio::spawn(async move { while command_rx.recv().await.is_some() {} });
 
-        let api = RunnerRpcApiImpl::new(
+        let api = RunnerRpcApiImpl::new(super::RunnerRpcApiParams {
             command_tx,
-            Arc::new(StubDriver::default()),
-            MockInboxReader::new(0, None, None),
-            Arc::new(MockLookaheadResolver::default()),
-            Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES)),
-            None,
-            "test-peer".to_string(),
-        );
+            driver: Arc::new(StubDriver::default()),
+            inbox_reader: MockInboxReader::new(0, None, None),
+            lookahead_resolver: Arc::new(MockLookaheadResolver::default()),
+            codec: Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES)),
+            expected_slasher: None,
+            signing_domain: preconfirmation_types::DOMAIN_PRECONF,
+            local_peer_id: "test-peer".to_string(),
+        });
 
         let slot_info = api.get_preconf_slot_info(U256::from(500)).await.unwrap();
         assert_eq!(slot_info.signer, alloy_primitives::Address::repeat_byte(0x11));

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/runner/mod.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/runner/mod.rs
@@ -15,7 +15,10 @@ use tracing::info;
 use crate::{
     ContractInboxReader, EventSyncerDriverClient, PreconfirmationClient,
     PreconfirmationClientConfig, PreconfirmationClientError,
-    rpc::{PreconfRpcApi, PreconfRpcServer, PreconfRpcServerConfig, runner_api::RunnerRpcApiImpl},
+    rpc::{
+        PreconfRpcApi, PreconfRpcServer, PreconfRpcServerConfig,
+        runner_api::{RunnerRpcApiImpl, RunnerRpcApiParams},
+    },
 };
 use protocol::preconfirmation::LookaheadResolver;
 use rpc::beacon::BeaconClient;
@@ -75,17 +78,30 @@ pub struct RunnerConfig {
     pub p2p_config: P2pConfig,
     /// Optional RPC server configuration for preconfirmation submissions.
     pub rpc_config: Option<PreconfRpcServerConfig>,
+    /// Chain-configured 32-byte signing domain for commitment signatures (spec §4.1/§8).
+    pub signing_domain: [u8; 32],
 }
 
 impl RunnerConfig {
     /// Build a runner configuration from driver and P2P config.
     pub fn new(driver_config: DriverConfig, p2p_config: P2pConfig) -> Self {
-        Self { driver_config, p2p_config, rpc_config: None }
+        Self {
+            driver_config,
+            p2p_config,
+            rpc_config: None,
+            signing_domain: preconfirmation_types::DOMAIN_PRECONF,
+        }
     }
 
     /// Enable the preconfirmation RPC server.
     pub fn with_rpc(mut self, rpc_config: Option<PreconfRpcServerConfig>) -> Self {
         self.rpc_config = rpc_config;
+        self
+    }
+
+    /// Override the chain-configured commitment signing domain.
+    pub fn with_signing_domain(mut self, signing_domain: [u8; 32]) -> Self {
+        self.signing_domain = signing_domain;
         self
     }
 }
@@ -145,10 +161,11 @@ impl PreconfirmationDriverRunner {
                 .map_err(PreconfirmationClientError::from)?;
 
         // Build the preconfirmation P2P client configuration.
-        let client_config = PreconfirmationClientConfig::new_with_resolver(
+        let mut client_config = PreconfirmationClientConfig::new_with_resolver(
             self.config.p2p_config,
             Arc::new(lookahead_resolver),
         );
+        client_config.signing_domain = self.config.signing_domain;
 
         // Wrap the driver so P2P submissions go through the event syncer.
         let driver_client =
@@ -169,15 +186,16 @@ impl PreconfirmationDriverRunner {
             let rpc_driver =
                 Arc::new(EventSyncerDriverClient::from_client(event_syncer.clone(), rpc_client));
             let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
-            let api: Arc<dyn PreconfRpcApi> = Arc::new(RunnerRpcApiImpl::new(
-                command_tx.clone(),
-                rpc_driver,
+            let api: Arc<dyn PreconfRpcApi> = Arc::new(RunnerRpcApiImpl::new(RunnerRpcApiParams {
+                command_tx: command_tx.clone(),
+                driver: rpc_driver,
                 inbox_reader,
                 lookahead_resolver,
                 codec,
                 expected_slasher,
+                signing_domain: self.config.signing_domain,
                 local_peer_id,
-            ));
+            }));
             let server = PreconfRpcServer::start(rpc_config.clone(), api).await?;
             info!(url = %server.http_url(), "preconfirmation RPC server started");
             rpc_server = Some(server);

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/event_handler.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/event_handler.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use alloy_primitives::{B256, U256};
 use preconfirmation_net::{NetworkCommand, NetworkEvent, PeerId};
 use preconfirmation_types::{
-    Bytes20, RawTxListGossip, SignedCommitment, uint256_to_u256, validate_raw_txlist_gossip,
+    Bytes20, DOMAIN_PRECONF, RawTxListGossip, SignedCommitment, uint256_to_u256,
+    validate_raw_txlist_gossip,
 };
 use protocol::{codec::ZlibTxListCodec, preconfirmation::PreconfSignerResolver};
 use tokio::sync::{broadcast, mpsc::Sender};
@@ -57,6 +58,8 @@ where
     pub(super) lookahead_resolver: Arc<dyn PreconfSignerResolver + Send + Sync>,
     /// Local libp2p peer ID used to ignore looped-back gossip messages.
     pub(super) local_peer_id: Option<PeerId>,
+    /// Chain-configured 32-byte signing domain for commitment signatures (spec §4.1/§8).
+    pub(super) signing_domain: [u8; 32],
 }
 
 /// Construction parameters for an [`EventHandler`].
@@ -104,6 +107,7 @@ where
             command_tx,
             lookahead_resolver,
             local_peer_id: None,
+            signing_domain: DOMAIN_PRECONF,
         }
     }
 
@@ -112,6 +116,12 @@ where
         let mut handler = Self::new(params);
         handler.local_peer_id = Some(local_peer_id);
         handler
+    }
+
+    /// Override the chain-configured signing domain used for signature recovery.
+    pub fn with_signing_domain(mut self, signing_domain: [u8; 32]) -> Self {
+        self.signing_domain = signing_domain;
+        self
     }
 
     /// Handle a network event.
@@ -237,7 +247,11 @@ where
         commitment: &SignedCommitment,
         current_block: U256,
     ) -> Option<alloy_primitives::Address> {
-        match validate_commitment_with_signer(commitment, self.expected_slasher.as_ref()) {
+        match validate_commitment_with_signer(
+            commitment,
+            self.expected_slasher.as_ref(),
+            &self.signing_domain,
+        ) {
             Ok(signer) => Some(signer),
             Err(err) => {
                 warn!(error = %err, "dropping invalid commitment");

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/mod.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/mod.rs
@@ -35,7 +35,7 @@ mod tests {
     use preconfirmation_types::{
         Bytes32, MAX_TXLIST_BYTES, PreconfCommitment, PreconfHead, Preconfirmation,
         RawTxListGossip, SignedCommitment, TxListBytes, Uint256, keccak256_bytes,
-        public_key_to_address, sign_commitment, uint256_to_u256,
+        preconfirmation_hash, public_key_to_address, sign_commitment, uint256_to_u256,
     };
 
     struct TestDriver {
@@ -419,13 +419,93 @@ mod tests {
         });
 
         let parent_hash = Bytes32::try_from(vec![9u8; 32]).expect("parent hash");
-        let commitment_two = build_signed_commitment(&sk, 2, parent_hash.clone(), 100, 200);
+        let commitment_one = build_signed_commitment(&sk, 1, parent_hash, 100, 200);
+        let commitment_two =
+            build_signed_commitment(&sk, 2, linkage_hash(&commitment_one), 100, 200);
+
         handler.handle_commitment(commitment_two).await.expect("gap buffered");
         assert_eq!(driver.submissions(), 0);
 
-        let commitment_one = build_signed_commitment(&sk, 1, parent_hash, 100, 200);
         handler.handle_commitment(commitment_one).await.expect("gap filled");
         assert_eq!(driver.submissions(), 2);
+    }
+
+    /// Convert a parent commitment's preconfirmation hash into the child's linkage field.
+    fn linkage_hash(parent: &SignedCommitment) -> Bytes32 {
+        let hash = preconfirmation_hash(&parent.commitment.preconf).expect("parent hash");
+        Bytes32::try_from(hash.as_slice().to_vec()).expect("linkage hash")
+    }
+
+    #[tokio::test]
+    async fn parent_hash_mismatch_blocks_submission() {
+        let store = Arc::new(InMemoryCommitmentStore::new());
+        let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
+        let driver = Arc::new(TestDriver::new());
+        let (event_tx, _event_rx) = broadcast::channel(16);
+        let (command_tx, _command_rx) = mpsc::channel(8);
+
+        let sk = SecretKey::from_slice(&[3u8; 32]).expect("secret key");
+        let signer = public_key_to_address(&PublicKey::from_secret_key(&Secp256k1::new(), &sk));
+        let lookahead_resolver = Arc::new(MockLookaheadResolver::new(signer, U256::from(200u64)));
+
+        let handler = EventHandler::new(EventHandlerParams {
+            store: store.clone(),
+            codec,
+            driver: driver.clone(),
+            expected_slasher: None,
+            event_tx,
+            command_tx,
+            lookahead_resolver,
+        });
+
+        let genesis_parent = Bytes32::try_from(vec![0u8; 32]).expect("parent hash");
+        let commitment_one = build_signed_commitment(&sk, 1, genesis_parent, 100, 200);
+        handler.handle_commitment(commitment_one).await.expect("block one processed");
+        assert_eq!(driver.submissions(), 1);
+
+        // Block two claims a parent hash that does not match block one's preconfirmation.
+        let bogus_parent = Bytes32::try_from(vec![9u8; 32]).expect("parent hash");
+        let commitment_two = build_signed_commitment(&sk, 2, bogus_parent, 100, 200);
+        handler.handle_commitment(commitment_two).await.expect("block two handled");
+
+        assert_eq!(driver.submissions(), 1, "linkage-broken commitment must not be submitted");
+        assert!(
+            store.get_commitment(&U256::from(2u64)).is_none(),
+            "linkage-broken commitment must be removed from the store"
+        );
+    }
+
+    #[tokio::test]
+    async fn chained_commitments_submit() {
+        let store = Arc::new(InMemoryCommitmentStore::new());
+        let codec = Arc::new(ZlibTxListCodec::new(MAX_TXLIST_BYTES));
+        let driver = Arc::new(TestDriver::new());
+        let (event_tx, _event_rx) = broadcast::channel(16);
+        let (command_tx, _command_rx) = mpsc::channel(8);
+
+        let sk = SecretKey::from_slice(&[3u8; 32]).expect("secret key");
+        let signer = public_key_to_address(&PublicKey::from_secret_key(&Secp256k1::new(), &sk));
+        let lookahead_resolver = Arc::new(MockLookaheadResolver::new(signer, U256::from(200u64)));
+
+        let handler = EventHandler::new(EventHandlerParams {
+            store: store.clone(),
+            codec,
+            driver: driver.clone(),
+            expected_slasher: None,
+            event_tx,
+            command_tx,
+            lookahead_resolver,
+        });
+
+        let genesis_parent = Bytes32::try_from(vec![0u8; 32]).expect("parent hash");
+        let commitment_one = build_signed_commitment(&sk, 1, genesis_parent, 100, 200);
+        let commitment_two =
+            build_signed_commitment(&sk, 2, linkage_hash(&commitment_one), 100, 200);
+
+        handler.handle_commitment(commitment_one).await.expect("block one processed");
+        handler.handle_commitment(commitment_two).await.expect("block two processed");
+
+        assert_eq!(driver.submissions(), 2, "properly linked commitments must both submit");
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/submission.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/subscription/submission.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{B256, U256};
 use preconfirmation_net::NetworkCommand;
-use preconfirmation_types::{PreconfHead, SignedCommitment, uint256_to_u256};
+use preconfirmation_types::{PreconfHead, SignedCommitment, uint256_to_u256, validate_parent_hash};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -19,10 +19,18 @@ where
     D: DriverClient,
 {
     /// Attempt to submit contiguous commitments starting at the provided block.
+    ///
+    /// Enforces spec §5 parent linkage: whenever the parent commitment is known locally,
+    /// the child's `parentPreconfirmationHash` must match the parent's preconfirmation
+    /// hash. When the parent commitment is unavailable (e.g. pruned or pre-startup) the
+    /// check is skipped per the spec's missing-parent rule.
     pub(super) async fn try_submit_contiguous_from(&self, start: U256) -> Result<()> {
         info!(start = %start, "attempting contiguous preconfirmation submit");
         let mut next = start;
         let mut submitted_count = 0usize;
+        let mut parent = start
+            .checked_sub(U256::ONE)
+            .and_then(|parent_block| self.store.get_commitment(&parent_block));
         loop {
             let Some(commitment) = self.store.get_commitment(&next) else {
                 debug!(
@@ -33,7 +41,23 @@ where
                 break;
             };
 
-            let submitted = self.submit_if_ready(commitment).await?;
+            if let Some(parent_commitment) = &parent &&
+                let Err(err) = validate_parent_hash(
+                    &commitment.commitment.preconf.parent_preconfirmation_hash,
+                    &parent_commitment.commitment.preconf,
+                )
+            {
+                warn!(
+                    block_number = %next,
+                    error = %err,
+                    "dropping commitment with broken parent linkage"
+                );
+                PreconfirmationClientMetrics::validation_failures_total().inc();
+                self.store.remove_commitment(&next);
+                break;
+            }
+
+            let submitted = self.submit_if_ready(commitment.clone()).await?;
             if !submitted {
                 debug!(
                     next = %next,
@@ -43,6 +67,7 @@ where
                 break;
             }
 
+            parent = Some(commitment);
             submitted_count += 1;
             next += U256::ONE;
         }

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/sync/catchup.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/sync/catchup.rs
@@ -123,6 +123,7 @@ impl TipCatchup {
             catchup_start_block,
             self.config.expected_slasher.as_ref(),
             self.config.lookahead_resolver.as_ref(),
+            &self.config.signing_domain,
         )
         .await;
 
@@ -214,14 +215,16 @@ pub(crate) async fn validate_commitment(
     commitment: &SignedCommitment,
     expected_slasher: Option<&preconfirmation_types::Bytes20>,
     lookahead_resolver: &(dyn PreconfSignerResolver + Send + Sync),
+    signing_domain: &[u8; 32],
 ) -> Option<SignedCommitment> {
-    let recovered_signer = match validate_commitment_with_signer(commitment, expected_slasher) {
-        Ok(signer) => signer,
-        Err(err) => {
-            warn!(error = %err, "dropping catch-up commitment with invalid basics");
-            return None;
-        }
-    };
+    let recovered_signer =
+        match validate_commitment_with_signer(commitment, expected_slasher, signing_domain) {
+            Ok(signer) => signer,
+            Err(err) => {
+                warn!(error = %err, "dropping catch-up commitment with invalid basics");
+                return None;
+            }
+        };
 
     let timestamp = uint256_to_u256(&commitment.commitment.preconf.timestamp);
     let expected_slot_info = match lookahead_resolver.slot_info_for_timestamp(timestamp).await {
@@ -263,6 +266,7 @@ pub(crate) async fn chain_from_tip(
     stop_block: U256,
     expected_slasher: Option<&preconfirmation_types::Bytes20>,
     lookahead_resolver: &(dyn PreconfSignerResolver + Send + Sync),
+    signing_domain: &[u8; 32],
 ) -> Vec<SignedCommitment> {
     let mut chain = Vec::new();
     let mut current = tip;
@@ -272,10 +276,13 @@ pub(crate) async fn chain_from_tip(
         return Vec::new();
     }
 
-    let tip = match validate_commitment(&current, expected_slasher, lookahead_resolver).await {
-        Some(commitment) => commitment,
-        None => return Vec::new(),
-    };
+    let tip =
+        match validate_commitment(&current, expected_slasher, lookahead_resolver, signing_domain)
+            .await
+        {
+            Some(commitment) => commitment,
+            None => return Vec::new(),
+        };
 
     chain.push(tip.clone());
     current = tip;
@@ -300,7 +307,13 @@ pub(crate) async fn chain_from_tip(
             }
         };
 
-        let parent = match validate_commitment(&parent, expected_slasher, lookahead_resolver).await
+        let parent = match validate_commitment(
+            &parent,
+            expected_slasher,
+            lookahead_resolver,
+            signing_domain,
+        )
+        .await
         {
             Some(commitment) => commitment,
             None => {

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/sync/mod.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/sync/mod.rs
@@ -55,7 +55,13 @@ mod tests {
         let parent_hash = Bytes32::try_from(vec![1u8; 32]).expect("parent hash");
         let commitment = make_commitment(1, parent_hash, 1000, 10, &sk);
 
-        let result = validate_commitment(&commitment, None, &resolver).await;
+        let result = validate_commitment(
+            &commitment,
+            None,
+            &resolver,
+            &preconfirmation_types::DOMAIN_PRECONF,
+        )
+        .await;
         assert!(result.is_some());
     }
 
@@ -67,7 +73,13 @@ mod tests {
         let parent_hash = Bytes32::try_from(vec![1u8; 32]).expect("parent hash");
         let commitment = make_commitment(1, parent_hash, 1000, 10, &sk);
 
-        let result = validate_commitment(&commitment, None, &resolver).await;
+        let result = validate_commitment(
+            &commitment,
+            None,
+            &resolver,
+            &preconfirmation_types::DOMAIN_PRECONF,
+        )
+        .await;
         assert!(result.is_none());
     }
 
@@ -82,7 +94,13 @@ mod tests {
         let zero_hash = Bytes32::try_from(vec![0u8; 32]).expect("zero hash");
         let commitment = make_commitment(0, zero_hash, 1000, 10, &sk);
 
-        let result = validate_commitment(&commitment, None, &resolver).await;
+        let result = validate_commitment(
+            &commitment,
+            None,
+            &resolver,
+            &preconfirmation_types::DOMAIN_PRECONF,
+        )
+        .await;
         assert!(result.is_some());
     }
 
@@ -121,7 +139,15 @@ mod tests {
         let tip = make_commitment(3, block3_parent, 1000, 30, &sk);
 
         let map = map_commitments(vec![block1.clone(), block2.clone()]);
-        let chain = chain_from_tip(tip, &map, U256::ONE, None, &resolver).await;
+        let chain = chain_from_tip(
+            tip,
+            &map,
+            U256::ONE,
+            None,
+            &resolver,
+            &preconfirmation_types::DOMAIN_PRECONF,
+        )
+        .await;
 
         assert_eq!(chain.len(), 3);
         assert_eq!(uint256_to_u256(&chain[0].commitment.preconf.block_number), U256::from(3));

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/validation/mod.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/validation/mod.rs
@@ -6,18 +6,22 @@
 use alloy_primitives::Address;
 use preconfirmation_types::{
     Bytes20, SignedCommitment, uint256_to_u256, validate_preconfirmation_basic,
-    verify_signed_commitment,
+    verify_signed_commitment_with_domain,
 };
 use protocol::preconfirmation::PreconfSlotInfo;
 
 use crate::error::{PreconfirmationClientError, Result, ValidationErrorCode};
 
 /// Validate a signed commitment with basic checks and return the recovered signer.
+///
+/// `signing_domain` is the chain-configured 32-byte `DOMAIN_PRECONF` separator used for
+/// the signature preimage (spec §4.1/§8).
 pub fn validate_commitment_with_signer(
     commitment: &SignedCommitment,
     expected_slasher: Option<&Bytes20>,
+    signing_domain: &[u8; 32],
 ) -> Result<Address> {
-    let recovered = verify_signed_commitment(commitment)
+    let recovered = verify_signed_commitment_with_domain(commitment, signing_domain)
         .map_err(|err| PreconfirmationClientError::Validation(err.to_string()))?;
     validate_preconfirmation_basic(&commitment.commitment.preconf)
         .map_err(|err| PreconfirmationClientError::Validation(err.to_string()))?;
@@ -65,10 +69,36 @@ pub fn validate_lookahead(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_eop_only, validate_lookahead};
+    use super::{is_eop_only, validate_commitment_with_signer, validate_lookahead};
     use alloy_primitives::{Address, U256};
-    use preconfirmation_types::{Bytes32, PreconfCommitment, Preconfirmation, SignedCommitment};
+    use preconfirmation_types::{
+        Bytes32, DOMAIN_PRECONF, PreconfCommitment, Preconfirmation, SignedCommitment,
+        public_key_to_address, sign_commitment_with_domain,
+    };
     use protocol::preconfirmation::PreconfSlotInfo;
+    use secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+    /// A commitment signed under a chain-specific domain verifies only with that domain.
+    #[test]
+    fn signing_domain_is_enforced() {
+        let domain = *b"CUSTOM_PRECONF_DOMAIN_FOR_TESTS!";
+        let sk = SecretKey::from_slice(&[5u8; 32]).expect("secret key");
+        let signer = public_key_to_address(&PublicKey::from_secret_key(&Secp256k1::new(), &sk));
+
+        let preconf = Preconfirmation { eop: true, ..Default::default() };
+        let commitment = PreconfCommitment { preconf, ..Default::default() };
+        let signature =
+            sign_commitment_with_domain(&commitment, &sk, &domain).expect("sign commitment");
+        let signed = SignedCommitment { commitment, signature };
+
+        let recovered =
+            validate_commitment_with_signer(&signed, None, &domain).expect("custom domain valid");
+        assert_eq!(recovered, signer);
+
+        // Under the default domain the recovered signer must differ (or recovery fails).
+        let default_result = validate_commitment_with_signer(&signed, None, &DOMAIN_PRECONF);
+        assert!(default_result.is_err() || default_result.unwrap() != signer);
+    }
 
     #[test]
     fn eop_only_detection() {


### PR DESCRIPTION
Follow-up to #21775, addressing the remaining spec-compliance findings from the preconfirmation-p2p package scan. Four logical commits, one per finding.

## 1. §5 parent-hash linkage on the live path (`d84234a`)

Catch-up already enforces hash-chain linkage structurally (parents are looked up by `preconfirmation_hash`), but the live gossip path only enforced block-number contiguity — a linkage-broken commitment from the elected preconfer would execute. The contiguous-submit loop now verifies `parentPreconfirmationHash` against the locally-known parent commitment before submitting, dropping broken commitments; when the parent commitment isn't available locally the check is skipped, per the spec's missing-parent rule. `validate_parent_hash` in `preconfirmation-types` (previously dead) gains its first production caller. New tests: `parent_hash_mismatch_blocks_submission` (watched failing first — the broken commitment was submitted on main), `chained_commitments_submit`; the pre-existing gap-fill test was building a non-chaining fixture and now chains properly.

## 2. §4.1/§8 chain-configurable `DOMAIN_PRECONF` (`1470feb`)

The signing domain was a hardcoded placeholder with no plumbing, so signatures could never interop with an independently configured deployment. Added `*_with_domain` variants for sign/recover/verify in `preconfirmation-types`, `with_domain` constructors on both net validation adapters, and a `signing_domain` threaded through `PreconfirmationClientConfig`, the event handler, catch-up, the RPC publish path, and a new `--preconf.signing-domain` CLI flag (32-byte hex). **All defaults remain byte-identical to the current placeholder domain** — nothing changes for existing networks until a chain configures a real value. A new test pins that the default-domain helpers stay byte-identical to the explicit-domain variants.

## 3. §7.1 reputation fine print (`3a9d31b`)

The local reputation store now implements the normative numbers it was missing:
- failure penalties cap at **−4 per 10s window per peer** (also defangs the out-of-scale reth action weights — a single req/resp error previously applied −16384)
- scores clamp to the **[−10, +10]** appScore bounds
- hard bans require the score to stay at/below the ban threshold **sustained >30s** (previously instantaneous); healing resets the timer
- defaults aligned to the spec: greylist/prune **−2**, ban **−5**, decay halflife **66s** (≈0.9 per 10s). The old defaults (−5/−10/600s) also disagreed with the store's own internal defaults.

The gossipsub app-score mirror from #21775 inherits the cap/clamp. Five new time-controlled tests via an `apply_at` seam (cap, window reset, clamp, sustained ban, heal-resets-timer), all watched failing first.

## 4. Spec/docs hygiene (`70ebce9`)

- fixed the off-by-one cross-references (§11–§12 → §10–§11 and the §6.2 pointers)
- `invalidMessageDeliveriesWeight` stated as the negative penalty weight **−2.0** (follow-up promised in #21775 — gossipsub rejects positive penalty weights)
- documented the `GetHeadRequest{reserved}` placeholder container actually sent on the wire
- documented the raw-txlist **not-found sentinel** (echoed hash + empty txlist, no penalty) that responders already send and requesters already handle
- dedup wording aligned with the implementation (per `blockNumber` / per `rawTxListHash`)
- fixed `Preconfirmation.blockNumber` doc comment (L2, not L1)

## Verification

- `preconfirmation-p2p`: `just fmt-check` / `just clippy` (`-D warnings -D missing_docs`) clean; 56/56 tests.
- `taiko-client-rs`: `just fmt-check` / `just clippy` clean; `preconfirmation-driver` lib 76/76; `taiko-client` bin 15/15.
- TDD throughout — every behavioral change had its test watched failing first.
- The `preconfirmation-driver` e2e suite requires the devnet harness env (`HARNESS_L1_WS` …) and panics at env load locally; deferring to CI for those. **Draft until CI e2e passes.**

## Notes for reviewers

- The ban-dynamics change (item 3) is the only behavioral change with operational impact: misbehaving peers now take ≥ ~40s of sustained abuse to hard-ban instead of one bad req/resp. Gossipsub-level penalties (P4 + app score) still throttle them immediately at the mesh level.
- The `(slot, signer)` dedup wording was relaxed to match the implementation rather than implementing tuple dedup — signer-per-slot binding is already enforced by lookahead validation, so the tuple added no protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)