### PR TITLE
fix(relayer): floor profitability estimate tip at MinTipCap

### DIFF
--- a/packages/relayer/fees.go
+++ b/packages/relayer/fees.go
@@ -1,5 +1,7 @@
 package relayer
 
+import "math/big"
+
 // PaddedMessageGasLimit returns the relayer gas limit after applying recipient padding.
 func PaddedMessageGasLimit(messageGasLimit uint64, isContractRecipient bool) uint64 {
 	multiplier := uint64(105)
@@ -8,4 +10,19 @@ func PaddedMessageGasLimit(messageGasLimit uint64, isContractRecipient bool) uin
 	}
 
 	return (messageGasLimit*multiplier + 99) / 100
+}
+
+// EffectiveGasTipCap returns the gas tip cap the transaction manager will
+// actually use when sending a transaction: the suggested tip, floored at the
+// configured minimum tip cap. The profitability estimate must use this same
+// value; otherwise it under-counts the tip whenever the suggested tip is below
+// the minimum (common on L2, where the suggested tip sits near zero), which
+// surfaces as false "unprofitable after transacting" events. A nil minTipCap
+// applies no floor.
+func EffectiveGasTipCap(suggestedTipCap, minTipCap *big.Int) *big.Int {
+	if minTipCap != nil && suggestedTipCap.Cmp(minTipCap) < 0 {
+		return new(big.Int).Set(minTipCap)
+	}
+
+	return suggestedTipCap
 }

--- a/packages/relayer/fees_test.go
+++ b/packages/relayer/fees_test.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,4 +10,33 @@ import (
 func TestPaddedMessageGasLimit(t *testing.T) {
 	assert.Equal(t, uint64(846990), PaddedMessageGasLimit(806657, false))
 	assert.Equal(t, uint64(1446896), PaddedMessageGasLimit(1315360, true))
+}
+
+func TestEffectiveGasTipCap(t *testing.T) {
+	// A suggested tip below the minimum is raised to the minimum, matching how
+	// the tx manager floors the tip before sending. This is the case that caused
+	// false "unprofitable after transacting" events on L2, where the suggested
+	// tip (~0.003 gwei) sits below the 0.01 gwei MinTipCap the tx manager pays.
+	assert.Equal(t,
+		big.NewInt(10_000_000),
+		EffectiveGasTipCap(big.NewInt(3_461_844), big.NewInt(10_000_000)),
+	)
+
+	// A suggested tip above the minimum is used unchanged.
+	assert.Equal(t,
+		big.NewInt(2_000_000_000),
+		EffectiveGasTipCap(big.NewInt(2_000_000_000), big.NewInt(1_000_000_000)),
+	)
+
+	// A suggested tip equal to the minimum is used unchanged.
+	assert.Equal(t,
+		big.NewInt(1_000_000_000),
+		EffectiveGasTipCap(big.NewInt(1_000_000_000), big.NewInt(1_000_000_000)),
+	)
+
+	// A nil minimum applies no floor (e.g. when no tx manager config is set).
+	assert.Equal(t,
+		big.NewInt(5),
+		EffectiveGasTipCap(big.NewInt(5), nil),
+	)
 }

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -339,6 +339,12 @@ func (p *Processor) sendProcessMessageCall(
 		return nil, err
 	}
 
+	// The tx manager floors the tip at its configured MinTipCap before sending,
+	// so use that same effective tip in the profitability estimate below.
+	// Otherwise the estimate under-counts the tip whenever the suggested tip is
+	// below MinTipCap, producing false "unprofitable after transacting" events.
+	gasTipCap = relayer.EffectiveGasTipCap(gasTipCap, p.minTipCap)
+
 	data, err := encoding.BridgeABI.Pack("processMessage", event.Message, proof)
 	if err != nil {
 		return nil, err

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	txmgrMetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 	"github.com/ethereum/go-ethereum"
@@ -118,6 +119,11 @@ type Processor struct {
 	processingTxHashMu sync.Mutex
 
 	minFeeToProcess uint64
+
+	// minTipCap is the minimum tip cap (in wei) the tx manager enforces when
+	// sending transactions. The profitability estimate floors the suggested tip
+	// at this value so it reflects what the tx manager actually pays.
+	minTipCap *big.Int
 }
 
 // InitFromCli creates a new processor from a cli context
@@ -267,6 +273,15 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 	); err != nil {
 		return err
 	}
+
+	// Mirror the tx manager's minimum tip cap so the profitability estimate can
+	// floor the suggested tip at the same value the tx manager will pay.
+	minTipCap, err := eth.GweiToWei(cfg.TxmgrConfigs.MinTipCapGwei)
+	if err != nil {
+		return err
+	}
+
+	p.minTipCap = minTipCap
 
 	p.prover = prover
 	p.eventRepo = eventRepository


### PR DESCRIPTION
## Problem

The mainnet Grafana alert **"Relayer Processor Unprofitable After Transacting"** (`increase(unprofitable_message_after_transacting_ops_total[15m]) > 0`) fires intermittently, warning that the relayer "may be underpricing transaction costs / gas estimation."

Investigation showed the alert is a **false positive** driven by an estimator/sender mismatch, not real underpricing:

- The counter is only emitted by the **L1→L2 processor** (`profitableOnly: true`), whose destination is **L2**, where the base fee sits at its `0.01 gwei` floor.
- The profitability estimate (`estimatedMaxCost`, and the `isProfitable` gate) prices the tip using `SuggestGasTipCap` (~`0.003 gwei` on L2).
- But the OP-Stack tx manager **floors the tip at `MinTipCap`** (`0.01 gwei` in mainnet config; see `templates/deployment/relayer-processor.yaml`) before sending — see `op-service/txmgr/txmgr.go` (`tip = new(big.Int).Set(minTipCap)`).

So the estimate under-counts the tip. Normally the estimate's 2× base-fee buffer masks it, but when the suggested tip is below the floor and the sampled base fee dips slightly, the realized `EffectiveGasPrice` (`baseFee + MinTipCap`) edges ~1–2% above `estimatedMaxCost`, ticking the counter. Measured over a 6h window: **157/159 txs profitable, 2 "unprofitable", combined overage ≈ 0.00000054 ETH (~$0.001)** — and that's vs. the internal estimate, which is ≤ the user's fee by construction, so no real loss.

## Fix

Make the estimate honest about the tip the tx manager will actually pay:

- Add `relayer.EffectiveGasTipCap(suggestedTipCap, minTipCap)` — returns the suggested tip floored at `MinTipCap` (mirrors the tx manager's logic; nil `minTipCap` applies no floor).
- Precompute `p.minTipCap` in the processor from `TxmgrConfigs.MinTipCapGwei` (via `eth.GweiToWei`).
- Apply the floor once in `sendProcessMessageCall`, right after `SuggestGasTipCap`, so **both** the `isProfitable` gate and `estimatedMaxCost` use the effective tip.

Net effect: `estimatedMaxCost` now reflects the tip actually paid, eliminating the spurious increments. The gate becomes marginally stricter (it requires the fee to cover the real, floored tip), which is the correct behavior. Economic impact is negligible in either direction; this is about alert fidelity.

## Testing

- New `TestEffectiveGasTipCap` (TDD: written first, watched fail, then implemented) — floor applied below min, passthrough at/above min, nil-floor case.
- Full `relayer` and `relayer/processor` suites pass (incl. `Test_isProfitable`, `Test_sendProcessMessageCall`, `Test_ProcessMessage_unprofitable`); `go build`, `go vet`, `gofmt` clean.

## Follow-ups (not in this PR)

- The alert threshold (`> 0` over 15m) is very sensitive; consider a small threshold or a ratio so single sub-cent events don't page.
- `MIN_BASE_FEE` is left at its `1 gwei` default (10000× the real L2 base fee). Harmless today (it only raises the fee *cap*, not the paid price), but worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)