### PR TITLE
chore(taiko-client): harden driver restarts in the beacon-sync handover window

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -41,8 +41,12 @@ type L2ChainSyncer struct {
 	// the latest verified block head
 	p2pSync bool
 
-	// True after a beacon sync trigger until the first event sync writes head L1 origin.
-	postBeaconSyncPending bool
+	// True while preconfirmation block imports must stay disabled: from process start and
+	// from each beacon sync trigger, until event synchronization establishes a safe base
+	// (head L1 origin written, or no proposal created yet). Starting as true keeps the gate
+	// closed across driver restarts that land between a beacon sync and the first event
+	// sync insertion, when the L1 origin base is still missing.
+	preconfImportsPending bool
 }
 
 // New creates a new chain syncer instance.
@@ -65,13 +69,14 @@ func New(
 	}
 
 	return &L2ChainSyncer{
-		ctx:             ctx,
-		rpc:             rpc,
-		state:           state,
-		beaconSyncer:    beaconSyncer,
-		eventSyncer:     eventSyncer,
-		progressTracker: tracker,
-		p2pSync:         p2pSync,
+		ctx:                   ctx,
+		rpc:                   rpc,
+		state:                 state,
+		beaconSyncer:          beaconSyncer,
+		eventSyncer:           eventSyncer,
+		progressTracker:       tracker,
+		p2pSync:               p2pSync,
+		preconfImportsPending: true,
 	}, nil
 }
 
@@ -91,7 +96,7 @@ func (s *L2ChainSyncer) Sync() error {
 			log.Info("Mark preconfirmation block server as not ready to insert blocks")
 			s.preconfBlockServer.SetSyncReady(false)
 		}
-		s.postBeaconSyncPending = true
+		s.preconfImportsPending = true
 		if err := s.beaconSyncer.TriggerBeaconSync(blockIDToSync); err != nil {
 			return fmt.Errorf("trigger beacon sync error: %w", err)
 		}
@@ -134,22 +139,17 @@ func (s *L2ChainSyncer) Sync() error {
 		}
 	}
 
-	// Mark the preconfirmation block server as ready to insert blocks unless we are
-	// waiting for the first event sync to establish head L1 origin after beacon sync.
-	if s.preconfBlockServer != nil && !s.postBeaconSyncPending {
-		log.Info("Mark preconfirmation block server as ready to insert blocks")
-		s.preconfBlockServer.SetSyncReady(true)
-	}
-
 	// Insert the proposed proposals one by one.
 	if err := s.eventSyncer.ProcessL1Blocks(s.ctx); err != nil {
 		return err
 	}
 
-	// After beacon sync, enable preconf imports once event sync has established a safe base:
-	// either head L1 origin has been written, or no proposal has been created yet.
-	// This avoids importing cached forks before the L1 origin base exists for non-genesis chains.
-	if s.preconfBlockServer != nil && s.postBeaconSyncPending {
+	// Enable preconf imports once event sync has established a safe base: either head
+	// L1 origin has been written, or no proposal has been created yet. This avoids
+	// importing cached forks before the L1 origin base exists for non-genesis chains.
+	// The gate holds from process start and from each beacon sync trigger, so it is
+	// checked here, after event synchronization, rather than enabling unconditionally.
+	if s.preconfBlockServer != nil && s.preconfImportsPending {
 		headL1Origin, err := s.rpc.L2.HeadL1Origin(s.ctx)
 		if err != nil && err.Error() != ethereum.NotFound.Error() {
 			return fmt.Errorf("failed to fetch head L1 origin after event sync: %w", err)
@@ -170,7 +170,7 @@ func (s *L2ChainSyncer) Sync() error {
 			if err := s.preconfBlockServer.ImportPendingBlocksFromCache(s.ctx); err != nil {
 				log.Warn("Failed to import pending preconfirmation blocks from cache, skip the import", "error", err)
 			}
-			s.postBeaconSyncPending = false
+			s.preconfImportsPending = false
 		} else {
 			log.Info("Head L1 origin not set after event sync, keep preconf imports disabled")
 		}
@@ -178,7 +178,7 @@ func (s *L2ChainSyncer) Sync() error {
 	return nil
 }
 
-// shouldEnablePreconfImports reports whether preconf imports can open after beacon sync.
+// shouldEnablePreconfImports reports whether preconf imports can open after event synchronization.
 func shouldEnablePreconfImports(headL1OriginWritten bool, nextProposalID *big.Int) bool {
 	return headL1OriginWritten || (nextProposalID != nil && nextProposalID.Cmp(common.Big1) <= 0)
 }

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -108,6 +108,13 @@ func (s *ChainSyncerTestSuite) TestGetInnerSyncers() {
 	s.NotNil(s.s.EventSyncer())
 }
 
+func (s *ChainSyncerTestSuite) TestPreconfImportsPendingOnStart() {
+	// The preconf import gate must start closed, so that a driver restart landing
+	// between a beacon sync and the first event sync insertion can not re-open
+	// imports while the head L1 origin base is still missing.
+	s.True(s.s.preconfImportsPending)
+}
+
 func (s *ChainSyncerTestSuite) TestSync() {
 	s.Nil(s.s.Sync())
 }

--- a/packages/taiko-client/driver/state/state.go
+++ b/packages/taiko-client/driver/state/state.go
@@ -111,6 +111,9 @@ func (s *State) initL1Current(ctx context.Context, l2Head *types.Header) error {
 	// restart before the first event sync insertion, or a snapshot restore without
 	// L1Origin data). Derive the cursor from the head block's anchor instead of falling
 	// back to the activation block, which would rescan the whole proposal history.
+	// A preconfirmation-tip head is safe here: preconfirmation blocks carry the same
+	// Shasta extra-data layout, proposal IDs <= 1 resolve to the activation block inside
+	// ResetL1Current, and any derivation failure falls through to the previous fallback.
 	if headL1Origin == nil && l2Head.Number.Sign() > 0 {
 		resetErr := s.ResetL1Current(ctx, l2Head.Number)
 		if resetErr == nil {

--- a/packages/taiko-client/driver/state/state.go
+++ b/packages/taiko-client/driver/state/state.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -74,13 +75,6 @@ func (s *State) init(ctx context.Context) error {
 
 	log.Info("Genesis L1 height", "height", s.GenesisL1Height)
 
-	// Set the L2 head's latest known L1 origin as current L1 sync cursor.
-	latestL2KnownL1Header, err := s.rpc.LatestL2KnownL1Header(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get latest L2 known L1 header: %w", err)
-	}
-	s.l1Current.Store(latestL2KnownL1Header)
-
 	// L1 head
 	l1Head, err := s.rpc.L1.HeaderByNumber(ctx, nil)
 	if err != nil {
@@ -96,6 +90,44 @@ func (s *State) init(ctx context.Context) error {
 
 	log.Info("L2 execution engine head", "blockID", l2Head.Number, "hash", l2Head.Hash())
 	s.setL2Head(l2Head)
+
+	// Set the L2 head's latest known L1 origin as current L1 sync cursor.
+	if err := s.initL1Current(ctx, l2Head); err != nil {
+		return fmt.Errorf("failed to initialize L1 current cursor: %w", err)
+	}
+
+	return nil
+}
+
+// initL1Current initializes the L1 current cursor from the L2 head's latest known L1 origin.
+func (s *State) initL1Current(ctx context.Context, l2Head *types.Header) error {
+	headL1Origin, err := s.rpc.L2.HeadL1Origin(ctx)
+	if err != nil && err.Error() != ethereum.NotFound.Error() {
+		return fmt.Errorf("failed to get head L1 origin: %w", err)
+	}
+
+	// The L2 chain is non-empty but has no head L1 origin recorded: the execution engine
+	// was synced without the driver writing L1 origins (a beacon sync interrupted by a
+	// restart before the first event sync insertion, or a snapshot restore without
+	// L1Origin data). Derive the cursor from the head block's anchor instead of falling
+	// back to the activation block, which would rescan the whole proposal history.
+	if headL1Origin == nil && l2Head.Number.Sign() > 0 {
+		resetErr := s.ResetL1Current(ctx, l2Head.Number)
+		if resetErr == nil {
+			return nil
+		}
+		log.Warn(
+			"Failed to derive the L1 current cursor from the L2 head, use the last known L1 origin instead",
+			"l2Head", l2Head.Number,
+			"error", resetErr,
+		)
+	}
+
+	latestL2KnownL1Header, err := s.rpc.LatestL2KnownL1Header(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get latest L2 known L1 header: %w", err)
+	}
+	s.l1Current.Store(latestL2KnownL1Header)
 
 	return nil
 }

--- a/packages/taiko-client/driver/state/state_test.go
+++ b/packages/taiko-client/driver/state/state_test.go
@@ -58,6 +58,13 @@ func (s *DriverStateTestSuite) TestSubL1HeadsFeed() {
 	s.NotNil(s.s.SubL1HeadsFeed(make(chan *types.Header)))
 }
 
+func (s *DriverStateTestSuite) TestInitL1Current() {
+	l2Head, err := s.RPCClient.L2.HeaderByNumber(s.ctx, nil)
+	s.Nil(err)
+	s.Nil(s.s.initL1Current(s.ctx, l2Head))
+	s.NotNil(s.s.GetL1Current())
+}
+
 func (s *DriverStateTestSuite) TestNewDriverContextErr() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## The window

After a beacon sync finishes, the driver hands over to event sync: `SetUpEventSync` repositions the L1 cursor, and the first re-processed proposal writes the L1Origins / `HeadL1Origin` that the freshly P2P-synced execution engine is missing. Until that first insertion lands, the node's `HeadL1Origin` is nil and all of the driver's recovery state (`progressTracker.triggered`, `postBeaconSyncPending`) is in-memory only.

A driver restart landing inside that window — or an EE synced out-of-band (snapshot restore without L1Origin data) — hit two holes:

## Fix 1: L1 cursor no longer falls back to the activation block

`state.init` → `LatestL2KnownL1Header` fell back to the **activation block** when `HeadL1Origin` was absent, and since the fresh tracker has `Triggered()==false`, nothing repositioned the cursor afterwards. `ProcessL1Blocks` then re-scanned every `Proposed` event since activation and re-derived every proposal — hours of backfill on mainnet for a chain whose data is already fully synced.

`state.initL1Current` now derives the cursor from the head block itself (proposal ID from extra-data → `LastBlockIDByBatchID(P-1)` → anchor), i.e. the exact path `SetUpEventSync`/`ResetL1Current` already uses after an in-process beacon sync. The activation-block fallback is preserved for genesis-only chains and heads the derivation cannot handle (e.g. pre-Shasta data).

## Fix 2: preconf import gate survives restarts

`postBeaconSyncPending` (added in #21232) kept preconf imports disabled until event sync established a safe base — but it reset to *open* on process start, so a restart in the window called `SetSyncReady(true)` immediately. `InsertPreconfBlockFromEnvelope` skips its canonical-ancestry check exactly when `HeadL1Origin` is nil (that check was written for genesis-only chains, but a freshly beacon-synced chain is in the same state), so gossiped/cached envelopes could be imported with no base validation.

The flag (renamed `preconfImportsPending`) now starts **closed** and opens only after event synchronization confirms the safe base via the existing `shouldEnablePreconfImports` predicate (head L1 origin written, or no proposal created yet). This unifies the two previous enable paths: steady-state nodes pass the predicate on the first Sync tick, brand-new chains still get pre-proposal preconf ingress (#21715 behavior preserved), and the gate can no longer be reopened by a restart while the L1 origin base is missing.

## Testing

- `go build ./...`, `go vet ./driver/...`, `golangci-lint run ./driver/...` — clean.
- Environment-free unit tests in `driver/chain_syncer` pass; added a regression test that the gate starts closed and a smoke test for `initL1Current`.
- The nil-`HeadL1Origin` derivation branch reuses `ResetL1Current`, which is covered by the existing suite; exercising the branch end-to-end needs an EE without L1Origin records, which the devnet harness cannot currently produce — flagging for reviewer attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)