### PR TITLE
chore(repo): keyless GAR auth for remaining image workflows

### DIFF
--- a/.github/workflows/ejector--docker.yml
+++ b/.github/workflows/ejector--docker.yml
@@ -1,6 +1,7 @@
 name: "Build and Push Multi-Arch Docker Image (ejector)"
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -19,6 +20,9 @@ env:
   REGISTRY_IMAGE: us-docker.pkg.dev/evmchain/images/ejector
   BUILD_CONTEXT: packages/ejector
   DOCKERFILE: packages/ejector/Dockerfile
+  # Keyless GAR auth via Workload Identity Federation (replaces secrets.GAR_JSON_KEY).
+  WIF_PROVIDER: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
+  WIF_SERVICE_ACCOUNT: gar-github-action@evmchain.iam.gserviceaccount.com
 
 jobs:
   build:
@@ -41,12 +45,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -130,12 +143,21 @@ jobs:
             type=sha
             type=match,pattern=ejector-v(\d+\.\d+\.\d+),group=1
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/.github/workflows/eventindexer--docker.yml
+++ b/.github/workflows/eventindexer--docker.yml
@@ -2,6 +2,7 @@ name: "Build and Push Multi-Arch Docker Image (eventindexer)"
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -15,6 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Keyless GAR auth via Workload Identity Federation (replaces secrets.GAR_JSON_KEY).
+  WIF_PROVIDER: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
+  WIF_SERVICE_ACCOUNT: gar-github-action@evmchain.iam.gserviceaccount.com
+
 jobs:
   push-eventindexer-docker-image:
     name: Build and push docker image
@@ -26,12 +32,21 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/relayer--docker.yml
+++ b/.github/workflows/relayer--docker.yml
@@ -2,6 +2,7 @@ name: "Build and Push Multi-Arch Docker Image (relayer)"
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -15,6 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Keyless GAR auth via Workload Identity Federation (replaces secrets.GAR_JSON_KEY).
+  WIF_PROVIDER: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
+  WIF_SERVICE_ACCOUNT: gar-github-action@evmchain.iam.gserviceaccount.com
+
 jobs:
   push-relayer-docker-image:
     name: Build and push docker image
@@ -26,12 +32,21 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/taiko-client-rs--docker.yml
+++ b/.github/workflows/taiko-client-rs--docker.yml
@@ -1,6 +1,7 @@
 name: "Build and Push Multi-Arch Docker Image (taiko-client-rs)"
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -16,6 +17,9 @@ concurrency:
 
 env:
   REGISTRY_IMAGE: us-docker.pkg.dev/evmchain/images/taiko-client-rs
+  # Keyless GAR auth via Workload Identity Federation (replaces secrets.GAR_JSON_KEY).
+  WIF_PROVIDER: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
+  WIF_SERVICE_ACCOUNT: gar-github-action@evmchain.iam.gserviceaccount.com
 
 jobs:
   build:
@@ -39,12 +43,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -122,12 +135,21 @@ jobs:
             type=ref,event=tag
             type=sha
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/.github/workflows/urcindexer-rs--docker.yml
+++ b/.github/workflows/urcindexer-rs--docker.yml
@@ -1,6 +1,7 @@
 name: "Build and Push Multi-Arch Docker Image (urcindexer)"
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -19,6 +20,9 @@ env:
   REGISTRY_IMAGE: us-docker.pkg.dev/evmchain/images/urcindexer-rs
   BUILD_CONTEXT: packages/urcindexer-rs
   DOCKERFILE: packages/urcindexer-rs/Dockerfile
+  # Keyless GAR auth via Workload Identity Federation (replaces secrets.GAR_JSON_KEY).
+  WIF_PROVIDER: projects/790288402401/locations/global/workloadIdentityPools/terraform-pool/providers/github-provider
+  WIF_SERVICE_ACCOUNT: gar-github-action@evmchain.iam.gserviceaccount.com
 
 jobs:
   docker:
@@ -40,12 +44,21 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -123,12 +136,21 @@ jobs:
             type=sha
             type=match,pattern=urcindexer-rs-v(\d+\.\d+\.\d+),group=1
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_lifetime: 3600s
+          create_credentials_file: false
       - name: Login to GAR
         uses: docker/login-action@v4
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
## What

Follow-up to the taiko-client pilot ([#21861](https://github.com/taikoxyz/taiko-mono/pull/21861), merged). Migrates the **remaining 5 image-build workflows** from the static `secrets.GAR_JSON_KEY` service-account key to keyless **Workload Identity Federation**:

- `ejector--docker.yml`
- `eventindexer--docker.yml`
- `relayer--docker.yml`
- `taiko-client-rs--docker.yml`
- `urcindexer-rs--docker.yml`

After this, **no taiko-mono workflow uses `GAR_JSON_KEY`**.

## Pattern (identical to the merged pilot)

Each job now:
- requests `id-token: write`,
- authenticates via `google-github-actions/auth@v2` impersonating `gar-github-action@evmchain` with `token_format: access_token`, `access_token_lifetime: 3600s`, and `create_credentials_file: false` (so no `gha-creds-*.json` ADC file can enter the Docker build context),
- `docker login`s with `oauth2accesstoken` + the short-lived token.

The WIF provider + service account are lifted to workflow-level `env` (`WIF_PROVIDER` / `WIF_SERVICE_ACCOUNT`).

## Note vs. the pilot

The pilot moved its build-job login to immediately before the build/push step (late token mint). Here the auth+login stays where the original `Login to GAR` step was, with the token lifetime maxed at the 1h limit. These are single-platform per-matrix builds well under that window. If any build ever runs long, we can move the step later for that workflow.

## Verification / rollout

- Same WIF binding (`taikoxyz/taiko-mono -> gar-github-action@evmchain`) already proven by the pilot smoke test on both `ubuntu-latest` and the self-hosted `arc-runner-set` / arm64 runners.
- These workflows only run on `push` to `main` and their release tags, so each cuts over on merge. Revert = restore the previous `Login to GAR` step; the key is still valid.
- `GAR_JSON_KEY` is intentionally **left in place** as a fallback until all of these are confirmed green on main. Then the `gar-github-action` keys get deleted and its extra `editor` role dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)