### PR TITLE
refactor(taiko-client-rs): sweep quick-win cleanups across crates

### DIFF
--- a/packages/taiko-client-rs/bin/client/src/commands/driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/driver.rs
@@ -26,7 +26,7 @@ pub struct DriverSubCommand {
 impl DriverSubCommand {
     /// Build driver configuration from command-line arguments.
     fn build_config(&self) -> Result<DriverConfig> {
-        build_driver_config(&self.common_flags, &self.driver_flags)
+        build_driver_config(&self.common_flags, &self.driver_flags, false)
     }
 
     /// Run the driver.

--- a/packages/taiko-client-rs/bin/client/src/commands/mod.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/mod.rs
@@ -17,25 +17,30 @@ pub mod driver;
 pub mod proposer;
 pub mod whitelist_preconfirmation_driver;
 
-/// Build a [`DriverConfig`] from the shared common/driver CLI flags.
-///
-/// The resulting config has `preconfirmation_enabled = false`; callers that need to enable
-/// preconfirmation ingress should toggle that flag on the returned value.
-pub fn build_driver_config(common: &CommonArgs, driver: &DriverArgs) -> Result<DriverConfig> {
-    let client_cfg = ClientConfig {
+/// Build a [`ClientConfig`] from the shared common CLI flags.
+pub fn build_client_config(common: &CommonArgs) -> Result<ClientConfig> {
+    Ok(ClientConfig {
         l1_provider_source: common.l1_provider_source()?,
         l2_provider_url: common.l2_http_endpoint.clone(),
         l2_auth_provider_url: common.l2_auth_endpoint.clone(),
         jwt_secret: common.l2_auth_jwt_secret.clone(),
         inbox_address: common.shasta_inbox_address,
-    };
+    })
+}
 
+/// Build a [`DriverConfig`] from the shared common/driver CLI flags.
+pub fn build_driver_config(
+    common: &CommonArgs,
+    driver: &DriverArgs,
+    preconfirmation_enabled: bool,
+) -> Result<DriverConfig> {
     Ok(DriverConfig::new(
-        client_cfg,
+        build_client_config(common)?,
         driver.retry_interval(),
         driver.l1_beacon_endpoint.clone(),
         driver.l2_checkpoint_endpoint.clone(),
         driver.blob_server_endpoint.clone(),
+        preconfirmation_enabled,
     ))
 }
 
@@ -74,6 +79,8 @@ pub trait Subcommand {
         let socket_addr: SocketAddr = metrics_addr.parse()?;
 
         self.register_metrics()?;
+        crate::metrics::version::VersionInfo::new(env!("CARGO_PKG_VERSION"))
+            .register_version_metrics();
         crate::metrics::spawn_server(socket_addr)?;
 
         info!(

--- a/packages/taiko-client-rs/bin/client/src/commands/proposer.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/proposer.rs
@@ -8,7 +8,7 @@ use proposer::{config::ProposerConfigs, metrics::ProposerMetrics, proposer::Prop
 use protocol::shasta::set_devnet_unzen_override;
 
 use crate::{
-    commands::Subcommand,
+    commands::{Subcommand, build_client_config},
     flags::{common::CommonArgs, proposer::ProposerArgs},
 };
 
@@ -30,14 +30,8 @@ pub struct ProposerSubCommand {
 impl ProposerSubCommand {
     /// Build proposer configuration from command-line arguments.
     fn build_config(&self) -> Result<ProposerConfigs> {
-        let l1_provider_source = self.common_flags.l1_provider_source()?;
-
         Ok(ProposerConfigs {
-            l1_provider_source,
-            l2_provider_url: self.common_flags.l2_http_endpoint.clone(),
-            l2_auth_provider_url: self.common_flags.l2_auth_endpoint.clone(),
-            jwt_secret: self.common_flags.l2_auth_jwt_secret.clone(),
-            inbox_address: self.common_flags.shasta_inbox_address,
+            client: build_client_config(&self.common_flags)?,
             l2_suggested_fee_recipient: self.proposer_flags.l2_suggested_fee_recipient,
             propose_interval: Duration::from_secs(self.proposer_flags.propose_interval),
             l1_proposer_private_key: self.proposer_flags.l1_proposer_private_key,

--- a/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
+++ b/packages/taiko-client-rs/bin/client/src/commands/whitelist_preconfirmation_driver.rs
@@ -64,10 +64,9 @@ pub struct WhitelistPreconfirmationDriverSubCommand {
 impl WhitelistPreconfirmationDriverSubCommand {
     /// Build driver configuration from command-line arguments.
     fn build_driver_config(&self) -> Result<DriverConfig> {
-        let mut cfg = build_driver_config(&self.common_flags, &self.driver_flags)?;
-        // Enable preconfirmation ingress so whitelist payload imports can reuse the driver queue.
-        cfg.preconfirmation_enabled = true;
-        Ok(cfg)
+        // Preconfirmation ingress is enabled so whitelist payload imports can reuse the
+        // driver queue.
+        build_driver_config(&self.common_flags, &self.driver_flags, true)
     }
 
     /// Build P2P configuration from command-line arguments.

--- a/packages/taiko-client-rs/bin/client/src/metrics/version.rs
+++ b/packages/taiko-client-rs/bin/client/src/metrics/version.rs
@@ -3,11 +3,11 @@
 use once_cell::sync::Lazy;
 use prometheus::{GaugeVec, Opts};
 
-/// Application version gauge grouped by build metadata.
+/// Application version gauge labelled by crate version.
 static VERSION_INFO: Lazy<GaugeVec> = Lazy::new(|| {
     let gauge = GaugeVec::new(
         Opts::new("taiko_client_info", "Taiko client build information"),
-        &["version", "target_triple"],
+        &["version"],
     )
     .expect("valid taiko client version gauge");
     prometheus::register(Box::new(gauge.clone()))
@@ -20,18 +20,16 @@ static VERSION_INFO: Lazy<GaugeVec> = Lazy::new(|| {
 pub struct VersionInfo {
     /// The version of the application.
     pub version: &'static str,
-    /// The target triple for the build.
-    pub target_triple: &'static str,
 }
 
 impl VersionInfo {
     /// Creates a new instance of [`VersionInfo`].
-    pub const fn new(version: &'static str, target_triple: &'static str) -> Self {
-        Self { version, target_triple }
+    pub const fn new(version: &'static str) -> Self {
+        Self { version }
     }
 
     /// Exposes taiko-client's version information over prometheus.
     pub fn register_version_metrics(&self) {
-        VERSION_INFO.with_label_values(&[self.version, self.target_triple]).set(1.0);
+        VERSION_INFO.with_label_values(&[self.version]).set(1.0);
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/anchor_tx.rs
+++ b/packages/taiko-client-rs/crates/driver/src/anchor_tx.rs
@@ -1,0 +1,28 @@
+//! Shared helper for locating the anchor transaction inside a fetched L2 block.
+
+use alloy_consensus::{TxEnvelope, transaction::Transaction as _};
+use alloy_primitives::{Address, Bytes};
+use alloy_rpc_types::eth::Block as RpcBlock;
+
+/// Return the calldata of the block's first transaction after verifying it targets the anchor
+/// contract.
+///
+/// Anchor transactions are injected as the first transaction of every non-genesis L2 block, so
+/// this is the shared admission preamble for every decoder that recovers anchor call data from
+/// a locally fetched block. On failure the static reason describes which structural expectation
+/// broke; callers wrap it in their own error type.
+pub(crate) fn first_anchor_tx_input(
+    block: &RpcBlock<TxEnvelope>,
+    anchor_address: Address,
+) -> Result<&Bytes, &'static str> {
+    let txs = block
+        .transactions
+        .as_transactions()
+        .ok_or("block body returned only transaction hashes")?;
+    let first_tx = txs.first().ok_or("block contains no transactions")?;
+    let destination = first_tx.to().ok_or("unable to determine anchor transaction recipient")?;
+    if destination != anchor_address {
+        return Err("first transaction is not the anchor contract");
+    }
+    Ok(first_tx.input())
+}

--- a/packages/taiko-client-rs/crates/driver/src/config.rs
+++ b/packages/taiko-client-rs/crates/driver/src/config.rs
@@ -18,8 +18,7 @@ pub struct DriverConfig {
     pub l2_checkpoint_url: Option<Url>,
     /// Optional blob server endpoint used when beacon blobs are unavailable.
     pub blob_server_endpoint: Option<Url>,
-    /// Enable preconfirmation handling (disabled by default).
-    /// NOTE: will be changed to be decided by flag in future.
+    /// Enable preconfirmation ingress handling.
     pub preconfirmation_enabled: bool,
 }
 
@@ -27,13 +26,15 @@ impl DriverConfig {
     /// Build a [`DriverConfig`] from raw parameters.
     ///
     /// The `client` argument bundles all RPC endpoints and contract metadata, while the remaining
-    /// parameters control retry behaviour and optional checkpointing resources.
+    /// parameters control retry behaviour, optional checkpointing resources, and whether the
+    /// preconfirmation ingress path is enabled.
     pub fn new(
         client: ClientConfig,
         retry_interval: Duration,
         l1_beacon_endpoint: Url,
         l2_checkpoint_url: Option<Url>,
         blob_server_endpoint: Option<Url>,
+        preconfirmation_enabled: bool,
     ) -> Self {
         Self {
             client,
@@ -41,7 +42,7 @@ impl DriverConfig {
             l1_beacon_endpoint,
             l2_checkpoint_url,
             blob_server_endpoint,
-            preconfirmation_enabled: false,
+            preconfirmation_enabled,
         }
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -8,7 +8,7 @@ use alloy::{
     rpc::types::Log,
     sol_types::{SolCall, SolEvent},
 };
-use alloy_consensus::{Transaction, TxEnvelope};
+use alloy_consensus::TxEnvelope;
 use alloy_provider::RootProvider;
 use alloy_rpc_types::{Transaction as RpcTransaction, eth::Block as RpcBlock};
 use anyhow::anyhow;
@@ -128,26 +128,9 @@ fn decode_parent_anchor_block_number(
     anchor_address: Address,
 ) -> Result<u64, DerivationError> {
     let block_number = parent_block.header.number;
-    let txs = parent_block.transactions.as_transactions().ok_or_else(|| {
-        DerivationError::Other(anyhow!(
-            "parent block {block_number} returned only transaction hashes"
-        ))
-    })?;
-    let first_tx = txs.first().ok_or_else(|| {
-        DerivationError::Other(anyhow!("parent block {block_number} contains no transactions"))
-    })?;
-    let destination = first_tx.to().ok_or_else(|| {
-        DerivationError::Other(anyhow!(
-            "unable to determine anchor transaction recipient for parent block {block_number}"
-        ))
-    })?;
-    if destination != anchor_address {
-        return Err(DerivationError::Other(anyhow!(
-            "parent block {block_number} first transaction is not the anchor contract"
-        )));
-    }
-
-    let input = first_tx.input();
+    let input = crate::anchor_tx::first_anchor_tx_input(parent_block, anchor_address).map_err(
+        |reason| DerivationError::Other(anyhow!("parent block {block_number}: {reason}")),
+    )?;
     if let Ok(call) = anchorV4Call::abi_decode(input) {
         return Ok(call.0.0.to::<u64>());
     }

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
@@ -397,20 +397,20 @@ impl ShastaDerivationPipeline {
         let derived_block = self.prepare_block(block, state, ctx).await?;
         let BlockDerivationContext { payload, parent_hash, is_final_block, .. } = derived_block;
 
-        let applied = applier.apply_payload(&payload, parent_hash, finalized_block_hash).await?;
-        let header = applied.outcome.block.header.clone().into_consensus();
+        let outcome = applier.apply_payload(&payload, parent_hash, finalized_block_hash).await?;
+        let header = outcome.block.header.clone().into_consensus();
         *state = state.advance(header, block.anchor_block_number)?;
 
         info!(
             proposal_id = meta.proposal_id,
-            block_number = applied.outcome.block_number(),
-            block_hash = ?applied.outcome.block_hash(),
+            block_number = outcome.block_number(),
+            block_hash = ?outcome.block_hash(),
             "payload applied to execution engine"
         );
 
-        self.sync_l1_origin(meta, &payload, &applied.outcome, is_final_block).await?;
+        self.sync_l1_origin(meta, &payload, &outcome, is_final_block).await?;
 
-        Ok(applied.outcome)
+        Ok(outcome)
     }
 
     /// Prepare the payload attributes and anchor transaction for a manifest block without

--- a/packages/taiko-client-rs/crates/driver/src/lib.rs
+++ b/packages/taiko-client-rs/crates/driver/src/lib.rs
@@ -7,6 +7,8 @@
 //! - Processing L1 inbox events to derive L2 blocks
 //! - Handling preconfirmation payloads for block production
 
+/// Shared helper for locating the anchor transaction inside a fetched L2 block.
+pub(crate) mod anchor_tx;
 /// Driver runtime configuration types.
 pub mod config;
 /// L1-to-L2 derivation pipelines and manifest handling.

--- a/packages/taiko-client-rs/crates/driver/src/production/path.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/path.rs
@@ -112,11 +112,11 @@ where
                     }
                 };
 
-                let applied =
+                let outcome =
                     self.applier.apply_payload(payload, parent_hash, None).await.map_err(
                         |err| DriverError::PreconfInjectionFailed { block_number, source: err },
                     )?;
-                Ok(vec![applied.outcome])
+                Ok(vec![outcome])
             }
             ProductionInput::L1ProposalLog(_) => Err(UnsupportedInputError.into()),
         }
@@ -165,7 +165,7 @@ mod tests {
     use super::*;
     use crate::{
         production::{PreconfPayload, ProductionRouter},
-        sync::{engine::AppliedPayload, error::EngineSubmissionError},
+        sync::error::EngineSubmissionError,
     };
     use alethia_reth_primitives::payload::attributes::{
         RpcL1Origin, TaikoBlockMetadata, TaikoPayloadAttributes,
@@ -174,7 +174,7 @@ mod tests {
     use alloy_consensus::TxEnvelope;
     use alloy_primitives::{Address, B256, Bytes, U256};
     use alloy_rpc_types::eth::Block as RpcBlock;
-    use alloy_rpc_types_engine::{ExecutionPayloadInputV2, ExecutionPayloadV1, PayloadId};
+    use alloy_rpc_types_engine::PayloadId;
     use alloy_rpc_types_engine_2::PayloadAttributes as EthPayloadAttributes;
     use std::sync::{Arc, Mutex};
     use tokio::runtime::Runtime;
@@ -238,33 +238,12 @@ mod tests {
             _payload: &TaikoPayloadAttributes,
             _parent_hash: B256,
             _finalized_block_hash: Option<B256>,
-        ) -> Result<AppliedPayload, EngineSubmissionError> {
+        ) -> Result<EngineBlockOutcome, EngineSubmissionError> {
             let mut guard = self.calls.lock().unwrap();
             *guard += 1;
             let block: RpcBlock<TxEnvelope> = RpcBlock::<TxEnvelope>::default();
             let payload_id = PayloadId::new([0u8; 8]);
-            Ok(AppliedPayload {
-                outcome: EngineBlockOutcome { block, payload_id },
-                payload: ExecutionPayloadInputV2 {
-                    execution_payload: ExecutionPayloadV1 {
-                        parent_hash: B256::ZERO,
-                        fee_recipient: Address::ZERO,
-                        state_root: B256::ZERO,
-                        receipts_root: B256::ZERO,
-                        logs_bloom: Default::default(),
-                        prev_randao: B256::ZERO,
-                        block_number: 0,
-                        gas_limit: 0,
-                        gas_used: 0,
-                        timestamp: 0,
-                        extra_data: Bytes::new(),
-                        base_fee_per_gas: U256::ZERO,
-                        block_hash: B256::ZERO,
-                        transactions: Vec::new(),
-                    },
-                    withdrawals: None,
-                },
-            })
+            Ok(EngineBlockOutcome { block, payload_id })
         }
     }
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/beacon.rs
@@ -190,20 +190,6 @@ fn resolve_checkpoint_forkchoice_status(
     }
 }
 
-/// Convert a beacon-sync poll failure (L1 target read or checkpoint block fetch) into either a
-/// fatal startup error or a retryable error.
-///
-/// Before the polled endpoint has answered successfully, failures indicate a misconfigured or
-/// unreachable endpoint and must fail fast. After the first successful answer the same failures
-/// are transient, so the caller logs the returned error and retries on the next tick instead of
-/// aborting a potentially hours-long catch-up.
-fn resolve_checkpoint_poll_error(
-    seen_once: bool,
-    error: SyncError,
-) -> Result<SyncError, SyncError> {
-    if seen_once { Ok(error) } else { Err(error) }
-}
-
 #[async_trait::async_trait]
 impl SyncStage for BeaconSyncer {
     /// Run the beacon sync stage, steering the local execution engine toward the proof-finalized
@@ -257,7 +243,7 @@ impl SyncStage for BeaconSyncer {
                     target
                 }
                 Err(err) => {
-                    let err = resolve_checkpoint_poll_error(target_seen_once, err)?;
+                    let err = super::retryable_after_first_success(target_seen_once, err)?;
                     warn!(error = %err, "failed to read finalized sync target from L1; retrying");
                     continue;
                 }
@@ -308,7 +294,7 @@ impl SyncStage for BeaconSyncer {
                         continue;
                     }
                     Err(err) => {
-                        let err = resolve_checkpoint_poll_error(
+                        let err = super::retryable_after_first_success(
                             checkpoint_seen_once,
                             SyncError::CheckpointQuery(RpcClientError::from(err)),
                         )?;
@@ -420,18 +406,5 @@ mod tests {
     #[test]
     fn checkpoint_forkchoice_rejects_accepted_as_unexpected() {
         assert!(resolve_checkpoint_forkchoice_status(&PayloadStatusEnum::Accepted, 7).is_err());
-    }
-
-    #[test]
-    fn checkpoint_poll_errors_fail_fast_only_before_first_success() {
-        let sample = || SyncError::CheckpointQuery(RpcClientError::Provider("unreachable".into()));
-        assert!(matches!(
-            resolve_checkpoint_poll_error(false, sample()),
-            Err(SyncError::CheckpointQuery(_))
-        ));
-        assert!(matches!(
-            resolve_checkpoint_poll_error(true, sample()),
-            Ok(SyncError::CheckpointQuery(_))
-        ));
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
@@ -47,41 +47,33 @@ impl EngineBlockOutcome {
 /// Trait that converts derivation payload attributes into concrete execution engine blocks.
 #[async_trait]
 pub trait PayloadApplier {
-    /// Submit a single payload to the execution engine while internally managing forkchoice state.
+    /// Submit a single payload to the execution engine while internally managing forkchoice
+    /// state, returning the inserted-block outcome.
     async fn apply_payload(
         &self,
         payload: &TaikoPayloadAttributes,
         parent_hash: B256,
         finalized_block_hash: Option<B256>,
-    ) -> Result<AppliedPayload, EngineSubmissionError>;
+    ) -> Result<EngineBlockOutcome, EngineSubmissionError>;
 }
 
 #[async_trait]
 impl PayloadApplier for Client {
-    /// Submit a single payload to the execution engine while internally managing forkchoice state.
+    /// Submit a single payload to the execution engine while internally managing forkchoice
+    /// state, returning the inserted-block outcome.
     #[instrument(skip(self, payload), fields(payload_id = tracing::field::Empty))]
     async fn apply_payload(
         &self,
         payload: &TaikoPayloadAttributes,
         parent_hash: B256,
         finalized_block_hash: Option<B256>,
-    ) -> Result<AppliedPayload, EngineSubmissionError> {
+    ) -> Result<EngineBlockOutcome, EngineSubmissionError> {
         let span = tracing::Span::current();
-        let applied =
+        let outcome =
             apply_payload_internal(self, payload, parent_hash, finalized_block_hash).await?;
-        span.record("payload_id", format_args!("{}", applied.outcome.payload_id));
-        Ok(applied)
+        span.record("payload_id", format_args!("{}", outcome.payload_id));
+        Ok(outcome)
     }
-}
-
-/// Description of a payload inserted into the execution engine, including the constructed
-/// execution payload.
-#[derive(Debug, Clone)]
-pub struct AppliedPayload {
-    /// Outcome metadata describing the inserted block.
-    pub outcome: EngineBlockOutcome,
-    /// The execution payload returned by the engine when building the block.
-    pub payload: ExecutionPayloadInputV2,
 }
 
 /// Submit the provided payload attributes to the execution engine, building canonical L2
@@ -92,7 +84,7 @@ async fn apply_payload_internal(
     payload: &TaikoPayloadAttributes,
     parent_hash: B256,
     finalized_block_hash: Option<B256>,
-) -> Result<AppliedPayload, EngineSubmissionError> {
+) -> Result<EngineBlockOutcome, EngineSubmissionError> {
     // Advertise the next payload attributes so the execution engine can build the block body.
     let forkchoice_state = ForkchoiceState {
         head_block_hash: parent_hash,
@@ -144,7 +136,7 @@ async fn apply_payload_internal(
         "inserted l2 block via payload applier",
     );
 
-    Ok(AppliedPayload { outcome, payload: payload_input })
+    Ok(outcome)
 }
 
 /// Derive the Taiko-specific execution data sidecar from the provided execution payload.

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -13,7 +13,7 @@ use alloy::{
     primitives::{Address, B256, U256},
     sol_types::SolEvent,
 };
-use alloy_consensus::{TxEnvelope, transaction::Transaction as _};
+use alloy_consensus::TxEnvelope;
 use alloy_provider::Provider;
 use alloy_rpc_types::{Log, Transaction as RpcTransaction, eth::Block as RpcBlock};
 use alloy_sol_types::SolCall;
@@ -106,7 +106,8 @@ fn resolve_confirmed_sync_probe(
     }
 }
 
-/// Resolve the L2 block number that event sync should use as its resume source.
+/// Resolve the L2 block number that event sync should use as its resume source, paired with a
+/// static label naming the chosen source so the caller's log cannot diverge from the decision.
 ///
 /// Any missing source is treated as a hard error to avoid silently falling back to an unsafe
 /// resume point such as `Latest`, which can include local preconfirmation-only blocks.
@@ -115,16 +116,20 @@ fn resolve_resume_head_block_number(
     checkpoint_synced_head: Option<u64>,
     head_l1_origin_block_id: Option<u64>,
     rpc_l2_block_number: Option<u64>,
-) -> Result<u64, SyncError> {
+) -> Result<(u64, &'static str), SyncError> {
     if checkpoint_configured {
-        return checkpoint_synced_head.ok_or(SyncError::MissingCheckpointResumeHead);
+        return checkpoint_synced_head
+            .map(|head| (head, "checkpoint-synced head"))
+            .ok_or(SyncError::MissingCheckpointResumeHead);
     }
     match (head_l1_origin_block_id, rpc_l2_block_number) {
-        (Some(origin), Some(rpc)) if rpc_head_is_safer_than_origin(rpc, origin) => Ok(rpc),
-        (Some(origin), _) => Ok(origin),
+        (Some(origin), Some(rpc)) if rpc_head_is_safer_than_origin(rpc, origin) => {
+            Ok((rpc, "lower rpc block number (instead of local head_l1_origin)"))
+        }
+        (Some(origin), _) => Ok((origin, "local head_l1_origin")),
         // Genesis fallback: no local origin yet and the RPC reports block 0, i.e. a brand-new
         // chain bootstrapped from genesis.
-        (None, Some(0)) => Ok(0),
+        (None, Some(0)) => Ok((0, "genesis fallback (head_l1_origin unavailable)")),
         (None, _) => Err(SyncError::MissingHeadL1OriginResume),
     }
 }
@@ -198,22 +203,6 @@ fn resolve_reconnect_start_block(
     let overlap_start_block_number = last_seen_l1_block_number.saturating_sub(1);
     finalized_l1_block_number
         .map_or(startup_anchor_block_number, |finalized| overlap_start_block_number.min(finalized))
-}
-
-/// Convert a scanner setup error into either a fatal startup error or a retryable reconnect error.
-///
-/// Before the first successful scanner start, setup failures must fail fast so callers waiting on
-/// ingress readiness observe a clear startup error. After the scanner has started once, the same
-/// failures are treated as transient reconnect errors.
-fn resolve_event_scanner_setup_error(
-    scanner_started_once: bool,
-    error_message: String,
-) -> Result<String, SyncError> {
-    if scanner_started_once {
-        Ok(error_message)
-    } else {
-        Err(SyncError::EventScannerInit(error_message))
-    }
 }
 
 /// Return true when a preconfirmation target block is stale against the confirmed tip boundary.
@@ -943,21 +932,13 @@ impl EventSyncer {
             (head_l1_origin_block_id, rpc_l2_block_number)
         };
 
-        let resume_head_block_number = resolve_resume_head_block_number(
+        let (resume_head_block_number, source) = resolve_resume_head_block_number(
             checkpoint_configured,
             self.checkpoint_resume_head.get(),
             head_l1_origin_block_id,
             rpc_l2_block_number,
         )?;
 
-        let source = match (checkpoint_configured, head_l1_origin_block_id, rpc_l2_block_number) {
-            (true, _, _) => "checkpoint-synced head",
-            (false, Some(origin), Some(rpc)) if rpc_head_is_safer_than_origin(rpc, origin) => {
-                "lower rpc block number (instead of local head_l1_origin)"
-            }
-            (false, Some(_), _) => "local head_l1_origin",
-            (false, None, _) => "genesis fallback (head_l1_origin unavailable)",
-        };
         info!(
             resume_head_block_number,
             head_l1_origin_block_id, rpc_l2_block_number, source, "resolved event resume source",
@@ -1212,20 +1193,8 @@ fn decode_anchor_call(
     let missing =
         |reason: &'static str| SyncError::MissingAnchorTransaction { block_number, reason };
 
-    let txs = block
-        .transactions
-        .as_transactions()
-        .ok_or_else(|| missing("block body returned only transaction hashes"))?;
-    let first_tx = txs.first().ok_or_else(|| missing("block contains no transactions"))?;
-    // Anchor transactions are injected as the first transaction for every non-genesis block.
-    let destination =
-        first_tx.to().ok_or_else(|| missing("unable to determine anchor transaction recipient"))?;
-    if destination != anchor_address {
-        return Err(missing("first transaction is not the anchor contract"));
-    }
-
-    anchorV4Call::abi_decode(first_tx.input())
-        .map_err(|_| missing("failed to decode anchorV4 calldata"))
+    let input = crate::anchor_tx::first_anchor_tx_input(block, anchor_address).map_err(missing)?;
+    anchorV4Call::abi_decode(input).map_err(|_| missing("failed to decode anchorV4 calldata"))
 }
 
 #[async_trait::async_trait]
@@ -1282,7 +1251,8 @@ impl SyncStage for EventSyncer {
                 Ok(scanner) => scanner,
                 Err(err) => {
                     let err =
-                        resolve_event_scanner_setup_error(scanner_started_once, err.to_string())?;
+                        super::retryable_after_first_success(scanner_started_once, err.to_string())
+                            .map_err(SyncError::EventScannerInit)?;
                     warn!(
                         error = %err,
                         start_tag = ?reconnect_start_tag,
@@ -1304,7 +1274,8 @@ impl SyncStage for EventSyncer {
                 }
                 Err(err) => {
                     let err =
-                        resolve_event_scanner_setup_error(scanner_started_once, err.to_string())?;
+                        super::retryable_after_first_success(scanner_started_once, err.to_string())
+                            .map_err(SyncError::EventScannerInit)?;
                     warn!(
                         error = %err,
                         start_tag = ?reconnect_start_tag,
@@ -1538,14 +1509,14 @@ mod tests {
             jwt_secret: PathBuf::from("/dev/null"),
             inbox_address: Address::ZERO,
         };
-        let mut cfg = DriverConfig::new(
+        let cfg = DriverConfig::new(
             client_config,
             Duration::from_secs(1),
             Url::parse("http://localhost:5052").expect("valid beacon url"),
             None,
             None,
+            true,
         );
-        cfg.preconfirmation_enabled = true;
 
         let (preconf_tx, preconf_rx) = mpsc::channel(PRECONF_CHANNEL_CAPACITY);
         let blob_source =
@@ -2024,7 +1995,7 @@ mod tests {
 
         let resolved = resolve_resume_head_block_number(true, Some(420), None, None)
             .expect("checkpoint resume head should be used when present");
-        assert_eq!(resolved, 420);
+        assert_eq!(resolved, (420, "checkpoint-synced head"));
     }
 
     #[test]
@@ -2035,29 +2006,29 @@ mod tests {
 
         let resolved = resolve_resume_head_block_number(false, Some(999), Some(64), Some(80))
             .expect("head_l1_origin should drive resume when rpc head is not lower");
-        assert_eq!(resolved, 64);
+        assert_eq!(resolved, (64, "local head_l1_origin"));
 
         let resolved = resolve_resume_head_block_number(false, None, None, Some(0))
             .expect("genesis fallback when rpc reports block 0 and origin is missing");
-        assert_eq!(resolved, 0);
+        assert_eq!(resolved, (0, "genesis fallback (head_l1_origin unavailable)"));
     }
 
     #[test]
     fn resume_head_resolution_prefers_lower_non_zero_rpc_over_origin() {
         let resolved = resolve_resume_head_block_number(false, None, Some(64), Some(32))
             .expect("lower non-zero rpc block number should win");
-        assert_eq!(resolved, 32);
+        assert_eq!(resolved, (32, "lower rpc block number (instead of local head_l1_origin)"));
 
         let resolved = resolve_resume_head_block_number(false, None, Some(64), Some(0))
             .expect("zero rpc block number must not override origin");
-        assert_eq!(resolved, 64);
+        assert_eq!(resolved, (64, "local head_l1_origin"));
     }
 
     #[test]
     fn resume_head_resolution_falls_back_to_origin_when_rpc_missing() {
         let resolved = resolve_resume_head_block_number(false, None, Some(64), None)
             .expect("missing rpc block number should fall back to local origin");
-        assert_eq!(resolved, 64);
+        assert_eq!(resolved, (64, "local head_l1_origin"));
     }
 
     #[test]
@@ -2113,17 +2084,6 @@ mod tests {
     fn reconnect_start_falls_back_to_startup_anchor_without_finalization() {
         let reconnect_start = resolve_reconnect_start_block(120, None, 10);
         assert_eq!(reconnect_start, 10);
-    }
-
-    #[test]
-    fn scanner_setup_errors_fail_fast_before_first_successful_start() {
-        let err = resolve_event_scanner_setup_error(false, "boom".into())
-            .expect_err("startup scanner errors should fail fast");
-        assert!(matches!(err, SyncError::EventScannerInit(reason) if reason == "boom"));
-
-        let err = resolve_event_scanner_setup_error(true, "boom".into())
-            .expect("post-start scanner errors should be retryable");
-        assert_eq!(err, "boom");
     }
 
     // -- resolve_missing_batch_mapping_fallback tests --

--- a/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/mod.rs
@@ -34,6 +34,15 @@ pub trait SyncStage {
     async fn run(&self) -> Result<(), SyncError>;
 }
 
+/// Classify a recurring-poll failure against the fail-closed startup rule.
+///
+/// Before the polled endpoint has answered successfully once, failures indicate a misconfigured
+/// or unreachable endpoint and must fail fast (`Err`). After the first success the same failures
+/// are transient (`Ok`), so callers log the returned error and retry on the next attempt.
+pub(crate) fn retryable_after_first_success<E>(seen_once: bool, error: E) -> Result<E, E> {
+    if seen_once { Ok(error) } else { Err(error) }
+}
+
 /// Factory helper assembling both sync stages.
 ///
 /// Runs the beacon syncer first to catch up via checkpoint sync,
@@ -72,5 +81,16 @@ impl SyncPipeline {
         info!("beacon syncer completed");
         self.event.run().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retryable_after_first_success;
+
+    #[test]
+    fn poll_errors_fail_fast_only_before_first_success() {
+        assert_eq!(retryable_after_first_success(false, "boom"), Err("boom"));
+        assert_eq!(retryable_after_first_success(true, "boom"), Ok("boom"));
     }
 }

--- a/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
@@ -111,14 +111,14 @@ async fn proposer_to_driver_event_sync(env: &mut ShastaEnv) -> Result<()> {
     beacon_stub.set_default_blob_sidecar(built_proposal_sidecar(&request));
 
     // Start event syncer before submitting the proposal.
-    let mut driver_config = DriverConfig::new(
+    let driver_config = DriverConfig::new(
         env.client_config.clone(),
         Duration::from_millis(50),
         beacon_stub.endpoint().clone(),
         None,
         None,
+        true,
     );
-    driver_config.preconfirmation_enabled = true;
     let driver_client = Client::new(driver_config.client.clone()).await?;
     let event_syncer = Arc::new(EventSyncer::new(&driver_config, driver_client.clone()).await?);
     let syncer_handle = {
@@ -172,14 +172,14 @@ async fn known_canonical_fast_path(env: &mut ShastaEnv) -> Result<()> {
     let request = builder.build(vec![Vec::new()], None).await?;
     beacon_stub.set_default_blob_sidecar(built_proposal_sidecar(&request));
 
-    let mut driver_config = DriverConfig::new(
+    let driver_config = DriverConfig::new(
         env.client_config.clone(),
         Duration::from_millis(50),
         beacon_endpoint.clone(),
         None,
         None,
+        true,
     );
-    driver_config.preconfirmation_enabled = true;
     let driver_client = Client::new(driver_config.client.clone()).await?;
     let event_syncer = Arc::new(EventSyncer::new(&driver_config, driver_client.clone()).await?);
     let syncer_handle = {
@@ -258,14 +258,14 @@ async fn multiple_proposals_event_sync(env: &mut ShastaEnv) -> Result<()> {
     let request = builder.build(vec![Vec::new()], None).await?;
     beacon_stub.set_default_blob_sidecar(built_proposal_sidecar(&request));
 
-    let mut driver_config = DriverConfig::new(
+    let driver_config = DriverConfig::new(
         env.client_config.clone(),
         Duration::from_millis(50),
         beacon_stub.endpoint().clone(),
         None,
         None,
+        true,
     );
-    driver_config.preconfirmation_enabled = true;
     let driver_client = Client::new(driver_config.client.clone()).await?;
     let event_syncer = Arc::new(EventSyncer::new(&driver_config, driver_client.clone()).await?);
     let syncer_handle = {

--- a/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
@@ -72,18 +72,18 @@ async fn wait_for_proposal_processed(
             .await?
             .map(|block_number| block_number.to::<u64>());
         let confirmed_head = event_syncer.confirmed_sync_snapshot().await?.event_sync_tip();
-        if let (Some(target_block), Some(head_block)) = (target_block, confirmed_head) {
-            if head_block >= target_block {
-                let l2_head = driver_client.l2_provider.get_block_number().await?;
-                if l2_head < l2_head_before {
-                    warn!(
-                        l2_head_before,
-                        l2_head, "L2 head moved backward while waiting for proposal processing"
-                    );
-                }
-                if l2_head >= target_block {
-                    return Ok(l2_head);
-                }
+        if let (Some(target_block), Some(head_block)) = (target_block, confirmed_head) &&
+            head_block >= target_block
+        {
+            let l2_head = driver_client.l2_provider.get_block_number().await?;
+            if l2_head < l2_head_before {
+                warn!(
+                    l2_head_before,
+                    l2_head, "L2 head moved backward while waiting for proposal processing"
+                );
+            }
+            if l2_head >= target_block {
+                return Ok(l2_head);
             }
         };
 

--- a/packages/taiko-client-rs/crates/driver/tests/shasta_event_sync.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/shasta_event_sync.rs
@@ -65,6 +65,7 @@ async fn syncs_shasta_proposal_into_l2(env: &mut ShastaEnv) -> Result<()> {
         beacon_endpoint.clone(),
         None,
         None,
+        false,
     );
     let driver = Driver::new(driver_config).await?;
     let driver_client = driver.rpc_client().clone();

--- a/packages/taiko-client-rs/crates/proposer/src/config.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/config.rs
@@ -1,28 +1,17 @@
 //! Configuration types for the proposer.
 
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
-use alloy::{
-    primitives::{Address, B256, utils::Unit},
-    transports::http::reqwest::Url,
-};
+use alloy::primitives::{Address, B256, utils::Unit};
 use base_tx_manager::{ConfigError, TxManagerConfig};
-use rpc::SubscriptionSource;
+use rpc::client::ClientConfig;
 
 /// Configuration for the proposer.
 #[derive(Debug, Clone)]
 pub struct ProposerConfigs {
-    /// L1 provider connection source (HTTP or WebSocket) for monitoring and submitting
-    /// transactions.
-    pub l1_provider_source: SubscriptionSource,
-    /// L2 provider URL for fetching execution data.
-    pub l2_provider_url: Url,
-    /// L2 authenticated provider URL for accessing the execution engine's privileged APIs.
-    pub l2_auth_provider_url: Url,
-    /// Path to the JWT secret file for authenticating with the L2 execution engine.
-    pub jwt_secret: PathBuf,
-    /// Address of the Shasta inbox contract on L1 where proposals are submitted.
-    pub inbox_address: Address,
+    /// RPC connection contract (L1 source, L2 endpoints, JWT secret, inbox address) shared
+    /// with the client, mirroring how `DriverConfig` embeds it.
+    pub client: ClientConfig,
     /// Address to receive L2 block transaction fees in proposed blocks.
     pub l2_suggested_fee_recipient: Address,
     /// Time interval between consecutive proposal attempts.

--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -31,10 +31,7 @@ use protocol::shasta::{
     },
     encode_extra_data,
 };
-use rpc::{
-    RpcClientError,
-    client::{Client, ClientConfig},
-};
+use rpc::{RpcClientError, client::Client};
 use serde_json::from_value;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::time::interval;
@@ -85,23 +82,16 @@ pub struct Proposer {
 
 impl Proposer {
     /// Creates a new proposer instance.
-    #[instrument(skip(cfg), fields(inbox_address = ?cfg.inbox_address))]
+    #[instrument(skip(cfg), fields(inbox_address = ?cfg.client.inbox_address))]
     pub async fn new(cfg: ProposerConfigs) -> Result<Self> {
         info!(
-            inbox_address = ?cfg.inbox_address,
+            inbox_address = ?cfg.client.inbox_address,
             l2_suggested_fee_recipient = ?cfg.l2_suggested_fee_recipient,
             propose_interval = ?cfg.propose_interval,
             "initializing proposer"
         );
 
-        let rpc_provider = Client::new(ClientConfig {
-            l1_provider_source: cfg.l1_provider_source.clone(),
-            l2_provider_url: cfg.l2_provider_url.clone(),
-            l2_auth_provider_url: cfg.l2_auth_provider_url.clone(),
-            jwt_secret: cfg.jwt_secret.clone(),
-            inbox_address: cfg.inbox_address,
-        })
-        .await?;
+        let rpc_provider = Client::new(cfg.client.clone()).await?;
 
         let transaction_builder = ShastaProposalTransactionBuilder::new(
             rpc_provider.clone(),

--- a/packages/taiko-client-rs/crates/proposer/src/tx_manager_adapter.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/tx_manager_adapter.rs
@@ -200,11 +200,13 @@ mod tests {
 
     fn proposer_config_for_tx_manager_mapping() -> ProposerConfigs {
         ProposerConfigs {
-            l1_provider_source: SubscriptionSource::try_from("http://localhost:8545").unwrap(),
-            l2_provider_url: Url::parse("http://localhost:9545").unwrap(),
-            l2_auth_provider_url: Url::parse("http://localhost:9551").unwrap(),
-            jwt_secret: PathBuf::from("/tmp/jwt.secret"),
-            inbox_address: Address::repeat_byte(0x11),
+            client: rpc::client::ClientConfig {
+                l1_provider_source: SubscriptionSource::try_from("http://localhost:8545").unwrap(),
+                l2_provider_url: Url::parse("http://localhost:9545").unwrap(),
+                l2_auth_provider_url: Url::parse("http://localhost:9551").unwrap(),
+                jwt_secret: PathBuf::from("/tmp/jwt.secret"),
+                inbox_address: Address::repeat_byte(0x11),
+            },
             l2_suggested_fee_recipient: Address::repeat_byte(0x22),
             propose_interval: Duration::from_secs(12),
             l1_proposer_private_key: alloy::primitives::B256::repeat_byte(0x33),

--- a/packages/taiko-client-rs/crates/proposer/tests/shasta_propose.rs
+++ b/packages/taiko-client-rs/crates/proposer/tests/shasta_propose.rs
@@ -8,11 +8,7 @@ use test_harness::{ShastaEnv, mine_l1_block, shasta::get_proposal_hash};
 
 fn base_proposer_config(env: &ShastaEnv) -> ProposerConfigs {
     ProposerConfigs {
-        l1_provider_source: env.l1_source.clone(),
-        l2_provider_url: env.l2_ws_0.clone(),
-        l2_auth_provider_url: env.l2_auth_0.clone(),
-        jwt_secret: env.jwt_secret.clone(),
-        inbox_address: env.inbox_address,
+        client: env.client_config.clone(),
         l2_suggested_fee_recipient: env.l2_suggested_fee_recipient,
         propose_interval: Duration::from_secs(0),
         l1_proposer_private_key: env.l1_proposer_private_key,

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/error.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/error.rs
@@ -9,10 +9,6 @@ pub type Result<T> = StdResult<T, ProtocolError>;
 /// Error types for Shasta protocol operations
 #[derive(Debug, Error)]
 pub enum ProtocolError {
-    /// IO error during encoding/decoding
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-
     /// Compression error
     #[error("compression error: {0}")]
     Compression(String),

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/manifest.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/manifest.rs
@@ -109,8 +109,12 @@ where
     let rlp_encoded = alloy_rlp::encode(manifest);
 
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
-    encoder.write_all(&rlp_encoded)?;
-    let compressed = encoder.finish()?;
+    encoder
+        .write_all(&rlp_encoded)
+        .map_err(|e| ProtocolError::Compression(format!("failed to compress manifest: {e}")))?;
+    let compressed = encoder
+        .finish()
+        .map_err(|e| ProtocolError::Compression(format!("failed to compress manifest: {e}")))?;
 
     let mut output = Vec::with_capacity(64 + compressed.len());
 

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
@@ -17,9 +17,8 @@ pub use blob_coder::BlobCoder;
 pub use constants::{
     set_devnet_unzen_override, unzen_active_for_chain_timestamp, unzen_fork_timestamp_for_chain,
 };
-pub use error::{ForkConfigError, ForkConfigResult, ProtocolError, Result};
+pub use error::{ProtocolError, Result};
 pub use payload_helpers::{
-    PAYLOAD_ID_VERSION_V2, PayloadAttributesInput, build_payload_attributes,
-    build_payload_attributes_with_id, calculate_shasta_mix_hash, encode_extra_data,
-    encode_transactions, encode_tx_list, payload_id_to_bytes,
+    PayloadAttributesInput, build_payload_attributes, build_payload_attributes_with_id,
+    calculate_shasta_mix_hash, encode_extra_data, encode_transactions,
 };

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/payload_helpers.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/payload_helpers.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types_engine_2::{PayloadAttributes as EthPayloadAttributes, Payloa
 /// Engine API `engine_getPayloadV2` discriminator.
 ///
 /// The 8-byte payload identifier prepends this version byte to match the Execution API spec.
-pub const PAYLOAD_ID_VERSION_V2: u8 = 2;
+const PAYLOAD_ID_VERSION_V2: u8 = 2;
 
 alloy::sol! {
     struct ShastaMixHashInput {
@@ -53,15 +53,8 @@ pub fn encode_transactions(transactions: &[TxEnvelope]) -> Bytes {
     Bytes::from(buf.freeze())
 }
 
-/// Encode a list of raw transaction bytes into the format expected by the execution engine.
-pub fn encode_tx_list(transactions: &[Bytes]) -> Bytes {
-    let mut buf = BytesMut::new();
-    encode_list::<Bytes, [u8]>(transactions, &mut buf);
-    Bytes::from(buf.freeze())
-}
-
 /// Convert a `PayloadId` into an array of bytes.
-pub fn payload_id_to_bytes(payload_id: PayloadId) -> [u8; 8] {
+fn payload_id_to_bytes(payload_id: PayloadId) -> [u8; 8] {
     payload_id.0.0
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -103,7 +103,7 @@ impl WhitelistApi for WhitelistApiService {
         // Insert the preconfirmation payload locally first to
         // obtain the canonical block hash before gossiping.
         let driver_payload =
-            self.build_driver_payload(&data, is_forced_inclusion, prev_randao, [0u8; 65])?;
+            self.driver_payload_from_request(&data, is_forced_inclusion, prev_randao, [0u8; 65])?;
         self.event_syncer
             .submit_preconfirmation_payload(PreconfPayload::new(driver_payload))
             .await?;
@@ -145,7 +145,6 @@ impl WhitelistApi for WhitelistApiService {
                 FixedBytes::<65>::from(block_hash_signature),
             )
             .await?;
-        self.state.set_highest_unsafe(block_number).await;
 
         let execution_payload = crate::payload::execution_payload_from_header(
             &inserted_block.header,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -145,6 +145,7 @@ impl WhitelistApi for WhitelistApiService {
                 FixedBytes::<65>::from(block_hash_signature),
             )
             .await?;
+        self.state.record_inserted_block(block_number);
 
         let execution_payload = crate::payload::execution_payload_from_header(
             &inserted_block.header,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -71,20 +71,6 @@ fn can_shutdown_for(last_preconf_request: Option<Instant>) -> bool {
     }
 }
 
-/// Report `head` whenever it is known; fall back to `tracked` when it is `None`.
-///
-/// The tracked value only moves on preconfirmation imports and local builds, so it can
-/// drift from the head in both directions: an L1 reorg rewinds the head below the
-/// counter, while canonical L1 derivation with no gossip traffic advances the head past
-/// it. Every canonical block was inserted by this driver, so the head is always an
-/// honest answer — and the Catalyst sidecar's sync gate requires the reported value to
-/// equal the execution head exactly before it starts (or resumes) preconfirming. A
-/// permanently lagging report would wedge the operator in a restart loop that only a
-/// driver restart clears.
-fn reconcile_highest_unsafe(tracked: u64, head: Option<u64>) -> u64 {
-    head.unwrap_or(tracked)
-}
-
 /// Implements whitelist preconfirmation API business logic.
 pub(crate) struct WhitelistApiService {
     /// Event syncer for L1 origin lookups.
@@ -104,7 +90,7 @@ pub(crate) struct WhitelistApiService {
     /// Lock-free shared set of whitelisted sequencer addresses; used to refuse
     /// build requests when this node's own P2P signer has been deregistered on-chain.
     operator_set: SharedOperatorSet,
-    /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).
+    /// Shared driver state (recent envelopes, EOS markers, last reported L2 head).
     state: SharedPreconfState,
     /// Broadcast channel for API `/ws` end-of-sequencing notifications.
     eos_notification_tx: broadcast::Sender<EndOfSequencingNotification>,
@@ -128,7 +114,7 @@ pub(crate) struct WhitelistApiServiceParams {
     pub(crate) beacon_client: Arc<BeaconClient>,
     /// Shared operator set used to gate the build API on the node's own whitelist status.
     pub(crate) operator_set: SharedOperatorSet,
-    /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).
+    /// Shared driver state (recent envelopes, EOS markers, last reported L2 head).
     pub(crate) state: SharedPreconfState,
     /// Network command sender for gossip publishing.
     pub(crate) network_command_tx: mpsc::Sender<NetworkCommand>,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
@@ -27,7 +27,7 @@ fn request_execution_payload(data: &ExecutableData, prev_randao: B256) -> Execut
 
 impl WhitelistApiService {
     /// Build driver payload attributes from the requested executable data.
-    pub(super) fn build_driver_payload(
+    pub(super) fn driver_payload_from_request(
         &self,
         data: &ExecutableData,
         is_forced_inclusion: Option<bool>,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -5,8 +5,8 @@ use super::*;
 impl WhitelistApiService {
     /// Build the current status snapshot served by the REST `/status` route.
     pub(super) async fn get_status_snapshot(&self) -> Result<ApiStatus> {
-        // Current L2 execution head, best-effort: a failed read yields `None`, which skips
-        // the reconciliation below and reports the tracked counter unchanged.
+        // Current L2 execution head, best-effort: a failed read yields `None` and the most
+        // recently observed head is reported instead.
         let l2_head = self
             .rpc
             .l2_provider
@@ -16,26 +16,9 @@ impl WhitelistApiService {
             .flatten()
             .map(|block| block.header.number);
 
-        // The counter only moves on imports/builds, so it can drift from the head in both
-        // directions: an L1 reorg rewinds the head below it, and canonical L1 derivation
-        // with no gossip traffic advances the head past it. Report the head in both cases —
-        // canonical blocks were inserted by this driver too, and the Catalyst sync gate
-        // only opens when the reported value equals the execution head exactly.
-        //
-        // Report only — do NOT write the reconciled value back. `l2_head` is read without
-        // the lock, so it can already be stale; persisting it could pin the stored counter
-        // wrong until the next import/build. Reconciling only the reported value keeps the
-        // counter intact, so the next poll recomputes against a fresh head and self-heals.
-        let tracked = self.state.highest_unsafe().await;
-        let highest_unsafe = reconcile_highest_unsafe(tracked, l2_head);
-        if highest_unsafe < tracked {
-            warn!(
-                tracked,
-                head = highest_unsafe,
-                "highest_unsafe ahead of head; reporting clamped value"
-            );
-        } else if highest_unsafe > tracked {
-            debug!(tracked, head = highest_unsafe, "highest_unsafe behind head; reporting head");
+        let highest_unsafe = self.state.reconcile_reported_head(l2_head);
+        if l2_head.is_none() {
+            warn!(reported = highest_unsafe, "L2 head unreadable; reporting last observed head");
         }
 
         let current_epoch = self.beacon_client.current_epoch();

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -6,7 +6,8 @@ use std::{
 use flate2::{Compression, write::ZlibEncoder};
 
 use crate::{
-    api::service::{SHUTDOWN_BLOCK_WINDOW, can_shutdown_for, reconcile_highest_unsafe},
+    api::service::{SHUTDOWN_BLOCK_WINDOW, can_shutdown_for},
+    cache::SharedPreconfState,
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, decompress_tx_list},
     error::WhitelistPreconfirmationDriverError,
 };
@@ -81,28 +82,22 @@ fn shutdown_block_window_is_one_hundred_forty_four_seconds() {
 }
 
 #[test]
-fn reconcile_clamps_down_when_counter_exceeds_reth_head() {
-    // The L1-reorg wedge: counter stuck above reth's rewound head -> report the head.
-    assert_eq!(reconcile_highest_unsafe(5_811_227, Some(5_811_208)), 5_811_208);
+fn reported_head_prefers_live_head_and_records_it_as_fallback() {
+    let state = SharedPreconfState::new(5_811_208);
+    // The live head always wins — the Catalyst sync gate compares the reported value
+    // against the execution head exactly, and reporting anything else wedges it in a
+    // restart loop. This covers both the L1-reorg (head rewound) and the catch-up
+    // (head advanced via canonical derivation with no gossip) directions.
+    assert_eq!(state.reconcile_reported_head(Some(5_811_227)), 5_811_227);
+    assert_eq!(state.reconcile_reported_head(Some(5_811_190)), 5_811_190);
+    // A later failed read reports the most recently observed head, not the startup seed.
+    assert_eq!(state.reconcile_reported_head(None), 5_811_190);
 }
 
 #[test]
-fn reconcile_keeps_counter_when_equal_to_reth_head() {
-    // Healthy steady state.
-    assert_eq!(reconcile_highest_unsafe(5_811_208, Some(5_811_208)), 5_811_208);
-}
-
-#[test]
-fn reconcile_reports_head_when_counter_below_reth_head() {
-    // The catch-up wedge: reth advanced via canonical L1 derivation while no gossip was
-    // flowing, so the counter was never raised. Catalyst's sync gate requires the
-    // reported value to equal the head exactly; a lagging report blocks preconfirmation
-    // (and triggers Catalyst self-restarts) until a driver restart re-seeds the counter.
-    assert_eq!(reconcile_highest_unsafe(5_811_208, Some(5_811_227)), 5_811_227);
-}
-
-#[test]
-fn reconcile_keeps_counter_when_reth_head_unknown() {
-    // Best-effort: a failed reth head read leaves the counter untouched.
-    assert_eq!(reconcile_highest_unsafe(5_811_227, None), 5_811_227);
+fn reported_head_falls_back_to_seed_before_first_observation() {
+    // Best-effort: a failed head read before any successful observation reports the
+    // startup seed.
+    let state = SharedPreconfState::new(5_811_208);
+    assert_eq!(state.reconcile_reported_head(None), 5_811_208);
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -101,3 +101,15 @@ fn reported_head_falls_back_to_seed_before_first_observation() {
     let state = SharedPreconfState::new(5_811_208);
     assert_eq!(state.reconcile_reported_head(None), 5_811_208);
 }
+
+#[test]
+fn reported_head_covers_locally_inserted_blocks_when_head_unreadable() {
+    // Blocks inserted by this process (cached import or local build) must survive a failed
+    // head read even before any successful status poll observed them.
+    let state = SharedPreconfState::new(5_811_208);
+    state.record_inserted_block(5_811_209);
+    assert_eq!(state.reconcile_reported_head(None), 5_811_209);
+    // A successful poll still overwrites the fallback with the live head.
+    assert_eq!(state.reconcile_reported_head(Some(5_811_210)), 5_811_210);
+    assert_eq!(state.reconcile_reported_head(None), 5_811_210);
+}

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -2,7 +2,10 @@
 
 use std::{
     collections::HashMap,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -29,29 +32,28 @@ pub(crate) const L1_EPOCH_DURATION_SECS: u64 = 12 * 32;
 ///
 /// Holds everything both the importer (P2P ingestion) and the API service
 /// (REST build/status) need to observe: end-of-sequencing markers, the
-/// recently validated envelopes served to request topics, and the highest
-/// unsafe L2 payload block id.
+/// recently validated envelopes served to request topics, and the most
+/// recently observed L2 head reported by `/status`.
 #[derive(Debug, Clone)]
 pub(crate) struct SharedPreconfState {
     /// End-of-sequencing markers tracked per epoch.
     end_of_sequencing_by_epoch: Arc<Mutex<LinkedHashMap<u64, B256>>>,
     /// Recently validated envelopes retained for serving request-topic responses.
     recent_envelopes: Arc<Mutex<EnvelopeCache>>,
-    /// Highest unsafe L2 payload block id observed via P2P import or local build.
-    highest_unsafe_l2_payload_block_id: Arc<Mutex<u64>>,
+    /// Most recent L2 execution head observed by `/status`, reported as a fallback when the
+    /// head becomes unreadable. Seeded with the head at startup.
+    last_reported_l2_head: Arc<AtomicU64>,
 }
 
 impl SharedPreconfState {
     /// Create shared state seeded with the current L2 head block number.
-    pub(crate) fn new(initial_highest_unsafe_l2_payload_block_id: u64) -> Self {
+    pub(crate) fn new(initial_l2_head: u64) -> Self {
         Self {
             end_of_sequencing_by_epoch: Arc::new(Mutex::new(LinkedHashMap::new())),
             recent_envelopes: Arc::new(Mutex::new(EnvelopeCache::with_capacity(
                 RECENT_ENVELOPE_CAPACITY,
             ))),
-            highest_unsafe_l2_payload_block_id: Arc::new(Mutex::new(
-                initial_highest_unsafe_l2_payload_block_id,
-            )),
+            last_reported_l2_head: Arc::new(AtomicU64::new(initial_l2_head)),
         }
     }
 
@@ -85,21 +87,21 @@ impl SharedPreconfState {
         self.recent_envelopes.lock().await.get(hash).cloned()
     }
 
-    /// Raise the highest unsafe block id to `block_number` when it is higher.
-    pub(crate) async fn raise_highest_unsafe(&self, block_number: u64) {
-        let mut guard = self.highest_unsafe_l2_payload_block_id.lock().await;
-        *guard = block_number.max(*guard);
-    }
-
-    /// Set the highest unsafe block id unconditionally (local builds may
-    /// legitimately lower it after an L1 reorg).
-    pub(crate) async fn set_highest_unsafe(&self, block_number: u64) {
-        *self.highest_unsafe_l2_payload_block_id.lock().await = block_number;
-    }
-
-    /// Read the highest unsafe block id.
-    pub(crate) async fn highest_unsafe(&self) -> u64 {
-        *self.highest_unsafe_l2_payload_block_id.lock().await
+    /// Record a freshly observed L2 head and return it; when the head is `None` (a failed RPC
+    /// read) return the most recently recorded value instead.
+    ///
+    /// The Catalyst sync gate only opens when the reported value equals the execution head
+    /// exactly, and every canonical block is inserted by this driver, so the live head is
+    /// always the honest answer. The stored value exists purely to keep `/status` answering
+    /// through transient L2 RPC failures.
+    pub(crate) fn reconcile_reported_head(&self, head: Option<u64>) -> u64 {
+        match head {
+            Some(head) => {
+                self.last_reported_l2_head.store(head, Ordering::Relaxed);
+                head
+            }
+            None => self.last_reported_l2_head.load(Ordering::Relaxed),
+        }
     }
 }
 
@@ -344,7 +346,7 @@ mod tests {
         let state = SharedPreconfState::new(7);
         let hash = B256::from([0x77u8; 32]);
 
-        assert_eq!(state.highest_unsafe().await, 7);
+        assert_eq!(state.reconcile_reported_head(None), 7, "seed backs the fallback");
         assert!(state.get_recent(&hash).await.is_none());
 
         state.insert_recent(Arc::new(sample_envelope(hash, 8))).await;
@@ -353,19 +355,5 @@ mod tests {
         state.record_end_of_sequencing(42, hash).await;
         assert_eq!(state.end_of_sequencing_for_epoch(42).await, Some(hash));
         assert_eq!(state.end_of_sequencing_for_epoch(43).await, None);
-    }
-
-    #[tokio::test]
-    async fn shared_state_highest_unsafe_raise_and_set_semantics() {
-        let state = SharedPreconfState::new(10);
-
-        state.raise_highest_unsafe(5).await;
-        assert_eq!(state.highest_unsafe().await, 10, "raise must never lower the counter");
-
-        state.raise_highest_unsafe(12).await;
-        assert_eq!(state.highest_unsafe().await, 12);
-
-        state.set_highest_unsafe(3).await;
-        assert_eq!(state.highest_unsafe().await, 3, "set may lower after an L1 reorg rebuild");
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -40,8 +40,8 @@ pub(crate) struct SharedPreconfState {
     end_of_sequencing_by_epoch: Arc<Mutex<LinkedHashMap<u64, B256>>>,
     /// Recently validated envelopes retained for serving request-topic responses.
     recent_envelopes: Arc<Mutex<EnvelopeCache>>,
-    /// Most recent L2 execution head observed by `/status`, reported as a fallback when the
-    /// head becomes unreadable. Seeded with the head at startup.
+    /// Most recent L2 head observed by `/status` or advanced by locally inserted blocks,
+    /// reported as a fallback when the head is unreadable. Seeded with the head at startup.
     last_reported_l2_head: Arc<AtomicU64>,
 }
 
@@ -93,7 +93,8 @@ impl SharedPreconfState {
     /// The Catalyst sync gate only opens when the reported value equals the execution head
     /// exactly, and every canonical block is inserted by this driver, so the live head is
     /// always the honest answer. The stored value exists purely to keep `/status` answering
-    /// through transient L2 RPC failures.
+    /// through transient L2 RPC failures; [`Self::record_inserted_block`] keeps it fresh for
+    /// blocks inserted between polls.
     pub(crate) fn reconcile_reported_head(&self, head: Option<u64>) -> u64 {
         match head {
             Some(head) => {
@@ -102,6 +103,16 @@ impl SharedPreconfState {
             }
             None => self.last_reported_l2_head.load(Ordering::Relaxed),
         }
+    }
+
+    /// Record a block this process just inserted (cached import or local build) so the
+    /// `/status` fallback covers blocks inserted since the last successful head read.
+    ///
+    /// A plain store suffices: cached imports drain in ascending block order, local builds
+    /// insert sequentially, and any successful status poll overwrites the value with the
+    /// live head anyway.
+    pub(crate) fn record_inserted_block(&self, block_number: u64) {
+        self.last_reported_l2_head.store(block_number, Ordering::Relaxed);
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -189,6 +189,8 @@ impl WhitelistPreconfirmationImporter {
             "inserted whitelist preconfirmation block"
         );
 
+        self.state.record_inserted_block(block_number);
+
         Ok(true)
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -15,7 +15,7 @@ use crate::{
 use super::WhitelistPreconfirmationImporter;
 
 /// Build the driver payload from a whitelist envelope.
-fn build_driver_payload(
+fn driver_payload_from_envelope(
     envelope: &WhitelistExecutionPayloadEnvelope,
 ) -> Result<TaikoPayloadAttributes> {
     let compressed_tx_list = envelope.execution_payload.transactions.first().ok_or_else(|| {
@@ -74,35 +74,37 @@ impl WhitelistPreconfirmationImporter {
                     Ok(false) => {
                         WhitelistPreconfirmationDriverMetrics::inc_cache_import_result("deferred");
                     }
-                    Err(err) if should_defer_cached_import_error(&err) => {
-                        WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
-                            "deferred_error",
-                        );
-                        debug!(
-                            block_hash = %hash,
-                            error = %err,
-                            "deferring cached whitelist preconfirmation payload import for retry"
-                        );
-                    }
-                    Err(err) if should_drop_cached_import_error(&err) => {
-                        WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
-                            "dropped_error",
-                        );
-                        warn!(
-                            block_hash = %hash,
-                            error = %err,
-                            "dropping cached whitelist preconfirmation payload after invalid import"
-                        );
-                        self.cache.remove(&hash);
-                        progressed = true;
-                    }
-                    Err(err) => {
-                        WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
-                            "fatal_error",
-                        );
-                        self.update_pending_cache_gauge();
-                        return Err(err);
-                    }
+                    Err(err) => match classify_cached_import_error(&err) {
+                        CachedImportDisposition::Defer => {
+                            WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
+                                "deferred_error",
+                            );
+                            debug!(
+                                block_hash = %hash,
+                                error = %err,
+                                "deferring cached whitelist preconfirmation payload import for retry"
+                            );
+                        }
+                        CachedImportDisposition::Drop => {
+                            WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
+                                "dropped_error",
+                            );
+                            warn!(
+                                block_hash = %hash,
+                                error = %err,
+                                "dropping cached whitelist preconfirmation payload after invalid import"
+                            );
+                            self.cache.remove(&hash);
+                            progressed = true;
+                        }
+                        CachedImportDisposition::Propagate => {
+                            WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
+                                "fatal_error",
+                            );
+                            self.update_pending_cache_gauge();
+                            return Err(err);
+                        }
+                    },
                 }
             }
 
@@ -167,7 +169,7 @@ impl WhitelistPreconfirmationImporter {
             return Ok(false);
         }
 
-        let driver_payload = build_driver_payload(envelope)?;
+        let driver_payload = driver_payload_from_envelope(envelope)?;
         let submit_start = Instant::now();
         let submit_result = self
             .event_syncer
@@ -187,58 +189,56 @@ impl WhitelistPreconfirmationImporter {
             "inserted whitelist preconfirmation block"
         );
 
-        self.state.raise_highest_unsafe(block_number).await;
-
         Ok(true)
     }
 }
 
-/// Returns true when a cached-envelope import error should be logged and dropped.
-pub(super) fn should_drop_cached_import_error(err: &WhitelistPreconfirmationDriverError) -> bool {
+/// Disposition of a cached-envelope import error: retry later, discard the envelope, or abort
+/// the drain loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CachedImportDisposition {
+    /// Transient condition; keep the envelope cached and retry on a later pass.
+    Defer,
+    /// Envelope-scoped rejection; log and discard the envelope.
+    Drop,
+    /// Unexpected failure; abort the drain loop and surface the error.
+    Propagate,
+}
+
+/// Classify a cached-envelope import error into exactly one disposition.
+pub(super) fn classify_cached_import_error(
+    err: &WhitelistPreconfirmationDriverError,
+) -> CachedImportDisposition {
     match err {
         WhitelistPreconfirmationDriverError::InvalidPayload(_) |
-        WhitelistPreconfirmationDriverError::InvalidSignature(_) => true,
+        WhitelistPreconfirmationDriverError::InvalidSignature(_) => CachedImportDisposition::Drop,
         WhitelistPreconfirmationDriverError::Driver(driver_err) => {
-            should_drop_cached_driver_error(driver_err)
+            classify_cached_driver_error(driver_err)
         }
-        _ => false,
+        _ => CachedImportDisposition::Propagate,
     }
 }
 
-/// Returns true when a cached-envelope import error should be retried later.
-pub(super) fn should_defer_cached_import_error(err: &WhitelistPreconfirmationDriverError) -> bool {
-    match err {
-        WhitelistPreconfirmationDriverError::Driver(driver_err) => {
-            should_defer_cached_driver_error(driver_err)
-        }
-        _ => false,
-    }
-}
+/// Classify a driver-layer error observed while importing a cached envelope.
+///
+/// Envelope-scoped rejections drop the envelope, sync-related conditions defer it, and
+/// anything else aborts the drain loop.
+fn classify_cached_driver_error(err: &driver::DriverError) -> CachedImportDisposition {
+    use driver::sync::error::EngineSubmissionError;
 
-/// Returns true when a driver error is envelope-scoped and safe to drop during cached import.
-fn should_drop_cached_driver_error(err: &driver::DriverError) -> bool {
     match err {
-        driver::DriverError::EngineInvalidPayload(_) => true,
-        driver::DriverError::PreconfInjectionFailed { source, .. } => {
-            matches!(source, driver::sync::error::EngineSubmissionError::InvalidBlock(_, _))
-        }
-        _ => false,
-    }
-}
-
-/// Returns true when a driver error is expected to recover after sync catches up.
-fn should_defer_cached_driver_error(err: &driver::DriverError) -> bool {
-    match err {
+        driver::DriverError::EngineInvalidPayload(_) => CachedImportDisposition::Drop,
         driver::DriverError::EngineSyncing(_) |
         driver::DriverError::BlockNotFound(_) |
         driver::DriverError::PreconfEnqueueTimeout { .. } |
-        driver::DriverError::PreconfResponseTimeout { .. } => true,
-        driver::DriverError::PreconfInjectionFailed { source, .. } => matches!(
-            source,
-            driver::sync::error::EngineSubmissionError::EngineSyncing(_) |
-                driver::sync::error::EngineSubmissionError::MissingPayloadId |
-                driver::sync::error::EngineSubmissionError::MissingInsertedBlock(_)
-        ),
-        _ => false,
+        driver::DriverError::PreconfResponseTimeout { .. } => CachedImportDisposition::Defer,
+        driver::DriverError::PreconfInjectionFailed { source, .. } => match source {
+            EngineSubmissionError::InvalidBlock(_, _) => CachedImportDisposition::Drop,
+            EngineSubmissionError::EngineSyncing(_) |
+            EngineSubmissionError::MissingPayloadId |
+            EngineSubmissionError::MissingInsertedBlock(_) => CachedImportDisposition::Defer,
+            _ => CachedImportDisposition::Propagate,
+        },
+        _ => CachedImportDisposition::Propagate,
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -81,25 +81,25 @@ impl WhitelistPreconfirmationImporter {
         payload: DecodedUnsafePayload,
     ) -> Result<()> {
         let envelope = normalize_unsafe_payload_envelope(payload.envelope, payload.wire_signature);
-        validate_execution_payload_for_preconf(
-            &envelope.execution_payload,
-            self.chain_id,
-            self.anchor_address,
-        )?;
-        validate_envelope_header_difficulty(
-            self.chain_id,
-            envelope.execution_payload.timestamp,
-            envelope.header_difficulty,
-        )?;
-        self.ingest_validated_envelope(Arc::new(envelope), "payload").await;
-
-        Ok(())
+        self.validate_and_ingest(envelope, "payload").await
     }
 
     /// Handle an incoming unsafe response from the `responsePreconfBlocks` topic.
     pub(super) async fn handle_unsafe_response(
         &mut self,
         envelope: WhitelistExecutionPayloadEnvelope,
+    ) -> Result<()> {
+        self.validate_and_ingest(envelope, "response").await
+    }
+
+    /// Run payload-level validation and ingest the envelope, tagged with its ingress source.
+    ///
+    /// This is the single ordering site for the validation that runs before any preconfirmation
+    /// envelope is cached.
+    async fn validate_and_ingest(
+        &mut self,
+        envelope: WhitelistExecutionPayloadEnvelope,
+        ingress_source: &'static str,
     ) -> Result<()> {
         validate_execution_payload_for_preconf(
             &envelope.execution_payload,
@@ -111,8 +111,7 @@ impl WhitelistPreconfirmationImporter {
             envelope.execution_payload.timestamp,
             envelope.header_difficulty,
         )?;
-
-        self.ingest_validated_envelope(Arc::new(envelope), "response").await;
+        self.ingest_validated_envelope(Arc::new(envelope), ingress_source).await;
 
         Ok(())
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -37,7 +37,7 @@ pub(crate) struct WhitelistPreconfirmationImporterParams {
     pub(crate) chain_id: u64,
     /// Command channel used to publish P2P requests/responses.
     pub(crate) network_command_tx: mpsc::Sender<NetworkCommand>,
-    /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).
+    /// Shared driver state (recent envelopes, EOS markers, last reported L2 head).
     pub(crate) state: SharedPreconfState,
     /// Beacon client used for EOS epoch validation.
     pub(crate) beacon_client: Arc<BeaconClient>,
@@ -56,7 +56,7 @@ pub(crate) struct WhitelistPreconfirmationImporter {
     rpc: Client,
     /// Chain id used for preconfirmation signature domain separation.
     chain_id: u64,
-    /// Shared driver state (recent envelopes, EOS markers, highest unsafe block id).
+    /// Shared driver state (recent envelopes, EOS markers, last reported L2 head).
     state: SharedPreconfState,
     /// Beacon client used for EOS epoch validation.
     beacon_client: Arc<BeaconClient>,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use super::{
-    cache_import::{should_defer_cached_import_error, should_drop_cached_import_error},
+    cache_import::{CachedImportDisposition, classify_cached_import_error},
     should_enable_preconf_imports,
     validation::{normalize_unsafe_payload_envelope, validate_execution_payload_for_preconf},
 };
@@ -117,22 +117,19 @@ fn valid_anchor_tx_list(anchor_address: Address) -> Bytes {
 #[test]
 fn drops_cached_import_errors_for_invalid_payload() {
     let err = WhitelistPreconfirmationDriverError::InvalidPayload("bad payload".to_string());
-    assert!(should_drop_cached_import_error(&err));
-    assert!(!should_defer_cached_import_error(&err));
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Drop);
 }
 
 #[test]
 fn drops_cached_import_errors_for_invalid_signature() {
     let err = WhitelistPreconfirmationDriverError::InvalidSignature("bad signature".to_string());
-    assert!(should_drop_cached_import_error(&err));
-    assert!(!should_defer_cached_import_error(&err));
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Drop);
 }
 
 #[test]
 fn defers_cached_import_errors_for_engine_syncing_driver_error() {
     let err = WhitelistPreconfirmationDriverError::Driver(driver::DriverError::EngineSyncing(42));
-    assert!(!should_drop_cached_import_error(&err));
-    assert!(should_defer_cached_import_error(&err));
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Defer);
 }
 
 #[test]
@@ -145,8 +142,7 @@ fn drops_cached_import_errors_for_invalid_block_driver_error() {
                 "invalid payload".to_string(),
             ),
         });
-    assert!(should_drop_cached_import_error(&err));
-    assert!(!should_defer_cached_import_error(&err));
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Drop);
 }
 
 #[test]
@@ -156,15 +152,13 @@ fn defers_cached_import_errors_for_missing_payload_id_driver_error() {
             block_number: 42,
             source: driver::sync::error::EngineSubmissionError::MissingPayloadId,
         });
-    assert!(!should_drop_cached_import_error(&err));
-    assert!(should_defer_cached_import_error(&err));
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Defer);
 }
 
 #[test]
 fn propagates_cached_import_errors_for_non_payload_failures() {
     let err = WhitelistPreconfirmationDriverError::MissingInsertedBlock(42);
-    assert!(!should_drop_cached_import_error(&err));
-    assert!(!should_defer_cached_import_error(&err));
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Propagate);
 }
 
 #[test]
@@ -173,8 +167,7 @@ fn defers_cached_import_errors_for_preconf_enqueue_timeout() {
         WhitelistPreconfirmationDriverError::Driver(driver::DriverError::PreconfEnqueueTimeout {
             waited: Duration::from_secs(1),
         });
-    assert!(!should_drop_cached_import_error(&err));
-    assert!(should_defer_cached_import_error(&err));
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Defer);
 }
 
 #[test]
@@ -183,8 +176,7 @@ fn defers_cached_import_errors_for_preconf_response_timeout() {
         WhitelistPreconfirmationDriverError::Driver(driver::DriverError::PreconfResponseTimeout {
             waited: Duration::from_secs(12),
         });
-    assert!(!should_drop_cached_import_error(&err));
-    assert!(should_defer_cached_import_error(&err));
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Defer);
 }
 
 #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -99,8 +99,8 @@ impl WhitelistPreconfirmationDriverRunner {
             "whitelist preconfirmation p2p subscriber started"
         );
 
-        // Seed the shared highest-unsafe counter with the current L2 head.
-        let initial_highest_unsafe_l2_payload_block_id = preconf_ingress_sync
+        // Seed the shared status-reporting fallback with the current L2 head.
+        let initial_l2_head = preconf_ingress_sync
             .client()
             .l2_provider
             .get_block_by_number(BlockNumberOrTag::Latest)
@@ -113,7 +113,7 @@ impl WhitelistPreconfirmationDriverRunner {
             })?
             .header
             .number;
-        let state = SharedPreconfState::new(initial_highest_unsafe_l2_payload_block_id);
+        let state = SharedPreconfState::new(initial_l2_head);
 
         // Optionally start the REST/WS server when both rpc_listen_addr and p2p_signer_key
         // are configured.


### PR DESCRIPTION
## Summary

The quick-win batch (#5–#16) from the 2026-07-07 all-crates architecture scan, follow-up to #21925. 36 files, **+321/−473**. No protocol/wire behavior changes; the two operator-visible changes are called out below.

### Dead surface removed
- `AppliedPayload.payload` had zero readers — `PayloadApplier::apply_payload` now returns `EngineBlockOutcome` directly and the struct is gone; mock appliers drop their fabricated execution payloads.
- `bin` `metrics/version.rs` was never registered anywhere. Rather than delete it, `init_metrics` now registers it, so `taiko_client_info{version}` actually exists (**new metric**). The unused `target_triple` label is dropped.
- protocol: `encode_tx_list` (zero callers) deleted; `PAYLOAD_ID_VERSION_V2`/`payload_id_to_bytes` demoted to module-private; `ForkConfigError`/`ForkConfigResult` dropped from the `shasta::` re-export list (no external consumer names them; still reachable via `shasta::error` for signatures).
- `ProtocolError::Io`: the scan called it dead, which was almost right — one implicit `?` conversion existed in `encode_manifest_payload`. That site now maps zlib-writer IO errors to `Compression` explicitly and the variant is deleted (error *message* for that path changes from "IO error: …" to "compression error: failed to compress manifest: …").

### Duplication collapsed
- The "fail fast before first success, retry after" poll classifier existed three times (beacon ×2 gates, event scanner) — now one `sync::retryable_after_first_success` with WLP-INV-001 semantics unchanged.
- The "first tx must target the anchor contract" decode preamble existed in `event.rs` and the derivation pipeline against two different `anchorV4Call` types — extracted to `driver::anchor_tx::first_anchor_tx_input`. The two call-site decode paths (bindings v4-only vs consensus v4/v3) are intentionally unchanged: the types are structurally different (named `_checkpoint` vs positional tuple).
- `resolve_resume_head_block_number` now returns `(block_number, source_label)` so the resume log label can't diverge from the decision (previously re-derived by a second match).
- whitelist ingress: `handle_unsafe_payload`/`handle_unsafe_response` were validate-then-ingest twins — merged into one `validate_and_ingest`, leaving signature normalization as the only visible difference.
- whitelist cached-import error policy: 4 boolean predicates + guard ordering → one `classify_cached_import_error() -> Defer | Drop | Propagate` enum; variant→disposition mapping is preserved exactly and mutual exclusivity is now structural.
- `build_driver_payload` existed under one name at three altitudes — the two thin adapters are renamed after their inputs (`driver_payload_from_envelope`, `driver_payload_from_request`); `payload::build_driver_payload` stays canonical.

### Config shape
- `ProposerConfigs` embeds `client: ClientConfig` (mirroring `DriverConfig`) instead of re-listing five fields; bin gains a shared `build_client_config` used by both commands.
- `preconfirmation_enabled` is now a `DriverConfig::new` parameter instead of a mutate-after-construction flag; the stale "will be a flag in future" NOTE is gone.

### Whitelist `/status` fallback (**operator-visible nuance**)
The `highest_unsafe` three-method mutex counter (raise-on-import / set-on-build / read) only ever surfaced when the L2 head read failed — `/status` already reports the live head whenever readable, which is what the Catalyst sync gate compares against. It collapses to a single last-observed-head `AtomicU64`: head readable → identical behavior; head unreadable → reports the newest of the last successful poll and the last locally inserted block, with a warn log. Both insert paths refresh the same atomic via `record_inserted_block` (a plain store suffices: imports drain in ascending order and any successful poll overwrites with the live head), so the fallback is never staler than the old counter. *(Amended per review: the first cut dropped the insert-path writes, which let the fallback lag just-inserted blocks during a head-read blip.)*

## Verification

```
just fmt && just clippy   # clean (-D warnings, missing-docs gates included)
just test                 # Summary [49.178s] 292 tests run: 292 passed, 0 skipped
```

Test count vs main's 295 is exactly accounted: 3 single-purpose tests deleted with their deduped helpers, 4 reconcile tests consolidated into 2, 1 new shared-classifier test, 1 new insert-path fallback regression test.

Note: #21915 also touches the driver e2e tests; conflicts should be mechanical.
