### PR TITLE
chore(taiko-client): key forced-inclusion single-block rule on isForcedInclusion, not array position

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher.go
+++ b/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher.go
@@ -127,16 +127,17 @@ func (f *DerivationSourceFetcher) manifestFromBlobBytes(
 		log.Warn("Failed to decode derivation source manifest bytes, use default payload instead", "error", err)
 		return defaultPayload, nil
 	}
-	if derivationIdx != len(meta.GetEventData().Sources)-1 {
-		// For forced-inclusion source, ensure it contains exactly one block.
-		if len(derivationSourceManifest.Blocks) != 1 {
-			log.Warn(
-				"Invalid blocks count in forced-inclusion source manifest, use default payload instead",
-				"blobs", len(meta.GetEventData().Sources[derivationIdx].BlobSlice.BlobHashes),
-				"blocks", len(derivationSourceManifest.Blocks),
-			)
-			return defaultPayload, nil
-		}
+	// A forced-inclusion source must contain exactly one block. This is keyed on the source's
+	// isForcedInclusion flag (not its position in the array) to match the derivation spec and the
+	// Rust client.
+	if meta.GetEventData().Sources[derivationIdx].IsForcedInclusion &&
+		len(derivationSourceManifest.Blocks) != 1 {
+		log.Warn(
+			"Invalid blocks count in forced-inclusion source manifest, use default payload instead",
+			"blobs", len(meta.GetEventData().Sources[derivationIdx].BlobSlice.BlobHashes),
+			"blocks", len(derivationSourceManifest.Blocks),
+		)
+		return defaultPayload, nil
 	}
 
 	// If there are too many blocks in the manifest, return the default payload.

--- a/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher_test.go
+++ b/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher_test.go
@@ -63,6 +63,32 @@ func (s *DerivationSourceFetcherTestSuite) TestManifestEncodeDecode() {
 	s.Equal(len(m.Blocks[0].Transactions), len(decoded.BlockPayloads[0].Transactions))
 }
 
+func (s *DerivationSourceFetcherTestSuite) TestForcedInclusionMustBeSingleBlock() {
+	// A forced-inclusion source must contain exactly one block. The rule is keyed on the source's
+	// IsForcedInclusion flag rather than its position, so a multi-block forced inclusion degrades to
+	// the default payload even when it is the last (or only) source.
+	b, err := builder.EncodeSourceManifest(sourceManifestWithBlockCount(2))
+	s.Nil(err)
+
+	meta := &metadata.TaikoProposalMetadataShasta{
+		ShastaInboxClientProposed: &shastaBindings.ShastaInboxClientProposed{
+			Sources: []shastaBindings.IInboxDerivationSource{
+				{
+					IsForcedInclusion: true,
+					BlobSlice: shastaBindings.LibBlobsBlobSlice{
+						Offset:    big.NewInt(0),
+						Timestamp: big.NewInt(0),
+					},
+				},
+			},
+		},
+	}
+
+	decoded, err := (&DerivationSourceFetcher{cli: s.RPCClient}).manifestFromBlobBytes(b, meta, 0)
+	s.Nil(err)
+	s.True(decoded.Default)
+}
+
 func (s *DerivationSourceFetcherTestSuite) TestManifestBlockLimitUsesProposalTimestamp() {
 	original := gethcore.DevnetUnzenTime
 	s.T().Cleanup(func() { gethcore.DevnetUnzenTime = original })


### PR DESCRIPTION
## Summary

The forced-inclusion "exactly one block" rule in the Shasta derivation source fetcher is gated on the source's **position** in the array (`derivationIdx != len(sources)-1`) as a proxy for whether the source is a forced inclusion. The canonical derivation spec ([Derivation.md](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/Derivation.md), step 8 — *Forced Inclusion Block Count Enforcement*) and the Rust client both key this rule on the source's **`isForcedInclusion` flag** instead.

## Why `chore` and not `fix`

The two criteria agree today: the inbox always emits forced-inclusion sources first and the proposer's source last, so "not last" ≡ `isForcedInclusion`. There is **no live divergence** — this is spec-alignment / defense-in-depth that removes the latent mismatch, so a Go driver and a Rust driver cannot disagree if that ordering ever changes.

## Change

[`source_fetcher.go`](https://github.com/taikoxyz/taiko-mono/blob/main/packages/taiko-client/driver/chain_syncer/event/derivation/source_fetcher.go): key the single-block check on `Sources[derivationIdx].IsForcedInclusion` (already present in the bindings) instead of array position. Logging and the default-payload fallback are otherwise unchanged.

```go
// before — positional proxy
if derivationIdx != len(meta.GetEventData().Sources)-1 {
    if len(derivationSourceManifest.Blocks) != 1 { ... return defaultPayload }
}
// after — flag-based, per spec
if meta.GetEventData().Sources[derivationIdx].IsForcedInclusion &&
    len(derivationSourceManifest.Blocks) != 1 {
    ... return defaultPayload
}
```

## Test

Adds `TestForcedInclusionMustBeSingleBlock`: a 2-block manifest posted as a forced-inclusion source must degrade to the default payload regardless of position. It fails on the old positional check (a single/last forced source skipped the rule and kept both blocks) and passes after the change.

```
PACKAGE=driver/chain_syncer/event/derivation make test
--- PASS: TestDerivationSourceFetcherTestSuite/TestForcedInclusionMustBeSingleBlock (0.02s)
ok  ...driver/chain_syncer/event/derivation  coverage: 71.1% of statements
```

## Context

Companion to the Rust-side derivation hardening in #21911; both bring the Go and Rust drivers in line with the derivation spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)