### PR TITLE
chore(repo): make deepseek-review non-blocking in merge-gatekeeper

### DIFF
--- a/.github/workflows/repo--merge-gatekeeper.yml
+++ b/.github/workflows/repo--merge-gatekeeper.yml
@@ -23,4 +23,4 @@ jobs:
           timeout: 1800
           interval: 60
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignored: "Integration tests (l2_nmc)"
+          ignored: "Integration tests (l2_nmc),deepseek-review"


### PR DESCRIPTION
## Summary

- Add `deepseek-review` to the Merge Gatekeeper ignored jobs list.
- Keep the existing `Integration tests (l2_nmc)` ignore unchanged.

## Why

DeepSeek review should still run and report comments, but its check status should not block `merge-gatekeeper` from passing.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/repo--merge-gatekeeper.yml"); puts "yaml ok"'`
- `/opt/homebrew/bin/pnpm prettier .github/workflows/repo--merge-gatekeeper.yml --check`