### PR TITLE
fix(protocol): make signal checkpoints immutable

### DIFF
--- a/packages/protocol/contracts/shared/signal/SignalService.sol
+++ b/packages/protocol/contracts/shared/signal/SignalService.sol
@@ -154,6 +154,9 @@ contract SignalService is EssentialContract, ISignalService {
         if (msg.sender != _authorizedSyncer) revert SS_UNAUTHORIZED();
         if (_checkpoint.stateRoot == bytes32(0)) revert SS_INVALID_CHECKPOINT();
         if (_checkpoint.blockHash == bytes32(0)) revert SS_INVALID_CHECKPOINT();
+        if (_checkpoints[_checkpoint.blockNumber].blockHash != bytes32(0)) {
+            revert SS_CHECKPOINT_ALREADY_EXISTS();
+        }
 
         _checkpoints[_checkpoint.blockNumber] = CheckpointRecord({
             blockHash: _checkpoint.blockHash, stateRoot: _checkpoint.stateRoot
@@ -277,6 +280,7 @@ contract SignalService is EssentialContract, ISignalService {
     // ---------------------------------------------------------------
 
     error SS_CHECKPOINT_NOT_FOUND();
+    error SS_CHECKPOINT_ALREADY_EXISTS();
     error SS_EMPTY_PROOF();
     error SS_INVALID_BLOCK_ID();
     error SS_INVALID_CHECKPOINT();

--- a/packages/protocol/test/shared/signal/SignalService.t.sol
+++ b/packages/protocol/test/shared/signal/SignalService.t.sol
@@ -67,6 +67,22 @@ contract TestSignalService is CommonTest {
         assertEq(stored.stateRoot, checkpoint.stateRoot);
     }
 
+    function test_saveCheckpoint_RevertWhen_CheckpointAlreadyExists() public {
+        ICheckpointStore.Checkpoint memory checkpoint = ICheckpointStore.Checkpoint({
+            blockNumber: 1, blockHash: bytes32(uint256(1)), stateRoot: bytes32(uint256(2))
+        });
+
+        vm.startPrank(AUTHORIZED_SYNCER);
+        signalService.saveCheckpoint(checkpoint);
+
+        vm.expectRevert(SignalService.SS_CHECKPOINT_ALREADY_EXISTS.selector);
+        signalService.saveCheckpoint(
+            ICheckpointStore.Checkpoint({
+                blockNumber: 1, blockHash: bytes32(uint256(3)), stateRoot: bytes32(uint256(4))
+            })
+        );
+    }
+
     function test_saveCheckpoint_RevertWhen_CheckpointFieldInvalid() public {
         ICheckpointStore.Checkpoint memory badStateRoot = ICheckpointStore.Checkpoint({
             blockNumber: 1, blockHash: bytes32(uint256(1)), stateRoot: bytes32(0)


### PR DESCRIPTION
## Summary

Make SignalService checkpoints immutable per block number: once an authorized syncer saves a checkpoint for a block, a later call cannot overwrite it with a different root/hash.

## Why

`saveCheckpoint` currently accepts a later write to the same `blockNumber`, replacing the stored checkpoint. Since successful signal proofs can be cached and later reused with an empty proof, allowing checkpoint replacement increases incident blast radius: a temporary or accidental bad root can be used for proofs and then overwritten, while cached signal state remains.

Immutability keeps checkpoint history auditable and prevents silent replacement for the same block number.

## Changes

- Add `SS_CHECKPOINT_ALREADY_EXISTS`.
- Reject `saveCheckpoint` when a checkpoint already exists for the block number.
- Add a unit test for duplicate checkpoint writes.

## Test plan

- Static check: `git diff --check` passed.
- Not run locally: this environment does not have Foundry/`forge` installed.
- Intended command: `cd packages/protocol && FOUNDRY_PROFILE=shared forge test --match-contract TestSignalService`.
