### PR TITLE
ci(protocol): add forge fmt --check gate for fork PRs

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -74,6 +74,17 @@ jobs:
           # Configure merge strategy for auto-generated files
           git config merge.ours.driver true
 
+      - name: Check Solidity formatting
+        # Fork PRs cannot be auto-formatted and auto-committed (no write token),
+        # so verify formatting and fail the run instead. Non-fork PRs are repaired
+        # by the "Clean up and fmt" + auto-commit steps below.
+        # The command is inlined (rather than calling `pnpm fmt:check`) so it works
+        # on fork branches cut before this script was added. Auto-generated
+        # *_Layout.sol files are excluded: gen-layouts.sh emits trailing whitespace.
+        if: github.event.pull_request.head.repo.fork == true
+        working-directory: ./packages/protocol
+        run: forge fmt --check $(find contracts test script -name '*.sol' ! -name '*_Layout.sol')
+
       - name: Clean up and fmt
         if: github.event.pull_request.head.repo.fork == false
         working-directory: ./packages/protocol

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -22,6 +22,7 @@
     "test:deploy:l1": "./script/layer1/core/deploy_protocol_on_l1.sh",
     "eslint": "pnpm exec eslint --fix --ignore-path .eslintignore --ext .js,.ts .",
     "fmt:sol": "forge fmt && pnpm solhint 'contracts/**/*.sol'",
+    "fmt:check": "forge fmt --check $(find contracts test script -name '*.sol' ! -name '*_Layout.sol')",
     "test:coverage": "mkdir -p coverage && forge coverage --report lcov && lcov --ignore-errors inconsistent --ignore-errors unused --remove ./lcov.info -o ./coverage/lcov.info 'test/' 'script/' 'contracts/thirdparty/' && genhtml coverage/lcov.info --branch-coverage --output-dir coverage --ignore-errors category --ignore-errors inconsistent --ignore-errors corrupt && open coverage/index.html",
     "proposal": "FOUNDRY_PROFILE=layer1 MODE=print forge script script/layer1/proposals/Proposal$P.s.sol:Proposal$P",
     "proposal:dryrun:l1": "FOUNDRY_PROFILE=layer1 MODE=l1dryrun forge script --chain-id=1 --broadcast --rpc-url https://ethereum.publicnode.com script/layer1/proposals/Proposal$P.s.sol:Proposal$P",


### PR DESCRIPTION
## Summary

Adds a `forge fmt --check` formatting gate to the protocol CI so mis-formatted Solidity from fork PRs fails the run instead of slipping through.

Today the `Clean up and fmt` step (`.github/workflows/protocol.yml`) runs `pnpm fmt:sol`, which auto-formats in place and is gated to non-fork PRs. Non-fork PRs additionally auto-commit the result via `git-auto-commit-action`, so their drift is repaired automatically. Fork PRs, however, run neither step (no write token to the fork), so formatting drift from forks was never verified.

This PR adds a `Check Solidity formatting` step gated to fork PRs (`github.event.pull_request.head.repo.fork == true`) that runs `forge fmt --check` and fails on drift. The non-fork auto-format + auto-commit repair path is left untouched.

Changes:
- `.github/workflows/protocol.yml`: new fork-only `Check Solidity formatting` step.
- `packages/protocol/package.json`: new `fmt:check` script for local verification (`pnpm fmt:check`).

Two implementation details worth noting:
- The auto-generated `*_Layout.sol` files (produced by `script/gen-layouts.sh`) carry trailing whitespace by design, so the check excludes them: `forge fmt --check $(find contracts test script -name '*.sol' ! -name '*_Layout.sol')`. Every other Solidity file is already `forge fmt`-clean at this base, so the new gate is green on `main`.
- The workflow inlines the command rather than calling `pnpm fmt:check`, because the protocol job checks out the fork's head commit; a fork branch cut before this change would not yet have the `fmt:check` script and would otherwise fail with "missing script".

## Why this matters

Per the discussion in #20906, there is currently no `forge fmt --check` gate in CI, so formatting only stays consistent when a contributor remembers to run the formatter locally. Fork PRs in particular have no safety net. This closes that gap with a minimal, fork-scoped check.

I also evaluated re-enabling `wrap_comments = true` in `foundry.toml` (the inline note there cites a foundry formatter bug). On the pinned foundry `v1.4.2`, `forge fmt` with `wrap_comments = true` is idempotent across runs, but it still mis-wraps multi-line NatSpec: it merges adjacent `@param` lines onto a wrapped continuation (e.g. in `IInbox.sol` two `@param` lines collapse into one), corrupting the documentation. Because the bug still reproduces, `wrap_comments` is left disabled and only the `--check` gate is shipped here.

## Testing

- `forge fmt --check $(find contracts test script -name '*.sol' ! -name '*_Layout.sol')` exits 0 on the current source tree (gate is green on `main`).
- Introducing deliberately mis-formatted Solidity makes the same command exit non-zero.
- Confirmed the generated `*_Layout.sol` files are excluded (they would otherwise fail on their by-design trailing whitespace).
- `.github/workflows/protocol.yml` validated as well-formed YAML.

Closes #20906
