### PR TITLE
fix(taiko-client-rs): decode legacy transactions in preconfirmation tx-lists

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/codec.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/codec.rs
@@ -2,7 +2,7 @@
 
 use std::io::{Read, Write};
 
-use alloy_rlp::{Bytes as RlpBytes, Decodable};
+use alloy_rlp::{Encodable, Header};
 use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
 use thiserror::Error;
 
@@ -65,10 +65,13 @@ impl ZlibTxListCodec {
     }
 
     /// Encode a list of raw transactions into zlib-compressed bytes.
+    ///
+    /// Each transaction must be in its canonical EIP-2718 network encoding. Legacy
+    /// (type-0) transactions are already RLP lists and are emitted verbatim, while
+    /// typed transactions are wrapped as RLP byte strings, matching go-ethereum's
+    /// `types.Transactions` encoding so tx-lists round-trip across clients.
     pub fn encode(&self, transactions: &[Vec<u8>]) -> Result<Vec<u8>> {
-        let mut rlp_encoded = Vec::new();
-        // Encode tx-lists as an RLP list of byte strings (`types.Transactions`).
-        alloy_rlp::encode_list::<_, [u8]>(transactions, &mut rlp_encoded);
+        let rlp_encoded = encode_transaction_list(transactions);
 
         let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(&rlp_encoded).map_err(|e| TxListCodecError::ZlibEncode(e.to_string()))?;
@@ -109,11 +112,79 @@ impl ZlibTxListCodec {
             });
         }
 
-        let mut payload = decoded.as_slice();
-        Vec::<RlpBytes>::decode(&mut payload)
-            .map(|txs| txs.into_iter().map(|tx| tx.to_vec()).collect())
-            .map_err(|err| TxListCodecError::RlpDecode(err.to_string()))
+        decode_transaction_list(&decoded)
     }
+}
+
+/// Returns `true` when `tx` is a legacy (type-0) transaction, i.e. a bare RLP list
+/// rather than an EIP-2718 typed transaction (`type || payload`). Legacy encodings
+/// begin with an RLP list header (`>= 0xc0`); typed encodings begin with the type
+/// byte (`< 0x80`).
+fn is_legacy_transaction(tx: &[u8]) -> bool {
+    tx.first().is_some_and(|first| *first >= 0xc0)
+}
+
+/// Encode transactions as an RLP list, matching go-ethereum's `types.Transactions`:
+/// legacy transactions (already RLP lists) are written verbatim, typed transactions
+/// are wrapped as RLP byte strings.
+fn encode_transaction_list(transactions: &[Vec<u8>]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    for tx in transactions {
+        if is_legacy_transaction(tx) {
+            payload.extend_from_slice(tx);
+        } else {
+            tx.as_slice().encode(&mut payload);
+        }
+    }
+
+    let mut out = Vec::new();
+    Header { list: true, payload_length: payload.len() }.encode(&mut out);
+    out.extend_from_slice(&payload);
+    out
+}
+
+/// Decode an RLP list of transactions, accepting both typed (byte string) and legacy
+/// (list) elements, and returning each transaction's canonical EIP-2718 network
+/// encoding. Mirrors go-ethereum's `types.Transactions` decoding; the previous
+/// `Vec::<Bytes>` decode rejected legacy transactions with an "unexpected list"
+/// error, which stalled real-time preconfirmation import.
+fn decode_transaction_list(decoded: &[u8]) -> Result<Vec<Vec<u8>>> {
+    let mut buf = decoded;
+    let header =
+        Header::decode(&mut buf).map_err(|err| TxListCodecError::RlpDecode(err.to_string()))?;
+    if !header.list {
+        return Err(TxListCodecError::RlpDecode("expected an RLP list of transactions".to_string()));
+    }
+    if buf.len() < header.payload_length {
+        return Err(TxListCodecError::RlpDecode("transaction list payload truncated".to_string()));
+    }
+
+    let mut payload = &buf[..header.payload_length];
+    let mut transactions = Vec::new();
+    while !payload.is_empty() {
+        let mut cursor = payload;
+        let element = Header::decode(&mut cursor)
+            .map_err(|err| TxListCodecError::RlpDecode(err.to_string()))?;
+        let header_len = payload.len() - cursor.len();
+        let element_len = header_len + element.payload_length;
+        if element_len > payload.len() {
+            return Err(TxListCodecError::RlpDecode(
+                "transaction element overruns list payload".to_string(),
+            ));
+        }
+
+        let (raw, rest) = payload.split_at(element_len);
+        if element.list {
+            // Legacy transaction: its canonical encoding is the RLP list itself.
+            transactions.push(raw.to_vec());
+        } else {
+            // Typed transaction: strip the byte-string header to recover `type || payload`.
+            transactions.push(raw[header_len..].to_vec());
+        }
+        payload = rest;
+    }
+
+    Ok(transactions)
 }
 
 #[cfg(test)]
@@ -179,21 +250,22 @@ mod tests {
     }
 
     #[test]
-    fn txlist_codec_rejects_legacy_rust_list_of_u8_encoding() {
-        let tx = vec![
+    fn txlist_codec_roundtrips_mixed_legacy_and_typed_transactions() {
+        let typed = vec![
             0x02, 0xeb, 0x81, 0xa7, 0x80, 0x80, 0x84, 0x3b, 0x9a, 0xca, 0x00, 0x82, 0x52, 0x08,
             0x94, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
             0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x80, 0x84, 0x52, 0x3e, 0x68, 0x54, 0xc0, 0x80,
             0x80, 0x80,
         ];
-        let mut rlp_encoded = Vec::new();
-        alloy_rlp::encode_list::<_, Vec<u8>>(std::slice::from_ref(&tx), &mut rlp_encoded);
-        let compressed = compress_payload(&rlp_encoded);
+        let legacy = sample_legacy_transaction();
 
-        let codec = ZlibTxListCodec::new(1024);
-        let err =
-            codec.decode(&compressed).expect_err("legacy rust tx-list encoding should be rejected");
-        assert!(matches!(err, super::TxListCodecError::RlpDecode(_)));
+        let codec = ZlibTxListCodec::new(4096);
+        let compressed =
+            codec.encode(&[legacy.clone(), typed.clone()]).expect("encode mixed tx-list");
+        let decoded = codec.decode(&compressed).expect("decode mixed tx-list");
+
+        // Order is preserved and both transaction forms survive the round trip.
+        assert_eq!(decoded, vec![legacy, typed]);
     }
 
     #[test]
@@ -212,5 +284,46 @@ mod tests {
         let mut expected_rlp = Vec::new();
         alloy_rlp::encode_list::<_, RlpBytes>(&[RlpBytes::from(tx)], &mut expected_rlp);
         assert_eq!(decoded, expected_rlp);
+    }
+
+    /// A legacy (type-0) transaction is RLP-encoded as a 9-field list with no type
+    /// prefix. Build one by hand so the codec test stays independent of tx-signing
+    /// helpers; the exact field values are irrelevant to the list codec.
+    fn sample_legacy_transaction() -> Vec<u8> {
+        use alloy_rlp::Encodable;
+        let fields: [&[u8]; 9] = [
+            &[0x01],                                           // nonce
+            &[0x04, 0xa8, 0x17, 0xc8, 0x00],                   // gas price
+            &[0x52, 0x08],                                     // gas limit
+            &[0x11u8; 20],                                     // to
+            &[0x0d, 0xe0, 0xb6, 0xb3, 0xa7, 0x64, 0x00, 0x00], // value
+            &[],                                               // data
+            &[0x1c],                                           // v
+            &[0x22u8; 32],                                     // r
+            &[0x33u8; 32],                                     // s
+        ];
+        let mut payload = Vec::new();
+        for field in fields {
+            field.encode(&mut payload);
+        }
+        let mut out = Vec::new();
+        alloy_rlp::Header { list: true, payload_length: payload.len() }.encode(&mut out);
+        out.extend_from_slice(&payload);
+        out
+    }
+
+    #[test]
+    fn txlist_codec_decodes_legacy_transaction_list() {
+        let legacy = sample_legacy_transaction();
+
+        // Go-style tx list: a legacy transaction is emitted as its RLP list verbatim.
+        let mut rlp_encoded = Vec::new();
+        alloy_rlp::Header { list: true, payload_length: legacy.len() }.encode(&mut rlp_encoded);
+        rlp_encoded.extend_from_slice(&legacy);
+        let compressed = compress_payload(&rlp_encoded);
+
+        let codec = ZlibTxListCodec::new(1024);
+        let decoded = codec.decode(&compressed).expect("legacy tx-list should decode successfully");
+        assert_eq!(decoded, vec![legacy]);
     }
 }


### PR DESCRIPTION
## Summary

On mainnet, the L2 node running the Rust `whitelist-preconfirmation-driver` (`l2-node-reth-0`) has been freezing its chain head for **~5–6 minutes at a time** since **2026-06-30 01:43 UTC**, only advancing in ~192-block bursts when the L1 Shasta event-syncer derives a proposal. The identically-configured node running the **Go** driver (`l2-node-reth-go-driver-0`) — same `alethia-reth`, same network, same preconf gossip — stayed at the tip the whole time.

## Root cause

`ZlibTxListCodec::decode` decoded the transaction list as `Vec::<alloy_rlp::Bytes>` — an RLP list of **byte strings**, assuming every transaction is EIP-2718 **typed** (`type || payload`). A **legacy (type-0) transaction** is a bare RLP **list** (`[nonce, gasPrice, …]`), so the moment a preconf block contained one, decoding failed:

```
invalid transactions list bytes: rlp decode failed: unexpected list
```

The importer dropped the whole payload, real-time preconf import stalled, and the head could only advance via the L1-derivation path (which uses a different, legacy-tolerant decoder), producing the freeze-then-burst pattern.

The Go driver never hit this because go-ethereum's `types.Transactions` decode is **polymorphic** — each tx's `DecodeRLP` accepts a legacy tx (list) *or* a typed tx (byte string).

### Evidence (7/2 07:50–08:20 UTC, the same window)

| Pod | Driver | Result |
|-----|--------|--------|
| `l2-node-reth-go-driver-0` | Go | 896 commits, one 11.8s blip, smooth ~2s/block ✅ |
| `l2-node-reth-0` | Rust | head froze at 8200564 / 8200777 / 8200955 for 5–6 min each ❌ |

Block hashes on both pods match exactly (8200565/8200600/8200700), so the Rust node was on the correct canonical chain — just delayed. This is a **liveness/latency** bug, not a divergence: no incorrect blocks, but real-time preconfirmation was effectively dead.

## Fix

Decode the tx-list element-by-element, accepting both byte-string (typed) and list (legacy) elements and returning each transaction's canonical EIP-2718 encoding, mirroring go-ethereum's `types.Transactions`. `encode` is made symmetric (legacy txs emitted verbatim, typed txs wrapped as byte strings) so mixed lists round-trip. Decoding is bounds-checked to stay panic-safe on untrusted P2P input.

The change is isolated to `crates/protocol/src/codec.rs`; the shared codec is used by both the whitelist driver and the `preconfirmation-driver`, so both decode paths are fixed.

## Testing

- New `txlist_codec_decodes_legacy_transaction_list` reproduces the exact production failure (`rlp decode failed: unexpected list`) and now passes.
- New `txlist_codec_roundtrips_mixed_legacy_and_typed_transactions` covers a mixed legacy+typed list through `encode` → `decode`.
- Existing typed-tx and size-cap tests unchanged and passing.
- `cargo test -p protocol -p whitelist-preconfirmation-driver -p preconfirmation-driver` green; `cargo clippy -p protocol --all-targets` and `cargo check --workspace --all-targets` clean.
