### PR TITLE
ci(taiko-client): keyless GAR auth via Workload Identity

### DIFF
--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -21,6 +21,8 @@ permissions:
 
 env:
   REGISTRY_IMAGE: us-docker.pkg.dev/evmchain/images/taiko-client
+  WIF_PROVIDER: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
+  WIF_SERVICE_ACCOUNT: gar-github-action@evmchain.iam.gserviceaccount.com
 
 jobs:
   build:
@@ -44,20 +46,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Authenticate to Google Cloud (Workload Identity)
-        id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
-          service_account: gar-github-action@evmchain.iam.gserviceaccount.com
-          token_format: access_token
-      - name: Login to GAR
-        uses: docker/login-action@v4
-        with:
-          registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
@@ -77,6 +65,23 @@ jobs:
             type=ref,event=pr
             type=ref,event=tag
             type=sha
+
+      # Auth + login run immediately before the build/push step: the WIF access
+      # token is short lived (~1h), so we mint it as late as possible to leave
+      # the most headroom for long multi-arch builds before the push.
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+      - name: Login to GAR
+        uses: docker/login-action@v4
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Build and push by digest
         id: build
@@ -137,8 +142,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
-          service_account: gar-github-action@evmchain.iam.gserviceaccount.com
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
           token_format: access_token
       - name: Login to GAR
         uses: docker/login-action@v4

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -14,6 +14,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Keyless GAR auth via Workload Identity Federation (replaces secrets.GAR_JSON_KEY).
+permissions:
+  contents: read
+  id-token: write
+
 env:
   REGISTRY_IMAGE: us-docker.pkg.dev/evmchain/images/taiko-client
 
@@ -39,12 +44,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
+          service_account: gar-github-action@evmchain.iam.gserviceaccount.com
+          token_format: access_token
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -121,12 +133,19 @@ jobs:
             type=ref,event=tag
             type=sha
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
+          service_account: gar-github-action@evmchain.iam.gserviceaccount.com
+          token_format: access_token
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/.github/workflows/taiko-client--docker.yml
+++ b/.github/workflows/taiko-client--docker.yml
@@ -76,6 +76,11 @@ jobs:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
           token_format: access_token
+          access_token_lifetime: 3600s
+          # Only the access_token output is consumed (for docker login), so skip
+          # writing a gha-creds-*.json ADC file. Otherwise it lands in the Docker
+          # build context (context: .) and could leak the credential.
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
@@ -145,6 +150,11 @@ jobs:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
           token_format: access_token
+          access_token_lifetime: 3600s
+          # Only the access_token output is consumed (for docker login), so skip
+          # writing a gha-creds-*.json ADC file. Otherwise it lands in the Docker
+          # build context (context: .) and could leak the credential.
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## What

Migrates the taiko-client multi-arch image release workflow (`.github/workflows/taiko-client--docker.yml`) from a static GAR service-account key (`secrets.GAR_JSON_KEY`) to keyless **Workload Identity Federation**.

Both jobs (`build` matrix + `merge`) now:
- request `id-token: write`,
- authenticate via `google-github-actions/auth@v2` impersonating `gar-github-action@evmchain.iam.gserviceaccount.com`,
- `docker login` to `us-docker.pkg.dev` with `oauth2accesstoken` + the short-lived access token instead of the long-lived JSON key.

## Why

Part of the org GCP hardening effort: retiring long-lived downloadable SA keys in favor of short-lived, keyless OIDC tokens. `gar-github-action` is responsible for image builds across most repos, so its static key is high blast-radius.

## Verification

Proven before touching this workflow with a temporary smoke test (`wif-gar-smoke.yml`) that authenticated via the same WIF provider/SA and pushed a probe image to `us-docker.pkg.dev/evmchain/images`, on **both** `ubuntu-latest` and the self-hosted `arc-runner-set` / arm64 runners this workflow actually uses. All steps green (auth, login, GAR write). The smoke branch and probe images have been cleaned up.

The WIF binding `taikoxyz/taiko-mono -> gar-github-action@evmchain` (principalSet on `attribute.repository`) is already in place.

## Rollout / safety

- This workflow runs only on `push` to `main` and `taiko-alethia-client-v*` tags, so the cutover happens on merge.
- The `GAR_JSON_KEY` org secret is intentionally **left in place** as a fallback until the keyless pattern is rolled out to the remaining image workflows; it will be retired (and the `gar-github-action` keys deleted) afterwards.
- Revert = restore the previous two `Login to GAR` steps; the key is still valid.

This is the pilot; follow-up PRs will migrate the other taiko-mono docker workflows and sibling repos.