### PR TITLE
fix(bridge-ui): show quota exhaustion claim error

### DIFF
--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.svelte
@@ -33,7 +33,7 @@
   import { ClaimAction } from '../Shared/types';
   import { DialogStep, DialogStepper } from '../Stepper';
   import ClaimStepNavigation from './ClaimStepNavigation.svelte';
-  import { isMessageNotReceivedError } from './error';
+  import { isMessageNotReceivedError, isQuotaManagerOutOfQuotaError } from './error';
   import { type ClaimDialogMode, shouldSkipMessageStatusCheck } from './mode';
   import { ClaimSteps, INITIAL_STEP } from './types';
 
@@ -154,6 +154,11 @@
           errorToast({
             title: $t('bridge.errors.claim.not_received.title'),
             message: $t('bridge.errors.claim.not_received.message'),
+          });
+        } else if (isQuotaManagerOutOfQuotaError(err)) {
+          errorToast({
+            title: $t('bridge.errors.claim.quota_reached.title'),
+            message: $t('bridge.errors.claim.quota_reached.message'),
           });
         } else {
           errorToast({

--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/error.test.ts
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isMessageNotReceivedError } from './error';
+import { isMessageNotReceivedError, isQuotaManagerOutOfQuotaError } from './error';
 
 describe('isMessageNotReceivedError', () => {
   it('returns true for legacy and current bridge not received errors', () => {
@@ -24,5 +24,48 @@ describe('isMessageNotReceivedError', () => {
 
   it('returns false for unrelated failures', () => {
     expect(isMessageNotReceivedError(new Error('execution reverted: B_PERMISSION_DENIED()'))).toBe(false);
+  });
+});
+
+describe('isQuotaManagerOutOfQuotaError', () => {
+  it('returns true when viem decodes the quota manager custom error name', () => {
+    const wrappedError = {
+      message: 'The contract function "processMessage" reverted.',
+      cause: {
+        shortMessage: 'The contract function reverted.',
+        data: {
+          errorName: 'QM_OUT_OF_QUOTA',
+        },
+      },
+    };
+
+    expect(isQuotaManagerOutOfQuotaError(wrappedError)).toBe(true);
+  });
+
+  it('returns true when viem cannot decode the custom error but includes its selector', () => {
+    const wrappedError = {
+      message: 'The contract function "processMessage" reverted.',
+      cause: {
+        shortMessage: 'Encoded error signature "0x51d8fe3a" not found on ABI.',
+        data: '0x51d8fe3a',
+      },
+    };
+
+    expect(isQuotaManagerOutOfQuotaError(wrappedError)).toBe(true);
+  });
+
+  it('returns true when viem exposes only the custom error signature field', () => {
+    const wrappedError = {
+      message: 'The contract function "processMessage" reverted.',
+      cause: {
+        signature: '0x51d8fe3a',
+      },
+    };
+
+    expect(isQuotaManagerOutOfQuotaError(wrappedError)).toBe(true);
+  });
+
+  it('returns false for unrelated quota manager errors', () => {
+    expect(isQuotaManagerOutOfQuotaError(new Error('execution reverted: QM_INVALID_PARAM()'))).toBe(false);
   });
 });

--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/error.ts
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/error.ts
@@ -1,4 +1,5 @@
 const MESSAGE_NOT_RECEIVED_ERRORS = ['B_NOT_RECEIVED', 'B_SIGNAL_NOT_RECEIVED'];
+const QUOTA_MANAGER_OUT_OF_QUOTA_ERRORS = ['QM_OUT_OF_QUOTA', '0x51d8fe3a'];
 
 function collectErrorTexts(error: unknown): string[] {
   if (!error || typeof error !== 'object') {
@@ -10,6 +11,8 @@ function collectErrorTexts(error: unknown): string[] {
     shortMessage?: unknown;
     details?: unknown;
     reason?: unknown;
+    signature?: unknown;
+    metaMessages?: unknown;
     data?: { errorName?: unknown } | unknown;
     cause?: unknown;
   };
@@ -19,6 +22,9 @@ function collectErrorTexts(error: unknown): string[] {
     maybeError.shortMessage,
     maybeError.details,
     maybeError.reason,
+    maybeError.signature,
+    ...(Array.isArray(maybeError.metaMessages) ? maybeError.metaMessages : []),
+    typeof maybeError.data === 'string' ? maybeError.data : undefined,
     typeof maybeError.data === 'object' && maybeError.data && 'errorName' in maybeError.data
       ? maybeError.data.errorName
       : undefined,
@@ -30,4 +36,9 @@ function collectErrorTexts(error: unknown): string[] {
 export function isMessageNotReceivedError(error: unknown): boolean {
   const haystacks = collectErrorTexts(error);
   return haystacks.some((text) => MESSAGE_NOT_RECEIVED_ERRORS.some((needle) => text.includes(needle)));
+}
+
+export function isQuotaManagerOutOfQuotaError(error: unknown): boolean {
+  const haystacks = collectErrorTexts(error);
+  return haystacks.some((text) => QUOTA_MANAGER_OUT_OF_QUOTA_ERRORS.some((needle) => text.includes(needle)));
 }

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -85,6 +85,10 @@
         "not_received": {
           "message": "The message is not proven and cannot be claimed right now.",
           "title": "Not received"
+        },
+        "quota_reached": {
+          "message": "This asset's withdrawal quota is currently used up. Your funds are safe; wait for the quota to replenish, then try claiming again.",
+          "title": "Withdrawal quota reached"
         }
       },
       "custom_token": {


### PR DESCRIPTION
Withdrawals that exhaust QuotaManager currently fall through to the generic claim error, which makes users think the bridge failed unexpectedly. This detects the `QM_OUT_OF_QUOTA` custom error/selector during claim and shows a quota-specific message telling users their funds are safe and to retry after the quota replenishes.

Validated with focused ClaimDialog tests and a local Anvil quota mock.

![bridge-quota-toast](https://storage.googleapis.com/gh-evidence/20260703-005059-73f9-codex-clipboard-hk8EQu.png)