### PR TITLE
feat(taiko-client-rs): log preconfirmation peer ticks

### DIFF
--- a/packages/preconfirmation-p2p/crates/net/Cargo.toml
+++ b/packages/preconfirmation-p2p/crates/net/Cargo.toml
@@ -25,8 +25,8 @@ libp2p-allow-block-list.workspace = true
 libp2p-connection-limits.workspace = true
 libp2p-request-response.workspace = true
 once_cell.workspace = true
-prometheus.workspace = true
 preconfirmation-types = { path = "../types" }
+prometheus.workspace = true
 rand.workspace = true
 reth-discv5.workspace = true
 reth-network-types.workspace = true

--- a/packages/preconfirmation-p2p/crates/net/src/command.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/command.rs
@@ -7,6 +7,28 @@ use libp2p::{Multiaddr, PeerId};
 use preconfirmation_types::{Bytes32, RawTxListGossip, SignedCommitment, Uint256};
 use tokio::sync::oneshot;
 
+/// Snapshot of peer state exposed for operator-facing logs and status checks.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PeerInfoSnapshot {
+    /// Local peer ID for this node.
+    pub local_peer_id: PeerId,
+    /// Currently connected peer IDs.
+    pub peers: Vec<PeerId>,
+    /// Known remote addresses for currently connected peers.
+    pub addr_info: Vec<Multiaddr>,
+    /// Current local listening addresses.
+    pub listen_addrs: Vec<Multiaddr>,
+    /// Current externally observed addresses for this swarm.
+    pub external_addrs: Vec<Multiaddr>,
+}
+
+impl PeerInfoSnapshot {
+    /// Return the number of connected peers represented in this snapshot.
+    pub fn peers_len(&self) -> usize {
+        self.peers.len()
+    }
+}
+
 /// Commands the service can issue to the network driver.
 ///
 /// These commands instruct the network layer to perform actions such as publishing
@@ -88,5 +110,10 @@ pub enum NetworkCommand {
     GetPeerCount {
         /// Responder to deliver the peer count.
         respond_to: oneshot::Sender<u64>,
+    },
+    /// Get a snapshot of connected peers and known peer/local addresses.
+    GetPeerInfo {
+        /// Responder to deliver the peer information snapshot.
+        respond_to: oneshot::Sender<PeerInfoSnapshot>,
     },
 }

--- a/packages/preconfirmation-p2p/crates/net/src/driver/behaviour.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/driver/behaviour.rs
@@ -67,8 +67,13 @@ impl NetworkDriver {
             SwarmEvent::NewListenAddr { address, .. } => {
                 let _ = self.events_tx.try_send(NetworkEvent::NewListenAddr(address));
             }
-            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+            SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
                 self.connected_peers += 1;
+                let remote_addr = endpoint.get_remote_address().clone();
+                let addrs = self.peer_addresses.entry(peer_id).or_default();
+                if !addrs.contains(&remote_addr) {
+                    addrs.push(remote_addr);
+                }
                 metrics::set_gauge("p2p_connected_peers", self.connected_peers as f64);
                 if self.reputation.is_banned(&peer_id) {
                     let _ = self.swarm.disconnect_peer_id(peer_id);
@@ -77,6 +82,9 @@ impl NetworkDriver {
             }
             SwarmEvent::ConnectionClosed { peer_id, .. } => {
                 self.connected_peers -= 1;
+                if !self.swarm.is_connected(&peer_id) {
+                    self.peer_addresses.remove(&peer_id);
+                }
                 metrics::set_gauge("p2p_connected_peers", self.connected_peers.max(0) as f64);
                 let _ = self.events_tx.try_send(NetworkEvent::PeerDisconnected(peer_id));
                 self.emit_error(
@@ -204,6 +212,9 @@ impl NetworkDriver {
             }
             NetworkCommand::GetPeerCount { respond_to } => {
                 let _ = respond_to.send(self.connected_peers.max(0) as u64);
+            }
+            NetworkCommand::GetPeerInfo { respond_to } => {
+                let _ = respond_to.send(self.peer_info_snapshot());
             }
         }
     }

--- a/packages/preconfirmation-p2p/crates/net/src/driver/mod.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/driver/mod.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender, error::TrySendError};
 use crate::{
     behaviour::NetBehaviourEvent,
     builder::build_transport_and_behaviour,
-    command::NetworkCommand,
+    command::{NetworkCommand, PeerInfoSnapshot},
     config::NetworkConfig,
     discovery::spawn_discovery,
     event::{NetworkError, NetworkErrorKind, NetworkEvent},
@@ -72,6 +72,8 @@ pub struct NetworkDriver {
     discovery_rx: Option<Receiver<Multiaddr>>,
     /// Counter for currently connected peers.
     connected_peers: i64,
+    /// Known remote addresses for currently connected peers.
+    peer_addresses: HashMap<PeerId, Vec<Multiaddr>>,
     /// The current local preconfirmation head, served to peers on request.
     head: PreconfHead,
     /// Kona connection gater for managing inbound and outbound connections.
@@ -184,6 +186,7 @@ impl NetworkDriver {
                 validator,
                 discovery_rx,
                 connected_peers: 0,
+                peer_addresses: HashMap::new(),
                 head: PreconfHead::default(),
                 kona_gater: build_kona_gater(&cfg),
                 storage: storage.unwrap_or_else(default_storage),
@@ -244,6 +247,26 @@ impl NetworkDriver {
         }
         if ev.is_greylisted && !ev.was_greylisted {
             metrics::inc("p2p_reputation_greylist");
+        }
+    }
+
+    /// Build a point-in-time snapshot of local and connected peer metadata.
+    fn peer_info_snapshot(&self) -> PeerInfoSnapshot {
+        let peers: Vec<_> = self.swarm.connected_peers().copied().collect();
+        let addr_info = peers
+            .iter()
+            .filter_map(|peer| self.peer_addresses.get(peer))
+            .flat_map(|addrs| addrs.iter().cloned())
+            .collect();
+        let listen_addrs = self.swarm.listeners().cloned().collect();
+        let external_addrs = self.swarm.external_addresses().cloned().collect();
+
+        PeerInfoSnapshot {
+            local_peer_id: *self.swarm.local_peer_id(),
+            peers,
+            addr_info,
+            listen_addrs,
+            external_addrs,
         }
     }
 }

--- a/packages/preconfirmation-p2p/crates/net/src/driver/tests.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/driver/tests.rs
@@ -180,6 +180,7 @@ fn driver_from_parts(
             validator: Box::new(LookaheadValidationAdapter::new(None, lookahead)),
             discovery_rx: None,
             connected_peers: 0,
+            peer_addresses: HashMap::new(),
             head: PreconfHead::default(),
             kona_gater: super::build_kona_gater(cfg),
             storage: crate::storage::default_storage(),
@@ -458,6 +459,43 @@ async fn reqresp_errors_when_no_peer_available() {
         panic!("expected req/resp error when no peers available");
     };
     assert_eq!(err.kind, NetworkErrorKind::ReqRespBackpressure);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn peer_info_command_reports_connected_peers_and_local_addresses() {
+    let cfg = NetworkConfig { enable_discovery: false, ..Default::default() };
+    let parts1 = build_memory_parts(cfg.chain_id, &cfg);
+    let parts2 = build_memory_parts(cfg.chain_id, &cfg);
+    let lookahead = Arc::new(StaticLookaheadResolver { signer: alloy_primitives::Address::ZERO });
+    let (mut driver1, handle1) = driver_from_parts(parts1, &cfg, lookahead.clone());
+    let (mut driver2, _handle2) = driver_from_parts(parts2, &cfg, lookahead);
+
+    let peer2_id = *driver2.swarm.local_peer_id();
+    let addr1: Multiaddr = "/memory/1201".parse().unwrap();
+    let mut addr1_full = addr1.clone();
+    addr1_full.push(libp2p::multiaddr::Protocol::P2p(*driver1.swarm.local_peer_id()));
+
+    driver1.swarm.listen_on(addr1.clone()).unwrap();
+    driver2.swarm.dial(addr1_full).unwrap();
+    for _ in 0..200 {
+        pump_async(&mut driver1).await;
+        pump_async(&mut driver2).await;
+        if driver1.swarm.is_connected(&peer2_id) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(driver1.swarm.is_connected(&peer2_id), "peers failed to connect");
+
+    let (tx, rx) = oneshot::channel();
+    handle1.commands.send(NetworkCommand::GetPeerInfo { respond_to: tx }).await.unwrap();
+    pump_async(&mut driver1).await;
+
+    let snapshot = rx.await.expect("peer info response");
+    assert_eq!(snapshot.local_peer_id, *driver1.swarm.local_peer_id());
+    assert_eq!(snapshot.peers_len(), 1);
+    assert_eq!(snapshot.peers, vec![peer2_id]);
+    assert!(snapshot.listen_addrs.contains(&addr1));
 }
 
 /// Local reputation changes are mirrored into gossipsub's app-specific score (spec §7.1),

--- a/packages/preconfirmation-p2p/crates/net/src/handle.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/handle.rs
@@ -14,7 +14,7 @@ use tokio::sync::{
 };
 
 use crate::{
-    command::NetworkCommand,
+    command::{NetworkCommand, PeerInfoSnapshot},
     driver::NetworkHandle,
     event::{NetworkError, NetworkErrorKind, NetworkEvent},
 };
@@ -84,6 +84,18 @@ impl P2pHandle {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.commands
             .send(NetworkCommand::GetPeerCount { respond_to: tx })
+            .await
+            .map_err(|_| NetworkError::new(NetworkErrorKind::Other, "command channel closed"))?;
+        rx.await.map_err(|_| NetworkError::new(NetworkErrorKind::Other, "response channel closed"))
+    }
+
+    /// Get a point-in-time snapshot of connected peers and known peer addresses.
+    ///
+    /// Sends a command to the network driver and awaits the response.
+    pub async fn peer_info(&self) -> Result<PeerInfoSnapshot, NetworkError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.commands
+            .send(NetworkCommand::GetPeerInfo { respond_to: tx })
             .await
             .map_err(|_| NetworkError::new(NetworkErrorKind::Other, "command channel closed"))?;
         rx.await.map_err(|_| NetworkError::new(NetworkErrorKind::Other, "response channel closed"))

--- a/packages/preconfirmation-p2p/crates/net/src/lib.rs
+++ b/packages/preconfirmation-p2p/crates/net/src/lib.rs
@@ -25,7 +25,7 @@ mod reputation;
 mod storage;
 mod validation;
 
-pub use command::NetworkCommand;
+pub use command::{NetworkCommand, PeerInfoSnapshot};
 pub use config::{NetworkConfig, P2pConfig, RateLimitConfig};
 pub use discovery::spawn_discovery;
 pub use driver::{NetworkDriver, NetworkHandle};

--- a/packages/taiko-client-rs/crates/preconfirmation-driver/src/client.rs
+++ b/packages/taiko-client-rs/crates/preconfirmation-driver/src/client.rs
@@ -6,14 +6,21 @@
 //! - Event handling for gossip subscriptions
 //! - Submitting preconfirmation inputs to the driver
 
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
-use tokio::sync::{broadcast, mpsc};
+use tokio::{
+    sync::{broadcast, mpsc, oneshot},
+    time::{self, MissedTickBehavior},
+};
 use tokio_stream::StreamExt;
 use tracing::{info, warn};
 
 use preconfirmation_net::{
-    LocalValidationAdapter, NetworkCommand, P2pHandle, P2pNode, PreconfStorage, ValidationAdapter,
+    LocalValidationAdapter, NetworkCommand, P2pHandle, P2pNode, PeerInfoSnapshot, PreconfStorage,
+    ValidationAdapter,
 };
 use preconfirmation_types::MAX_TXLIST_BYTES;
 use protocol::codec::ZlibTxListCodec;
@@ -30,6 +37,8 @@ use crate::{
 
 /// Capacity for the broadcast event channel used by the client.
 const EVENT_CHANNEL_CAPACITY: usize = 16;
+/// Interval for logging preconfirmation P2P peer state.
+const PEER_LOOP_REPORT_INTERVAL: Duration = Duration::from_secs(30);
 
 /// A ready-to-run client that has completed sync and catchup.
 ///
@@ -59,10 +68,19 @@ where
         let node_handle = &mut self.node_handle;
         let handle = &mut self.handle;
         let handler = &self.handler;
+        let command_tx = handle.command_sender();
+        let mut peer_report_interval = time::interval_at(
+            time::Instant::now() + PEER_LOOP_REPORT_INTERVAL,
+            PEER_LOOP_REPORT_INTERVAL,
+        );
+        peer_report_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         let mut events = handle.events();
         loop {
             tokio::select! {
+                _ = peer_report_interval.tick() => {
+                    log_peer_tick(&command_tx).await;
+                }
                 result = &mut *node_handle => {
                     return Err(PreconfirmationClientError::Network(match result {
                         Ok(Ok(())) => "p2p node exited unexpectedly".to_string(),
@@ -79,6 +97,42 @@ where
                     handler.handle_event(event).await?;
                 }
             }
+        }
+    }
+}
+
+/// Query the P2P network driver for a point-in-time peer information snapshot.
+async fn query_peer_info(command_tx: &mpsc::Sender<NetworkCommand>) -> Result<PeerInfoSnapshot> {
+    let (tx, rx) = oneshot::channel();
+    command_tx.send(NetworkCommand::GetPeerInfo { respond_to: tx }).await.map_err(|_| {
+        PreconfirmationClientError::Network(
+            "peer info query failed: P2P command channel closed".to_string(),
+        )
+    })?;
+
+    rx.await.map_err(|_| {
+        PreconfirmationClientError::Network(
+            "peer info query failed: response channel dropped".to_string(),
+        )
+    })
+}
+
+/// Log connected preconfirmation P2P peer state without interrupting the event loop.
+async fn log_peer_tick(command_tx: &mpsc::Sender<NetworkCommand>) {
+    match query_peer_info(command_tx).await {
+        Ok(snapshot) => {
+            info!(
+                peersLen = snapshot.peers_len(),
+                peers = ?snapshot.peers,
+                addrInfo = ?snapshot.addr_info,
+                id = %snapshot.local_peer_id,
+                listenAddrs = ?snapshot.listen_addrs,
+                externalAddrs = ?snapshot.external_addrs,
+                "Peer tick"
+            );
+        }
+        Err(err) => {
+            warn!(error = %err, "failed to log peer tick");
         }
     }
 }
@@ -276,4 +330,38 @@ where
         .observe(catchup_start.elapsed().as_secs_f64());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use preconfirmation_net::{PeerId, PeerInfoSnapshot};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn query_peer_info_returns_snapshot_from_network_command() {
+        let (command_tx, mut command_rx) = mpsc::channel::<NetworkCommand>(1);
+        let expected = PeerInfoSnapshot {
+            local_peer_id: PeerId::random(),
+            peers: vec![PeerId::random()],
+            addr_info: vec!["/memory/1".parse().unwrap()],
+            listen_addrs: vec!["/memory/2".parse().unwrap()],
+            external_addrs: vec![],
+        };
+        let response = expected.clone();
+
+        let responder = tokio::spawn(async move {
+            match command_rx.recv().await.expect("peer info command") {
+                NetworkCommand::GetPeerInfo { respond_to } => {
+                    respond_to.send(response).expect("send peer info response");
+                }
+                command => panic!("unexpected command: {command:?}"),
+            }
+        });
+
+        let snapshot = query_peer_info(&command_tx).await.expect("peer info snapshot");
+        responder.await.expect("responder task");
+
+        assert_eq!(snapshot, expected);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `Peer tick` log to the Rust preconfirmation driver so operators can inspect connected preconfirmation P2P peers with a shape similar to the Go `taiko-client` peer loop.

The network layer now exposes a `PeerInfoSnapshot` through `NetworkCommand::GetPeerInfo` and `P2pHandle::peer_info()`. The preconfirmation driver event loop queries that snapshot every 30 seconds and logs `peersLen`, `peers`, `addrInfo`, `id`, `listenAddrs`, and `externalAddrs`.

## Motivation

The Go client already prints periodic peer state, but the Rust preconfirmation path did not expose comparable peer visibility. This makes it harder to debug whether a preconfirmation node has live P2P connectivity, what peer IDs are connected, and which addresses are associated with those connections.

## Changes

- Track connected peer remote multiaddrs inside `preconfirmation-net`.
- Add `PeerInfoSnapshot` and a `GetPeerInfo` network command.
- Add a `P2pHandle::peer_info()` helper for callers.
- Log preconfirmation peer snapshots every 30 seconds from the Rust preconfirmation event loop.
- Add a focused network test covering peer snapshot reporting.

## Validation

- `just fmt` in `packages/preconfirmation-p2p`
- `just fmt` in `packages/taiko-client-rs`
- `cargo test -p preconfirmation-net peer_info_command_reports_connected_peers_and_local_addresses`
- `cargo check -p preconfirmation-net`
- `git diff --check`

`cargo test -p preconfirmation-driver query_peer_info_returns_snapshot_from_network_command --lib` was attempted, but local native dependency builds for `librocksdb-sys` / `openssl-sys` did not complete in the available time and were interrupted.
