### PR TITLE
test(taiko-client): isolate tx manager selector tests

### DIFF
--- a/packages/taiko-client/pkg/utils/txmgr_selector_test.go
+++ b/packages/taiko-client/pkg/utils/txmgr_selector_test.go
@@ -2,28 +2,63 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	testTxMgr    = &txmgr.SimpleTxManager{}
-	testSelector = NewTxMgrSelector(testTxMgr, nil, nil)
-)
-
 func TestNewTxMgrSelector(t *testing.T) {
-	require.Equal(t, defaultPrivateTxMgrRetryInterval, testSelector.privateTxMgrRetryInterval)
+	selector := NewTxMgrSelector(&txmgr.SimpleTxManager{}, nil, nil)
+	require.Equal(t, defaultPrivateTxMgrRetryInterval, selector.privateTxMgrRetryInterval)
 }
 
 func TestSelect(t *testing.T) {
-	txMgr, isPrivate := testSelector.Select()
-	require.NotNil(t, txMgr)
+	normalTxMgr := &txmgr.SimpleTxManager{}
+	selector := NewTxMgrSelector(normalTxMgr, nil, nil)
+
+	selectedTxMgr, isPrivate := selector.Select()
+	require.Same(t, normalTxMgr, selectedTxMgr)
 	require.False(t, isPrivate)
 }
 
+func TestSelectPrivateTxMgr(t *testing.T) {
+	normalTxMgr := &txmgr.SimpleTxManager{}
+	privateTxMgr := &txmgr.SimpleTxManager{}
+	selector := NewTxMgrSelector(normalTxMgr, privateTxMgr, nil)
+
+	selectedTxMgr, isPrivate := selector.Select()
+	require.Same(t, privateTxMgr, selectedTxMgr)
+	require.True(t, isPrivate)
+}
+
+func TestSelectNormalTxMgrAfterPrivateFailure(t *testing.T) {
+	normalTxMgr := &txmgr.SimpleTxManager{}
+	privateTxMgr := &txmgr.SimpleTxManager{}
+	selector := NewTxMgrSelector(normalTxMgr, privateTxMgr, nil)
+	selector.RecordPrivateTxMgrFailed()
+
+	selectedTxMgr, isPrivate := selector.Select()
+	require.Same(t, normalTxMgr, selectedTxMgr)
+	require.False(t, isPrivate)
+}
+
+func TestSelectRetriesPrivateTxMgrAfterRetryInterval(t *testing.T) {
+	normalTxMgr := &txmgr.SimpleTxManager{}
+	privateTxMgr := &txmgr.SimpleTxManager{}
+	retryInterval := time.Minute
+	selector := NewTxMgrSelector(normalTxMgr, privateTxMgr, &retryInterval)
+	failedAt := time.Now().Add(-retryInterval - time.Second)
+	selector.privateTxMgrFailedAt = &failedAt
+
+	selectedTxMgr, isPrivate := selector.Select()
+	require.Same(t, privateTxMgr, selectedTxMgr)
+	require.True(t, isPrivate)
+}
+
 func TestRecordPrivateTxMgrFailed(t *testing.T) {
-	require.Nil(t, testSelector.privateTxMgrFailedAt)
-	testSelector.RecordPrivateTxMgrFailed()
-	require.NotNil(t, testSelector.privateTxMgrFailedAt)
+	selector := NewTxMgrSelector(&txmgr.SimpleTxManager{}, nil, nil)
+	require.Nil(t, selector.privateTxMgrFailedAt)
+	selector.RecordPrivateTxMgrFailed()
+	require.NotNil(t, selector.privateTxMgrFailedAt)
 }


### PR DESCRIPTION
## Summary

Isolate the `TxMgrSelector` tests so they no longer share a package-level selector instance.

The previous tests mutated shared state through `RecordPrivateTxMgrFailed`, which made the package order-dependent under `go test -shuffle`. This keeps each test self-contained and adds coverage for:

- selecting the private transaction manager when available
- falling back to the normal transaction manager after a private transaction manager failure
- retrying the private transaction manager after the retry interval has elapsed

## Verification

- `go test -shuffle=on -count=20 ./pkg/utils`
- `go test -count=1 ./pkg/utils`
- `typos packages/taiko-client/pkg/utils/txmgr_selector_test.go`