### PR TITLE
feat(taiko-client): bump default --p2p.syncTimeout to 72h

### DIFF
--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -19,9 +19,10 @@ var (
 	}
 	P2PSyncTimeout = &cli.DurationFlag{
 		Name: "p2p.syncTimeout",
-		Usage: "P2P syncing timeout, if no sync progress is made within this time span, " +
-			"driver will stop the P2P sync and insert all remaining L2 blocks one by one",
-		Value:    1 * time.Hour,
+		Usage: "P2P syncing watchdog, if no sync progress at all is made within this time span " +
+			"(any progress resets it, it is not a total sync time budget), driver will stop " +
+			"the P2P sync and insert all remaining L2 blocks one by one",
+		Value:    72 * time.Hour,
 		Category: driverCategory,
 		EnvVars:  []string{"P2P_SYNC_TIMEOUT"},
 	}


### PR DESCRIPTION
## Why

`--p2p.syncTimeout` is a rolling **zero-progress watchdog**, not a total sync time budget: the tracker polls `eth_syncing` every 12s and any progress (headers, bodies, snap accounts, healing bytes) resets the clock. A multi-hour snap sync never trips it as long as data keeps flowing.

Tripping it, however, is currently one-shot and permanent for the process: `outOfSync` stops beacon-sync re-triggering and `MarkFinished` disarms it, downgrading the node to one-by-one event sync — which cannot even insert payloads while the execution engine is still snap syncing (the inserter requires `VALID`, a snap-syncing geth answers `SYNCING`). So a transient stall of just over an hour (e.g. waiting for state-serving peers on a small network) permanently costs the node its P2P sync path.

Until the trip is made recoverable, give the watchdog a much wider margin: 1h → 72h. The flag usage text is also reworded to make the watchdog (not budget) semantics explicit.

No test changes needed: config tests pass an explicit `120s` and nothing asserts the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)