### PR TITLE
fix(taiko-client-rs): degrade undecodable derivation source blob to default payload

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/manifest/fetcher/shasta.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/manifest/fetcher/shasta.rs
@@ -92,3 +92,41 @@ impl ShastaSourceManifestFetcher {
         Ok(manifest)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::BlobTransactionSidecar;
+    use alloy_eips::eip4844::{BYTES_PER_BLOB, Blob};
+
+    use super::{ManifestFetcherError, decode_manifest_from_sidecars};
+
+    /// Build a single-blob sidecar whose Kona encoding is invalid: it declares a payload length of
+    /// zero yet carries a stray non-zero byte past that length. This mirrors the forced-inclusion
+    /// blob observed on-chain (proposal 1812 / L1 block 5167) that wedged derivation: the first
+    /// field element is all zeros (version 0, length 0), so the decoder's trailing-zero check
+    /// rejects the stray byte.
+    fn sidecar_with_undecodable_blob() -> BlobTransactionSidecar {
+        let mut raw = [0u8; BYTES_PER_BLOB];
+        // byte[0] header, byte[1] version, byte[2..5] 24-bit length (all zero => length 0);
+        // byte[6] sits past the declared length, so a non-zero value is "extraneous data".
+        raw[6] = 0x02;
+        BlobTransactionSidecar {
+            blobs: vec![Blob::from(raw)],
+            commitments: Vec::new(),
+            proofs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn decode_manifest_rejects_undecodable_blob_with_invalid_error() {
+        let sidecar = sidecar_with_undecodable_blob();
+
+        let err = decode_manifest_from_sidecars(&[sidecar], 0, 100)
+            .expect_err("an undecodable blob must not decode into a manifest");
+
+        assert!(
+            matches!(&err, ManifestFetcherError::Invalid(msg) if msg == "invalid blob encoding"),
+            "expected invalid-blob-encoding error, got {err:?}"
+        );
+    }
+}

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -25,7 +25,7 @@ use rpc::{blob::BlobDataSource, client::Client};
 use tracing::{debug, info, instrument, warn};
 
 use crate::{
-    derivation::manifest::fetcher::shasta::ShastaSourceManifestFetcher,
+    derivation::manifest::{ManifestFetcherError, fetcher::shasta::ShastaSourceManifestFetcher},
     metrics::DriverMetrics,
     sync::engine::{EngineBlockOutcome, PayloadApplier},
 };
@@ -182,6 +182,49 @@ fn validate_forced_inclusion_manifest(
         DerivationSourceManifest::default()
     } else {
         manifest
+    }
+}
+
+/// Returns whether a manifest fetch error reflects undecodable blob/manifest *content* rather
+/// than a transient fetch/RPC failure.
+///
+/// Any party can post an arbitrarily encoded (or empty) blob for a derivation source — most
+/// commonly a forced inclusion, where the blob bytes are attacker-controlled. Such a blob is not
+/// a fatal condition: it must degrade to the default payload, matching the Go reference's
+/// `ErrInvalidBlobBytes` handling in `DerivationSourceFetcher.Fetch`. Transient errors (beacon or
+/// RPC unavailability, blob-count mismatch) must instead propagate so derivation retries them.
+fn is_undecodable_manifest_error(err: &DerivationError) -> bool {
+    matches!(
+        err,
+        DerivationError::Manifest(
+            ManifestFetcherError::Invalid(_) | ManifestFetcherError::EmptyBlobSidecars
+        )
+    )
+}
+
+/// Resolve a derivation source's manifest from its fetch/decode result.
+///
+/// A successfully decoded manifest is passed through forced-inclusion validation. A failure caused
+/// by undecodable blob/manifest content degrades to the default payload instead of stalling
+/// derivation (see [`is_undecodable_manifest_error`]). Transient failures are returned unchanged so
+/// the caller retries them.
+fn resolve_source_manifest(
+    proposal_id: u64,
+    source: &DerivationSource,
+    result: Result<DerivationSourceManifest, DerivationError>,
+) -> Result<DerivationSourceManifest, DerivationError> {
+    match result {
+        Ok(manifest) => Ok(validate_forced_inclusion_manifest(proposal_id, source, manifest)),
+        Err(err) if is_undecodable_manifest_error(&err) => {
+            warn!(
+                proposal_id,
+                is_forced_inclusion = source.isForcedInclusion,
+                %err,
+                "undecodable blob/manifest for derivation source, using default payload instead"
+            );
+            Ok(DerivationSourceManifest::default())
+        }
+        Err(err) => Err(err),
     }
 }
 
@@ -396,8 +439,10 @@ where
             let manifest = if !is_source_offset_valid(source) {
                 DerivationSourceManifest::default()
             } else {
-                let manifest = self.fetch_and_decode_manifest(source, event.l1_timestamp).await?;
-                validate_forced_inclusion_manifest(proposal_id, source, manifest)
+                // An undecodable blob/manifest degrades to the default payload rather than
+                // stalling derivation; only transient errors propagate to be retried.
+                let result = self.fetch_and_decode_manifest(source, event.l1_timestamp).await;
+                resolve_source_manifest(proposal_id, source, result)?
             };
             manifest_segments.push(SourceManifestSegment {
                 manifest,
@@ -734,6 +779,81 @@ mod tests {
         let validated = validate_forced_inclusion_manifest(1, &source, manifest);
 
         assert_eq!(validated.blocks.len(), 1);
+    }
+
+    #[test]
+    fn resolve_source_manifest_defaults_on_undecodable_blob() {
+        // Regression: a forced-inclusion source whose blob fails to decode (the on-chain
+        // proposal 1812 / L1 block 5167 case) must degrade to the default payload, not propagate
+        // a fatal error that stalls derivation and retries forever.
+        let source = sample_derivation_source(vec![FixedBytes::from([1u8; 32])], true);
+        let result = Err(DerivationError::Manifest(ManifestFetcherError::Invalid(
+            "invalid blob encoding".to_string(),
+        )));
+
+        let resolved = resolve_source_manifest(1812, &source, result)
+            .expect("an undecodable blob must resolve to the default payload, not an error");
+
+        assert_eq!(resolved.blocks.len(), DerivationSourceManifest::default().blocks.len());
+    }
+
+    #[test]
+    fn resolve_source_manifest_defaults_on_empty_blob_sidecars() {
+        let source = sample_derivation_source(vec![FixedBytes::from([1u8; 32])], false);
+        let result = Err(DerivationError::Manifest(ManifestFetcherError::EmptyBlobSidecars));
+
+        let resolved = resolve_source_manifest(1, &source, result)
+            .expect("empty blob sidecars must resolve to the default payload");
+
+        assert_eq!(resolved.blocks.len(), DerivationSourceManifest::default().blocks.len());
+    }
+
+    #[test]
+    fn resolve_source_manifest_propagates_transient_error() {
+        // Transient fetch failures (e.g. the beacon returned the wrong sidecar count) must still
+        // propagate so derivation retries them instead of silently defaulting forever.
+        let source = sample_derivation_source(vec![FixedBytes::from([1u8; 32])], true);
+        let result = Err(DerivationError::Manifest(ManifestFetcherError::BlobCountMismatch {
+            expected: 1,
+            actual: 0,
+        }));
+
+        let resolved = resolve_source_manifest(1, &source, result);
+
+        assert!(
+            matches!(
+                resolved,
+                Err(DerivationError::Manifest(ManifestFetcherError::BlobCountMismatch { .. }))
+            ),
+            "transient errors must propagate, got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_source_manifest_passes_through_valid_manifest() {
+        let source = sample_derivation_source(vec![FixedBytes::from([1u8; 32])], true);
+        let manifest = DerivationSourceManifest { blocks: vec![BlockManifest::default()] };
+
+        let resolved = resolve_source_manifest(1, &source, Ok(manifest))
+            .expect("a valid manifest must pass through unchanged");
+
+        assert_eq!(resolved.blocks.len(), 1);
+    }
+
+    #[test]
+    fn is_undecodable_manifest_error_distinguishes_content_from_transient() {
+        assert!(is_undecodable_manifest_error(&DerivationError::Manifest(
+            ManifestFetcherError::Invalid("invalid blob encoding".to_string())
+        )));
+        assert!(is_undecodable_manifest_error(&DerivationError::Manifest(
+            ManifestFetcherError::EmptyBlobSidecars
+        )));
+        assert!(!is_undecodable_manifest_error(&DerivationError::Manifest(
+            ManifestFetcherError::BlobCountMismatch { expected: 1, actual: 0 }
+        )));
+        assert!(!is_undecodable_manifest_error(&DerivationError::Manifest(
+            ManifestFetcherError::EmptyBlobHashes
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A forced-inclusion derivation source can reference an **arbitrarily encoded (or empty) blob** whose Kona encoding fails to decode. When `BlobCoder::decode_blobs` returns `None`, the fetcher raises `Manifest(Invalid("invalid blob encoding"))`, which propagates out of `build_manifest_from_event` via `?`. Proposal derivation then fails and **retries forever**, wedging the L2 node:

```
WARN driver::sync::event: proposal derivation failed; retrying
  err=Sync(Derivation(Manifest(Invalid("invalid blob encoding"))))
  tx_hash=0x7d3d…e034e block_number=5167
```

### Root cause (verified on-chain, internal devnet)

L1 tx `0x7d3d…e034e` (block 5167) is **proposal 1812** with two derivation sources:

| # | `isForcedInclusion` | blob | decodes? |
|---|---|---|---|
| 0 | **true**  | `0x01c59e4d…` | ❌ |
| 1 | false | `0x0136c8…` | ✅ |

The forced-inclusion blob's first field element is `00000000 00000 2 …`: it declares **payload length 0** but carries a stray `0x02` byte past that length. The decoder's trailing-zero check (`output.iter().skip(length).any(non-zero)`) correctly rejects it and returns `None`.

The existing graceful-default path (`validate_forced_inclusion_manifest`) only runs **after** a successful decode, so a decode *error* short-circuits via `?` before the payload can be defaulted.

### Reference behaviour

The Go `taiko-client` (same monorepo HEAD) already handles this: `DerivationSourceFetcher.Fetch` treats `ErrInvalidBlobBytes` as a default payload, and every decode-failure branch in `manifestFromBlobBytes` returns the default — see also #21849 (`handle empty blob case`). The Rust port was missing this graceful degradation.

## Fix

Classify manifest-fetch errors as **undecodable content** (`Invalid`, `EmptyBlobSidecars`) vs **transient** (beacon/RPC unavailability, blob-count mismatch). Undecodable content degrades to the default payload (matching Go); transient errors still propagate so derivation retries them.

The change is isolated to `build_manifest_from_event` via two small, unit-tested helpers (`is_undecodable_manifest_error`, `resolve_source_manifest`).

## Testing

- `decode_manifest_rejects_undecodable_blob_with_invalid_error` — reproduces the exact on-chain failure (length 0 + stray byte → `Invalid`).
- `resolve_source_manifest_defaults_on_undecodable_blob` / `…_on_empty_blob_sidecars` — undecodable content → default payload (these **fail** without the fix, with the production error).
- `resolve_source_manifest_propagates_transient_error` — transient errors still propagate (no silent forever-default).
- `resolve_source_manifest_passes_through_valid_manifest`, `is_undecodable_manifest_error_distinguishes_content_from_transient`.

`cargo test -p driver --lib` (77 passed), `cargo clippy` (repo lint flags) and `fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)