### PR TITLE
chore(taiko-client,taiko-client-rs): bump execution client deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260612022329-f003739ec4e7
+replace github.com/ethereum/go-ethereum v1.15.5 => github.com/taikoxyz/taiko-geth v1.18.1-0.20260709024242-8f5abc6d0636
 
 replace github.com/ethereum-optimism/optimism v1.7.4 => github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828
 

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828 h1:8TqBxcCsk7TNvGHjTuStB2waN3KPpTJYeqpk7JY5t+o=
 github.com/taikoxyz/optimism v0.0.0-20260420065638-5490c5186828/go.mod h1:V0VCkKtCzuaJH6qcL75SRcbdlakM9LhurMEJUhO6VXA=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260612022329-f003739ec4e7 h1:uMcjRtbbTqiZv+tRFu3OU4yixTLsY2ntJq35+rw6Y+A=
-github.com/taikoxyz/taiko-geth v1.18.1-0.20260612022329-f003739ec4e7/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260709024242-8f5abc6d0636 h1:PxU90oZ+B8SiiRqXYiYXqzjhf52tj7mnGIahQeExml0=
+github.com/taikoxyz/taiko-geth v1.18.1-0.20260709024242-8f5abc6d0636/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.2.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=2c791d83843e81828411ca7a4aaadb7f6149983f#2c791d83843e81828411ca7a4aaadb7f6149983f"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6c4d19979ca632a169627c8463c7452c4b82214c#6c4d19979ca632a169627c8463c7452c4b82214c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.2.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=2c791d83843e81828411ca7a4aaadb7f6149983f#2c791d83843e81828411ca7a4aaadb7f6149983f"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6c4d19979ca632a169627c8463c7452c4b82214c#6c4d19979ca632a169627c8463c7452c4b82214c"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.0.4",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.2.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=2c791d83843e81828411ca7a4aaadb7f6149983f#2c791d83843e81828411ca7a4aaadb7f6149983f"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6c4d19979ca632a169627c8463c7452c4b82214c#6c4d19979ca632a169627c8463c7452c4b82214c"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.2.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=2c791d83843e81828411ca7a4aaadb7f6149983f#2c791d83843e81828411ca7a4aaadb7f6149983f"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=6c4d19979ca632a169627c8463c7452c4b82214c#6c4d19979ca632a169627c8463c7452c4b82214c"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3752,7 +3752,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -6121,7 +6121,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6159,7 +6159,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -75,12 +75,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "2c791d83843e81828411ca7a4aaadb7f6149983f", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "2c791d83843e81828411ca7a4aaadb7f6149983f", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "2c791d83843e81828411ca7a4aaadb7f6149983f", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "6c4d19979ca632a169627c8463c7452c4b82214c", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "6c4d19979ca632a169627c8463c7452c4b82214c", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "6c4d19979ca632a169627c8463c7452c4b82214c", default-features = false, features = [
     "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "2c791d83843e81828411ca7a4aaadb7f6149983f" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "6c4d19979ca632a169627c8463c7452c4b82214c" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary
- Bump `github.com/taikoxyz/taiko-geth` to taiko branch commit `8f5abc6d06365ca8d4ef3c5c081d05cd88d46dbd` (`v1.18.1-0.20260709024242-8f5abc6d0636`).
- Bump Alethia Reth Rust deps to main branch commit `6c4d19979ca632a169627c8463c7452c4b82214c`.
- Update `go.sum` and `packages/taiko-client-rs/Cargo.lock`.

## Validation
- `/opt/homebrew/bin/pnpm install`
- `cd packages/taiko-client && PACKAGE=... make test`
- `cargo check --manifest-path packages/taiko-client-rs/Cargo.toml --workspace --all-targets --locked`
- `git diff --check`