### PR TITLE
chore(taiko-client-rs): reject trailing bytes after manifest RLP

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/shasta/manifest.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/manifest.rs
@@ -7,7 +7,7 @@ use std::{
 
 use alloy::primitives::{Address, U256};
 use alloy_consensus::TxEnvelope;
-use alloy_rlp::{self, Decodable, Encodable, RlpDecodable, RlpEncodable};
+use alloy_rlp::{self, Encodable, RlpDecodable, RlpEncodable};
 use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
 use serde::{Deserialize, Serialize};
 
@@ -76,8 +76,11 @@ impl DerivationSourceManifest {
             }
         };
 
-        let mut decoded_slice = decoded.as_slice();
-        let manifest = match <DerivationSourceManifest as Decodable>::decode(&mut decoded_slice) {
+        // Decode with `decode_exact`, which rejects any bytes left after the RLP structure instead
+        // of silently ignoring them. A lenient decode would let a proposer append junk to an
+        // otherwise valid manifest and still have the crafted blocks derived; such trailing data
+        // must instead degrade the source to the default payload.
+        let manifest = match alloy_rlp::decode_exact::<DerivationSourceManifest>(&decoded) {
             Ok(m) => m,
             Err(err) => {
                 warn!(?err, "failed to decode derivation manifest RLP; returning default manifest");
@@ -280,6 +283,39 @@ mod tests {
 
         let decoded = DerivationSourceManifest::decompress_and_decode(&payload, 0).unwrap();
         assert_eq!(decoded.blocks.len(), DerivationSourceManifest::default().blocks.len());
+    }
+
+    #[test]
+    fn test_derivation_manifest_decode_rejects_trailing_bytes() {
+        use flate2::{Compression, write::ZlibEncoder};
+
+        // A valid single-block manifest with a stray byte appended past the RLP structure. Trailing
+        // data must be rejected so the source degrades to the default payload rather than deriving
+        // the crafted block.
+        let manifest = manifest_with_gas_limit(0xBEEF);
+        let mut body = alloy_rlp::encode(&manifest);
+        body.push(0xFF);
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&body).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let mut payload = Vec::with_capacity(64 + compressed.len());
+        let mut version_bytes = [0u8; 32];
+        version_bytes[31] = SHASTA_PAYLOAD_VERSION;
+        payload.extend_from_slice(&version_bytes);
+
+        let len_bytes = U256::from(compressed.len()).to_be_bytes::<32>();
+        payload.extend_from_slice(&len_bytes);
+        payload.extend_from_slice(&compressed);
+
+        let decoded = DerivationSourceManifest::decompress_and_decode(&payload, 0).unwrap();
+        // Falls back to the default single-block manifest, not the crafted 0xBEEF block.
+        assert_eq!(decoded.blocks.len(), DerivationSourceManifest::default().blocks.len());
+        assert_eq!(
+            decoded.blocks[0].gas_limit,
+            DerivationSourceManifest::default().blocks[0].gas_limit
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The Shasta derivation-source manifest decoder in `taiko-client-rs` accepts **trailing bytes** after the RLP structure, while the Go `taiko-client` driver rejects them. Given the same on-chain proposal, the two drivers can therefore derive a **different L2 block**, splitting consensus.

- **Rust (before):** [`manifest.rs`](https://github.com/taikoxyz/taiko-mono/blob/main/packages/taiko-client-rs/crates/protocol/src/shasta/manifest.rs) used `<DerivationSourceManifest as Decodable>::decode(&mut slice)`, which reads one RLP item and silently ignores whatever follows.
- **Go:** [`source_fetcher.go`](https://github.com/taikoxyz/taiko-mono/blob/main/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher.go) uses `rlp.DecodeBytes`, which returns `ErrMoreThanOneValue` on leftover bytes and degrades the source to the **default payload** (empty block).

## Impact

A proposer — permissionlessly, via **forced inclusion** — can post a blob whose decompressed payload is `rlp(manifest) ‖ garbage`. The single-block manifest passes both drivers' forced-inclusion checks, but:

- **Go** → trailing bytes rejected → default empty block
- **Rust** → trailing bytes ignored → derives the crafted blocks

The result is a different L2 block hash on each client. At most one of the two chains matches what the prover computes, so the divergent chain is also **unprovable**. This matters directly for running the Rust driver alongside (or in place of) the Go driver.

## Fix

Switch the decode to [`alloy_rlp::decode_exact`](https://docs.rs/alloy-rlp/0.3.15/alloy_rlp/fn.decode_exact.html), which decodes one item and then errors if any bytes remain — exactly matching Go's `rlp.DecodeBytes` semantics. The existing error arm already falls back to `DerivationSourceManifest::default()`, so both drivers now degrade to the default payload identically. The now-unused `Decodable` import is dropped.

## Test

Adds `test_derivation_manifest_decode_rejects_trailing_bytes`: it builds `rlp(single-block manifest) ‖ 0xFF`, compresses and wraps it in the Shasta payload header, and asserts the decoder falls back to the **default** single-block manifest rather than deriving the crafted block. Verified this test **fails** on the pre-fix lenient decode (derives the crafted `0xBEEF` gas-limit block) and **passes** after the fix.

```
cargo test -p protocol shasta::manifest  →  12 passed; 0 failed
cargo +nightly fmt -p protocol -- --check →  clean
cargo clippy -p protocol --no-deps -- -D warnings → clean
```

## Notes / out of scope

- **Distinct from #21854.** That fix added a trailing-byte check at the *blob (Kona) encoding* layer; this fixes the *RLP* layer one step later in the pipeline. They are independent.
- **Follow-up (Go side, not in this PR):** the forced-inclusion "exactly one block" rule is keyed on **array position** in Go (`derivationIdx != len(sources)-1`) but on the **`isForcedInclusion` flag** in Rust. Rust matches the canonical spec ([Derivation.md](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/Derivation.md) step 8); Go's positional proxy is currently masked by the contract emitting forced sources first. A separate Go-side change should switch it to the flag.
- Broader hardening — reconciling the derivation decode 3-way against the prover guest — is worth a dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)