### PR TITLE
feat(taiko-client): configurable SGX/SP1 ZK fallback target + risc0-idle resume

### DIFF
--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -82,6 +82,15 @@ var (
 		Category: proverCategory,
 		EnvVars:  []string{"PROVER_MAX_ZK_PROOF_PROPOSAL_DISTANCE"},
 	}
+	ZKFallbackProofType = &cli.StringFlag{
+		Name: "prover.zkFallbackProofType",
+		Usage: "Which proof type to fall back to when the ZK (zk_any) backlog breaches " +
+			"prover.maxZKProofProposalDistance: 'sgx' (the base proof) or 'sp1' (force the stable " +
+			"ZK proof, avoiding risc0). 'sp1' requires a ZKVM endpoint. Post Shasta fork only.",
+		Value:    "sgx",
+		Category: proverCategory,
+		EnvVars:  []string{"PROVER_ZK_FALLBACK_PROOF_TYPE"},
+	}
 	// Special flags for testing.
 	Dummy = &cli.BoolFlag{
 		Name:     "prover.dummy",
@@ -161,4 +170,5 @@ var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	ForceBatchProvingInterval,
 	ProposalWindowSize,
 	MaxZKProofProposalDistance,
+	ZKFallbackProofType,
 }, opsigner.CLIFlags("PROVER", proverCategory), TxmgrFlags)

--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -75,9 +75,9 @@ var (
 		Name: "prover.maxZKProofProposalDistance",
 		Usage: "The maximum proposal distance counted from lastFinalizedProposalID for requesting ZK proofs. " +
 			"When proposalID exceeds lastFinalizedProposalID + maxZKProofProposalDistance, the prover stops " +
-			"requesting ZK proofs, clears the ZK backlog, and drains via the base (SGX) proof until the backlog " +
-			"is cleared and the ZK endpoint reports clean, then resumes ZK. Set to 0 to disable ZK proving " +
-			"(always use the base/SGX proof). Post Shasta fork only.",
+			"requesting ZK (zk_any) proofs, clears the ZK backlog, and drains via the fallback proof " +
+			"(see prover.zkFallbackProofType) until the backlog is drained and risc0 is idle, then resumes ZK. " +
+			"Set to 0 to disable ZK proving (always use the base/SGX proof). Post Shasta fork only.",
 		Value:    30,
 		Category: proverCategory,
 		EnvVars:  []string{"PROVER_MAX_ZK_PROOF_PROPOSAL_DISTANCE"},

--- a/packages/taiko-client/internal/metrics/metrics.go
+++ b/packages/taiko-client/internal/metrics/metrics.go
@@ -96,7 +96,7 @@ var (
 	ProverQueuedProofCounter         = factory.NewCounter(prometheus.CounterOpts{Name: "prover_proof_all_queued"})
 	ProverSentProofCounter           = factory.NewCounter(prometheus.CounterOpts{Name: "prover_proof_all_sent"})
 	ProverProofsAssigned             = factory.NewCounter(prometheus.CounterOpts{Name: "prover_proof_assigned"})
-	ProverZKBacklogModeGauge         = factory.NewGauge(prometheus.GaugeOpts{Name: "prover_zk_backlog_sgx_mode"})
+	ProverZKBacklogModeGauge         = factory.NewGauge(prometheus.GaugeOpts{Name: "prover_zk_backlog_fallback_mode"})
 	ProverZKBacklogClearCounter      = factory.NewCounter(prometheus.CounterOpts{Name: "prover_zk_backlog_clear"})
 	ProverReceivedProposedBlockGauge = factory.NewGauge(prometheus.GaugeOpts{Name: "prover_proposed_received"})
 	ProverReceivedProvenBlockGauge   = factory.NewGauge(prometheus.GaugeOpts{Name: "prover_proven_received"})

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/cmd/flags"
 	pkgFlags "github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/flags"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/jwt"
+	producer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
 )
 
 // Config contains the configurations to initialize a Taiko prover.
@@ -50,6 +51,24 @@ type Config struct {
 	Dummy                      bool
 	ProposalWindowSize         uint64
 	MaxZKProofProposalDistance uint64
+	ZKFallbackProofType        producer.ProofType
+}
+
+// parseZKFallbackProofType maps the prover.zkFallbackProofType flag value to a
+// proof type. Empty (the default) and "sgx" select the base proof; "sp1" selects
+// the stable ZK proof. Any other value is rejected.
+func parseZKFallbackProofType(v string) (producer.ProofType, error) {
+	switch v {
+	case "", string(producer.ProofTypeSgx):
+		return producer.ProofTypeSgx, nil
+	case string(producer.ProofTypeZKSP1):
+		return producer.ProofTypeZKSP1, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid --%s: %q (want %q or %q)",
+			flags.ZKFallbackProofType.Name, v, producer.ProofTypeSgx, producer.ProofTypeZKSP1,
+		)
+	}
 }
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
@@ -101,6 +120,11 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	}
 	log.Info("Local proposer addresses", "addresses", localProposerAddresses)
 
+	zkFallbackProofType, err := parseZKFallbackProofType(c.String(flags.ZKFallbackProofType.Name))
+	if err != nil {
+		return nil, err
+	}
+
 	return &Config{
 		L1WsEndpoint:             c.String(flags.L1WSEndpoint.Name),
 		L1BeaconEndpoint:         c.String(flags.L1BeaconEndpoint.Name),
@@ -123,6 +147,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		MaxZKProofProposalDistance: c.Uint64(
 			flags.MaxZKProofProposalDistance.Name,
 		),
+		ZKFallbackProofType:    zkFallbackProofType,
 		RPCTimeout:             c.Duration(flags.RPCTimeout.Name),
 		ProveBatchesGasLimit:   c.Uint64(flags.TxGasLimit.Name),
 		LocalProposerAddresses: localProposerAddresses,

--- a/packages/taiko-client/prover/config_test.go
+++ b/packages/taiko-client/prover/config_test.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/urfave/cli/v2"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/encoding"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/cmd/flags"
+	producer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
 )
 
 func (s *ProverTestSuite) TestProverConfigShastaOnlySurface() {
@@ -47,6 +49,7 @@ func (s *ProverTestSuite) TestProverConfigShastaOnlySurface() {
 		s.Equal("http://raiko.zkvm", c.RaikoZKVMHostEndpoint)
 		s.Equal("secret-key", c.RaikoApiKey)
 		s.Equal(7*time.Second, c.RaikoRequestTimeout)
+		s.Equal(producer.ProofTypeSgx, c.ZKFallbackProofType)
 
 		return nil
 	}
@@ -160,4 +163,29 @@ func newTestConfigFromCLI(t *testing.T, extraArgs ...string) *Config {
 
 	require.NoError(t, app.Run(args))
 	return cfg
+}
+
+type ZKFallbackWiringTestSuite struct {
+	suite.Suite
+}
+
+func TestZKFallbackWiringTestSuite(t *testing.T) {
+	suite.Run(t, new(ZKFallbackWiringTestSuite))
+}
+
+func (s *ZKFallbackWiringTestSuite) TestParseZKFallbackProofType() {
+	sgx, err := parseZKFallbackProofType("sgx")
+	s.NoError(err)
+	s.Equal(producer.ProofTypeSgx, sgx)
+
+	def, err := parseZKFallbackProofType("")
+	s.NoError(err)
+	s.Equal(producer.ProofTypeSgx, def)
+
+	sp1, err := parseZKFallbackProofType("sp1")
+	s.NoError(err)
+	s.Equal(producer.ProofTypeZKSP1, sp1)
+
+	_, err = parseZKFallbackProofType("risc0")
+	s.Error(err)
 }

--- a/packages/taiko-client/prover/config_test.go
+++ b/packages/taiko-client/prover/config_test.go
@@ -189,3 +189,38 @@ func (s *ZKFallbackWiringTestSuite) TestParseZKFallbackProofType() {
 	_, err = parseZKFallbackProofType("risc0")
 	s.Error(err)
 }
+
+func (s *ZKFallbackWiringTestSuite) TestBuildZKFallbackProducer() {
+	ids := map[producer.ProofType]uint8{producer.ProofTypeZKSP1: 6}
+	geth := &producer.SgxGethProofProducer{}
+
+	// Default (sgx) -> nil even with a ZKVM endpoint. Assert with `== nil` rather than
+	// s.Nil (which unwraps typed nils) to lock in the untyped-nil-interface contract that
+	// the submitter's `fallbackProofProducer != nil` guards depend on.
+	p := buildZKFallbackProducer(
+		&Config{ZKFallbackProofType: producer.ProofTypeSgx, RaikoZKVMHostEndpoint: "http://zkvm"}, ids, geth,
+	)
+	s.True(p == nil)
+
+	// sp1 but no ZKVM endpoint -> nil.
+	p = buildZKFallbackProducer(
+		&Config{ZKFallbackProofType: producer.ProofTypeZKSP1}, ids, geth,
+	)
+	s.True(p == nil)
+
+	// sp1 + ZKVM endpoint -> a forced-SP1 ComposeProofProducer.
+	p = buildZKFallbackProducer(
+		&Config{
+			ZKFallbackProofType:   producer.ProofTypeZKSP1,
+			RaikoZKVMHostEndpoint: "http://zkvm",
+			RaikoApiKey:           "key",
+		}, ids, geth,
+	)
+	s.Require().NotNil(p)
+	cp, ok := p.(*producer.ComposeProofProducer)
+	s.True(ok)
+	s.Equal(producer.ProofTypeZKSP1, cp.ProofType)
+	s.Equal("http://zkvm", cp.RaikoHostEndpoint)
+	s.Equal(ids, cp.VerifierIDs)
+	s.Same(geth, cp.SgxGethProducer)
+}

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -99,7 +99,7 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 		p.ctx,
 		sgxRethProducer,
 		zkvmProducer,
-		nil, // fallbackProofProducer wired in the next task
+		buildZKFallbackProducer(p.cfg, zkVerifierIDs, sgxGethProducer),
 		p.batchProofGenerationCh,
 		p.batchesAggregationNotify,
 		p.proofSubmissionCh,
@@ -203,4 +203,27 @@ func (p *Prover) initEventHandlers() error {
 	)
 
 	return nil
+}
+
+// buildZKFallbackProducer returns the producer the drain/resume machine falls
+// back to: a forced-SP1 ZK producer when configured (and a ZKVM endpoint exists),
+// or nil to fall back to the base (SGX) producer. Without a ZKVM endpoint there is
+// no ZK proving, so the machine never engages and nil (base) is correct.
+func buildZKFallbackProducer(
+	cfg *Config,
+	zkVerifierIDs map[producer.ProofType]uint8,
+	sgxGethProducer *producer.SgxGethProofProducer,
+) producer.ProofProducer {
+	if cfg.ZKFallbackProofType != producer.ProofTypeZKSP1 || len(cfg.RaikoZKVMHostEndpoint) == 0 {
+		return nil
+	}
+	return &producer.ComposeProofProducer{
+		VerifierIDs:         zkVerifierIDs,
+		SgxGethProducer:     sgxGethProducer,
+		RaikoHostEndpoint:   cfg.RaikoZKVMHostEndpoint,
+		ApiKey:              cfg.RaikoApiKey,
+		RaikoRequestTimeout: cfg.RaikoRequestTimeout,
+		ProofType:           producer.ProofTypeZKSP1,
+		Dummy:               cfg.Dummy,
+	}
 }

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -99,6 +99,7 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 		p.ctx,
 		sgxRethProducer,
 		zkvmProducer,
+		nil, // fallbackProofProducer wired in the next task
 		p.batchProofGenerationCh,
 		p.batchesAggregationNotify,
 		p.proofSubmissionCh,

--- a/packages/taiko-client/prover/proof_producer/zk_backlog.go
+++ b/packages/taiko-client/prover/proof_producer/zk_backlog.go
@@ -10,22 +10,26 @@ import (
 
 // ZKBacklogController is implemented by proof producers whose backend exposes the
 // raiko2 control-plane endpoints for draining the ZK (`zk_any`) task backlog and
-// reporting when the backend is idle. See raiko2 issue #93.
+// reporting risc0 progress. See raiko2 issue #93.
 type ZKBacklogController interface {
 	// ClearBacklog discards all non-terminal `zk_any` tasks on the ZK backend
 	// (POST /v3/prover/clear).
 	ClearBacklog(ctx context.Context) error
-	// StatusClean reports whether the ZK backend is fully idle, i.e. the
-	// `data.clean` field of GET /v3/prover/status is true.
-	StatusClean(ctx context.Context) (bool, error)
+	// Risc0Idle reports whether the ZK backend has no in-flight risc0 orders, i.e.
+	// `data.network.risc0.inflight_orders` of GET /v3/prover/status is 0.
+	Risc0Idle(ctx context.Context) (bool, error)
 }
 
 // raikoProverStatusResponse is the body returned by GET /v3/prover/status. Only
-// `data.clean` is consumed; the remaining fields (`status`, `tasks`, `network`)
-// are intentionally ignored.
+// `data.network.risc0.inflight_orders` is consumed; the remaining fields
+// (`status`, `tasks`, `network.sp1`, `data.clean`, ...) are intentionally ignored.
 type raikoProverStatusResponse struct {
 	Data struct {
-		Clean bool `json:"clean"`
+		Network struct {
+			Risc0 struct {
+				InflightOrders uint64 `json:"inflight_orders"`
+			} `json:"risc0"`
+		} `json:"network"`
 	} `json:"data"`
 }
 
@@ -50,8 +54,8 @@ func (s *ComposeProofProducer) ClearBacklog(ctx context.Context) error {
 	return nil
 }
 
-// StatusClean implements the ZKBacklogController interface.
-func (s *ComposeProofProducer) StatusClean(ctx context.Context) (bool, error) {
+// Risc0Idle implements the ZKBacklogController interface.
+func (s *ComposeProofProducer) Risc0Idle(ctx context.Context) (bool, error) {
 	if s.Dummy {
 		return true, nil
 	}
@@ -68,5 +72,5 @@ func (s *ComposeProofProducer) StatusClean(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to get ZK prover status: %w", err)
 	}
-	return out.Data.Clean, nil
+	return out.Data.Network.Risc0.InflightOrders == 0, nil
 }

--- a/packages/taiko-client/prover/proof_producer/zk_backlog.go
+++ b/packages/taiko-client/prover/proof_producer/zk_backlog.go
@@ -23,11 +23,14 @@ type ZKBacklogController interface {
 // raikoProverStatusResponse is the body returned by GET /v3/prover/status. Only
 // `data.network.risc0.inflight_orders` is consumed; the remaining fields
 // (`status`, `tasks`, `network.sp1`, `data.clean`, ...) are intentionally ignored.
+// The risc0 section and its inflight_orders are pointers so a response that omits
+// them (e.g. an older status schema) is treated as "unavailable" rather than
+// silently decoding to a zero (idle) value.
 type raikoProverStatusResponse struct {
 	Data struct {
 		Network struct {
-			Risc0 struct {
-				InflightOrders uint64 `json:"inflight_orders"`
+			Risc0 *struct {
+				InflightOrders *uint64 `json:"inflight_orders"`
 			} `json:"risc0"`
 		} `json:"network"`
 	} `json:"data"`
@@ -72,5 +75,10 @@ func (s *ComposeProofProducer) Risc0Idle(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to get ZK prover status: %w", err)
 	}
-	return out.Data.Network.Risc0.InflightOrders == 0, nil
+	// Treat a missing risc0 section as unavailable (not idle) so canResumeZK takes
+	// the status-unavailable path instead of silently trusting a zero value.
+	if out.Data.Network.Risc0 == nil || out.Data.Network.Risc0.InflightOrders == nil {
+		return false, fmt.Errorf("risc0 inflight_orders missing from /v3/prover/status response")
+	}
+	return *out.Data.Network.Risc0.InflightOrders == 0, nil
 }

--- a/packages/taiko-client/prover/proof_producer/zk_backlog_test.go
+++ b/packages/taiko-client/prover/proof_producer/zk_backlog_test.go
@@ -20,50 +20,50 @@ func TestZKBacklogTestSuite(t *testing.T) {
 	suite.Run(t, new(ZKBacklogTestSuite))
 }
 
-func (s *ZKBacklogTestSuite) TestStatusCleanReturnsTrue() {
+func (s *ZKBacklogTestSuite) TestRisc0IdleReturnsTrueWhenZero() {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.Equal(http.MethodGet, r.Method)
 		s.Equal("/v3/prover/status", r.URL.Path)
 		_, _ = w.Write([]byte(
-			`{"status":"ok","data":{"clean":true,"tasks":{"pending":0},"network":{"risc0":{"inflight_orders":0}}}}`,
+			`{"status":"ok","data":{"network":{"risc0":{"inflight_orders":0}}}}`,
 		))
 	}))
 	defer server.Close()
 
 	p := &ComposeProofProducer{RaikoHostEndpoint: server.URL, RaikoRequestTimeout: time.Second}
-	clean, err := p.StatusClean(s.T().Context())
+	idle, err := p.Risc0Idle(s.T().Context())
 	s.NoError(err)
-	s.True(clean)
+	s.True(idle)
 }
 
-func (s *ZKBacklogTestSuite) TestStatusCleanReturnsFalse() {
+func (s *ZKBacklogTestSuite) TestRisc0IdleReturnsFalseWhenInflight() {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"status":"ok","data":{"clean":false}}`))
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"network":{"risc0":{"inflight_orders":3}}}}`))
 	}))
 	defer server.Close()
 
 	p := &ComposeProofProducer{RaikoHostEndpoint: server.URL, RaikoRequestTimeout: time.Second}
-	clean, err := p.StatusClean(s.T().Context())
+	idle, err := p.Risc0Idle(s.T().Context())
 	s.NoError(err)
-	s.False(clean)
+	s.False(idle)
 }
 
-func (s *ZKBacklogTestSuite) TestStatusCleanErrorsOnNon200() {
+func (s *ZKBacklogTestSuite) TestRisc0IdleErrorsOnNon200() {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
 
 	p := &ComposeProofProducer{RaikoHostEndpoint: server.URL, RaikoRequestTimeout: time.Second}
-	_, err := p.StatusClean(s.T().Context())
+	_, err := p.Risc0Idle(s.T().Context())
 	s.Error(err)
 }
 
-func (s *ZKBacklogTestSuite) TestStatusCleanDummyShortCircuits() {
+func (s *ZKBacklogTestSuite) TestRisc0IdleDummyShortCircuits() {
 	p := &ComposeProofProducer{Dummy: true}
-	clean, err := p.StatusClean(s.T().Context())
+	idle, err := p.Risc0Idle(s.T().Context())
 	s.NoError(err)
-	s.True(clean)
+	s.True(idle)
 }
 
 func (s *ZKBacklogTestSuite) TestClearBacklogPostsToEndpoint() {

--- a/packages/taiko-client/prover/proof_producer/zk_backlog_test.go
+++ b/packages/taiko-client/prover/proof_producer/zk_backlog_test.go
@@ -59,6 +59,31 @@ func (s *ZKBacklogTestSuite) TestRisc0IdleErrorsOnNon200() {
 	s.Error(err)
 }
 
+func (s *ZKBacklogTestSuite) TestRisc0IdleErrorsWhenRisc0Missing() {
+	// 200 with an older schema lacking network.risc0: treated as unavailable, not
+	// silently idle (a busy `clean:false` must not be read as idle).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"clean":false}}`))
+	}))
+	defer server.Close()
+
+	p := &ComposeProofProducer{RaikoHostEndpoint: server.URL, RaikoRequestTimeout: time.Second}
+	_, err := p.Risc0Idle(s.T().Context())
+	s.Error(err)
+}
+
+func (s *ZKBacklogTestSuite) TestRisc0IdleErrorsWhenInflightMissing() {
+	// risc0 present but without inflight_orders: also unavailable, not idle.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"network":{"risc0":{}}}}`))
+	}))
+	defer server.Close()
+
+	p := &ComposeProofProducer{RaikoHostEndpoint: server.URL, RaikoRequestTimeout: time.Second}
+	_, err := p.Risc0Idle(s.T().Context())
+	s.Error(err)
+}
+
 func (s *ZKBacklogTestSuite) TestRisc0IdleDummyShortCircuits() {
 	p := &ComposeProofProducer{Dummy: true}
 	idle, err := p.Risc0Idle(s.T().Context())

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -269,8 +269,7 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 		// While latched with an SP1 target this is the SP1 producer; otherwise (SGX target,
 		// or a per-call zk_any_not_drawn / timeout) it is the base (SGX) producer.
 		if proofResponse == nil {
-			fallbackProducer := s.resolveFallbackProducer()
-			if proofResponse, err = fallbackProducer.RequestProof(
+			if proofResponse, err = s.resolveFallbackProducer().RequestProof(
 				ctx,
 				opts,
 				meta.Shasta().GetEventData().Id,

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -116,7 +116,7 @@ func NewProofSubmitter(
 		ctx:                        ctx,
 	}
 
-	// Wire the raiko2 control-plane client (ClearBacklog/StatusClean) when a ZK
+	// Wire the raiko2 control-plane client (ClearBacklog/Risc0Idle) when a ZK
 	// producer is configured. This is a compile-time capability check, not a probe
 	// of the remote host: with no ZK endpoint set, zkvmProofProducer is nil and
 	// zkBacklog stays nil, so decideUseZK bypasses the drain/resume machine. When a

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -40,6 +40,11 @@ type ProofSubmitter struct {
 	// Proof producers
 	baseLevelProofProducer proofProducer.ProofProducer
 	zkvmProofProducer      proofProducer.ProofProducer
+	// fallbackProofProducer is the producer used while latched into fallback when a
+	// non-base (SP1) target is configured; nil means fall back to the base (SGX)
+	// baseLevelProofProducer. Distinguishes the SP1 target from SGX for both the
+	// request routing and the on-latch buffer flush.
+	fallbackProofProducer proofProducer.ProofProducer
 	// Channels
 	batchResultCh          chan *proofProducer.BatchProofs
 	batchAggregationNotify chan proofProducer.ProofType
@@ -71,6 +76,7 @@ func NewProofSubmitter(
 	ctx context.Context,
 	baseLevelProofProducer proofProducer.ProofProducer,
 	zkvmProofProducer proofProducer.ProofProducer,
+	fallbackProofProducer proofProducer.ProofProducer,
 	batchResultCh chan *proofProducer.BatchProofs,
 	batchAggregationNotify chan proofProducer.ProofType,
 	proofSubmissionCh chan *proofProducer.ProofRequestBody,
@@ -88,6 +94,7 @@ func NewProofSubmitter(
 		rpc:                    senderOpts.RPCClient,
 		baseLevelProofProducer: baseLevelProofProducer,
 		zkvmProofProducer:      zkvmProofProducer,
+		fallbackProofProducer:  fallbackProofProducer,
 		batchResultCh:          batchResultCh,
 		batchAggregationNotify: batchAggregationNotify,
 		proofSubmissionCh:      proofSubmissionCh,
@@ -258,9 +265,12 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 				}
 			}
 		}
-		// If zk proof is not enabled or zk proof is not drawn, request the base level proof.
+		// If zk proof is not enabled or zk proof is not drawn, request the fallback proof.
+		// While latched with an SP1 target this is the SP1 producer; otherwise (SGX target,
+		// or a per-call zk_any_not_drawn / timeout) it is the base (SGX) producer.
 		if proofResponse == nil {
-			if proofResponse, err = s.baseLevelProofProducer.RequestProof(
+			fallbackProducer := s.resolveFallbackProducer()
+			if proofResponse, err = fallbackProducer.RequestProof(
 				ctx,
 				opts,
 				meta.Shasta().GetEventData().Id,
@@ -270,7 +280,7 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoPr
 				if time.Since(startAt) > maxProofRequestTimeout {
 					log.Warn("WARN: Proof generation taking too long, please investigate")
 				}
-				return fmt.Errorf("failed to request base proof, error: %w", err)
+				return fmt.Errorf("failed to request fallback proof, error: %w", err)
 			}
 		}
 		return s.handleProofResponse(meta, fromID, proofResponse)

--- a/packages/taiko-client/prover/proof_submitter/zk_fallback.go
+++ b/packages/taiko-client/prover/proof_submitter/zk_fallback.go
@@ -47,6 +47,17 @@ func (s *ProofSubmitter) inFallback() bool {
 	return s.zkFallback.latched
 }
 
+// resolveFallbackProducer returns the producer for the non-zk_any attempt. While
+// latched into fallback with a configured non-base (SP1) target it returns that
+// producer; otherwise (a per-call zk_any_not_drawn / timeout, or an SGX target) it
+// returns the base producer.
+func (s *ProofSubmitter) resolveFallbackProducer() proofProducer.ProofProducer {
+	if s.inFallback() && s.fallbackProofProducer != nil {
+		return s.fallbackProofProducer
+	}
+	return s.baseLevelProofProducer
+}
+
 // resumeZK unlatches fallback-draining mode so subsequent proposals use ZK again.
 // It returns true only for the caller that performed the transition.
 func (s *ProofSubmitter) resumeZK() bool {
@@ -161,19 +172,23 @@ func (s *ProofSubmitter) fireClearAsync() {
 	}()
 }
 
-// zkProofTypes are the ZK proof types whose local buffers and caches are flushed
-// when entering SGX-draining mode.
-var zkProofTypes = []proofProducer.ProofType{
-	proofProducer.ProofTypeZKR0,
-	proofProducer.ProofTypeZKSP1,
+// zkFallbackFlushTypes lists the ZK proof types flushed when entering fallback
+// mode. Falling back to the base (SGX) producer stops all ZK proving, so both ZK
+// buffers must be flushed and re-proven. Falling back to SP1 keeps producing sp1
+// proofs, so the ZKSP1 buffer still aggregates and is kept; only the stranded
+// risc0 (ZKR0) proofs are flushed and re-proven as sp1.
+func (s *ProofSubmitter) zkFallbackFlushTypes() []proofProducer.ProofType {
+	if s.fallbackProofProducer != nil {
+		return []proofProducer.ProofType{proofProducer.ProofTypeZKR0}
+	}
+	return []proofProducer.ProofType{proofProducer.ProofTypeZKR0, proofProducer.ProofTypeZKSP1}
 }
 
-// clearZKProofBuffersAndResend discards any buffered or cached ZK proofs and
-// re-enqueues their proposals so they are re-proven via SGX while draining. This
-// prevents a partially-filled ZK proof batch from stranding once new ZK requests
-// stop.
+// clearZKProofBuffersAndResend discards buffered/cached ZK proofs for the
+// target-dependent set and re-enqueues their proposals so they are re-proven via
+// the fallback producer while draining.
 func (s *ProofSubmitter) clearZKProofBuffersAndResend() {
-	for _, proofType := range zkProofTypes {
+	for _, proofType := range s.zkFallbackFlushTypes() {
 		s.clearProofBufferAndResend(proofType)
 	}
 }
@@ -222,7 +237,7 @@ func (s *ProofSubmitter) clearProofBufferAndResend(proofType proofProducer.Proof
 	}
 	if len(resend) > 0 {
 		log.Info(
-			"Cleared ZK proof buffer and resent proposals for SGX draining",
+			"Cleared ZK proof buffer and resent proposals for fallback draining",
 			"proofType", proofType,
 			"count", len(resend),
 		)

--- a/packages/taiko-client/prover/proof_submitter/zk_fallback.go
+++ b/packages/taiko-client/prover/proof_submitter/zk_fallback.go
@@ -14,54 +14,55 @@ import (
 )
 
 // clearBackoffMaxRetries bounds the best-effort retries of POST /v3/prover/clear
-// when entering SGX-draining mode.
+// when entering fallback mode.
 const clearBackoffMaxRetries uint64 = 5
 
-// zkFallback tracks whether the submitter is draining the ZK backlog via SGX.
-// It is shared across the concurrent RequestProof goroutines, so all access is
-// guarded by mu.
+// zkFallback tracks whether the submitter is draining the ZK backlog via the
+// fallback producer (SGX or SP1). It is shared across the concurrent RequestProof
+// goroutines, so all access is guarded by mu.
 type zkFallback struct {
-	mu    sync.Mutex
-	inSGX bool
+	mu      sync.Mutex
+	latched bool
 }
 
-// markSGXFallback latches into SGX-draining mode. It returns true only for the
+// markFallback latches into fallback-draining mode. It returns true only for the
 // first caller that performs the transition; that caller is responsible for
 // clearing the ZK backlog exactly once.
-func (s *ProofSubmitter) markSGXFallback() bool {
+func (s *ProofSubmitter) markFallback() bool {
 	s.zkFallback.mu.Lock()
 	defer s.zkFallback.mu.Unlock()
-	if s.zkFallback.inSGX {
+	if s.zkFallback.latched {
 		return false
 	}
-	s.zkFallback.inSGX = true
+	s.zkFallback.latched = true
 	metrics.ProverZKBacklogModeGauge.Set(1)
 	return true
 }
 
-// inSGXFallback reports whether the submitter is currently draining via SGX.
-func (s *ProofSubmitter) inSGXFallback() bool {
+// inFallback reports whether the submitter is currently draining via the fallback
+// producer.
+func (s *ProofSubmitter) inFallback() bool {
 	s.zkFallback.mu.Lock()
 	defer s.zkFallback.mu.Unlock()
-	return s.zkFallback.inSGX
+	return s.zkFallback.latched
 }
 
-// resumeZK unlatches SGX-draining mode so subsequent proposals use ZK again.
+// resumeZK unlatches fallback-draining mode so subsequent proposals use ZK again.
 // It returns true only for the caller that performed the transition.
 func (s *ProofSubmitter) resumeZK() bool {
 	s.zkFallback.mu.Lock()
 	defer s.zkFallback.mu.Unlock()
-	if !s.zkFallback.inSGX {
+	if !s.zkFallback.latched {
 		return false
 	}
-	s.zkFallback.inSGX = false
+	s.zkFallback.latched = false
 	metrics.ProverZKBacklogModeGauge.Set(0)
 	return true
 }
 
 // decideUseZK applies the ZK backlog drain/resume state machine and reports
 // whether this proposal should be proven via ZK. It has side effects: it latches
-// into SGX-draining mode (and fires a one-off backlog clear) on the first
+// into fallback mode (and fires a one-off backlog clear) on the first
 // distance breach, and unlatches when the backlog is drained.
 func (s *ProofSubmitter) decideUseZK(
 	ctx context.Context,
@@ -78,7 +79,7 @@ func (s *ProofSubmitter) decideUseZK(
 		return s.shouldUseZKProof(proposalID, lastFinalizedProposalID)
 	}
 
-	if s.inSGXFallback() {
+	if s.inFallback() {
 		if s.canResumeZK(ctx, proposalID, lastFinalizedProposalID) {
 			if s.resumeZK() {
 				log.Info(
@@ -93,9 +94,9 @@ func (s *ProofSubmitter) decideUseZK(
 	}
 
 	if !s.shouldUseZKProof(proposalID, lastFinalizedProposalID) {
-		if s.markSGXFallback() {
+		if s.markFallback() {
 			log.Warn(
-				"ZK proof backlog detected, clearing ZK backlog and draining via SGX",
+				"ZK proof backlog detected, clearing ZK backlog and draining via fallback",
 				"proposalID", proposalID,
 				"lastFinalizedProposalID", lastFinalizedProposalID,
 				"maxZKProofProposalDistance", s.maxZKProofProposalDistance,
@@ -108,8 +109,8 @@ func (s *ProofSubmitter) decideUseZK(
 	return true
 }
 
-// canResumeZK reports whether SGX-draining mode can switch back to ZK. It checks
-// the cheap local "backlog drained" condition first and only queries the ZK
+// canResumeZK reports whether fallback-draining mode can switch back to ZK. It
+// checks the cheap local "backlog drained" condition first and only queries the ZK
 // backend status when that holds. A status error (e.g. the endpoint is absent)
 // degrades to resuming on the backlog-drained condition alone.
 func (s *ProofSubmitter) canResumeZK(
@@ -121,8 +122,8 @@ func (s *ProofSubmitter) canResumeZK(
 	if proposalID.Cmp(new(big.Int).Add(lastFinalizedProposalID, common.Big1)) > 0 {
 		return false
 	}
-	// (B) ZK backend idle.
-	clean, err := s.zkBacklog.StatusClean(ctx)
+	// (B) ZK backend risc0 idle.
+	idle, err := s.zkBacklog.Risc0Idle(ctx)
 	if err != nil {
 		log.Warn(
 			"ZK prover status unavailable, resuming ZK on backlog-drained condition alone",
@@ -131,7 +132,7 @@ func (s *ProofSubmitter) canResumeZK(
 		)
 		return true
 	}
-	return clean
+	return idle
 }
 
 // fireClearAsync clears the ZK backlog in the background with bounded retries.
@@ -156,7 +157,7 @@ func (s *ProofSubmitter) fireClearAsync() {
 			log.Warn("Failed to clear ZK backlog after retries", "error", err)
 			return
 		}
-		log.Info("Cleared ZK backlog after entering SGX-draining mode")
+		log.Info("Cleared ZK backlog after entering fallback mode")
 	}()
 }
 

--- a/packages/taiko-client/prover/proof_submitter/zk_fallback_test.go
+++ b/packages/taiko-client/prover/proof_submitter/zk_fallback_test.go
@@ -270,3 +270,71 @@ func (s *ZKFallbackTestSuite) TestDecideUseZKBreachClearsLocalZKBuffers() {
 		s.FailNow("expected raiko backlog clear")
 	}
 }
+
+func (s *ZKFallbackTestSuite) TestResolveFallbackProducer() {
+	base := &mockProofProducer{}
+	sp1 := &mockProofProducer{}
+
+	// Not latched -> base, even with an SP1 target configured.
+	sub := &ProofSubmitter{baseLevelProofProducer: base, fallbackProofProducer: sp1}
+	s.Same(base, sub.resolveFallbackProducer())
+
+	// Latched + SP1 target -> SP1.
+	s.True(sub.markFallback())
+	s.Same(sp1, sub.resolveFallbackProducer())
+
+	// Latched + no SP1 target (nil) -> base.
+	sub2 := &ProofSubmitter{baseLevelProofProducer: base}
+	s.True(sub2.markFallback())
+	s.Same(base, sub2.resolveFallbackProducer())
+}
+
+func (s *ZKFallbackTestSuite) TestDecideUseZKBreachSP1KeepsZKSP1Buffer() {
+	r0Buf := proofProducer.NewProofBuffer(8)
+	sp1Buf := proofProducer.NewProofBuffer(8)
+	r0Cache := cmap.New[*proofProducer.ProofResponse]()
+	sp1Cache := cmap.New[*proofProducer.ProofResponse]()
+
+	_, err := r0Buf.Write(&proofProducer.ProofResponse{BatchID: big.NewInt(5), Meta: newShastaMetaForTest(5)})
+	s.NoError(err)
+	_, err = sp1Buf.Write(&proofProducer.ProofResponse{BatchID: big.NewInt(7), Meta: newShastaMetaForTest(7)})
+	s.NoError(err)
+
+	fake := &fakeZKBacklog{cleared: make(chan struct{}, 1)}
+	ch := make(chan *proofProducer.ProofRequestBody, 8)
+	sub := &ProofSubmitter{
+		maxZKProofProposalDistance: big.NewInt(30),
+		zkBacklog:                  fake,
+		proofPollingInterval:       time.Millisecond,
+		ctx:                        context.Background(),
+		fallbackProofProducer:      &mockProofProducer{}, // non-nil => SP1 target
+		proofBuffers: map[proofProducer.ProofType]*proofProducer.ProofBuffer{
+			proofProducer.ProofTypeZKR0:  r0Buf,
+			proofProducer.ProofTypeZKSP1: sp1Buf,
+		},
+		proofCacheMaps: map[proofProducer.ProofType]cmap.ConcurrentMap[string, *proofProducer.ProofResponse]{
+			proofProducer.ProofTypeZKR0:  r0Cache,
+			proofProducer.ProofTypeZKSP1: sp1Cache,
+		},
+		proofSubmissionCh: ch,
+	}
+
+	// Breach (41 > 10+30): latch, flush ZKR0 only (keep ZKSP1), resend the risc0 proposal.
+	s.False(sub.decideUseZK(context.Background(), big.NewInt(41), big.NewInt(10)))
+	s.True(sub.inFallback())
+	s.Equal(0, r0Buf.Len())  // risc0 flushed
+	s.Equal(1, sp1Buf.Len()) // sp1 kept
+
+	select {
+	case req := <-ch:
+		s.Equal(uint64(5), req.Meta.GetProposalID().Uint64())
+	case <-time.After(time.Second):
+		s.FailNow("expected risc0 proposal resent")
+	}
+	// No second resend: the sp1 buffer was not flushed.
+	select {
+	case <-ch:
+		s.FailNow("did not expect the sp1 proposal to be resent")
+	default:
+	}
+}

--- a/packages/taiko-client/prover/proof_submitter/zk_fallback_test.go
+++ b/packages/taiko-client/prover/proof_submitter/zk_fallback_test.go
@@ -19,7 +19,7 @@ import (
 type fakeZKBacklog struct {
 	clearCalls  atomic.Int32
 	clearErr    error
-	clean       bool
+	risc0Idle   bool
 	statusErr   error
 	statusCalls atomic.Int32
 	cleared     chan struct{}
@@ -36,9 +36,9 @@ func (f *fakeZKBacklog) ClearBacklog(_ context.Context) error {
 	return f.clearErr
 }
 
-func (f *fakeZKBacklog) StatusClean(_ context.Context) (bool, error) {
+func (f *fakeZKBacklog) Risc0Idle(_ context.Context) (bool, error) {
 	f.statusCalls.Add(1)
-	return f.clean, f.statusErr
+	return f.risc0Idle, f.statusErr
 }
 
 func newZKFallbackSubmitter(backlog proofProducer.ZKBacklogController) *ProofSubmitter {
@@ -59,19 +59,19 @@ func TestZKFallbackTestSuite(t *testing.T) {
 	suite.Run(t, new(ZKFallbackTestSuite))
 }
 
-func (s *ZKFallbackTestSuite) TestMarkSGXFallbackOnlyFirstCallerWins() {
+func (s *ZKFallbackTestSuite) TestMarkFallbackOnlyFirstCallerWins() {
 	sub := &ProofSubmitter{}
-	s.False(sub.inSGXFallback())
-	s.True(sub.markSGXFallback())  // first caller latches
-	s.False(sub.markSGXFallback()) // already latched
-	s.True(sub.inSGXFallback())
+	s.False(sub.inFallback())
+	s.True(sub.markFallback())  // first caller latches
+	s.False(sub.markFallback()) // already latched
+	s.True(sub.inFallback())
 
 	sub.resumeZK()
-	s.False(sub.inSGXFallback())
-	s.True(sub.markSGXFallback()) // can latch again after a resume
+	s.False(sub.inFallback())
+	s.True(sub.markFallback()) // can latch again after a resume
 }
 
-func (s *ZKFallbackTestSuite) TestMarkSGXFallbackConcurrentSingleWinner() {
+func (s *ZKFallbackTestSuite) TestMarkFallbackConcurrentSingleWinner() {
 	sub := &ProofSubmitter{}
 	const n = 50
 	var (
@@ -82,14 +82,14 @@ func (s *ZKFallbackTestSuite) TestMarkSGXFallbackConcurrentSingleWinner() {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			if sub.markSGXFallback() {
+			if sub.markFallback() {
 				winners.Add(1)
 			}
 		}()
 	}
 	wg.Wait()
 	s.Equal(int32(1), winners.Load())
-	s.True(sub.inSGXFallback())
+	s.True(sub.inFallback())
 }
 
 func (s *ZKFallbackTestSuite) TestDecideUseZKDistanceZeroSkipsZK() {
@@ -97,7 +97,7 @@ func (s *ZKFallbackTestSuite) TestDecideUseZKDistanceZeroSkipsZK() {
 	// drain/resume machine stays inactive (no latch, no clear).
 	sub := &ProofSubmitter{maxZKProofProposalDistance: big.NewInt(0), zkBacklog: &fakeZKBacklog{}}
 	s.False(sub.decideUseZK(context.Background(), big.NewInt(1000), big.NewInt(1)))
-	s.False(sub.inSGXFallback())
+	s.False(sub.inFallback())
 }
 
 func (s *ZKFallbackTestSuite) TestDecideUseZKNilBacklogFallsBackToStateless() {
@@ -105,13 +105,13 @@ func (s *ZKFallbackTestSuite) TestDecideUseZKNilBacklogFallsBackToStateless() {
 	// 40 <= 10+30 stays ZK; 41 > 10+30 skips ZK; neither latches without a control-plane client.
 	s.True(sub.decideUseZK(context.Background(), big.NewInt(40), big.NewInt(10)))
 	s.False(sub.decideUseZK(context.Background(), big.NewInt(41), big.NewInt(10)))
-	s.False(sub.inSGXFallback())
+	s.False(sub.inFallback())
 }
 
 func (s *ZKFallbackTestSuite) TestDecideUseZKWithinDistanceStaysZK() {
 	sub := newZKFallbackSubmitter(&fakeZKBacklog{})
 	s.True(sub.decideUseZK(context.Background(), big.NewInt(40), big.NewInt(10)))
-	s.False(sub.inSGXFallback())
+	s.False(sub.inFallback())
 }
 
 func (s *ZKFallbackTestSuite) TestDecideUseZKBreachLatchesAndClearsOnce() {
@@ -119,7 +119,7 @@ func (s *ZKFallbackTestSuite) TestDecideUseZKBreachLatchesAndClearsOnce() {
 	sub := newZKFallbackSubmitter(fake)
 
 	s.False(sub.decideUseZK(context.Background(), big.NewInt(41), big.NewInt(10))) // breach
-	s.True(sub.inSGXFallback())
+	s.True(sub.inFallback())
 
 	select {
 	case <-fake.cleared:
@@ -138,7 +138,7 @@ func (s *ZKFallbackTestSuite) TestFireClearAsyncRetriesThenGivesUp() {
 
 	// Distance breach: 41 > 10 + 30 -> latch + fireClearAsync (which will keep failing).
 	s.False(sub.decideUseZK(context.Background(), big.NewInt(41), big.NewInt(10)))
-	s.True(sub.inSGXFallback())
+	s.True(sub.inFallback())
 
 	// fireClearAsync retries 1 + clearBackoffMaxRetries times, then gives up.
 	s.Eventually(func() bool {
@@ -146,49 +146,49 @@ func (s *ZKFallbackTestSuite) TestFireClearAsyncRetriesThenGivesUp() {
 	}, 2*time.Second, 5*time.Millisecond)
 
 	// Still latched after clear ultimately failed (best-effort; resume is gated elsewhere).
-	s.True(sub.inSGXFallback())
+	s.True(sub.inFallback())
 }
 
-func (s *ZKFallbackTestSuite) TestDecideUseZKResumeWhenDrainedAndClean() {
-	fake := &fakeZKBacklog{clean: true}
+func (s *ZKFallbackTestSuite) TestDecideUseZKResumeWhenDrainedAndRisc0Idle() {
+	fake := &fakeZKBacklog{risc0Idle: true}
 	sub := newZKFallbackSubmitter(fake)
-	s.True(sub.markSGXFallback())
+	s.True(sub.markFallback())
 
-	// (A) 11 <= 10+1 holds and status is clean -> resume ZK.
+	// (A) 11 <= 10+1 holds and risc0 is idle -> resume ZK.
 	s.True(sub.decideUseZK(context.Background(), big.NewInt(11), big.NewInt(10)))
-	s.False(sub.inSGXFallback())
+	s.False(sub.inFallback())
 	s.Equal(int32(1), fake.statusCalls.Load())
 }
 
-func (s *ZKFallbackTestSuite) TestDecideUseZKStaysSGXWhenNotDrained() {
-	fake := &fakeZKBacklog{clean: true}
+func (s *ZKFallbackTestSuite) TestDecideUseZKStaysInFallbackWhenNotDrained() {
+	fake := &fakeZKBacklog{risc0Idle: true}
 	sub := newZKFallbackSubmitter(fake)
-	s.True(sub.markSGXFallback())
+	s.True(sub.markFallback())
 
-	// (A) fails (20 > 10+1) -> stay SGX; status must not be queried until (A) holds.
+	// (A) fails (20 > 10+1) -> stay in fallback; status must not be queried until (A) holds.
 	s.False(sub.decideUseZK(context.Background(), big.NewInt(20), big.NewInt(10)))
-	s.True(sub.inSGXFallback())
+	s.True(sub.inFallback())
 	s.Equal(int32(0), fake.statusCalls.Load())
 }
 
-func (s *ZKFallbackTestSuite) TestDecideUseZKStaysSGXWhenNotClean() {
-	fake := &fakeZKBacklog{clean: false}
+func (s *ZKFallbackTestSuite) TestDecideUseZKStaysInFallbackWhenRisc0Busy() {
+	fake := &fakeZKBacklog{risc0Idle: false}
 	sub := newZKFallbackSubmitter(fake)
-	s.True(sub.markSGXFallback())
+	s.True(sub.markFallback())
 
 	s.False(sub.decideUseZK(context.Background(), big.NewInt(11), big.NewInt(10)))
-	s.True(sub.inSGXFallback())
+	s.True(sub.inFallback())
 	s.Equal(int32(1), fake.statusCalls.Load())
 }
 
 func (s *ZKFallbackTestSuite) TestDecideUseZKDegradesOnStatusError() {
 	fake := &fakeZKBacklog{statusErr: errors.New("status endpoint absent")}
 	sub := newZKFallbackSubmitter(fake)
-	s.True(sub.markSGXFallback())
+	s.True(sub.markFallback())
 
 	// (A) holds but status errors -> degrade -> resume on backlog-drained alone.
 	s.True(sub.decideUseZK(context.Background(), big.NewInt(11), big.NewInt(10)))
-	s.False(sub.inSGXFallback())
+	s.False(sub.inFallback())
 }
 
 func (s *ZKFallbackTestSuite) TestDecideUseZKConcurrentBreachClearsOnce() {
@@ -213,7 +213,7 @@ func (s *ZKFallbackTestSuite) TestDecideUseZKConcurrentBreachClearsOnce() {
 	wg.Wait()
 
 	s.Equal(int32(0), nonBreach.Load()) // every caller saw the breach
-	s.True(sub.inSGXFallback())
+	s.True(sub.inFallback())
 	select {
 	case <-fake.cleared:
 	case <-time.After(time.Second):
@@ -248,7 +248,7 @@ func (s *ZKFallbackTestSuite) TestDecideUseZKBreachClearsLocalZKBuffers() {
 
 	// Breach (41 > 10+30): latch, flush local ZK buffer/cache, resend, clear raiko.
 	s.False(sub.decideUseZK(context.Background(), big.NewInt(41), big.NewInt(10)))
-	s.True(sub.inSGXFallback())
+	s.True(sub.inFallback())
 	s.Equal(0, buffer.Len())
 	s.Equal(0, cache.Count())
 


### PR DESCRIPTION
## Summary

Builds on #21795. Lets the prover choose **what** the ZK drain/resume state machine falls back to when the ZK (`zk_any`) backlog breaches `prover.maxZKProofProposalDistance`: the base **SGX** proof (default, unchanged) or an explicit **SP1** ZK proof. Since risc0 is the unstable proving path, falling back to SP1 keeps the prover on the ZK endpoint while avoiding risc0. The resume signal also changes from "ZK backend clean" to "risc0 idle" (`data.network.risc0.inflight_orders == 0`), since risc0 recovery is the only condition that matters for resuming `zk_any`.

## Changes

- **New flag** `prover.zkFallbackProofType` (`sgx` default | `sp1`, env `PROVER_ZK_FALLBACK_PROOF_TYPE`). Unknown values fail at startup. Default `sgx` preserves #21795 behavior byte-for-byte.
- **SP1 fallback producer:** when configured (and a ZKVM endpoint exists), init builds a forced-`sp1` `ComposeProofProducer`; the submitter routes the latched-fallback proof through a nil-able `fallbackProofProducer` (nil ⇒ base SGX). A per-call `zk_any_not_drawn`/timeout still falls to SGX — only the latched machine uses the configured target.
- **Resume gate** now `Risc0Idle` (`GET /v3/prover/status` → `data.network.risc0.inflight_orders == 0`) instead of `data.clean`; still ANDed with backlog-drained (`proposalID ≤ lastFinalized + 1`), and still degrades to backlog-drained alone on a status error.
- **Per-target buffer flush on latch:** SGX flushes both ZK buffers (all ZK proving stops); SP1 flushes only the stranded risc0 (`ZKR0`) buffer and keeps completed `ZKSP1` proofs, which still aggregate.
- Renamed the now target-agnostic latch internals (`inFallback`/`markFallback`, gauge `prover_zk_backlog_sgx_mode` → `prover_zk_backlog_fallback_mode`).

## Compatibility

Default `prover.zkFallbackProofType=sgx` ⇒ identical to #21795: the new fallback branch is a no-op, and the flush set + routing are unchanged. The only always-on change is the resume signal (`clean` → risc0-idle).

## Testing

- `go test -race ./packages/taiko-client/prover/proof_producer/ ./packages/taiko-client/prover/proof_submitter/` ✅
- `go test ./packages/taiko-client/prover/ -run TestZKFallbackWiringTestSuite` ✅
- `golangci-lint run --config=.golangci.yml ./...` → 0 issues
- New/updated suite tests cover: `Risc0Idle` parsing/semantics, flag parse + validation, `buildZKFallbackProducer`, `resolveFallbackProducer` (latched vs per-call), the SP1 keeps-`ZKSP1` flush, resume gating (drained AND risc0-idle; status-error degrade), and the concurrent single-winner latch.

Refs raiko2 #93 (control-plane `/v3/prover/clear`, `/v3/prover/status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)