### PR TITLE
feat(protocol): Ethereum Hoodi deployment verifier for the SGX/DCAP proof stack

### DIFF
--- a/packages/protocol/script/layer1/verifiers/README.md
+++ b/packages/protocol/script/layer1/verifiers/README.md
@@ -231,3 +231,38 @@ The script interacts with these `SgxVerifier` functions:
 - [SecureSgxVerifier.sol](../../../contracts/layer1/verifiers/SecureSgxVerifier.sol)
 - [InsecureSgxVerifier.sol](../../../contracts/layer1/verifiers/InsecureSgxVerifier.sol)
 - [IDcapAttestation.sol](../../../contracts/layer1/verifiers/IDcapAttestation.sol)
+
+## Deployment Verification
+
+After deploying the Taiko Hoodi proof stack, verify it end-to-end (read-only, no key) with
+[VerifyHoodiDeployment.s.sol](./VerifyHoodiDeployment.s.sol) via its wrapper:
+
+```bash
+./script/layer1/verifiers/verify_hoodi_deployment.sh \
+  --inbox 0xShastaInboxProxy \
+  --attestation 0xAutomataDcapAttestationFee \
+  --pccs 0xPccsRouter   # optional
+```
+
+It self-discovers the rest of the tree from the two roots
+(`inbox → MainnetVerifier → {sgxReth, sgxGeth, risc0, sp1}` and
+`attestation → V3QuoteVerifier → PCCS`) and asserts:
+
+- **Entrypoint:** Taiko-owned, fee `bp == 0`, wired to a v3 quote verifier, and live (an empty
+  quote is rejected via `verifyAndAttestOnChain`).
+- **SGX verifiers (×2):** the strict `SecureSgxVerifier` (rejects out-of-date TCB), pointed at the
+  shared entrypoint, on `TAIKO_HOODI`, Taiko-owned, `checkLocalEnclaveReport == true`, 24h validity
+  delay.
+- **Risc0 / SP1 tiers:** correct chain id and owner, with deployed sub-verifiers (SP1 remote gateway
+  is the #21907 v6.1 verifier).
+- **MainnetVerifier:** TDX/OP tiers disabled, four active tiers distinct and non-zero, and the inbox
+  points at it.
+
+The report tags each check `[PASS]` / `[FAIL]` / `[WARN]`. Advisories (`[WARN]`, e.g. the
+MRENCLAVE/MRSIGNER allowlist not yet populated by `ConfigureSgxVerifier`) do not fail the run; any
+`[FAIL]` makes the script exit non-zero.
+
+> **Migration gate.** Until `DeployShastaHoodi` is rewired from the legacy codesize-170 Automata
+> proxies to the new `AutomataDcapAttestationFee` (deployed via `DeployAutomataDcapAttestation` +
+> `DCAP_ATTESTATION`), the SGX-verifier → entrypoint checks will fail by design — the script doubles
+> as a readiness gate for that migration.

--- a/packages/protocol/script/layer1/verifiers/README.md
+++ b/packages/protocol/script/layer1/verifiers/README.md
@@ -253,10 +253,11 @@ It self-discovers the rest of the tree from the two roots
 - **SGX verifiers (×2):** the strict `SecureSgxVerifier` (rejects out-of-date TCB), pointed at the
   shared entrypoint, on `TAIKO_HOODI`, Taiko-owned, `checkLocalEnclaveReport == true`, 24h validity
   delay.
-- **Risc0 / SP1 tiers:** correct chain id and owner, with deployed sub-verifiers (SP1 remote gateway
-  is the #21907 v6.1 verifier).
-- **MainnetVerifier:** TDX/OP tiers disabled, four active tiers distinct and non-zero, and the inbox
-  points at it.
+- **Risc0 / SP1 tiers:** correct chain id and owner, with deployed sub-verifiers (the SP1 remote
+  gateway, expected to be the #21907 v6.1 verifier — only checked to have code, not its version).
+- **MainnetVerifier:** TDX/OP tiers disabled, four active tiers distinct and non-zero. (The
+  MainnetVerifier is the one the inbox's config points at — read from it during discovery, so that
+  link holds by construction.)
 
 The report tags each check `[PASS]` / `[FAIL]` / `[WARN]`. Advisories (`[WARN]`, e.g. the
 MRENCLAVE/MRSIGNER allowlist not yet populated by `ConfigureSgxVerifier`) do not fail the run; any

--- a/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
+++ b/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
@@ -135,7 +135,7 @@ contract VerifyHoodiDeployment is Script {
         _hard(_hasCode(risc0), "Risc0Verifier has code");
         _hard(_hasCode(sp1), "SP1Verifier has code");
 
-        // (later tasks insert _check* calls here)
+        _checkEntrypoint(attestation, v3, pccs, pccsExpected);
 
         console2.log("---");
         console2.log("[PASS] count :", passes);
@@ -147,6 +147,44 @@ contract VerifyHoodiDeployment is Script {
     // ---------------------------------------------------------------
     // Internal Functions
     // ---------------------------------------------------------------
+
+    /// @dev Asserts the DCAP entrypoint is Taiko-owned, fee-free, wired to a v3 quote verifier, and
+    /// live (an empty quote is rejected, proving entrypoint -> V3 -> PCCS plumbing is real).
+    function _checkEntrypoint(
+        address attestation,
+        address v3,
+        address pccs,
+        address pccsExpected
+    )
+        internal
+    {
+        // The has-code hard check already recorded the [FAIL] for a codeless entrypoint; returning
+        // here keeps the high-level reads below (which revert on a codeless address) from reverting
+        // the whole run, so a codeless root still surfaces as > 0 hardFails instead of a revert.
+        if (!_hasCode(attestation)) return;
+
+        _hard(
+            IEntrypointView(attestation).owner() == EXPECTED_OWNER,
+            "entrypoint owner == Hoodi owner"
+        );
+        _hard(v3 != address(0), "entrypoint quoteVerifiers(3) set");
+        _hard(IEntrypointView(attestation).getBp() == 0, "entrypoint fee bp == 0");
+
+        // Liveness: an empty quote must return success == false (Automata's early length rejection)
+        // without reverting. bp == 0 (asserted above) keeps this staticcall state-change-free.
+        (bool callOk, bytes memory ret) = attestation.staticcall(
+            abi.encodeWithSelector(IEntrypointView.verifyAndAttestOnChain.selector, bytes(""))
+        );
+        bool attestOk = callOk && ret.length >= 32 && abi.decode(ret, (bool));
+        _hard(callOk && !attestOk, "entrypoint liveness: empty quote rejected");
+
+        if (v3 != address(0)) {
+            _hard(IV3QuoteVerifierView(v3).quoteVersion() == 3, "V3QuoteVerifier.quoteVersion == 3");
+        }
+        if (pccsExpected != address(0)) {
+            _warn(pccs == pccsExpected, "PCCS router == expected (optional)");
+        }
+    }
 
     /// @dev Records a hard check: increments passes or hardFails and logs the outcome.
     function _hard(bool ok, string memory label) internal {

--- a/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
+++ b/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
@@ -141,7 +141,6 @@ contract VerifyHoodiDeployment is Script {
         _checkRisc0(risc0);
         _checkSp1(sp1);
         _checkAggregation(compose, sgxGeth, sgxReth, risc0, sp1);
-        _checkCrossCutting(sgxReth, sgxGeth, attestation);
 
         console2.log("---");
         console2.log("[PASS] count :", passes);
@@ -196,6 +195,10 @@ contract VerifyHoodiDeployment is Script {
     /// on the Hoodi chain id, Taiko-owned, and fail-closed. Allowlist population is advisory
     /// (ConfigureSgxVerifier runs after deployment).
     function _checkSgx(address sgx, address attestation, string memory tag) internal {
+        // The has-code hard check already recorded the [FAIL] for a codeless verifier; returning
+        // here keeps the typed reads below from reverting the whole run on a codeless target.
+        if (!_hasCode(sgx)) return;
+
         // Secure/Insecure discriminator: both implement isTcbStatusAccepted; only Secure rejects
         // out-of-date TCB. Expressed against the pinned Automata TCBStatus enum.
         bool rejectsOutOfDate = !ISgxView(sgx).isTcbStatusAccepted(uint8(TCBStatus.TCB_OUT_OF_DATE));
@@ -235,11 +238,22 @@ contract VerifyHoodiDeployment is Script {
             ISgxView(sgx).nextInstanceId() >= 1,
             string.concat(tag, ": >= 1 instance registered (advisory)")
         );
+
+        // Advisory: the current deploy leaves the registrar unset (address(0)); a non-zero
+        // registrar is a deviation worth flagging, never a hard failure.
+        _warn(
+            ISgxView(sgx).registrar() == address(0),
+            string.concat(tag, ": registrar == address(0) (advisory)")
+        );
     }
 
     /// @dev Asserts the Risc0 tier verifier is on the Hoodi chain id, Taiko-owned, and wired to a
     /// deployed groth16 verifier.
     function _checkRisc0(address risc0) internal {
+        // The has-code hard check already recorded the [FAIL] for a codeless verifier; returning
+        // here keeps the typed reads below from reverting the whole run on a codeless target.
+        if (!_hasCode(risc0)) return;
+
         _hard(
             IRisc0View(risc0).taikoChainId() == EXPECTED_CHAIN_ID,
             "Risc0: taikoChainId == TAIKO_HOODI"
@@ -253,6 +267,10 @@ contract VerifyHoodiDeployment is Script {
     /// @dev Asserts the SP1 tier verifier is on the Hoodi chain id, Taiko-owned, and wired to a
     /// deployed remote verifier (the v6.1 gateway).
     function _checkSp1(address sp1) internal {
+        // The has-code hard check already recorded the [FAIL] for a codeless verifier; returning
+        // here keeps the typed reads below from reverting the whole run on a codeless target.
+        if (!_hasCode(sp1)) return;
+
         _hard(ISP1View(sp1).taikoChainId() == EXPECTED_CHAIN_ID, "SP1: taikoChainId == TAIKO_HOODI");
         _hard(ISP1View(sp1).owner() == EXPECTED_OWNER, "SP1: owner == Hoodi owner");
         _hard(_hasCode(ISP1View(sp1).sp1RemoteVerifier()), "SP1: remote verifier has code");
@@ -270,6 +288,11 @@ contract VerifyHoodiDeployment is Script {
     )
         internal
     {
+        // The has-code hard check already recorded the [FAIL] for a codeless MainnetVerifier;
+        // returning here keeps the typed reads below from reverting the whole run on a codeless
+        // target (e.g. a wrong --inbox, or the MainnetVerifier not deployed yet).
+        if (!_hasCode(compose)) return;
+
         _hard(
             IComposeView(compose).tdxGethVerifier() == address(0), "Mainnet: tdxGethVerifier == 0"
         );
@@ -280,15 +303,6 @@ contract VerifyHoodiDeployment is Script {
         bool nonZero = sgxGeth != address(0) && sgxReth != address(0) && risc0 != address(0)
             && sp1 != address(0);
         _hard(nonZero, "Mainnet: four tiers are non-zero");
-    }
-
-    /// @dev Asserts the stack-wide invariant that both SGX verifiers share the same entrypoint.
-    function _checkCrossCutting(address sgxReth, address sgxGeth, address attestation) internal {
-        _hard(
-            ISgxView(sgxReth).automataDcapAttestation() == attestation
-                && ISgxView(sgxGeth).automataDcapAttestation() == attestation,
-            "cross-cut: both SGX verifiers share the entrypoint"
-        );
     }
 
     /// @dev Records a hard check: increments passes or hardFails and logs the outcome.

--- a/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
+++ b/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
@@ -138,6 +138,8 @@ contract VerifyHoodiDeployment is Script {
         _checkEntrypoint(attestation, v3, pccs, pccsExpected);
         _checkSgx(sgxReth, attestation, "SGX-reth");
         _checkSgx(sgxGeth, attestation, "SGX-geth");
+        _checkRisc0(risc0);
+        _checkSp1(sp1);
 
         console2.log("---");
         console2.log("[PASS] count :", passes);
@@ -231,6 +233,27 @@ contract VerifyHoodiDeployment is Script {
             ISgxView(sgx).nextInstanceId() >= 1,
             string.concat(tag, ": >= 1 instance registered (advisory)")
         );
+    }
+
+    /// @dev Asserts the Risc0 tier verifier is on the Hoodi chain id, Taiko-owned, and wired to a
+    /// deployed groth16 verifier.
+    function _checkRisc0(address risc0) internal {
+        _hard(
+            IRisc0View(risc0).taikoChainId() == EXPECTED_CHAIN_ID,
+            "Risc0: taikoChainId == TAIKO_HOODI"
+        );
+        _hard(IRisc0View(risc0).owner() == EXPECTED_OWNER, "Risc0: owner == Hoodi owner");
+        _hard(
+            _hasCode(IRisc0View(risc0).riscoGroth16Verifier()), "Risc0: groth16 verifier has code"
+        );
+    }
+
+    /// @dev Asserts the SP1 tier verifier is on the Hoodi chain id, Taiko-owned, and wired to a
+    /// deployed remote verifier (the v6.1 gateway).
+    function _checkSp1(address sp1) internal {
+        _hard(ISP1View(sp1).taikoChainId() == EXPECTED_CHAIN_ID, "SP1: taikoChainId == TAIKO_HOODI");
+        _hard(ISP1View(sp1).owner() == EXPECTED_OWNER, "SP1: owner == Hoodi owner");
+        _hard(_hasCode(ISP1View(sp1).sp1RemoteVerifier()), "SP1: remote verifier has code");
     }
 
     /// @dev Records a hard check: increments passes or hardFails and logs the outcome.

--- a/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
+++ b/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { TCBStatus } from "@automata-network/on-chain-pccs/helpers/FmspcTcbHelper.sol";
+import "forge-std/src/Script.sol";
+import "forge-std/src/console2.sol";
+import { IInbox } from "src/layer1/core/iface/IInbox.sol";
+import { LibL1HoodiAddrs } from "src/layer1/hoodi/LibL1HoodiAddrs.sol";
+import { LibNetwork } from "src/shared/libs/LibNetwork.sol";
+
+/// @dev Minimal read view of the Taiko-owned AutomataDcapAttestationFee entrypoint.
+interface IEntrypointView {
+    function owner() external view returns (address);
+    function quoteVerifiers(uint16 version) external view returns (address);
+    function getBp() external view returns (uint16);
+    function verifyAndAttestOnChain(bytes calldata rawQuote)
+        external
+        payable
+        returns (bool success, bytes memory output);
+}
+
+/// @dev Minimal read view of the Automata V3 quote verifier.
+interface IV3QuoteVerifierView {
+    function pccsRouter() external view returns (address);
+    function quoteVersion() external view returns (uint16);
+}
+
+/// @dev Minimal read view of ComposeVerifier/MainnetVerifier tier wiring.
+interface IComposeView {
+    function sgxGethVerifier() external view returns (address);
+    function sgxRethVerifier() external view returns (address);
+    function risc0RethVerifier() external view returns (address);
+    function sp1RethVerifier() external view returns (address);
+    function tdxGethVerifier() external view returns (address);
+    function opVerifier() external view returns (address);
+}
+
+/// @dev Minimal read view of an SgxVerifier (Secure or Insecure).
+interface ISgxView {
+    function taikoChainId() external view returns (uint64);
+    function automataDcapAttestation() external view returns (address);
+    function checkLocalEnclaveReport() external view returns (bool);
+    function registrar() external view returns (address);
+    function nextInstanceId() external view returns (uint256);
+    function owner() external view returns (address);
+    function isTcbStatusAccepted(uint8 status) external view returns (bool);
+    function instanceValidityDelay() external view returns (uint64);
+}
+
+/// @dev Minimal read view of Risc0Verifier.
+interface IRisc0View {
+    function taikoChainId() external view returns (uint64);
+    function riscoGroth16Verifier() external view returns (address);
+    function owner() external view returns (address);
+}
+
+/// @dev Minimal read view of SP1Verifier.
+interface ISP1View {
+    function taikoChainId() external view returns (uint64);
+    function sp1RemoteVerifier() external view returns (address);
+    function owner() external view returns (address);
+}
+
+/// @title VerifyHoodiDeployment
+/// @notice Read-only verifier for the Taiko Hoodi proof stack: walks the deployment from the
+/// Shasta inbox and the Taiko-owned AutomataDcapAttestationFee entrypoint and asserts the SGX/DCAP
+/// wiring (#21827), Risc0/SP1 tiers (#21907) and MainnetVerifier aggregation are correct and safe.
+/// @dev Uses minimal local interfaces so it compiles under the non-IR `layer1` profile (the concrete
+/// Automata contracts require `via_ir`). No broadcast, no PRIVATE_KEY — every read is a staticcall.
+/// @custom:security-contact security@taiko.xyz
+contract VerifyHoodiDeployment is Script {
+    address internal constant EXPECTED_OWNER = LibL1HoodiAddrs.HOODI_CONTRACT_OWNER;
+    uint64 internal constant EXPECTED_CHAIN_ID = LibNetwork.TAIKO_HOODI;
+    uint64 internal constant EXPECTED_VALIDITY_DELAY = 24 hours;
+
+    uint256 internal passes;
+    uint256 internal advisories;
+    uint256 internal hardFails;
+
+    /// @notice Env-driven entrypoint. Reads INBOX, ATTESTATION and optional PCCS_ROUTER, runs the
+    /// full check suite, and reverts (non-zero exit) iff any hard check failed.
+    function run() external {
+        address inbox = vm.envAddress("INBOX");
+        address attestation = vm.envAddress("ATTESTATION");
+        address pccsExpected = vm.envOr("PCCS_ROUTER", address(0));
+        uint256 fails = verify(inbox, attestation, pccsExpected);
+        require(fails == 0, "Hoodi deployment verification FAILED");
+    }
+
+    /// @notice Runs every check against the deployment reachable from the two roots and returns the
+    /// number of hard failures (0 == deployment OK). Advisories never count as failures.
+    /// @param inbox The Shasta inbox proxy (root of tier/aggregation discovery).
+    /// @param attestation The AutomataDcapAttestationFee entrypoint (root of the DCAP subtree).
+    /// @param pccsExpected Optional expected PCCS router; when non-zero it is asserted (advisory).
+    /// @return hardFails_ The number of hard-check failures.
+    function verify(
+        address inbox,
+        address attestation,
+        address pccsExpected
+    )
+        public
+        returns (uint256 hardFails_)
+    {
+        passes = 0;
+        advisories = 0;
+        hardFails = 0;
+
+        // ---- discovery walk ----
+        // Each external read is guarded by a has-code check so that a missing (codeless) node
+        // leaves the downstream local as address(0) and surfaces as a [FAIL] in the has-code
+        // section below, rather than reverting the whole run on `call to non-contract address`.
+        address compose = _hasCode(inbox) ? IInbox(inbox).getConfig().proofVerifier : address(0);
+        address sgxReth = _hasCode(compose) ? IComposeView(compose).sgxRethVerifier() : address(0);
+        address sgxGeth = _hasCode(compose) ? IComposeView(compose).sgxGethVerifier() : address(0);
+        address risc0 = _hasCode(compose) ? IComposeView(compose).risc0RethVerifier() : address(0);
+        address sp1 = _hasCode(compose) ? IComposeView(compose).sp1RethVerifier() : address(0);
+        address v3 =
+            _hasCode(attestation) ? IEntrypointView(attestation).quoteVerifiers(3) : address(0);
+        address pccs = _hasCode(v3) ? IV3QuoteVerifierView(v3).pccsRouter() : address(0);
+
+        console2.log("=== Hoodi deployment verification ===");
+        console2.log("inbox                        :", inbox);
+        console2.log("proofVerifier (Mainnet)      :", compose);
+        console2.log("attestation (DCAP entrypoint):", attestation);
+        console2.log("V3QuoteVerifier              :", v3);
+        console2.log("PCCS router                  :", pccs);
+
+        // ---- has-code checks ----
+        _hard(_hasCode(attestation), "entrypoint has code");
+        _hard(_hasCode(v3), "V3QuoteVerifier has code");
+        _hard(_hasCode(pccs), "PCCS router has code");
+        _hard(_hasCode(compose), "MainnetVerifier has code");
+        _hard(_hasCode(sgxReth), "SGX-reth verifier has code");
+        _hard(_hasCode(sgxGeth), "SGX-geth verifier has code");
+        _hard(_hasCode(risc0), "Risc0Verifier has code");
+        _hard(_hasCode(sp1), "SP1Verifier has code");
+
+        // (later tasks insert _check* calls here)
+
+        console2.log("---");
+        console2.log("[PASS] count :", passes);
+        console2.log("[WARN] count :", advisories);
+        console2.log("[FAIL] count :", hardFails);
+        return hardFails;
+    }
+
+    // ---------------------------------------------------------------
+    // Internal Functions
+    // ---------------------------------------------------------------
+
+    /// @dev Records a hard check: increments passes or hardFails and logs the outcome.
+    function _hard(bool ok, string memory label) internal {
+        if (ok) {
+            ++passes;
+            console2.log("  [PASS]", label);
+        } else {
+            ++hardFails;
+            console2.log("  [FAIL]", label);
+        }
+    }
+
+    /// @dev Records an advisory check: increments passes or advisories and logs the outcome.
+    function _warn(bool ok, string memory label) internal {
+        if (ok) {
+            ++passes;
+            console2.log("  [PASS]", label);
+        } else {
+            ++advisories;
+            console2.log("  [WARN]", label);
+        }
+    }
+
+    /// @dev True when the address hosts contract code.
+    function _hasCode(address a) internal view returns (bool) {
+        return a.code.length != 0;
+    }
+}

--- a/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
+++ b/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
@@ -136,6 +136,8 @@ contract VerifyHoodiDeployment is Script {
         _hard(_hasCode(sp1), "SP1Verifier has code");
 
         _checkEntrypoint(attestation, v3, pccs, pccsExpected);
+        _checkSgx(sgxReth, attestation, "SGX-reth");
+        _checkSgx(sgxGeth, attestation, "SGX-geth");
 
         console2.log("---");
         console2.log("[PASS] count :", passes);
@@ -184,6 +186,51 @@ contract VerifyHoodiDeployment is Script {
         if (pccsExpected != address(0)) {
             _warn(pccs == pccsExpected, "PCCS router == expected (optional)");
         }
+    }
+
+    /// @dev Asserts an SGX verifier is the strict Secure variant, wired to the shared entrypoint,
+    /// on the Hoodi chain id, Taiko-owned, and fail-closed. Allowlist population is advisory
+    /// (ConfigureSgxVerifier runs after deployment).
+    function _checkSgx(address sgx, address attestation, string memory tag) internal {
+        // Secure/Insecure discriminator: both implement isTcbStatusAccepted; only Secure rejects
+        // out-of-date TCB. Expressed against the pinned Automata TCBStatus enum.
+        bool rejectsOutOfDate = !ISgxView(sgx).isTcbStatusAccepted(uint8(TCBStatus.TCB_OUT_OF_DATE));
+        bool acceptsOk = ISgxView(sgx).isTcbStatusAccepted(uint8(TCBStatus.OK));
+        _hard(
+            rejectsOutOfDate && acceptsOk,
+            string.concat(tag, ": Secure TCB policy (rejects OUT_OF_DATE)")
+        );
+
+        // Secure-only immutable; reverts on an Insecure verifier (caught as a failure).
+        try ISgxView(sgx).instanceValidityDelay() returns (uint64 d) {
+            _hard(
+                d == EXPECTED_VALIDITY_DELAY, string.concat(tag, ": instanceValidityDelay == 24h")
+            );
+        } catch {
+            _hard(false, string.concat(tag, ": instanceValidityDelay getter (Secure-only) present"));
+        }
+
+        _hard(
+            ISgxView(sgx).automataDcapAttestation() == attestation,
+            string.concat(tag, ": automataDcapAttestation == entrypoint")
+        );
+        _hard(
+            ISgxView(sgx).taikoChainId() == EXPECTED_CHAIN_ID,
+            string.concat(tag, ": taikoChainId == TAIKO_HOODI")
+        );
+        _hard(ISgxView(sgx).owner() == EXPECTED_OWNER, string.concat(tag, ": owner == Hoodi owner"));
+        _hard(
+            ISgxView(sgx).checkLocalEnclaveReport(),
+            string.concat(tag, ": checkLocalEnclaveReport == true")
+        );
+
+        // Advisory: instances are registered post-deploy by ConfigureSgxVerifier. The allowlist
+        // mappings are keyed by value and cannot be enumerated on-chain, so nextInstanceId is the
+        // readable proxy for "at least one instance has been registered".
+        _warn(
+            ISgxView(sgx).nextInstanceId() >= 1,
+            string.concat(tag, ": >= 1 instance registered (advisory)")
+        );
     }
 
     /// @dev Records a hard check: increments passes or hardFails and logs the outcome.

--- a/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
+++ b/packages/protocol/script/layer1/verifiers/VerifyHoodiDeployment.s.sol
@@ -140,6 +140,8 @@ contract VerifyHoodiDeployment is Script {
         _checkSgx(sgxGeth, attestation, "SGX-geth");
         _checkRisc0(risc0);
         _checkSp1(sp1);
+        _checkAggregation(compose, sgxGeth, sgxReth, risc0, sp1);
+        _checkCrossCutting(sgxReth, sgxGeth, attestation);
 
         console2.log("---");
         console2.log("[PASS] count :", passes);
@@ -254,6 +256,39 @@ contract VerifyHoodiDeployment is Script {
         _hard(ISP1View(sp1).taikoChainId() == EXPECTED_CHAIN_ID, "SP1: taikoChainId == TAIKO_HOODI");
         _hard(ISP1View(sp1).owner() == EXPECTED_OWNER, "SP1: owner == Hoodi owner");
         _hard(_hasCode(ISP1View(sp1).sp1RemoteVerifier()), "SP1: remote verifier has code");
+    }
+
+    /// @dev Asserts the MainnetVerifier aggregation shape: TDX/OP tiers disabled, and the four
+    /// active tiers non-zero and mutually distinct. The inbox -> aggregator identity needs no check:
+    /// `compose` is read from `inbox.getConfig().proofVerifier`, so it holds by construction.
+    function _checkAggregation(
+        address compose,
+        address sgxGeth,
+        address sgxReth,
+        address risc0,
+        address sp1
+    )
+        internal
+    {
+        _hard(
+            IComposeView(compose).tdxGethVerifier() == address(0), "Mainnet: tdxGethVerifier == 0"
+        );
+        _hard(IComposeView(compose).opVerifier() == address(0), "Mainnet: opVerifier == 0");
+        bool distinct = sgxGeth != sgxReth && sgxGeth != risc0 && sgxGeth != sp1 && sgxReth != risc0
+            && sgxReth != sp1 && risc0 != sp1;
+        _hard(distinct, "Mainnet: four tiers are distinct");
+        bool nonZero = sgxGeth != address(0) && sgxReth != address(0) && risc0 != address(0)
+            && sp1 != address(0);
+        _hard(nonZero, "Mainnet: four tiers are non-zero");
+    }
+
+    /// @dev Asserts the stack-wide invariant that both SGX verifiers share the same entrypoint.
+    function _checkCrossCutting(address sgxReth, address sgxGeth, address attestation) internal {
+        _hard(
+            ISgxView(sgxReth).automataDcapAttestation() == attestation
+                && ISgxView(sgxGeth).automataDcapAttestation() == attestation,
+            "cross-cut: both SGX verifiers share the entrypoint"
+        );
     }
 
     /// @dev Records a hard check: increments passes or hardFails and logs the outcome.

--- a/packages/protocol/script/layer1/verifiers/verify_hoodi_deployment.sh
+++ b/packages/protocol/script/layer1/verifiers/verify_hoodi_deployment.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Read-only verifier for a Taiko Hoodi proof-stack deployment.
+#
+# Walks the deployment from two roots (the Shasta inbox and the Taiko-owned
+# AutomataDcapAttestationFee entrypoint) and asserts the SGX/DCAP wiring, the
+# SecureSgxVerifier policy, the Risc0/SP1 tiers and the MainnetVerifier
+# aggregation. Exits non-zero if any hard check fails. No broadcast, no key.
+
+set -euo pipefail
+
+FORK_URL="${FORK_URL:-https://ethereum-hoodi-rpc.publicnode.com}"
+
+usage() {
+    cat << 'EOF'
+Verify Hoodi Deployment
+
+Usage:
+  ./verify_hoodi_deployment.sh --inbox 0x... --attestation 0x... [--pccs 0x...] [--rpc URL]
+
+Required:
+  --inbox ADDR          Shasta inbox proxy (root of tier discovery)
+  --attestation ADDR    AutomataDcapAttestationFee entrypoint (root of the DCAP subtree)
+
+Optional:
+  --pccs ADDR           Expected PCCS router (asserted as an advisory when supplied)
+  --rpc URL             RPC endpoint (default: https://ethereum-hoodi-rpc.publicnode.com,
+                        or the FORK_URL env var)
+
+Example:
+  ./verify_hoodi_deployment.sh \
+    --inbox 0xInbox --attestation 0xEntrypoint --pccs 0xPccsRouter
+EOF
+}
+
+INBOX=""
+ATTESTATION=""
+PCCS_ROUTER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --inbox) INBOX="$2"; shift 2 ;;
+        --attestation) ATTESTATION="$2"; shift 2 ;;
+        --pccs) PCCS_ROUTER="$2"; shift 2 ;;
+        --rpc|--fork-url) FORK_URL="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$INBOX" || -z "$ATTESTATION" ]]; then
+    echo "Error: --inbox and --attestation are required" >&2
+    usage
+    exit 1
+fi
+
+export INBOX ATTESTATION
+if [[ -n "$PCCS_ROUTER" ]]; then
+    export PCCS_ROUTER
+fi
+
+FOUNDRY_PROFILE=layer1 forge script \
+    script/layer1/verifiers/VerifyHoodiDeployment.s.sol:VerifyHoodiDeployment \
+    --fork-url "$FORK_URL" \
+    -vvv

--- a/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
+++ b/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
@@ -202,16 +202,12 @@ contract VerifyHoodiDeploymentTest is Test {
         assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
     }
 
-    function test_verify_sgxDifferentEntrypoints_fails() public {
-        // reth points at goodEntrypoint, geth points at a different entrypoint -> cross-cutting fail.
-        address other = _entrypoint(OWNER, 0);
-        address reth =
-            address(new SecureSgxVerifier(CHAIN_ID, OWNER, goodEntrypoint, address(0), 24 hours));
-        address geth = address(new SecureSgxVerifier(CHAIN_ID, OWNER, other, address(0), 24 hours));
-        address risc0 = address(new Risc0Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
-        address sp1 = address(new SP1Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
-        address mv = address(new MainnetVerifier(geth, reth, risc0, sp1));
-        address inbox = address(new MockInbox(mv));
+    function test_verify_codelessAggregator_reportsNotReverts() public {
+        // A MockInbox whose proofVerifier is a codeless address (EOA-style, no code). Discovery
+        // leaves the tier locals as address(0); the check bodies must early-return on the codeless
+        // target so the run RETURNS a positive hardFail count rather than reverting on a typed call
+        // to address(0). Before the has-code guards in _check* this reverts with empty `0x`.
+        address inbox = address(new MockInbox(address(0xC0DE1E55)));
         assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
     }
 }

--- a/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
+++ b/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
@@ -117,4 +117,27 @@ contract VerifyHoodiDeploymentTest is Test {
         // An EOA-style address (no code) as the attestation root trips the has-code check.
         assertGt(verifier.verify(goodInbox, address(0xEE), address(0)), 0);
     }
+
+    function test_verify_entrypointWrongOwner_fails() public {
+        address badEntry = _entrypoint(address(0xBAD), 0);
+        (address inbox,) = _stack(badEntry, badEntry, false, CHAIN_ID, OWNER);
+        assertGt(verifier.verify(inbox, badEntry, address(0)), 0);
+    }
+
+    function test_verify_entrypointNonZeroFee_fails() public {
+        address badEntry = _entrypoint(OWNER, 100); // bp != 0
+        (address inbox,) = _stack(badEntry, badEntry, false, CHAIN_ID, OWNER);
+        assertGt(verifier.verify(inbox, badEntry, address(0)), 0);
+    }
+
+    function test_verify_entrypointStubLiveness_fails() public {
+        // A stub entrypoint that "accepts" an empty quote must be caught by the liveness probe.
+        MockEntrypoint(goodEntrypoint).setStubAccept(true);
+        assertGt(verifier.verify(goodInbox, goodEntrypoint, address(0)), 0);
+    }
+
+    function test_verify_pccsMismatch_advisoryNotHardFail() public {
+        // Supplying a wrong expected PCCS is an advisory: hardFails stays 0 on an otherwise-good stack.
+        assertEq(verifier.verify(goodInbox, goodEntrypoint, address(0x9999)), 0);
+    }
 }

--- a/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
+++ b/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
@@ -140,4 +140,28 @@ contract VerifyHoodiDeploymentTest is Test {
         // Supplying a wrong expected PCCS is an advisory: hardFails stays 0 on an otherwise-good stack.
         assertEq(verifier.verify(goodInbox, goodEntrypoint, address(0x9999)), 0);
     }
+
+    function test_verify_insecureSgxPolicy_fails() public {
+        // A public testnet must use SecureSgxVerifier; the lenient one must be rejected.
+        (address inbox, address att) = _stack(goodEntrypoint, goodEntrypoint, true, CHAIN_ID, OWNER);
+        assertGt(verifier.verify(inbox, att, address(0)), 0);
+    }
+
+    function test_verify_sgxWrongChainId_fails() public {
+        (address inbox, address att) = _stack(goodEntrypoint, goodEntrypoint, false, 999, OWNER);
+        assertGt(verifier.verify(inbox, att, address(0)), 0);
+    }
+
+    function test_verify_sgxWrongOwner_fails() public {
+        (address inbox, address att) =
+            _stack(goodEntrypoint, goodEntrypoint, false, CHAIN_ID, address(0xBAD));
+        assertGt(verifier.verify(inbox, att, address(0)), 0);
+    }
+
+    function test_verify_sgxPointsAtWrongEntrypoint_fails() public {
+        address other = _entrypoint(OWNER, 0);
+        // SGX verifiers point at `other`, but we verify against `goodEntrypoint` as the root.
+        (address inbox,) = _stack(goodEntrypoint, other, false, CHAIN_ID, OWNER);
+        assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
+    }
 }

--- a/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
+++ b/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
@@ -164,4 +164,30 @@ contract VerifyHoodiDeploymentTest is Test {
         (address inbox,) = _stack(goodEntrypoint, other, false, CHAIN_ID, OWNER);
         assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
     }
+
+    function test_verify_risc0WrongChainId_fails() public {
+        // Build a stack whose Risc0 verifier has a wrong chain id.
+        address reth =
+            address(new SecureSgxVerifier(CHAIN_ID, OWNER, goodEntrypoint, address(0), 24 hours));
+        address geth =
+            address(new SecureSgxVerifier(CHAIN_ID, OWNER, goodEntrypoint, address(0), 24 hours));
+        address risc0 = address(new Risc0Verifier(999, address(new MockCoded()), OWNER));
+        address sp1 = address(new SP1Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
+        address mv = address(new MainnetVerifier(geth, reth, risc0, sp1));
+        address inbox = address(new MockInbox(mv));
+        assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
+    }
+
+    function test_verify_sp1RemoteWithoutCode_fails() public {
+        // SP1's remote verifier is an EOA (no code) -> has-code sub-check fails.
+        address reth =
+            address(new SecureSgxVerifier(CHAIN_ID, OWNER, goodEntrypoint, address(0), 24 hours));
+        address geth =
+            address(new SecureSgxVerifier(CHAIN_ID, OWNER, goodEntrypoint, address(0), 24 hours));
+        address risc0 = address(new Risc0Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
+        address sp1 = address(new SP1Verifier(CHAIN_ID, address(0xEE), OWNER)); // 0xEE has no code
+        address mv = address(new MainnetVerifier(geth, reth, risc0, sp1));
+        address inbox = address(new MockInbox(mv));
+        assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
+    }
 }

--- a/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
+++ b/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
@@ -190,4 +190,28 @@ contract VerifyHoodiDeploymentTest is Test {
         address inbox = address(new MockInbox(mv));
         assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
     }
+
+    function test_verify_mainnetTiersNotDistinct_fails() public {
+        // The same verifier is wired into both SGX tiers -> the "four tiers distinct" check fails.
+        address sgx =
+            address(new SecureSgxVerifier(CHAIN_ID, OWNER, goodEntrypoint, address(0), 24 hours));
+        address risc0 = address(new Risc0Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
+        address sp1 = address(new SP1Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
+        address mv = address(new MainnetVerifier(sgx, sgx, risc0, sp1)); // sgxGeth == sgxReth
+        address inbox = address(new MockInbox(mv));
+        assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
+    }
+
+    function test_verify_sgxDifferentEntrypoints_fails() public {
+        // reth points at goodEntrypoint, geth points at a different entrypoint -> cross-cutting fail.
+        address other = _entrypoint(OWNER, 0);
+        address reth =
+            address(new SecureSgxVerifier(CHAIN_ID, OWNER, goodEntrypoint, address(0), 24 hours));
+        address geth = address(new SecureSgxVerifier(CHAIN_ID, OWNER, other, address(0), 24 hours));
+        address risc0 = address(new Risc0Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
+        address sp1 = address(new SP1Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
+        address mv = address(new MainnetVerifier(geth, reth, risc0, sp1));
+        address inbox = address(new MockInbox(mv));
+        assertGt(verifier.verify(inbox, goodEntrypoint, address(0)), 0);
+    }
 }

--- a/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
+++ b/packages/protocol/test/layer1/verifiers/VerifyHoodiDeployment.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/src/Test.sol";
+import { VerifyHoodiDeployment } from "script/layer1/verifiers/VerifyHoodiDeployment.s.sol";
+import { IInbox } from "src/layer1/core/iface/IInbox.sol";
+import { LibL1HoodiAddrs } from "src/layer1/hoodi/LibL1HoodiAddrs.sol";
+import { MainnetVerifier } from "src/layer1/mainnet/MainnetVerifier.sol";
+import { InsecureSgxVerifier } from "src/layer1/verifiers/InsecureSgxVerifier.sol";
+import { Risc0Verifier } from "src/layer1/verifiers/Risc0Verifier.sol";
+import { SP1Verifier } from "src/layer1/verifiers/SP1Verifier.sol";
+import { SecureSgxVerifier } from "src/layer1/verifiers/SecureSgxVerifier.sol";
+import { LibNetwork } from "src/shared/libs/LibNetwork.sol";
+
+/// @dev An empty contract; used wherever a check only needs `code.length > 0`.
+contract MockCoded { }
+
+/// @dev Returns an IInbox.Config with only `proofVerifier` populated.
+contract MockInbox {
+    address internal immutable pv;
+
+    constructor(address _pv) {
+        pv = _pv;
+    }
+
+    function getConfig() external view returns (IInbox.Config memory c) {
+        c.proofVerifier = pv;
+    }
+}
+
+/// @dev Minimal AutomataDcapAttestationFee stand-in (the real one needs via_ir).
+contract MockEntrypoint {
+    address public owner;
+    uint16 internal bp;
+    bool internal stubAccept; // when true, empty-quote "succeeds" (a broken stub)
+    mapping(uint16 => address) public quoteVerifiers;
+
+    constructor(address _owner, uint16 _bp, address _v3) {
+        owner = _owner;
+        bp = _bp;
+        quoteVerifiers[3] = _v3;
+    }
+
+    function getBp() external view returns (uint16) {
+        return bp;
+    }
+
+    function setStubAccept(bool _v) external {
+        stubAccept = _v;
+    }
+
+    function verifyAndAttestOnChain(bytes calldata) external payable returns (bool, bytes memory) {
+        return (stubAccept, bytes("mock"));
+    }
+}
+
+/// @dev Minimal V3QuoteVerifier stand-in.
+contract MockV3 {
+    address public pccsRouter;
+    uint16 public quoteVersion = 3;
+
+    constructor(address _pccs) {
+        pccsRouter = _pccs;
+    }
+}
+
+contract VerifyHoodiDeploymentTest is Test {
+    address internal constant OWNER = LibL1HoodiAddrs.HOODI_CONTRACT_OWNER;
+    uint64 internal constant CHAIN_ID = LibNetwork.TAIKO_HOODI;
+
+    VerifyHoodiDeployment internal verifier;
+    address internal goodInbox;
+    address internal goodEntrypoint;
+
+    function setUp() public {
+        verifier = new VerifyHoodiDeployment();
+        goodEntrypoint = _entrypoint(OWNER, 0);
+        (goodInbox,) = _stack(goodEntrypoint, goodEntrypoint, false, CHAIN_ID, OWNER);
+    }
+
+    /// @dev Builds a correctly-wired AutomataDcapAttestationFee stand-in.
+    function _entrypoint(address owner_, uint16 bp_) internal returns (address) {
+        address pccs = address(new MockCoded());
+        address v3 = address(new MockV3(pccs));
+        return address(new MockEntrypoint(owner_, bp_, v3));
+    }
+
+    /// @dev Builds inbox -> MainnetVerifier -> {sgx x2, risc0, sp1}; SGX verifiers point at sgxAtt_.
+    function _stack(
+        address entrypoint_,
+        address sgxAtt_,
+        bool insecure_,
+        uint64 sgxChainId_,
+        address sgxOwner_
+    )
+        internal
+        returns (address inbox_, address attestation_)
+    {
+        address reth = insecure_
+            ? address(new InsecureSgxVerifier(sgxChainId_, sgxOwner_, sgxAtt_, address(0)))
+            : address(new SecureSgxVerifier(sgxChainId_, sgxOwner_, sgxAtt_, address(0), 24 hours));
+        address geth = insecure_
+            ? address(new InsecureSgxVerifier(sgxChainId_, sgxOwner_, sgxAtt_, address(0)))
+            : address(new SecureSgxVerifier(sgxChainId_, sgxOwner_, sgxAtt_, address(0), 24 hours));
+        address risc0 = address(new Risc0Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
+        address sp1 = address(new SP1Verifier(CHAIN_ID, address(new MockCoded()), OWNER));
+        address mv = address(new MainnetVerifier(geth, reth, risc0, sp1));
+        inbox_ = address(new MockInbox(mv));
+        attestation_ = entrypoint_;
+    }
+
+    function test_verify_happyPath_passes() public {
+        assertEq(verifier.verify(goodInbox, goodEntrypoint, address(0)), 0);
+    }
+
+    function test_verify_entrypointWithoutCode_fails() public {
+        // An EOA-style address (no code) as the attestation root trips the has-code check.
+        assertGt(verifier.verify(goodInbox, address(0xEE), address(0)), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **read-only, post-deployment verifier** for the Taiko Hoodi SGX/DCAP proof stack — the `AutomataDcapAttestationFee` entrypoint introduced in #21827 plus the SP1 v6.1 verifier from #21907. It lets an operator (or CI) gate go-live for Taiko Hoodi SGX proving with one command: it walks the deployment from two roots, asserts every wiring/policy invariant, and exits non-zero if any hard check fails.

It **only reads and asserts** — no broadcast, no private key, every read is a `staticcall`/view. It uses minimal local interfaces for the Automata types, so it compiles under the non-IR `layer1` profile (the concrete Automata contracts need `via_ir`).

## Migration gate

On Hoodi today there is **no `AutomataDcapAttestationFee` deployed** — `DeployShastaHoodi` still wires both SGX verifiers to the legacy codesize-170 `AutomataDcapV3Attestation` proxies. So this verifier encodes the #21827 **target end-state**: run before the migration, its SGX→entrypoint checks fail by design, reporting that the SGX verifiers are still on the legacy proxies. It doubles as a migration-readiness gate. (Rewiring `DeployShastaHoodi` to the new entrypoint via `DeployAutomataDcapAttestation` + `DCAP_ATTESTATION` is a separate deploy-script change.)

## How to run

```bash
./script/layer1/verifiers/verify_hoodi_deployment.sh \
  --inbox 0xShastaInboxProxy \
  --attestation 0xAutomataDcapAttestationFee \
  --pccs 0xPccsRouter   # optional
```

From the two roots it self-discovers the rest of the tree: `inbox → MainnetVerifier → {sgxReth, sgxGeth, risc0, sp1}` and `attestation → V3QuoteVerifier → PCCS`.

## What it checks

- **Entrypoint** — Taiko-owned, fee `bp == 0`, wired to a v3 quote verifier, and **live** (an empty quote is rejected via a `staticcall` of `verifyAndAttestOnChain(0x)` — staticcall-safe at `bp == 0`).
- **SGX verifiers (×2)** — the strict `SecureSgxVerifier` (rejects out-of-date TCB via `isTcbStatusAccepted`), pointed at the shared entrypoint, on `TAIKO_HOODI`, Taiko-owned, `checkLocalEnclaveReport == true`, 24h validity delay. Allowlist population and `registrar` are advisories.
- **Risc0 / SP1 tiers** — correct chain id and owner, with deployed sub-verifiers (SP1 remote gateway expected to be the #21907 v6.1 verifier).
- **MainnetVerifier** — TDX/OP tiers disabled, four active tiers distinct and non-zero.

Each check is tagged `[PASS]` / `[FAIL]` / `[WARN]`. Advisories (`[WARN]`) never fail the run; any `[FAIL]` makes the script exit non-zero.

## Testing

`test/layer1/verifiers/VerifyHoodiDeployment.t.sol` deploys the stack in-memory — **real** `SecureSgxVerifier`/`InsecureSgxVerifier`/`Risc0Verifier`/`SP1Verifier`/`MainnetVerifier`, with lightweight mocks only for the via_ir Automata entrypoint — asserts a clean pass, then flips individual fields (Insecure policy, wrong owner/chain id, fee ≠ 0, wrong entrypoint wiring, non-distinct tiers, codeless sub-verifier, codeless aggregator) to assert each is caught. 14 tests, all passing under `FOUNDRY_PROFILE=layer1`.

```bash
FOUNDRY_PROFILE=layer1 forge test --match-path "test/layer1/verifiers/VerifyHoodiDeployment.t.sol" -vv
```

## Notes

- **Robust to bad roots.** Every discovery read and every `_check*` body is guarded on `_hasCode`, so a wrong `--inbox` or a not-yet-deployed aggregator reports `[FAIL]` lines and a non-zero exit rather than reverting with an opaque `0x`.
- Constants are pinned to a single source of truth (`LibL1HoodiAddrs.HOODI_CONTRACT_OWNER`, `LibNetwork.TAIKO_HOODI`); the TCB policy is expressed against Automata's `TCBStatus` enum so a dependency reorder breaks the build, not the logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
