### PR TITLE
fix(protocol): track preconf metadata existence with explicit flag

### DIFF
--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -47,7 +47,13 @@ contract Anchor is EssentialContract {
     }
 
     /// @notice Metadata that will be required for slashing violations of permissionless preconfs.
+    /// @dev `exists` is an explicit existence flag. Every other field can legitimately be zero
+    /// (`anchorBlockNumber` is `0` when a block skips anchoring, and `submissionWindowEnd` and the
+    /// tx-list hashes are `0` for whitelist preconfs), so none of them can act as a sentinel to
+    /// tell a recorded block apart from one that was never recorded. It packs into the same storage
+    /// slot as the three `uint48` fields, so tracking it adds no storage slot and no extra SSTORE.
     struct PreconfMetadata {
+        bool exists;
         uint48 anchorBlockNumber;
         uint48 submissionWindowEnd;
         uint48 parentSubmissionWindowEnd;
@@ -199,13 +205,20 @@ contract Anchor is EssentialContract {
         return _blockState;
     }
 
+    /// @notice Returns the preconfirmation metadata recorded for a given L2 block.
+    /// @dev Reverts with `InvalidBlockNumber` when no metadata has been recorded for the block.
+    /// Existence is determined by the explicit `exists` flag rather than by `anchorBlockNumber`,
+    /// which is legitimately `0` for blocks that skip anchoring and would otherwise make a recorded
+    /// block indistinguishable from an unrecorded one.
+    /// @param _blockNumber The L2 block number to query.
+    /// @return The preconfirmation metadata recorded for `_blockNumber`.
     function getPreconfMetadata(uint256 _blockNumber)
         external
         view
         returns (PreconfMetadata memory)
     {
         PreconfMetadata memory preconfMetadata = _preconfMetadata[_blockNumber];
-        require(preconfMetadata.anchorBlockNumber != 0, InvalidBlockNumber());
+        require(preconfMetadata.exists, InvalidBlockNumber());
         return preconfMetadata;
     }
 
@@ -248,6 +261,7 @@ contract Anchor is EssentialContract {
     {
         PreconfMetadata storage parentPreconfMetadata = _preconfMetadata[block.number - 1];
         _preconfMetadata[block.number] = PreconfMetadata({
+            exists: true,
             anchorBlockNumber: _blockParams.anchorBlockNumber,
             submissionWindowEnd: _proposalParams.submissionWindowEnd,
             parentSubmissionWindowEnd: parentPreconfMetadata.submissionWindowEnd,

--- a/packages/protocol/contracts/layer2/core/Anchor.sol
+++ b/packages/protocol/contracts/layer2/core/Anchor.sol
@@ -50,13 +50,15 @@ contract Anchor is EssentialContract {
     /// @dev `exists` is an explicit existence flag. Every other field can legitimately be zero
     /// (`anchorBlockNumber` is `0` when a block skips anchoring, and `submissionWindowEnd` and the
     /// tx-list hashes are `0` for whitelist preconfs), so none of them can act as a sentinel to
-    /// tell a recorded block apart from one that was never recorded. It packs into the same storage
-    /// slot as the three `uint48` fields, so tracking it adds no storage slot and no extra SSTORE.
+    /// tell a recorded block apart from one that was never recorded. It is declared after the three
+    /// `uint48` fields so it fills otherwise-unused space in their shared storage slot: tracking it
+    /// adds no storage slot and no extra SSTORE, and — being appended in free space rather than
+    /// prepended — it leaves every existing field at its original offset for upgrade safety.
     struct PreconfMetadata {
-        bool exists;
         uint48 anchorBlockNumber;
         uint48 submissionWindowEnd;
         uint48 parentSubmissionWindowEnd;
+        bool exists;
         bytes32 rawTxListHash;
         bytes32 parentRawTxListHash;
     }
@@ -259,12 +261,15 @@ contract Anchor is EssentialContract {
     )
         private
     {
+        // anchorV4 runs on every block, so the parent (the preceding block) exists for all but the
+        // first recorded block; there the zero-defaults are the correct "no parent" values, so the
+        // parent is read without an existence check by design.
         PreconfMetadata storage parentPreconfMetadata = _preconfMetadata[block.number - 1];
         _preconfMetadata[block.number] = PreconfMetadata({
-            exists: true,
             anchorBlockNumber: _blockParams.anchorBlockNumber,
             submissionWindowEnd: _proposalParams.submissionWindowEnd,
             parentSubmissionWindowEnd: parentPreconfMetadata.submissionWindowEnd,
+            exists: true,
             rawTxListHash: _blockParams.rawTxListHash,
             parentRawTxListHash: parentPreconfMetadata.rawTxListHash
         });

--- a/packages/protocol/test/layer2/core/Anchor.t.sol
+++ b/packages/protocol/test/layer2/core/Anchor.t.sol
@@ -106,6 +106,72 @@ contract AnchorTest is Test {
     }
 
     // ---------------------------------------------------------------
+    // getPreconfMetadata
+    // ---------------------------------------------------------------
+
+    function test_getPreconfMetadata_returnsMetadataForRecordedBlock() external {
+        vm.roll(SHASTA_FORK_HEIGHT);
+        vm.prank(GOLDEN_TOUCH);
+        anchor.anchorV4(
+            Anchor.ProposalParams({ submissionWindowEnd: 42 }),
+            _blockParamsWithTxList(1000, bytes32(uint256(0xBEEF)))
+        );
+
+        Anchor.PreconfMetadata memory metadata = anchor.getPreconfMetadata(block.number);
+        assertTrue(metadata.exists);
+        assertEq(metadata.anchorBlockNumber, 1000);
+        assertEq(metadata.submissionWindowEnd, 42);
+        assertEq(metadata.rawTxListHash, bytes32(uint256(0xBEEF)));
+    }
+
+    /// @dev Regression test: a block recorded with `anchorBlockNumber == 0` (anchoring skipped)
+    /// must remain retrievable. Before the explicit existence flag, `getPreconfMetadata` treated
+    /// `anchorBlockNumber == 0` as "never recorded" and reverted, blocking PreconfSlasherL2 from
+    /// validating faults for that block or its predecessor.
+    function test_getPreconfMetadata_returnsMetadataWhenAnchorBlockNumberIsZero() external {
+        vm.roll(SHASTA_FORK_HEIGHT);
+        vm.prank(GOLDEN_TOUCH);
+        anchor.anchorV4(
+            Anchor.ProposalParams({ submissionWindowEnd: 7 }),
+            _blockParamsWithTxList(0, bytes32(uint256(0xC0FFEE)))
+        );
+
+        Anchor.PreconfMetadata memory metadata = anchor.getPreconfMetadata(block.number);
+        assertTrue(metadata.exists);
+        assertEq(metadata.anchorBlockNumber, 0);
+        assertEq(metadata.submissionWindowEnd, 7);
+        assertEq(metadata.rawTxListHash, bytes32(uint256(0xC0FFEE)));
+    }
+
+    function test_getPreconfMetadata_RevertWhen_BlockNeverRecorded() external {
+        vm.expectRevert(Anchor.InvalidBlockNumber.selector);
+        anchor.getPreconfMetadata(999_999);
+    }
+
+    function test_getPreconfMetadata_inheritsParentMetadataAcrossBlocks() external {
+        vm.roll(SHASTA_FORK_HEIGHT);
+        vm.prank(GOLDEN_TOUCH);
+        anchor.anchorV4(
+            Anchor.ProposalParams({ submissionWindowEnd: 10 }),
+            _blockParamsWithTxList(1000, bytes32(uint256(0xAAAA)))
+        );
+
+        vm.roll(SHASTA_FORK_HEIGHT + 1);
+        vm.prank(GOLDEN_TOUCH);
+        anchor.anchorV4(
+            Anchor.ProposalParams({ submissionWindowEnd: 20 }),
+            _blockParamsWithTxList(1001, bytes32(uint256(0xBBBB)))
+        );
+
+        Anchor.PreconfMetadata memory childMeta = anchor.getPreconfMetadata(block.number);
+        assertTrue(childMeta.exists);
+        assertEq(childMeta.submissionWindowEnd, 20);
+        assertEq(childMeta.rawTxListHash, bytes32(uint256(0xBBBB)));
+        assertEq(childMeta.parentSubmissionWindowEnd, 10);
+        assertEq(childMeta.parentRawTxListHash, bytes32(uint256(0xAAAA)));
+    }
+
+    // ---------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------
 
@@ -123,6 +189,22 @@ contract AnchorTest is Test {
             anchorBlockHash: bytes32(_blockHash),
             anchorStateRoot: bytes32(_stateRoot),
             rawTxListHash: bytes32(0)
+        });
+    }
+
+    function _blockParamsWithTxList(
+        uint48 _anchorBlockNumber,
+        bytes32 _rawTxListHash
+    )
+        internal
+        pure
+        returns (Anchor.BlockParams memory)
+    {
+        return Anchor.BlockParams({
+            anchorBlockNumber: _anchorBlockNumber,
+            anchorBlockHash: bytes32(0),
+            anchorStateRoot: bytes32(0),
+            rawTxListHash: _rawTxListHash
         });
     }
 }

--- a/packages/protocol/test/layer2/core/Anchor.t.sol
+++ b/packages/protocol/test/layer2/core/Anchor.t.sol
@@ -171,6 +171,32 @@ contract AnchorTest is Test {
         assertEq(childMeta.parentRawTxListHash, bytes32(uint256(0xAAAA)));
     }
 
+    /// @dev The parent-linkage counterpart of the zero-anchor regression: a parent recorded with
+    /// `anchorBlockNumber == 0` must still propagate its `submissionWindowEnd` / `rawTxListHash`
+    /// into the child's parent fields, which `PreconfSlasherL2` consumes.
+    function test_getPreconfMetadata_inheritsMetadataThroughZeroAnchorParent() external {
+        // Parent block skips anchoring (anchorBlockNumber == 0) but still carries metadata.
+        vm.roll(SHASTA_FORK_HEIGHT);
+        vm.prank(GOLDEN_TOUCH);
+        anchor.anchorV4(
+            Anchor.ProposalParams({ submissionWindowEnd: 15 }),
+            _blockParamsWithTxList(0, bytes32(uint256(0xDEAD)))
+        );
+
+        vm.roll(SHASTA_FORK_HEIGHT + 1);
+        vm.prank(GOLDEN_TOUCH);
+        anchor.anchorV4(
+            Anchor.ProposalParams({ submissionWindowEnd: 25 }),
+            _blockParamsWithTxList(1001, bytes32(uint256(0xF00D)))
+        );
+
+        Anchor.PreconfMetadata memory childMeta = anchor.getPreconfMetadata(block.number);
+        assertTrue(childMeta.exists);
+        assertEq(childMeta.submissionWindowEnd, 25);
+        assertEq(childMeta.parentSubmissionWindowEnd, 15);
+        assertEq(childMeta.parentRawTxListHash, bytes32(uint256(0xDEAD)));
+    }
+
     // ---------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Problem

`Anchor.getPreconfMetadata` used `anchorBlockNumber != 0` as its "metadata exists" check, but `_storePreconfMetadata` records metadata for **every** block and `anchorBlockNumber` is documented "0 to skip". A block legitimately anchored with `anchorBlockNumber == 0` was therefore indistinguishable from one never recorded, so `getPreconfMetadata` reverted for it — blocking `PreconfSlasherL2` from validating faults for that block *and its predecessor* (which reads `blockNumber + 1`'s metadata). Every consumer-read field can also be zero, so none can serve as a sentinel, and nothing on-chain prevents the collision — leaving a slashing-safety invariant reliant on the driver always passing non-zero L1 block numbers.

## Fix

Add an explicit `bool exists` flag to `PreconfMetadata`, set it in `_storePreconfMetadata`, and gate `getPreconfMetadata` on it. It sits after the three `uint48` fields, filling unused bytes in their shared slot: no extra storage slot or SSTORE, and no existing field offset changes (upgrade-safe; `Anchor_Layout.sol` unchanged).

Tests cover the normal path, the zero-`anchorBlockNumber` regression, the never-recorded revert, and parent inheritance through a zero-anchor parent.

## Target branch

Against `permissionless-preconf`, not `main`: #21887 moved this code off `main` to that branch and directs new preconf PRs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)