### PR TITLE
refactor(protocol): derive SGX quote freshness from the registrar (drop the toggle)

### DIFF
--- a/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
+++ b/packages/protocol/contracts/layer1/verifiers/SgxVerifier.sol
@@ -96,6 +96,10 @@ abstract contract SgxVerifier is IProofVerifier, Ownable2Step, ReentrancyGuard {
     /// @notice The address authorized to register SGX instances via `registerInstance`.
     /// @dev If set to a non-zero address, only this address may call `registerInstance`.
     /// If set to `address(0)`, `registerInstance` is permissionless and callable by anyone.
+    /// The registrar also selects the quote-freshness policy: permissionless registration requires
+    /// the attested quote to commit a recent L1 block (see `registerInstance`), while a trusted
+    /// registrar vouches for the provenance — and thus the age — of the quotes it submits, so its
+    /// registrations are exempt.
     address public immutable registrar;
 
     /// @dev For gas savings, we assign each SGX instance with an ID to minimize storage operations.
@@ -130,10 +134,6 @@ abstract contract SgxVerifier is IProofVerifier, Ownable2Step, ReentrancyGuard {
     /// pre-migration security model. Enabled by default (set in the constructor); toggle off with
     /// toggleLocalReportCheck().
     bool public checkLocalEnclaveReport;
-    /// @notice Whether `registerInstance` requires the attested quote to commit a recent L1 block,
-    /// bounding how old the quote may be. Off by default (backward compatible; requires prover
-    /// support to embed the block commitment in reportData). Toggle with `toggleQuoteFreshnessCheck`.
-    bool public requireQuoteFreshness;
     /// @dev Trusted-MRENCLAVE allowlist + policy version, co-located per measurement. Exposed via the
     /// `trustedUserMrEnclave` view (allowlist flag) and, in versioned subclasses, a policy-version
     /// view; `internal` so those subclasses can maintain the version in the same slot.
@@ -184,10 +184,6 @@ abstract contract SgxVerifier is IProofVerifier, Ownable2Step, ReentrancyGuard {
     /// @notice Emitted when enforcement of the local enclave identity allowlist is toggled.
     /// @param checkLocalEnclaveReport Whether the allowlist is enforced.
     event LocalReportCheckToggled(bool checkLocalEnclaveReport);
-
-    /// @notice Emitted when enforcement of the quote-freshness gate is toggled.
-    /// @param requireQuoteFreshness Whether a recent-block commitment is required at registration.
-    event QuoteFreshnessCheckToggled(bool requireQuoteFreshness);
 
     error SGX_ALREADY_ATTESTED();
     error SGX_DEBUG_ENCLAVE();
@@ -303,15 +299,6 @@ abstract contract SgxVerifier is IProofVerifier, Ownable2Step, ReentrancyGuard {
         emit LocalReportCheckToggled(checkLocalEnclaveReport);
     }
 
-    /// @notice Toggles enforcement of the quote-freshness gate in `registerInstance`.
-    /// @dev Enable only once the prover embeds a recent L1 block commitment (block number then that
-    /// block's hash) into reportData immediately after the instance address; otherwise every
-    /// registration reverts with `SGX_STALE_QUOTE`.
-    function toggleQuoteFreshnessCheck() external onlyOwner {
-        requireQuoteFreshness = !requireQuoteFreshness;
-        emit QuoteFreshnessCheckToggled(requireQuoteFreshness);
-    }
-
     /// @notice Adds an SGX instance after remote attestation is verified fully on-chain.
     /// @dev Migrated to the Automata DCAP attestation entrypoint
     /// (`IDcapAttestation.verifyAndAttestOnChain`), which consumes a raw quote and reads Intel
@@ -320,6 +307,10 @@ abstract contract SgxVerifier is IProofVerifier, Ownable2Step, ReentrancyGuard {
     /// @dev A non-owner (permissionless or registrar) registration is subject to the validity
     /// delay; an owner-submitted registration is as trusted as `addInstances` and takes effect
     /// immediately.
+    /// @dev When registration is permissionless (`registrar == address(0)`), the quote must also
+    /// commit a recent L1 block in reportData — block number (8 bytes, big-endian) then that
+    /// block's hash (32 bytes), right after the 20-byte instance address — proving the quote was
+    /// generated within the last 256 blocks (see the freshness gate below).
     /// @param _rawQuote The raw Intel DCAP v3 (SGX) attestation quote.
     /// @return The respective instanceId.
     function registerInstance(bytes calldata _rawQuote) external nonReentrant returns (uint256) {
@@ -430,16 +421,20 @@ abstract contract SgxVerifier is IProofVerifier, Ownable2Step, ReentrancyGuard {
         address[] memory addresses = new address[](1);
         addresses[0] = address(bytes20(_rawQuote[REPORT_DATA_OFFSET:REPORT_DATA_OFFSET + 20]));
 
-        // Optional quote-freshness gate. INSTANCE_EXPIRY only bounds key exposure *after*
-        // registration; nothing otherwise bounds how old the attested quote itself is, so a quote (or
-        // a slowly side-channel-extracted key) from long ago could be registered today and trusted
-        // for a fresh 90-day window. When enabled, require the enclave to have committed a recent L1
-        // block into reportData right after the instance address — block number (8 bytes, BE) then
-        // that block's hash (32 bytes) — and check the hash matches on-chain. `blockhash` returns
-        // zero outside the most recent 256 blocks, so a non-zero match bounds the quote's age to that
-        // window. Both fields are bound to the verified enclave report by the body-hash check above.
-        // Off by default (backward compatible); requires prover support to embed the block commitment.
-        if (requireQuoteFreshness) {
+        // Quote-freshness gate, derived from the registration trust model rather than stored
+        // config. INSTANCE_EXPIRY only bounds key exposure *after* registration; nothing otherwise
+        // bounds how old the attested quote itself is, so a quote (or a slowly side-channel-
+        // extracted key) from long ago could be registered today and trusted for a fresh 90-day
+        // window. Permissionless registration (no registrar) therefore fails closed: the enclave
+        // must have committed a recent L1 block into reportData right after the instance address —
+        // block number (8 bytes, BE) then that block's hash (32 bytes) — and the hash must match
+        // on-chain. `blockhash` returns zero outside the most recent 256 blocks, so a non-zero match
+        // bounds the quote's age to that window (the prover embeds the commitment and the
+        // registration must land within that window). With a registrar, the trusted registrar
+        // vouches for the provenance — and thus the age — of the quotes it submits, and registrar
+        // flows (e.g. a multisig) are typically slower than 256 blocks, so the gate is skipped.
+        // Both fields are bound to the verified enclave report by the body-hash check above.
+        if (registrar == address(0)) {
             uint64 quoteBlock =
                 uint64(bytes8(_rawQuote[REPORT_DATA_OFFSET + 20:REPORT_DATA_OFFSET + 28]));
             bytes32 quoteBlockHash =

--- a/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol
+++ b/packages/protocol/script/layer1/core/DeployProtocolOnL1.s.sol
@@ -158,6 +158,11 @@ contract DeployProtocolOnL1 is DeployCapability {
         // instance-validity delay gives off-chain monitoring time to evict a rogue self-registered
         // instance before it can prove (owner `addInstances` registrations are not delayed); it
         // applies to SecureSgxVerifier only.
+        // NOTE: with registrar == address(0) the quote-freshness gate is enforced (permissionless
+        // registration fails closed): `registerInstance` reverts with SGX_STALE_QUOTE unless the
+        // prover embeds the recent-block commitment in reportData and the registration lands within
+        // the 256-block window. Deploy with a non-zero registrar (or use owner `addInstances`) if
+        // the prover does not embed the commitment yet.
         verifiers.sgx = config.useInsecureSgxPolicy
             ? address(
                 new InsecureSgxVerifier(

--- a/packages/protocol/script/layer1/core/DeployShastaContracts.s.sol
+++ b/packages/protocol/script/layer1/core/DeployShastaContracts.s.sol
@@ -157,6 +157,11 @@ abstract contract DeployShastaContracts is DeployCapability {
         // instance-validity delay gives off-chain monitoring time to evict a rogue self-registered
         // instance before it can prove (owner `addInstances` registrations are not delayed); it
         // applies to SecureSgxVerifier only.
+        // NOTE: with registrar == address(0) the quote-freshness gate is enforced (permissionless
+        // registration fails closed): `registerInstance` reverts with SGX_STALE_QUOTE unless the
+        // prover embeds the recent-block commitment in reportData and the registration lands within
+        // the 256-block window. Deploy with a non-zero registrar (or use owner `addInstances`) if
+        // the prover does not embed the commitment yet.
         verifiers.sgxReth = _deploySgxVerifier(
             config.useInsecureSgxPolicy,
             config.l2ChainId,
@@ -186,9 +191,11 @@ abstract contract DeployShastaContracts is DeployCapability {
 
     /// @dev Deploys an SGX verifier, selecting the strict SecureSgxVerifier by default and the
     /// lenient InsecureSgxVerifier only when `useInsecureSgxPolicy` is true. The registrar is set to
-    /// address(0), leaving registerInstance permissionless. SecureSgxVerifier is given a 24h
-    /// instance-validity delay so off-chain monitoring can evict a rogue self-registered instance
-    /// before it can prove (owner `addInstances` registrations are not delayed).
+    /// address(0), leaving registerInstance permissionless — which also enforces the quote-freshness
+    /// gate (see SgxVerifier.registerInstance): registration requires the prover to embed a
+    /// recent-block commitment in reportData. SecureSgxVerifier is given a 24h instance-validity
+    /// delay so off-chain monitoring can evict a rogue self-registered instance before it can prove
+    /// (owner `addInstances` registrations are not delayed).
     function _deploySgxVerifier(
         bool useInsecureSgxPolicy,
         uint64 l2ChainId,

--- a/packages/protocol/test/layer1/verifiers/InsecureSgxVerifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/InsecureSgxVerifier.t.sol
@@ -36,6 +36,10 @@ contract InsecureSgxVerifierTest is Test {
     bytes32 internal constant MR_SIGNER = bytes32(uint256(0x2222));
 
     function setUp() external {
+        // The permissionless verifier (registrar == address(0)) enforces the quote-freshness gate,
+        // so the mock quotes embed a commitment to a recent block; roll to a sane height so
+        // blockhash(block.number - 1) is available and non-zero.
+        vm.roll(1000);
         // owner == address(this) so this test can call the onlyOwner admin functions.
         verifier = new InsecureSgxVerifier(CHAIN_ID, address(this), ATTESTATION, address(0));
         // The MRENCLAVE/MRSIGNER allowlist is enforced by default; trust the standard enclave so
@@ -49,6 +53,9 @@ contract InsecureSgxVerifierTest is Test {
     // ---------------------------------------------------------------
 
     /// @dev Builds a 384-byte SGX enclave report with the given fields at their Intel-spec offsets.
+    /// reportData embeds a fresh recent-block commitment after the instance address — block number
+    /// (8 bytes, BE) then that block's hash (32 bytes) — so success-path registrations pass the
+    /// permissionless quote-freshness gate.
     function _report(
         bool debug,
         bytes32 mrEnclave,
@@ -56,11 +63,17 @@ contract InsecureSgxVerifierTest is Test {
         address instance
     )
         internal
-        pure
+        view
         returns (bytes memory)
     {
         bytes16 attributes = debug ? bytes16(0x02000000000000000000000000000000) : bytes16(0);
-        bytes memory reportData = abi.encodePacked(bytes20(instance), new bytes(44)); // 64 bytes
+        // 64 bytes: instance(20) | blockNumber(8, BE) | blockHash(32) | zero padding(4)
+        bytes memory reportData = abi.encodePacked(
+            bytes20(instance),
+            bytes8(uint64(block.number - 1)),
+            blockhash(block.number - 1),
+            new bytes(4)
+        );
         return abi.encodePacked(
             new bytes(48), // cpuSvn(16)+miscSelect(4)+reserved1(28)        [0:48]
             attributes, //                                                  [48:64]

--- a/packages/protocol/test/layer1/verifiers/SgxVerifier.t.sol
+++ b/packages/protocol/test/layer1/verifiers/SgxVerifier.t.sol
@@ -57,6 +57,10 @@ abstract contract SgxVerifierTestBase is Test {
     SgxVerifier internal verifier;
 
     function setUp() external {
+        // The permissionless verifier (registrar == address(0)) enforces the quote-freshness gate,
+        // so the mock quotes embed a commitment to a recent block; roll to a sane height so
+        // blockhash(block.number - 1) is available and non-zero.
+        vm.roll(1000);
         // owner == address(this) so this test can call the onlyOwner admin functions.
         verifier = _deployVerifier(CHAIN_ID, address(this), ATTESTATION, address(0));
     }
@@ -83,18 +87,32 @@ abstract contract SgxVerifierTestBase is Test {
     // Raw-quote helpers
     // ---------------------------------------------------------------
 
-    /// @dev Builds a 384-byte SGX enclave report with the given fields at their Intel-spec offsets.
-    function _report(
-        bytes16 attributes,
-        bytes32 mrEnclave,
-        bytes32 mrSigner,
-        address instance
+    /// @dev Builds a 64-byte reportData: instance address (20) then a recent-block commitment used by
+    /// the quote-freshness gate — block number (8, BE) and that block's hash (32) — then 4 zero bytes.
+    function _reportData(
+        address instance,
+        uint64 blockNumber,
+        bytes32 blockHash
     )
         internal
         pure
         returns (bytes memory)
     {
-        bytes memory reportData = abi.encodePacked(bytes20(instance), new bytes(44)); // 64 bytes
+        return abi.encodePacked(bytes20(instance), bytes8(blockNumber), blockHash, new bytes(4));
+    }
+
+    /// @dev Composes a 384-byte SGX enclave report with the given fields and reportData at their
+    /// Intel-spec offsets — the single layout path every report builder below goes through.
+    function _reportWithData(
+        bytes16 attributes,
+        bytes32 mrEnclave,
+        bytes32 mrSigner,
+        bytes memory reportData
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
         return abi.encodePacked(
             new bytes(48), // cpuSvn(16)+miscSelect(4)+reserved1(28)        [0:48]
             attributes, //                                                  [48:64]
@@ -107,7 +125,46 @@ abstract contract SgxVerifierTestBase is Test {
         );
     }
 
-    /// @dev Builds a 432-byte raw quote (48-byte header + 384-byte SGX enclave report).
+    /// @dev Builds a 384-byte SGX enclave report whose reportData carries NO block commitment (zero
+    /// bytes after the instance address). Only for quotes that revert before the permissionless
+    /// quote-freshness gate; success-path quotes must go through `_freshReport`.
+    function _report(
+        bytes16 attributes,
+        bytes32 mrEnclave,
+        bytes32 mrSigner,
+        address instance
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return _reportWithData(
+            attributes, mrEnclave, mrSigner, abi.encodePacked(bytes20(instance), new bytes(44))
+        );
+    }
+
+    /// @dev Builds a 384-byte SGX enclave report whose reportData commits to the previous block, so
+    /// the quote passes the permissionless quote-freshness gate at the current height.
+    function _freshReport(
+        bytes16 attributes,
+        bytes32 mrEnclave,
+        bytes32 mrSigner,
+        address instance
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        return _reportWithData(
+            attributes,
+            mrEnclave,
+            mrSigner,
+            _reportData(instance, uint64(block.number - 1), blockhash(block.number - 1))
+        );
+    }
+
+    /// @dev Builds a 432-byte raw quote (48-byte header + 384-byte SGX enclave report) with no
+    /// block commitment; only for registrations that revert before the quote-freshness gate.
     function _rawQuote(
         bytes16 attributes,
         bytes32 mrEnclave,
@@ -145,7 +202,8 @@ abstract contract SgxVerifierTestBase is Test {
         );
     }
 
-    /// @dev Builds a raw quote and mocks the entrypoint to return a *matching* verified Output
+    /// @dev Builds a raw quote (with a fresh block commitment, so it can pass the permissionless
+    /// quote-freshness gate) and mocks the entrypoint to return a *matching* verified Output
     /// (body == the quote's enclave report, so the verified-body binding passes). Returns the quote.
     function _mockQuote(
         bytes16 attributes,
@@ -159,31 +217,18 @@ abstract contract SgxVerifierTestBase is Test {
         internal
         returns (bytes memory quote)
     {
-        bytes memory report = _report(attributes, mrEnclave, mrSigner, instance);
+        bytes memory report = _freshReport(attributes, mrEnclave, mrSigner, instance);
         quote = abi.encodePacked(new bytes(48), report);
         _mockAttest(true, _output(version, bodyType, tcbStatus, report));
     }
 
-    /// @dev Common valid case: non-debug, trusted MR values, V3/SGX/OK.
+    /// @dev Common valid case: non-debug, trusted MR values, V3/SGX/OK, fresh block commitment.
     function _mockValidQuote(address instance) internal returns (bytes memory) {
         return _mockQuote(bytes16(0), MR_ENCLAVE, MR_SIGNER, instance, 3, 1, TCB_OK);
     }
 
-    /// @dev Builds a 64-byte reportData: instance address (20) then a recent-block commitment used by
-    /// the quote-freshness gate — block number (8, BE) and that block's hash (32) — then 4 zero bytes.
-    function _reportData(
-        address instance,
-        uint64 blockNumber,
-        bytes32 blockHash
-    )
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodePacked(bytes20(instance), bytes8(blockNumber), blockHash, new bytes(4));
-    }
-
-    /// @dev Like `_mockValidQuote` but embeds a block commitment in reportData for the freshness gate.
+    /// @dev Like `_mockValidQuote` but embeds an explicit block commitment in reportData, for
+    /// exercising the quote-freshness gate boundaries (including a zero/absent commitment).
     function _mockFreshQuote(
         address instance,
         uint64 blockNumber,
@@ -192,16 +237,8 @@ abstract contract SgxVerifierTestBase is Test {
         internal
         returns (bytes memory quote)
     {
-        bytes memory reportData = _reportData(instance, blockNumber, blockHash);
-        bytes memory report = abi.encodePacked(
-            new bytes(48), // cpuSvn+miscSelect+reserved1                    [0:48]
-            bytes16(0), // attributes                                       [48:64]
-            MR_ENCLAVE, //                                                  [64:96]
-            bytes32(0), // reserved2                                        [96:128]
-            MR_SIGNER, //                                                   [128:160]
-            new bytes(96), // reserved3                                     [160:256]
-            new bytes(64), // isvProdId+isvSvn+reserved4                    [256:320]
-            reportData //                                                   [320:384]
+        bytes memory report = _reportWithData(
+            bytes16(0), MR_ENCLAVE, MR_SIGNER, _reportData(instance, blockNumber, blockHash)
         );
         quote = abi.encodePacked(new bytes(48), report);
         _mockAttest(true, _output(3, 1, TCB_OK, report));
@@ -596,41 +633,41 @@ abstract contract SgxVerifierTestBase is Test {
     }
 
     // ---------------------------------------------------------------
-    // admin: toggleQuoteFreshnessCheck / quote-freshness gate
+    // quote-freshness gate (permissionless registrations only)
     // ---------------------------------------------------------------
 
-    function test_toggleQuoteFreshnessCheck_togglesAndEmits() external {
-        // Off by default (backward compatible).
-        assertFalse(verifier.requireQuoteFreshness());
-        vm.expectEmit();
-        emit SgxVerifier.QuoteFreshnessCheckToggled(true);
-        verifier.toggleQuoteFreshnessCheck();
-        assertTrue(verifier.requireQuoteFreshness());
-        verifier.toggleQuoteFreshnessCheck();
-        assertFalse(verifier.requireQuoteFreshness());
+    /// @dev With a registrar configured the gate is skipped: the trusted registrar vouches for the
+    /// provenance — and thus the age — of the quotes it submits, so no on-chain freshness proof is
+    /// required and a quote carrying no block commitment (all-zero, like the pre-gate reportData)
+    /// still registers.
+    function test_registerInstance_SkipsFreshnessWhen_RegistrarSet() external {
+        address someRegistrar = address(0x5151);
+        SgxVerifier gated = _deployVerifier(CHAIN_ID, address(this), ATTESTATION, someRegistrar);
+        _trustEnclaveOn(gated);
+
+        address instance = address(0xC0FFEE);
+        bytes memory quote = _mockFreshQuote(instance, 0, bytes32(0));
+        vm.prank(someRegistrar);
+        gated.registerInstance(quote);
+        assertTrue(gated.addressRegistered(instance));
     }
 
-    function test_toggleQuoteFreshnessCheck_RevertWhen_NotOwner() external {
-        vm.prank(address(0xD00D));
-        vm.expectRevert();
-        verifier.toggleQuoteFreshnessCheck();
-    }
-
-    /// @dev With the gate off (default), a quote carrying no block commitment registers normally.
-    function test_registerInstance_FreshnessOffIgnoresBlockCommitment() external {
+    /// @dev Permissionless registration fails closed without a recent-block commitment: a quote
+    /// whose reportData carries only zeros after the instance address commits to block 0, whose
+    /// `blockhash` reads back as zero at the test height, so it is rejected as stale.
+    function test_registerInstance_RevertWhen_NoCommitmentPermissionless() external {
         _trustStandardEnclave();
-        address instance = address(0xBEEF);
-        verifier.registerInstance(_mockValidQuote(instance));
-        assertTrue(verifier.addressRegistered(instance));
+        bytes memory quote = _mockFreshQuote(address(0xC0FFEE), 0, bytes32(0));
+        vm.expectRevert(SgxVerifier.SGX_STALE_QUOTE.selector);
+        verifier.registerInstance(quote);
     }
 
-    /// @dev With the gate on, a quote committing a recent, correct block hash registers.
+    /// @dev The gate is always on for the permissionless verifier: a quote committing a recent,
+    /// correct block hash registers.
     function test_registerInstance_SucceedsWhen_FreshQuote() external {
         _trustStandardEnclave();
-        verifier.toggleQuoteFreshnessCheck();
 
-        // Move well past block 256 so a recent block's hash is available and non-zero.
-        vm.roll(1000);
+        // setUp rolled well past block 256, so a recent block's hash is available and non-zero.
         uint64 bn = uint64(block.number - 1);
         bytes32 bh = blockhash(bn);
         assertTrue(bh != bytes32(0));
@@ -641,26 +678,22 @@ abstract contract SgxVerifierTestBase is Test {
         assertTrue(verifier.addressRegistered(instance));
     }
 
-    /// @dev With the gate on, a quote committing a block outside the 256-block `blockhash` window
-    /// (its on-chain hash reads back as zero) is rejected as stale.
+    /// @dev A quote committing a block outside the 256-block `blockhash` window (its on-chain hash
+    /// reads back as zero) is rejected as stale.
     function test_registerInstance_RevertWhen_StaleQuote() external {
         _trustStandardEnclave();
-        verifier.toggleQuoteFreshnessCheck();
 
-        vm.roll(1000);
         // Block 1 is >256 behind, so blockhash(1) == 0 → the committed hash cannot match.
         bytes memory quote = _mockFreshQuote(address(0xC0FFEE), 1, blockhash(1));
         vm.expectRevert(SgxVerifier.SGX_STALE_QUOTE.selector);
         verifier.registerInstance(quote);
     }
 
-    /// @dev With the gate on, a recent block number paired with a wrong hash is rejected with the
-    /// dedicated mismatch error (distinct from the stale/out-of-window case).
+    /// @dev A recent block number paired with a wrong hash is rejected with the dedicated mismatch
+    /// error (distinct from the stale/out-of-window case).
     function test_registerInstance_RevertWhen_FreshQuoteHashMismatch() external {
         _trustStandardEnclave();
-        verifier.toggleQuoteFreshnessCheck();
 
-        vm.roll(1000);
         uint64 bn = uint64(block.number - 1);
         bytes memory quote = _mockFreshQuote(address(0xC0FFEE), bn, bytes32(uint256(0xBAD)));
         vm.expectRevert(SgxVerifier.SGX_QUOTE_BLOCK_HASH_MISMATCH.selector);
@@ -671,9 +704,7 @@ abstract contract SgxVerifierTestBase is Test {
     /// correct commitment to it is accepted — the exact freshness boundary.
     function test_registerInstance_SucceedsAtOldestFreshBlock() external {
         _trustStandardEnclave();
-        verifier.toggleQuoteFreshnessCheck();
 
-        vm.roll(1000);
         uint64 bn = uint64(block.number - 256);
         bytes32 bh = blockhash(bn);
         assertTrue(bh != bytes32(0));
@@ -687,9 +718,7 @@ abstract contract SgxVerifierTestBase is Test {
     /// is rejected as stale.
     function test_registerInstance_RevertWhen_JustOutsideFreshWindow() external {
         _trustStandardEnclave();
-        verifier.toggleQuoteFreshnessCheck();
 
-        vm.roll(1000);
         uint64 bn = uint64(block.number - 257);
         assertEq(blockhash(bn), bytes32(0));
 


### PR DESCRIPTION
## Context

Stacked on #21895 (base = `claude/sgx-fix-quote-freshness`), so this diff is only the delta. It responds to @smtmfft's review comment on #21895:

> this would also require a prover to register its instance within the 256-block window. Since we are currently still in multi-sig mode, this may not be achievable in practice. […] Should we merge it with the freshness check disabled for now, and enable it later once we move from multi-sig to permissionless mode?

The observation is exactly right: registration under a Gnosis-safe multisig takes hours-to-days to collect approvals, but the `blockhash` freshness window is 256 blocks (~51 min on mainnet), so an enforced gate would make every multisig registration revert with `SGX_STALE_QUOTE`.

## What changed

Instead of a standalone `requireQuoteFreshness` storage flag + owner toggle (as in #21895), the gate is now **derived from the registration trust model** already encoded by the immutable `registrar`:

| Registration mode | `registrar` | Freshness gate |
|---|---|---|
| Permissionless (anyone can register) | `address(0)` | **enforced** — the quote must commit a recent L1 block |
| Registrar-gated (multisig / trusted EOA) | non-zero | **skipped** — the registrar vouches for provenance/age |

This makes the two concerns that must move together move together, with no separate switch to forget:

- **Multisig mode today** already sets a non-zero registrar (`MULTISIG_ADMIN_TAIKO_ETH` in `DeployHackRecoveryContracts.s.sol`), so the gate is off and slow multisig registrations are unaffected — no toggle, no toggle/mempool race.
- **Permissionless mode later** deploys with `registrar == address(0)`, which is precisely when a submitter you don't trust could replay an old quote, so the freshness proof becomes mandatory automatically. Since `registrar` is immutable, going permissionless already means deploying a new verifier — the natural point to coordinate prover (raiko) support for embedding the commitment.

Net effect: the same coupling @smtmfft described, expressed as an invariant of the contract rather than an operational runbook step.

## Changes

- **`SgxVerifier.sol`**: removed the `requireQuoteFreshness` state var, the `toggleQuoteFreshnessCheck()` function, and the `QuoteFreshnessCheckToggled` event. The gate in `registerInstance` now runs under `if (registrar == address(0))`. Reworked NatSpec on `registrar` and `registerInstance` to document the derived policy. The reportData encoding and the `blockhash` check itself are unchanged from #21895.
- **Deploy scripts** (`DeployProtocolOnL1.s.sol`, `DeployShastaContracts.s.sol`): the `registrar == address(0)` paths now note that permissionless registration fails closed until the prover embeds the recent-block commitment; deploy with a non-zero registrar (or use owner `addInstances`) if the prover doesn't embed it yet.
- **`ConfigureSgxVerifier.s.sol`**: reverted the toggle env-var plumbing that the flag-based approach needed.

## Tests

Adapted the two SGX verifier suites to the always-on permissionless gate (the shared harness deploys with `registrar == address(0)`):

- `setUp` rolls to a sane block height; mock-quote builders embed a recent-block commitment through a single `_reportWithData` layout path (backing both the zero-commitment `_report` for pre-gate reverts and the fresh `_freshReport`).
- Removed the deleted flag/toggle tests.
- Added `test_registerInstance_SkipsFreshnessWhen_RegistrarSet` (registrar-gated deployment registers a commitment-less quote) and `test_registerInstance_RevertWhen_NoCommitmentPermissionless` (permissionless registration without a commitment reverts `SGX_STALE_QUOTE`).
- Kept the freshness boundary tests (`SucceedsWhen_FreshQuote`, `RevertWhen_StaleQuote`, `RevertWhen_FreshQuoteHashMismatch`, `SucceedsAtOldestFreshBlock`, `RevertWhen_JustOutsideFreshWindow`).

`FOUNDRY_PROFILE=layer1 forge test --match-path "test/layer1/verifiers/*Sgx*"` → **175 passed, 0 failed** across `SecureSgxVerifier` and `InsecureSgxVerifier`. `forge fmt --check` clean.

## Trade-off to weigh

The flag gave a one-transaction off-switch if the commitment path ever misbehaved after going permissionless (a raiko encoding bug, a reorg edge case). This version trades that away for a simpler, harder-to-misconfigure contract: recovering from such a case means deploying a fresh verifier (with owner `addInstances` as the interim path). That's the right call if you value "impossible to have permissionless-without-freshness by accident" over "instant toggle" — flagging it explicitly so reviewers can decide.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmrDHD5zectNprQQWmgok8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmrDHD5zectNprQQWmgok8)_