### PR TITLE
fix(protocol): restrict preconfirmation operator additions

### DIFF
--- a/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
+++ b/packages/protocol/contracts/layer1/preconf/impl/PreconfWhitelist.sol
@@ -91,7 +91,7 @@ contract PreconfWhitelist is EssentialContract, IPreconfWhitelist, IProposerChec
 
     /// @inheritdoc IPreconfWhitelist
     /// @dev The operator only becomes active after `OPERATOR_CHANGE_DELAY` epochs.
-    function addOperator(address _proposer, address _sequencer) external onlyOwnerOrEjecter {
+    function addOperator(address _proposer, address _sequencer) external onlyOwner {
         _addOperator(_proposer, _sequencer);
     }
 

--- a/packages/protocol/test/layer1/preconf/whitelist/PreconfWhitelist.t.sol
+++ b/packages/protocol/test/layer1/preconf/whitelist/PreconfWhitelist.t.sol
@@ -239,6 +239,15 @@ contract TestPreconfWhitelist is CommonTest {
         assertEq(index, 0);
     }
 
+    function test_addOperator_RevertWhen_CallerIsEjecter() external {
+        vm.prank(whitelistOwner);
+        whitelist.setEjecter(ejecter, true);
+
+        vm.expectRevert();
+        vm.prank(ejecter);
+        whitelist.addOperator(Bob, _sequencer(Bob));
+    }
+
     function test_removeOperator_RevertWhen_LastOperator() external {
         _addOperator(Bob);
         vm.prank(whitelistOwner);


### PR DESCRIPTION

### Summary

This restricts `PreconfWhitelist.addOperator` to the owner. Ejecters can still remove operators, but can no longer add new proposer/sequencer pairs.

### Security impact

Ejecters are documented and configured as an operator-removal role. Allowing the same role to add operators expands that authority and can make newly added proposers eligible after the activation delay.

### Changes

- Change `addOperator` from `onlyOwnerOrEjecter` to `onlyOwner`.
- Add a regression test confirming ejecters cannot add operators.

### Validation

- `git diff --check origin/main..HEAD` passed.
- Targeted Foundry tests were not run because `forge` is unavailable in this OpenClaw host environment.

<!-- failsafe-scan-id: cmqrca2m7003yqj011lmwh4vf -->
