### PR TITLE
fix(taiko-client): report actual fork label in preconf block log

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/inserter.go
+++ b/packages/taiko-client/driver/chain_syncer/event/blocks_inserter/inserter.go
@@ -303,7 +303,7 @@ func (i *Shasta) InsertPreconfBlocksFromEnvelopes(
 			"⏰ New preconfirmation L2 block inserted",
 			"blockID", header.Number,
 			"hash", header.Hash(),
-			"fork", "Shasta",
+			"fork", rpc.ForkLabel(i.rpc.L2.ChainID, header.Time),
 			"coinbase", header.Coinbase.Hex(),
 			"timestamp", header.Time,
 			"baseFee", utils.WeiToGWei(header.BaseFee),


### PR DESCRIPTION
## Summary

The `⏰ New preconfirmation L2 block inserted` log line in `InsertPreconfBlocksFromEnvelopes` hardcoded `"fork", "Shasta"`, so Unzen-era preconfirmation blocks were still printed as `fork=Shasta`.

This is **purely cosmetic** — the block itself is produced correctly as Unzen (the execution engine selects the fork by timestamp, and the resulting `header.Difficulty` is non-zero = block zk gas, the Unzen-era signature). Only the log label was stale.

The fix swaps the literal for the existing `rpc.ForkLabel(chainID, timestamp)` helper, which already backs the three derivation-path log sites in the same file (`inserter.go:122/184/251`) and returns `"Unzen"` or `"Shasta"` based on the block timestamp.

## Change

```go
-			"fork", "Shasta",
+			"fork", rpc.ForkLabel(i.rpc.L2.ChainID, header.Time),
```

## Testing

- `go build ./driver/chain_syncer/event/blocks_inserter/`
- `go vet ./driver/chain_syncer/event/blocks_inserter/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)