### PR TITLE
fix(taiko-client): only postpone event sync while chain data is syncing

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker.go
@@ -81,7 +81,7 @@ func (t *SyncProgressTracker) track(ctx context.Context) {
 		return
 	}
 
-	progress, err := t.SyncProgress(ctx)
+	progress, err := t.client.SyncProgress(ctx)
 	if err != nil {
 		log.Error("Get L2 execution engine sync progress error", "error", err)
 		return
@@ -137,11 +137,6 @@ func (t *SyncProgressTracker) track(ctx context.Context) {
 			"timeout", t.timeout,
 		)
 	}
-}
-
-// SyncProgress fetches the L2 execution engine's current sync progress.
-func (t *SyncProgressTracker) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
-	return t.client.SyncProgress(ctx)
 }
 
 // UpdateMeta updates the inner beacon sync metadata.
@@ -244,6 +239,14 @@ func (t *SyncProgressTracker) LastSyncedBlockHash() common.Hash {
 	defer t.mutex.RUnlock()
 
 	return t.lastSyncedBlockHash
+}
+
+// LastSyncProgress returns tracker.lastSyncProgress.
+func (t *SyncProgressTracker) LastSyncProgress() *ethereum.SyncProgress {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
+
+	return t.lastSyncProgress
 }
 
 // syncProgressed checks whether there is any new progress since last sync progress check.

--- a/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker_test.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
@@ -83,6 +84,18 @@ func (s *BeaconSyncProgressTrackerTestSuite) TestLastSyncedVerifiedBlockHash() {
 	randomHash := testutils.RandomHash()
 	s.t.lastSyncedBlockHash = randomHash
 	s.Equal(randomHash, s.t.LastSyncedBlockHash())
+}
+
+func TestLastSyncProgress(t *testing.T) {
+	tracker := NewSyncProgressTracker(nil, time.Hour)
+	require.Nil(t, tracker.LastSyncProgress())
+
+	progress := &ethereum.SyncProgress{CurrentBlock: 1, HighestBlock: 2}
+	tracker.mutex.Lock()
+	tracker.lastSyncProgress = progress
+	tracker.mutex.Unlock()
+
+	require.Equal(t, progress, tracker.LastSyncProgress())
 }
 
 func TestBeaconSyncProgressTrackerTestSuite(t *testing.T) {

--- a/packages/taiko-client/driver/chain_syncer/beaconsync/syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/syncer.go
@@ -43,7 +43,7 @@ func (s *Syncer) TriggerBeaconSync(blockID uint64) error {
 		return nil
 	}
 
-	if s.progressTracker.Triggered() && s.progressTracker.lastSyncProgress == nil {
+	if s.progressTracker.Triggered() && s.progressTracker.LastSyncProgress() == nil {
 		log.Info(
 			"Syncing beacon headers, please check L2 execution engine logs for progress",
 			"currentSyncHead", s.progressTracker.LastSyncedBlockID(),

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -188,6 +188,9 @@ func shouldEnablePreconfImports(headL1OriginWritten bool, nextProposalID *big.In
 // `eth_syncing` also stays non-nil during the post-sync transaction / state index backfill
 // (`SyncProgress.Done` requires both indexes to finish), but chain data is already complete
 // then and event synchronization is safe to start, so index-only progress does not count.
+// The legacy fast-sync fields (`PulledStates` / `KnownStates`) are deliberately ignored:
+// they have been dead since go-ethereum v1.10 and taiko-geth's `eth_syncing` response
+// never populates them.
 func chainDataStillSyncing(progress *ethereum.SyncProgress) bool {
 	if progress == nil {
 		return false

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -99,13 +99,19 @@ func (s *L2ChainSyncer) Sync() error {
 		return nil
 	}
 
+	// If we have triggered a beacon sync and the L2 execution engine is still catching up
+	// on chain data, postpone event synchronization until it finishes. Index-only progress
+	// (see chainDataStillSyncing) does not postpone.
 	if s.progressTracker.Triggered() && !s.progressTracker.Finished() && !s.progressTracker.OutOfSync() {
-		progress, err := s.progressTracker.SyncProgress(s.ctx)
+		progress, err := s.rpc.L2.SyncProgress(s.ctx)
 		if err != nil {
 			return fmt.Errorf("failed to fetch L2 execution engine sync progress: %w", err)
 		}
-		if progress != nil {
-			log.Info("L2 execution engine is still syncing, postpone event synchronization", "progress", progress)
+		if chainDataStillSyncing(progress) {
+			log.Info(
+				"L2 execution engine is still syncing chain data, postpone event synchronization",
+				"progress", progress,
+			)
 			return nil
 		}
 	}
@@ -175,6 +181,20 @@ func (s *L2ChainSyncer) Sync() error {
 // shouldEnablePreconfImports reports whether preconf imports can open after beacon sync.
 func shouldEnablePreconfImports(headL1OriginWritten bool, nextProposalID *big.Int) bool {
 	return headL1OriginWritten || (nextProposalID != nil && nextProposalID.Cmp(common.Big1) <= 0)
+}
+
+// chainDataStillSyncing reports whether the given sync progress indicates the L2 execution
+// engine is still downloading or executing chain data (block download or state healing).
+// `eth_syncing` also stays non-nil during the post-sync transaction / state index backfill
+// (`SyncProgress.Done` requires both indexes to finish), but chain data is already complete
+// then and event synchronization is safe to start, so index-only progress does not count.
+func chainDataStillSyncing(progress *ethereum.SyncProgress) bool {
+	if progress == nil {
+		return false
+	}
+	return progress.CurrentBlock < progress.HighestBlock ||
+		progress.HealingTrienodes > 0 ||
+		progress.HealingBytecode > 0
 }
 
 // SetUpEventSync resets the L1Current cursor to the latest L2 execution engine's chain head.

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -111,6 +112,36 @@ func (s *ChainSyncerTestSuite) TestSync() {
 	s.Nil(s.s.Sync())
 }
 
+func TestChainDataStillSyncing(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress *ethereum.SyncProgress
+		want     bool
+	}{
+		{"notSyncing", nil, false},
+		{"blockDownloadInProgress", &ethereum.SyncProgress{CurrentBlock: 1, HighestBlock: 2}, true},
+		{"stateHealInProgress", &ethereum.SyncProgress{CurrentBlock: 2, HighestBlock: 2, HealingTrienodes: 5}, true},
+		{"bytecodeHealInProgress", &ethereum.SyncProgress{CurrentBlock: 2, HighestBlock: 2, HealingBytecode: 1}, true},
+		{
+			"txIndexBackfillOnly",
+			&ethereum.SyncProgress{CurrentBlock: 2, HighestBlock: 2, TxIndexRemainingBlocks: 100},
+			false,
+		},
+		{
+			"stateIndexBackfillOnly",
+			&ethereum.SyncProgress{CurrentBlock: 2, HighestBlock: 2, StateIndexRemaining: 7},
+			false,
+		},
+		{"chainDataComplete", &ethereum.SyncProgress{CurrentBlock: 2, HighestBlock: 2}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, chainDataStillSyncing(tt.progress))
+		})
+	}
+}
+
 func TestSyncPostponesEventSyncWhileExecutionEngineSyncing(t *testing.T) {
 	l2Client := newSyncingEthClient(t)
 	tracker := beaconsync.NewSyncProgressTracker(l2Client, time.Hour)
@@ -118,6 +149,7 @@ func TestSyncPostponesEventSyncWhileExecutionEngineSyncing(t *testing.T) {
 
 	syncer := &L2ChainSyncer{
 		ctx:             context.Background(),
+		rpc:             &rpc.Client{L2: l2Client},
 		progressTracker: tracker,
 	}
 
@@ -131,14 +163,18 @@ func TestSyncPostponesEventSyncWhileExecutionEngineSyncing(t *testing.T) {
 func newSyncingEthClient(t *testing.T) *rpc.EthClient {
 	t.Helper()
 
+	// NOTE: the handler runs on the HTTP server's goroutine, where t.Fatalf / require
+	// (testing.T.FailNow) must not be used; report failures with t.Errorf instead.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Helper()
-
 		var req struct {
 			ID     json.RawMessage `json:"id"`
 			Method string          `json:"method"`
 		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode RPC request: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
 		var result any
 		switch req.Method {
@@ -151,14 +187,18 @@ func newSyncingEthClient(t *testing.T) *rpc.EthClient {
 				"highestBlock":  "0x2",
 			}
 		default:
-			t.Fatalf("unexpected RPC method: %s", req.Method)
+			t.Errorf("unexpected RPC method: %s", req.Method)
+			http.Error(w, "unexpected RPC method", http.StatusInternalServerError)
+			return
 		}
 
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+		if err := json.NewEncoder(w).Encode(map[string]any{
 			"jsonrpc": "2.0",
 			"id":      req.ID,
 			"result":  result,
-		}))
+		}); err != nil {
+			t.Errorf("failed to encode RPC response: %v", err)
+		}
 	}))
 	t.Cleanup(server.Close)
 


### PR DESCRIPTION
## Summary

Follow-up to #21877, which added a gate that postpones the beacon→event sync handoff while the L2 execution engine reports `eth_syncing` progress. That gate treats **any** non-nil progress as "still syncing", but in the pinned taiko-geth (`v1.18.1-0.20260612`), `SyncProgress.Done()` also requires the post-sync **transaction / state index backfills** to finish (`interfaces.go`: `TxIndexRemainingBlocks == 0 && StateIndexRemaining == 0`). During that backfill tail the chain data is already complete and event sync is safe to start, yet the gate keeps postponing:

- On a quiet chain, event sync (and preconf `SetSyncReady(true)`) is delayed until the `--p2p.syncTimeout` (default **1h**) `outOfSync` escape fires — with a misleading "L2 execution engine is not able to sync through P2P" warning.
- On a busy chain it is **unbounded**: every ≥2-block checkpoint advance re-triggers a beacon hop, which advances `CurrentBlock`, which `syncProgressed()` counts as progress and resets the stall clock — so the postpone lasts the entire index backfill (potentially hours on a fresh sync), with preconf ingestion disabled throughout.

## Changes

1. **Narrow the postpone predicate** (`chainDataStillSyncing`): postpone only while chain data is genuinely incomplete — `CurrentBlock < HighestBlock` or state-heal fields pending. Index-only progress no longer postpones, restoring the immediate handoff at the (deliberate) `heightToSync-1` point once chain data is in. Note geth guarantees state availability at `CurrentBlock`, so proceeding during the index tail cannot read missing state.
2. **Remove the lock-free `SyncProgressTracker.SyncProgress` pass-through.** It was the only exported method on the mutex-guarded type that takes no lock, and it was called from `track()` **while the write lock is held** and from `Sync()` without it — the next "add the missing lock" sweep (exactly what #21877 did for `MarkFinished`/`Finished`) would self-deadlock the Track loop. `Sync()` now uses `s.rpc.L2.SyncProgress` directly (`s.rpc.L2` is the same `*rpc.EthClient` instance the tracker wraps).
3. **Add a mutex-guarded `LastSyncProgress()` accessor** and use it in `TriggerBeaconSync`, removing the last unsynchronized read of tracker state (`lastSyncProgress` is written under the mutex by `track()` every 12s; the raw read was a data race under the Go memory model).
4. **Test hygiene:** the mock RPC server's handler no longer calls `require` / `t.Fatalf` from the server's connection goroutine (`testing.T.FailNow` must run on the test goroutine); failures are reported with `t.Errorf` + `http.Error`.

## Not addressed (known limitation, unchanged from #21877)

The gate remains process-local and one-shot: a driver restart during the sync tail bypasses it (`Triggered()` is in-memory), and a sticky `outOfSync` bypasses it permanently (`finished` is never reset). Since geth's `CurrentBlock` invariants make the bypassed window benign for head state, this is left as-is rather than growing the gate's scope.

## Validation

- `go test ./driver/chain_syncer ./driver/chain_syncer/beaconsync -run 'TestChainDataStillSyncing|TestSyncPostponesEventSyncWhileExecutionEngineSyncing|TestShouldEnablePreconfImportsAfterEventSync|TestLastSyncProgress' -count=1` — pass
- Same targeted tests under `-race` — pass
- `go test ./driver/chain_syncer -run '^$'` / `./driver/chain_syncer/beaconsync -run '^$'` — suites compile
- `golangci-lint run driver/chain_syncer/...` — 0 issues

(The suite-based integration tests require the local test-chain env, same as noted in #21877.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)