### PR TITLE
refactor(taiko-client-rs): drop the `Client<P>` provider generic

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -62,13 +62,7 @@ pub use bundle::ShastaProposalBundle;
 ///
 /// Failures are downgraded to `None` so proposal derivation can proceed without finalized
 /// forkchoice hints.
-async fn try_last_finalized_proposal_id_at_block<P>(
-    rpc: &Client<P>,
-    block_hash: B256,
-) -> Option<u64>
-where
-    P: Provider + Clone + 'static,
-{
+async fn try_last_finalized_proposal_id_at_block(rpc: &Client, block_hash: B256) -> Option<u64> {
     match rpc
         .shasta
         .inbox
@@ -233,12 +227,9 @@ fn resolve_source_manifest(
 /// The pipeline consumes proposal logs emitted by the Shasta inbox, resolves the
 /// referenced manifests, and converts them into execution payloads that materialise new
 /// blocks in the execution engine.
-pub struct ShastaDerivationPipeline<P>
-where
-    P: Provider + Clone + 'static,
-{
+pub struct ShastaDerivationPipeline {
     /// RPC client bundle used for L1/L2 queries and engine calls.
-    rpc: Client<P>,
+    rpc: Client,
     /// Builder for Shasta anchor transactions.
     anchor_constructor: AnchorTxConstructor<RootProvider>,
     /// Manifest fetcher used to resolve derivation-source blobs.
@@ -253,17 +244,14 @@ where
     initial_proposal_id: U256,
 }
 
-impl<P> ShastaDerivationPipeline<P>
-where
-    P: Provider + Clone + 'static,
-{
+impl ShastaDerivationPipeline {
     /// Create a new derivation pipeline instance.
     ///
     /// Manifests are fetched via the supplied blob source while the driver client is
     /// reused to query both L1 contracts and L2 execution state.
     #[instrument(skip(rpc, blob_source), name = "shasta_derivation_new")]
     pub async fn new(
-        rpc: Client<P>,
+        rpc: Client,
         blob_source: Arc<BlobDataSource>,
         initial_proposal_id: U256,
     ) -> Result<Self, DerivationError> {
@@ -517,10 +505,7 @@ where
     }
 }
 
-impl<P> ShastaDerivationPipeline<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl ShastaDerivationPipeline {
     /// Convert a manifest into execution engine blocks for block production.
     #[instrument(skip(self, manifest, applier), name = "shasta_manifest_to_blocks")]
     async fn manifest_to_engine_blocks(
@@ -624,7 +609,7 @@ mod tests {
         rpc::types::eth::BlockTransactions,
         sol_types::SolCall,
     };
-    use alloy_provider::{ProviderBuilder, RootProvider};
+    use alloy_provider::ProviderBuilder;
     use alloy_transport::mock::Asserter;
     use bindings::{
         anchor::{Anchor::AnchorInstance, ICheckpointStore::Checkpoint},
@@ -677,7 +662,7 @@ mod tests {
         }
     }
 
-    fn mock_client_with_l1_asserter(l1_asserter: Asserter) -> Client<RootProvider> {
+    fn mock_client_with_l1_asserter(l1_asserter: Asserter) -> Client {
         mock_client_with_asserters(l1_asserter, Asserter::new(), Asserter::new(), Address::ZERO)
     }
 
@@ -686,9 +671,8 @@ mod tests {
         l2_asserter: Asserter,
         l2_auth_asserter: Asserter,
         anchor_address: Address,
-    ) -> Client<RootProvider> {
-        let l1_provider =
-            ProviderBuilder::new().disable_recommended_fillers().connect_mocked_client(l1_asserter);
+    ) -> Client {
+        let l1_provider = ProviderBuilder::new().connect_mocked_client(l1_asserter);
         let l2_provider =
             ProviderBuilder::new().disable_recommended_fillers().connect_mocked_client(l2_asserter);
         let l2_auth_provider = ProviderBuilder::new()

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
@@ -165,10 +165,7 @@ struct VerifiedCanonicalBlock {
     header: Header,
 }
 
-impl<P> ShastaDerivationPipeline<P>
-where
-    P: Provider + Clone + 'static,
-{
+impl ShastaDerivationPipeline {
     /// Resolve the hash of the last finalized proposal's block if available.
     ///
     /// Errors are logged but never propagated so payload application can proceed even when the

--- a/packages/taiko-client-rs/crates/driver/src/driver.rs
+++ b/packages/taiko-client-rs/crates/driver/src/driver.rs
@@ -1,20 +1,16 @@
 //! High level driver orchestration.
 
-use alloy_provider::{RootProvider, fillers::FillProvider, utils::JoinedRecommendedFillers};
 use tracing::{info, instrument};
 
 use crate::{config::DriverConfig, error::Result, sync::SyncPipeline};
 use rpc::client::Client;
-
-/// Type alias for the default RPC client used by the driver.
-pub type DriverRpcClient = Client<FillProvider<JoinedRecommendedFillers, RootProvider>>;
 
 /// Shasta driver responsible for keeping an execution engine in sync with protocol state.
 pub struct Driver {
     /// Static configuration loaded at startup.
     cfg: DriverConfig,
     /// RPC client wrapper shared with derivation and sync subsystems.
-    rpc: DriverRpcClient,
+    rpc: Client,
 }
 
 impl Driver {
@@ -36,7 +32,7 @@ impl Driver {
     }
 
     /// Access the underlying RPC client (primarily for tests).
-    pub fn rpc_client(&self) -> &DriverRpcClient {
+    pub fn rpc_client(&self) -> &Client {
         &self.rpc
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/preconf_ingress_sync.rs
+++ b/packages/taiko-client-rs/crates/driver/src/preconf_ingress_sync.rs
@@ -7,7 +7,6 @@
 
 use std::{future::Future, result, sync::Arc};
 
-use rpc::client::DefaultProvider;
 use thiserror::Error;
 
 use crate::{
@@ -54,9 +53,9 @@ impl From<DriverError> for PreconfIngressSyncError {
 /// Runs the preconfirmation ingress event syncer and exposes handles to its resources.
 pub struct PreconfIngressSync {
     /// RPC client shared across ingress sync and driver integrations.
-    client: rpc::client::Client<DefaultProvider>,
+    client: rpc::client::Client,
     /// Event syncer exposing ingress readiness and preconfirmation submit hooks.
-    event_syncer: Arc<EventSyncer<DefaultProvider>>,
+    event_syncer: Arc<EventSyncer>,
     /// Join handle for the background sync pipeline task.
     handle: tokio::task::JoinHandle<EventSyncResult>,
 }
@@ -78,12 +77,12 @@ impl PreconfIngressSync {
     }
 
     /// Access the preconfirmation ingress RPC client.
-    pub fn client(&self) -> &rpc::client::Client<DefaultProvider> {
+    pub fn client(&self) -> &rpc::client::Client {
         &self.client
     }
 
     /// Access the event syncer handle.
-    pub fn event_syncer(&self) -> Arc<EventSyncer<DefaultProvider>> {
+    pub fn event_syncer(&self) -> Arc<EventSyncer> {
         self.event_syncer.clone()
     }
 

--- a/packages/taiko-client-rs/crates/driver/src/production/path.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/path.rs
@@ -33,10 +33,7 @@ pub trait BlockHashReader: Send + Sync {
 }
 
 #[async_trait]
-impl<P> BlockHashReader for Client<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl BlockHashReader for Client {
     /// Fetch the parent hash for the given block number via RPC.
     async fn block_hash_by_number(&self, block_number: u64) -> Result<B256, DriverError> {
         let block = self
@@ -127,23 +124,17 @@ where
 }
 
 /// `BlockProductionPath` implementation for canonical L1 proposal logs.
-pub struct CanonicalL1ProductionPath<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+pub struct CanonicalL1ProductionPath {
     /// Derivation pipeline used to decode L1 proposal logs.
-    derivation: Arc<ShastaDerivationPipeline<P>>,
+    derivation: Arc<ShastaDerivationPipeline>,
     /// Engine payload applier shared with the canonical path.
     applier: Arc<dyn PayloadApplier + Send + Sync>,
 }
 
-impl<P> CanonicalL1ProductionPath<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl CanonicalL1ProductionPath {
     /// Construct a new canonical path backed by the provided derivation pipeline.
     pub fn new(
-        derivation: Arc<ShastaDerivationPipeline<P>>,
+        derivation: Arc<ShastaDerivationPipeline>,
         applier: Arc<dyn PayloadApplier + Send + Sync>,
     ) -> Self {
         Self { derivation, applier }
@@ -151,10 +142,7 @@ where
 }
 
 #[async_trait]
-impl<P> BlockProductionPath for CanonicalL1ProductionPath<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl BlockProductionPath for CanonicalL1ProductionPath {
     /// Produce blocks by processing L1 proposal logs via the derivation pipeline.
     async fn produce(
         &self,

--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -45,29 +45,23 @@ struct FinalizedSyncTarget {
 }
 
 /// Drives the L2 execution engine toward the proof-finalized block recorded on L1.
-pub struct BeaconSyncer<P>
-where
-    P: Provider + Clone,
-{
+pub struct BeaconSyncer {
     /// Interval between beacon sync retries.
     retry_interval: Duration,
     /// RPC client used for L1 inbox reads and local engine calls.
-    rpc: Client<P>,
+    rpc: Client,
     /// Optional untrusted provider used to fetch catch-up block bodies.
     checkpoint: Option<RootProvider>,
     /// Shared resume head consumed by event sync after this stage completes.
     checkpoint_resume_head: Arc<CheckpointResumeHead>,
 }
 
-impl<P> BeaconSyncer<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl BeaconSyncer {
     /// Construct a new beacon syncer from the provided configuration and RPC client.
     #[instrument(skip(config, rpc))]
     pub fn new(
         config: &DriverConfig,
-        rpc: Client<P>,
+        rpc: Client,
         checkpoint_resume_head: Arc<CheckpointResumeHead>,
     ) -> Self {
         let checkpoint =
@@ -211,10 +205,7 @@ fn resolve_checkpoint_poll_error(
 }
 
 #[async_trait::async_trait]
-impl<P> SyncStage for BeaconSyncer<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl SyncStage for BeaconSyncer {
     /// Run the beacon sync stage, steering the local execution engine toward the proof-finalized
     /// block recorded on L1 until the local canonical chain contains it.
     #[instrument(skip(self), name = "beacon_syncer_run")]

--- a/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
@@ -57,10 +57,7 @@ pub trait PayloadApplier {
 }
 
 #[async_trait]
-impl<P> PayloadApplier for Client<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl PayloadApplier for Client {
     /// Submit a single payload to the execution engine while internally managing forkchoice state.
     #[instrument(skip(self, payload), fields(payload_id = tracing::field::Empty))]
     async fn apply_payload(
@@ -90,15 +87,12 @@ pub struct AppliedPayload {
 /// Submit the provided payload attributes to the execution engine, building canonical L2
 /// blocks.
 #[instrument(skip(rpc, payload), fields(payload_id = tracing::field::Empty))]
-async fn apply_payload_internal<P>(
-    rpc: &Client<P>,
+async fn apply_payload_internal(
+    rpc: &Client,
     payload: &TaikoPayloadAttributes,
     parent_hash: B256,
     finalized_block_hash: Option<B256>,
-) -> Result<AppliedPayload, EngineSubmissionError>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+) -> Result<AppliedPayload, EngineSubmissionError> {
     // Advertise the next payload attributes so the execution engine can build the block body.
     let forkchoice_state = ForkchoiceState {
         head_block_hash: parent_hash,
@@ -234,13 +228,10 @@ fn promotion_forkchoice_state(
 }
 
 /// Fetch the inserted block by number and map provider errors into submission errors.
-async fn fetch_block_by_number<P>(
-    rpc: &Client<P>,
+async fn fetch_block_by_number(
+    rpc: &Client,
     block_number: u64,
-) -> Result<RpcBlock<TxEnvelope>, EngineSubmissionError>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+) -> Result<RpcBlock<TxEnvelope>, EngineSubmissionError> {
     rpc.l2_provider
         .get_block_by_number(BlockNumberOrTag::Number(block_number))
         .await
@@ -250,18 +241,15 @@ where
 }
 
 /// Common flow to submit a payload to the engine, promote forkchoice, and read back the block.
-async fn submit_payload_to_engine<P>(
-    rpc: &Client<P>,
+async fn submit_payload_to_engine(
+    rpc: &Client,
     payload_input: &ExecutionPayloadInputV2,
     sidecar: &TaikoExecutionDataSidecar,
     block_hash: B256,
     block_number: u64,
     finalized_block_hash: Option<B256>,
     payload_id: PayloadId,
-) -> Result<EngineBlockOutcome, EngineSubmissionError>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+) -> Result<EngineBlockOutcome, EngineSubmissionError> {
     let status = rpc.engine_new_payload_v2(payload_input, sidecar).await?;
     ensure_valid_payload_status(block_number, status.status)?;
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -223,12 +223,9 @@ fn is_stale_preconf(block_number: u64, confirmed_tip: u64) -> bool {
 }
 
 /// Responsible for following inbox events and updating the L2 execution engine accordingly.
-pub struct EventSyncer<P>
-where
-    P: Provider + Clone,
-{
+pub struct EventSyncer {
     /// RPC client shared with derivation pipeline.
-    rpc: Client<P>,
+    rpc: Client,
     /// Static driver configuration.
     cfg: DriverConfig,
     /// Beacon-sync checkpoint head shared by the sync pipeline.
@@ -279,13 +276,10 @@ pub struct PreconfJob {
 ///
 /// Materialization requires both the per-block L1 origin record and the execution header to match
 /// the payload attributes previously submitted to the engine.
-async fn preconfirmation_payload_is_materialized<P>(
-    rpc: &Client<P>,
+async fn preconfirmation_payload_is_materialized(
+    rpc: &Client,
     payload: &PreconfPayload,
-) -> Result<bool, DriverError>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+) -> Result<bool, DriverError> {
     let block_number = payload.block_number();
     let expected_payload = payload.payload();
     let Some(origin) = rpc.l1_origin_by_id(U256::from(block_number)).await? else {
@@ -337,14 +331,11 @@ where
     ))
 }
 
-impl<P> EventSyncer<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl EventSyncer {
     /// Build the production router with the enabled paths.
     fn build_router(
         &self,
-        derivation: Arc<ShastaDerivationPipeline<P>>,
+        derivation: Arc<ShastaDerivationPipeline>,
     ) -> Arc<AsyncMutex<ProductionRouter>> {
         let canonical_path: Arc<dyn BlockProductionPath + Send + Sync> = Arc::new(
             CanonicalL1ProductionPath::new(derivation.clone(), Arc::new(self.rpc.clone())),
@@ -364,7 +355,7 @@ where
         &self,
         router: Arc<AsyncMutex<ProductionRouter>>,
         mut rx: PreconfReceiver,
-        rpc: Client<P>,
+        rpc: Client,
         ready_flag: Arc<AtomicBool>,
         ready_notify: Arc<Notify>,
     ) {
@@ -706,7 +697,7 @@ where
 
     /// Construct a new event syncer from the provided configuration and RPC client.
     #[instrument(skip(cfg, rpc))]
-    pub async fn new(cfg: &DriverConfig, rpc: Client<P>) -> Result<Self, SyncError> {
+    pub async fn new(cfg: &DriverConfig, rpc: Client) -> Result<Self, SyncError> {
         Self::new_with_checkpoint_resume_head(cfg, rpc, Arc::new(CheckpointResumeHead::default()))
             .await
     }
@@ -715,7 +706,7 @@ where
     #[instrument(skip(cfg, rpc, checkpoint_resume_head))]
     pub(crate) async fn new_with_checkpoint_resume_head(
         cfg: &DriverConfig,
-        rpc: Client<P>,
+        rpc: Client,
         checkpoint_resume_head: Arc<CheckpointResumeHead>,
     ) -> Result<Self, SyncError> {
         let blob_source = Arc::new(
@@ -1147,10 +1138,7 @@ where
     }
 }
 
-impl<P> EventSyncer<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl EventSyncer {
     /// Resolve the activation block number by converting the inbox activation timestamp through
     /// the beacon endpoint.
     async fn activation_block_number(&self) -> Result<u64, SyncError> {
@@ -1241,10 +1229,7 @@ fn decode_anchor_call(
 }
 
 #[async_trait::async_trait]
-impl<P> SyncStage for EventSyncer<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl SyncStage for EventSyncer {
     /// Start the event syncer.
     #[instrument(skip(self), name = "event_syncer_run")]
     async fn run(&self) -> Result<(), SyncError> {
@@ -1479,7 +1464,7 @@ mod tests {
         },
         transports::http::reqwest::Url,
     };
-    use alloy_provider::{ProviderBuilder, RootProvider};
+    use alloy_provider::ProviderBuilder;
     use alloy_rpc_types_engine::PayloadId;
     use alloy_rpc_types_engine_2::PayloadAttributes as EthPayloadAttributes;
     use alloy_transport::mock::Asserter;
@@ -1539,11 +1524,11 @@ mod tests {
         }
     }
 
-    fn mock_client() -> Client<RootProvider> {
+    fn mock_client() -> Client {
         mock_client_with_l1_asserter(Asserter::new())
     }
 
-    async fn build_syncer() -> EventSyncer<RootProvider> {
+    async fn build_syncer() -> EventSyncer {
         let client_config = ClientConfig {
             l1_provider_source: SubscriptionSource::Http(
                 Url::parse("http://localhost:8545").expect("valid http url"),
@@ -1741,16 +1726,12 @@ mod tests {
         }
     }
 
-    fn mock_client_with_l1_asserter(l1_asserter: Asserter) -> Client<RootProvider> {
+    fn mock_client_with_l1_asserter(l1_asserter: Asserter) -> Client {
         mock_client_with_asserters(l1_asserter, Asserter::new())
     }
 
-    fn mock_client_with_asserters(
-        l1_asserter: Asserter,
-        l2_auth_asserter: Asserter,
-    ) -> Client<RootProvider> {
-        let l1_provider =
-            ProviderBuilder::new().disable_recommended_fillers().connect_mocked_client(l1_asserter);
+    fn mock_client_with_asserters(l1_asserter: Asserter, l2_auth_asserter: Asserter) -> Client {
+        let l1_provider = ProviderBuilder::new().connect_mocked_client(l1_asserter);
         let l2_provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .connect_mocked_client(Asserter::new());

--- a/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 /// Geth error message returned when no finalized block exists yet (e.g. fresh devnets).
 pub(crate) const FINALIZED_BLOCK_NOT_FOUND: &str = "finalized block not found";
 
-use alloy_provider::Provider;
 use async_trait::async_trait;
 use rpc::client::Client;
 use tracing::{info, instrument};
@@ -39,23 +38,17 @@ pub trait SyncStage {
 ///
 /// Runs the beacon syncer first to catch up via checkpoint sync,
 /// then hands off to the event syncer for real-time L1 event processing.
-pub struct SyncPipeline<P>
-where
-    P: Provider + Clone,
-{
+pub struct SyncPipeline {
     /// Beacon syncer for checkpoint-based catch-up.
-    beacon: BeaconSyncer<P>,
+    beacon: BeaconSyncer,
     /// Event syncer for following L1 inbox proposals in real time.
-    event: Arc<EventSyncer<P>>,
+    event: Arc<EventSyncer>,
 }
 
-impl<P> SyncPipeline<P>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+impl SyncPipeline {
     /// Construct a new pipeline from the runtime configuration.
     #[instrument(skip(cfg, rpc), name = "sync_pipeline_new")]
-    pub async fn new(cfg: DriverConfig, rpc: Client<P>) -> Result<Self, DriverError> {
+    pub async fn new(cfg: DriverConfig, rpc: Client) -> Result<Self, DriverError> {
         // Shared cross-stage state: beacon sync writes the checkpoint head it caught up to,
         // event sync consumes that head as its resume anchor when checkpoint mode is enabled.
         let checkpoint_resume_head = Arc::new(CheckpointResumeHead::default());
@@ -67,7 +60,7 @@ where
     }
 
     /// Access the event syncer instance.
-    pub fn event_syncer(&self) -> Arc<EventSyncer<P>> {
+    pub fn event_syncer(&self) -> Arc<EventSyncer> {
         self.event.clone()
     }
 

--- a/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
@@ -15,20 +15,15 @@ use driver::{
     sync::{SyncStage, engine::PayloadApplier, event::EventSyncer},
 };
 use proposer::transaction_builder::{BuiltProposalTx, ShastaProposalTransactionBuilder};
-use rpc::{
-    blob::BlobDataSource,
-    client::{Client, ClientWithWallet},
-};
+use rpc::{blob::BlobDataSource, client::Client};
 use serial_test::serial;
 use test_context::test_context;
 use test_harness::{BeaconStubServer, ShastaEnv, verify_anchor_block};
 use tokio::spawn;
 use tracing::{info, warn};
 
-async fn proposer_client(env: &ShastaEnv) -> Result<ClientWithWallet> {
-    Client::new_with_wallet(env.client_config.clone(), env.l1_proposer_private_key)
-        .await
-        .map_err(Into::into)
+async fn proposer_client(env: &ShastaEnv) -> Result<Client> {
+    Client::new(env.client_config.clone()).await.map_err(Into::into)
 }
 
 fn decode_proposal_id(log: &Log) -> Result<u64> {
@@ -37,20 +32,24 @@ fn decode_proposal_id(log: &Log) -> Result<u64> {
         .map_err(|err| anyhow!("decode proposal log failed: {err}"))
 }
 
-/// Submits a proposal transaction and returns the proposal ID and log.
-async fn submit_proposal(
-    proposer: &ClientWithWallet,
-    request: BuiltProposalTx,
-    inbox: alloy_primitives::Address,
-) -> Result<(u64, Log)> {
-    let pending_tx =
-        proposer.l1_provider.send_transaction(request.to_transaction_request()).await?;
+/// Submits a proposal transaction through a wallet-backed L1 provider and returns the
+/// proposal ID and log.
+///
+/// The wallet lives only in this test helper: the production `Client` is walletless and
+/// all production L1 sends flow through the proposer's tx-manager.
+async fn submit_proposal(env: &ShastaEnv, request: BuiltProposalTx) -> Result<(u64, Log)> {
+    let wallet_provider = env
+        .client_config
+        .l1_provider_source
+        .to_provider_with_wallet(env.l1_proposer_private_key)
+        .await?;
+    let pending_tx = wallet_provider.send_transaction(request.to_transaction_request()).await?;
     let receipt = pending_tx.get_receipt().await?;
     ensure!(receipt.status(), "proposal transaction failed");
     let proposal_log: Log = receipt
         .logs()
         .iter()
-        .find(|log| log.address() == inbox)
+        .find(|log| log.address() == env.inbox_address)
         .cloned()
         .context("missing Proposed log in receipt")?;
     let proposal_id = decode_proposal_id(&proposal_log)?;
@@ -58,16 +57,13 @@ async fn submit_proposal(
 }
 
 /// Waits for the event syncer to process a specific proposal using confirmed-sync state polling.
-async fn wait_for_proposal_processed<P>(
-    event_syncer: &EventSyncer<P>,
-    driver_client: &Client<P>,
+async fn wait_for_proposal_processed(
+    event_syncer: &EventSyncer,
+    driver_client: &Client,
     expected_proposal_id: u64,
     l2_head_before: u64,
     timeout: Duration,
-) -> Result<u64>
-where
-    P: Provider + Clone + 'static,
-{
+) -> Result<u64> {
     let deadline = tokio::time::Instant::now() + timeout;
 
     loop {
@@ -137,7 +133,7 @@ async fn proposer_to_driver_event_sync(env: &mut ShastaEnv) -> Result<()> {
 
     let l2_head_before = driver_client.l2_provider.get_block_number().await?;
 
-    let (proposal_id, _log) = submit_proposal(&proposer, request, env.inbox_address).await?;
+    let (proposal_id, _log) = submit_proposal(env, request).await?;
 
     let l2_head_after = wait_for_proposal_processed(
         &event_syncer,
@@ -197,8 +193,7 @@ async fn known_canonical_fast_path(env: &mut ShastaEnv) -> Result<()> {
     event_syncer.wait_preconf_ingress_ready().await?;
 
     let l2_head_before = driver_client.l2_provider.get_block_number().await?;
-    let (proposal_id, proposal_log) =
-        submit_proposal(&proposer, request, env.inbox_address).await?;
+    let (proposal_id, proposal_log) = submit_proposal(env, request).await?;
 
     let l2_head_after = wait_for_proposal_processed(
         &event_syncer,
@@ -286,7 +281,7 @@ async fn multiple_proposals_event_sync(env: &mut ShastaEnv) -> Result<()> {
     let l2_head_before = driver_client.l2_provider.get_block_number().await?;
 
     // Submit first proposal.
-    let (proposal_id_1, _) = submit_proposal(&proposer, request.clone(), env.inbox_address).await?;
+    let (proposal_id_1, _) = submit_proposal(env, request.clone()).await?;
     let l2_head_after_first = wait_for_proposal_processed(
         &event_syncer,
         &driver_client,
@@ -297,7 +292,7 @@ async fn multiple_proposals_event_sync(env: &mut ShastaEnv) -> Result<()> {
     .await?;
 
     // Submit second proposal (same manifest/sidecar).
-    let (proposal_id_2, _) = submit_proposal(&proposer, request, env.inbox_address).await?;
+    let (proposal_id_2, _) = submit_proposal(env, request).await?;
     let l2_head_after_second = wait_for_proposal_processed(
         &event_syncer,
         &driver_client,

--- a/packages/taiko-client-rs/crates/driver/tests/shasta_event_sync.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/shasta_event_sync.rs
@@ -17,8 +17,7 @@ use test_harness::{BeaconStubServer, ShastaEnv, verify_anchor_block};
 #[serial]
 #[test_log::test(tokio::test)]
 async fn syncs_shasta_proposal_into_l2(env: &mut ShastaEnv) -> Result<()> {
-    let proposer_client =
-        Client::new_with_wallet(env.client_config.clone(), env.l1_proposer_private_key).await?;
+    let proposer_client = Client::new(env.client_config.clone()).await?;
 
     let builder = ShastaProposalTransactionBuilder::new(
         proposer_client.clone(),
@@ -33,8 +32,13 @@ async fn syncs_shasta_proposal_into_l2(env: &mut ShastaEnv) -> Result<()> {
     let beacon_stub = BeaconStubServer::start().await?;
     let beacon_endpoint = beacon_stub.endpoint().clone();
 
-    let pending_tx =
-        proposer_client.l1_provider.send_transaction(request.to_transaction_request()).await?;
+    // Sends are signed by a test-local wallet provider; the `Client` itself is walletless.
+    let wallet_provider = env
+        .client_config
+        .l1_provider_source
+        .to_provider_with_wallet(env.l1_proposer_private_key)
+        .await?;
+    let pending_tx = wallet_provider.send_transaction(request.to_transaction_request()).await?;
     let receipt =
         pending_tx.get_receipt().await.context("fetching proposal transaction receipt")?;
     ensure!(receipt.status(), "proposal transaction failed");

--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -33,7 +33,7 @@ use protocol::shasta::{
 };
 use rpc::{
     RpcClientError,
-    client::{Client, ClientConfig, ClientWithWallet},
+    client::{Client, ClientConfig},
 };
 use serde_json::from_value;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -67,8 +67,8 @@ pub struct EngineBuildContext {
 
 /// Proposer loop that builds and submits Shasta proposals at a fixed interval.
 pub struct Proposer {
-    /// RPC client bundle with signing wallet for L1 submission.
-    rpc_provider: ClientWithWallet,
+    /// RPC client bundle used for L1/L2 reads; L1 submission is signed by the tx-manager.
+    rpc_provider: Client,
     /// Builder that converts txpool content into proposal transactions.
     transaction_builder: ShastaProposalTransactionBuilder,
     /// Tx-manager responsible for proposal submission and retry handling.
@@ -94,25 +94,22 @@ impl Proposer {
             "initializing proposer"
         );
 
-        let rpc_provider = Client::new_with_wallet(
-            ClientConfig {
-                l1_provider_source: cfg.l1_provider_source.clone(),
-                l2_provider_url: cfg.l2_provider_url.clone(),
-                l2_auth_provider_url: cfg.l2_auth_provider_url.clone(),
-                jwt_secret: cfg.jwt_secret.clone(),
-                inbox_address: cfg.inbox_address,
-            },
-            cfg.l1_proposer_private_key,
-        )
+        let rpc_provider = Client::new(ClientConfig {
+            l1_provider_source: cfg.l1_provider_source.clone(),
+            l2_provider_url: cfg.l2_provider_url.clone(),
+            l2_auth_provider_url: cfg.l2_auth_provider_url.clone(),
+            jwt_secret: cfg.jwt_secret.clone(),
+            inbox_address: cfg.inbox_address,
+        })
         .await?;
 
         let transaction_builder = ShastaProposalTransactionBuilder::new(
             rpc_provider.clone(),
             cfg.l2_suggested_fee_recipient,
         );
-        // The RPC client wallet and tx-manager signer are both derived from the same
-        // proposer key, so all L1 proposal submissions must continue to flow through
-        // tx-manager to avoid splitting nonce management across two send paths.
+        // The RPC client carries no wallet; the tx-manager owns the proposer key, so all
+        // L1 proposal submissions flow through tx-manager and nonce management stays on a
+        // single send path.
         let tx_manager = build_tx_manager(&cfg, rpc_provider.l1_provider.root().to_owned()).await?;
         let l1_proposer_address = proposer_address_from_key(&cfg.l1_proposer_private_key)?;
         // Match proposer-side base-fee clamping to chain policy used by derivation.
@@ -235,7 +232,7 @@ impl Proposer {
     }
 
     /// Return a clone of the RPC client bundle used by the proposer.
-    pub fn rpc_client(&self) -> ClientWithWallet {
+    pub fn rpc_client(&self) -> Client {
         self.rpc_provider.clone()
     }
 

--- a/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
@@ -18,7 +18,7 @@ use protocol::shasta::{
     constants::DERIVATION_SOURCE_MAX_BLOCKS,
     manifest::{BlockManifest, DerivationSourceManifest},
 };
-use rpc::client::ClientWithWallet;
+use rpc::client::Client;
 use tracing::info;
 
 use crate::{
@@ -82,15 +82,15 @@ impl BuiltProposalTx {
 
 /// A transaction builder for Shasta `propose` transactions.
 pub struct ShastaProposalTransactionBuilder {
-    /// The RPC provider with wallet.
-    pub rpc_provider: ClientWithWallet,
+    /// The RPC client used for L1/L2 reads while assembling proposals.
+    pub rpc_provider: Client,
     /// The address of the suggested fee recipient for the proposed L2 block.
     pub l2_suggested_fee_recipient: Address,
 }
 
 impl ShastaProposalTransactionBuilder {
     /// Creates a new `ShastaProposalTransactionBuilder`.
-    pub fn new(rpc_provider: ClientWithWallet, l2_suggested_fee_recipient: Address) -> Self {
+    pub fn new(rpc_provider: Client, l2_suggested_fee_recipient: Address) -> Self {
         Self { rpc_provider, l2_suggested_fee_recipient }
     }
 
@@ -218,11 +218,9 @@ mod tests {
                 Id, RequestPacket, Response, ResponsePacket, ResponsePayload, SerializedRequest,
             },
         },
-        signers::local::PrivateKeySigner,
         sol_types::{SolCall, SolValue},
         transports::{TransportError, TransportFut},
     };
-    use alloy_network::EthereumWallet;
     use alloy_provider::ProviderBuilder;
     use alloy_rpc_types::eth::{Block as RpcBlock, Header as RpcHeader};
     use bindings::{
@@ -233,7 +231,7 @@ mod tests {
         },
     };
     use protocol::shasta::{BlobCoder, manifest::DerivationSourceManifest};
-    use rpc::client::{Client, ClientWithWallet, ShastaProtocolInstance};
+    use rpc::client::{Client, ShastaProtocolInstance};
     use std::sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -489,14 +487,8 @@ mod tests {
     fn test_rpc_client(
         l1_transport: ManifestTestTransport,
         l2_transport: ManifestTestTransport,
-    ) -> ClientWithWallet {
-        let signer = PrivateKeySigner::from_bytes(&alloy::primitives::B256::from([1u8; 32]))
-            .expect("test private key should be valid");
-        let wallet = EthereumWallet::new(signer);
-
-        let l1_provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect_client(RpcClient::new(l1_transport, true));
+    ) -> Client {
+        let l1_provider = ProviderBuilder::new().connect_client(RpcClient::new(l1_transport, true));
         let l2_provider =
             ProviderBuilder::default().connect_client(RpcClient::new(l2_transport, true));
         let l2_auth_provider = l2_provider.clone();

--- a/packages/taiko-client-rs/crates/rpc/src/auth.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/auth.rs
@@ -78,7 +78,7 @@ fn engine_new_payload_v2_value(
     .map_err(|err| RpcClientError::Other(anyhow!(err)))
 }
 
-impl<P: Provider + Clone> Client<P> {
+impl Client {
     /// Issue an L1-origin lookup against the given provider, mapping ignorable engine errors to
     /// `Ok(None)` and converting the transport wrapper into the public [`RpcL1Origin`] type.
     pub(crate) async fn request_l1_origin<Params: RpcSend>(

--- a/packages/taiko-client-rs/crates/rpc/src/client.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/client.rs
@@ -28,17 +28,11 @@ use tower::{ServiceBuilder, timeout::TimeoutLayer};
 use tracing::info;
 
 use crate::{
-    JoinedRecommendedFillersWithWallet, SubscriptionSource,
+    SubscriptionSource,
     error::{Result, RpcClientError},
 };
 
-/// Type alias for a Client with a provider that includes a wallet.
-pub type ClientWithWallet = Client<FillProvider<JoinedRecommendedFillersWithWallet, RootProvider>>;
-
-/// Default walletless L1 provider type: recommended fillers over an HTTP/WS root provider.
-///
-/// Every read-only consumer (driver, whitelist preconfirmation driver) uses exactly this
-/// provider, so those crates can name it concretely instead of threading a generic.
+/// L1 provider type used by [`Client`]: recommended fillers over an HTTP/WS root provider.
 pub type DefaultProvider = FillProvider<JoinedRecommendedFillers, RootProvider>;
 
 /// Default HTTP timeout for RPC and auxiliary HTTP clients.
@@ -46,26 +40,30 @@ pub const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(12);
 
 /// Instances of Shasta protocol contracts.
 #[derive(Clone, Debug)]
-pub struct ShastaProtocolInstance<P: Provider + Clone> {
+pub struct ShastaProtocolInstance {
     /// Inbox contract instance on L1.
-    pub inbox: InboxInstance<P>,
+    pub inbox: InboxInstance<DefaultProvider>,
     /// Anchor contract instance on L2 (auth provider).
     pub anchor: AnchorInstance<RootProvider>,
 }
 
 /// A client for interacting with L1 and L2 providers and Shasta protocol contracts.
+///
+/// The client is read-only towards L1: it never signs or submits transactions, so it
+/// carries no wallet. L1 transaction submission is owned by the proposer's transaction
+/// manager, which keeps nonce management on a single path.
 #[derive(Clone, Debug)]
-pub struct Client<P: Provider + Clone> {
+pub struct Client {
     /// L2 chain ID, fetched from the L2 provider at startup.
     pub chain_id: u64,
-    /// L1 provider (optionally with wallet) used for contract calls.
-    pub l1_provider: P,
+    /// Walletless L1 provider used for contract calls and event scans.
+    pub l1_provider: DefaultProvider,
     /// L2 public provider for read-only access.
     pub l2_provider: RootProvider,
     /// L2 authenticated provider for engine/anchor interactions.
     pub l2_auth_provider: RootProvider,
     /// Shasta protocol contract bundle (Inbox/Anchor).
-    pub shasta: ShastaProtocolInstance<P>,
+    pub shasta: ShastaProtocolInstance,
 }
 
 /// Configuration for the `Client`.
@@ -83,8 +81,8 @@ pub struct ClientConfig {
     pub inbox_address: Address,
 }
 
-impl Client<DefaultProvider> {
-    /// Create a new `Client` without a wallet from the given configuration.
+impl Client {
+    /// Create a new `Client` from the given configuration.
     pub async fn new(config: ClientConfig) -> Result<Self> {
         let l1_provider = config.l1_provider_source.to_provider().await.map_err(|e| {
             RpcClientError::Connection(format!(
@@ -92,27 +90,6 @@ impl Client<DefaultProvider> {
                 e
             ))
         })?;
-        Self::new_with_l1_provider(l1_provider, config).await
-    }
-}
-
-impl Client<FillProvider<JoinedRecommendedFillersWithWallet, RootProvider>> {
-    /// Create a new `Client` with a wallet from the given configuration.
-    pub async fn new_with_wallet(config: ClientConfig, private_key: B256) -> Result<Self> {
-        let l1_provider =
-            config.l1_provider_source.to_provider_with_wallet(private_key).await.map_err(|e| {
-                RpcClientError::Connection(format!(
-                    "L1 provider source (l1.http or l1.ws) connection failed: {}",
-                    e
-                ))
-            })?;
-        Self::new_with_l1_provider(l1_provider, config).await
-    }
-}
-
-impl<P: Provider + Clone> Client<P> {
-    /// Create a new `Client` from the given L1 provider and configuration.
-    async fn new_with_l1_provider(l1_provider: P, config: ClientConfig) -> Result<Self> {
         let l2_provider =
             connect_provider_with_timeout(config.l2_provider_url.clone()).await.map_err(|e| {
                 RpcClientError::Connection(format!(

--- a/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/l1_origin.rs
@@ -2,7 +2,6 @@
 
 use alethia_reth_primitives::payload::attributes::RpcL1Origin;
 use alloy_primitives::U256;
-use alloy_provider::Provider;
 
 /// Public alias for execution-engine L1 origin payloads.
 pub type L1Origin = RpcL1Origin;
@@ -12,7 +11,7 @@ pub(crate) use alethia_reth_primitives::payload::attributes::EngineRpcL1Origin;
 
 use crate::{client::Client, error::Result};
 
-impl<P: Provider + Clone> Client<P> {
+impl Client {
     /// Fetch the L1 origin payload for the given block id via the public engine API.
     pub async fn l1_origin_by_id(&self, block_id: U256) -> Result<Option<L1Origin>> {
         Self::request_l1_origin(&self.l2_provider, "taiko_l1OriginByID", (block_id,)).await

--- a/packages/taiko-client-rs/crates/rpc/src/lib.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/lib.rs
@@ -11,6 +11,4 @@ pub mod l1_origin;
 
 pub use auth::TxPoolContentParams;
 pub use error::{Result, RpcClientError};
-pub use protocol::subscription_source::{
-    JoinedRecommendedFillersWithWallet, SubscriptionSource, SubscriptionSourceError,
-};
+pub use protocol::subscription_source::{SubscriptionSource, SubscriptionSourceError};

--- a/packages/taiko-client-rs/crates/test-harness/src/helper.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/helper.rs
@@ -9,10 +9,7 @@ use rpc::client::Client;
 pub(crate) const PRIORITY_FEE_GWEI: u128 = 10_000_000_000;
 
 /// Mines a single empty L1 block via the connected execution engine.
-pub async fn mine_l1_block<P>(client: &Client<P>) -> anyhow::Result<()>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+pub async fn mine_l1_block(client: &Client) -> anyhow::Result<()> {
     client
         .l1_provider
         .raw_request::<_, String>(Cow::Borrowed("evm_mine"), NoParams::default())
@@ -22,10 +19,7 @@ where
 }
 
 /// Increases L1 time by the specified number of seconds.
-pub(crate) async fn increase_l1_time<P>(client: &Client<P>, seconds: u64) -> anyhow::Result<()>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+pub(crate) async fn increase_l1_time(client: &Client, seconds: u64) -> anyhow::Result<()> {
     client
         .l1_provider
         .raw_request::<_, i64>(Cow::Borrowed("evm_increaseTime"), (seconds,))
@@ -37,10 +31,7 @@ where
 /// Mines multiple L1 blocks at once using Anvil's batch mining.
 ///
 /// This is more efficient than calling `mine_l1_block` in a loop.
-pub(crate) async fn mine_l1_blocks<P>(client: &Client<P>, count: usize) -> anyhow::Result<()>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+pub(crate) async fn mine_l1_blocks(client: &Client, count: usize) -> anyhow::Result<()> {
     client
         .l1_provider
         .raw_request::<_, ()>(Cow::Borrowed("anvil_mine"), (count,))

--- a/packages/taiko-client-rs/crates/test-harness/src/shasta/env.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/shasta/env.rs
@@ -13,8 +13,8 @@ use test_context::AsyncTestContext;
 use tracing::info;
 
 use super::helpers::{
-    RpcClient, create_snapshot, ensure_preconf_whitelist_active, reset_head_l1_origin,
-    reset_to_base_block, revert_snapshot,
+    create_snapshot, ensure_preconf_whitelist_active, reset_head_l1_origin, reset_to_base_block,
+    revert_snapshot,
 };
 
 /// Environment configuration required to exercise Shasta fork integration tests against
@@ -32,7 +32,7 @@ pub struct ShastaEnv {
     pub l1_proposer_private_key: B256,
     pub taiko_anchor_address: Address,
     pub client_config: ClientConfig,
-    pub client: RpcClient,
+    pub client: Client,
     cleanup_provider: RootProvider,
     snapshot_id: String,
     /// Secondary L2 WebSocket endpoint for dual-driver E2E tests.

--- a/packages/taiko-client-rs/crates/test-harness/src/shasta/helpers.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/shasta/helpers.rs
@@ -4,9 +4,7 @@ use alethia_reth_primitives::payload::attributes::RpcL1Origin;
 use alloy::{eips::BlockNumberOrTag, rpc::client::NoParams, sol_types::SolCall};
 use alloy_consensus::{Transaction, TxEnvelope};
 use alloy_primitives::{Address, B256, Bytes, FixedBytes, U256};
-use alloy_provider::{
-    Provider, RootProvider, fillers::FillProvider, utils::JoinedRecommendedFillers,
-};
+use alloy_provider::{Provider, RootProvider};
 use alloy_rlp::{BytesMut, encode_list};
 use alloy_rpc_types::{Transaction as RpcTransaction, eth::Block as RpcBlock};
 use alloy_rpc_types_engine::{
@@ -15,16 +13,10 @@ use alloy_rpc_types_engine::{
 use anyhow::{Context, Result, ensure};
 use bindings::anchor::Anchor::anchorV4Call;
 use protocol::shasta::{PayloadAttributesInput, build_payload_attributes};
-use rpc::{
-    client::{Client, ClientWithWallet},
-    error::RpcClientError,
-};
+use rpc::{client::Client, error::RpcClientError};
 use tracing::{info, warn};
 
 use crate::helper::{increase_l1_time, mine_l1_blocks};
-
-/// The RPC client type used in Shasta tests.
-pub type RpcClient = Client<FillProvider<JoinedRecommendedFillers, RootProvider>>;
 
 /// Number of L1 blocks to mine to ensure preconfigured operator whitelist is active.
 const PRECONF_OPERATOR_ACTIVATION_BLOCKS: usize = 64;
@@ -35,7 +27,7 @@ const L1_BLOCK_TIME_SECONDS: u64 = 12;
 ///
 /// Uses batch operations (single `evm_increaseTime` + single `anvil_mine`) instead of
 /// looping 64 times, reducing RPC calls from 128 to 2.
-pub async fn ensure_preconf_whitelist_active(client: &RpcClient) -> Result<()> {
+pub async fn ensure_preconf_whitelist_active(client: &Client) -> Result<()> {
     let total_seconds = PRECONF_OPERATOR_ACTIVATION_BLOCKS as u64 * L1_BLOCK_TIME_SECONDS;
     increase_l1_time(client, total_seconds).await?;
     mine_l1_blocks(client, PRECONF_OPERATOR_ACTIVATION_BLOCKS).await?;
@@ -52,7 +44,7 @@ fn is_not_found_error(err: &RpcClientError) -> bool {
 }
 
 /// Reset the authenticated L1 RPC head.
-pub(crate) async fn reset_head_l1_origin(client: &RpcClient) -> Result<()> {
+pub(crate) async fn reset_head_l1_origin(client: &Client) -> Result<()> {
     // Choose the highest L2 block that actually has an L1 origin row, then repoint
     // `head_l1_origin` there. Hardcoding block 1 is brittle when tests reset chains to genesis
     // or run against nodes with sparse origin rows.
@@ -119,7 +111,7 @@ fn payload_status_is_ok(status: &PayloadStatusEnum) -> bool {
 }
 
 /// Reset the L2 chain head to the base block (height 1) using the engine API.
-pub(crate) async fn reset_to_base_block(client: &RpcClient) -> Result<()> {
+pub(crate) async fn reset_to_base_block(client: &Client) -> Result<()> {
     let head: RpcBlock<TxEnvelope> = client
         .l2_provider
         .get_block_by_number(BlockNumberOrTag::Latest)
@@ -182,7 +174,7 @@ pub(crate) async fn reset_to_base_block(client: &RpcClient) -> Result<()> {
 }
 
 async fn fork_to(
-    client: &RpcClient,
+    client: &Client,
     block: &RpcBlock<TxEnvelope>,
     l1_origin: &RpcL1Origin,
     parent_hash: B256,
@@ -301,16 +293,13 @@ async fn fork_to(
 }
 
 /// Fetch proposal hash from the inbox contract.
-pub async fn get_proposal_hash(client: &ClientWithWallet, proposal_id: U256) -> Result<B256> {
+pub async fn get_proposal_hash(client: &Client, proposal_id: U256) -> Result<B256> {
     let hash: FixedBytes<32> = client.shasta.inbox.getProposalHash(proposal_id).call().await?;
     Ok(hash)
 }
 
 /// Ensures the latest L2 block contains an Anchor `anchorV4` call.
-pub async fn verify_anchor_block<P>(client: &Client<P>, anchor_address: Address) -> Result<()>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+pub async fn verify_anchor_block(client: &Client, anchor_address: Address) -> Result<()> {
     let latest_block: RpcBlock<TxEnvelope> = client
         .l2_provider
         .get_block_by_number(BlockNumberOrTag::Latest)

--- a/packages/taiko-client-rs/crates/test-harness/src/transactions/anchor.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/transactions/anchor.rs
@@ -41,15 +41,12 @@ use rpc::client::Client;
 /// let mut txlist = vec![anchor_tx];
 /// txlist.extend(transfer_txs);
 /// ```
-pub(crate) async fn build_anchor_tx_bytes<P>(
-    client: &Client<P>,
+pub(crate) async fn build_anchor_tx_bytes(
+    client: &Client,
     parent_hash: B256,
     block_number: u64,
     base_fee: u64,
-) -> Result<Bytes>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+) -> Result<Bytes> {
     let anchor_block_number = client.l1_provider.get_block_number().await?;
     let anchor_block = client
         .l1_provider

--- a/packages/taiko-client-rs/crates/test-harness/src/transactions/txlist.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/transactions/txlist.rs
@@ -5,7 +5,6 @@
 //! - [`build_preconf_txlist`]: Builds anchor + test transfers in one call.
 
 use alloy_primitives::{B256, Bytes};
-use alloy_provider::Provider;
 use anyhow::Result;
 use rpc::client::Client;
 
@@ -62,15 +61,12 @@ pub struct PreconfTxList {
 ///     assert!(block_contains_tx(&block, transfer.hash));
 /// }
 /// ```
-pub async fn build_preconf_txlist<P>(
-    client: &Client<P>,
+pub async fn build_preconf_txlist(
+    client: &Client,
     parent_hash: B256,
     block_number: u64,
     base_fee: u64,
-) -> Result<PreconfTxList>
-where
-    P: Provider + Clone + Send + Sync + 'static,
-{
+) -> Result<PreconfTxList> {
     let anchor_tx = build_anchor_tx_bytes(client, parent_hash, block_number, base_fee).await?;
     let transfers = build_test_transfers(&client.l2_provider, block_number).await?;
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -14,10 +14,7 @@ use alloy_rpc_types_engine::ExecutionPayloadV1;
 use async_trait::async_trait;
 use driver::{PreconfPayload, sync::event::EventSyncer};
 use protocol::{shasta::calculate_shasta_mix_hash, signer::FixedKSigner};
-use rpc::{
-    beacon::BeaconClient,
-    client::{Client, DefaultProvider},
-};
+use rpc::{beacon::BeaconClient, client::Client};
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tracing::{debug, warn};
 
@@ -91,9 +88,9 @@ fn reconcile_highest_unsafe(tracked: u64, head: Option<u64>) -> u64 {
 /// Implements whitelist preconfirmation API business logic.
 pub(crate) struct WhitelistApiService {
     /// Event syncer for L1 origin lookups.
-    event_syncer: Arc<EventSyncer<DefaultProvider>>,
+    event_syncer: Arc<EventSyncer>,
     /// RPC client for L1/L2 reads.
-    rpc: Client<DefaultProvider>,
+    rpc: Client,
     /// Chain ID for signature domain separation.
     chain_id: u64,
     /// Deterministic signer for block signing.
@@ -120,9 +117,9 @@ pub(crate) struct WhitelistApiService {
 /// Dependency bundle for constructing `WhitelistApiService`.
 pub(crate) struct WhitelistApiServiceParams {
     /// Shared event syncer used to read the current L1 origin.
-    pub(crate) event_syncer: Arc<EventSyncer<DefaultProvider>>,
+    pub(crate) event_syncer: Arc<EventSyncer>,
     /// L1/L2 RPC client.
-    pub(crate) rpc: Client<DefaultProvider>,
+    pub(crate) rpc: Client,
     /// Chain ID used for signing and payload hashing.
     pub(crate) chain_id: u64,
     /// Signer used for block signing operations.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -5,10 +5,7 @@ use std::sync::Arc;
 use alloy_primitives::{Address, B256};
 use alloy_provider::Provider;
 use driver::sync::event::EventSyncer;
-use rpc::{
-    beacon::BeaconClient,
-    client::{Client, DefaultProvider},
-};
+use rpc::{beacon::BeaconClient, client::Client};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
@@ -33,9 +30,9 @@ pub(crate) use validation::validate_execution_payload_for_preconf;
 /// Dependency bundle for constructing [`WhitelistPreconfirmationImporter`].
 pub(crate) struct WhitelistPreconfirmationImporterParams {
     /// Event syncer used to submit validated preconfirmation payloads.
-    pub(crate) event_syncer: Arc<EventSyncer<DefaultProvider>>,
+    pub(crate) event_syncer: Arc<EventSyncer>,
     /// RPC client used for L1/L2 reads and head-origin updates.
-    pub(crate) rpc: Client<DefaultProvider>,
+    pub(crate) rpc: Client,
     /// Chain id used for preconfirmation signature domain separation.
     pub(crate) chain_id: u64,
     /// Command channel used to publish P2P requests/responses.
@@ -54,9 +51,9 @@ pub(crate) struct WhitelistPreconfirmationImporterParams {
 /// importer. The importer performs payload-level validation only.
 pub(crate) struct WhitelistPreconfirmationImporter {
     /// Event syncer used to submit validated preconfirmation payloads.
-    event_syncer: Arc<EventSyncer<DefaultProvider>>,
+    event_syncer: Arc<EventSyncer>,
     /// RPC client used for L1/L2 reads and head-origin updates.
-    rpc: Client<DefaultProvider>,
+    rpc: Client,
     /// Chain id used for preconfirmation signature domain separation.
     chain_id: u64,
     /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).


### PR DESCRIPTION
## Summary

`rpc::client::Client<P>` carried a provider generic that no longer bought anything:

- `P` typed only `l1_provider` and the `Inbox` instance; **no rpc method body used a `P`-specific capability** (`auth.rs`/`l1_origin.rs` only touch the concrete L2 providers, and the anchor instance was already `RootProvider`).
- The only wallet-carrying instantiation immediately discarded the wallet: the proposer hands `l1_provider.root()` to the tx-manager, which signs with its own wallet built from the proposer key (`tx_manager_adapter.rs`). Nothing ever sent a transaction through the client's L1 provider.

This makes `Client` (and `ShastaProtocolInstance`) non-generic over the existing `DefaultProvider` and removes the wallet path entirely:

- deleted `ClientWithWallet` + `Client::new_with_wallet`; the client is now explicitly read-only towards L1 (documented on the struct), so all production L1 sends stay on the tx-manager's single nonce path
- de-generified everything that carried `<P>` only to hold a `Client`: `EventSyncer`, `BeaconSyncer`, `SyncPipeline`, `ShastaDerivationPipeline`, `CanonicalL1ProductionPath`, the `PayloadApplier`/`BlockHashReader` impls, engine submission helpers, `PreconfIngressSync`, and the whitelist importer/API service
- folded the aliases that hand-spelled the same provider stack in three crates: `driver::DriverRpcClient` and test-harness `RpcClient` are gone; `rpc::client::DefaultProvider` remains the single name
- driver e2e tests now sign proposal submissions through a test-local `SubscriptionSource::to_provider_with_wallet` provider, keeping the walletless-`Client` invariant intact

Net: **24 files, +162/−316**. No behavior change intended.

## Verification

```
just fmt && just clippy   # clean (-D warnings, missing-docs gates included)
just test                 # Summary [42.813s] 295 tests run: 295 passed, 0 skipped
```

Baseline on main before the change: the same 295/295.

Note: #21915 also touches the driver e2e tests; any conflicts with this PR should be mechanical.