### PR TITLE
feat(taiko-client): clear zk proof backlog before fallback

### DIFF
--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -67,6 +67,43 @@ type ProofDataV2 struct {
 	Quote    string `json:"quote"`
 }
 
+// RaikoProverStatusResponse represents the JSON body of /v3/prover/status.
+type RaikoProverStatusResponse struct {
+	Status string                `json:"status"`
+	Data   RaikoProverStatusData `json:"data"`
+}
+
+// RaikoProverStatusData contains Raiko prover backlog state.
+type RaikoProverStatusData struct {
+	Clean   bool               `json:"clean"`
+	Tasks   RaikoProverTasks   `json:"tasks"`
+	Network RaikoProverNetwork `json:"network"`
+}
+
+// RaikoProverTasks contains local Raiko task counts.
+type RaikoProverTasks struct {
+	Pending  uint64 `json:"pending"`
+	Ready    uint64 `json:"ready"`
+	Retrying uint64 `json:"retrying"`
+	Running  uint64 `json:"running"`
+}
+
+// RaikoProverNetwork contains upstream prover network counts.
+type RaikoProverNetwork struct {
+	SP1   RaikoProverNetworkStatus `json:"sp1"`
+	Risc0 RaikoProverNetworkStatus `json:"risc0"`
+}
+
+// RaikoProverNetworkStatus contains upstream inflight orders.
+type RaikoProverNetworkStatus struct {
+	InflightOrders uint64 `json:"inflight_orders"`
+}
+
+// RaikoProverClearResponse represents the JSON body of /v3/prover/clear.
+type RaikoProverClearResponse struct {
+	Status string `json:"status"`
+}
+
 // requestHTTPProof sends a POST request to the given URL with the given ApiKey and request body,
 // to get a proof of the given type.
 func requestHTTPProof[T, U any](ctx context.Context, url string, apiKey string, reqBody T) (*U, error) {
@@ -74,20 +111,25 @@ func requestHTTPProof[T, U any](ctx context.Context, url string, apiKey string, 
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	return decodeHTTPResponse[U](url, res)
+}
 
-	resBytes, err := io.ReadAll(res.Body)
+func requestHTTPGet[U any](ctx context.Context, url string, apiKey string) (*U, error) {
+	log.Debug("Requesting proof", "url", url, "body", "")
+	res, err := requestHTTPResponse(ctx, http.MethodGet, url, apiKey, nil)
 	if err != nil {
 		return nil, err
 	}
+	return decodeHTTPResponse[U](url, res)
+}
 
-	log.Debug("Proof generation output", "url", url, "output", string(resBytes))
-	var output U
-	if err := json.Unmarshal(resBytes, &output); err != nil {
+func requestHTTPNoBody[U any](ctx context.Context, method string, url string, apiKey string) (*U, error) {
+	log.Debug("Requesting proof", "url", url, "body", "")
+	res, err := requestHTTPResponse(ctx, method, url, apiKey, nil)
+	if err != nil {
 		return nil, err
 	}
-
-	return &output, nil
+	return decodeHTTPResponse[U](url, res)
 }
 
 // requestHTTPProofResponse sends a POST request to the given URL with the given ApiKey and request body,
@@ -98,19 +140,30 @@ func requestHTTPProofResponse[T any](
 	apiKey string,
 	reqBody T,
 ) (*http.Response, error) {
-	client := http.DefaultClient
-
 	jsonValue, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, err
 	}
 
 	log.Debug("Requesting proof", "url", url, "body", string(jsonValue))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonValue))
+	return requestHTTPResponse(ctx, http.MethodPost, url, apiKey, bytes.NewBuffer(jsonValue))
+}
+
+func requestHTTPResponse(
+	ctx context.Context,
+	method string,
+	url string,
+	apiKey string,
+	body io.Reader,
+) (*http.Response, error) {
+	client := http.DefaultClient
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	if len(apiKey) > 0 {
 		req.Header.Set("X-API-KEY", apiKey)
 	}
@@ -134,6 +187,23 @@ func requestHTTPProofResponse[T any](
 	}
 
 	return res, nil
+}
+
+func decodeHTTPResponse[U any](url string, res *http.Response) (*U, error) {
+	defer res.Body.Close()
+
+	resBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug("Raiko HTTP output", "url", url, "output", string(resBytes))
+	var output U
+	if err := json.Unmarshal(resBytes, &output); err != nil {
+		return nil, err
+	}
+
+	return &output, nil
 }
 
 // updateProvingMetrics updates the metrics for the given proof type, including

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"net/http"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -219,6 +220,58 @@ func (s *ComposeProofProducer) Aggregate(
 		SgxGethProofVerifier: sgxGethBatchProofs.Verifier,
 		SgxGethVerifierID:    sgxGethBatchProofs.VerifierID,
 	}, nil
+}
+
+// ClearProver discards all non-terminal zk_any tasks in Raiko.
+func (s *ComposeProofProducer) ClearProver(ctx context.Context) error {
+	if s.Dummy {
+		return nil
+	}
+
+	ctx, cancel := rpc.CtxWithTimeoutOrDefault(ctx, s.RaikoRequestTimeout)
+	defer cancel()
+
+	output, err := requestHTTPNoBody[RaikoProverClearResponse](
+		ctx,
+		http.MethodPost,
+		s.RaikoHostEndpoint+"/v3/prover/clear",
+		s.ApiKey,
+	)
+	if err != nil {
+		return err
+	}
+	if output.Status != "ok" {
+		return fmt.Errorf("failed to clear Raiko prover, status: %s", output.Status)
+	}
+	return nil
+}
+
+// ProverStatus returns Raiko prover backlog state.
+func (s *ComposeProofProducer) ProverStatus(ctx context.Context) (*RaikoProverStatusResponse, error) {
+	if s.Dummy {
+		return &RaikoProverStatusResponse{
+			Status: "ok",
+			Data: RaikoProverStatusData{
+				Clean: true,
+			},
+		}, nil
+	}
+
+	ctx, cancel := rpc.CtxWithTimeoutOrDefault(ctx, s.RaikoRequestTimeout)
+	defer cancel()
+
+	output, err := requestHTTPGet[RaikoProverStatusResponse](
+		ctx,
+		s.RaikoHostEndpoint+"/v3/prover/status",
+		s.ApiKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if output.Status != "ok" {
+		return nil, fmt.Errorf("failed to get Raiko prover status, status: %s", output.Status)
+	}
+	return output, nil
 }
 
 // requestBatchProof poll the proof aggregation service to get the aggregated proof.

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer_test.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer_test.go
@@ -2,6 +2,9 @@ package producer
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -32,4 +35,58 @@ func TestComposeProducerRequestProof(t *testing.T) {
 
 	require.Equal(t, res.BatchID, blockID)
 	require.NotEmpty(t, res.Proof)
+}
+
+func TestComposeProducerProverStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v3/prover/status", r.URL.Path)
+		require.Equal(t, "test-key", r.Header.Get("X-API-KEY"))
+
+		require.NoError(t, json.NewEncoder(w).Encode(RaikoProverStatusResponse{
+			Status: "ok",
+			Data: RaikoProverStatusData{
+				Clean: true,
+				Tasks: RaikoProverTasks{
+					Running: 0,
+				},
+				Network: RaikoProverNetwork{
+					SP1: RaikoProverNetworkStatus{
+						InflightOrders: 0,
+					},
+				},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	producer := &ComposeProofProducer{
+		RaikoHostEndpoint:   server.URL,
+		ApiKey:              "test-key",
+		RaikoRequestTimeout: time.Second,
+	}
+
+	status, err := producer.ProverStatus(t.Context())
+	require.NoError(t, err)
+	require.True(t, status.Data.Clean)
+}
+
+func TestComposeProducerClearProver(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v3/prover/clear", r.URL.Path)
+		require.Equal(t, "test-key", r.Header.Get("X-API-KEY"))
+		require.Equal(t, http.NoBody, r.Body)
+
+		require.NoError(t, json.NewEncoder(w).Encode(RaikoProverClearResponse{Status: "ok"}))
+	}))
+	defer server.Close()
+
+	producer := &ComposeProofProducer{
+		RaikoHostEndpoint:   server.URL,
+		ApiKey:              "test-key",
+		RaikoRequestTimeout: time.Second,
+	}
+
+	require.NoError(t, producer.ClearProver(t.Context()))
 }

--- a/packages/taiko-client/prover/proof_producer/proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_producer.go
@@ -47,6 +47,12 @@ type BatchProofs struct {
 	SgxGethVerifierID    uint8
 }
 
+// ProverAdmin contains Raiko prover administration APIs.
+type ProverAdmin interface {
+	ClearProver(ctx context.Context) error
+	ProverStatus(ctx context.Context) (*RaikoProverStatusResponse, error)
+}
+
 // ProofProducer is an interface that contains all methods to generate a proof.
 type ProofProducer interface {
 	RequestProof(

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -51,8 +52,9 @@ type ProofSubmitter struct {
 	// Addresses
 	proverAddress common.Address
 	// Batch proof related
-	proofBuffers   map[proofProducer.ProofType]*proofProducer.ProofBuffer
-	proofCacheMaps map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse]
+	proofBuffers                  map[proofProducer.ProofType]*proofProducer.ProofBuffer
+	proofCacheMaps                map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse]
+	proofItemsClearResendExecuted atomic.Bool
 	// Intervals
 	forceBatchProvingInterval  time.Duration
 	proofPollingInterval       time.Duration
@@ -187,6 +189,7 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 			return fmt.Errorf("failed to get core state: %w", err)
 		}
 		lastFinalizedProposalID := coreState.LastFinalizedProposalId
+		nextProposalID := coreState.NextProposalId
 		fromID := new(big.Int).Add(lastFinalizedProposalID, common.Big1)
 		if fromID.Cmp(proposalID) > 0 {
 			log.Info(
@@ -206,14 +209,21 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 			)
 			return ErrProposalOutOfAllowedRange
 		}
-		if !s.shouldUseZKProof(proposalID, lastFinalizedProposalID) {
+		if !s.shouldUseZKProof(nextProposalID, lastFinalizedProposalID) {
 			log.Info(
 				"Proposal too far from the last finalized proposal, skipping ZK proof",
+				"nextProposalID", nextProposalID,
 				"proposalID", proposalID,
 				"lastFinalizedProposalID", lastFinalizedProposalID,
 				"maxZKProofProposalDistance", s.maxZKProofProposalDistance,
 			)
 			useZK = false
+			if proofResponse != nil && proofResponse.ProofType != "" {
+				if err := s.clearProofItemsByTypeAndResendOnce(ctx, proofResponse.ProofType); err != nil {
+					return err
+				}
+				proofResponse = nil
+			}
 		}
 
 		// If zk proof is enabled, request zk proof first, and check if ZK proof is drawn.
@@ -289,14 +299,14 @@ func (s *ProofSubmitter) isProposalOutOfRange(
 	return proposalID.Cmp(maxAllowedProposalID) > 0 || proposalID.Cmp(lastFinalizedProposalID) <= 0
 }
 
-func (s *ProofSubmitter) shouldUseZKProof(proposalID *big.Int, lastFinalizedProposalID *big.Int) bool {
+func (s *ProofSubmitter) shouldUseZKProof(nextProposalID *big.Int, lastFinalizedProposalID *big.Int) bool {
 	maxZKProofProposalDistance := s.maxZKProofProposalDistance
 	if maxZKProofProposalDistance == nil {
 		return true
 	}
 
 	maxZKProofProposalID := new(big.Int).Add(lastFinalizedProposalID, maxZKProofProposalDistance)
-	return proposalID.Cmp(maxZKProofProposalID) <= 0
+	return nextProposalID.Cmp(maxZKProofProposalID) <= 0
 }
 
 // handleProofResponse routes a new proof into either the sequential buffer or cache.
@@ -430,6 +440,89 @@ func (s *ProofSubmitter) ClearProofBuffers(batchProof *proofProducer.BatchProofs
 		}
 	}
 	return nil
+}
+
+func (s *ProofSubmitter) clearProofItemsByTypeAndResend(proofType proofProducer.ProofType) error {
+	proofBuffer, exist := s.proofBuffers[proofType]
+	if !exist {
+		return fmt.Errorf("unexpected proof type to clear and resend: %s", proofType)
+	}
+	cacheMap, exist := s.proofCacheMaps[proofType]
+	if !exist {
+		return fmt.Errorf("unexpected proof type cache to clear and resend: %s", proofType)
+	}
+
+	bufferedProofs, err := proofBuffer.ReadAll()
+	if err != nil {
+		return fmt.Errorf("failed to read proof buffer: %w", err)
+	}
+
+	resendProofs := make([]*proofProducer.ProofResponse, 0, len(bufferedProofs)+cacheMap.Count())
+	batchIDs := make([]uint64, 0, len(bufferedProofs))
+	for _, proof := range bufferedProofs {
+		if proof == nil || proof.BatchID == nil {
+			continue
+		}
+		resendProofs = append(resendProofs, proof)
+		batchIDs = append(batchIDs, proof.BatchID.Uint64())
+	}
+	proofBuffer.ClearItems(batchIDs...)
+
+	for item := range cacheMap.IterBuffered() {
+		if item.Val != nil {
+			resendProofs = append(resendProofs, item.Val)
+		}
+		cacheMap.Remove(item.Key)
+	}
+
+	for _, proof := range resendProofs {
+		s.proofSubmissionCh <- &proofProducer.ProofRequestBody{Meta: proof.Meta}
+	}
+	return nil
+}
+
+func (s *ProofSubmitter) clearProofItemsByTypeAndResendOnce(ctx context.Context, proofType proofProducer.ProofType) error {
+	if !s.proofItemsClearResendExecuted.CompareAndSwap(false, true) {
+		return nil
+	}
+	if err := s.clearZKVMProofProducerAndWaitClean(ctx); err != nil {
+		return err
+	}
+	return s.clearProofItemsByTypeAndResend(proofType)
+}
+
+func (s *ProofSubmitter) clearZKVMProofProducerAndWaitClean(ctx context.Context) error {
+	proverAdmin, ok := s.zkvmProofProducer.(proofProducer.ProverAdmin)
+	if !ok {
+		return nil
+	}
+	if err := proverAdmin.ClearProver(ctx); err != nil {
+		return fmt.Errorf("failed to clear zkvm prover: %w", err)
+	}
+
+	pollingInterval := s.proofPollingInterval
+	if pollingInterval <= 0 {
+		pollingInterval = chainiterator.DefaultRetryInterval
+	}
+	return backoff.Retry(func() error {
+		status, err := proverAdmin.ProverStatus(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get zkvm prover status: %w", err)
+		}
+		if status.Data.Clean {
+			return nil
+		}
+		log.Info(
+			"Waiting for zkvm prover to become clean",
+			"pending", status.Data.Tasks.Pending,
+			"ready", status.Data.Tasks.Ready,
+			"retrying", status.Data.Tasks.Retrying,
+			"running", status.Data.Tasks.Running,
+			"sp1InflightOrders", status.Data.Network.SP1.InflightOrders,
+			"risc0InflightOrders", status.Data.Network.Risc0.InflightOrders,
+		)
+		return proofProducer.ErrProofInProgress
+	}, backoff.WithContext(backoff.NewConstantBackOff(pollingInterval), ctx))
 }
 
 // TryAggregate tries to aggregate the proofs in the buffer, if the buffer is full,

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -311,22 +311,19 @@ func (s *ProofSubmitter) shouldUseZKProof(
 	lastFinalizedProposalID *big.Int,
 ) (bool, error) {
 	maxZKProofProposalDistance := s.maxZKProofProposalDistance
-	if maxZKProofProposalDistance == nil {
-		return s.isZKVMProofProducerClean(ctx)
+	if maxZKProofProposalDistance != nil {
+		maxZKProofProposalID := new(big.Int).Add(lastFinalizedProposalID, maxZKProofProposalDistance)
+		if nextProposalID.Cmp(maxZKProofProposalID) > 0 {
+			return false, nil
+		}
 	}
-
-	maxZKProofProposalID := new(big.Int).Add(lastFinalizedProposalID, maxZKProofProposalDistance)
-	if nextProposalID.Cmp(maxZKProofProposalID) > 0 {
-		return false, nil
+	if !s.proofItemsClearResendExecuted.Load() {
+		return true, nil
 	}
 	return s.isZKVMProofProducerClean(ctx)
 }
 
 func (s *ProofSubmitter) isZKVMProofProducerClean(ctx context.Context) (bool, error) {
-	if !s.proofItemsClearResendExecuted.Load() {
-		return false, nil
-	}
-
 	proverAdmin, ok := s.zkvmProofProducer.(proofProducer.ProverAdmin)
 	if !ok {
 		return true, nil

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -234,13 +234,16 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 
 		// If zk proof is enabled, request zk proof first, and check if ZK proof is drawn.
 		if s.zkvmProofProducer != nil && useZK {
-			if proofResponse, err = s.zkvmProofProducer.RequestProof(
+			wasClearResendExecuted := s.proofItemsClearResendExecuted.Load()
+			proofResponse, err = s.zkvmProofProducer.RequestProof(
 				ctx,
 				opts,
 				meta.Shasta().GetEventData().Id,
 				meta,
 				startAt,
-			); err != nil {
+			)
+			s.resetProofItemsClearResendAfterZKProofRequest(wasClearResendExecuted)
+			if err != nil {
 				if time.Since(startAt) > maxProofRequestTimeout {
 					log.Warn("Retry timeout exceeded maxProofRequestTimeout, switching to SGX proof as fallback")
 					useZK = false
@@ -515,6 +518,12 @@ func (s *ProofSubmitter) clearProofItemsByTypeAndResendOnce(ctx context.Context,
 		return err
 	}
 	return s.clearProofItemsByTypeAndResend(proofType)
+}
+
+func (s *ProofSubmitter) resetProofItemsClearResendAfterZKProofRequest(wasClearResendExecuted bool) {
+	if wasClearResendExecuted {
+		s.proofItemsClearResendExecuted.Store(false)
+	}
 }
 
 func (s *ProofSubmitter) clearZKVMProofProducer(ctx context.Context) error {

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -209,9 +209,13 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 			)
 			return ErrProposalOutOfAllowedRange
 		}
-		if !s.shouldUseZKProof(nextProposalID, lastFinalizedProposalID) {
+		shouldUseZK, err := s.shouldUseZKProof(ctx, nextProposalID, lastFinalizedProposalID)
+		if err != nil {
+			return err
+		}
+		if !shouldUseZK {
 			log.Info(
-				"Proposal too far from the last finalized proposal, skipping ZK proof",
+				"Skipping ZK proof",
 				"nextProposalID", nextProposalID,
 				"proposalID", proposalID,
 				"lastFinalizedProposalID", lastFinalizedProposalID,
@@ -299,14 +303,33 @@ func (s *ProofSubmitter) isProposalOutOfRange(
 	return proposalID.Cmp(maxAllowedProposalID) > 0 || proposalID.Cmp(lastFinalizedProposalID) <= 0
 }
 
-func (s *ProofSubmitter) shouldUseZKProof(nextProposalID *big.Int, lastFinalizedProposalID *big.Int) bool {
+func (s *ProofSubmitter) shouldUseZKProof(
+	ctx context.Context,
+	nextProposalID *big.Int,
+	lastFinalizedProposalID *big.Int,
+) (bool, error) {
 	maxZKProofProposalDistance := s.maxZKProofProposalDistance
 	if maxZKProofProposalDistance == nil {
-		return true
+		return s.isZKVMProofProducerClean(ctx)
 	}
 
 	maxZKProofProposalID := new(big.Int).Add(lastFinalizedProposalID, maxZKProofProposalDistance)
-	return nextProposalID.Cmp(maxZKProofProposalID) <= 0
+	if nextProposalID.Cmp(maxZKProofProposalID) > 0 {
+		return false, nil
+	}
+	return s.isZKVMProofProducerClean(ctx)
+}
+
+func (s *ProofSubmitter) isZKVMProofProducerClean(ctx context.Context) (bool, error) {
+	proverAdmin, ok := s.zkvmProofProducer.(proofProducer.ProverAdmin)
+	if !ok {
+		return true, nil
+	}
+	status, err := proverAdmin.ProverStatus(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get zkvm prover status: %w", err)
+	}
+	return status.Data.Clean, nil
 }
 
 // handleProofResponse routes a new proof into either the sequential buffer or cache.

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -209,24 +209,26 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 			)
 			return ErrProposalOutOfAllowedRange
 		}
-		shouldUseZK, err := s.shouldUseZKProof(ctx, nextProposalID, lastFinalizedProposalID)
-		if err != nil {
-			return err
-		}
-		if !shouldUseZK {
-			log.Info(
-				"Skipping ZK proof",
-				"nextProposalID", nextProposalID,
-				"proposalID", proposalID,
-				"lastFinalizedProposalID", lastFinalizedProposalID,
-				"maxZKProofProposalDistance", s.maxZKProofProposalDistance,
-			)
-			useZK = false
-			if proofResponse != nil && proofResponse.ProofType != "" {
-				if err := s.clearProofItemsByTypeAndResendOnce(ctx, proofResponse.ProofType); err != nil {
-					return err
+		if s.zkvmProofProducer != nil {
+			shouldUseZK, err := s.shouldUseZKProof(ctx, nextProposalID, lastFinalizedProposalID)
+			if err != nil {
+				return err
+			}
+			if !shouldUseZK {
+				log.Info(
+					"Skipping ZK proof",
+					"nextProposalID", nextProposalID,
+					"proposalID", proposalID,
+					"lastFinalizedProposalID", lastFinalizedProposalID,
+					"maxZKProofProposalDistance", s.maxZKProofProposalDistance,
+				)
+				useZK = false
+				if proofResponse != nil && proofResponse.ProofType != "" {
+					if err := s.clearProofItemsByTypeAndResendOnce(ctx, proofResponse.ProofType); err != nil {
+						return err
+					}
+					proofResponse = nil
 				}
-				proofResponse = nil
 			}
 		}
 

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -321,6 +321,10 @@ func (s *ProofSubmitter) shouldUseZKProof(
 }
 
 func (s *ProofSubmitter) isZKVMProofProducerClean(ctx context.Context) (bool, error) {
+	if !s.proofItemsClearResendExecuted.Load() {
+		return false, nil
+	}
+
 	proverAdmin, ok := s.zkvmProofProducer.(proofProducer.ProverAdmin)
 	if !ok {
 		return true, nil

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -223,10 +223,10 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 					"maxZKProofProposalDistance", s.maxZKProofProposalDistance,
 				)
 				useZK = false
-				if proofResponse != nil && proofResponse.ProofType != "" {
-					if err := s.clearProofItemsByTypeAndResendOnce(ctx, proofResponse.ProofType); err != nil {
-						return err
-					}
+				if err := s.clearZKProofItemsAndResendOnce(ctx); err != nil {
+					return err
+				}
+				if proofResponse != nil {
 					proofResponse = nil
 				}
 			}
@@ -511,13 +511,31 @@ func (s *ProofSubmitter) clearProofItemsByTypeAndResend(proofType proofProducer.
 }
 
 func (s *ProofSubmitter) clearProofItemsByTypeAndResendOnce(ctx context.Context, proofType proofProducer.ProofType) error {
+	return s.clearProofItemsByTypesAndResendOnce(ctx, proofType)
+}
+
+func (s *ProofSubmitter) clearZKProofItemsAndResendOnce(ctx context.Context) error {
+	return s.clearProofItemsByTypesAndResendOnce(ctx, proofProducer.ProofTypeZKR0, proofProducer.ProofTypeZKSP1)
+}
+
+func (s *ProofSubmitter) clearProofItemsByTypesAndResendOnce(
+	ctx context.Context,
+	proofTypes ...proofProducer.ProofType,
+) error {
 	if !s.proofItemsClearResendExecuted.CompareAndSwap(false, true) {
 		return nil
 	}
 	if err := s.clearZKVMProofProducer(ctx); err != nil {
+		s.proofItemsClearResendExecuted.Store(false)
 		return err
 	}
-	return s.clearProofItemsByTypeAndResend(proofType)
+	for _, proofType := range proofTypes {
+		if err := s.clearProofItemsByTypeAndResend(proofType); err != nil {
+			s.proofItemsClearResendExecuted.Store(false)
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *ProofSubmitter) resetProofItemsClearResendAfterZKProofRequest(wasClearResendExecuted bool) {

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -508,13 +508,13 @@ func (s *ProofSubmitter) clearProofItemsByTypeAndResendOnce(ctx context.Context,
 	if !s.proofItemsClearResendExecuted.CompareAndSwap(false, true) {
 		return nil
 	}
-	if err := s.clearZKVMProofProducerAndWaitClean(ctx); err != nil {
+	if err := s.clearZKVMProofProducer(ctx); err != nil {
 		return err
 	}
 	return s.clearProofItemsByTypeAndResend(proofType)
 }
 
-func (s *ProofSubmitter) clearZKVMProofProducerAndWaitClean(ctx context.Context) error {
+func (s *ProofSubmitter) clearZKVMProofProducer(ctx context.Context) error {
 	proverAdmin, ok := s.zkvmProofProducer.(proofProducer.ProverAdmin)
 	if !ok {
 		return nil
@@ -522,30 +522,7 @@ func (s *ProofSubmitter) clearZKVMProofProducerAndWaitClean(ctx context.Context)
 	if err := proverAdmin.ClearProver(ctx); err != nil {
 		return fmt.Errorf("failed to clear zkvm prover: %w", err)
 	}
-
-	pollingInterval := s.proofPollingInterval
-	if pollingInterval <= 0 {
-		pollingInterval = chainiterator.DefaultRetryInterval
-	}
-	return backoff.Retry(func() error {
-		status, err := proverAdmin.ProverStatus(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get zkvm prover status: %w", err)
-		}
-		if status.Data.Clean {
-			return nil
-		}
-		log.Info(
-			"Waiting for zkvm prover to become clean",
-			"pending", status.Data.Tasks.Pending,
-			"ready", status.Data.Tasks.Ready,
-			"retrying", status.Data.Tasks.Retrying,
-			"running", status.Data.Tasks.Running,
-			"sp1InflightOrders", status.Data.Network.SP1.InflightOrders,
-			"risc0InflightOrders", status.Data.Network.Risc0.InflightOrders,
-		)
-		return proofProducer.ErrProofInProgress
-	}, backoff.WithContext(backoff.NewConstantBackOff(pollingInterval), ctx))
+	return nil
 }
 
 // TryAggregate tries to aggregate the proofs in the buffer, if the buffer is full,

--- a/packages/taiko-client/prover/proof_submitter/submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/submitter_test.go
@@ -17,13 +17,17 @@ import (
 
 type mockProverAdminProducer struct {
 	proofProducer.ProofProducer
-	clearCount  int
-	statusCount int
-	cleanAfter  int
+	clearCount     int
+	statusCount    int
+	cleanAfter     int
+	failClearCount int
 }
 
 func (m *mockProverAdminProducer) ClearProver(_ context.Context) error {
 	m.clearCount++
+	if m.clearCount <= m.failClearCount {
+		return context.Canceled
+	}
 	return nil
 }
 
@@ -155,6 +159,77 @@ func TestClearProofItemsByTypeAndResendOnceOnlyTriggersOnce(t *testing.T) {
 	require.True(t, cacheMap.Has(secondCachedProof.BatchID.String()))
 	require.Equal(t, 1, zkvmProducer.clearCount)
 	require.Zero(t, zkvmProducer.statusCount)
+}
+
+func TestClearZKProofItemsAndResendOnceClearsBothZKProofTypes(t *testing.T) {
+	risc0Buffer := proofProducer.NewProofBuffer(8)
+	sp1Buffer := proofProducer.NewProofBuffer(8)
+	risc0CacheMap := cmap.New[*proofProducer.ProofResponse]()
+	sp1CacheMap := cmap.New[*proofProducer.ProofResponse]()
+	proofSubmissionCh := make(chan *proofProducer.ProofRequestBody, 4)
+	zkvmProducer := &mockProverAdminProducer{cleanAfter: 1}
+
+	risc0BufferedProof := newProofResponse(1)
+	risc0BufferedProof.ProofType = proofProducer.ProofTypeZKR0
+	risc0BufferedProof.Meta = newShastaMetaForTest(1)
+	_, err := risc0Buffer.Write(risc0BufferedProof)
+	require.NoError(t, err)
+
+	sp1CachedProof := newProofResponse(2)
+	sp1CachedProof.ProofType = proofProducer.ProofTypeZKSP1
+	sp1CachedProof.Meta = newShastaMetaForTest(2)
+	sp1CacheMap.Set(sp1CachedProof.BatchID.String(), sp1CachedProof)
+
+	submitter := &ProofSubmitter{
+		proofBuffers: map[proofProducer.ProofType]*proofProducer.ProofBuffer{
+			proofProducer.ProofTypeZKR0:  risc0Buffer,
+			proofProducer.ProofTypeZKSP1: sp1Buffer,
+		},
+		proofCacheMaps: map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse]{
+			proofProducer.ProofTypeZKR0:  risc0CacheMap,
+			proofProducer.ProofTypeZKSP1: sp1CacheMap,
+		},
+		proofSubmissionCh: proofSubmissionCh,
+		zkvmProofProducer: zkvmProducer,
+	}
+
+	require.NoError(t, submitter.clearZKProofItemsAndResendOnce(t.Context()))
+
+	require.Zero(t, risc0Buffer.Len())
+	require.Zero(t, sp1Buffer.Len())
+	require.Empty(t, risc0CacheMap.Keys())
+	require.Empty(t, sp1CacheMap.Keys())
+	require.Len(t, proofSubmissionCh, 2)
+	require.Equal(t, 1, zkvmProducer.clearCount)
+	require.True(t, submitter.proofItemsClearResendExecuted.Load())
+}
+
+func TestClearZKProofItemsAndResendOnceRetriesAfterClearFailure(t *testing.T) {
+	proofSubmissionCh := make(chan *proofProducer.ProofRequestBody, 1)
+	zkvmProducer := &mockProverAdminProducer{
+		cleanAfter:     1,
+		failClearCount: 1,
+	}
+
+	submitter := &ProofSubmitter{
+		proofBuffers: map[proofProducer.ProofType]*proofProducer.ProofBuffer{
+			proofProducer.ProofTypeZKR0:  proofProducer.NewProofBuffer(8),
+			proofProducer.ProofTypeZKSP1: proofProducer.NewProofBuffer(8),
+		},
+		proofCacheMaps: map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse]{
+			proofProducer.ProofTypeZKR0:  cmap.New[*proofProducer.ProofResponse](),
+			proofProducer.ProofTypeZKSP1: cmap.New[*proofProducer.ProofResponse](),
+		},
+		proofSubmissionCh: proofSubmissionCh,
+		zkvmProofProducer: zkvmProducer,
+	}
+
+	require.Error(t, submitter.clearZKProofItemsAndResendOnce(t.Context()))
+	require.False(t, submitter.proofItemsClearResendExecuted.Load())
+
+	require.NoError(t, submitter.clearZKProofItemsAndResendOnce(t.Context()))
+	require.True(t, submitter.proofItemsClearResendExecuted.Load())
+	require.Equal(t, 2, zkvmProducer.clearCount)
 }
 
 func TestResetProofItemsClearResendAfterZKProofRequest(t *testing.T) {

--- a/packages/taiko-client/prover/proof_submitter/submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/submitter_test.go
@@ -231,7 +231,7 @@ func TestShouldUseZKProofRequiresCleanProver(t *testing.T) {
 	require.False(t, useZK)
 }
 
-func TestShouldUseZKProofRequiresClearResendExecuted(t *testing.T) {
+func TestShouldUseZKProofAllowsZKBeforeClearResendExecuted(t *testing.T) {
 	submitter := &ProofSubmitter{
 		maxZKProofProposalDistance: big.NewInt(30),
 		zkvmProofProducer:          &mockProverAdminProducer{cleanAfter: 1},
@@ -239,7 +239,18 @@ func TestShouldUseZKProofRequiresClearResendExecuted(t *testing.T) {
 
 	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(40), big.NewInt(10))
 	require.NoError(t, err)
-	require.False(t, useZK)
+	require.True(t, useZK)
+}
+
+func TestShouldUseZKProofAllowsZKBeforeClearResendExecutedWithoutDistanceLimit(t *testing.T) {
+	submitter := &ProofSubmitter{
+		maxZKProofProposalDistance: nil,
+		zkvmProofProducer:          &mockProverAdminProducer{cleanAfter: 2},
+	}
+
+	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(1000), big.NewInt(10))
+	require.NoError(t, err)
+	require.True(t, useZK)
 }
 
 func TestFlushCacheSkipsEmptyCache(t *testing.T) {

--- a/packages/taiko-client/prover/proof_submitter/submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/submitter_test.go
@@ -1,6 +1,7 @@
 package submitter
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -13,6 +14,28 @@ import (
 	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
 	proofProducer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
 )
+
+type mockProverAdminProducer struct {
+	proofProducer.ProofProducer
+	clearCount  int
+	statusCount int
+	cleanAfter  int
+}
+
+func (m *mockProverAdminProducer) ClearProver(_ context.Context) error {
+	m.clearCount++
+	return nil
+}
+
+func (m *mockProverAdminProducer) ProverStatus(_ context.Context) (*proofProducer.RaikoProverStatusResponse, error) {
+	m.statusCount++
+	return &proofProducer.RaikoProverStatusResponse{
+		Status: "ok",
+		Data: proofProducer.RaikoProverStatusData{
+			Clean: m.statusCount >= m.cleanAfter,
+		},
+	}, nil
+}
 
 func TestProofDistributionWithOutOfOrderResponses(t *testing.T) {
 	buffer := proofProducer.NewProofBuffer(8)
@@ -56,6 +79,82 @@ func TestProofDistributionWithOutOfOrderResponses(t *testing.T) {
 	require.Equal(t, uint64(3), bufferItems[2].BatchID.Uint64())
 
 	require.Empty(t, cacheMap.Keys())
+}
+
+func TestClearProofItemsByTypeAndResend(t *testing.T) {
+	buffer := proofProducer.NewProofBuffer(8)
+	cacheMap := cmap.New[*proofProducer.ProofResponse]()
+	proofSubmissionCh := make(chan *proofProducer.ProofRequestBody, 4)
+
+	bufferedProof := newProofResponse(1)
+	bufferedProof.Meta = newShastaMetaForTest(1)
+	cachedProof := newProofResponse(2)
+	cachedProof.Meta = newShastaMetaForTest(2)
+
+	_, err := buffer.Write(bufferedProof)
+	require.NoError(t, err)
+	cacheMap.Set(cachedProof.BatchID.String(), cachedProof)
+
+	submitter := &ProofSubmitter{
+		proofBuffers: map[proofProducer.ProofType]*proofProducer.ProofBuffer{
+			proofProducer.ProofTypeOp: buffer,
+		},
+		proofCacheMaps: map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse]{
+			proofProducer.ProofTypeOp: cacheMap,
+		},
+		proofSubmissionCh: proofSubmissionCh,
+	}
+
+	require.NoError(t, submitter.clearProofItemsByTypeAndResend(proofProducer.ProofTypeOp))
+
+	require.Zero(t, buffer.Len())
+	require.Empty(t, cacheMap.Keys())
+	require.Len(t, proofSubmissionCh, 2)
+
+	require.Equal(t, big.NewInt(1), (<-proofSubmissionCh).Meta.GetProposalID())
+	require.Equal(t, big.NewInt(2), (<-proofSubmissionCh).Meta.GetProposalID())
+}
+
+func TestClearProofItemsByTypeAndResendOnceOnlyTriggersOnce(t *testing.T) {
+	buffer := proofProducer.NewProofBuffer(8)
+	cacheMap := cmap.New[*proofProducer.ProofResponse]()
+	proofSubmissionCh := make(chan *proofProducer.ProofRequestBody, 4)
+	zkvmProducer := &mockProverAdminProducer{cleanAfter: 1}
+
+	firstProof := newProofResponse(1)
+	firstProof.Meta = newShastaMetaForTest(1)
+	_, err := buffer.Write(firstProof)
+	require.NoError(t, err)
+
+	submitter := &ProofSubmitter{
+		proofBuffers: map[proofProducer.ProofType]*proofProducer.ProofBuffer{
+			proofProducer.ProofTypeOp: buffer,
+		},
+		proofCacheMaps: map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse]{
+			proofProducer.ProofTypeOp: cacheMap,
+		},
+		proofSubmissionCh: proofSubmissionCh,
+		zkvmProofProducer: zkvmProducer,
+	}
+
+	require.NoError(t, submitter.clearProofItemsByTypeAndResendOnce(t.Context(), proofProducer.ProofTypeOp))
+
+	secondBufferedProof := newProofResponse(2)
+	secondBufferedProof.Meta = newShastaMetaForTest(2)
+	secondCachedProof := newProofResponse(3)
+	secondCachedProof.Meta = newShastaMetaForTest(3)
+	_, err = buffer.Write(secondBufferedProof)
+	require.NoError(t, err)
+	cacheMap.Set(secondCachedProof.BatchID.String(), secondCachedProof)
+
+	require.NoError(t, submitter.clearProofItemsByTypeAndResendOnce(t.Context(), proofProducer.ProofTypeOp))
+
+	require.Len(t, proofSubmissionCh, 1)
+	require.Equal(t, big.NewInt(1), (<-proofSubmissionCh).Meta.GetProposalID())
+	require.Equal(t, 1, buffer.Len())
+	require.True(t, cacheMap.Has(secondCachedProof.BatchID.String()))
+	require.Equal(t, 1, zkvmProducer.clearCount)
+	require.Equal(t, 1, zkvmProducer.statusCount)
 }
 
 func TestIsProposalOutOfRange(t *testing.T) {

--- a/packages/taiko-client/prover/proof_submitter/submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/submitter_test.go
@@ -154,7 +154,7 @@ func TestClearProofItemsByTypeAndResendOnceOnlyTriggersOnce(t *testing.T) {
 	require.Equal(t, 1, buffer.Len())
 	require.True(t, cacheMap.Has(secondCachedProof.BatchID.String()))
 	require.Equal(t, 1, zkvmProducer.clearCount)
-	require.Equal(t, 1, zkvmProducer.statusCount)
+	require.Zero(t, zkvmProducer.statusCount)
 }
 
 func TestIsProposalOutOfRange(t *testing.T) {

--- a/packages/taiko-client/prover/proof_submitter/submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/submitter_test.go
@@ -184,19 +184,48 @@ func TestIsProposalOutOfRange(t *testing.T) {
 }
 
 func TestShouldUseZKProof(t *testing.T) {
-	submitter := &ProofSubmitter{maxZKProofProposalDistance: big.NewInt(30)}
+	zkvmProducer := &mockProverAdminProducer{cleanAfter: 1}
+	submitter := &ProofSubmitter{
+		maxZKProofProposalDistance: big.NewInt(30),
+		zkvmProofProducer:          zkvmProducer,
+	}
 
 	lastFinalizedProposalID := big.NewInt(10)
-	require.True(t, submitter.shouldUseZKProof(big.NewInt(40), lastFinalizedProposalID))
-	require.False(t, submitter.shouldUseZKProof(big.NewInt(41), lastFinalizedProposalID))
+	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(40), lastFinalizedProposalID)
+	require.NoError(t, err)
+	require.True(t, useZK)
+
+	useZK, err = submitter.shouldUseZKProof(t.Context(), big.NewInt(41), lastFinalizedProposalID)
+	require.NoError(t, err)
+	require.False(t, useZK)
+	require.Equal(t, 1, zkvmProducer.statusCount)
 }
 
 func TestShouldUseZKProofUsesConfiguredDistance(t *testing.T) {
-	submitter := &ProofSubmitter{maxZKProofProposalDistance: big.NewInt(5)}
+	submitter := &ProofSubmitter{
+		maxZKProofProposalDistance: big.NewInt(5),
+		zkvmProofProducer:          &mockProverAdminProducer{cleanAfter: 1},
+	}
 
 	lastFinalizedProposalID := big.NewInt(10)
-	require.True(t, submitter.shouldUseZKProof(big.NewInt(15), lastFinalizedProposalID))
-	require.False(t, submitter.shouldUseZKProof(big.NewInt(16), lastFinalizedProposalID))
+	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(15), lastFinalizedProposalID)
+	require.NoError(t, err)
+	require.True(t, useZK)
+
+	useZK, err = submitter.shouldUseZKProof(t.Context(), big.NewInt(16), lastFinalizedProposalID)
+	require.NoError(t, err)
+	require.False(t, useZK)
+}
+
+func TestShouldUseZKProofRequiresCleanProver(t *testing.T) {
+	submitter := &ProofSubmitter{
+		maxZKProofProposalDistance: big.NewInt(30),
+		zkvmProofProducer:          &mockProverAdminProducer{cleanAfter: 2},
+	}
+
+	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(40), big.NewInt(10))
+	require.NoError(t, err)
+	require.False(t, useZK)
 }
 
 func TestFlushCacheSkipsEmptyCache(t *testing.T) {

--- a/packages/taiko-client/prover/proof_submitter/submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/submitter_test.go
@@ -157,6 +157,22 @@ func TestClearProofItemsByTypeAndResendOnceOnlyTriggersOnce(t *testing.T) {
 	require.Zero(t, zkvmProducer.statusCount)
 }
 
+func TestResetProofItemsClearResendAfterZKProofRequest(t *testing.T) {
+	submitter := &ProofSubmitter{}
+
+	submitter.resetProofItemsClearResendAfterZKProofRequest(false)
+	require.False(t, submitter.proofItemsClearResendExecuted.Load())
+
+	submitter.proofItemsClearResendExecuted.Store(true)
+	require.True(t, submitter.proofItemsClearResendExecuted.Load())
+
+	submitter.resetProofItemsClearResendAfterZKProofRequest(false)
+	require.True(t, submitter.proofItemsClearResendExecuted.Load())
+
+	submitter.resetProofItemsClearResendAfterZKProofRequest(true)
+	require.False(t, submitter.proofItemsClearResendExecuted.Load())
+}
+
 func TestIsProposalOutOfRange(t *testing.T) {
 	t.Run("nil window size disables range check", func(t *testing.T) {
 		submitter := &ProofSubmitter{proposalWindowSize: nil}

--- a/packages/taiko-client/prover/proof_submitter/submitter_test.go
+++ b/packages/taiko-client/prover/proof_submitter/submitter_test.go
@@ -189,6 +189,7 @@ func TestShouldUseZKProof(t *testing.T) {
 		maxZKProofProposalDistance: big.NewInt(30),
 		zkvmProofProducer:          zkvmProducer,
 	}
+	submitter.proofItemsClearResendExecuted.Store(true)
 
 	lastFinalizedProposalID := big.NewInt(10)
 	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(40), lastFinalizedProposalID)
@@ -206,6 +207,7 @@ func TestShouldUseZKProofUsesConfiguredDistance(t *testing.T) {
 		maxZKProofProposalDistance: big.NewInt(5),
 		zkvmProofProducer:          &mockProverAdminProducer{cleanAfter: 1},
 	}
+	submitter.proofItemsClearResendExecuted.Store(true)
 
 	lastFinalizedProposalID := big.NewInt(10)
 	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(15), lastFinalizedProposalID)
@@ -221,6 +223,18 @@ func TestShouldUseZKProofRequiresCleanProver(t *testing.T) {
 	submitter := &ProofSubmitter{
 		maxZKProofProposalDistance: big.NewInt(30),
 		zkvmProofProducer:          &mockProverAdminProducer{cleanAfter: 2},
+	}
+	submitter.proofItemsClearResendExecuted.Store(true)
+
+	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(40), big.NewInt(10))
+	require.NoError(t, err)
+	require.False(t, useZK)
+}
+
+func TestShouldUseZKProofRequiresClearResendExecuted(t *testing.T) {
+	submitter := &ProofSubmitter{
+		maxZKProofProposalDistance: big.NewInt(30),
+		zkvmProofProducer:          &mockProverAdminProducer{cleanAfter: 1},
 	}
 
 	useZK, err := submitter.shouldUseZKProof(t.Context(), big.NewInt(40), big.NewInt(10))


### PR DESCRIPTION
## Summary

- add Raiko prover admin APIs for `GET /v3/prover/status` and `POST /v3/prover/clear`
- clear local proof buffers/caches once and resend queued proof submissions after the zk prover reports clean
- add tests for Raiko prover admin calls and one-time local clear/resend behavior

## Validation

```bash
/usr/local/go/bin/go test ./packages/taiko-client/prover/proof_producer -count=1
/usr/local/go/bin/go test ./packages/taiko-client/prover/proof_submitter -count=1
```

Both pass locally. The output includes existing macOS linker warnings from `libbls384_256.a`.