### PR TITLE
test(taiko-client): send `numForcedInclusions=0` to match current Shasta Inbox

### DIFF
--- a/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
+++ b/packages/taiko-client/driver/chain_syncer/chain_syncer_test.go
@@ -482,6 +482,13 @@ func (s *ChainSyncerTestSuite) TestShastaProposalWithTooMuchBlocks() {
 }
 
 func (s *ChainSyncerTestSuite) TestShastaProposalsWithInvalidForcedInclusion() {
+	// TODO(temporary): forced inclusions are disabled in the current protocol
+	// (Inbox._validateProposeInput requires numForcedInclusions == 0) and the
+	// proposer now sends 0, so forced-inclusion proposals cannot be produced.
+	// Re-enable once forced inclusions are supported in the protocol again and the
+	// proposer sends math.MaxUint16 (see proposer/transaction_builder/blob.go).
+	s.T().Skip("temporarily disabled: forced inclusions are turned off in the protocol")
+
 	head, err := s.RPCClient.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
 
@@ -584,6 +591,13 @@ func (s *ChainSyncerTestSuite) TestShastaProposalsWithInvalidForcedInclusion() {
 }
 
 func (s *ChainSyncerTestSuite) TestShastaProposalsWithForcedInclusion() {
+	// TODO(temporary): forced inclusions are disabled in the current protocol
+	// (Inbox._validateProposeInput requires numForcedInclusions == 0) and the
+	// proposer now sends 0, so forced-inclusion proposals cannot be produced.
+	// Re-enable once forced inclusions are supported in the protocol again and the
+	// proposer sends math.MaxUint16 (see proposer/transaction_builder/blob.go).
+	s.T().Skip("temporarily disabled: forced inclusions are turned off in the protocol")
+
 	head, err := s.RPCClient.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
 

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -388,6 +388,13 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 }
 
 func (s *DriverTestSuite) TestForcedInclusion() {
+	// TODO(temporary): forced inclusions are disabled in the current protocol
+	// (Inbox._validateProposeInput requires numForcedInclusions == 0) and the
+	// proposer now sends 0, so forced-inclusion proposals cannot be produced.
+	// Re-enable once forced inclusions are supported in the protocol again and the
+	// proposer sends math.MaxUint16 (see proposer/transaction_builder/blob.go).
+	s.T().Skip("temporarily disabled: forced inclusions are turned off in the protocol")
+
 	nonce, err := s.RPCClient.L2.NonceAt(context.Background(), s.TestAddr, nil)
 	s.Nil(err)
 

--- a/packages/taiko-client/proposer/transaction_builder/blob.go
+++ b/packages/taiko-client/proposer/transaction_builder/blob.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -113,8 +112,13 @@ func (b *BlobTransactionBuilder) Build(
 				NumBlobs:       uint16(len(blobs)),
 				Offset:         common.Big0,
 			},
-			// We try to include all the forced inclusions in the source manifest.
-			NumForcedInclusions: math.MaxUint16,
+			// TODO(temporary): the current Shasta Inbox rejects a non-zero
+			// numForcedInclusions (Inbox._validateProposeInput requires it to be 0), so
+			// forced inclusions are disabled in the protocol for now. Sending anything
+			// else makes propose revert. Once forced inclusions are re-enabled in the
+			// protocol, change this back to math.MaxUint16 (import "math") to include all
+			// pending forced inclusions in the source manifest.
+			NumForcedInclusions: 0,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Temporary fix so `Inbox.propose` stops reverting against the current Shasta protocol: the blob transaction builder now sends `numForcedInclusions = 0` instead of `math.MaxUint16`.

## Root cause

The v3.0.0 protocol realign (#21922) rewrote the Inbox `propose` path and dropped forced-inclusion support. `_validateProposeInput` now hard-rejects any non-zero value:

```solidity
// packages/protocol/contracts/layer1/core/impl/Inbox.sol
function _validateProposeInput(ProposeInput memory _input) private view {
    require(_input.numForcedInclusions == 0);   // plain require, no message → reverts with empty 0x
    require(_input.deadline == 0 || block.timestamp <= _input.deadline, DeadlineExceeded());
}
```

The proposer — unchanged since the forced-inclusion era, where `min(n, MAX_FORCED_INCLUSIONS_PER_PROPOSAL)` was consumed — still sent `math.MaxUint16` ("consume all pending"). So every `propose` reverted with an empty `0x` at gas-estimation time, `txmgr` retried forever (`Failed to create a transaction, will retry ... execution reverted, reason: 0x`), and the integration suites (`driver`, `proposer`) hung in `SetupTest` until the 700s timeout.

This affects **all** L2 lanes — `l2_geth` and `l2_reth` reproduce identically (it is not an L2-image issue). CI didn't catch it because `taiko-client--test.yml` is path-filtered to `packages/taiko-client/**`, and #21922 only touched `packages/protocol/**`, so the integration lane never ran on the realign merge.

## Fix

- Send `numForcedInclusions = 0` for now, aligning `main` with prod (forced inclusions are currently disabled in the protocol). Documented inline with a `TODO(temporary)`. Only the blob builder set this field (the driver proposes via blobs); no other call site is affected.
- Temporarily `t.Skip(...)` the three forced-inclusion integration tests, which can no longer produce forced-inclusion proposals: `TestForcedInclusion` (driver), `TestShastaProposalsWithForcedInclusion` and `TestShastaProposalsWithInvalidForcedInclusion` (chain_syncer). Each skip has a matching `TODO(temporary)`.

This is explicitly temporary — once forced inclusions are re-enabled in the protocol, change the proposer back to `math.MaxUint16` and un-skip the tests.

## Verification

- **Live root-cause proof:** captured the reverting `propose` calldata from anvil, and `cast call --trace` showed the revert at ~1753 gas inside `_validateProposeInput` (before the first `_coreState` SLOAD). Flipping `numForcedInclusions` `0xffff → 0` on the same deployed contract moved the revert *past* that guard (gas 1753 → 7902), proving line 741 was the blocker.
- **`PACKAGE=driver make test`** → `ok .../driver` — **21 PASS / 0 FAIL / 1 SKIP**, zero propose reverts (previously hung until timeout).
- **`PACKAGE=driver/chain_syncer make test`** → `ok .../chain_syncer` — **24 PASS / 0 FAIL / 2 SKIP**, zero propose reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
