### PR TITLE
chore(protocol): align mainnet LibL1Addrs with main (drop unused LEGACY_PACAYA_INBOX)

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
+++ b/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
@@ -5,10 +5,16 @@ pragma solidity ^0.8.24;
 /// @custom:security-contact security@taiko.xyz
 library LibL1Addrs {
     address public constant DAO = 0x9CDf589C941ee81D75F34d3755671d614f7cf261;
+    address public constant DAO_SIGNER_LIST = 0x0F95E6968EC1B28c794CF1aD99609431de5179c2;
+    address public constant DAO_STANDARD_MULTISIG = 0xD7dA1C25E915438720692bC55eb3a7170cA90321;
+    address public constant DAO_EMERGENCY_MULTISIG = 0x2AffADEb2ef5e1F2a7F58964ee191F1e88317ECd;
     address public constant DAO_CONTROLLER = 0x75Ba76403b13b26AD1beC70D6eE937314eeaCD0a;
+    address public constant DAO_OPTIMISTIC_TOKEN_VOTING_PLUGIN =
+        0x989E348275b659d36f8751ea1c10D146211650BE;
+
     address public constant FORCED_INCLUSION_STORE = 0x05d88855361808fA1d7fc28084Ef3fCa191c4e03;
     address public constant TAIKO_WRAPPER = 0x9F9D2fC7abe74C79f86F0D1212107692430eef72;
-    address public constant INBOX = 0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a;
+    address public constant INBOX = 0x6f21C543a4aF5189eBdb0723827577e1EF57ef1f;
     address public constant PRECONF_WHITELIST = 0xFD019460881e6EeC632258222393d5821029b2ac;
 
     address public constant BRIDGE = 0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC;


### PR DESCRIPTION
## What

Copies `LibL1Addrs.sol` and `LibL2Addrs.sol` from `main` onto the `taiko-alethia-protocol-v3.0.0` branch.

- **`LibL2Addrs.sol`** — already byte-identical to `main`, so this PR contains no change for it.
- **`LibL1Addrs.sol`** — updated to match `main`, with one deliberate exception: `LEGACY_PACAYA_INBOX` is **omitted** because it is no longer used (no references anywhere on this branch).

## Net effect on `LibL1Addrs.sol` (vs the v3.0.0 base)

| Change | Detail |
| --- | --- |
| `INBOX` repointed | `0x06a9Ab27…Feb19a` (Pacaya inbox) → `0x6f21C543…57ef1f` (current mainnet inbox) |
| Added | `DAO_SIGNER_LIST`, `DAO_STANDARD_MULTISIG`, `DAO_EMERGENCY_MULTISIG`, `DAO_OPTIMISTIC_TOKEN_VOTING_PLUGIN` |
| Intentionally not added | `LEGACY_PACAYA_INBOX` (unused) |

Everything else (`PRECONF_WHITELIST`, `MULTISIG_ADMIN_TAIKO_ETH`, bridge/vault/bridged-token addresses, third-party addresses) is unchanged.

## For review (@ggonzalez94)

The main semantic point to confirm: this **repoints `INBOX`** from the old Pacaya inbox to the current mainnet inbox on the v3.0.0 branch. Please confirm that is the intended value for v3.0.0, and that dropping `LEGACY_PACAYA_INBOX` (rather than carrying it as on `main`) is correct here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
