### PR TITLE
fix(taiko-client-rs): survive checkpoint sync handoff and harden the catch-up loop

### DIFF
--- a/packages/taiko-client-rs/bin/client/src/flags/driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/flags/driver.rs
@@ -23,11 +23,13 @@ pub struct DriverArgs {
         help = "HTTP endpoint of the L1 beacon node"
     )]
     pub l1_beacon_endpoint: Url,
-    /// Optional HTTP endpoint of a checkpointed L2 execution engine.
+    /// Optional HTTP endpoint of an L2 execution engine used as an untrusted block-body source
+    /// for checkpoint catch-up; the sync target itself is read from the L1 inbox.
     #[clap(
         long = "l2.checkpoint",
         env = "L2_CHECKPOINT",
-        help = "Optional HTTP endpoint of a checkpointed L2 execution engine"
+        help = "Optional HTTP endpoint of an L2 execution engine used as an untrusted \
+                block-body source for checkpoint catch-up"
     )]
     pub l2_checkpoint_endpoint: Option<Url>,
     /// Optional HTTP endpoint of a blob server to use as fallback.

--- a/packages/taiko-client-rs/crates/driver/src/config.rs
+++ b/packages/taiko-client-rs/crates/driver/src/config.rs
@@ -14,7 +14,7 @@ pub struct DriverConfig {
     pub retry_interval: Duration,
     /// L1 beacon endpoint used for lookahead / slot metadata.
     pub l1_beacon_endpoint: Url,
-    /// Optional L2 checkpoint endpoint used for beacon sync.
+    /// Optional L2 checkpoint endpoint used as an untrusted block-body source for beacon sync.
     pub l2_checkpoint_url: Option<Url>,
     /// Optional blob server endpoint used when beacon blobs are unavailable.
     pub blob_server_endpoint: Option<Url>,

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -294,7 +294,8 @@ where
     /// Load the parent L2 block used as context when constructing payload attributes.
     ///
     /// Preference is given to the execution engine's cached origin pointer for the proposal.
-    /// If unavailable, fall back to the latest canonical block.
+    /// If unavailable, fall back to the batch-to-block mapping so derivation always anchors to
+    /// the last execution block of the preceding proposal.
     #[instrument(skip(self), fields(proposal_id), level = "debug")]
     async fn load_parent_block(
         &self,

--- a/packages/taiko-client-rs/crates/driver/src/metrics.rs
+++ b/packages/taiko-client-rs/crates/driver/src/metrics.rs
@@ -166,9 +166,9 @@ static METRICS: Lazy<DriverMetricHandles> = Lazy::new(DriverMetricHandles::new);
 struct DriverMetricHandles {
     /// Latest L2 head observed on the execution engine during beacon sync.
     beacon_sync_local_head_block: Gauge,
-    /// Checkpoint node head height.
+    /// Proof-finalized sync target block height read from the L1 inbox.
     beacon_sync_checkpoint_head_block: Gauge,
-    /// Delta between checkpoint and local heads.
+    /// Delta between the sync target and the local head.
     beacon_sync_head_lag_blocks: Gauge,
     /// Submitted checkpoint blocks.
     beacon_sync_remote_submissions_total: IntCounter,
@@ -234,11 +234,11 @@ impl DriverMetricHandles {
             ),
             beacon_sync_checkpoint_head_block: gauge(
                 "driver_beacon_sync_checkpoint_head_block",
-                "Checkpoint node head height sampled during beacon sync",
+                "Proof-finalized sync target block height read from the L1 inbox",
             ),
             beacon_sync_head_lag_blocks: gauge(
                 "driver_beacon_sync_head_lag_blocks",
-                "Checkpoint vs local head lag tracked by beacon sync",
+                "Sync target vs local head lag tracked by beacon sync",
             ),
             beacon_sync_remote_submissions_total: counter(
                 "driver_beacon_sync_remote_submissions_total",

--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -1,11 +1,18 @@
-//! Beacon sync logic.
+//! Checkpoint-assisted execution engine sync toward the proof-finalized L2 block.
+//!
+//! The sync target is read trustlessly from the L1 inbox core state
+//! (`lastFinalizedProposalId` / `lastFinalizedBlockHash`) at the finalized L1 block, so the
+//! target is final on both layers. The optional checkpoint node only serves block bodies:
+//! every fetched block is verified against the L1-recorded hash before submission, and the
+//! execution engine backfills its hash-linked ancestors over P2P.
 
-use std::{borrow::Cow, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use alethia_reth_primitives::engine::types::TaikoExecutionDataSidecar;
 use alloy::providers::Provider;
 use alloy_consensus::{self, Block, TxEnvelope};
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_primitives::B256;
 use alloy_provider::RootProvider;
 use alloy_rpc_types::{Transaction as RpcTransaction, eth::Block as RpcBlock};
 use alloy_rpc_types_engine::{
@@ -15,29 +22,39 @@ use anyhow::anyhow;
 use rpc::{
     client::{Client, connect_http_with_timeout},
     error::RpcClientError,
-    l1_origin::L1Origin,
 };
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::{debug, info, instrument, warn};
 
-use super::{SyncError, SyncStage, checkpoint_resume_head::CheckpointResumeHead};
+use super::{
+    FINALIZED_BLOCK_NOT_FOUND, SyncError, SyncStage, checkpoint_resume_head::CheckpointResumeHead,
+};
 use crate::{config::DriverConfig, error::DriverError, metrics::DriverMetrics};
 
 /// Default polling interval used when no retry interval is configured.
 const DEFAULT_BEACON_SYNC_POLL_INTERVAL: Duration = Duration::from_secs(12);
 
-/// Handles triggering beacon syncs when the L2 execution engine lags behind the protocol head.
+/// Proof-finalized sync target read from the L1 inbox core state.
+#[derive(Debug, Clone, Copy)]
+struct FinalizedSyncTarget {
+    /// Last proposal id finalized by proof on L1.
+    proposal_id: u64,
+    /// L2 block hash recorded on L1 for that finalized proposal.
+    block_hash: B256,
+}
+
+/// Drives the L2 execution engine toward the proof-finalized block recorded on L1.
 pub struct BeaconSyncer<P>
 where
     P: Provider + Clone,
 {
     /// Interval between beacon sync retries.
     retry_interval: Duration,
-    /// RPC client used for local node engine and chain calls.
+    /// RPC client used for L1 inbox reads and local engine calls.
     rpc: Client<P>,
-    /// Optional checkpoint provider used for remote catch-up blocks.
+    /// Optional untrusted provider used to fetch catch-up block bodies.
     checkpoint: Option<RootProvider>,
-    /// Shared checkpoint head used to resume event sync after beacon sync.
+    /// Shared resume head consumed by event sync after this stage completes.
     checkpoint_resume_head: Arc<CheckpointResumeHead>,
 }
 
@@ -58,33 +75,48 @@ where
         Self { retry_interval: config.retry_interval, rpc, checkpoint, checkpoint_resume_head }
     }
 
-    /// Query the checkpoint node for its head L1 origin block number.
+    /// Read the proof-finalized sync target from the L1 inbox core state.
+    ///
+    /// The core state is queried at the finalized L1 block so the returned checkpoint cannot be
+    /// reorged away on either layer. Chains without L1 finality yet (fresh devnets) fall back to
+    /// the latest block.
     #[instrument(skip(self), level = "debug")]
-    async fn checkpoint_head(&self) -> Result<Option<u64>, RpcClientError> {
-        let Some(provider) = &self.checkpoint else {
-            debug!("checkpoint provider not configured");
-            return Ok(None);
+    async fn finalized_sync_target(&self) -> Result<FinalizedSyncTarget, SyncError> {
+        let core_state = match self
+            .rpc
+            .shasta
+            .inbox
+            .getCoreState()
+            .block(BlockId::Number(BlockNumberOrTag::Finalized))
+            .call()
+            .await
+        {
+            Ok(core_state) => core_state,
+            Err(err) if err.to_string().contains(FINALIZED_BLOCK_NOT_FOUND) => self
+                .rpc
+                .shasta
+                .inbox
+                .getCoreState()
+                .call()
+                .await
+                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?,
+            Err(err) => return Err(SyncError::Rpc(RpcClientError::Provider(err.to_string()))),
         };
 
-        let response: Option<L1Origin> = provider
-            .raw_request(Cow::Borrowed("taiko_headL1Origin"), ())
-            .await
-            .map_err(RpcClientError::from)?;
-
-        let head = response.map(|origin| origin.block_id.to::<u64>());
-        debug!(?head, "queried checkpoint head");
-        Ok(head)
+        Ok(FinalizedSyncTarget {
+            proposal_id: core_state.lastFinalizedProposalId.to::<u64>(),
+            block_hash: core_state.lastFinalizedBlockHash,
+        })
     }
 
-    /// Submit a block from the checkpoint node to the local execution engine, to start
-    /// a beacon sync.
+    /// Submit a proof-finalized block body to the local execution engine, starting or advancing
+    /// the engine's backfill toward it.
     #[instrument(skip(self, block), level = "debug")]
     async fn submit_remote_block(&self, block: RpcBlock<TxEnvelope>) -> Result<(), DriverError> {
         let block_number = block.header.number;
         let block_hash = block.hash();
         let tx_root = block.header.transactions_root;
         let header_difficulty = block.header.difficulty;
-        let parent_hash = block.header.parent_hash;
         let withdrawals_root = block.header.withdrawals_root;
         debug!(block_number, ?block_hash, "submitting checkpoint block to execution engine");
 
@@ -121,10 +153,12 @@ where
             }
         }
 
+        // The submitted block is proof-finalized on L1 and read at a finalized L1 block, so
+        // advertising it as finalized to the engine is sound.
         let forkchoice_state = ForkchoiceState {
             head_block_hash: block_hash,
             safe_block_hash: block_hash,
-            finalized_block_hash: parent_hash,
+            finalized_block_hash: block_hash,
         };
 
         let forkchoice = self.rpc.engine_forkchoice_updated_v2(forkchoice_state, None).await?;
@@ -161,17 +195,18 @@ fn resolve_checkpoint_forkchoice_status(
     }
 }
 
-/// Convert a checkpoint poll failure into either a fatal startup error or a retryable error.
+/// Convert a beacon-sync poll failure (L1 target read or checkpoint block fetch) into either a
+/// fatal startup error or a retryable error.
 ///
-/// Before the checkpoint node has answered successfully, poll failures indicate a misconfigured
-/// or unreachable checkpoint endpoint and must fail fast. After the first successful answer the
-/// same failures are transient, so the caller logs the returned error and retries on the next
-/// tick instead of aborting a potentially hours-long catch-up.
+/// Before the polled endpoint has answered successfully, failures indicate a misconfigured or
+/// unreachable endpoint and must fail fast. After the first successful answer the same failures
+/// are transient, so the caller logs the returned error and retries on the next tick instead of
+/// aborting a potentially hours-long catch-up.
 fn resolve_checkpoint_poll_error(
-    checkpoint_seen_once: bool,
+    seen_once: bool,
     error: SyncError,
 ) -> Result<SyncError, SyncError> {
-    if checkpoint_seen_once { Ok(error) } else { Err(error) }
+    if seen_once { Ok(error) } else { Err(error) }
 }
 
 #[async_trait::async_trait]
@@ -179,8 +214,8 @@ impl<P> SyncStage for BeaconSyncer<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    /// Run the beacon sync stage, periodically checking the checkpoint node and submitting
-    /// missing blocks to the local execution engine.
+    /// Run the beacon sync stage, steering the local execution engine toward the proof-finalized
+    /// block recorded on L1 until the local canonical chain contains it.
     #[instrument(skip(self), name = "beacon_syncer_run")]
     async fn run(&self) -> Result<(), SyncError> {
         // Always clear stale state from previous attempts so event sync cannot accidentally
@@ -203,9 +238,10 @@ where
 
         info!(interval_secs = poll_interval.as_secs(), "beacon sync stage started");
 
-        // Flips once the checkpoint node has reported a head, gating fail-fast startup errors
-        // from retryable mid-catch-up errors. The first tick fires immediately, so a
-        // misconfigured endpoint still fails at startup.
+        // Fail-fast gates: each flips once its endpoint has answered successfully, so startup
+        // misconfiguration still aborts while mid-catch-up blips retry. The first tick fires
+        // immediately, preserving fail-fast timing at startup.
+        let mut target_seen_once = false;
         let mut checkpoint_seen_once = false;
 
         loop {
@@ -223,78 +259,124 @@ where
                     }
                 };
 
-            let checkpoint_head = match self.checkpoint_head().await {
-                Ok(Some(head)) => {
-                    checkpoint_seen_once = true;
-                    head
-                }
-                Ok(None) => {
-                    let err = resolve_checkpoint_poll_error(
-                        checkpoint_seen_once,
-                        SyncError::CheckpointNoOrigin,
-                    )?;
-                    warn!(error = %err, "checkpoint node reported no L1 origin; retrying");
-                    continue;
+            let target = match self.finalized_sync_target().await {
+                Ok(target) => {
+                    target_seen_once = true;
+                    target
                 }
                 Err(err) => {
-                    let err = resolve_checkpoint_poll_error(
-                        checkpoint_seen_once,
-                        SyncError::CheckpointQuery(err),
-                    )?;
-                    warn!(error = %err, "failed to query checkpoint head; retrying");
+                    let err = resolve_checkpoint_poll_error(target_seen_once, err)?;
+                    warn!(error = %err, "failed to read finalized sync target from L1; retrying");
                     continue;
                 }
             };
-            DriverMetrics::beacon_sync_checkpoint_head_block().set(checkpoint_head as f64);
-            DriverMetrics::beacon_sync_head_lag_blocks()
-                .set(checkpoint_head.saturating_sub(local_head) as f64);
 
-            if checkpoint_head <= local_head {
-                // Persist the checkpoint head we have confirmed local execution is synced to.
-                // Event sync uses this exact value as its authoritative resume source when
-                // checkpoint mode is enabled.
-                self.checkpoint_resume_head.set(checkpoint_head);
-                info!(checkpoint_head, local_head, "local engine at or ahead of checkpoint; done");
+            // A zero hash means the inbox has finalized nothing and recorded no genesis
+            // checkpoint yet; event sync will derive everything from the activation block.
+            if target.block_hash == B256::ZERO {
+                self.checkpoint_resume_head.set(0);
+                info!("no proof-finalized checkpoint on L1 yet; skipping checkpoint catch-up");
                 break Ok(());
             }
 
-            info!(checkpoint_head, local_head, "checkpoint head ahead of local engine; syncing");
-
-            let block = match checkpoint_provider
-                .get_block_by_number(BlockNumberOrTag::Number(checkpoint_head))
-                .full()
-                .await
+            let block = match checkpoint_provider.get_block_by_hash(target.block_hash).full().await
             {
-                Ok(Some(block)) => block.map_transactions(|tx: RpcTransaction| tx.into()),
+                Ok(Some(block)) => {
+                    checkpoint_seen_once = true;
+                    block.map_transactions(|tx: RpcTransaction| tx.into())
+                }
                 Ok(None) => {
-                    warn!(checkpoint_head, "checkpoint node missing its own head block; retrying");
+                    checkpoint_seen_once = true;
+                    warn!(
+                        target_proposal_id = target.proposal_id,
+                        target_hash = ?target.block_hash,
+                        "checkpoint node does not have the finalized target block; retrying"
+                    );
                     continue;
                 }
                 Err(err) => {
+                    let err = resolve_checkpoint_poll_error(
+                        checkpoint_seen_once,
+                        SyncError::CheckpointQuery(RpcClientError::from(err)),
+                    )?;
                     warn!(
-                        checkpoint_head,
                         error = %err,
-                        "failed to fetch checkpoint head block; retrying"
+                        "failed to fetch finalized target block from checkpoint node; retrying"
                     );
                     continue;
                 }
             };
 
+            // Never trust the checkpoint response: the body must hash to the L1-recorded value.
+            // The engine re-checks this on newPayload, but verifying here keeps a lying
+            // checkpoint node a retryable condition instead of a fatal INVALID.
+            if block.header.inner.hash_slow() != target.block_hash {
+                warn!(
+                    target_proposal_id = target.proposal_id,
+                    target_hash = ?target.block_hash,
+                    "checkpoint node returned a block that does not hash to the L1 checkpoint; retrying"
+                );
+                continue;
+            }
+
+            let target_block_number = block.header.number;
+            DriverMetrics::beacon_sync_checkpoint_head_block().set(target_block_number as f64);
+            DriverMetrics::beacon_sync_head_lag_blocks()
+                .set(target_block_number.saturating_sub(local_head) as f64);
+
+            // Done once the local canonical chain contains the finalized target. Checking the
+            // hash at the target height (rather than comparing heights) also catches a local
+            // chain that diverges from the proof-finalized one.
+            match self
+                .rpc
+                .l2_provider
+                .get_block_by_number(BlockNumberOrTag::Number(target_block_number))
+                .await
+            {
+                Ok(Some(local_block)) if local_block.header.hash == target.block_hash => {
+                    // Persist the finalized block number event sync uses as its authoritative
+                    // resume source when checkpoint mode is enabled.
+                    self.checkpoint_resume_head.set(target_block_number);
+                    info!(
+                        target_proposal_id = target.proposal_id,
+                        target_block_number,
+                        target_hash = ?target.block_hash,
+                        local_head,
+                        "local engine contains the proof-finalized target; done"
+                    );
+                    break Ok(());
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    warn!(
+                        target_block_number,
+                        error = %err,
+                        "failed to query local block at finalized target height; retrying"
+                    );
+                    continue;
+                }
+            }
+
+            info!(
+                target_proposal_id = target.proposal_id,
+                target_block_number, local_head, "syncing execution engine toward finalized target"
+            );
+
             match self.submit_remote_block(block).await {
                 Ok(()) => DriverMetrics::beacon_sync_remote_submissions_total().inc(),
-                // An INVALID verdict is not transient: the checkpoint served a block the local
-                // engine rejects, which needs operator attention rather than retries.
+                // An INVALID verdict is not transient: the block hashes to the L1 checkpoint yet
+                // the engine rejects it, which needs operator attention rather than retries.
                 Err(err @ DriverError::EngineInvalidPayload(_)) => {
                     return Err(SyncError::RemoteBlockSubmit {
-                        block_number: checkpoint_head,
+                        block_number: target_block_number,
                         error: err.into(),
                     });
                 }
                 Err(err) => {
                     warn!(
-                        checkpoint_head,
+                        target_block_number,
                         error = %err,
-                        "failed to submit checkpoint block; retrying"
+                        "failed to submit finalized target block; retrying"
                     );
                 }
             }
@@ -328,13 +410,14 @@ mod tests {
 
     #[test]
     fn checkpoint_poll_errors_fail_fast_only_before_first_success() {
+        let sample = || SyncError::CheckpointQuery(RpcClientError::Provider("unreachable".into()));
         assert!(matches!(
-            resolve_checkpoint_poll_error(false, SyncError::CheckpointNoOrigin),
-            Err(SyncError::CheckpointNoOrigin)
+            resolve_checkpoint_poll_error(false, sample()),
+            Err(SyncError::CheckpointQuery(_))
         ));
         assert!(matches!(
-            resolve_checkpoint_poll_error(true, SyncError::CheckpointNoOrigin),
-            Ok(SyncError::CheckpointNoOrigin)
+            resolve_checkpoint_poll_error(true, sample()),
+            Ok(SyncError::CheckpointQuery(_))
         ));
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -2,9 +2,10 @@
 //!
 //! The sync target is read trustlessly from the L1 inbox core state
 //! (`lastFinalizedProposalId` / `lastFinalizedBlockHash`) at the finalized L1 block, so the
-//! target is final on both layers. The optional checkpoint node only serves block bodies:
-//! every fetched block is verified against the L1-recorded hash before submission, and the
-//! execution engine backfills its hash-linked ancestors over P2P.
+//! target is final on both layers. The optional checkpoint node only serves block bodies and is
+//! consulted only when the target body is not already stored locally: every fetched block is
+//! verified against the L1-recorded hash before submission, and the execution engine backfills
+//! its hash-linked ancestors over P2P.
 
 use std::{sync::Arc, time::Duration};
 
@@ -109,10 +110,10 @@ where
         })
     }
 
-    /// Submit a proof-finalized block body to the local execution engine, starting or advancing
-    /// the engine's backfill toward it.
+    /// Submit a proof-finalized block body (from either the local store or the checkpoint node)
+    /// to the execution engine, starting or advancing the engine's backfill toward it.
     #[instrument(skip(self, block), level = "debug")]
-    async fn submit_remote_block(&self, block: RpcBlock<TxEnvelope>) -> Result<(), DriverError> {
+    async fn submit_target_block(&self, block: RpcBlock<TxEnvelope>) -> Result<(), DriverError> {
         let block_number = block.header.number;
         let block_hash = block.hash();
         let tx_root = block.header.transactions_root;
@@ -279,42 +280,64 @@ where
                 break Ok(());
             }
 
-            let block = match checkpoint_provider.get_block_by_hash(target.block_hash).full().await
-            {
-                Ok(Some(block)) => {
-                    checkpoint_seen_once = true;
-                    block.map_transactions(|tx: RpcTransaction| tx.into())
-                }
-                Ok(None) => {
-                    checkpoint_seen_once = true;
-                    warn!(
-                        target_proposal_id = target.proposal_id,
-                        target_hash = ?target.block_hash,
-                        "checkpoint node does not have the finalized target block; retrying"
-                    );
-                    continue;
-                }
-                Err(err) => {
-                    let err = resolve_checkpoint_poll_error(
-                        checkpoint_seen_once,
-                        SyncError::CheckpointQuery(RpcClientError::from(err)),
-                    )?;
-                    warn!(
-                        error = %err,
-                        "failed to fetch finalized target block from checkpoint node; retrying"
-                    );
-                    continue;
-                }
+            // Prefer a locally stored body: after a routine restart the target is usually
+            // already canonical, and any locally available copy keeps this stage independent
+            // of checkpoint availability. Trust comes from hashing to the L1-recorded value,
+            // not from the body's source.
+            let local_body =
+                match self.rpc.l2_provider.get_block_by_hash(target.block_hash).full().await {
+                    Ok(block) => {
+                        block.map(|block| block.map_transactions(|tx: RpcTransaction| tx.into()))
+                    }
+                    Err(err) => {
+                        warn!(
+                            target_hash = ?target.block_hash,
+                            error = %err,
+                            "failed to query local engine for the finalized target body; retrying"
+                        );
+                        continue;
+                    }
+                };
+
+            let block = match local_body {
+                Some(block) => block,
+                None => match checkpoint_provider.get_block_by_hash(target.block_hash).full().await
+                {
+                    Ok(Some(block)) => {
+                        checkpoint_seen_once = true;
+                        block.map_transactions(|tx: RpcTransaction| tx.into())
+                    }
+                    Ok(None) => {
+                        checkpoint_seen_once = true;
+                        warn!(
+                            target_proposal_id = target.proposal_id,
+                            target_hash = ?target.block_hash,
+                            "checkpoint node does not have the finalized target block; retrying"
+                        );
+                        continue;
+                    }
+                    Err(err) => {
+                        let err = resolve_checkpoint_poll_error(
+                            checkpoint_seen_once,
+                            SyncError::CheckpointQuery(RpcClientError::from(err)),
+                        )?;
+                        warn!(
+                            error = %err,
+                            "failed to fetch finalized target block from checkpoint node; retrying"
+                        );
+                        continue;
+                    }
+                },
             };
 
-            // Never trust the checkpoint response: the body must hash to the L1-recorded value.
-            // The engine re-checks this on newPayload, but verifying here keeps a lying
-            // checkpoint node a retryable condition instead of a fatal INVALID.
+            // Never trust the body source: it must hash to the L1-recorded value. The engine
+            // re-checks this on newPayload, but verifying here keeps a bad source a retryable
+            // condition instead of a fatal INVALID.
             if block.header.inner.hash_slow() != target.block_hash {
                 warn!(
                     target_proposal_id = target.proposal_id,
                     target_hash = ?target.block_hash,
-                    "checkpoint node returned a block that does not hash to the L1 checkpoint; retrying"
+                    "fetched target block does not hash to the L1 checkpoint; retrying"
                 );
                 continue;
             }
@@ -362,7 +385,7 @@ where
                 target_block_number, local_head, "syncing execution engine toward finalized target"
             );
 
-            match self.submit_remote_block(block).await {
+            match self.submit_target_block(block).await {
                 Ok(()) => DriverMetrics::beacon_sync_remote_submissions_total().inc(),
                 // An INVALID verdict is not transient: the block hashes to the L1 checkpoint yet
                 // the engine rejects it, which needs operator attention rather than retries.

--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -128,17 +128,50 @@ where
         };
 
         let forkchoice = self.rpc.engine_forkchoice_updated_v2(forkchoice_state, None).await?;
-        if forkchoice.payload_status.status != PayloadStatusEnum::Syncing {
-            return Err(DriverError::Other(anyhow!(
-                "unexpected forkchoice status {:?} for block {}",
-                forkchoice.payload_status.status,
-                block_number
-            )));
-        }
+        resolve_checkpoint_forkchoice_status(&forkchoice.payload_status.status, block_number)?;
 
-        info!(block_number, ?block_hash, "checkpoint block submitted");
+        info!(
+            block_number,
+            ?block_hash,
+            forkchoice_status = ?forkchoice.payload_status.status,
+            "checkpoint block submitted"
+        );
         Ok(())
     }
+}
+
+/// Classify the forkchoice status returned while importing a checkpoint block.
+///
+/// `SYNCING` means the engine started backfilling toward the submitted head; `VALID` means the
+/// head connected to the local chain immediately (small gap or final catch-up tick). Both are
+/// successful imports. `INVALID` is a hard rejection, and `ACCEPTED` is never returned by
+/// forkchoice updates per the engine API spec.
+fn resolve_checkpoint_forkchoice_status(
+    status: &PayloadStatusEnum,
+    block_number: u64,
+) -> Result<(), DriverError> {
+    match status {
+        PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => Ok(()),
+        PayloadStatusEnum::Invalid { validation_error } => {
+            Err(DriverError::EngineInvalidPayload(validation_error.clone()))
+        }
+        PayloadStatusEnum::Accepted => Err(DriverError::Other(anyhow!(
+            "unexpected forkchoice status ACCEPTED for block {block_number}"
+        ))),
+    }
+}
+
+/// Convert a checkpoint poll failure into either a fatal startup error or a retryable error.
+///
+/// Before the checkpoint node has answered successfully, poll failures indicate a misconfigured
+/// or unreachable checkpoint endpoint and must fail fast. After the first successful answer the
+/// same failures are transient, so the caller logs the returned error and retries on the next
+/// tick instead of aborting a potentially hours-long catch-up.
+fn resolve_checkpoint_poll_error(
+    checkpoint_seen_once: bool,
+    error: SyncError,
+) -> Result<SyncError, SyncError> {
+    if checkpoint_seen_once { Ok(error) } else { Err(error) }
 }
 
 #[async_trait::async_trait]
@@ -154,19 +187,10 @@ where
         // consume an old checkpoint head after a failed or skipped beacon sync run.
         self.checkpoint_resume_head.clear();
 
-        if self.checkpoint.is_none() {
+        let Some(checkpoint_provider) = &self.checkpoint else {
             info!("no checkpoint endpoint configured; skipping beacon sync stage");
             return Ok(());
-        }
-
-        let Some(mut checkpoint_head) =
-            self.checkpoint_head().await.map_err(SyncError::CheckpointQuery)?
-        else {
-            return Err(SyncError::CheckpointNoOrigin);
         };
-
-        DriverMetrics::beacon_sync_checkpoint_head_block().set(checkpoint_head as f64);
-        info!(checkpoint_head, "initial checkpoint head");
 
         let poll_interval = if self.retry_interval.is_zero() {
             DEFAULT_BEACON_SYNC_POLL_INTERVAL
@@ -178,6 +202,11 @@ where
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         info!(interval_secs = poll_interval.as_secs(), "beacon sync stage started");
+
+        // Flips once the checkpoint node has reported a head, gating fail-fast startup errors
+        // from retryable mid-catch-up errors. The first tick fires immediately, so a
+        // misconfigured endpoint still fails at startup.
+        let mut checkpoint_seen_once = false;
 
         loop {
             ticker.tick().await;
@@ -194,46 +223,33 @@ where
                     }
                 };
 
-            checkpoint_head = self
-                .checkpoint_head()
-                .await
-                .map_err(SyncError::CheckpointQuery)?
-                .ok_or(SyncError::CheckpointNoOrigin)?;
+            let checkpoint_head = match self.checkpoint_head().await {
+                Ok(Some(head)) => {
+                    checkpoint_seen_once = true;
+                    head
+                }
+                Ok(None) => {
+                    let err = resolve_checkpoint_poll_error(
+                        checkpoint_seen_once,
+                        SyncError::CheckpointNoOrigin,
+                    )?;
+                    warn!(error = %err, "checkpoint node reported no L1 origin; retrying");
+                    continue;
+                }
+                Err(err) => {
+                    let err = resolve_checkpoint_poll_error(
+                        checkpoint_seen_once,
+                        SyncError::CheckpointQuery(err),
+                    )?;
+                    warn!(error = %err, "failed to query checkpoint head; retrying");
+                    continue;
+                }
+            };
             DriverMetrics::beacon_sync_checkpoint_head_block().set(checkpoint_head as f64);
             DriverMetrics::beacon_sync_head_lag_blocks()
                 .set(checkpoint_head.saturating_sub(local_head) as f64);
 
-            if checkpoint_head > local_head {
-                info!(
-                    checkpoint_head,
-                    local_head, "checkpoint head ahead of local engine; syncing"
-                );
-                let checkpoint_provider =
-                    self.checkpoint.as_ref().ok_or(SyncError::CheckpointNoOrigin)?;
-
-                let block = checkpoint_provider
-                    .get_block_by_number(BlockNumberOrTag::Number(checkpoint_head))
-                    .full()
-                    .await
-                    .map_err(RpcClientError::from)
-                    .map_err(|err| SyncError::RemoteBlockSubmit {
-                        block_number: checkpoint_head,
-                        error: DriverError::from(err).into(),
-                    })?
-                    .ok_or_else(|| SyncError::RemoteBlockSubmit {
-                        block_number: checkpoint_head,
-                        error: DriverError::BlockNotFound(checkpoint_head).into(),
-                    })?
-                    .map_transactions(|tx: RpcTransaction| tx.into());
-
-                self.submit_remote_block(block).await.map_err(|err| {
-                    SyncError::RemoteBlockSubmit {
-                        block_number: checkpoint_head,
-                        error: err.into(),
-                    }
-                })?;
-                DriverMetrics::beacon_sync_remote_submissions_total().inc();
-            } else {
+            if checkpoint_head <= local_head {
                 // Persist the checkpoint head we have confirmed local execution is synced to.
                 // Event sync uses this exact value as its authoritative resume source when
                 // checkpoint mode is enabled.
@@ -241,6 +257,84 @@ where
                 info!(checkpoint_head, local_head, "local engine at or ahead of checkpoint; done");
                 break Ok(());
             }
+
+            info!(checkpoint_head, local_head, "checkpoint head ahead of local engine; syncing");
+
+            let block = match checkpoint_provider
+                .get_block_by_number(BlockNumberOrTag::Number(checkpoint_head))
+                .full()
+                .await
+            {
+                Ok(Some(block)) => block.map_transactions(|tx: RpcTransaction| tx.into()),
+                Ok(None) => {
+                    warn!(checkpoint_head, "checkpoint node missing its own head block; retrying");
+                    continue;
+                }
+                Err(err) => {
+                    warn!(
+                        checkpoint_head,
+                        error = %err,
+                        "failed to fetch checkpoint head block; retrying"
+                    );
+                    continue;
+                }
+            };
+
+            match self.submit_remote_block(block).await {
+                Ok(()) => DriverMetrics::beacon_sync_remote_submissions_total().inc(),
+                // An INVALID verdict is not transient: the checkpoint served a block the local
+                // engine rejects, which needs operator attention rather than retries.
+                Err(err @ DriverError::EngineInvalidPayload(_)) => {
+                    return Err(SyncError::RemoteBlockSubmit {
+                        block_number: checkpoint_head,
+                        error: err.into(),
+                    });
+                }
+                Err(err) => {
+                    warn!(
+                        checkpoint_head,
+                        error = %err,
+                        "failed to submit checkpoint block; retrying"
+                    );
+                }
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkpoint_forkchoice_accepts_syncing_and_valid() {
+        assert!(resolve_checkpoint_forkchoice_status(&PayloadStatusEnum::Syncing, 7).is_ok());
+        assert!(resolve_checkpoint_forkchoice_status(&PayloadStatusEnum::Valid, 7).is_ok());
+    }
+
+    #[test]
+    fn checkpoint_forkchoice_rejects_invalid_with_engine_error() {
+        let status = PayloadStatusEnum::Invalid { validation_error: "bad state root".into() };
+        assert!(matches!(
+            resolve_checkpoint_forkchoice_status(&status, 7),
+            Err(DriverError::EngineInvalidPayload(message)) if message == "bad state root"
+        ));
+    }
+
+    #[test]
+    fn checkpoint_forkchoice_rejects_accepted_as_unexpected() {
+        assert!(resolve_checkpoint_forkchoice_status(&PayloadStatusEnum::Accepted, 7).is_err());
+    }
+
+    #[test]
+    fn checkpoint_poll_errors_fail_fast_only_before_first_success() {
+        assert!(matches!(
+            resolve_checkpoint_poll_error(false, SyncError::CheckpointNoOrigin),
+            Err(SyncError::CheckpointNoOrigin)
+        ));
+        assert!(matches!(
+            resolve_checkpoint_poll_error(true, SyncError::CheckpointNoOrigin),
+            Ok(SyncError::CheckpointNoOrigin)
+        ));
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/error.rs
@@ -43,13 +43,6 @@ pub enum SyncError {
         number: u64,
     },
 
-    /// Event sync: execution engine missing batch-to-block mapping.
-    #[error("no execution block found for batch {proposal_id}")]
-    MissingExecutionBlockForBatch {
-        /// Proposal id whose batch mapping was absent.
-        proposal_id: u64,
-    },
-
     /// Event sync: failed to locate the expected anchor transaction for deriving resume point.
     #[error("anchor transaction missing in l2 block {block_number}: {reason}")]
     MissingAnchorTransaction {

--- a/packages/taiko-client-rs/crates/driver/src/sync/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/error.rs
@@ -10,12 +10,8 @@ use crate::derivation::DerivationError;
 /// Errors emitted by sync components.
 #[derive(Debug, Error)]
 pub enum SyncError {
-    /// Beacon sync: checkpoint node has no L1 origin.
-    #[error("checkpoint node has no L1 origin")]
-    CheckpointNoOrigin,
-
-    /// Beacon sync: failed to query checkpoint head.
-    #[error("failed to query checkpoint head")]
+    /// Beacon sync: failed to query the checkpoint node.
+    #[error("failed to query checkpoint node")]
     CheckpointQuery(#[source] RpcClientError),
 
     /// Beacon sync: failed to submit remote block.

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -1,8 +1,5 @@
 //! Event sync logic.
 
-/// Geth error message returned when no finalized block exists yet (e.g. fresh devnets).
-const FINALIZED_BLOCK_NOT_FOUND: &str = "finalized block not found";
-
 use std::{
     sync::{
         Arc, Mutex,
@@ -33,7 +30,7 @@ use tokio_stream::StreamExt;
 use tracing::{debug, error, info, instrument, warn};
 
 use super::{
-    SyncError, SyncStage,
+    FINALIZED_BLOCK_NOT_FOUND, SyncError, SyncStage,
     checkpoint_resume_head::CheckpointResumeHead,
     confirmed_sync::{ConfirmedSyncSnapshot, build_confirmed_sync_snapshot},
 };

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -138,17 +138,6 @@ fn rpc_head_is_safer_than_origin(rpc_l2_block_number: u64, head_l1_origin_block_
     rpc_l2_block_number != 0 && rpc_l2_block_number < head_l1_origin_block_id
 }
 
-/// Select scanner start block when the resolved target proposal id is zero.
-///
-/// - If finalized-safe proposal id is zero, scanner can safely start from finalized L1 block.
-/// - Otherwise, keep genesis start to avoid skipping historical proposal events.
-fn resolve_zero_target_start_block(
-    finalized_safe_proposal_id: u64,
-    finalized_block_number: u64,
-) -> u64 {
-    if finalized_safe_proposal_id == 0 { finalized_block_number } else { 0 }
-}
-
 /// Resolve the target proposal id and finalized-safe proposal id, accounting for the
 /// finalized snapshot being unavailable on fresh chains.
 ///
@@ -170,19 +159,21 @@ fn resolve_target_with_optional_finalization(
 enum MissingBatchMappingFallback {
     /// Extract the scanner anchor from the resume head block itself.
     UseResumeHead,
-    /// Restart derivation from genesis.
-    GenesisReplay,
+    /// Restart derivation from proposal zero, scanning from the inbox activation block.
+    ReplayFromActivation,
 }
 
-/// Decide how to bootstrap when `last_block_id_by_batch_id(target)` has no answer.
+/// Decide how to bootstrap when no batch mapping exists for the target proposal.
 ///
 /// Blocks reached via checkpoint/P2P sync bypass derivation, so the engine's custom tables hold
 /// no rows for them and the lookup reports the match at head as uncertain. When the target is
 /// the resume head's own proposal, the resume head block substitutes for the mapped target
 /// block: it belongs to the target proposal, and every later proposal is included on L1 after
-/// that proposal's anchor. When the finalized bound rewound the target below the resume
-/// proposal, no local substitute exists and derivation restarts from genesis, which is safe
-/// because derivation is idempotent.
+/// that proposal's anchor. This arm also covers the genesis bootstrap, where the zero target
+/// resolves its anchor through the genesis block's activation fallback. When the finalized
+/// bound rewound the target below the resume proposal, no local substitute exists and
+/// derivation replays from the activation block instead — safe because derivation is
+/// idempotent and no proposal events exist before activation.
 fn resolve_missing_batch_mapping_fallback(
     target_proposal_id: u64,
     resume_proposal_id: u64,
@@ -190,7 +181,7 @@ fn resolve_missing_batch_mapping_fallback(
     if target_proposal_id == resume_proposal_id {
         MissingBatchMappingFallback::UseResumeHead
     } else {
-        MissingBatchMappingFallback::GenesisReplay
+        MissingBatchMappingFallback::ReplayFromActivation
     }
 }
 
@@ -1058,35 +1049,24 @@ where
             resume_number = resume_head_block.number(),
             "selected finalized-bounded proposal id from resume-source anchor metadata",
         );
-        if target_proposal_id == 0 {
-            let start_block = finalized_snapshot.as_ref().map_or(0, |snapshot| {
-                resolve_zero_target_start_block(
-                    snapshot.finalized_safe_proposal_id,
-                    snapshot.block_number,
-                )
-            });
-            info!(
-                start_block,
-                finalized_safe_proposal_id,
-                finalized_block_number,
-                "resolved zero-target scanner start block",
-            );
-            return Ok(EventStreamStartPoint {
-                anchor_block_number: start_block,
-                initial_proposal_id: 0,
-                bootstrap_confirmed_tip: 0,
-            });
-        }
-
-        let target_block_number = self
-            .rpc
-            .last_block_id_by_batch_id(U256::from(target_proposal_id))
-            .await
-            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
+        // Batch zero is the genesis boundary: the engine has no mapping for it and looking it up
+        // would trigger a full backward chain scan, so route it through the fallback arms below.
+        let target_block_number = if target_proposal_id == 0 {
+            None
+        } else {
+            self.rpc
+                .last_block_id_by_batch_id(U256::from(target_proposal_id))
+                .await
+                .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
+                .map(|block_number| block_number.to::<u64>())
+        };
 
         let (target_block, bootstrap_confirmed_tip) = match target_block_number {
+            // The mapped target block usually is the resume head itself; skip the refetch.
+            Some(block_number) if block_number == resume_head_block.header.number => {
+                (resume_head_block, block_number)
+            }
             Some(block_number) => {
-                let block_number = block_number.to::<u64>();
                 let block = self
                     .rpc
                     .l2_provider
@@ -1102,24 +1082,42 @@ where
                 match resolve_missing_batch_mapping_fallback(target_proposal_id, resume_proposal_id)
                 {
                     MissingBatchMappingFallback::UseResumeHead => {
-                        warn!(
-                            target_proposal_id,
-                            resume_number = resume_head_block.header.number,
-                            "batch mapping unavailable for resume-head proposal; extracting anchor \
-                         from the resume head block",
-                        );
+                        if target_proposal_id == 0 {
+                            info!(
+                                resume_number = resume_head_block.header.number,
+                                "bootstrapping event sync from the genesis resume head",
+                            );
+                        } else {
+                            warn!(
+                                target_proposal_id,
+                                resume_number = resume_head_block.header.number,
+                                "batch mapping unavailable for resume-head proposal; extracting \
+                                 anchor from the resume head block",
+                            );
+                        }
                         let resume_number = resume_head_block.header.number;
                         (resume_head_block, resume_number)
                     }
-                    MissingBatchMappingFallback::GenesisReplay => {
-                        warn!(
-                            target_proposal_id,
-                            resume_proposal_id,
-                            "batch mapping unavailable for finalized-bounded target; falling back \
-                         to genesis replay",
-                        );
+                    MissingBatchMappingFallback::ReplayFromActivation => {
+                        let anchor_block_number = self.activation_block_number().await?;
+                        if target_proposal_id == 0 {
+                            info!(
+                                resume_proposal_id,
+                                anchor_block_number,
+                                "no finalized proposal to resume from; replaying derivation from \
+                                 the activation block",
+                            );
+                        } else {
+                            warn!(
+                                target_proposal_id,
+                                resume_proposal_id,
+                                anchor_block_number,
+                                "batch mapping unavailable for finalized-bounded target; replaying \
+                                 derivation from the activation block",
+                            );
+                        }
                         return Ok(EventStreamStartPoint {
-                            anchor_block_number: 0,
+                            anchor_block_number,
                             initial_proposal_id: 0,
                             bootstrap_confirmed_tip: 0,
                         });
@@ -1128,11 +1126,6 @@ where
             }
         };
 
-        info!(
-            target_hash = ?target_block.hash(),
-            target_block_number = target_block.number(),
-            "determined target block for anchor extraction",
-        );
         let anchor_block_number =
             self.decode_anchor_block_number(&target_block, anchor_address).await?;
         info!(
@@ -1140,7 +1133,7 @@ where
             target_hash = ?target_block.hash(),
             target_number = target_block.number(),
             target_proposal_id,
-            "derived anchor block number from anchorV4 transaction",
+            "derived anchor block number from target block",
         );
         Ok(EventStreamStartPoint {
             anchor_block_number,
@@ -2091,18 +2084,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zero_target_uses_finalized_block_when_finalized_safe_is_zero() {
-        let start_block = resolve_zero_target_start_block(0, 4_096);
-        assert_eq!(start_block, 4_096);
-    }
-
-    #[test]
-    fn zero_target_uses_genesis_when_finalized_safe_exists() {
-        let start_block = resolve_zero_target_start_block(17, 4_096);
-        assert_eq!(start_block, 0);
-    }
-
     // -- resolve_target_with_optional_finalization tests --
 
     #[test]
@@ -2171,10 +2152,26 @@ mod tests {
     }
 
     #[test]
-    fn missing_batch_mapping_replays_from_genesis_for_rewound_target() {
+    fn missing_batch_mapping_replays_from_activation_for_rewound_target() {
         assert_eq!(
             resolve_missing_batch_mapping_fallback(18_045, 18_058),
-            MissingBatchMappingFallback::GenesisReplay
+            MissingBatchMappingFallback::ReplayFromActivation
+        );
+    }
+
+    #[test]
+    fn missing_batch_mapping_uses_resume_head_for_genesis_target() {
+        assert_eq!(
+            resolve_missing_batch_mapping_fallback(0, 0),
+            MissingBatchMappingFallback::UseResumeHead
+        );
+    }
+
+    #[test]
+    fn missing_batch_mapping_replays_from_activation_for_zero_target_with_nonzero_resume() {
+        assert_eq!(
+            resolve_missing_batch_mapping_fallback(0, 7),
+            MissingBatchMappingFallback::ReplayFromActivation
         );
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -142,8 +142,9 @@ fn rpc_head_is_safer_than_origin(rpc_l2_block_number: u64, head_l1_origin_block_
 /// finalized snapshot being unavailable on fresh chains.
 ///
 /// - When finalization is available, target is bounded by `min(resume, finalized_safe)`.
-/// - When finalization is unavailable, both values reset to 0 triggering a full genesis replay.
-///   This is safe because derivation is idempotent (the engine skips already-known blocks).
+/// - When finalization is unavailable, both values reset to 0 so the caller can replay from the
+///   inbox activation block. This is safe because derivation is idempotent (the engine skips
+///   already-known blocks).
 fn resolve_target_with_optional_finalization(
     resume_proposal_id: u64,
     finalized_safe_proposal_id: Option<u64>,
@@ -1023,8 +1024,8 @@ where
         let anchor_address = *self.rpc.shasta.anchor.address();
         let resume_proposal_id = decode_anchor_proposal_id(&resume_head_block)?;
 
-        // Try to get finalized snapshot. When unavailable, fall back to genesis replay
-        // which is safe because derivation is idempotent.
+        // Try to get finalized snapshot. When unavailable, replay proposal zero from the inbox
+        // activation block, which is safe because derivation is idempotent.
         let finalized_snapshot = self.try_finalized_l1_snapshot().await?;
 
         let (target_proposal_id, finalized_safe_proposal_id) =

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -165,6 +165,35 @@ fn resolve_target_with_optional_finalization(
     }
 }
 
+/// Fallback strategy when the execution engine has no batch mapping for the resume target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MissingBatchMappingFallback {
+    /// Extract the scanner anchor from the resume head block itself.
+    UseResumeHead,
+    /// Restart derivation from genesis.
+    GenesisReplay,
+}
+
+/// Decide how to bootstrap when `last_block_id_by_batch_id(target)` has no answer.
+///
+/// Blocks reached via checkpoint/P2P sync bypass derivation, so the engine's custom tables hold
+/// no rows for them and the lookup reports the match at head as uncertain. When the target is
+/// the resume head's own proposal, the resume head block substitutes for the mapped target
+/// block: it belongs to the target proposal, and every later proposal is included on L1 after
+/// that proposal's anchor. When the finalized bound rewound the target below the resume
+/// proposal, no local substitute exists and derivation restarts from genesis, which is safe
+/// because derivation is idempotent.
+fn resolve_missing_batch_mapping_fallback(
+    target_proposal_id: u64,
+    resume_proposal_id: u64,
+) -> MissingBatchMappingFallback {
+    if target_proposal_id == resume_proposal_id {
+        MissingBatchMappingFallback::UseResumeHead
+    } else {
+        MissingBatchMappingFallback::GenesisReplay
+    }
+}
+
 /// Resolve the reconnect start block after a scanner interruption.
 ///
 /// - Rewind one block from the last seen height to cover partial delivery from the boundary block.
@@ -1053,17 +1082,51 @@ where
             .rpc
             .last_block_id_by_batch_id(U256::from(target_proposal_id))
             .await
-            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
-            .ok_or(SyncError::MissingExecutionBlockForBatch { proposal_id: target_proposal_id })?;
-        let target_block = self
-            .rpc
-            .l2_provider
-            .get_block_by_number(BlockNumberOrTag::Number(target_block_number.to()))
-            .full()
-            .await
-            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
-            .ok_or(SyncError::MissingExecutionBlock { number: target_block_number.to() })?
-            .map_transactions(|tx: RpcTransaction| tx.into());
+            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
+
+        let (target_block, bootstrap_confirmed_tip) = match target_block_number {
+            Some(block_number) => {
+                let block_number = block_number.to::<u64>();
+                let block = self
+                    .rpc
+                    .l2_provider
+                    .get_block_by_number(BlockNumberOrTag::Number(block_number))
+                    .full()
+                    .await
+                    .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?
+                    .ok_or(SyncError::MissingExecutionBlock { number: block_number })?
+                    .map_transactions(|tx: RpcTransaction| tx.into());
+                (block, block_number)
+            }
+            None => {
+                match resolve_missing_batch_mapping_fallback(target_proposal_id, resume_proposal_id)
+                {
+                    MissingBatchMappingFallback::UseResumeHead => {
+                        warn!(
+                            target_proposal_id,
+                            resume_number = resume_head_block.header.number,
+                            "batch mapping unavailable for resume-head proposal; extracting anchor \
+                         from the resume head block",
+                        );
+                        let resume_number = resume_head_block.header.number;
+                        (resume_head_block, resume_number)
+                    }
+                    MissingBatchMappingFallback::GenesisReplay => {
+                        warn!(
+                            target_proposal_id,
+                            resume_proposal_id,
+                            "batch mapping unavailable for finalized-bounded target; falling back \
+                         to genesis replay",
+                        );
+                        return Ok(EventStreamStartPoint {
+                            anchor_block_number: 0,
+                            initial_proposal_id: 0,
+                            bootstrap_confirmed_tip: 0,
+                        });
+                    }
+                }
+            }
+        };
 
         info!(
             target_hash = ?target_block.hash(),
@@ -1082,7 +1145,7 @@ where
         Ok(EventStreamStartPoint {
             anchor_block_number,
             initial_proposal_id: target_proposal_id,
-            bootstrap_confirmed_tip: target_block_number.to::<u64>(),
+            bootstrap_confirmed_tip,
         })
     }
 }
@@ -2095,5 +2158,23 @@ mod tests {
         let err = resolve_event_scanner_setup_error(true, "boom".into())
             .expect("post-start scanner errors should be retryable");
         assert_eq!(err, "boom");
+    }
+
+    // -- resolve_missing_batch_mapping_fallback tests --
+
+    #[test]
+    fn missing_batch_mapping_uses_resume_head_for_resume_proposal() {
+        assert_eq!(
+            resolve_missing_batch_mapping_fallback(18_058, 18_058),
+            MissingBatchMappingFallback::UseResumeHead
+        );
+    }
+
+    #[test]
+    fn missing_batch_mapping_replays_from_genesis_for_rewound_target() {
+        assert_eq!(
+            resolve_missing_batch_mapping_fallback(18_045, 18_058),
+            MissingBatchMappingFallback::GenesisReplay
+        );
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
@@ -2,6 +2,9 @@
 
 use std::sync::Arc;
 
+/// Geth error message returned when no finalized block exists yet (e.g. fresh devnets).
+pub(crate) const FINALIZED_BLOCK_NOT_FOUND: &str = "finalized block not found";
+
 use alloy_provider::Provider;
 use async_trait::async_trait;
 use rpc::client::Client;

--- a/packages/taiko-client-rs/crates/rpc/src/auth.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/auth.rs
@@ -256,8 +256,13 @@ impl<P: Provider + Clone> Client<P> {
 }
 
 /// Checks whether the underlying RPC error message represents a "not found" or ignorable response.
+///
+/// Covers all three "no usable mapping" responses emitted by the execution engine's batch
+/// lookup: missing entry, uncertain match at head, and backward-scan lookback exhaustion.
 fn is_ignorable_origin_error(message: &str) -> bool {
-    message.contains("not found") || message.contains("proposal last block uncertain")
+    message.contains("not found") ||
+        message.contains("proposal last block uncertain") ||
+        message.contains("proposal last block lookback exceeded")
 }
 
 /// Converts an RPC error into an optional origin, mapping ignorable errors to `Ok(None)`.
@@ -275,6 +280,18 @@ mod tests {
     use alethia_reth_primitives::engine::types::TaikoExecutionDataSidecar;
     use alloy_primitives::{Address, B256, Bytes, U256};
     use alloy_rpc_types_engine::ExecutionPayloadV1;
+
+    #[test]
+    fn ignorable_origin_errors_cover_all_engine_lookup_miss_messages() {
+        assert!(is_ignorable_origin_error("not found"));
+        assert!(is_ignorable_origin_error(
+            "proposal last block uncertain: BatchToLastBlockID missing and no newer proposal observed"
+        ));
+        assert!(is_ignorable_origin_error(
+            "proposal last block lookback exceeded: BatchToLastBlockID missing and lookback limit reached"
+        ));
+        assert!(!is_ignorable_origin_error("connection refused"));
+    }
 
     #[test]
     fn engine_new_payload_v2_value_preserves_header_difficulty() {


### PR DESCRIPTION
## Problem

After a checkpoint (beacon) sync, the Rust driver crashes permanently at the event-sync handoff. This is the `l2-node-reth-0` mainnet crashloop from 2026-06-24 (235+ restarts, `WhitelistPreconfirmation(Sync(MissingExecutionBlockForBatch { proposal_id: 18058 }))`):

1. Checkpoint-synced blocks bypass derivation, so alethia-reth's custom tables (`StoredL1Origin`, `BatchToLastBlock`) have no rows for them — those are only written on the FCU-with-payload-attributes path.
2. `event_stream_start_block` calls `taikoAuth_lastBlockIDByBatchID(target)`; reth's backward scan finds the match at head but, without an L1-origin row, correctly reports `proposal last block uncertain`.
3. The client maps that to `None`, and the resume path turned `None` into a **fatal** `MissingExecutionBlockForBatch`.
4. On restart, beacon sync completes instantly (already synced) and hits the same error — a self-sustaining deadlock, since the missing rows would only ever be written by the derivation that never starts.

Beyond the crashloop, the catch-up loop was fragile against transient failures, and the whole stage trusted the checkpoint node blindly — including advertising unverified remote data as *finalized* to the engine.

## Commit 1 — fix: survive the handoff, harden the loop

**Resume without the batch mapping (`event.rs`)** — when `last_block_id_by_batch_id(target)` has no answer:
- `target == resume proposal`: extract the scanner anchor from the resume head block itself. The block already belongs to the target proposal, and every later proposal is included on L1 after that proposal's anchor, so scanning from its anchorV4 checkpoint cannot miss a `Proposed` event.
- `target < resume proposal` (finalized bound rewound the target): fall back to a full replay bootstrap, which is safe because derivation is idempotent.
- `MissingExecutionBlockForBatch` is now unconstructable and removed.

Why this is sufficient (verified against the derivation pipeline): `initial_proposal_id` is inclusive — the pipeline skips only `id < initial`, so the target proposal re-derives on startup. Its parent resolves via the *previous* proposal's boundary, which reth's backward scan finds with certainty below head even with empty custom tables (only at-head matches are uncertain). The re-derivation rebuilds hash-identical payloads through the engine, which rewrites the missing custom-table rows and head origin — so the confirmed-sync gate opens and subsequent lookups become certain, with no manual table seeding. This also self-heals the mid-proposal edge (checkpoint sampled mid-batch): rebuilding from the previous boundary extends the partial proposal to its true last block.

**Accept `VALID` forkchoice during checkpoint import (`beacon.rs`)** — the loop hard-required `SYNCING` from FCU, but the engine returns `VALID` when the submitted head connects immediately. That aborted the stage right as catch-up completed. `VALID`/`SYNCING` now both succeed; `INVALID` remains fatal.

**Retry transient failures mid catch-up (`beacon.rs`)** — poll and submission failures now warn-and-retry on the next tick instead of exiting the process. Failures still fail fast until the polled endpoint has answered once (misconfigured endpoint ≙ startup error), and an `INVALID` payload verdict stays fatal.

**Treat lookback exhaustion as a lookup miss (`rpc/auth.rs`)** — `proposal last block lookback exceeded` now maps to `None` like the other two engine miss-messages.

## Commit 2 — refactor: unify the bootstrap paths

`event_stream_start_block` had three bootstrap shapes (zero-target early return, mapped-target path, missing-mapping fallbacks). Now one match handles all of them:

- The zero-target early return is folded into the match: the engine lookup is skipped for batch 0 (it would trigger a full backward chain scan), and the genesis resume head flows through the resume-head arm, resolving its anchor via the existing genesis→activation fallback.
- Replay bootstraps anchor the scanner at the **inbox activation block instead of L1 block 0**. No `Proposed` event exists before activation, so this is semantics-preserving — and it turns the worst case from "scan all of Ethereum history" into "scan since activation".
- The already-fetched resume head block is reused when the batch mapping points back at it (the common startup case), saving a duplicate full-block fetch.
- Fixes a stale `load_parent_block` doc comment (it falls back to the batch mapping, not the latest canonical block).

## Commit 3 — feat: trustless beacon-sync target from the L1 finalized checkpoint

Previously the sync target was the checkpoint node's `taiko_headL1Origin` — unverified, usually unfinalized remote data — and the catch-up FCU marked the fetched block's parent as **finalized**, teaching the engine to treat unverified data as final (which can wedge recovery from a bad checkpoint, since engines resist reorging below the finalized mark).

Now:
- The target is read from the **L1 inbox core state** (`lastFinalizedProposalId` / `lastFinalizedBlockHash`) at the **finalized L1 block**, so it is final on both layers: proof-finalized by the inbox, and that finalization can't be reorged away on L1. (Fresh devnets without L1 finality fall back to the latest block; an inbox with nothing finalized skips catch-up entirely and lets event sync derive from the activation block.)
- The checkpoint node degrades to an **untrusted block-body source**: the fetched body must hash to the L1-recorded value (verified client-side, and again by the engine's mandatory blockHash validation), and ancestors backfill over hash-linked P2P download. A lying checkpoint is a retryable condition, not a poisoned chain.
- Marking the submitted block `finalized` in the forkchoice is now sound instead of a lie.
- The stage completes when the **local canonical chain contains the target hash** (not a height comparison): healthy restarts exit without touching the forkchoice, while a divergent local chain is steered back to the proof-finalized one.

Trade-off (intentional): proposals between the last proof-finalization and the L1 tip are no longer bulk-downloaded from the checkpoint — they're covered by ordinary event-sync derivation on top of the resume head, re-verified against `Proposed` events. Catch-up freshness now depends on prover liveness; if proving stalls, the derivation window grows accordingly.

## Testing

- Unit tests: missing-mapping fallback selection (incl. genesis and zero-target cases), forkchoice status classification, poll-error fail-fast gating, ignorable-error message coverage.
- `cargo test -p driver --lib` (83 passed), `cargo test -p rpc --lib` (12 passed), `cargo build -p taiko-client`.
- `cargo clippy -p driver -p rpc --all-targets` clean for the touched code (one pre-existing `collapsible_if` in an untouched e2e test remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)