### PR TITLE
refactor(taiko-client): remove --p2p.syncTimeout flag and out-of-sync fallback

### DIFF
--- a/packages/taiko-client/cmd/flags/driver.go
+++ b/packages/taiko-client/cmd/flags/driver.go
@@ -1,8 +1,6 @@
 package flags
 
 import (
-	"time"
-
 	p2pFlags "github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/urfave/cli/v2"
 )
@@ -16,14 +14,6 @@ var (
 		Value:    false,
 		Category: driverCategory,
 		EnvVars:  []string{"P2P_SYNC"},
-	}
-	P2PSyncTimeout = &cli.DurationFlag{
-		Name: "p2p.syncTimeout",
-		Usage: "P2P syncing timeout, if no sync progress is made within this time span, " +
-			"driver will stop the P2P sync and insert all remaining L2 blocks one by one",
-		Value:    1 * time.Hour,
-		Category: driverCategory,
-		EnvVars:  []string{"P2P_SYNC_TIMEOUT"},
 	}
 	CheckPointSyncURL = &cli.StringFlag{
 		Name:     "p2p.checkPointSyncUrl",
@@ -75,7 +65,6 @@ var DriverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	L2AuthEndpoint,
 	JWTSecret,
 	P2PSync,
-	P2PSyncTimeout,
 	CheckPointSyncURL,
 	BlobServerEndpoint,
 	PreconfBlockServerPort,

--- a/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker.go
@@ -30,12 +30,9 @@ type SyncProgressTracker struct {
 	lastSyncedBlockID   *big.Int
 	lastSyncedBlockHash common.Hash
 
-	// Out-of-sync check related
-	lastSyncProgress   *ethereum.SyncProgress
-	lastProgressedTime time.Time
-	timeout            time.Duration
-	outOfSync          bool
-	ticker             *time.Ticker
+	// Sync progress tracking
+	lastSyncProgress *ethereum.SyncProgress
+	ticker           *time.Ticker
 
 	// A marker to indicate whether the beacon sync has been finished.
 	finished bool
@@ -45,8 +42,8 @@ type SyncProgressTracker struct {
 }
 
 // NewSyncProgressTracker creates a new SyncProgressTracker instance.
-func NewSyncProgressTracker(c *rpc.EthClient, timeout time.Duration) *SyncProgressTracker {
-	return &SyncProgressTracker{client: c, timeout: timeout, ticker: time.NewTicker(syncProgressCheckInterval)}
+func NewSyncProgressTracker(c *rpc.EthClient) *SyncProgressTracker {
+	return &SyncProgressTracker{client: c, ticker: time.NewTicker(syncProgressCheckInterval)}
 }
 
 // Track starts the inner event loop, to monitor the sync progress.
@@ -77,10 +74,6 @@ func (t *SyncProgressTracker) track(ctx context.Context) {
 		return
 	}
 
-	if t.outOfSync {
-		return
-	}
-
 	progress, err := t.client.SyncProgress(ctx)
 	if err != nil {
 		log.Error("Get L2 execution engine sync progress error", "error", err)
@@ -88,12 +81,7 @@ func (t *SyncProgressTracker) track(ctx context.Context) {
 	}
 
 	if progress != nil {
-		log.Info(
-			"L2 execution engine sync progress",
-			"progress", progress,
-			"lastProgressedTime", t.lastProgressedTime,
-			"timeout", t.timeout,
-		)
+		log.Info("L2 execution engine sync progress", "progress", progress)
 	}
 
 	if progress == nil {
@@ -104,7 +92,6 @@ func (t *SyncProgressTracker) track(ctx context.Context) {
 		}
 
 		if new(big.Int).SetUint64(headHeight).Cmp(t.lastSyncedBlockID) >= 0 {
-			t.lastProgressedTime = time.Now()
 			log.Info(
 				"L2 execution engine has finished the P2P sync work, all verified blocks synced, "+
 					"will switch to insert pending blocks one by one",
@@ -114,29 +101,10 @@ func (t *SyncProgressTracker) track(ctx context.Context) {
 			return
 		}
 
-		log.Info("L2 execution engine has not started P2P syncing yet", "timeout", t.timeout)
+		log.Info("L2 execution engine has not started P2P syncing yet")
 	}
 
-	defer func() { t.lastSyncProgress = progress }()
-
-	// Check whether the L2 execution engine has synced any new block through P2P since last event loop.
-	if syncProgressed(t.lastSyncProgress, progress) {
-		t.outOfSync = false
-		t.lastProgressedTime = time.Now()
-		return
-	}
-
-	// Has not synced any new block since last loop, check whether reaching the timeout.
-	if time.Since(t.lastProgressedTime) > t.timeout {
-		// Mark the L2 execution engine out of sync.
-		t.outOfSync = true
-
-		log.Warn(
-			"L2 execution engine is not able to sync through P2P",
-			"lastProgressedTime", t.lastProgressedTime,
-			"timeout", t.timeout,
-		)
-	}
+	t.lastSyncProgress = progress
 }
 
 // UpdateMeta updates the inner beacon sync metadata.
@@ -145,10 +113,6 @@ func (t *SyncProgressTracker) UpdateMeta(id *big.Int, blockHash common.Hash) {
 	defer t.mutex.Unlock()
 
 	log.Debug("Update sync progress tracker meta", "id", id, "hash", blockHash)
-
-	if !t.triggered {
-		t.lastProgressedTime = time.Now()
-	}
 
 	t.triggered = true
 	t.lastSyncedBlockID = id
@@ -165,7 +129,6 @@ func (t *SyncProgressTracker) ClearMeta() {
 	t.triggered = false
 	t.lastSyncedBlockID = nil
 	t.lastSyncedBlockHash = common.Hash{}
-	t.outOfSync = false
 }
 
 // NeedReSync checks if a new beacon sync request will be needed:
@@ -205,14 +168,6 @@ func (t *SyncProgressTracker) NeedReSync(newID *big.Int) (bool, error) {
 	return false, nil
 }
 
-// OutOfSync tells whether the L2 execution engine is marked as out of sync.
-func (t *SyncProgressTracker) OutOfSync() bool {
-	t.mutex.RLock()
-	defer t.mutex.RUnlock()
-
-	return t.outOfSync
-}
-
 // Triggered returns tracker.triggered.
 func (t *SyncProgressTracker) Triggered() bool {
 	t.mutex.RLock()
@@ -247,45 +202,6 @@ func (t *SyncProgressTracker) LastSyncProgress() *ethereum.SyncProgress {
 	defer t.mutex.RUnlock()
 
 	return t.lastSyncProgress
-}
-
-// syncProgressed checks whether there is any new progress since last sync progress check.
-func syncProgressed(last *ethereum.SyncProgress, new *ethereum.SyncProgress) bool {
-	if last == nil {
-		return false
-	}
-
-	if new == nil {
-		return true
-	}
-
-	// Block
-	if new.CurrentBlock > last.CurrentBlock {
-		return true
-	}
-
-	// Fast sync fields
-	if new.PulledStates > last.PulledStates {
-		return true
-	}
-
-	// Snap sync fields
-	if new.SyncedAccounts > last.SyncedAccounts ||
-		new.SyncedAccountBytes > last.SyncedAccountBytes ||
-		new.SyncedBytecodes > last.SyncedBytecodes ||
-		new.SyncedBytecodeBytes > last.SyncedBytecodeBytes ||
-		new.SyncedStorage > last.SyncedStorage ||
-		new.SyncedStorageBytes > last.SyncedStorageBytes ||
-		new.HealedTrienodes > last.HealedTrienodes ||
-		new.HealedTrienodeBytes > last.HealedTrienodeBytes ||
-		new.HealedBytecodes > last.HealedBytecodes ||
-		new.HealedBytecodeBytes > last.HealedBytecodeBytes ||
-		new.HealingTrienodes > last.HealingTrienodes ||
-		new.HealingBytecode > last.HealingBytecode {
-		return true
-	}
-
-	return false
 }
 
 // MarkFinished marks the current beacon sync as finished.

--- a/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker.go
@@ -18,9 +18,8 @@ var (
 	gapToResync               = new(big.Int).SetUint64(64)
 )
 
-// SyncProgressTracker is responsible for tracking the L2 execution engine's sync progress, after
-// a beacon sync is triggered, and check whether the L2 execution is not able to sync through P2P (due to no
-// connected peer or some other reasons).
+// SyncProgressTracker is responsible for tracking the L2 execution engine's sync progress
+// after a beacon sync is triggered.
 type SyncProgressTracker struct {
 	// RPC client
 	client *rpc.EthClient

--- a/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker_test.go
+++ b/packages/taiko-client/driver/chain_syncer/beaconsync/progress_tracker_test.go
@@ -2,7 +2,6 @@ package beaconsync
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,34 +19,7 @@ type BeaconSyncProgressTrackerTestSuite struct {
 func (s *BeaconSyncProgressTrackerTestSuite) SetupTest() {
 	s.ClientTestSuite.SetupTest()
 
-	s.t = NewSyncProgressTracker(s.RPCClient.L2, 30*time.Second)
-}
-
-func (s *BeaconSyncProgressTrackerTestSuite) TestSyncProgressed() {
-	s.False(syncProgressed(nil, &ethereum.SyncProgress{}), nil)
-	s.False(syncProgressed(&ethereum.SyncProgress{}, &ethereum.SyncProgress{}))
-
-	// Block
-	s.True(syncProgressed(&ethereum.SyncProgress{CurrentBlock: 0}, &ethereum.SyncProgress{CurrentBlock: 1}))
-	s.False(syncProgressed(&ethereum.SyncProgress{CurrentBlock: 0}, &ethereum.SyncProgress{CurrentBlock: 0}))
-	s.False(syncProgressed(&ethereum.SyncProgress{CurrentBlock: 1}, &ethereum.SyncProgress{CurrentBlock: 1}))
-
-	// Fast sync fields
-	s.True(syncProgressed(&ethereum.SyncProgress{PulledStates: 0}, &ethereum.SyncProgress{PulledStates: 1}))
-
-	// Snap sync fields
-	s.True(syncProgressed(&ethereum.SyncProgress{SyncedAccounts: 0}, &ethereum.SyncProgress{SyncedAccounts: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{SyncedAccountBytes: 0}, &ethereum.SyncProgress{SyncedAccountBytes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{SyncedBytecodes: 0}, &ethereum.SyncProgress{SyncedBytecodes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{SyncedBytecodeBytes: 0}, &ethereum.SyncProgress{SyncedBytecodeBytes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{SyncedStorage: 0}, &ethereum.SyncProgress{SyncedStorage: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{SyncedStorageBytes: 0}, &ethereum.SyncProgress{SyncedStorageBytes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{HealedTrienodes: 0}, &ethereum.SyncProgress{HealedTrienodes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{HealedTrienodeBytes: 0}, &ethereum.SyncProgress{HealedTrienodeBytes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{HealedBytecodes: 0}, &ethereum.SyncProgress{HealedBytecodes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{HealedBytecodeBytes: 0}, &ethereum.SyncProgress{HealedBytecodeBytes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{HealingTrienodes: 0}, &ethereum.SyncProgress{HealingTrienodes: 1}))
-	s.True(syncProgressed(&ethereum.SyncProgress{HealingBytecode: 0}, &ethereum.SyncProgress{HealingBytecode: 1}))
+	s.t = NewSyncProgressTracker(s.RPCClient.L2)
 }
 
 func (s *BeaconSyncProgressTrackerTestSuite) TestClearMeta() {
@@ -60,10 +32,6 @@ func (s *BeaconSyncProgressTrackerTestSuite) TestHeadChanged() {
 	s.True(s.t.NeedReSync(common.Big256))
 	s.t.triggered = true
 	s.True(s.t.NeedReSync(common.Big256))
-}
-
-func (s *BeaconSyncProgressTrackerTestSuite) TestOutOfSync() {
-	s.False(s.t.OutOfSync())
 }
 
 func (s *BeaconSyncProgressTrackerTestSuite) TestTriggered() {
@@ -87,7 +55,7 @@ func (s *BeaconSyncProgressTrackerTestSuite) TestLastSyncedVerifiedBlockHash() {
 }
 
 func TestLastSyncProgress(t *testing.T) {
-	tracker := NewSyncProgressTracker(nil, time.Hour)
+	tracker := NewSyncProgressTracker(nil)
 	require.Nil(t, tracker.LastSyncProgress())
 
 	progress := &ethereum.SyncProgress{CurrentBlock: 1, HighestBlock: 2}

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
-	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -51,7 +50,6 @@ func New(
 	rpc *rpc.Client,
 	state *state.State,
 	p2pSync bool,
-	p2pSyncTimeout time.Duration,
 	blobServerEndpoint *url.URL,
 	latestSeenProposalCh chan *encoding.LastSeenProposal,
 ) (*L2ChainSyncer, error) {

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer.go
@@ -55,7 +55,7 @@ func New(
 	blobServerEndpoint *url.URL,
 	latestSeenProposalCh chan *encoding.LastSeenProposal,
 ) (*L2ChainSyncer, error) {
-	tracker := beaconsync.NewSyncProgressTracker(rpc.L2, p2pSyncTimeout)
+	tracker := beaconsync.NewSyncProgressTracker(rpc.L2)
 	go tracker.Track(ctx)
 
 	beaconSyncer := beaconsync.NewSyncer(ctx, rpc, state, tracker)
@@ -102,7 +102,7 @@ func (s *L2ChainSyncer) Sync() error {
 	// If we have triggered a beacon sync and the L2 execution engine is still catching up
 	// on chain data, postpone event synchronization until it finishes. Index-only progress
 	// (see chainDataStillSyncing) does not postpone.
-	if s.progressTracker.Triggered() && !s.progressTracker.Finished() && !s.progressTracker.OutOfSync() {
+	if s.progressTracker.Triggered() && !s.progressTracker.Finished() {
 		progress, err := s.rpc.L2.SyncProgress(s.ctx)
 		if err != nil {
 			return fmt.Errorf("failed to fetch L2 execution engine sync progress: %w", err)
@@ -126,7 +126,6 @@ func (s *L2ChainSyncer) Sync() error {
 		log.Info(
 			"Switch to insert pending proposals one by one",
 			"p2pEnabled", s.p2pSync,
-			"p2pOutOfSync", s.progressTracker.OutOfSync(),
 		)
 
 		if err := s.SetUpEventSync(blockIDToSync); err != nil {
@@ -204,16 +203,15 @@ func chainDataStillSyncing(progress *ethereum.SyncProgress) bool {
 // This method should only be called after the L2 execution engine's chain has just finished a beacon sync.
 func (s *L2ChainSyncer) SetUpEventSync(blockIDToSync uint64) error {
 	var headNumber = new(big.Int).SetUint64(blockIDToSync)
-	// Fall back to the live EE head when the tracker is OutOfSync, or when
-	// blockIDToSync is 0 (the Finished() short-circuit path) — otherwise
-	// HeaderByNumber(0) resolves to genesis and resets L1Current there.
-	if s.progressTracker.OutOfSync() || blockIDToSync == 0 {
+	// Fall back to the live EE head when blockIDToSync is 0 (the Finished()
+	// short-circuit path) — otherwise HeaderByNumber(0) resolves to genesis
+	// and resets L1Current there.
+	if blockIDToSync == 0 {
 		headNumber = nil
 	}
 	log.Info(
 		"Setting up event synchronization",
 		"blockIDToSync", blockIDToSync,
-		"outOfSync", s.progressTracker.OutOfSync(),
 		"headNumber", headNumber,
 	)
 	l2Head, err := s.rpc.L2.HeaderByNumber(s.ctx, headNumber)
@@ -286,7 +284,6 @@ func (s *L2ChainSyncer) AheadOfHeadToSync(heightToSync uint64) bool {
 // 1. The `--p2p.sync` flag is set.
 // 2. The protocol's (last verified) block head is not zero.
 // 3. The L2 execution engine's chain is behind of the protocol's (latest verified) block head.
-// 4. The L2 execution engine's chain has met a sync timeout issue.
 func (s *L2ChainSyncer) needNewBeaconSyncTriggered() (uint64, bool, error) {
 	// If the flag is not set or there was a finished beacon sync, we simply return false.
 	if !s.p2pSync || s.progressTracker.Finished() {
@@ -315,8 +312,7 @@ func (s *L2ChainSyncer) needNewBeaconSyncTriggered() (uint64, bool, error) {
 		return 0, false, nil
 	}
 
-	return head.BlockID.Uint64(), !s.AheadOfHeadToSync(head.BlockID.Uint64()) &&
-		!s.progressTracker.OutOfSync(), nil
+	return head.BlockID.Uint64(), !s.AheadOfHeadToSync(head.BlockID.Uint64()), nil
 }
 
 // BeaconSyncer returns the inner beacon syncer.

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -144,7 +144,7 @@ func TestChainDataStillSyncing(t *testing.T) {
 
 func TestSyncPostponesEventSyncWhileExecutionEngineSyncing(t *testing.T) {
 	l2Client := newSyncingEthClient(t)
-	tracker := beaconsync.NewSyncProgressTracker(l2Client, time.Hour)
+	tracker := beaconsync.NewSyncProgressTracker(l2Client)
 	tracker.UpdateMeta(common.Big1, common.Hash{})
 
 	syncer := &L2ChainSyncer{

--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -50,7 +50,6 @@ func (s *ChainSyncerTestSuite) SetupTest() {
 		s.RPCClient,
 		state,
 		false,
-		1*time.Hour,
 		s.ParseL1HttpURLFromEnv(),
 		nil,
 	)

--- a/packages/taiko-client/driver/chain_syncer/event/syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/event/syncer_test.go
@@ -42,7 +42,7 @@ func (s *EventSyncerTestSuite) SetupTest() {
 		context.Background(),
 		s.RPCClient,
 		state2,
-		beaconsync.NewSyncProgressTracker(s.RPCClient.L2, 1*time.Hour),
+		beaconsync.NewSyncProgressTracker(s.RPCClient.L2),
 		s.ParseL1HttpURLFromEnv(),
 		nil,
 	)

--- a/packages/taiko-client/driver/config.go
+++ b/packages/taiko-client/driver/config.go
@@ -41,7 +41,6 @@ func resolveEndpoints(ws, http string) (string, error) {
 type Config struct {
 	*rpc.ClientConfig
 	P2PSync                       bool
-	P2PSyncTimeout                time.Duration
 	RetryInterval                 time.Duration
 	BlobServerEndpoint            *url.URL
 	PreconfBlockServerPort        uint64
@@ -166,7 +165,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		ClientConfig:                  clientConfig,
 		RetryInterval:                 c.Duration(flags.BackOffRetryInterval.Name),
 		P2PSync:                       p2pSync,
-		P2PSyncTimeout:                c.Duration(flags.P2PSyncTimeout.Name),
 		BlobServerEndpoint:            blobServerEndpoint,
 		PreconfBlockServerPort:        c.Uint64(flags.PreconfBlockServerPort.Name),
 		PreconfBlockServerJWTSecret:   preconfBlockServerJWTSecret,

--- a/packages/taiko-client/driver/config_test.go
+++ b/packages/taiko-client/driver/config_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/urfave/cli/v2"
@@ -77,7 +76,6 @@ func (s *DriverTestSuite) TestNewConfigFromCliContext() {
 		s.Equal(l2EngineEndpoint, c.L2EngineEndpoint)
 		s.Equal(inbox, c.InboxAddress.String())
 		s.Equal(taikoAnchor, c.TaikoAnchorAddress.String())
-		s.Equal(120*time.Second, c.P2PSyncTimeout)
 		s.Equal(uint64(8), c.HandoverSkipSlots)
 		s.NotEmpty(c.JwtSecret)
 		s.True(c.P2PSync)
@@ -96,7 +94,6 @@ func (s *DriverTestSuite) TestNewConfigFromCliContext() {
 		"--" + flags.InboxAddress.Name, inbox,
 		"--" + flags.TaikoAnchorAddress.Name, taikoAnchor,
 		"--" + flags.JWTSecret.Name, os.Getenv("JWT_SECRET"),
-		"--" + flags.P2PSyncTimeout.Name, "120s",
 		"--" + flags.RPCTimeout.Name, "5s",
 		"--" + flags.P2PSync.Name,
 		"--" + flags.CheckPointSyncURL.Name, l2CheckPoint,
@@ -153,7 +150,6 @@ func (s *DriverTestSuite) SetupApp() *cli.App {
 		&cli.StringFlag{Name: flags.PreconfBlockServerJWTSecret.Name},
 		&cli.StringFlag{Name: flags.JWTSecret.Name},
 		&cli.BoolFlag{Name: flags.P2PSync.Name},
-		&cli.DurationFlag{Name: flags.P2PSyncTimeout.Name},
 		&cli.DurationFlag{Name: flags.RPCTimeout.Name},
 		&cli.StringFlag{Name: flags.CheckPointSyncURL.Name},
 	}, p2pFlags.P2PFlags("PRECONFIRMATION"))
@@ -198,7 +194,6 @@ func (s *DriverTestSuite) defaultCliP2PConfigs() (*p2p.Config, p2p.SignerSetup) 
 		"--" + flags.InboxAddress.Name, inbox,
 		"--" + flags.TaikoAnchorAddress.Name, taikoAnchor,
 		"--" + flags.JWTSecret.Name, os.Getenv("JWT_SECRET"),
-		"--" + flags.P2PSyncTimeout.Name, "120s",
 		"--" + flags.RPCTimeout.Name, "5s",
 		"--" + flags.P2PSync.Name,
 		"--" + flags.CheckPointSyncURL.Name, l2CheckPoint,

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -106,7 +106,6 @@ func (d *Driver) InitFromConfig(ctx context.Context, cfg *Config) (err error) {
 		d.rpc,
 		d.state,
 		cfg.P2PSync,
-		cfg.P2PSyncTimeout,
 		cfg.BlobServerEndpoint,
 		latestSeenProposalCh,
 	); err != nil {

--- a/packages/taiko-client/proposer/proposer_test.go
+++ b/packages/taiko-client/proposer/proposer_test.go
@@ -48,7 +48,7 @@ func (s *ProposerTestSuite) SetupTest() {
 		context.Background(),
 		s.RPCClient,
 		state2,
-		beaconsync.NewSyncProgressTracker(s.RPCClient.L2, 1*time.Hour),
+		beaconsync.NewSyncProgressTracker(s.RPCClient.L2),
 		s.ParseL1HttpURLFromEnv(),
 		nil,
 	)

--- a/packages/taiko-client/prover/event_handler/proofs_received_handler_test.go
+++ b/packages/taiko-client/prover/event_handler/proofs_received_handler_test.go
@@ -56,7 +56,7 @@ func (s *EventHandlerTestSuite) SetupTest() {
 	s.Nil(err)
 	s.Nil(testState.ResetL1Current(context.Background(), common.Big0))
 
-	tracker := beaconsync.NewSyncProgressTracker(s.RPCClient.L2, 30*time.Second)
+	tracker := beaconsync.NewSyncProgressTracker(s.RPCClient.L2)
 	s.eventSyncer, err = event.NewSyncer(
 		context.Background(),
 		s.RPCClient,


### PR DESCRIPTION
## Summary

Removes the driver's `--p2p.syncTimeout` CLI flag (`P2P_SYNC_TIMEOUT`) and the deadline-based **out-of-sync fallback** it configured. When P2P beacon sync stalled with no progress for the timeout (default `1h`), the tracker marked the L2 execution engine `outOfSync`, which stopped further beacon-sync triggers and fell back to inserting L2 blocks one-by-one. This machinery predates the current `eth_syncing`-based sync gating (`chainDataStillSyncing`) and is removed here to simplify the beacon-sync path.

## ⚠️ Behavior change (breaking)

The `--p2p.syncTimeout` flag is no longer accepted, and there is no longer a deadline-based give-up on a stalled P2P sync:

- **Normal case** (P2P sync works / the EE catches up): unchanged — sync exits via `AheadOfHeadToSync` / `Finished`.
- **Pathological case** (`--p2p.sync=true` but P2P can never progress, e.g. no peers): the driver now **re-triggers beacon sync indefinitely instead of self-healing after a timeout**. Operators of such nodes should run with `--p2p.sync=false` (go straight to event sync) or use checkpoint sync via `--p2p.checkPointSyncUrl`.

This tradeoff is intentional.

## What changed

- **`beaconsync.SyncProgressTracker`**: removed the `timeout` / `lastProgressedTime` / `outOfSync` fields, the `OutOfSync()` method, the dead `syncProgressed` helper, and the timeout branch in `track()`. The tracker still maintains `lastSyncProgress` for `NeedReSync` / `LastSyncProgress`.
- **`chain_syncer.go`**: simplified the three `OutOfSync()` consumers (the only nonzero-`blockIDToSync` path into `SetUpEventSync` is now the "EE caught up" case, so the head-fallback reduces to `blockIDToSync == 0`).
- **Flag / config**: removed the `P2PSyncTimeout` flag, `Config.P2PSyncTimeout`, the `chainSyncer.New` parameter, and now-unused `"time"` imports.
- Removed the tracker's stale doc comment that described the deleted check.

The `--p2p.sync` flag and beacon sync itself are unchanged.

## Testing

- `go build ./...` and `go vet ./...` clean (no unused imports/params; source grep for the flag is clean).
- Pure removal — no new tests; the timeout-specific unit tests (`TestOutOfSync`, `TestSyncProgressed`) were removed with their subjects.
- Integration suites need a devnet. Recommended focused runs there: `TestSyncPostponesEventSyncWhileExecutionEngineSyncing` and the driver reorg tests that exercise beacon-sync → event-sync transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
