### PR TITLE
feat(taiko-client): expose zk proof distance flag

### DIFF
--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -71,6 +71,15 @@ var (
 		Category: proverCategory,
 		EnvVars:  []string{"PROVER_PROPOSAL_WINDOW_SIZE"},
 	}
+	MaxZKProofProposalDistance = &cli.Uint64Flag{
+		Name: "prover.maxZKProofProposalDistance",
+		Usage: "The maximum proposal distance counted from lastFinalizedProposalID for requesting ZK proofs. " +
+			"When proposalID is greater than lastFinalizedProposalID + maxZKProofProposalDistance, " +
+			"the prover skips ZK proof and requests base proof instead. This flag only works for post Shasta fork. ",
+		Value:    30,
+		Category: proverCategory,
+		EnvVars:  []string{"PROVER_MAX_ZK_PROOF_PROPOSAL_DISTANCE"},
+	}
 	// Special flags for testing.
 	Dummy = &cli.BoolFlag{
 		Name:     "prover.dummy",
@@ -149,4 +158,5 @@ var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	ZKVMBatchSize,
 	ForceBatchProvingInterval,
 	ProposalWindowSize,
+	MaxZKProofProposalDistance,
 }, opsigner.CLIFlags("PROVER", proverCategory), TxmgrFlags)

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -21,34 +21,35 @@ import (
 
 // Config contains the configurations to initialize a Taiko prover.
 type Config struct {
-	L1WsEndpoint              string
-	L1BeaconEndpoint          string
-	L2WsEndpoint              string
-	L2EngineEndpoint          string
-	JwtSecret                 string
-	InboxAddress              common.Address
-	TaikoAnchorAddress        common.Address
-	L1ProverPrivKey           *ecdsa.PrivateKey
-	StartingProposalID        *big.Int
-	BackOffMaxRetries         uint64
-	BackOffRetryInterval      time.Duration
-	ProveUnassignedProposals  bool
-	RPCTimeout                time.Duration
-	ProveBatchesGasLimit      uint64
-	RaikoHostEndpoint         string
-	RaikoZKVMHostEndpoint     string
-	RaikoApiKey               string
-	RaikoRequestTimeout       time.Duration
-	LocalProposerAddresses    []common.Address
-	BlockConfirmations        uint64
-	TxmgrConfigs              *txmgr.CLIConfig
-	PrivateTxmgrConfigs       *txmgr.CLIConfig
-	SGXProofBufferSize        uint64
-	ZKVMProofBufferSize       uint64
-	ForceBatchProvingInterval time.Duration
-	ProofPollingInterval      time.Duration
-	Dummy                     bool
-	ProposalWindowSize        uint64
+	L1WsEndpoint               string
+	L1BeaconEndpoint           string
+	L2WsEndpoint               string
+	L2EngineEndpoint           string
+	JwtSecret                  string
+	InboxAddress               common.Address
+	TaikoAnchorAddress         common.Address
+	L1ProverPrivKey            *ecdsa.PrivateKey
+	StartingProposalID         *big.Int
+	BackOffMaxRetries          uint64
+	BackOffRetryInterval       time.Duration
+	ProveUnassignedProposals   bool
+	RPCTimeout                 time.Duration
+	ProveBatchesGasLimit       uint64
+	RaikoHostEndpoint          string
+	RaikoZKVMHostEndpoint      string
+	RaikoApiKey                string
+	RaikoRequestTimeout        time.Duration
+	LocalProposerAddresses     []common.Address
+	BlockConfirmations         uint64
+	TxmgrConfigs               *txmgr.CLIConfig
+	PrivateTxmgrConfigs        *txmgr.CLIConfig
+	SGXProofBufferSize         uint64
+	ZKVMProofBufferSize        uint64
+	ForceBatchProvingInterval  time.Duration
+	ProofPollingInterval       time.Duration
+	Dummy                      bool
+	ProposalWindowSize         uint64
+	MaxZKProofProposalDistance uint64
 }
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
@@ -119,11 +120,14 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		BackOffRetryInterval:     c.Duration(flags.BackOffRetryInterval.Name),
 		ProveUnassignedProposals: c.Bool(flags.ProveUnassignedProposals.Name),
 		ProposalWindowSize:       c.Uint64(flags.ProposalWindowSize.Name),
-		RPCTimeout:               c.Duration(flags.RPCTimeout.Name),
-		ProveBatchesGasLimit:     c.Uint64(flags.TxGasLimit.Name),
-		LocalProposerAddresses:   localProposerAddresses,
-		BlockConfirmations:       c.Uint64(flags.BlockConfirmations.Name),
-		TxmgrConfigs:             pkgFlags.InitTxmgrConfigsFromCli(c.String(flags.L1WSEndpoint.Name), l1ProverPrivKey, c),
+		MaxZKProofProposalDistance: c.Uint64(
+			flags.MaxZKProofProposalDistance.Name,
+		),
+		RPCTimeout:             c.Duration(flags.RPCTimeout.Name),
+		ProveBatchesGasLimit:   c.Uint64(flags.TxGasLimit.Name),
+		LocalProposerAddresses: localProposerAddresses,
+		BlockConfirmations:     c.Uint64(flags.BlockConfirmations.Name),
+		TxmgrConfigs:           pkgFlags.InitTxmgrConfigsFromCli(c.String(flags.L1WSEndpoint.Name), l1ProverPrivKey, c),
 		PrivateTxmgrConfigs: pkgFlags.InitTxmgrConfigsFromCli(
 			c.String(flags.L1PrivateEndpoint.Name),
 			l1ProverPrivKey,

--- a/packages/taiko-client/prover/config_test.go
+++ b/packages/taiko-client/prover/config_test.go
@@ -2,9 +2,11 @@ package prover
 
 import (
 	"os"
+	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/encoding"
@@ -68,6 +70,20 @@ func (s *ProverTestSuite) TestProverConfigShastaOnlySurface() {
 	}))
 }
 
+func TestNewConfigFromCliContextMaxZKProofProposalDistance(t *testing.T) {
+	t.Run("uses default value", func(t *testing.T) {
+		cfg := newTestConfigFromCLI(t)
+
+		require.Equal(t, uint64(30), cfg.MaxZKProofProposalDistance)
+	})
+
+	t.Run("uses flag value", func(t *testing.T) {
+		cfg := newTestConfigFromCLI(t, "--"+flags.MaxZKProofProposalDistance.Name, "12")
+
+		require.Equal(t, uint64(12), cfg.MaxZKProofProposalDistance)
+	})
+}
+
 func (s *ProverTestSuite) TestNewConfigFromCliContextProverKeyError() {
 	app := s.SetupApp()
 
@@ -98,4 +114,50 @@ func (s *ProverTestSuite) SetupApp() *cli.App {
 		return err
 	}
 	return app
+}
+
+func newTestConfigFromCLI(t *testing.T, extraArgs ...string) *Config {
+	t.Helper()
+
+	jwtSecret := t.TempDir() + "/jwt-secret.txt"
+	require.NoError(
+		t,
+		os.WriteFile(
+			jwtSecret,
+			[]byte("0x1000000000000000000000000000000000000000000000000000000000000000"),
+			0o600,
+		),
+	)
+
+	app := cli.NewApp()
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{Name: flags.L1WSEndpoint.Name},
+		&cli.StringFlag{Name: flags.L2WSEndpoint.Name},
+		&cli.StringFlag{Name: flags.InboxAddress.Name},
+		&cli.StringFlag{Name: flags.TaikoAnchorAddress.Name},
+		&cli.StringFlag{Name: flags.L1ProverPrivKey.Name},
+		&cli.StringFlag{Name: flags.JWTSecret.Name},
+		&cli.Uint64Flag{Name: flags.MaxZKProofProposalDistance.Name, Value: flags.MaxZKProofProposalDistance.Value},
+	}
+
+	var cfg *Config
+	app.Action = func(ctx *cli.Context) error {
+		var err error
+		cfg, err = NewConfigFromCliContext(ctx)
+		return err
+	}
+
+	args := []string{
+		"TestNewConfigFromCliContextMaxZKProofProposalDistance",
+		"--" + flags.L1WSEndpoint.Name, "http://localhost:8545",
+		"--" + flags.L2WSEndpoint.Name, "http://localhost:9545",
+		"--" + flags.InboxAddress.Name, common.HexToAddress("0x00000000000000000000000000000000000000aa").Hex(),
+		"--" + flags.TaikoAnchorAddress.Name, common.HexToAddress("0x00000000000000000000000000000000000000bb").Hex(),
+		"--" + flags.L1ProverPrivKey.Name, encoding.GoldenTouchPrivKey,
+		"--" + flags.JWTSecret.Name, jwtSecret,
+	}
+	args = append(args, extraArgs...)
+
+	require.NoError(t, app.Run(args))
+	return cfg
 }

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -115,6 +115,7 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 		cacheMaps,
 		p.flushCacheNotify,
 		new(big.Int).SetUint64(p.cfg.ProposalWindowSize),
+		new(big.Int).SetUint64(p.cfg.MaxZKProofProposalDistance),
 	); err != nil {
 		return fmt.Errorf("failed to initialize proof submitter: %w", err)
 	}

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -54,9 +54,10 @@ type ProofSubmitter struct {
 	proofBuffers   map[proofProducer.ProofType]*proofProducer.ProofBuffer
 	proofCacheMaps map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse]
 	// Intervals
-	forceBatchProvingInterval time.Duration
-	proofPollingInterval      time.Duration
-	proposalWindowSize        *big.Int
+	forceBatchProvingInterval  time.Duration
+	proofPollingInterval       time.Duration
+	proposalWindowSize         *big.Int
+	maxZKProofProposalDistance *big.Int
 }
 
 // NewProofSubmitter creates a new ProofSubmitter instance.
@@ -75,6 +76,7 @@ func NewProofSubmitter(
 	proofCacheMaps map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse],
 	flushCacheNotify chan proofProducer.ProofType,
 	proposalWindowSize *big.Int,
+	maxZKProofProposalDistance *big.Int,
 ) (*ProofSubmitter, error) {
 	proofSubmitter := &ProofSubmitter{
 		rpc:                    senderOpts.RPCClient,
@@ -90,13 +92,14 @@ func NewProofSubmitter(
 			senderOpts.PrivateTxmgr,
 			senderOpts.GasLimit,
 		),
-		proverAddress:             senderOpts.Txmgr.From(),
-		proofPollingInterval:      proofPollingInterval,
-		proofBuffers:              proofBuffers,
-		forceBatchProvingInterval: forceBatchProvingInterval,
-		proofCacheMaps:            proofCacheMaps,
-		flushCacheNotify:          flushCacheNotify,
-		proposalWindowSize:        proposalWindowSize,
+		proverAddress:              senderOpts.Txmgr.From(),
+		proofPollingInterval:       proofPollingInterval,
+		proofBuffers:               proofBuffers,
+		forceBatchProvingInterval:  forceBatchProvingInterval,
+		proofCacheMaps:             proofCacheMaps,
+		flushCacheNotify:           flushCacheNotify,
+		proposalWindowSize:         proposalWindowSize,
+		maxZKProofProposalDistance: maxZKProofProposalDistance,
 	}
 
 	proofSubmitter.startBackgroundWorkers(ctx)
@@ -203,6 +206,15 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 			)
 			return ErrProposalOutOfAllowedRange
 		}
+		if !s.shouldUseZKProof(proposalID, lastFinalizedProposalID) {
+			log.Info(
+				"Proposal too far from the last finalized proposal, skipping ZK proof",
+				"proposalID", proposalID,
+				"lastFinalizedProposalID", lastFinalizedProposalID,
+				"maxZKProofProposalDistance", s.maxZKProofProposalDistance,
+			)
+			useZK = false
+		}
 
 		// If zk proof is enabled, request zk proof first, and check if ZK proof is drawn.
 		if s.zkvmProofProducer != nil && useZK {
@@ -275,6 +287,16 @@ func (s *ProofSubmitter) isProposalOutOfRange(
 
 	maxAllowedProposalID := new(big.Int).Add(lastFinalizedProposalID, s.proposalWindowSize)
 	return proposalID.Cmp(maxAllowedProposalID) > 0 || proposalID.Cmp(lastFinalizedProposalID) <= 0
+}
+
+func (s *ProofSubmitter) shouldUseZKProof(proposalID *big.Int, lastFinalizedProposalID *big.Int) bool {
+	maxZKProofProposalDistance := s.maxZKProofProposalDistance
+	if maxZKProofProposalDistance == nil {
+		return true
+	}
+
+	maxZKProofProposalID := new(big.Int).Add(lastFinalizedProposalID, maxZKProofProposalDistance)
+	return proposalID.Cmp(maxZKProofProposalID) <= 0
 }
 
 // handleProofResponse routes a new proof into either the sequential buffer or cache.

--- a/packages/taiko-client/prover/proof_submitter/submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/submitter_test.go
@@ -84,6 +84,22 @@ func TestIsProposalOutOfRange(t *testing.T) {
 	})
 }
 
+func TestShouldUseZKProof(t *testing.T) {
+	submitter := &ProofSubmitter{maxZKProofProposalDistance: big.NewInt(30)}
+
+	lastFinalizedProposalID := big.NewInt(10)
+	require.True(t, submitter.shouldUseZKProof(big.NewInt(40), lastFinalizedProposalID))
+	require.False(t, submitter.shouldUseZKProof(big.NewInt(41), lastFinalizedProposalID))
+}
+
+func TestShouldUseZKProofUsesConfiguredDistance(t *testing.T) {
+	submitter := &ProofSubmitter{maxZKProofProposalDistance: big.NewInt(5)}
+
+	lastFinalizedProposalID := big.NewInt(10)
+	require.True(t, submitter.shouldUseZKProof(big.NewInt(15), lastFinalizedProposalID))
+	require.False(t, submitter.shouldUseZKProof(big.NewInt(16), lastFinalizedProposalID))
+}
+
 func TestFlushCacheSkipsEmptyCache(t *testing.T) {
 	submitter := &ProofSubmitter{
 		proofBuffers: map[proofProducer.ProofType]*proofProducer.ProofBuffer{


### PR DESCRIPTION
## Summary
- Add `prover.maxZKProofProposalDistance` with default value `30` and env var `PROVER_MAX_ZK_PROOF_PROPOSAL_DISTANCE`.
- Pass the configured value into the Shasta proof submitter.
- Skip requesting ZK proofs when `proposalID > lastFinalizedProposalID + maxZKProofProposalDistance`, then fall back to the base proof path.
- Add coverage for the default config value, custom flag value, and submitter boundary behavior.

## Validation
- `go test -count=1 ./packages/taiko-client/prover/proof_submitter`
- `go test -count=1 ./packages/taiko-client/prover -run TestNewConfigFromCliContextMaxZKProofProposalDistance`

Note: these commands emit existing macOS linker warnings from `github.com/herumi/bls-eth-go-binary`, but exit successfully.