### PR TITLE
fix(protocol): reject DEBUG-mode SGX enclaves in SgxVerifier

### DIFF
--- a/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
@@ -31,6 +31,10 @@ contract SgxVerifier is IProofVerifier, Ownable2Step {
     /// verification
     uint64 public constant INSTANCE_VALIDITY_DELAY = 0;
 
+    /// @dev DEBUG bit (bit 1) of the little-endian SGX ATTRIBUTES flags. The flags occupy the low
+    /// 8 bytes of the 16-byte `attributes` field, so the DEBUG bit lives in its first byte.
+    uint8 private constant SGX_FLAGS_DEBUG = 0x02;
+
     uint64 public immutable taikoChainId;
     address public immutable automataDcapAttestation;
 
@@ -68,6 +72,7 @@ contract SgxVerifier is IProofVerifier, Ownable2Step {
     event InstanceDeleted(uint256 indexed id, address indexed instance);
 
     error SGX_ALREADY_ATTESTED();
+    error SGX_DEBUG_ENCLAVE();
     error SGX_INVALID_ATTESTATION();
     error SGX_INVALID_INSTANCE();
     error SGX_INVALID_PROOF();
@@ -116,6 +121,18 @@ contract SgxVerifier is IProofVerifier, Ownable2Step {
     {
         (bool verified,) = IAttestation(automataDcapAttestation).verifyParsedQuote(_attestation);
         require(verified, SGX_INVALID_ATTESTATION());
+
+        // Reject DEBUG-mode enclaves: a debug enclave's memory (including the in-enclave signing
+        // key recorded in reportData) is readable and writable by the host, so its quotes must
+        // never be trusted on-chain. DEBUG is bit 1 of the SGX ATTRIBUTES flags; the flags are
+        // little-endian, so the bit lives in the low byte of the 16-byte `attributes` field. The
+        // attributes are authenticated by verifyParsedQuote (covered by the attestation-key
+        // signature over the serialized enclave report), so a forged/cleared value would fail
+        // verification above — making this check on the parsed field sound.
+        require(
+            (uint8(_attestation.localEnclaveReport.attributes[0]) & SGX_FLAGS_DEBUG) == 0,
+            SGX_DEBUG_ENCLAVE()
+        );
 
         address[] memory addresses = new address[](1);
         addresses[0] = address(bytes20(_attestation.localEnclaveReport.reportData));

--- a/packages/protocol/test/layer1/verifiers/SgxVerifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/SgxVerifier.t.sol
@@ -116,6 +116,28 @@ contract SgxVerifierTest is Test {
         verifier.registerInstance(_makeQuote(newInstance));
     }
 
+    function test_registerInstance_RevertWhen_DebugEnclave() external {
+        attestation.setResult(true);
+        V3Struct.ParsedV3QuoteStruct memory quote = _makeQuote(address(0xC0FFEE));
+        // Set the SGX DEBUG attribute bit (bit 1 of the little-endian flags = low byte of the
+        // 16-byte attributes field), as a genuine debug enclave's quote would carry.
+        quote.localEnclaveReport.attributes = bytes16(0x02000000000000000000000000000000);
+
+        vm.expectRevert(SgxVerifier.SGX_DEBUG_ENCLAVE.selector);
+        verifier.registerInstance(quote);
+    }
+
+    function test_registerInstance_AcceptsNonDebugEnclave() external {
+        attestation.setResult(true);
+        V3Struct.ParsedV3QuoteStruct memory quote = _makeQuote(address(0xC0FFEE));
+        // INIT bit set (0x01) but not DEBUG (0x02) -> must be accepted.
+        quote.localEnclaveReport.attributes = bytes16(0x01000000000000000000000000000000);
+
+        verifier.registerInstance(quote);
+        (address stored,) = verifier.instances(0);
+        assertEq(stored, address(0xC0FFEE));
+    }
+
     // ---------------------------------------------------------------
     // Proof verification
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replacing https://github.com/taikoxyz/taiko-mono/pull/21817


Closes the SGX **DEBUG-attribute gap** on the v3.0.0 release line: `SgxVerifier.registerInstance` now rejects any DCAP quote whose enclave report has the SGX **DEBUG** attribute bit set (revert `SGX_DEBUG_ENCLAVE`).

> A debug enclave's memory — including the in-enclave signing key recorded in `reportData` — is host-readable/writable, so its quotes must never be trusted on-chain. Previously the on-chain attestation accepted DEBUG-enabled enclaves as long as they carried a matching MRENCLAVE/MRSIGNER.

## The fix

In `registerInstance(V3Struct.ParsedV3QuoteStruct)`, after `verifyParsedQuote` succeeds:

```solidity
require(
    (uint8(_attestation.localEnclaveReport.attributes[0]) & SGX_FLAGS_DEBUG) == 0,
    SGX_DEBUG_ENCLAVE()
);
```

DEBUG is bit 1 of the little-endian SGX `ATTRIBUTES` flags (the low byte of the 16-byte `attributes` field).

## Why this is sound

The `attributes` field is **authenticated**. `verifyParsedQuote` → `_verifyParsedQuote` → `_enclaveReportSigVerification` rebuilds `signedQuoteData` from the supplied `localEnclaveReport` (the packing includes `attributes`) and checks it against the attestation-key ECDSA signature. A quote with forged/cleared attributes therefore fails verification *before* this check runs, so reading the parsed `attributes` here reflects the genuine, signed enclave report.

## Scope

Minimal, targeted security fix for the **v3.0.0 release branch** — no dependency changes, no behavioral change beyond rejecting DEBUG enclaves. The broader migration of SGX attestation onto the upstream Automata DCAP npm packages (Taiko-owned entrypoint, raw-quote flow, verified-body binding, etc.) is tracked separately against `main` in #21817.

## Tests

Adds `test_registerInstance_RevertWhen_DebugEnclave` and `test_registerInstance_AcceptsNonDebugEnclave`. The full `SgxVerifier.t.sol` suite passes (12/12) under `FOUNDRY_PROFILE=layer1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuqAQwotd9UN2RXxpGdgzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuqAQwotd9UN2RXxpGdgzp)_