### PR TITLE
feat(protocol): allow Bridge to receive Ether via plain transfers

### DIFF
--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -119,6 +119,12 @@ contract Bridge is EssentialResolverContract, IBridge {
     // External & Public Functions
     // ---------------------------------------------------------------
 
+    /// @notice Allows the contract to receive Ether via plain transfers.
+    /// @dev Enables funding the bridge directly (e.g. topping up its Ether buffer). Kept empty so
+    /// that even gas-limited transfers (`transfer`/`send`, 2300 gas) succeed. Ether bridged through
+    /// the protocol continues to arrive via the payable `sendMessage` function.
+    receive() external payable { }
+
     /// @notice Initializes the contract.
     /// @param _owner The owner of this contract. msg.sender will be used if this value is zero.
     function init(address _owner) external initializer {

--- a/packages/protocol/test/shared/CommonTest.sol
+++ b/packages/protocol/test/shared/CommonTest.sol
@@ -228,9 +228,11 @@ abstract contract CommonTest is Test, Script {
 
     function deployBridge(address bridgeImpl) internal returns (Bridge) {
         return Bridge(
-            deploy({
-                name: "bridge", impl: bridgeImpl, data: abi.encodeCall(Bridge.init, (address(0)))
-            })
+            payable(deploy({
+                    name: "bridge",
+                    impl: bridgeImpl,
+                    data: abi.encodeCall(Bridge.init, (address(0)))
+                }))
         );
     }
 

--- a/packages/protocol/test/shared/bridge/Bridge1.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge1.t.sol
@@ -58,6 +58,21 @@ contract TestBridge1 is CommonTest {
         vm.deal(address(tBridge), 100 ether);
     }
 
+    function test_bridge1_receive_ether_via_plain_transfer() public {
+        uint256 starterBalance = address(eBridge).balance;
+
+        // Low-level call with empty calldata triggers receive().
+        vm.prank(Alice);
+        (bool success,) = address(eBridge).call{ value: 1 ether }("");
+        assertTrue(success);
+        assertEq(address(eBridge).balance, starterBalance + 1 ether);
+
+        // transfer() forwards only 2300 gas; the empty receive() must still accept it.
+        vm.prank(Alice);
+        payable(address(eBridge)).transfer(1 ether);
+        assertEq(address(eBridge).balance, starterBalance + 2 ether);
+    }
+
     function test_bridge1_send_ether_to_to_with_value() public {
         IBridge.Message memory message = IBridge.Message({
             id: 0,


### PR DESCRIPTION
## Summary

`Bridge.sol` could **not** receive plain ETH transfers. It could only receive Ether through the `payable` `sendMessage(...)` function (which requires `msg.value == _message.value + _message.fee`). A plain transfer — `address.transfer()`, `address.send()`, or `address.call{value: x}("")` with empty calldata — would **revert**, because neither `Bridge` nor any contract in its inheritance chain (`EssentialResolverContract` → `EssentialContract` → `UUPSUpgradeable` / `Ownable2StepUpgradeable`) defined a `receive()` or payable `fallback()` function.

This is why the test suite funds the bridge with `vm.deal(...)` rather than transferring to it.

This PR adds an empty `receive() external payable` so the bridge can be funded directly (e.g. to top up its Ether buffer), following the existing pattern in `Controller.sol`.

## Changes

- **`Bridge.sol`**: add `receive() external payable { }`. Kept empty so that even gas-limited transfers (`transfer`/`send`, 2300 gas) succeed, maximizing compatibility. Ether bridged through the protocol continues to arrive via the payable `sendMessage` function.
- **`CommonTest.sol`**: because the contract now has a payable `receive`, Solidity requires `address → Bridge` casts to go through `payable`; updated the `deployBridge` test helper accordingly.
- **`Bridge1.t.sol`**: added `test_bridge1_receive_ether_via_plain_transfer` covering both a low-level `call` with empty calldata and a 2300-gas `transfer`.

## Notes

- **Storage layout unchanged** — only a function was added, no new state variables (the `uint256[44] __gap` is untouched).
- **Accounting unaffected** — the bridge's Ether quota is debited only for funds *leaving* the bridge; a direct deposit simply adds to the balance buffer and credits no quota.
- The absence of a `fallback()` is intentional and preserved: calls with unknown selectors still revert.

## Testing

- `forge test --match-path "test/shared/bridge/*"` — all pass
- `forge test --match-path "test/shared/vault/*"` — all pass (exercises the modified `deployBridge` helper)
- `forge test --match-path "test/layer2/governance/DelegateController.t.sol"` — pass
- `shared`, `layer1`, `layer2` profiles all compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CWuLVU5zLy9savrSQtabX

---
_Generated by [Claude Code](https://claude.ai/code/session_013CWuLVU5zLy9savrSQtabX)_