### PR TITLE
docs(repo): update root package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Get started with Taiko Alethia:
 | [eventindexer](./packages/eventindexer)                       | Event indexer.                                                     |
 | [fork-diff](./packages/fork-diff)                             | Fork diff page.                                                    |
 | [nfts](./packages/nfts)                                       | NFT-related smart contracts and utilities.                         |
+| [preconfirmation-p2p](./packages/preconfirmation-p2p)         | Permissionless preconfirmation P2P networking libraries.           |
 | [protocol](./packages/protocol)                               | Taiko Alethia protocol smart contracts.                            |
 | [relayer](./packages/relayer)                                 | Bridge backend relayer.                                            |
 | [snaefell-ui](./packages/snaefell-ui)                         | Snaefell UI.                                                       |
@@ -53,6 +54,7 @@ Get started with Taiko Alethia:
 | [taiko-client-rs](./packages/taiko-client-rs)                 | Taiko Alethia client implementation in Rust.                       |
 | [taikoon-ui](./packages/taikoon-ui)                           | Taikoon UI.                                                        |
 | [ui-lib](./packages/ui-lib)                                   | UI library.                                                        |
+| [urcindexer-rs](./packages/urcindexer-rs)                     | URC registry indexer service backed by MySQL.                      |
 
 ## Issues
 


### PR DESCRIPTION
## Summary

- Add `preconfirmation-p2p` to the root README package table.
- Add `urcindexer-rs` to the root README package table.

## Motivation

Both packages exist in the monorepo, have their own README files, and are covered by dedicated CI workflows, but they were missing from the root package inventory. Listing them in the root README makes the active package list easier to discover for new contributors and operators.

## Testing

- `pnpm exec prettier --check README.md`
- `git diff --check`