### PR TITLE
fix(protocol): deploy SP1 v6.1 verifier

### DIFF
--- a/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "@risc0/contracts/groth16/RiscZeroGroth16Verifier.sol";
-import { SP1Verifier as SuccinctVerifier } from "@sp1-contracts/v5.0.0/SP1VerifierPlonk.sol";
+import { SP1Verifier as SuccinctVerifier } from "@sp1-contracts/v6.1.0/SP1VerifierPlonk.sol";
 
 import { Inbox } from "src/layer1/core/impl/Inbox.sol";
 import { ProverWhitelist } from "src/layer1/core/impl/ProverWhitelist.sol";


### PR DESCRIPTION
**Why**
- Fresh L1 deployments still compiled the bundled SP1 v5 Plonk verifier even though the branch already includes `sp1-contracts#v6.1.1`.
- SP1 6.x aggregate proofs are rejected by a v5 remote verifier.

**How**
- Update `DeployProtocolOnL1` to import the included `@sp1-contracts/v6.1.0/SP1VerifierPlonk.sol`.
- Leave `package.json`, `pnpm-lock.yaml`, and wrapper contracts unchanged.

**Tests**
- `git diff --check`
- `FOUNDRY_PROFILE=layer1 forge build --build-info --extra-output storage-layout` (passes with existing mutability warnings)
- `FOUNDRY_PROFILE=layer1 forge test --extra-output storage-layout --match-path 'test/layer1/verifiers/SP1Verifier.t.sol'` (6 passed)
- `pnpm --filter @taiko/protocol compile:l1` (blocked before forge by pnpm ignored-builds policy; not a Solidity compile failure)
