### PR TITLE
feat(taiko-client): add local proposal metadata API

### DIFF
--- a/packages/taiko-client/README.md
+++ b/packages/taiko-client/README.md
@@ -45,6 +45,25 @@ Review each sub-command's command line flags:
 bin/taiko-client <sub-command> --help
 ```
 
+### Local proposal metadata API
+
+The driver can expose a disabled-by-default, loopback-only Shasta proposal metadata API for co-located
+TDX provers:
+
+```sh
+bin/taiko-client driver --proposalApi.enabled --proposalApi.addr 127.0.0.1:9876 ...
+```
+
+The API rejects non-loopback bind addresses. The only endpoint is:
+
+```sh
+GET /internal/shasta/proposals/{proposal_id}
+```
+
+The response contains the reconstructed Shasta proposal, its `hashProposal` value, and the source L1
+event coordinates. It is intended for local validation by a prover running on the same machine, not as
+a public API.
+
 ## Testing
 
 Ensure you have Docker running, and pnpm installed.

--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -65,6 +65,20 @@ var (
 		Category: driverCategory,
 		EnvVars:  []string{"PRECONFIRMATION_HANDOVER_SKIP_SLOTS"},
 	}
+	ProposalAPIEnabled = &cli.BoolFlag{
+		Name:     "proposalApi.enabled",
+		Usage:    "Enable the local-only Shasta proposal metadata API for co-located TDX provers",
+		Value:    false,
+		Category: driverCategory,
+		EnvVars:  []string{"PROPOSAL_API_ENABLED"},
+	}
+	ProposalAPIAddr = &cli.StringFlag{
+		Name:     "proposalApi.addr",
+		Usage:    "Loopback listen address for the local-only Shasta proposal metadata API",
+		Value:    "127.0.0.1:9876",
+		Category: driverCategory,
+		EnvVars:  []string{"PROPOSAL_API_ADDR"},
+	}
 )
 
 // DriverFlags All driver flags.
@@ -82,4 +96,6 @@ var DriverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	PreconfBlockServerJWTSecret,
 	PreconfBlockServerCORSOrigins,
 	PreconfHandoverSkipSlots,
+	ProposalAPIEnabled,
+	ProposalAPIAddr,
 }, p2pFlags.P2PFlags("PRECONFIRMATION"))

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/cmd/flags"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/jwt"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/proposalapi"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
@@ -47,6 +48,8 @@ type Config struct {
 	PreconfBlockServerPort        uint64
 	PreconfBlockServerJWTSecret   []byte
 	PreconfBlockServerCORSOrigins string
+	ProposalAPIEnabled            bool
+	ProposalAPIAddr               string
 	HandoverSkipSlots             uint64
 	P2PConfigs                    *p2p.Config
 	P2PSignerConfigs              p2p.SignerSetup
@@ -98,6 +101,11 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	}
 	if c.Uint64(flags.PreconfBlockServerPort.Name) > 0 && len(preconfBlockServerJWTSecret) == 0 {
 		return nil, errors.New("preconfirmation.jwtSecret is required when preconfirmation.serverPort is enabled")
+	}
+	if c.Bool(flags.ProposalAPIEnabled.Name) {
+		if err := proposalapi.ValidateLoopbackAddress(c.String(flags.ProposalAPIAddr.Name)); err != nil {
+			return nil, fmt.Errorf("invalid proposal API address: %w", err)
+		}
 	}
 
 	// Resolve L1 / L2 endpoints (WS preferred, HTTP fallback).
@@ -171,6 +179,8 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		PreconfBlockServerPort:        c.Uint64(flags.PreconfBlockServerPort.Name),
 		PreconfBlockServerJWTSecret:   preconfBlockServerJWTSecret,
 		PreconfBlockServerCORSOrigins: c.String(flags.PreconfBlockServerCORSOrigins.Name),
+		ProposalAPIEnabled:            c.Bool(flags.ProposalAPIEnabled.Name),
+		ProposalAPIAddr:               c.String(flags.ProposalAPIAddr.Name),
 		HandoverSkipSlots:             c.Uint64(flags.PreconfHandoverSkipSlots.Name),
 		P2PConfigs:                    p2pConfigs,
 		P2PSignerConfigs:              signerConfigs,

--- a/packages/taiko-client/driver/config_test.go
+++ b/packages/taiko-client/driver/config_test.go
@@ -151,6 +151,8 @@ func (s *DriverTestSuite) SetupApp() *cli.App {
 		&cli.Uint64Flag{Name: flags.PreconfHandoverSkipSlots.Name, Value: 8},
 		&cli.Uint64Flag{Name: flags.PreconfBlockServerPort.Name},
 		&cli.StringFlag{Name: flags.PreconfBlockServerJWTSecret.Name},
+		&cli.BoolFlag{Name: flags.ProposalAPIEnabled.Name},
+		&cli.StringFlag{Name: flags.ProposalAPIAddr.Name, Value: "127.0.0.1:9876"},
 		&cli.StringFlag{Name: flags.JWTSecret.Name},
 		&cli.BoolFlag{Name: flags.P2PSync.Name},
 		&cli.DurationFlag{Name: flags.P2PSyncTimeout.Name},
@@ -213,4 +215,35 @@ func (s *DriverTestSuite) defaultCliP2PConfigs() (*p2p.Config, p2p.SignerSetup) 
 	}))
 
 	return <-p2pConfigCh, <-signerSetupCh
+}
+
+func TestNewConfigFromCliContextRejectsRemoteProposalAPIAddress(t *testing.T) {
+	jwtFile := t.TempDir() + "/jwt.hex"
+	if err := os.WriteFile(jwtFile, []byte(strings.Repeat("11", 32)), 0o600); err != nil {
+		t.Fatalf("write jwt file: %v", err)
+	}
+
+	app := cli.NewApp()
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{Name: flags.JWTSecret.Name},
+		&cli.StringFlag{Name: flags.L1BeaconEndpoint.Name},
+		&cli.Uint64Flag{Name: flags.PreconfBlockServerPort.Name},
+		&cli.StringFlag{Name: flags.PreconfBlockServerJWTSecret.Name},
+		&cli.BoolFlag{Name: flags.ProposalAPIEnabled.Name},
+		&cli.StringFlag{Name: flags.ProposalAPIAddr.Name, Value: "127.0.0.1:9876"},
+	}
+	app.Action = func(ctx *cli.Context) error {
+		_, err := NewConfigFromCliContext(ctx)
+		return err
+	}
+
+	if err := app.Run([]string{
+		"TestNewConfigFromCliContextRejectsRemoteProposalAPIAddress",
+		"--" + flags.JWTSecret.Name, jwtFile,
+		"--" + flags.L1BeaconEndpoint.Name, "http://localhost:5052",
+		"--" + flags.ProposalAPIEnabled.Name,
+		"--" + flags.ProposalAPIAddr.Name, "0.0.0.0:9876",
+	}); err == nil || !strings.Contains(err.Error(), "invalid proposal API address") {
+		t.Fatalf("expected invalid proposal API address error, got %v", err)
+	}
 }

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -202,10 +202,13 @@ func (d *Driver) Start() error {
 		go d.preconfBlockServer.LatestSeenProposalEventLoop(d.ctx)
 	}
 	if d.proposalAPIServer != nil {
+		d.wg.Add(1)
 		go func() {
+			defer d.wg.Done()
 			log.Info("Starting local proposal API", "addr", d.ProposalAPIAddr)
 			if err := d.proposalAPIServer.Start(); err != nil {
-				log.Crit("Failed to start local proposal API", "error", err)
+				log.Error("Failed to start local proposal API", "error", err)
+				d.cancel()
 			}
 		}()
 	}

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/driver/state"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/metrics"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/config"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/proposalapi"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
@@ -42,6 +43,7 @@ type Driver struct {
 	rpc                *rpc.Client
 	l2ChainSyncer      *chainSyncer.L2ChainSyncer
 	preconfBlockServer *preconfBlocks.PreconfBlockAPIServer
+	proposalAPIServer  *proposalapi.Server
 	state              *state.State
 	protocolConfig     config.ProtocolConfigs
 
@@ -170,6 +172,16 @@ func (d *Driver) InitFromConfig(ctx context.Context, cfg *Config) (err error) {
 		d.l2ChainSyncer.SetPreconfBlockServer(d.preconfBlockServer)
 	}
 
+	if cfg.ProposalAPIEnabled {
+		source, err := proposalapi.NewRPCSource(d.rpc)
+		if err != nil {
+			return fmt.Errorf("failed to create proposal API source: %w", err)
+		}
+		if d.proposalAPIServer, err = proposalapi.New(cfg.ProposalAPIAddr, source); err != nil {
+			return fmt.Errorf("failed to create proposal API server: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -188,6 +200,14 @@ func (d *Driver) Start() error {
 		}()
 
 		go d.preconfBlockServer.LatestSeenProposalEventLoop(d.ctx)
+	}
+	if d.proposalAPIServer != nil {
+		go func() {
+			log.Info("Starting local proposal API", "addr", d.ProposalAPIAddr)
+			if err := d.proposalAPIServer.Start(); err != nil {
+				log.Crit("Failed to start local proposal API", "error", err)
+			}
+		}()
 	}
 	if d.p2pNode != nil && d.p2pNode.Dv5Udp() != nil {
 		log.Info("Start P2P discovery process")
@@ -223,6 +243,11 @@ func (d *Driver) Close(_ context.Context) {
 	if d.preconfBlockServer != nil {
 		if err := d.preconfBlockServer.Shutdown(d.ctx); err != nil {
 			log.Error("Failed to shutdown preconfirmation block server", "error", err)
+		}
+	}
+	if d.proposalAPIServer != nil {
+		if err := d.proposalAPIServer.Shutdown(d.ctx); err != nil {
+			log.Error("Failed to shutdown local proposal API", "error", err)
 		}
 	}
 	d.wg.Wait()

--- a/packages/taiko-client/pkg/proposalapi/server.go
+++ b/packages/taiko-client/pkg/proposalapi/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
@@ -20,6 +21,7 @@ import (
 
 const (
 	defaultReadHeaderTimeout = 5 * time.Second
+	defaultRequestTimeout    = rpc.DefaultRpcTimeout
 	proposalPathPrefix       = "/internal/shasta/proposals/"
 )
 
@@ -82,7 +84,11 @@ func New(addr string, source Source) (*Server, error) {
 
 	server := &Server{addr: addr, source: source}
 	mux := http.NewServeMux()
-	mux.HandleFunc(proposalPathPrefix, server.handleProposal)
+	mux.Handle(proposalPathPrefix, http.TimeoutHandler(
+		http.HandlerFunc(server.handleProposal),
+		defaultRequestTimeout,
+		`{"error":"request timed out"}`+"\n",
+	))
 	server.handler = mux
 	return server, nil
 }
@@ -152,13 +158,13 @@ func (s *RPCSource) ProposalByID(ctx context.Context, id *big.Int) (*ProposalRes
 
 	proposalHash, err := s.client.ShastaClients.Inbox.HashProposal(
 		&bind.CallOpts{Context: ctx},
-		proposalFromEvent(event, header.Time),
+		proposalFromEvent(event, header),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash proposal: %w", err)
 	}
 
-	return buildProposalResponse(event, header.Time, common.Hash(proposalHash)), nil
+	return buildProposalResponse(event, header, common.Hash(proposalHash))
 }
 
 func ValidateLoopbackAddress(addr string) error {
@@ -226,21 +232,27 @@ func parseProposalID(path string) (*big.Int, bool) {
 func writeError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+	if err := json.NewEncoder(w).Encode(map[string]string{"error": message}); err != nil {
+		return
+	}
 }
 
 func proposalFromEvent(
 	event *shastaBindings.ShastaInboxClientProposed,
-	timestamp uint64,
+	header *types.Header,
 ) shastaBindings.IInboxProposal {
+	originBlockNumber := new(big.Int)
+	if header.Number != nil {
+		originBlockNumber = new(big.Int).Sub(header.Number, common.Big1)
+	}
 	return shastaBindings.IInboxProposal{
 		Id:                             cloneBig(event.Id),
-		Timestamp:                      new(big.Int).SetUint64(timestamp),
+		Timestamp:                      new(big.Int).SetUint64(header.Time),
 		EndOfSubmissionWindowTimestamp: cloneBig(event.EndOfSubmissionWindowTimestamp),
 		Proposer:                       event.Proposer,
 		ParentProposalHash:             event.ParentProposalHash,
-		OriginBlockNumber:              new(big.Int).SetUint64(event.Raw.BlockNumber),
-		OriginBlockHash:                event.Raw.BlockHash,
+		OriginBlockNumber:              originBlockNumber,
+		OriginBlockHash:                header.ParentHash,
 		BasefeeSharingPctg:             event.BasefeeSharingPctg,
 		Sources:                        event.Sources,
 	}
@@ -248,21 +260,44 @@ func proposalFromEvent(
 
 func buildProposalResponse(
 	event *shastaBindings.ShastaInboxClientProposed,
-	timestamp uint64,
+	header *types.Header,
 	proposalHash common.Hash,
-) *ProposalResponse {
+) (*ProposalResponse, error) {
+	proposalID, err := checkedUint64("proposal ID", event.Id)
+	if err != nil {
+		return nil, err
+	}
+	endOfSubmissionWindowTimestamp, err := checkedUint64(
+		"end of submission window timestamp",
+		event.EndOfSubmissionWindowTimestamp,
+	)
+	if err != nil {
+		return nil, err
+	}
+	originBlockNumber, err := eventOriginBlockNumber(header)
+	if err != nil {
+		return nil, err
+	}
 	sources := make([]DerivationSource, 0, len(event.Sources))
 	for _, source := range event.Sources {
 		blobHashes := make([]string, 0, len(source.BlobSlice.BlobHashes))
 		for _, blobHash := range source.BlobSlice.BlobHashes {
 			blobHashes = append(blobHashes, common.Hash(blobHash).Hex())
 		}
+		offset, err := checkedUint64("blob slice offset", source.BlobSlice.Offset)
+		if err != nil {
+			return nil, err
+		}
+		timestamp, err := checkedUint64("blob slice timestamp", source.BlobSlice.Timestamp)
+		if err != nil {
+			return nil, err
+		}
 		sources = append(sources, DerivationSource{
 			IsForcedInclusion: source.IsForcedInclusion,
 			BlobSlice: BlobSlice{
 				BlobHashes: blobHashes,
-				Offset:     bigToUint64(source.BlobSlice.Offset),
-				Timestamp:  bigToUint64(source.BlobSlice.Timestamp),
+				Offset:     offset,
+				Timestamp:  timestamp,
 			},
 		})
 	}
@@ -270,13 +305,13 @@ func buildProposalResponse(
 	return &ProposalResponse{
 		ProposalHash: proposalHash.Hex(),
 		Proposal: Proposal{
-			ID:                             bigToUint64(event.Id),
-			Timestamp:                      timestamp,
-			EndOfSubmissionWindowTimestamp: bigToUint64(event.EndOfSubmissionWindowTimestamp),
+			ID:                             proposalID,
+			Timestamp:                      header.Time,
+			EndOfSubmissionWindowTimestamp: endOfSubmissionWindowTimestamp,
 			Proposer:                       event.Proposer.Hex(),
 			ParentProposalHash:             common.Hash(event.ParentProposalHash).Hex(),
-			OriginBlockNumber:              event.Raw.BlockNumber,
-			OriginBlockHash:                event.Raw.BlockHash.Hex(),
+			OriginBlockNumber:              originBlockNumber,
+			OriginBlockHash:                header.ParentHash.Hex(),
 			BasefeeSharingPctg:             event.BasefeeSharingPctg,
 			Sources:                        sources,
 		},
@@ -286,7 +321,7 @@ func buildProposalResponse(
 			TxHash:      event.Raw.TxHash.Hex(),
 			LogIndex:    event.Raw.Index,
 		},
-	}
+	}, nil
 }
 
 func cloneBig(value *big.Int) *big.Int {
@@ -296,9 +331,22 @@ func cloneBig(value *big.Int) *big.Int {
 	return new(big.Int).Set(value)
 }
 
-func bigToUint64(value *big.Int) uint64 {
+func checkedUint64(name string, value *big.Int) (uint64, error) {
 	if value == nil {
-		return 0
+		return 0, fmt.Errorf("%s is nil", name)
 	}
-	return value.Uint64()
+	if !value.IsUint64() {
+		return 0, fmt.Errorf("%s does not fit in uint64: %s", name, value.String())
+	}
+	return value.Uint64(), nil
+}
+
+func eventOriginBlockNumber(header *types.Header) (uint64, error) {
+	if header == nil || header.Number == nil {
+		return 0, errors.New("proposal L1 header number is missing")
+	}
+	if header.Number.Sign() == 0 {
+		return 0, errors.New("proposal L1 header has no parent block")
+	}
+	return checkedUint64("origin block number", new(big.Int).Sub(header.Number, common.Big1))
 }

--- a/packages/taiko-client/pkg/proposalapi/server.go
+++ b/packages/taiko-client/pkg/proposalapi/server.go
@@ -1,0 +1,304 @@
+package proposalapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
+)
+
+const (
+	defaultReadHeaderTimeout = 5 * time.Second
+	proposalPathPrefix       = "/internal/shasta/proposals/"
+)
+
+var ErrProposalNotFound = errors.New("proposal not found")
+
+type Source interface {
+	ProposalByID(context.Context, *big.Int) (*ProposalResponse, error)
+}
+
+type Server struct {
+	addr    string
+	source  Source
+	handler http.Handler
+	server  *http.Server
+}
+
+type ProposalResponse struct {
+	ProposalHash string        `json:"proposal_hash"`
+	Proposal     Proposal      `json:"proposal"`
+	Event        ProposalEvent `json:"event"`
+}
+
+type Proposal struct {
+	ID                             uint64             `json:"id"`
+	Timestamp                      uint64             `json:"timestamp"`
+	EndOfSubmissionWindowTimestamp uint64             `json:"end_of_submission_window_timestamp"`
+	Proposer                       string             `json:"proposer"`
+	ParentProposalHash             string             `json:"parent_proposal_hash"`
+	OriginBlockNumber              uint64             `json:"origin_block_number"`
+	OriginBlockHash                string             `json:"origin_block_hash"`
+	BasefeeSharingPctg             uint8              `json:"basefee_sharing_pctg"`
+	Sources                        []DerivationSource `json:"sources"`
+}
+
+type DerivationSource struct {
+	IsForcedInclusion bool      `json:"is_forced_inclusion"`
+	BlobSlice         BlobSlice `json:"blob_slice"`
+}
+
+type BlobSlice struct {
+	BlobHashes []string `json:"blob_hashes"`
+	Offset     uint64   `json:"offset"`
+	Timestamp  uint64   `json:"timestamp"`
+}
+
+type ProposalEvent struct {
+	BlockNumber uint64 `json:"block_number"`
+	BlockHash   string `json:"block_hash"`
+	TxHash      string `json:"tx_hash"`
+	LogIndex    uint   `json:"log_index"`
+}
+
+func New(addr string, source Source) (*Server, error) {
+	if source == nil {
+		return nil, errors.New("proposal source is required")
+	}
+	if err := ValidateLoopbackAddress(addr); err != nil {
+		return nil, err
+	}
+
+	server := &Server{addr: addr, source: source}
+	mux := http.NewServeMux()
+	mux.HandleFunc(proposalPathPrefix, server.handleProposal)
+	server.handler = mux
+	return server, nil
+}
+
+func (s *Server) Handler() http.Handler {
+	return s.handler
+}
+
+func (s *Server) Start() error {
+	s.server = &http.Server{
+		Addr:              s.addr,
+		Handler:           s.handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
+	}
+	if err := s.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.server == nil {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return s.server.Close()
+	}
+	return s.server.Shutdown(ctx)
+}
+
+type RPCSource struct {
+	client *rpc.Client
+}
+
+func NewRPCSource(client *rpc.Client) (*RPCSource, error) {
+	if client == nil {
+		return nil, errors.New("rpc client is required")
+	}
+	if client.L1 == nil {
+		return nil, errors.New("L1 client is required")
+	}
+	if client.L2 == nil {
+		return nil, errors.New("L2 client is required")
+	}
+	if client.L2Engine == nil {
+		return nil, errors.New("L2 engine client is required")
+	}
+	if client.ShastaClients == nil || client.ShastaClients.Inbox == nil {
+		return nil, errors.New("Shasta inbox client is required")
+	}
+	return &RPCSource{client: client}, nil
+}
+
+func (s *RPCSource) ProposalByID(ctx context.Context, id *big.Int) (*ProposalResponse, error) {
+	event, _, err := s.client.GetProposalByID(ctx, id)
+	if err != nil {
+		if strings.Contains(err.Error(), "proposal event not found") {
+			return nil, ErrProposalNotFound
+		}
+		return nil, err
+	}
+
+	header, err := s.client.L1.HeaderByHash(ctx, event.Raw.BlockHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get proposal L1 header: %w", err)
+	}
+
+	proposalHash, err := s.client.ShastaClients.Inbox.HashProposal(
+		&bind.CallOpts{Context: ctx},
+		proposalFromEvent(event, header.Time),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash proposal: %w", err)
+	}
+
+	return buildProposalResponse(event, header.Time, common.Hash(proposalHash)), nil
+}
+
+func ValidateLoopbackAddress(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid local proposal API address: %w", err)
+	}
+	if host == "" {
+		return errors.New("local proposal API address must bind to an explicit loopback host")
+	}
+	if strings.EqualFold(host, "localhost") {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("local proposal API address must bind to loopback, got %q", host)
+	}
+	return nil
+}
+
+func (s *Server) handleProposal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	id, ok := parseProposalID(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid proposal ID")
+		return
+	}
+
+	response, err := s.source.ProposalByID(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrProposalNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	if response == nil {
+		writeError(w, http.StatusNotFound, ErrProposalNotFound.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to encode response")
+	}
+}
+
+func parseProposalID(path string) (*big.Int, bool) {
+	rawID := strings.TrimPrefix(path, proposalPathPrefix)
+	if rawID == "" || rawID == path || strings.Contains(rawID, "/") {
+		return nil, false
+	}
+	id, ok := new(big.Int).SetString(rawID, 10)
+	if !ok || id.Sign() < 0 {
+		return nil, false
+	}
+	return id, true
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+func proposalFromEvent(
+	event *shastaBindings.ShastaInboxClientProposed,
+	timestamp uint64,
+) shastaBindings.IInboxProposal {
+	return shastaBindings.IInboxProposal{
+		Id:                             cloneBig(event.Id),
+		Timestamp:                      new(big.Int).SetUint64(timestamp),
+		EndOfSubmissionWindowTimestamp: cloneBig(event.EndOfSubmissionWindowTimestamp),
+		Proposer:                       event.Proposer,
+		ParentProposalHash:             event.ParentProposalHash,
+		OriginBlockNumber:              new(big.Int).SetUint64(event.Raw.BlockNumber),
+		OriginBlockHash:                event.Raw.BlockHash,
+		BasefeeSharingPctg:             event.BasefeeSharingPctg,
+		Sources:                        event.Sources,
+	}
+}
+
+func buildProposalResponse(
+	event *shastaBindings.ShastaInboxClientProposed,
+	timestamp uint64,
+	proposalHash common.Hash,
+) *ProposalResponse {
+	sources := make([]DerivationSource, 0, len(event.Sources))
+	for _, source := range event.Sources {
+		blobHashes := make([]string, 0, len(source.BlobSlice.BlobHashes))
+		for _, blobHash := range source.BlobSlice.BlobHashes {
+			blobHashes = append(blobHashes, common.Hash(blobHash).Hex())
+		}
+		sources = append(sources, DerivationSource{
+			IsForcedInclusion: source.IsForcedInclusion,
+			BlobSlice: BlobSlice{
+				BlobHashes: blobHashes,
+				Offset:     bigToUint64(source.BlobSlice.Offset),
+				Timestamp:  bigToUint64(source.BlobSlice.Timestamp),
+			},
+		})
+	}
+
+	return &ProposalResponse{
+		ProposalHash: proposalHash.Hex(),
+		Proposal: Proposal{
+			ID:                             bigToUint64(event.Id),
+			Timestamp:                      timestamp,
+			EndOfSubmissionWindowTimestamp: bigToUint64(event.EndOfSubmissionWindowTimestamp),
+			Proposer:                       event.Proposer.Hex(),
+			ParentProposalHash:             common.Hash(event.ParentProposalHash).Hex(),
+			OriginBlockNumber:              event.Raw.BlockNumber,
+			OriginBlockHash:                event.Raw.BlockHash.Hex(),
+			BasefeeSharingPctg:             event.BasefeeSharingPctg,
+			Sources:                        sources,
+		},
+		Event: ProposalEvent{
+			BlockNumber: event.Raw.BlockNumber,
+			BlockHash:   event.Raw.BlockHash.Hex(),
+			TxHash:      event.Raw.TxHash.Hex(),
+			LogIndex:    event.Raw.Index,
+		},
+	}
+}
+
+func cloneBig(value *big.Int) *big.Int {
+	if value == nil {
+		return new(big.Int)
+	}
+	return new(big.Int).Set(value)
+}
+
+func bigToUint64(value *big.Int) uint64 {
+	if value == nil {
+		return 0
+	}
+	return value.Uint64()
+}

--- a/packages/taiko-client/pkg/proposalapi/server_test.go
+++ b/packages/taiko-client/pkg/proposalapi/server_test.go
@@ -232,7 +232,8 @@ func TestBuildProposalResponse(t *testing.T) {
 
 	var (
 		parentProposalHash = common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-		originBlockHash    = common.HexToHash("0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+		eventBlockHash     = common.HexToHash("0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+		originBlockHash    = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 		txHash             = common.HexToHash("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
 		blobHash           = common.HexToHash("0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 		proposalHash       = common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
@@ -254,14 +255,22 @@ func TestBuildProposalResponse(t *testing.T) {
 			},
 		}},
 		Raw: types.Log{
-			BlockNumber: 999,
-			BlockHash:   originBlockHash,
+			BlockNumber: 1000,
+			BlockHash:   eventBlockHash,
 			TxHash:      txHash,
 			Index:       7,
 		},
 	}
+	header := &types.Header{
+		Number:     big.NewInt(1000),
+		ParentHash: originBlockHash,
+		Time:       1000,
+	}
 
-	response := buildProposalResponse(event, 1000, proposalHash)
+	response, err := buildProposalResponse(event, header, proposalHash)
+	if err != nil {
+		t.Fatalf("build response: %v", err)
+	}
 
 	if response.ProposalHash != proposalHash.Hex() {
 		t.Fatalf("unexpected proposal hash: %s", response.ProposalHash)
@@ -274,6 +283,9 @@ func TestBuildProposalResponse(t *testing.T) {
 	}
 	if response.Proposal.OriginBlockNumber != 999 || response.Proposal.OriginBlockHash != originBlockHash.Hex() {
 		t.Fatalf("unexpected origin: %+v", response.Proposal)
+	}
+	if response.Event.BlockNumber != 1000 || response.Event.BlockHash != eventBlockHash.Hex() {
+		t.Fatalf("unexpected event block: %+v", response.Event)
 	}
 	if response.Event.LogIndex != 7 || response.Event.TxHash != txHash.Hex() {
 		t.Fatalf("unexpected event: %+v", response.Event)

--- a/packages/taiko-client/pkg/proposalapi/server_test.go
+++ b/packages/taiko-client/pkg/proposalapi/server_test.go
@@ -1,0 +1,287 @@
+package proposalapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
+)
+
+type fakeProposalSource struct {
+	response *ProposalResponse
+	err      error
+	seenID   *big.Int
+}
+
+func (s *fakeProposalSource) ProposalByID(_ context.Context, id *big.Int) (*ProposalResponse, error) {
+	s.seenID = new(big.Int).Set(id)
+	return s.response, s.err
+}
+
+func TestValidateLoopbackAddress(t *testing.T) {
+	t.Parallel()
+
+	for _, addr := range []string{"127.0.0.1:9876", "localhost:9876", "[::1]:9876"} {
+		if err := ValidateLoopbackAddress(addr); err != nil {
+			t.Fatalf("expected %q to be accepted: %v", addr, err)
+		}
+	}
+
+	for _, addr := range []string{":9876", "0.0.0.0:9876", "192.0.2.1:9876", "bad-address"} {
+		if err := ValidateLoopbackAddress(addr); err == nil {
+			t.Fatalf("expected %q to be rejected", addr)
+		}
+	}
+}
+
+func TestNewRPCSourceRequiresProposalLookupClients(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		client *rpc.Client
+	}{
+		{name: "nil client"},
+		{name: "missing L1", client: &rpc.Client{}},
+		{
+			name: "missing L2",
+			client: &rpc.Client{
+				L1:            &rpc.EthClient{},
+				ShastaClients: &rpc.ShastaClients{Inbox: &shastaBindings.ShastaInboxClient{}},
+			},
+		},
+		{
+			name: "missing L2 engine",
+			client: &rpc.Client{
+				L1:            &rpc.EthClient{},
+				L2:            &rpc.EthClient{},
+				ShastaClients: &rpc.ShastaClients{Inbox: &shastaBindings.ShastaInboxClient{}},
+			},
+		},
+		{
+			name: "missing inbox",
+			client: &rpc.Client{
+				L1:            &rpc.EthClient{},
+				L2:            &rpc.EthClient{},
+				L2Engine:      &rpc.EngineClient{},
+				ShastaClients: &rpc.ShastaClients{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewRPCSource(test.client); err == nil {
+				t.Fatalf("expected NewRPCSource to reject %s", test.name)
+			}
+		})
+	}
+}
+
+func TestGetProposalRejectsInvalidID(t *testing.T) {
+	t.Parallel()
+
+	server, err := New("127.0.0.1:0", &fakeProposalSource{})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/internal/shasta/proposals/not-a-number", nil)
+
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+}
+
+func TestGetProposalReturnsMetadata(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeProposalSource{response: &ProposalResponse{
+		ProposalHash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Proposal: Proposal{
+			ID:                             42,
+			Timestamp:                      1000,
+			EndOfSubmissionWindowTimestamp: 1100,
+			Proposer:                       "0x1111111111111111111111111111111111111111",
+			ParentProposalHash:             "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			OriginBlockNumber:              999,
+			OriginBlockHash:                "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			BasefeeSharingPctg:             1,
+			Sources: []DerivationSource{{
+				IsForcedInclusion: true,
+				BlobSlice: BlobSlice{
+					BlobHashes: []string{
+						"0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+					},
+					Offset:    12,
+					Timestamp: 990,
+				},
+			}},
+		},
+		Event: ProposalEvent{
+			BlockNumber: 999,
+			BlockHash:   "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			TxHash:      "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			LogIndex:    3,
+		},
+	}}
+	server, err := New("127.0.0.1:0", source)
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/internal/shasta/proposals/42", nil)
+
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+	if source.seenID == nil || source.seenID.Uint64() != 42 {
+		t.Fatalf("expected source to see proposal ID 42, got %v", source.seenID)
+	}
+
+	var response ProposalResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ProposalHash != source.response.ProposalHash {
+		t.Fatalf("unexpected proposal hash: %s", response.ProposalHash)
+	}
+	if response.Proposal.ID != 42 {
+		t.Fatalf("unexpected proposal ID: %d", response.Proposal.ID)
+	}
+	if len(response.Proposal.Sources) != 1 || len(response.Proposal.Sources[0].BlobSlice.BlobHashes) != 1 {
+		t.Fatalf("expected source blob hashes to be encoded: %+v", response.Proposal.Sources)
+	}
+}
+
+func TestGetProposalMapsNotFound(t *testing.T) {
+	t.Parallel()
+
+	server, err := New("127.0.0.1:0", &fakeProposalSource{err: ErrProposalNotFound})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/internal/shasta/proposals/7", nil)
+
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, recorder.Code)
+	}
+}
+
+func TestGetProposalMapsSourceErrors(t *testing.T) {
+	t.Parallel()
+
+	server, err := New("127.0.0.1:0", &fakeProposalSource{err: errors.New("rpc unavailable")})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/internal/shasta/proposals/7", nil)
+
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("expected status %d, got %d", http.StatusBadGateway, recorder.Code)
+	}
+}
+
+func TestShutdownFallsBackToCloseWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer httpServer.Close()
+
+	server := &Server{server: httpServer.Config}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown with canceled context: %v", err)
+	}
+
+	if response, err := http.Get(httpServer.URL); err == nil {
+		_ = response.Body.Close()
+		t.Fatalf("expected server to be closed")
+	}
+}
+
+func TestBuildProposalResponse(t *testing.T) {
+	t.Parallel()
+
+	var (
+		parentProposalHash = common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+		originBlockHash    = common.HexToHash("0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+		txHash             = common.HexToHash("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+		blobHash           = common.HexToHash("0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+		proposalHash       = common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+		proposer           = common.HexToAddress("0x1111111111111111111111111111111111111111")
+	)
+
+	event := &shastaBindings.ShastaInboxClientProposed{
+		Id:                             big.NewInt(42),
+		Proposer:                       proposer,
+		ParentProposalHash:             parentProposalHash,
+		EndOfSubmissionWindowTimestamp: big.NewInt(1100),
+		BasefeeSharingPctg:             3,
+		Sources: []shastaBindings.IInboxDerivationSource{{
+			IsForcedInclusion: true,
+			BlobSlice: shastaBindings.LibBlobsBlobSlice{
+				BlobHashes: [][32]byte{blobHash},
+				Offset:     big.NewInt(12),
+				Timestamp:  big.NewInt(990),
+			},
+		}},
+		Raw: types.Log{
+			BlockNumber: 999,
+			BlockHash:   originBlockHash,
+			TxHash:      txHash,
+			Index:       7,
+		},
+	}
+
+	response := buildProposalResponse(event, 1000, proposalHash)
+
+	if response.ProposalHash != proposalHash.Hex() {
+		t.Fatalf("unexpected proposal hash: %s", response.ProposalHash)
+	}
+	if response.Proposal.ID != 42 {
+		t.Fatalf("unexpected proposal ID: %d", response.Proposal.ID)
+	}
+	if response.Proposal.Timestamp != 1000 {
+		t.Fatalf("unexpected proposal timestamp: %d", response.Proposal.Timestamp)
+	}
+	if response.Proposal.OriginBlockNumber != 999 || response.Proposal.OriginBlockHash != originBlockHash.Hex() {
+		t.Fatalf("unexpected origin: %+v", response.Proposal)
+	}
+	if response.Event.LogIndex != 7 || response.Event.TxHash != txHash.Hex() {
+		t.Fatalf("unexpected event: %+v", response.Event)
+	}
+	if len(response.Proposal.Sources) != 1 {
+		t.Fatalf("expected one source, got %d", len(response.Proposal.Sources))
+	}
+	if response.Proposal.Sources[0].BlobSlice.BlobHashes[0] != blobHash.Hex() {
+		t.Fatalf("unexpected blob hash: %+v", response.Proposal.Sources[0].BlobSlice.BlobHashes)
+	}
+}


### PR DESCRIPTION
## Summary
- add a disabled-by-default loopback-only driver API for Shasta proposal metadata
- expose `GET /internal/shasta/proposals/{proposal_id}` with reconstructed proposal, `hashProposal`, and L1 event coordinates
- wire `proposalApi.enabled` / `proposalApi.addr` flags and reject non-loopback binds

## Tests
- `go test ./packages/taiko-client/pkg/proposalapi ./packages/taiko-client/cmd/flags`
- `go test ./packages/taiko-client/driver -run 'TestNewConfigFromCliContextRejectsRemoteProposalAPIAddress|TestResolveEndpointsPrefersWSOverHTTP'`\n- `git diff --check`\n\n## Notes\n- Full `go test ./packages/taiko-client/driver` was not usable in this local environment: the existing driver suite expects devnet env vars/JWT and fails during `internal/testutils` setup with empty env parsing / invalid JWT length before reaching these changes.\n- `golangci-lint` is not installed in this environment (`command not found`).