### PR TITLE
refactor(taiko-client): use resty for raiko HTTP requests

### DIFF
--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -1,15 +1,13 @@
 package producer
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/go-resty/resty/v2"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/metrics"
 )
@@ -67,73 +65,57 @@ type ProofDataV2 struct {
 	Quote    string `json:"quote"`
 }
 
-// requestHTTPProof sends a POST request to the given URL with the given ApiKey and request body,
-// to get a proof of the given type.
-func requestHTTPProof[T, U any](ctx context.Context, url string, apiKey string, reqBody T) (*U, error) {
-	res, err := requestHTTPProofResponse(ctx, url, apiKey, reqBody)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
+// raikoHTTPClient is the shared resty client used for all raiko HTTP requests.
+// Each request carries its own deadline via the per-call context, matching the
+// previous net/http behavior.
+var raikoHTTPClient = resty.New()
 
-	resBytes, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Debug("Proof generation output", "url", url, "output", string(resBytes))
-	var output U
-	if err := json.Unmarshal(resBytes, &output); err != nil {
-		return nil, err
-	}
-
-	return &output, nil
-}
-
-// requestHTTPProofResponse sends a POST request to the given URL with the given ApiKey and request body,
-// and returns the raw HTTP response, the caller is responsible for closing the response body.
-func requestHTTPProofResponse[T any](
+// requestRaiko sends an HTTP request to a raiko endpoint with the shared resty
+// client and unmarshals a successful (HTTP 200) JSON response into U. A nil body
+// is sent without a request body; a non-nil body is JSON-encoded. The response is
+// always parsed as JSON, regardless of the Content-Type the server returns.
+func requestRaiko[U any](
 	ctx context.Context,
+	method string,
 	url string,
 	apiKey string,
-	reqBody T,
-) (*http.Response, error) {
-	client := http.DefaultClient
-
-	jsonValue, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, err
+	body any,
+) (*U, error) {
+	var output U
+	req := raikoHTTPClient.R().
+		SetContext(ctx).
+		ForceContentType("application/json").
+		SetResult(&output)
+	if body != nil {
+		req = req.SetHeader("Content-Type", "application/json").SetBody(body)
 	}
-
-	log.Debug("Requesting proof", "url", url, "body", string(jsonValue))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonValue))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
 	if len(apiKey) > 0 {
-		req.Header.Set("X-API-KEY", apiKey)
+		req = req.SetHeader("X-API-KEY", apiKey)
 	}
 
-	res, err := client.Do(req)
+	log.Debug("Requesting raiko", "url", url, "method", method)
+	resp, err := req.Execute(method, url)
 	if err != nil {
 		return nil, err
 	}
 
-	if res.StatusCode != http.StatusOK {
+	if resp.StatusCode() != http.StatusOK {
 		// Check for rate limiting (429 Too Many Requests)
-		if res.StatusCode == http.StatusTooManyRequests {
+		if resp.StatusCode() == http.StatusTooManyRequests {
 			log.Error("Rate limit on L2 RPC has been reached. Using your own Taiko L2 node as RPC for Raiko is recommended")
 		}
 
-		return nil, fmt.Errorf(
-			"failed to request proof, url: %s, statusCode: %d",
-			url,
-			res.StatusCode,
-		)
+		return nil, fmt.Errorf("failed to request raiko, url: %s, statusCode: %d", url, resp.StatusCode())
 	}
 
-	return res, nil
+	log.Debug("Raiko response", "url", url, "body", string(resp.Body()))
+	return &output, nil
+}
+
+// requestHTTPProof sends a POST request with the given JSON body to a raiko proof
+// endpoint and unmarshals the response into U.
+func requestHTTPProof[T, U any](ctx context.Context, url string, apiKey string, reqBody T) (*U, error) {
+	return requestRaiko[U](ctx, http.MethodPost, url, apiKey, reqBody)
 }
 
 // updateProvingMetrics updates the metrics for the given proof type, including

--- a/packages/taiko-client/prover/proof_producer/zk_backlog.go
+++ b/packages/taiko-client/prover/proof_producer/zk_backlog.go
@@ -2,9 +2,7 @@ package producer
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
@@ -31,45 +29,6 @@ type raikoProverStatusResponse struct {
 	} `json:"data"`
 }
 
-// requestRaikoControlPlane sends a bodyless request (GET or POST) to a raiko2
-// control-plane endpoint and unmarshals the JSON response into U. A non-200
-// status code (including 404 when the endpoint is absent) returns an error.
-func requestRaikoControlPlane[U any](
-	ctx context.Context,
-	method string,
-	url string,
-	apiKey string,
-) (*U, error) {
-	req, err := http.NewRequestWithContext(ctx, method, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	if len(apiKey) > 0 {
-		req.Header.Set("X-API-KEY", apiKey)
-	}
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code from %s: %d", url, res.StatusCode)
-	}
-
-	resBytes, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var output U
-	if err := json.Unmarshal(resBytes, &output); err != nil {
-		return nil, err
-	}
-	return &output, nil
-}
-
 // ClearBacklog implements the ZKBacklogController interface.
 func (s *ComposeProofProducer) ClearBacklog(ctx context.Context) error {
 	if s.Dummy {
@@ -79,11 +38,12 @@ func (s *ComposeProofProducer) ClearBacklog(ctx context.Context) error {
 	defer cancel()
 
 	// The clear endpoint only needs to return HTTP 200; its response body is unused.
-	if _, err := requestRaikoControlPlane[struct{}](
+	if _, err := requestRaiko[struct{}](
 		ctx,
 		http.MethodPost,
 		s.RaikoHostEndpoint+"/v3/prover/clear",
 		s.ApiKey,
+		nil,
 	); err != nil {
 		return fmt.Errorf("failed to clear ZK backlog: %w", err)
 	}
@@ -98,11 +58,12 @@ func (s *ComposeProofProducer) StatusClean(ctx context.Context) (bool, error) {
 	ctx, cancel := rpc.CtxWithTimeoutOrDefault(ctx, s.RaikoRequestTimeout)
 	defer cancel()
 
-	out, err := requestRaikoControlPlane[raikoProverStatusResponse](
+	out, err := requestRaiko[raikoProverStatusResponse](
 		ctx,
 		http.MethodGet,
 		s.RaikoHostEndpoint+"/v3/prover/status",
 		s.ApiKey,
+		nil,
 	)
 	if err != nil {
 		return false, fmt.Errorf("failed to get ZK prover status: %w", err)


### PR DESCRIPTION
## Summary

Follow-up to #21795. Consolidates all raiko HTTP onto a single shared **resty** client, so raiko requests use the same HTTP library already used elsewhere in the client (`pkg/rpc/blob_datasource.go`) instead of bespoke `net/http` plumbing.

- New `requestRaiko[U]` helper in `common.go` wraps a package-level `resty.New()` client (shared connection pool; per-call deadline via context, matching the old `http.DefaultClient` behavior).
- `requestHTTPProof` is now a thin POST wrapper over it (proof-request call sites unchanged).
- The ZK control-plane calls `ClearBacklog` / `StatusClean` route through `requestRaiko` too, replacing the hand-rolled `requestRaikoControlPlane`/`requestHTTPProofResponse` `net/http` helpers (both removed).
- `ForceContentType("application/json")` preserves the previous unconditional-unmarshal behavior regardless of the server's `Content-Type` header, and the 429 rate-limit log + HTTP-200 check are kept.

Net: three bespoke `net/http` helpers collapse into one resty-based helper.

## Why

#21795 review raised that raiko HTTP used raw `net/http` while the rest of the client uses resty. This makes it uniform.

## Stacking

Based on `prover/zk-sgx-drain-resume` (#21795) because the control-plane client (`zk_backlog.go`) only exists on that branch. The diff here is just the resty migration; merge #21795 first (or this will retarget to `main` automatically once #21795 merges).

## Test plan

- `go test -count=1 -race ./packages/taiko-client/prover/proof_producer/ ./packages/taiko-client/prover/proof_submitter/` — ✅ pass, no data races
- `golangci-lint run --config=.golangci.yml ./prover/...` — ✅ 0 issues
- The existing `zk_backlog` httptest suite exercises `requestRaiko` end to end (method, path, JSON parsing via `ForceContentType`, non-200 → error) for the control-plane GET/POST paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)