### PR TITLE
docs(protocol): document pauser constructor param and cover paused Bridge

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/MainnetBridge.sol
+++ b/packages/protocol/contracts/layer1/mainnet/MainnetBridge.sol
@@ -26,6 +26,11 @@ contract MainnetBridge is Bridge {
     bytes32 private constant _CTX_SLOT =
         0xe4ece82196de19aabe639620d7f716c433d1348f96ce727c9989a982dbadc2b9;
 
+    /// @notice Initializes the mainnet bridge's immutable state.
+    /// @param _resolver The address of the resolver contract.
+    /// @param _signalService The address of the signal service contract.
+    /// @param _pauser Address authorized to pause/unpause alongside the owner. Optional (may be
+    /// zero).
     constructor(
         address _resolver,
         address _signalService,

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -102,6 +102,11 @@ contract Bridge is EssentialResolverContract, IBridge, IEthMinter {
         _;
     }
 
+    /// @notice Initializes the bridge's immutable state.
+    /// @param _resolver The address of the resolver contract.
+    /// @param _signalService The address of the signal service contract.
+    /// @param _pauser Address authorized to pause/unpause alongside the owner. Optional (may be
+    /// zero).
     constructor(
         address _resolver,
         address _signalService,

--- a/packages/protocol/contracts/shared/signal/SignalService.sol
+++ b/packages/protocol/contracts/shared/signal/SignalService.sol
@@ -66,6 +66,11 @@ contract SignalService is EssentialContract, ISignalService {
     // Constructor and Initialization
     // ---------------------------------------------------------------
 
+    /// @notice Initializes the signal service's immutable state.
+    /// @param authorizedSyncer Address that can save checkpoints to this contract.
+    /// @param remoteSignalService Address of the remote signal service.
+    /// @param _pauser Address authorized to pause/unpause alongside the owner. Optional (may be
+    /// zero).
     constructor(address authorizedSyncer, address remoteSignalService, address _pauser) {
         require(authorizedSyncer != address(0), ZERO_ADDRESS());
         require(remoteSignalService != address(0), ZERO_ADDRESS());

--- a/packages/protocol/test/shared/bridge/Bridge2_pauser.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_pauser.t.sol
@@ -53,6 +53,33 @@ contract TestBridgePauser is CommonTest {
         bridge.pause();
     }
 
+    function test_bridge_pause_blocksMessageProcessing() public {
+        Bridge bridge = _deployBridgeWithPauser(Alice);
+
+        // A message whose fields satisfy the modifiers guarding each entry point, so that
+        // execution reaches the `whenNotPaused` check instead of reverting earlier.
+        IBridge.Message memory message;
+        message.srcOwner = Alice;
+        message.destOwner = Bob;
+        message.to = Carol;
+        message.srcChainId = ethereumChainId;
+        message.destChainId = taikoChainId;
+
+        vm.prank(Alice);
+        bridge.pause();
+        assertTrue(bridge.paused());
+
+        // While paused, the Bridge must reject sending, processing and recalling messages.
+        vm.expectRevert(EssentialContract.INVALID_PAUSE_STATUS.selector);
+        bridge.sendMessage(message);
+
+        vm.expectRevert(EssentialContract.INVALID_PAUSE_STATUS.selector);
+        bridge.processMessage(message, "");
+
+        vm.expectRevert(EssentialContract.INVALID_PAUSE_STATUS.selector);
+        bridge.recallMessage(message, "");
+    }
+
     function _deployBridgeWithPauser(address pauser) private returns (Bridge) {
         Bridge impl = new Bridge(address(resolver), address(eSignalService), pauser);
         return Bridge(


### PR DESCRIPTION
## Summary

Follow-up review fixes for the pauser work on `dantaik/signalservice-pauser-address`.

### 1. Missing NatSpec for new `_pauser` constructor parameter
The `Bridge` and `SignalService` constructors now accept `_pauser`, but the role was undocumented in source. Added full constructor NatSpec (`@notice` + all `@param`s) — including `@param _pauser` — to:
- `Bridge`
- `SignalService`
- `MainnetBridge`

The `_pauser` description matches the existing immutable-variable comment: _"Address authorized to pause/unpause alongside the owner. Optional (may be zero)."_

### 2. Test coverage for pause affecting message processing
`Bridge2_pauser.t.sol` previously only verified pause/unpause **access control**, not that a paused Bridge actually blocks message flow. Added `test_bridge_pause_blocksMessageProcessing`, which pauses the Bridge and asserts that `sendMessage`, `processMessage`, and `recallMessage` all revert with `EssentialContract.INVALID_PAUSE_STATUS`.

The test message is populated so each call's guarding modifiers (`nonZeroAddr`, `sameChain`/`diffChain`) pass and execution reaches the `whenNotPaused` check rather than reverting earlier.

## Testing
- `FOUNDRY_PROFILE=shared forge test --match-path "test/shared/bridge/Bridge2_pauser.t.sol"` — all 5 tests pass (4 existing + 1 new).
- `forge fmt --check` and `solhint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rDjJzW4qpFPkSG8Hc2XdV

---
_Generated by [Claude Code](https://claude.ai/code/session_013rDjJzW4qpFPkSG8Hc2XdV)_