### PR TITLE
ci(repo): fix Rust CI cache reliability across the four Rust workflows

### DIFF
--- a/.github/workflows/ejector--test.yml
+++ b/.github/workflows/ejector--test.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -41,6 +41,8 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "ejector"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             packages/ejector
 
@@ -73,6 +75,8 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "ejector"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             packages/ejector
 
@@ -104,6 +108,8 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "ejector"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             packages/ejector
 

--- a/.github/workflows/ejector--test.yml
+++ b/.github/workflows/ejector--test.yml
@@ -42,7 +42,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "ejector"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Only the Test job saves this shared key; lint just consumes it.
+          save-if: "false"
           workspaces: |
             packages/ejector
 
@@ -109,7 +110,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "ejector"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Only the Test job saves this shared key; coverage just consumes it.
+          save-if: "false"
           workspaces: |
             packages/ejector
 

--- a/.github/workflows/preconfirmation-p2p.yml
+++ b/.github/workflows/preconfirmation-p2p.yml
@@ -59,7 +59,8 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: "preconfirmation-p2p"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Only the Tests job saves this shared key; lint just consumes it.
+          save-if: "false"
           workspaces: |
             packages/preconfirmation-p2p
 

--- a/.github/workflows/preconfirmation-p2p.yml
+++ b/.github/workflows/preconfirmation-p2p.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   lint:
@@ -58,7 +58,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "preconfirmation-p2p"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            packages/preconfirmation-p2p
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -88,13 +91,8 @@ jobs:
     if: ${{ github.event.pull_request.draft == false && !startsWith(github.head_ref, 'release-please') }}
     name: Tests
     runs-on: [arc-runner-set]
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.13.1
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v6
 
       - name: Ensure native build tools
@@ -147,7 +145,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "preconfirmation-p2p"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            packages/preconfirmation-p2p
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: taiko-client-rs-test-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   lockfile:
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') && !startsWith(github.head_ref, 'dependabot') }}
     name: Lint
     runs-on: [arc-runner-set]
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -81,7 +81,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "taiko-client-rs"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             packages/taiko-client-rs -> target
 
@@ -107,16 +108,11 @@ jobs:
     if: ${{ github.event.pull_request.draft == false  && !startsWith(github.head_ref, 'release-please') }}
     name: Tests
     runs-on: [arc-runner-set]
-    timeout-minutes: 30
+    timeout-minutes: 50
     env:
       PROTOCOL_FORK_DIR: protocol-taiko-mono
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.13.1
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v6
 
       - name: Ensure native build tools
@@ -209,7 +205,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "taiko-client-rs"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             packages/taiko-client-rs -> target
 

--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -82,7 +82,10 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: "taiko-client-rs"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Only the Tests job saves this shared key; lint just consumes it.
+          # (immutable cache keys mean the first saver wins, and lint compiles
+          # less than nextest — see clippy's --exclude test-harness)
+          save-if: "false"
           workspaces: |
             packages/taiko-client-rs -> target
 

--- a/.github/workflows/urcindexer-rs--ci.yml
+++ b/.github/workflows/urcindexer-rs--ci.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   RUST_TOOLCHAIN: stable
@@ -39,7 +39,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: ${{ runner.os }}-urcindexer-rs-${{ hashFiles('packages/urcindexer-rs/Cargo.lock') }}
+          shared-key: "urcindexer-rs"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            packages/urcindexer-rs
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -59,22 +62,20 @@ jobs:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.draft == false && !startsWith(github.head_ref, 'release-please')) }}
     name: Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: lint
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.13.1
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v6
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: ${{ runner.os }}-urcindexer-rs-${{ hashFiles('packages/urcindexer-rs/Cargo.lock') }}
+          shared-key: "urcindexer-rs"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            packages/urcindexer-rs
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/urcindexer-rs--ci.yml
+++ b/.github/workflows/urcindexer-rs--ci.yml
@@ -40,7 +40,8 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: "urcindexer-rs"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Only the Tests job saves this shared key; lint just consumes it.
+          save-if: "false"
           workspaces: |
             packages/urcindexer-rs
 


### PR DESCRIPTION
## What

Stops the intermittent `cancelled` runs on the Rust CI workflows — most visibly the `taiko-client-rs` **Tests** job that needs 1–2 retries to go green.

## Root cause

The job doesn't fail on tests (all 383 pass in ~2 min). It gets **`cancelled`**: a cold `Swatinem/rust-cache` forces a ~30+ min build that the 30‑minute job timeout kills mid cache‑save, so the cache is never re‑warmed. Run durations are starkly bimodal — **warm cache ≈ 7–8 min ✅, cold cache 28–40 min ❌** (the cluster at exactly 35 min is the 30 min timeout + GitHub's ~5 min cancellation grace).

Caches keep going cold because:
1. The lockfile‑pinned key (`hashFiles('**/Cargo.lock')`) defeats `rust-cache`'s built‑in incremental restore, so every lockfile change is a full cold rebuild (and the `**` glob means *any* Rust package's lockfile invalidates it).
2. Repo cache sits at ~8.3 GB / 10 GB; the 2.3–2.8 GB Rust caches written by PRs evict `main`'s cache (LRU), so the next push to `main` starts cold.
3. A cold `main` run that exceeds the timeout is cancelled mid‑save → never writes a fresh cache → stays cold until a retry squeaks through.

## Changes (all four Rust workflows)

- **Cache key:** drop the lockfile‑pinned `key` → distinct per‑workflow `shared-key`. Restores incremental restore and fixes a key collision between `taiko-client-rs` and `preconfirmation-p2p` (they shared an identical key and overwrote each other's cache).
- **`save-if: github.ref == 'refs/heads/main'`** — only `main` writes the cache, so PR caches stop evicting it (frees ~half the budget).
- **Concurrency:** `cancel-in-progress: github.ref != 'refs/heads/main'` + removed the redundant `styfle/cancel-workflow-action` steps, so `main` runs always finish and re‑warm the cache.
- **Timeouts** (safety net for the now‑rare cold build): taiko-client-rs Tests 30→50 / Lint 15→25; preconfirmation-p2p Tests 15→30; urcindexer-rs Tests 15→25.
- Added missing `workspaces:` for preconfirmation-p2p and urcindexer-rs (no root Cargo workspace, so the cache was targeting the wrong dir).

## Verification

`actionlint` is clean (only the pre‑existing `arc-runner-set` self‑hosted‑label warnings remain). Behavioral confirmation can only happen on `main` after merge:

- [ ] First `main` run is cold‑by‑design (new shared‑key namespace) but now **finishes and saves** the cache (no `cancelled`); ≤ ~45 min.
- [ ] The next `main` run is warm (~7–8 min for taiko-client-rs).
- [ ] A lockfile‑bump PR builds incrementally (~12–20 min), not a 35‑min cold‑then‑cancelled run.
- [ ] `gh api repos/taikoxyz/taiko-mono/actions/cache/usage` trends down as PR caches stop being written.

## Out of scope

Self‑hosted compilation cache (sccache / persistent ARC volume) to remove the 10 GB GitHub cap entirely — possible future follow‑up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)