### PR TITLE
fix(protocol): harden automata-attestation PCK certificate parsing

### DIFF
--- a/packages/protocol/contracts/layer1/automata-attestation/lib/PEMCertChainLib.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/lib/PEMCertChainLib.sol
@@ -260,11 +260,23 @@ contract PEMCertChainLib is IPEMCertChainLib {
     {
         uint256 n = input.length;
 
-        if (n <= expectedLength) {
+        if (n == expectedLength) {
             return input;
+        } else if (n > expectedLength) {
+            // Drop the extra leading bytes, e.g. the sign byte of a DER integer
+            // or the 0x04 prefix of an uncompressed public key.
+            uint256 lengthDiff = n - expectedLength;
+            output = input.substring(lengthDiff, expectedLength);
+        } else {
+            // Left-pad with zeros. DER integers are minimally encoded, so an
+            // ECDSA r/s component < 2 ** (8 * expectedLength) loses its leading
+            // zero bytes and must be padded back to the fixed width.
+            output = new bytes(expectedLength);
+            uint256 offset = expectedLength - n;
+            for (uint256 i; i < n; ++i) {
+                output[offset + i] = input[i];
+            }
         }
-        uint256 lengthDiff = n - expectedLength;
-        output = input.substring(lengthDiff, expectedLength);
     }
 
     function _findPckTcbInfo(

--- a/packages/protocol/contracts/layer1/automata-attestation/lib/PEMCertChainLib.sol
+++ b/packages/protocol/contracts/layer1/automata-attestation/lib/PEMCertChainLib.sol
@@ -352,6 +352,11 @@ contract PEMCertChainLib is IPEMCertChainLib {
         // get the first svn object in the sequence
         uint256 svnParentPtr = der.firstChildOf(tcbPtr);
         cpusvns = new uint256[](SGX_TCB_CPUSVN_SIZE);
+        // Track how many cpusvns have been written so far. The cpusvns must be
+        // indexed independently of the loop counter: the loop also visits the
+        // PCESVN entry, and not relying on it being in a fixed position avoids
+        // an out-of-bounds write when the entries are ordered unexpectedly.
+        uint256 cpusvnsFound;
         for (uint256 i; i < SGX_TCB_CPUSVN_SIZE + 1; ++i) {
             uint256 svnPtr = der.firstChildOf(svnParentPtr); // OID
             uint256 svnValuePtr = der.nextSiblingOf(svnPtr); // value
@@ -362,10 +367,9 @@ contract PEMCertChainLib is IPEMCertChainLib {
             if (BytesUtils.compareBytes(der.bytesAt(svnPtr), PCESVN_OID)) {
                 // pcesvn is 4 bytes in size
                 pcesvn = uint256(svnValue);
-            } else {
+            } else if (cpusvnsFound < SGX_TCB_CPUSVN_SIZE) {
                 // each cpusvn is at maximum two bytes in size
-                uint256 cpusvn = uint256(svnValue);
-                cpusvns[i] = cpusvn;
+                cpusvns[cpusvnsFound++] = uint256(svnValue);
             }
 
             // iterate to the next svn object in the sequence

--- a/packages/protocol/test/layer1/automata-attestation/PEMCertChainLibTest.t.sol
+++ b/packages/protocol/test/layer1/automata-attestation/PEMCertChainLibTest.t.sol
@@ -27,6 +27,13 @@ contract TestPEMCertChainLib is Test {
     uint256 internal constant SUBSEQ_LEN = 18;
     uint256 internal constant NOT_BEFORE_TAG_OFF = 164;
 
+    // A minimal, structurally valid (non-PCK) X509 certificate whose ECDSA
+    // signature has a 30-byte `r` component. DER encodes integers minimally, so
+    // an r/s value < 2**248 (leading zero bytes) is shorter than 32 bytes. Such
+    // a certificate is produced by ~0.4% of keys at random.
+    bytes internal constant SHORT_SIG_CERT =
+        hex"3081e030818aa00302010202020123300a06082a8648ce3d0403023000301e170d3233303832383131313330355a170d3330303832383131313330355a3000304f300906072a8648ce3d02010342000411111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111300a06082a8648ce3d0403020345003042021e7f111111111111111111111111111111111111111111111111111111111102207f22222222222222222222222222222222222222222222222222222222222222";
+
     function setUp() public {
         lib = new PEMCertChainLib();
     }
@@ -76,5 +83,24 @@ contract TestPEMCertChainLib is Test {
 
         (bool ok,) = lib.decodeCert(der, true);
         assertFalse(ok, "invalid notBefore date tag must be rejected");
+    }
+
+    /// @dev Regression test for ECDSA signature extraction (`_trimBytes`).
+    ///
+    /// The signature stored on the parsed certificate must always be 64 bytes
+    /// (a 32-byte `r` concatenated with a 32-byte `s`) so that the ES256
+    /// verifier accepts it. DER integers are minimally encoded, so a component
+    /// shorter than 32 bytes must be left-padded with zeros. Returning the raw,
+    /// shorter bytes yields a <64-byte signature that the verifier rejects,
+    /// failing certificate-chain verification for otherwise valid certificates.
+    function test_decodeCert_padsShortSignatureComponentTo64Bytes() public view {
+        (bool ok, IPEMCertChainLib.ECSha256Certificate memory cert) =
+            lib.decodeCert(SHORT_SIG_CERT, false);
+        assertTrue(ok, "minimal cert must decode");
+        assertEq(cert.signature.length, 64, "signature must be 64 bytes");
+        // The 30-byte r is left-padded with two zero bytes.
+        assertEq(uint8(cert.signature[0]), 0, "r pad byte 0");
+        assertEq(uint8(cert.signature[1]), 0, "r pad byte 1");
+        assertEq(uint8(cert.signature[2]), 0x7f, "r first significant byte");
     }
 }

--- a/packages/protocol/test/layer1/automata-attestation/PEMCertChainLibTest.t.sol
+++ b/packages/protocol/test/layer1/automata-attestation/PEMCertChainLibTest.t.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/src/Test.sol";
+import "src/layer1/automata-attestation/lib/PEMCertChainLib.sol";
+import "src/layer1/automata-attestation/lib/interfaces/IPEMCertChainLib.sol";
+
+/// @title TestPEMCertChainLib
+/// @notice Unit tests for PEMCertChainLib.decodeCert covering the SGX PCK
+/// certificate extension parsing (`_findTcb`) and the X509 validity date-tag check.
+/// @custom:security-contact security@taiko.xyz
+contract TestPEMCertChainLib is Test {
+    PEMCertChainLib internal lib;
+
+    // A real Intel SGX PCK certificate (DER), extracted from the sample DCAP v3
+    // quote used by the existing attestation tests.
+    //
+    // Relevant offsets inside this DER (verified against the ASN.1 structure):
+    //  - [164]      notBefore UTCTime tag (0x17)
+    //  - [685..703] first SGX TCB component sub-sequence (OID ...1.2.1), 18 bytes
+    //  - [975..993] PCESVN sub-sequence (OID ...1.2.17),                 18 bytes
+    bytes internal constant PCK_DER =
+        hex"308204f330820499a003020102021500bcfe8d88f1717f9f26898051b089aa089f22897a300a06082a8648ce3d04030230703122302006035504030c19496e74656c205347582050434b20506c6174666f726d204341311a3018060355040a0c11496e74656c20436f72706f726174696f6e3114301206035504070c0b53616e746120436c617261310b300906035504080c024341310b3009060355040613025553301e170d3233303832383131313330355a170d3330303832383131313330355a30703122302006035504030c19496e74656c205347582050434b204365727469666963617465311a3018060355040a0c11496e74656c20436f72706f726174696f6e3114301206035504070c0b53616e746120436c617261310b300906035504080c024341310b30090603550406130255533059301306072a8648ce3d020106082a8648ce3d0301070342000432b004ab4baae47a3d781dfd494a9b8f3b5343515cb35c10afa75878d85d74514d001545a0d58e3ca1e060eedbcde57d884c6101e731c18f38eff64b96c948d4a382030e3082030a301f0603551d23041830168014956f5dcdbd1be1e94049c9d4f433ce01570bde54306b0603551d1f046430623060a05ea05c865a68747470733a2f2f6170692e7472757374656473657276696365732e696e74656c2e636f6d2f7367782f63657274696669636174696f6e2f76342f70636b63726c3f63613d706c6174666f726d26656e636f64696e673d646572301d0603551d0e041604145357a665cf5bc991849f9098fc3627f3aa06b058300e0603551d0f0101ff0404030206c0300c0603551d130101ff040230003082023b06092a864886f84d010d010482022c30820228301e060a2a864886f84d010d01010410fe46ae011cce8a4d6e8334b08d1bb40130820165060a2a864886f84d010d0102308201553010060b2a864886f84d010d01020102010b3010060b2a864886f84d010d01020202010b3010060b2a864886f84d010d0102030201033010060b2a864886f84d010d0102040201033011060b2a864886f84d010d010205020200ff3011060b2a864886f84d010d010206020200ff3010060b2a864886f84d010d0102070201003010060b2a864886f84d010d0102080201003010060b2a864886f84d010d0102090201003010060b2a864886f84d010d01020a0201003010060b2a864886f84d010d01020b0201003010060b2a864886f84d010d01020c0201003010060b2a864886f84d010d01020d0201003010060b2a864886f84d010d01020e0201003010060b2a864886f84d010d01020f0201003010060b2a864886f84d010d0102100201003010060b2a864886f84d010d01021102010d301f060b2a864886f84d010d01021204100b0b0303ffff000000000000000000003010060a2a864886f84d010d0103040200003014060a2a864886f84d010d0104040600606a000000300f060a2a864886f84d010d01050a0101301e060a2a864886f84d010d010604104589ccebf2644f0ade48ff1e15c46bfb3044060a2a864886f84d010d010730363010060b2a864886f84d010d0107010101ff3010060b2a864886f84d010d0107020101ff3010060b2a864886f84d010d0107030101ff300a06082a8648ce3d040302034800304502201ab7bf1d8335a99004599474c7be98f6040aef385e0a050a0230489578709693022100e37a7bb6bc01f34b3eda2c1a8660dd02708cc0954f2e2484bb00d017c544812c";
+
+    uint256 internal constant COMP01_OFF = 685;
+    uint256 internal constant PCESVN_OFF = 975;
+    uint256 internal constant SUBSEQ_LEN = 18;
+    uint256 internal constant NOT_BEFORE_TAG_OFF = 164;
+
+    function setUp() public {
+        lib = new PEMCertChainLib();
+    }
+
+    /// @dev Sanity check: the unmodified PCK certificate decodes successfully and
+    /// the 16 TCB component SVNs plus PCESVN are parsed as expected.
+    function test_decodeCert_parsesRealPckCertificate() public view {
+        (bool ok, IPEMCertChainLib.ECSha256Certificate memory cert) = lib.decodeCert(PCK_DER, true);
+        assertTrue(ok, "real PCK cert must decode");
+        assertEq(cert.pck.sgxExtension.sgxTcbCompSvnArr.length, 16, "16 cpusvns");
+        assertEq(cert.pck.sgxExtension.sgxTcbCompSvnArr[0], 11, "first comp svn");
+        assertEq(cert.pck.sgxExtension.pcesvn, 13, "pcesvn");
+    }
+
+    /// @dev Regression test for the SGX-extension TCB parser (`_findTcb`).
+    ///
+    /// `_findTcb` iterates over the 17 leading entries of the TCB sequence (16
+    /// component SVNs followed by PCESVN). A structurally valid PCK certificate
+    /// whose PCESVN entry is not in the final position causes a component SVN to
+    /// be written past the end of the fixed length-16 `cpusvns` array, panicking
+    /// with an out-of-bounds access instead of failing gracefully like every
+    /// other malformed-input path in `decodeCert`.
+    ///
+    /// We reproduce this by swapping the (equal length) PCESVN sub-sequence with
+    /// the first component SVN sub-sequence; all DER length prefixes stay valid.
+    function test_decodeCert_reorderedTcbExtension_doesNotPanic() public view {
+        bytes memory der = PCK_DER;
+        // Swap the two 18-byte sub-sequences in place.
+        for (uint256 k; k < SUBSEQ_LEN; ++k) {
+            (der[COMP01_OFF + k], der[PCESVN_OFF + k]) = (der[PCESVN_OFF + k], der[COMP01_OFF + k]);
+        }
+
+        // Must return gracefully (no array out-of-bounds panic).
+        (bool ok,) = lib.decodeCert(der, true);
+        assertTrue(ok, "reordered TCB extension must not panic");
+    }
+
+    /// @dev Regression test for the X509 validity date-tag check.
+    ///
+    /// The validity tags must be either UTCTime (0x17) or GeneralizedTime (0x18).
+    /// An earlier version of this check accepted certain invalid notBefore tags;
+    /// a certificate whose notBefore tag is neither 0x17 nor 0x18 must be rejected.
+    function test_decodeCert_rejectsInvalidNotBeforeDateTag() public view {
+        bytes memory der = PCK_DER;
+        // 0x16 (IA5String) is not a valid X509 time tag.
+        der[NOT_BEFORE_TAG_OFF] = 0x16;
+
+        (bool ok,) = lib.decodeCert(der, true);
+        assertFalse(ok, "invalid notBefore date tag must be rejected");
+    }
+}


### PR DESCRIPTION
## Summary

Compared `contracts/layer1/automata-attestation` against its upstream source
([`automata-network/automata-dcap-v3-attestation`](https://github.com/automata-network/automata-dcap-v3-attestation),
now archived) and its successor parser
([`automata-network/automata-on-chain-pccs`](https://github.com/automata-network/automata-on-chain-pccs)),
and fixed two real bugs in `PEMCertChainLib`. Both bugs sit in on-chain X.509/PCK
certificate parsing and exist identically in upstream — they are latent rather
than introduced by Taiko's fork.

Tests are committed first (failing), then each fix makes them green.

## Findings

**Bugs fixed in upstream PRs — already applied locally.** The one clear logic
bug in the forked code (upstream PR&nbsp;#6 / `parse-quote-offline`) was the X.509
validity date-tag check: `notBeforeTag != 0x17 && notBeforeTag == 0x18` instead
of `!= 0x18`, which accepted certain invalid `notBefore` tags. This is **already
fixed** in Taiko's copy. Added `test_decodeCert_rejectsInvalidNotBeforeDateTag`
as a regression guard.

**Bugs introduced locally:** none. Aside from the upgradeable/`EssentialContract`
refactor and a deliberate `_attestationTcbIsValid` policy widening (accepting
`TCB_OUT_OF_DATE*`, a `virtual` override point), Taiko's port is faithful to
upstream.

**Latent bugs fixed here (present in both Taiko and upstream):**

### 1. `_findTcb` out-of-bounds write
The SGX TCB extension parser writes each component SVN into a fixed length-16
`cpusvns` array using the loop counter as the index, while the loop also visits
the PCESVN entry. A structurally valid PCK certificate whose PCESVN entry is not
in the final position writes to `cpusvns[16]`, panicking with an out-of-bounds
access (0x32) and reverting `decodeCert` instead of failing gracefully like every
other malformed-input path. Fixed with a dedicated, bounds-checked counter.
Behaviour for well-formed Intel certificates (PCESVN last) is unchanged.

### 2. `_trimBytes` drops leading zeros from signature components
DER encodes integers minimally, so an ECDSA `r`/`s` value `< 2**248` loses its
leading zero byte(s) and is shorter than 32 bytes. `_trimBytes` returned such
inputs unchanged, producing a `< 64`-byte signature that the ES256 verifier
rejects (it requires exactly 64 bytes), so certificate-chain verification fails
for ~0.4% of otherwise valid certificates. Fixed by left-padding short inputs to
the fixed width; oversized-input trimming (DER sign byte, `0x04` key prefix) is
unchanged.

## Tests

New `test/layer1/automata-attestation/PEMCertChainLibTest.t.sol`:
- `test_decodeCert_parsesRealPckCertificate` — happy-path decode of a real Intel PCK cert.
- `test_decodeCert_reorderedTcbExtension_doesNotPanic` — reveals/guards bug #1.
- `test_decodeCert_padsShortSignatureComponentTo64Bytes` — reveals/guards bug #2.
- `test_decodeCert_rejectsInvalidNotBeforeDateTag` — guards the date-tag fix.

All 17 automata-attestation tests and 35 verifier tests pass; existing tests are
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiWBfQmrWGYp6K4fqES3Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiWBfQmrWGYp6K4fqES3Hd)_