### PR TITLE
fix(taiko-client): bound preconfirmation tx list decompression

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -46,6 +46,8 @@ var (
 )
 
 const requestSyncMargin = uint64(128) // Margin for requesting sync, to avoid requesting very old blocks.
+const maxCompressedPreconfTxListBytes = eth.MaxBlobDataSize * eth.MaxBlobsPerBlobTx
+
 // monitorLatestProposalOnChainInterval defines how often we reconcile the cached proposal with on-chain state.
 const monitorLatestProposalOnChainInterval = 10 * time.Second
 
@@ -930,12 +932,12 @@ func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionP
 	if len(payload.Transactions) != 1 {
 		return fmt.Errorf("only one transaction list is allowed")
 	}
-	if len(payload.Transactions[0]) > (eth.MaxBlobDataSize * eth.MaxBlobsPerBlobTx) {
+	if len(payload.Transactions[0]) > maxCompressedPreconfTxListBytes {
 		return errors.New("compressed transactions size exceeds max blob data size")
 	}
 
 	var txs types.Transactions
-	b, err := utils.Decompress(payload.Transactions[0])
+	b, err := utils.DecompressWithLimit(payload.Transactions[0], int64(maxCompressedPreconfTxListBytes))
 	if err != nil {
 		return fmt.Errorf("invalid zlib bytes for transactions: %w", err)
 	}
@@ -1306,7 +1308,10 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 			if len(cachedParent.Payload.Transactions) == 0 {
 				return false, fmt.Errorf("cached parent envelope has empty transactions: %s", msg.ExecutionPayload.ParentHash.Hex())
 			}
-			decompressedTxs, err := utils.Decompress(cachedParent.Payload.Transactions[0])
+			decompressedTxs, err := utils.DecompressWithLimit(
+				cachedParent.Payload.Transactions[0],
+				int64(maxCompressedPreconfTxListBytes),
+			)
 			if err != nil {
 				return false, fmt.Errorf("failed to decompress cached parent tx list: %w", err)
 			}

--- a/packages/taiko-client/pkg/utils/util_test.go
+++ b/packages/taiko-client/pkg/utils/util_test.go
@@ -24,6 +24,22 @@ func TestEncodeDecodeBytes(t *testing.T) {
 	require.Equal(t, b, decompressed)
 }
 
+func TestDecompressWithLimitRejectsOversizedOutput(t *testing.T) {
+	b := testutils.RandomBytes(1024)
+
+	compressed, err := utils.Compress(b)
+	require.Nil(t, err)
+	require.NotEmpty(t, compressed)
+
+	decompressed, err := utils.DecompressWithLimit(compressed, int64(len(b)))
+	require.Nil(t, err)
+	require.Equal(t, b, decompressed)
+
+	_, err = utils.DecompressWithLimit(compressed, int64(len(b)-1))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decompressed tx list exceeds limit")
+}
+
 func TestGWeiToWei(t *testing.T) {
 	wei, err := utils.GWeiToWei(1.0)
 	require.Nil(t, err)

--- a/packages/taiko-client/pkg/utils/utils.go
+++ b/packages/taiko-client/pkg/utils/utils.go
@@ -89,17 +89,32 @@ func Compress(txList []byte) ([]byte, error) {
 
 // Decompress decompresses the given txList bytes using zlib, it checks the ErrUnexpectedEOF error.
 func Decompress(compressedTxList []byte) ([]byte, error) {
+	return DecompressWithLimit(compressedTxList, 0)
+}
+
+// DecompressWithLimit decompresses the given txList bytes using zlib and rejects outputs
+// that exceed maxDecompressedBytes. A non-positive limit preserves the legacy unbounded behavior.
+func DecompressWithLimit(compressedTxList []byte, maxDecompressedBytes int64) ([]byte, error) {
 	r, err := zlib.NewReader(bytes.NewBuffer(compressedTxList))
 	if err != nil {
 		return nil, err
 	}
 	defer r.Close()
 
-	b, err := io.ReadAll(r)
+	reader := io.Reader(r)
+	if maxDecompressedBytes > 0 {
+		reader = io.LimitReader(r, maxDecompressedBytes+1)
+	}
+
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		if !errors.Is(err, io.EOF) {
 			return nil, err
 		}
+	}
+
+	if maxDecompressedBytes > 0 && int64(len(b)) > maxDecompressedBytes {
+		return nil, fmt.Errorf("decompressed tx list exceeds limit: %d > %d", len(b), maxDecompressedBytes)
 	}
 
 	return b, nil


### PR DESCRIPTION

### Summary

This bounds zlib decompression for preconfirmation transaction lists before RLP decoding. The existing validation capped the compressed input size, but `utils.Decompress` read the decompressed stream without an output limit.

### Security impact

A compressed transaction list can expand beyond the expected preconfirmation tx-list budget during validation. Bounding the decompressed output avoids unnecessary memory growth before the payload is rejected.

### Changes

- Add `utils.DecompressWithLimit` while preserving existing `Decompress` behavior for other callers.
- Use a preconfirmation tx-list decompression ceiling in payload validation and cached-parent handling.
- Add a unit test covering oversized decompressed output rejection.

### Validation

- `git diff --check origin/main..HEAD` passed.
- Targeted Go tests were not run because `go`/`gofmt` are unavailable in this OpenClaw host environment.

<!-- failsafe-scan-id: cmqrca2m7003yqj011lmwh4vf -->
