### PR TITLE
fix(protocol): prevent quota issuance overflow in QuotaManager

### DIFF
--- a/packages/protocol/contracts/shared/bridge/QuotaManager.sol
+++ b/packages/protocol/contracts/shared/bridge/QuotaManager.sol
@@ -81,19 +81,26 @@ contract QuotaManager is Ownable2Step, IQuotaManager {
 
     /// @notice Returns the available quota for a given token.
     /// @param _token The token address with Ether represented by address(0).
-    /// @param _leap Amount of seconds in the future.
+    /// @param _leap Number of seconds in the future to look ahead. Values greater than or equal
+    /// to `quotaPeriod` are treated as a full period (the quota is fully restored), so arbitrarily
+    /// large values are safe and never overflow.
     /// @return The available quota.
     function availableQuota(address _token, uint256 _leap) public view returns (uint256) {
         Quota memory q = tokenQuota[_token];
         if (q.quota == 0) return UNLIMITED_QUOTA;
         if (q.updatedAt == 0) return q.quota;
 
-        // Cap the elapsed time at `quotaPeriod`. Once a full period has passed the quota is
+        // Cap the elapsed time at `quotaPeriod`: once a full period has passed the quota is
         // fully restored, so a larger elapsed value would not change the result (it is capped
-        // at `q.quota` below anyway). Capping it also bounds the multiplication to
-        // `q.quota * quotaPeriod`, which can never overflow uint256 and keeps `consumeQuota`
-        // working even though `block.timestamp - q.updatedAt` grows without bound.
-        uint256 elapsed = (block.timestamp + _leap - q.updatedAt).min(quotaPeriod);
+        // at `q.quota` below anyway). A `_leap` of at least `quotaPeriod` already implies full
+        // restoration, so it is short-circuited; this also avoids overflowing `block.timestamp +
+        // _leap` for extreme caller-supplied lookahead values. Capping `elapsed` bounds the
+        // multiplication to `q.quota * quotaPeriod`, which can never overflow uint256, so
+        // `consumeQuota` keeps working even though `block.timestamp - q.updatedAt` grows without
+        // bound.
+        uint256 elapsed = _leap >= quotaPeriod
+            ? quotaPeriod
+            : (block.timestamp + _leap - q.updatedAt).min(quotaPeriod);
         uint256 issuance = q.quota * elapsed / quotaPeriod;
         return (issuance + q.available).min(q.quota);
     }

--- a/packages/protocol/contracts/shared/bridge/QuotaManager.sol
+++ b/packages/protocol/contracts/shared/bridge/QuotaManager.sol
@@ -88,7 +88,13 @@ contract QuotaManager is Ownable2Step, IQuotaManager {
         if (q.quota == 0) return UNLIMITED_QUOTA;
         if (q.updatedAt == 0) return q.quota;
 
-        uint256 issuance = q.quota * (block.timestamp + _leap - q.updatedAt) / quotaPeriod;
+        // Cap the elapsed time at `quotaPeriod`. Once a full period has passed the quota is
+        // fully restored, so a larger elapsed value would not change the result (it is capped
+        // at `q.quota` below anyway). Capping it also bounds the multiplication to
+        // `q.quota * quotaPeriod`, which can never overflow uint256 and keeps `consumeQuota`
+        // working even though `block.timestamp - q.updatedAt` grows without bound.
+        uint256 elapsed = (block.timestamp + _leap - q.updatedAt).min(quotaPeriod);
+        uint256 issuance = q.quota * elapsed / quotaPeriod;
         return (issuance + q.available).min(q.quota);
     }
 

--- a/packages/protocol/test/shared/bridge/QuotaManager.t.sol
+++ b/packages/protocol/test/shared/bridge/QuotaManager.t.sol
@@ -126,6 +126,21 @@ contract TestQuotaManager is CommonTest {
         assertEq(qm.availableQuota(Ether, hugeLeap), type(uint104).max);
     }
 
+    function test_quota_manager_no_overflow_with_max_leap() public {
+        address Ether = address(0);
+
+        vm.prank(deployer);
+        qm.updateQuota(Ether, type(uint104).max);
+
+        // Set a non-zero `updatedAt` so the issuance branch (not the early return) is taken.
+        vm.prank(bridge);
+        qm.consumeQuota(Ether, 1);
+
+        // A `_leap` near uint256 max must not overflow the `block.timestamp + _leap` addition.
+        // The lookahead saturates at `quotaPeriod`, so the fully restored quota is reported.
+        assertEq(qm.availableQuota(Ether, type(uint256).max), type(uint104).max);
+    }
+
     function test_calc_quota() public pure {
         uint24 quotaPeriod = 24 hours;
         uint104 value = 4_000_000; // USD

--- a/packages/protocol/test/shared/bridge/QuotaManager.t.sol
+++ b/packages/protocol/test/shared/bridge/QuotaManager.t.sol
@@ -85,6 +85,47 @@ contract TestQuotaManager is CommonTest {
         assertEq(qm.availableQuota(Ether, 0), 4 ether);
     }
 
+    function test_quota_manager_restores_fully_after_long_period() public {
+        address Ether = address(0);
+
+        vm.prank(deployer);
+        qm.updateQuota(Ether, 10 ether);
+
+        vm.prank(bridge);
+        qm.consumeQuota(Ether, 6 ether);
+        assertEq(qm.availableQuota(Ether, 0), 4 ether);
+
+        // Warp far beyond a single quota period (~100 years). The quota must be fully restored
+        // and capped at the configured quota, and consumeQuota must keep working.
+        vm.warp(block.timestamp + 36_500 days);
+        assertEq(qm.availableQuota(Ether, 0), 10 ether);
+
+        vm.prank(bridge);
+        qm.consumeQuota(Ether, 10 ether);
+        assertEq(qm.availableQuota(Ether, 0), 0);
+    }
+
+    function test_quota_manager_no_overflow_with_max_quota_and_large_elapsed() public {
+        address Ether = address(0);
+
+        // Configure the maximum possible quota to maximize the overflow risk in the issuance
+        // calculation `q.quota * elapsed`.
+        vm.prank(deployer);
+        qm.updateQuota(Ether, type(uint104).max);
+
+        // Consume a tiny amount so that `updatedAt` becomes non-zero and the issuance branch
+        // (rather than the early `q.updatedAt == 0` return) is exercised.
+        vm.prank(bridge);
+        qm.consumeQuota(Ether, 1);
+
+        // With an unbounded elapsed time, `q.quota * elapsed` would exceed uint256 and revert,
+        // bricking `consumeQuota`. Capping elapsed at `quotaPeriod` keeps it safe and simply
+        // returns the fully restored quota. `2 ** 160` is large enough to overflow the product
+        // while keeping `block.timestamp + _leap` itself within uint256.
+        uint256 hugeLeap = 1 << 160;
+        assertEq(qm.availableQuota(Ether, hugeLeap), type(uint104).max);
+    }
+
     function test_calc_quota() public pure {
         uint24 quotaPeriod = 24 hours;
         uint104 value = 4_000_000; // USD


### PR DESCRIPTION
## Problem

Follow-up to #21821. In `QuotaManager.availableQuota`, the issuance calculation could overflow:

```solidity
uint256 issuance = q.quota * (block.timestamp + _leap - q.updatedAt) / quotaPeriod;
```

`block.timestamp - q.updatedAt` grows **without bound** over time (and `_leap` is a caller-supplied `uint256` on the public `availableQuota`). With a sufficiently large quota and elapsed time, the multiplication `q.quota * (...)` can exceed `uint256`, causing the call to revert. Since `consumeQuota` calls `availableQuota` on every release, an overflow would brick the quota mechanism and **halt the bridge**.

It is a minor risk in practice (timestamps grow slowly and quotas are unlikely to be configured that high), but the calculation is fragile and worth hardening.

## Fix

Cap the elapsed time at `quotaPeriod`:

```solidity
uint256 elapsed = (block.timestamp + _leap - q.updatedAt).min(quotaPeriod);
uint256 issuance = q.quota * elapsed / quotaPeriod;
return (issuance + q.available).min(q.quota);
```

This is **mathematically equivalent** to the original: once a full period has elapsed the quota is fully restored, and the result is already capped at `q.quota` by the final `.min(q.quota)`. Capping `elapsed` therefore never changes the returned value, while bounding the multiplication to `q.quota * quotaPeriod` (≤ 2¹⁰⁴ × 2²⁴ = 2¹²⁸), which can never overflow `uint256`.

## Tests

- `test_quota_manager_restores_fully_after_long_period` — quota fully restores and `consumeQuota` keeps working after warping ~100 years past the period.
- `test_quota_manager_no_overflow_with_max_quota_and_large_elapsed` — with `quota == type(uint104).max` and a large elapsed time, `availableQuota` returns the full quota instead of reverting. This test **panics with `arithmetic overflow (0x11)` on the pre-fix code** and passes with the fix, confirming it captures the reported bug.

All existing `QuotaManager` and `Bridge2_quota` tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTM1Zt7VL5wwg9vvShtdvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTM1Zt7VL5wwg9vvShtdvL)_