### PR TITLE
ci(repo): grant pull-requests: write to OpenRouter PR reviewer

### DIFF
--- a/.github/workflows/repo--openrouter-review.yml
+++ b/.github/workflows/repo--openrouter-review.yml
@@ -35,7 +35,13 @@ jobs:
     # overhead, so a slow first attempt + retry is never killed mid-run.
     timeout-minutes: 8
     permissions:
-      pull-requests: read
+      # `pull-requests: write` is required to post the review: the job comments
+      # via issues.createComment against the PR number, and on a pull request
+      # that write is governed by the pull-requests scope (not issues). With
+      # only read access the post fails with "Resource not accessible by
+      # integration" even though the diff fetch (a read) and the model call
+      # both succeed.
+      pull-requests: write
       issues: write
     steps:
       # No checkout / setup-node: github-script runs on the runner's Node and


### PR DESCRIPTION
## What

Grants `pull-requests: write` to the on-demand OpenRouter PR reviewer (`.github/workflows/repo--openrouter-review.yml`, added in #21823).

## Why

`@review <model>` triggers the workflow correctly and the model call succeeds, but the job fails at the final step — posting the review as a PR comment — with:

```
##[warning]Failed to post error comment: Resource not accessible by integration
##[error]Resource not accessible by integration
```

The reviewer posts via `issues.createComment` against the PR number. On a **pull request**, that comment write is governed by the `pull-requests` permission, **not** `issues`. The job had `pull-requests: read` + `issues: write`, so the diff fetch (a read) and the model call both worked, but the comment write was denied — which is why an `@review` looks silent on the PR even though the run executes for ~2.5 min.

Observed on #21827: runs [27997038870](https://github.com/taikoxyz/taiko-mono/actions/runs/27997038870) (`@review`) and [28001002242](https://github.com/taikoxyz/taiko-mono/actions/runs/28001002242) (`@review z-ai/glm-5.2`) both failed this way; the log confirms `OPENROUTER_API_KEY` is set (masked) and the failure is purely the comment write.

## Fix

Bump `pull-requests: read` → `pull-requests: write` (keeping `issues: write`).

## Notes

- `issue_comment` workflows execute from the **default branch**, so this takes effect only **after it merges to `main`** — it can't be exercised on this PR pre-merge.
- If posting still fails after merge, also verify **Settings → Actions → General → Workflow permissions** allows read/write — an org/repo-level cap there can override a workflow's `permissions:` block.
- Reminder: the workflow triggers on comment **creation** (`types: [created]`), so re-run by posting a **new** `@review …` comment, not by editing an existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01248XHaEfbSGwDsTNrbNMVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01248XHaEfbSGwDsTNrbNMVU)_