### PR TITLE
chore(taiko-client-rs): harden whitelist preconfirmation ingress

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::{result::Result as StdResult, time::Duration};
 
+use alloy::primitives::B256;
 use anyhow::Error as AnyhowError;
 use rpc::error::RpcClientError;
 use thiserror::Error;
@@ -30,6 +31,19 @@ pub enum DriverError {
     /// Preconfirmation ingress loop has not started yet.
     #[error("preconfirmation ingress loop is not ready")]
     PreconfIngressNotReady,
+
+    /// Canonical parent changed after the preconfirmation was authenticated.
+    #[error(
+        "preconfirmation parent mismatch for block {block_number}: expected {expected}, got {actual}"
+    )]
+    PreconfParentMismatch {
+        /// L2 block number targeted by the preconfirmation.
+        block_number: u64,
+        /// Parent hash authenticated by the preconfirmation sender.
+        expected: B256,
+        /// Parent hash currently canonical in the execution engine.
+        actual: B256,
+    },
 
     /// Block not found on remote node.
     #[error("remote node missing block {0}")]

--- a/packages/taiko-client-rs/crates/driver/src/lib.rs
+++ b/packages/taiko-client-rs/crates/driver/src/lib.rs
@@ -29,5 +29,5 @@ pub mod sync;
 pub use config::DriverConfig;
 pub use driver::Driver;
 pub use error::DriverError;
-pub use production::PreconfPayload;
+pub use production::{PreconfPayload, PreconfSubmissionOutcome};
 pub use sync::{ConfirmedSyncSnapshot, SyncPipeline, SyncStage, event::EventSyncer};

--- a/packages/taiko-client-rs/crates/driver/src/production/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/mod.rs
@@ -12,7 +12,7 @@
 use std::sync::Arc;
 
 use alethia_reth_primitives::payload::attributes::TaikoPayloadAttributes;
-use alloy::rpc::types::Log;
+use alloy::{primitives::B256, rpc::types::Log};
 
 use crate::error::DriverError;
 
@@ -54,12 +54,14 @@ pub enum ProductionInput {
 pub struct PreconfPayload {
     /// Wrapped payload attributes submitted through preconfirmation ingress.
     payload: TaikoPayloadAttributes,
+    /// Parent block hash authenticated by the preconfirmation sender.
+    expected_parent_hash: B256,
 }
 
 impl PreconfPayload {
-    /// Create a new preconfirmation payload.
-    pub fn new(payload: TaikoPayloadAttributes) -> Self {
-        Self { payload }
+    /// Create a new preconfirmation payload bound to its authenticated parent hash.
+    pub fn new(payload: TaikoPayloadAttributes, expected_parent_hash: B256) -> Self {
+        Self { payload, expected_parent_hash }
     }
 
     /// Access the underlying Taiko payload attributes.
@@ -67,10 +69,26 @@ impl PreconfPayload {
         &self.payload
     }
 
+    /// Return the parent block hash authenticated by the sender.
+    pub fn expected_parent_hash(&self) -> B256 {
+        self.expected_parent_hash
+    }
+
     /// Return the target block number for the preconfirmation payload.
     pub fn block_number(&self) -> u64 {
         self.payload.l1_origin.block_id.to::<u64>()
     }
+}
+
+/// Terminal outcome of submitting one preconfirmation payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreconfSubmissionOutcome {
+    /// The payload was injected through the execution-engine production path.
+    Inserted,
+    /// The exact payload was already materialized in local execution state.
+    AlreadyMaterialized,
+    /// The payload was at or below the event-confirmed L2 tip and was dropped.
+    Stale,
 }
 
 /// Routes `ProductionInput` to the matching `BlockProductionPath`.

--- a/packages/taiko-client-rs/crates/driver/src/production/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/mod.rs
@@ -81,12 +81,23 @@ impl PreconfPayload {
 }
 
 /// Terminal outcome of submitting one preconfirmation payload.
+///
+/// `Inserted` and `AlreadyMaterialized` carry the exact block hash observed by the
+/// serialized submission path so callers can resolve the block by hash instead of by
+/// height — a same-height sibling can become canonical immediately after submission,
+/// and a height lookup would then bind the caller to a block the payload never produced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreconfSubmissionOutcome {
     /// The payload was injected through the execution-engine production path.
-    Inserted,
+    Inserted {
+        /// Hash of the block the execution engine produced for this payload.
+        block_hash: B256,
+    },
     /// The exact payload was already materialized in local execution state.
-    AlreadyMaterialized,
+    AlreadyMaterialized {
+        /// Hash of the materialized block observed by the submission check.
+        block_hash: B256,
+    },
     /// The payload was at or below the event-confirmed L2 tip and was dropped.
     Stale,
 }

--- a/packages/taiko-client-rs/crates/driver/src/production/path.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/path.rs
@@ -112,6 +112,15 @@ where
                     }
                 };
 
+                let expected_parent_hash = preconf.expected_parent_hash();
+                if parent_hash != expected_parent_hash {
+                    return Err(DriverError::PreconfParentMismatch {
+                        block_number,
+                        expected: expected_parent_hash,
+                        actual: parent_hash,
+                    });
+                }
+
                 let outcome =
                     self.applier.apply_payload(payload, parent_hash, None).await.map_err(
                         |err| DriverError::PreconfInjectionFailed { block_number, source: err },
@@ -308,7 +317,7 @@ mod tests {
         let canonical = Arc::new(MockPath::new());
         let preconf = Arc::new(MockPath::new());
         let router = ProductionRouter::new(canonical.clone(), Some(preconf.clone()));
-        let payload = Arc::new(PreconfPayload::new(sample_payload(0)));
+        let payload = Arc::new(PreconfPayload::new(sample_payload(0), B256::ZERO));
 
         let rt = Runtime::new().unwrap();
         let outcomes = rt
@@ -324,7 +333,7 @@ mod tests {
     fn router_rejects_preconf_without_path() {
         let canonical = Arc::new(MockPath::new());
         let router = ProductionRouter::new(canonical.clone(), None);
-        let payload = Arc::new(PreconfPayload::new(sample_payload(0)));
+        let payload = Arc::new(PreconfPayload::new(sample_payload(0), B256::ZERO));
 
         let rt = Runtime::new().unwrap();
         let err = rt
@@ -340,7 +349,7 @@ mod tests {
         let parent_hash = B256::from([1u8; 32]);
         let applier = MockApplier::new(0, parent_hash);
         let path = PreconfirmationPath::new(applier.clone());
-        let payload = Arc::new(PreconfPayload::new(sample_payload(1)));
+        let payload = Arc::new(PreconfPayload::new(sample_payload(1), parent_hash));
 
         let rt = Runtime::new().unwrap();
         let outcomes = rt
@@ -356,7 +365,7 @@ mod tests {
         let parent_hash = B256::from([1u8; 32]);
         let applier = MockApplier::new(1, parent_hash);
         let path = PreconfirmationPath::new(applier.clone());
-        let payload = Arc::new(PreconfPayload::new(sample_payload(2)));
+        let payload = Arc::new(PreconfPayload::new(sample_payload(2), parent_hash));
 
         let rt = Runtime::new().unwrap();
         let outcomes = rt
@@ -365,5 +374,26 @@ mod tests {
 
         assert_eq!(applier.calls(), 1);
         assert_eq!(outcomes.len(), 1);
+    }
+
+    #[test]
+    fn preconfirmation_path_rejects_unexpected_parent() {
+        let canonical_parent = B256::from([1u8; 32]);
+        let signed_parent = B256::from([2u8; 32]);
+        let applier = MockApplier::new(1, canonical_parent);
+        let path = PreconfirmationPath::new(applier.clone());
+        let payload = Arc::new(PreconfPayload::new(sample_payload(2), signed_parent));
+
+        let err = Runtime::new()
+            .unwrap()
+            .block_on(path.produce(ProductionInput::Preconfirmation(payload)))
+            .expect_err("wrong-parent preconfirmation must fail");
+
+        assert!(matches!(
+            err,
+            DriverError::PreconfParentMismatch { block_number: 2, expected, actual }
+                if expected == signed_parent && actual == canonical_parent
+        ));
+        assert_eq!(applier.calls(), 0);
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -205,13 +205,10 @@ fn resolve_reconnect_start_block(
         .map_or(startup_anchor_block_number, |finalized| overlap_start_block_number.min(finalized))
 }
 
-/// Return the terminal stale outcome when a target is at or below the confirmed tip.
+/// Return whether a preconfirmation target is at or below the confirmed tip.
 #[inline]
-fn stale_preconf_outcome(
-    block_number: u64,
-    confirmed_tip: u64,
-) -> Option<PreconfSubmissionOutcome> {
-    (block_number <= confirmed_tip).then_some(PreconfSubmissionOutcome::Stale)
+fn is_stale_preconf(block_number: u64, confirmed_tip: u64) -> bool {
+    block_number <= confirmed_tip
 }
 
 /// Responsible for following inbox events and updating the L2 execution engine accordingly.
@@ -411,8 +408,7 @@ impl EventSyncer {
                         continue;
                     }
                 };
-                if let Some(outcome) = stale_preconf_outcome(block_number, head_l1_origin_block_id)
-                {
+                if is_stale_preconf(block_number, head_l1_origin_block_id) {
                     DriverMetrics::preconf_stale_dropped_total().inc();
                     DriverMetrics::preconf_stale_dropped_ingress_total().inc();
                     warn!(
@@ -420,7 +416,7 @@ impl EventSyncer {
                         head_l1_origin_block_id,
                         "dropping stale preconfirmation payload in ingress loop"
                     );
-                    let _ = job.respond_to.send(Ok(outcome));
+                    let _ = job.respond_to.send(Ok(PreconfSubmissionOutcome::Stale));
                     DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                     continue;
                 }
@@ -841,14 +837,14 @@ impl EventSyncer {
             Some(origin) => origin.block_id.to::<u64>(),
             None => 0,
         };
-        if let Some(outcome) = stale_preconf_outcome(block_number, head_l1_origin_block_id) {
+        if is_stale_preconf(block_number, head_l1_origin_block_id) {
             DriverMetrics::preconf_stale_dropped_total().inc();
             DriverMetrics::preconf_stale_dropped_before_enqueue_total().inc();
             warn!(
                 block_number,
                 head_l1_origin_block_id, "dropping stale preconfirmation payload before enqueue"
             );
-            return Ok(outcome);
+            return Ok(PreconfSubmissionOutcome::Stale);
         }
         if is_materialized {
             return Ok(PreconfSubmissionOutcome::AlreadyMaterialized);
@@ -1993,9 +1989,9 @@ mod tests {
     }
 
     #[test]
-    fn stale_preconfirmation_maps_to_explicit_outcome() {
-        assert_eq!(stale_preconf_outcome(42, 42), Some(PreconfSubmissionOutcome::Stale));
-        assert_eq!(stale_preconf_outcome(43, 42), None);
+    fn stale_preconfirmation_boundary_is_inclusive() {
+        assert!(is_stale_preconf(42, 42));
+        assert!(!is_stale_preconf(43, 42));
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -260,26 +260,28 @@ pub struct PreconfJob {
     respond_to: oneshot::Sender<Result<PreconfSubmissionOutcome, DriverError>>,
 }
 
-/// Return whether the provided preconfirmation payload already materialized into the local L2
-/// chain state.
+/// Return the block hash of the local L2 block the provided preconfirmation payload already
+/// materialized into, or `None` when it is not materialized.
 ///
 /// Materialization requires both the per-block L1 origin record and the execution header to match
-/// the payload attributes previously submitted to the engine.
-async fn preconfirmation_payload_is_materialized(
+/// the payload attributes previously submitted to the engine. The returned hash is the one
+/// observed by this check, so callers can bind their follow-up reads to the exact block that
+/// satisfied the comparison rather than re-resolving by height.
+async fn materialized_preconfirmation_block_hash(
     rpc: &Client,
     payload: &PreconfPayload,
-) -> Result<bool, DriverError> {
+) -> Result<Option<B256>, DriverError> {
     let block_number = payload.block_number();
     let expected_payload = payload.payload();
     let Some(origin) = rpc.l1_origin_by_id(U256::from(block_number)).await? else {
-        return Ok(false);
+        return Ok(None);
     };
     // Treat a zero build-payload id as an uninitialized origin record so we fail closed and
     // re-submit rather than falsely acknowledging a materialized payload.
     if origin.build_payload_args_id == [0u8; 8] ||
         origin.build_payload_args_id != expected_payload.l1_origin.build_payload_args_id
     {
-        return Ok(false);
+        return Ok(None);
     }
 
     let Some(block) = rpc
@@ -288,39 +290,40 @@ async fn preconfirmation_payload_is_materialized(
         .await
         .map_err(|err| DriverError::Rpc(RpcClientError::Provider(err.to_string())))?
     else {
-        return Ok(false);
+        return Ok(None);
     };
     let header = &block.header;
 
     if header.parent_hash != payload.expected_parent_hash() {
-        return Ok(false);
+        return Ok(None);
     }
     if origin.l2_block_hash != B256::ZERO && header.hash != origin.l2_block_hash {
-        return Ok(false);
+        return Ok(None);
     }
     if header.number != block_number {
-        return Ok(false);
+        return Ok(None);
     }
     if header.beneficiary != expected_payload.payload_attributes.suggested_fee_recipient {
-        return Ok(false);
+        return Ok(None);
     }
     if header.mix_hash != expected_payload.payload_attributes.prev_randao {
-        return Ok(false);
+        return Ok(None);
     }
     if header.gas_limit != expected_payload.block_metadata.gas_limit {
-        return Ok(false);
+        return Ok(None);
     }
     if header.timestamp != expected_payload.payload_attributes.timestamp {
-        return Ok(false);
+        return Ok(None);
     }
     if header.extra_data != expected_payload.block_metadata.extra_data {
-        return Ok(false);
+        return Ok(None);
     }
 
-    Ok(matches!(
+    let matches_base_fee = matches!(
         header.base_fee_per_gas,
         Some(base_fee) if U256::from(base_fee) == expected_payload.base_fee_per_gas
-    ))
+    );
+    Ok(matches_base_fee.then_some(header.hash))
 }
 
 impl EventSyncer {
@@ -366,35 +369,9 @@ impl EventSyncer {
                 DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                 let start = Instant::now();
                 let block_number = job.payload.block_number();
-                let is_materialized = match preconfirmation_payload_is_materialized(
-                    &rpc,
-                    job.payload.as_ref(),
-                )
-                .await
-                {
-                    Ok(true) => {
-                        debug!(
-                            block_number,
-                            build_payload_args_id = %PayloadId::new(job.payload.payload().l1_origin.build_payload_args_id),
-                            "preconfirmation payload is already materialized"
-                        );
-                        true
-                    }
-                    Ok(false) => false,
-                    Err(err) => {
-                        error!(
-                            ?err,
-                            block_number, "failed to check preconfirmation materialization state"
-                        );
-                        let _ = job.respond_to.send(Err(err));
-                        DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
-                        continue;
-                    }
-                };
-
                 let router_guard = router.lock().await;
-                // Re-check after acquiring router lock so event-sync updates cannot race this
-                // preconfirmation submission.
+                // All checks below run while holding the router lock so event-sync updates and
+                // sibling injections cannot race this preconfirmation submission.
                 // On genesis chains head_l1_origin is not yet written; default to 0 so
                 // the staleness check passes for any block_number >= 1.  This matches the
                 // Go driver's `checkMessageBlockNumber` which skips the check when nil.
@@ -420,10 +397,33 @@ impl EventSyncer {
                     DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                     continue;
                 }
-                if is_materialized {
-                    let _ = job.respond_to.send(Ok(PreconfSubmissionOutcome::AlreadyMaterialized));
-                    DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
-                    continue;
+                // Decide materialization inside the serialized section and bind the outcome to
+                // the exact observed block hash: once the lock is released a same-height sibling
+                // can become canonical, so callers must never re-resolve the block by height.
+                match materialized_preconfirmation_block_hash(&rpc, job.payload.as_ref()).await {
+                    Ok(Some(block_hash)) => {
+                        debug!(
+                            block_number,
+                            build_payload_args_id = %PayloadId::new(job.payload.payload().l1_origin.build_payload_args_id),
+                            %block_hash,
+                            "preconfirmation payload is already materialized"
+                        );
+                        let _ = job
+                            .respond_to
+                            .send(Ok(PreconfSubmissionOutcome::AlreadyMaterialized { block_hash }));
+                        DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
+                        continue;
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        error!(
+                            ?err,
+                            block_number, "failed to check preconfirmation materialization state"
+                        );
+                        let _ = job.respond_to.send(Err(err));
+                        DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
+                        continue;
+                    }
                 }
 
                 // Single-shot injection while holding router lock to avoid interleaving.
@@ -435,17 +435,34 @@ impl EventSyncer {
                 DriverMetrics::preconf_injection_duration_seconds().observe(duration_secs);
 
                 match router_call {
-                    Ok(_) => {
-                        DriverMetrics::preconf_injection_success_total().inc();
-                        info!(
-                            block_number,
-                            build_payload_args_id = %PayloadId::new(job.payload.payload().l1_origin.build_payload_args_id),
-                            duration_secs,
-                            "preconfirmation payload injected"
-                        );
-                        // Return success to the original sender.
-                        let _ = job.respond_to.send(Ok(PreconfSubmissionOutcome::Inserted));
-                    }
+                    Ok(outcomes) => match outcomes.last() {
+                        Some(outcome) => {
+                            DriverMetrics::preconf_injection_success_total().inc();
+                            let block_hash = outcome.block.header.hash;
+                            info!(
+                                block_number,
+                                build_payload_args_id = %PayloadId::new(job.payload.payload().l1_origin.build_payload_args_id),
+                                %block_hash,
+                                duration_secs,
+                                "preconfirmation payload injected"
+                            );
+                            // Return the produced block identity to the original sender.
+                            let _ = job
+                                .respond_to
+                                .send(Ok(PreconfSubmissionOutcome::Inserted { block_hash }));
+                        }
+                        // The preconfirmation path always yields exactly one outcome; treat an
+                        // empty result as a missing block rather than fabricating an identity.
+                        None => {
+                            DriverMetrics::preconf_injection_failures_total().inc();
+                            error!(
+                                block_number,
+                                duration_secs, "preconfirmation injection returned no block"
+                            );
+                            let _ =
+                                job.respond_to.send(Err(DriverError::BlockNotFound(block_number)));
+                        }
+                    },
                     Err(err) => {
                         DriverMetrics::preconf_injection_failures_total().inc();
                         error!(
@@ -821,11 +838,16 @@ impl EventSyncer {
             return Err(DriverError::PreconfIngressNotReady);
         }
 
-        let is_materialized = preconfirmation_payload_is_materialized(&self.rpc, &payload).await?;
-        if is_materialized {
+        // Best-effort duplicate fast path outside the serialized loop: the returned outcome
+        // carries the exact hash this check observed, so it stays self-consistent even if a
+        // sibling becomes canonical afterwards.
+        let materialized_block_hash =
+            materialized_preconfirmation_block_hash(&self.rpc, &payload).await?;
+        if let Some(block_hash) = materialized_block_hash {
             debug!(
                 block_number = payload.block_number(),
                 build_payload_args_id = %PayloadId::new(payload.payload().l1_origin.build_payload_args_id),
+                %block_hash,
                 "preconfirmation payload is already materialized"
             );
         }
@@ -846,8 +868,8 @@ impl EventSyncer {
             );
             return Ok(PreconfSubmissionOutcome::Stale);
         }
-        if is_materialized {
-            return Ok(PreconfSubmissionOutcome::AlreadyMaterialized);
+        if let Some(block_hash) = materialized_block_hash {
+            return Ok(PreconfSubmissionOutcome::AlreadyMaterialized { block_hash });
         }
 
         debug!(block_number, "submitting preconfirmation payload to queue");
@@ -1659,6 +1681,22 @@ mod tests {
     }
 
     #[derive(Clone)]
+    struct MockPreconfPath;
+
+    #[async_trait]
+    impl BlockProductionPath for MockPreconfPath {
+        async fn produce(
+            &self,
+            input: ProductionInput,
+        ) -> Result<Vec<EngineBlockOutcome>, DriverError> {
+            let ProductionInput::Preconfirmation(preconf) = input else {
+                panic!("mock preconf path only supports preconfirmation inputs");
+            };
+            Ok(vec![sample_engine_outcome(preconf.block_number())])
+        }
+    }
+
+    #[derive(Clone)]
     struct MockRetryBatchPath {
         fail_once_tx_hashes: StdArc<Mutex<HashSet<B256>>>,
         seen_tx_hashes: StdArc<Mutex<Vec<B256>>>,
@@ -1944,9 +1982,44 @@ mod tests {
         l2_asserter.push_success(&Some(block));
 
         assert!(
-            !preconfirmation_payload_is_materialized(&client, &payload)
+            materialized_preconfirmation_block_hash(&client, &payload)
                 .await
                 .expect("materialization lookup should succeed")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn materialized_preconfirmation_returns_observed_block_hash() {
+        let l2_asserter = Asserter::new();
+        let client =
+            mock_client_with_all_asserters(Asserter::new(), l2_asserter.clone(), Asserter::new());
+        let mut attributes = sample_payload(2);
+        attributes.l1_origin.build_payload_args_id = [0x11; 8];
+        let origin = attributes.l1_origin.clone();
+        let expected_parent_hash = B256::from([0x22; 32]);
+        let payload = PreconfPayload::new(attributes.clone(), expected_parent_hash);
+
+        let observed_block_hash = B256::from([0x66; 32]);
+        let mut block = RpcBlock::<TxEnvelope>::default();
+        block.header.hash = observed_block_hash;
+        block.header.parent_hash = expected_parent_hash;
+        block.header.number = 2;
+        block.header.beneficiary = attributes.payload_attributes.suggested_fee_recipient;
+        block.header.mix_hash = attributes.payload_attributes.prev_randao;
+        block.header.gas_limit = attributes.block_metadata.gas_limit;
+        block.header.timestamp = attributes.payload_attributes.timestamp;
+        block.header.extra_data = attributes.block_metadata.extra_data.clone();
+        block.header.base_fee_per_gas = Some(0);
+
+        l2_asserter.push_success(&Some(origin));
+        l2_asserter.push_success(&Some(block));
+
+        assert_eq!(
+            materialized_preconfirmation_block_hash(&client, &payload)
+                .await
+                .expect("materialization lookup should succeed"),
+            Some(observed_block_hash)
         );
     }
 
@@ -2027,9 +2100,11 @@ mod tests {
         initial_head.block_id = U256::ZERO;
         let mut advanced_head = initial_head.clone();
         advanced_head.block_id = U256::from(1u64);
+        // Pre-enqueue: materialization origin miss, then non-stale head; ingress loop reads the
+        // advanced head first (under the router lock) and short-circuits as stale before any
+        // materialization lookup.
         l2_asserter.push_success(&Option::<RpcL1Origin>::None);
         l2_asserter.push_success(&Some(initial_head));
-        l2_asserter.push_success(&Option::<RpcL1Origin>::None);
         l2_asserter.push_success(&Some(advanced_head));
 
         let outcome = syncer
@@ -2038,6 +2113,55 @@ mod tests {
             .expect("stale payload should return a terminal outcome");
 
         assert_eq!(outcome, PreconfSubmissionOutcome::Stale);
+    }
+
+    #[tokio::test]
+    async fn queued_preconfirmation_binds_inserted_outcome_to_produced_block() {
+        let l2_asserter = Asserter::new();
+        let client =
+            mock_client_with_all_asserters(Asserter::new(), l2_asserter.clone(), Asserter::new());
+        let syncer = EventSyncer { rpc: client.clone(), ..build_syncer().await };
+        let rx = syncer
+            .preconf_rx
+            .lock()
+            .expect("preconfirmation receiver mutex should not be poisoned")
+            .take()
+            .expect("preconfirmation receiver should be available");
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(
+            Arc::new(MockBatchPath::new([])),
+            Some(Arc::new(MockPreconfPath)),
+        )));
+        syncer.spawn_preconf_ingress(
+            router,
+            rx,
+            client,
+            Arc::clone(&syncer.preconf_ingress_ready),
+            Arc::clone(&syncer.preconf_ingress_notify),
+        );
+        syncer
+            .wait_preconf_ingress_ready()
+            .await
+            .expect("preconfirmation ingress should become ready");
+
+        let mut head = sample_payload(0).l1_origin;
+        head.block_id = U256::ZERO;
+        // Pre-enqueue: materialization origin miss + non-stale head; ingress loop: non-stale
+        // head (under the router lock) + materialization origin miss, then injection.
+        l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        l2_asserter.push_success(&Some(head.clone()));
+        l2_asserter.push_success(&Some(head));
+        l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+
+        let outcome = syncer
+            .submit_preconfirmation_payload(PreconfPayload::new(sample_payload(1), B256::ZERO))
+            .await
+            .expect("inserted payload should return a terminal outcome");
+
+        // `MockPreconfPath` replies with `sample_engine_outcome(1)`, whose block hash is below.
+        assert_eq!(
+            outcome,
+            PreconfSubmissionOutcome::Inserted { block_hash: B256::from([1u8; 32]) }
+        );
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -40,8 +40,8 @@ use crate::{
     error::DriverError,
     metrics::DriverMetrics,
     production::{
-        BlockProductionPath, CanonicalL1ProductionPath, PreconfPayload, PreconfirmationPath,
-        ProductionInput, ProductionRouter, path::EngineBlockOutcome,
+        BlockProductionPath, CanonicalL1ProductionPath, PreconfPayload, PreconfSubmissionOutcome,
+        PreconfirmationPath, ProductionInput, ProductionRouter, path::EngineBlockOutcome,
     },
 };
 
@@ -205,10 +205,13 @@ fn resolve_reconnect_start_block(
         .map_or(startup_anchor_block_number, |finalized| overlap_start_block_number.min(finalized))
 }
 
-/// Return true when a preconfirmation target block is stale against the confirmed tip boundary.
+/// Return the terminal stale outcome when a target is at or below the confirmed tip.
 #[inline]
-fn is_stale_preconf(block_number: u64, confirmed_tip: u64) -> bool {
-    block_number <= confirmed_tip
+fn stale_preconf_outcome(
+    block_number: u64,
+    confirmed_tip: u64,
+) -> Option<PreconfSubmissionOutcome> {
+    (block_number <= confirmed_tip).then_some(PreconfSubmissionOutcome::Stale)
 }
 
 /// Responsible for following inbox events and updating the L2 execution engine accordingly.
@@ -257,7 +260,7 @@ pub struct PreconfJob {
     /// The preconfirmation payload to be processed.
     payload: Arc<PreconfPayload>,
     /// Oneshot channel to send the processing result back to the caller.
-    respond_to: oneshot::Sender<Result<(), DriverError>>,
+    respond_to: oneshot::Sender<Result<PreconfSubmissionOutcome, DriverError>>,
 }
 
 /// Return whether the provided preconfirmation payload already materialized into the local L2
@@ -292,6 +295,9 @@ async fn preconfirmation_payload_is_materialized(
     };
     let header = &block.header;
 
+    if header.parent_hash != payload.expected_parent_hash() {
+        return Ok(false);
+    }
     if origin.l2_block_hash != B256::ZERO && header.hash != origin.l2_block_hash {
         return Ok(false);
     }
@@ -363,18 +369,21 @@ impl EventSyncer {
                 DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                 let start = Instant::now();
                 let block_number = job.payload.block_number();
-                match preconfirmation_payload_is_materialized(&rpc, job.payload.as_ref()).await {
+                let is_materialized = match preconfirmation_payload_is_materialized(
+                    &rpc,
+                    job.payload.as_ref(),
+                )
+                .await
+                {
                     Ok(true) => {
                         debug!(
                             block_number,
                             build_payload_args_id = %PayloadId::new(job.payload.payload().l1_origin.build_payload_args_id),
-                            "acknowledging already materialized preconfirmation payload"
+                            "preconfirmation payload is already materialized"
                         );
-                        let _ = job.respond_to.send(Ok(()));
-                        DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
-                        continue;
+                        true
                     }
-                    Ok(false) => {}
+                    Ok(false) => false,
                     Err(err) => {
                         error!(
                             ?err,
@@ -384,7 +393,7 @@ impl EventSyncer {
                         DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                         continue;
                     }
-                }
+                };
 
                 let router_guard = router.lock().await;
                 // Re-check after acquiring router lock so event-sync updates cannot race this
@@ -402,7 +411,8 @@ impl EventSyncer {
                         continue;
                     }
                 };
-                if is_stale_preconf(block_number, head_l1_origin_block_id) {
+                if let Some(outcome) = stale_preconf_outcome(block_number, head_l1_origin_block_id)
+                {
                     DriverMetrics::preconf_stale_dropped_total().inc();
                     DriverMetrics::preconf_stale_dropped_ingress_total().inc();
                     warn!(
@@ -410,7 +420,12 @@ impl EventSyncer {
                         head_l1_origin_block_id,
                         "dropping stale preconfirmation payload in ingress loop"
                     );
-                    let _ = job.respond_to.send(Ok(()));
+                    let _ = job.respond_to.send(Ok(outcome));
+                    DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
+                    continue;
+                }
+                if is_materialized {
+                    let _ = job.respond_to.send(Ok(PreconfSubmissionOutcome::AlreadyMaterialized));
                     DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                     continue;
                 }
@@ -433,7 +448,7 @@ impl EventSyncer {
                             "preconfirmation payload injected"
                         );
                         // Return success to the original sender.
-                        let _ = job.respond_to.send(Ok(()));
+                        let _ = job.respond_to.send(Ok(PreconfSubmissionOutcome::Inserted));
                     }
                     Err(err) => {
                         DriverMetrics::preconf_injection_failures_total().inc();
@@ -789,7 +804,7 @@ impl EventSyncer {
     pub async fn submit_preconfirmation_payload(
         &self,
         payload: PreconfPayload,
-    ) -> Result<(), DriverError> {
+    ) -> Result<PreconfSubmissionOutcome, DriverError> {
         self.submit_preconfirmation_payload_with_timeout(
             payload,
             PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT,
@@ -802,7 +817,7 @@ impl EventSyncer {
         &self,
         payload: PreconfPayload,
         timeout_duration: Duration,
-    ) -> Result<(), DriverError> {
+    ) -> Result<PreconfSubmissionOutcome, DriverError> {
         let tx = self.preconf_tx.as_ref().ok_or(DriverError::PreconfirmationDisabled)?;
 
         // Reject early if strict ingress gating is not satisfied yet.
@@ -810,13 +825,13 @@ impl EventSyncer {
             return Err(DriverError::PreconfIngressNotReady);
         }
 
-        if preconfirmation_payload_is_materialized(&self.rpc, &payload).await? {
+        let is_materialized = preconfirmation_payload_is_materialized(&self.rpc, &payload).await?;
+        if is_materialized {
             debug!(
                 block_number = payload.block_number(),
                 build_payload_args_id = %PayloadId::new(payload.payload().l1_origin.build_payload_args_id),
-                "skipping already materialized preconfirmation payload"
+                "preconfirmation payload is already materialized"
             );
-            return Ok(());
         }
 
         let block_number = payload.block_number();
@@ -826,14 +841,17 @@ impl EventSyncer {
             Some(origin) => origin.block_id.to::<u64>(),
             None => 0,
         };
-        if is_stale_preconf(block_number, head_l1_origin_block_id) {
+        if let Some(outcome) = stale_preconf_outcome(block_number, head_l1_origin_block_id) {
             DriverMetrics::preconf_stale_dropped_total().inc();
             DriverMetrics::preconf_stale_dropped_before_enqueue_total().inc();
             warn!(
                 block_number,
                 head_l1_origin_block_id, "dropping stale preconfirmation payload before enqueue"
             );
-            return Ok(());
+            return Ok(outcome);
+        }
+        if is_materialized {
+            return Ok(PreconfSubmissionOutcome::AlreadyMaterialized);
         }
 
         debug!(block_number, "submitting preconfirmation payload to queue");
@@ -870,7 +888,7 @@ impl EventSyncer {
         // Await the processing result with timeout.
         let response_result = timeout(timeout_duration, resp_rx).await;
 
-        match response_result {
+        let outcome = match response_result {
             Err(_) => {
                 DriverMetrics::preconf_response_timeouts_total().inc();
                 error!(
@@ -889,12 +907,12 @@ impl EventSyncer {
                 if let Err(ref err) = inner_result {
                     warn!(block_number, ?err, "preconfirmation processing returned error");
                 }
-                inner_result?;
+                inner_result?
             }
-        }
+        };
 
-        debug!(block_number, "preconfirmation payload processed successfully");
-        Ok(())
+        debug!(block_number, ?outcome, "preconfirmation payload processed successfully");
+        Ok(outcome)
     }
 
     /// Resolve the L2 execution block used as event-sync resume source.
@@ -1702,10 +1720,17 @@ mod tests {
     }
 
     fn mock_client_with_asserters(l1_asserter: Asserter, l2_auth_asserter: Asserter) -> Client {
+        mock_client_with_all_asserters(l1_asserter, Asserter::new(), l2_auth_asserter)
+    }
+
+    fn mock_client_with_all_asserters(
+        l1_asserter: Asserter,
+        l2_asserter: Asserter,
+        l2_auth_asserter: Asserter,
+    ) -> Client {
         let l1_provider = ProviderBuilder::new().connect_mocked_client(l1_asserter);
-        let l2_provider = ProviderBuilder::new()
-            .disable_recommended_fillers()
-            .connect_mocked_client(Asserter::new());
+        let l2_provider =
+            ProviderBuilder::new().disable_recommended_fillers().connect_mocked_client(l2_asserter);
         let l2_auth_provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .connect_mocked_client(l2_auth_asserter);
@@ -1889,13 +1914,134 @@ mod tests {
     #[tokio::test]
     async fn preconf_submit_rejected_before_first_event_sync_gate() {
         let syncer = build_syncer().await;
-        let payload = PreconfPayload::new(sample_payload(1));
+        let payload = PreconfPayload::new(sample_payload(1), B256::ZERO);
         let err = syncer
             .submit_preconfirmation_payload_with_timeout(payload, Duration::from_millis(10))
             .await
             .expect_err("expected ingress not ready error");
 
         assert!(matches!(err, DriverError::PreconfIngressNotReady));
+    }
+
+    #[tokio::test]
+    async fn materialized_preconfirmation_requires_expected_parent() {
+        let l2_asserter = Asserter::new();
+        let client =
+            mock_client_with_all_asserters(Asserter::new(), l2_asserter.clone(), Asserter::new());
+        let mut attributes = sample_payload(2);
+        attributes.l1_origin.build_payload_args_id = [0x11; 8];
+        let origin = attributes.l1_origin.clone();
+        let expected_parent_hash = B256::from([0x22; 32]);
+        let payload = PreconfPayload::new(attributes.clone(), expected_parent_hash);
+
+        let mut block = RpcBlock::<TxEnvelope>::default();
+        block.header.parent_hash = B256::from([0x33; 32]);
+        block.header.number = 2;
+        block.header.beneficiary = attributes.payload_attributes.suggested_fee_recipient;
+        block.header.mix_hash = attributes.payload_attributes.prev_randao;
+        block.header.gas_limit = attributes.block_metadata.gas_limit;
+        block.header.timestamp = attributes.payload_attributes.timestamp;
+        block.header.extra_data = attributes.block_metadata.extra_data.clone();
+        block.header.base_fee_per_gas = Some(0);
+
+        l2_asserter.push_success(&Some(origin));
+        l2_asserter.push_success(&Some(block));
+
+        assert!(
+            !preconfirmation_payload_is_materialized(&client, &payload)
+                .await
+                .expect("materialization lookup should succeed")
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_materialized_preconfirmation_reports_stale() {
+        let l2_asserter = Asserter::new();
+        let client =
+            mock_client_with_all_asserters(Asserter::new(), l2_asserter.clone(), Asserter::new());
+        let syncer = EventSyncer { rpc: client, ..build_syncer().await };
+        syncer.preconf_ingress_ready.store(true, Ordering::Release);
+
+        let mut attributes = sample_payload(2);
+        attributes.l1_origin.build_payload_args_id = [0x44; 8];
+        let origin = attributes.l1_origin.clone();
+        let expected_parent_hash = B256::from([0x55; 32]);
+        let payload = PreconfPayload::new(attributes.clone(), expected_parent_hash);
+
+        let mut block = RpcBlock::<TxEnvelope>::default();
+        block.header.parent_hash = expected_parent_hash;
+        block.header.number = 2;
+        block.header.beneficiary = attributes.payload_attributes.suggested_fee_recipient;
+        block.header.mix_hash = attributes.payload_attributes.prev_randao;
+        block.header.gas_limit = attributes.block_metadata.gas_limit;
+        block.header.timestamp = attributes.payload_attributes.timestamp;
+        block.header.extra_data = attributes.block_metadata.extra_data.clone();
+        block.header.base_fee_per_gas = Some(0);
+
+        let mut confirmed_head = origin.clone();
+        confirmed_head.block_id = U256::from(2u64);
+        l2_asserter.push_success(&Some(origin));
+        l2_asserter.push_success(&Some(block));
+        l2_asserter.push_success(&Some(confirmed_head));
+
+        let outcome = syncer
+            .submit_preconfirmation_payload(payload)
+            .await
+            .expect("materialized payload should return a terminal outcome");
+
+        assert_eq!(outcome, PreconfSubmissionOutcome::Stale);
+    }
+
+    #[test]
+    fn stale_preconfirmation_maps_to_explicit_outcome() {
+        assert_eq!(stale_preconf_outcome(42, 42), Some(PreconfSubmissionOutcome::Stale));
+        assert_eq!(stale_preconf_outcome(43, 42), None);
+    }
+
+    #[tokio::test]
+    async fn queued_preconfirmation_reports_stale_after_confirmed_tip_advances() {
+        let l2_asserter = Asserter::new();
+        let client =
+            mock_client_with_all_asserters(Asserter::new(), l2_asserter.clone(), Asserter::new());
+        let syncer = EventSyncer { rpc: client.clone(), ..build_syncer().await };
+        let rx = syncer
+            .preconf_rx
+            .lock()
+            .expect("preconfirmation receiver mutex should not be poisoned")
+            .take()
+            .expect("preconfirmation receiver should be available");
+        let path = MockBatchPath::new([]);
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(
+            Arc::new(path.clone()),
+            Some(Arc::new(path)),
+        )));
+        syncer.spawn_preconf_ingress(
+            router,
+            rx,
+            client,
+            Arc::clone(&syncer.preconf_ingress_ready),
+            Arc::clone(&syncer.preconf_ingress_notify),
+        );
+        syncer
+            .wait_preconf_ingress_ready()
+            .await
+            .expect("preconfirmation ingress should become ready");
+
+        let mut initial_head = sample_payload(0).l1_origin;
+        initial_head.block_id = U256::ZERO;
+        let mut advanced_head = initial_head.clone();
+        advanced_head.block_id = U256::from(1u64);
+        l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        l2_asserter.push_success(&Some(initial_head));
+        l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        l2_asserter.push_success(&Some(advanced_head));
+
+        let outcome = syncer
+            .submit_preconfirmation_payload(PreconfPayload::new(sample_payload(1), B256::ZERO))
+            .await
+            .expect("stale payload should return a terminal outcome");
+
+        assert_eq!(outcome, PreconfSubmissionOutcome::Stale);
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http.rs
@@ -44,6 +44,8 @@ fn map_rest_error_status(err: &WhitelistPreconfirmationDriverError) -> StatusCod
         WhitelistPreconfirmationDriverError::Driver(driver::DriverError::EngineSyncing(_)) => {
             StatusCode::BAD_REQUEST
         }
+        // The Go preconfirmation server maps block-insertion failures to 500. Keep parent
+        // mismatches and other production-path failures in this catch-all for REST parity.
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -104,9 +104,16 @@ impl WhitelistApi for WhitelistApiService {
         // obtain the canonical block hash before gossiping.
         let driver_payload =
             self.driver_payload_from_request(&data, is_forced_inclusion, prev_randao, [0u8; 65])?;
-        self.event_syncer
-            .submit_preconfirmation_payload(PreconfPayload::new(driver_payload))
+        let submission_outcome = self
+            .event_syncer
+            .submit_preconfirmation_payload(PreconfPayload::new(driver_payload, data.parent_hash))
             .await?;
+        if matches!(submission_outcome, PreconfSubmissionOutcome::Stale) {
+            return Err(WhitelistPreconfirmationDriverError::invalid_payload(format!(
+                "preconfirmation block {} is stale",
+                data.block_number
+            )));
+        }
 
         let inserted_block = self
             .rpc

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -108,17 +108,24 @@ impl WhitelistApi for WhitelistApiService {
             .event_syncer
             .submit_preconfirmation_payload(PreconfPayload::new(driver_payload, data.parent_hash))
             .await?;
-        if matches!(submission_outcome, PreconfSubmissionOutcome::Stale) {
-            return Err(WhitelistPreconfirmationDriverError::invalid_payload(format!(
-                "preconfirmation block {} is stale",
-                data.block_number
-            )));
-        }
+        let bound_block_hash = match submission_outcome {
+            PreconfSubmissionOutcome::Inserted { block_hash } |
+            PreconfSubmissionOutcome::AlreadyMaterialized { block_hash } => block_hash,
+            PreconfSubmissionOutcome::Stale => {
+                return Err(WhitelistPreconfirmationDriverError::invalid_payload(format!(
+                    "preconfirmation block {} is stale",
+                    data.block_number
+                )));
+            }
+        };
 
+        // Resolve the block by the hash bound to the submission outcome: a same-height sibling
+        // can become canonical between submission and this read, and a height lookup would then
+        // sign a hash that does not match the request's transactions.
         let inserted_block = self
             .rpc
             .l2_provider
-            .get_block_by_number(BlockNumberOrTag::Number(data.block_number))
+            .get_block_by_hash(bound_block_hash)
             .await
             .map_err(WhitelistPreconfirmationDriverError::provider)?
             .ok_or(WhitelistPreconfirmationDriverError::MissingInsertedBlock(data.block_number))?;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -12,7 +12,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types::SyncStatus;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
 use async_trait::async_trait;
-use driver::{PreconfPayload, sync::event::EventSyncer};
+use driver::{PreconfPayload, PreconfSubmissionOutcome, sync::event::EventSyncer};
 use protocol::{shasta::calculate_shasta_mix_hash, signer::FixedKSigner};
 use rpc::{beacon::BeaconClient, client::Client};
 use tokio::sync::{Mutex, broadcast, mpsc};

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
@@ -51,6 +51,7 @@ pub struct BuildPreconfBlockResponse {
 #[serde(rename_all = "camelCase")]
 pub struct ApiStatus {
     /// Highest unsafe payload block ID tracked by this node.
+    #[serde(rename = "highestUnsafeL2PayloadBlockID")]
     pub highest_unsafe_l2_payload_block_id: u64,
     /// End-of-sequencing block hash for current epoch (zero hash when unknown).
     pub end_of_sequencing_block_hash: String,
@@ -112,11 +113,12 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(&serde_json::to_string(&status).unwrap())
                 .expect("status should serialize as JSON");
         assert_eq!(
-            json["highestUnsafeL2PayloadBlockId"]
+            json["highestUnsafeL2PayloadBlockID"]
                 .as_u64()
-                .expect("missing highest unsafe block id"),
+                .expect("missing highest unsafe block ID"),
             1
         );
+        assert!(json.get("highestUnsafeL2PayloadBlockId").is_none());
         assert!(
             json["endOfSequencingBlockHash"].as_str().expect("missing EOS hash").starts_with("0x")
         );

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -87,6 +87,17 @@ impl SharedPreconfState {
         self.recent_envelopes.lock().await.get(hash).cloned()
     }
 
+    /// Remove a recent envelope that is no longer safe to serve.
+    pub(crate) async fn remove_recent(
+        &self,
+        hash: &B256,
+    ) -> Option<Arc<WhitelistExecutionPayloadEnvelope>> {
+        let mut recent = self.recent_envelopes.lock().await;
+        let removed = recent.remove(hash);
+        WhitelistPreconfirmationDriverMetrics::set_cache_recent_count(recent.len());
+        removed
+    }
+
     /// Record a freshly observed L2 head and return it; when the head is `None` (a failed RPC
     /// read) return the most recently recorded value instead.
     ///
@@ -366,5 +377,15 @@ mod tests {
         state.record_end_of_sequencing(42, hash).await;
         assert_eq!(state.end_of_sequencing_for_epoch(42).await, Some(hash));
         assert_eq!(state.end_of_sequencing_for_epoch(43).await, None);
+    }
+
+    #[tokio::test]
+    async fn shared_state_removes_recent_envelopes() {
+        let state = SharedPreconfState::new(0);
+        let hash = B256::from([0x42u8; 32]);
+        state.insert_recent(Arc::new(sample_envelope(hash, 8))).await;
+
+        assert!(state.remove_recent(&hash).await.is_some());
+        assert!(state.get_recent(&hash).await.is_none());
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -3,7 +3,7 @@
 use std::time::Instant;
 
 use alethia_reth_primitives::payload::attributes::TaikoPayloadAttributes;
-use driver::PreconfPayload;
+use driver::{PreconfPayload, PreconfSubmissionOutcome};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -169,27 +169,46 @@ impl WhitelistPreconfirmationImporter {
             return Ok(false);
         }
 
+        let expected_parent_hash = envelope.execution_payload.parent_hash;
         let driver_payload = driver_payload_from_envelope(envelope)?;
         let submit_start = Instant::now();
         let submit_result = self
             .event_syncer
-            .submit_preconfirmation_payload(PreconfPayload::new(driver_payload))
+            .submit_preconfirmation_payload(PreconfPayload::new(
+                driver_payload,
+                expected_parent_hash,
+            ))
             .await;
         WhitelistPreconfirmationDriverMetrics::observe_driver_submit(
             if submit_result.is_ok() { "success" } else { "failure" },
             submit_start.elapsed().as_secs_f64(),
         );
-        submit_result?;
-
-        info!(
-            block_number,
-            block_hash = %block_hash,
-            parent_hash = %parent_hash,
-            end_of_sequencing,
-            "inserted whitelist preconfirmation block"
-        );
-
-        self.state.record_inserted_block(block_number);
+        match submit_result? {
+            PreconfSubmissionOutcome::Inserted => {
+                info!(
+                    block_number,
+                    block_hash = %block_hash,
+                    parent_hash = %parent_hash,
+                    end_of_sequencing,
+                    "inserted whitelist preconfirmation block"
+                );
+                self.state.record_inserted_block(block_number);
+            }
+            PreconfSubmissionOutcome::AlreadyMaterialized => {
+                debug!(
+                    block_number,
+                    block_hash = %block_hash,
+                    "cached preconfirmation already materialized"
+                );
+            }
+            PreconfSubmissionOutcome::Stale => {
+                debug!(
+                    block_number,
+                    block_hash = %block_hash,
+                    "cached preconfirmation became stale"
+                );
+            }
+        }
 
         Ok(true)
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -251,6 +251,7 @@ fn classify_cached_driver_error(err: &driver::DriverError) -> CachedImportDispos
         driver::DriverError::EngineInvalidPayload(_) => CachedImportDisposition::Drop,
         driver::DriverError::EngineSyncing(_) |
         driver::DriverError::BlockNotFound(_) |
+        driver::DriverError::PreconfParentMismatch { .. } |
         driver::DriverError::PreconfEnqueueTimeout { .. } |
         driver::DriverError::PreconfResponseTimeout { .. } => CachedImportDisposition::Defer,
         driver::DriverError::PreconfInjectionFailed { source, .. } => match source {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -184,22 +184,47 @@ impl WhitelistPreconfirmationImporter {
             submit_start.elapsed().as_secs_f64(),
         );
         match submit_result? {
-            PreconfSubmissionOutcome::Inserted => {
-                info!(
-                    block_number,
-                    block_hash = %block_hash,
-                    parent_hash = %parent_hash,
-                    end_of_sequencing,
-                    "inserted whitelist preconfirmation block"
-                );
+            PreconfSubmissionOutcome::Inserted { block_hash: inserted_block_hash } => {
+                if inserted_block_hash == block_hash {
+                    info!(
+                        block_number,
+                        block_hash = %block_hash,
+                        parent_hash = %parent_hash,
+                        end_of_sequencing,
+                        "inserted whitelist preconfirmation block"
+                    );
+                } else {
+                    // The operator-signed hash does not match the block its own payload
+                    // produces; stop re-serving the inconsistent envelope to peers. The
+                    // produced block still advanced the local unsafe head, so it is recorded.
+                    warn!(
+                        block_number,
+                        envelope_block_hash = %block_hash,
+                        inserted_block_hash = %inserted_block_hash,
+                        "operator-signed envelope hash mismatches inserted block; purging envelope"
+                    );
+                    self.state.remove_recent(&block_hash).await;
+                }
                 self.state.record_inserted_block(block_number);
             }
-            PreconfSubmissionOutcome::AlreadyMaterialized => {
-                debug!(
-                    block_number,
-                    block_hash = %block_hash,
-                    "cached preconfirmation already materialized"
-                );
+            PreconfSubmissionOutcome::AlreadyMaterialized {
+                block_hash: materialized_block_hash,
+            } => {
+                if materialized_block_hash == block_hash {
+                    debug!(
+                        block_number,
+                        block_hash = %block_hash,
+                        "cached preconfirmation already materialized"
+                    );
+                } else {
+                    warn!(
+                        block_number,
+                        envelope_block_hash = %block_hash,
+                        materialized_block_hash = %materialized_block_hash,
+                        "operator-signed envelope hash mismatches materialized block; purging envelope"
+                    );
+                    self.state.remove_recent(&block_hash).await;
+                }
             }
             PreconfSubmissionOutcome::Stale => {
                 debug!(

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -33,17 +33,35 @@ use super::{
     },
 };
 
+/// Return whether an envelope is at or below a written event-confirmed tip.
+pub(super) fn is_stale_at_confirmed_tip(block_number: u64, confirmed_tip: Option<u64>) -> bool {
+    confirmed_tip.is_some_and(|tip| block_number <= tip)
+}
+
 impl WhitelistPreconfirmationImporter {
     /// Cache a validated envelope and persist EOS epoch mapping when applicable.
     async fn ingest_validated_envelope(
         &mut self,
         envelope: Arc<WhitelistExecutionPayloadEnvelope>,
         ingress_source: &'static str,
-    ) {
+    ) -> Result<()> {
+        let confirmed_tip = self.head_l1_origin_block_id().await?;
+        if is_stale_at_confirmed_tip(envelope.execution_payload.block_number, confirmed_tip) {
+            debug!(
+                block_number = envelope.execution_payload.block_number,
+                block_hash = %envelope.execution_payload.block_hash,
+                ?confirmed_tip,
+                ingress_source,
+                "ignoring stale whitelist preconfirmation envelope"
+            );
+            return Ok(());
+        }
+
         self.cache.insert(envelope.clone());
         self.update_pending_cache_gauge();
         self.state.insert_recent(envelope.clone()).await;
         self.record_eos_epoch_if_marked(&envelope, ingress_source).await;
+        Ok(())
     }
 
     /// Record the envelope block hash for its beacon epoch when `end_of_sequencing` is set.
@@ -111,9 +129,7 @@ impl WhitelistPreconfirmationImporter {
             envelope.execution_payload.timestamp,
             envelope.header_difficulty,
         )?;
-        self.ingest_validated_envelope(Arc::new(envelope), ingress_source).await;
-
-        Ok(())
+        self.ingest_validated_envelope(Arc::new(envelope), ingress_source).await
     }
 
     /// Serve an envelope by block hash from the recent cache or local L2 state,
@@ -137,6 +153,19 @@ impl WhitelistPreconfirmationImporter {
         } else {
             return Ok(None);
         };
+
+        let confirmed_tip = self.head_l1_origin_block_id().await?;
+        if is_stale_at_confirmed_tip(envelope.execution_payload.block_number, confirmed_tip) {
+            debug!(
+                block_number = envelope.execution_payload.block_number,
+                block_hash = %hash,
+                ?confirmed_tip,
+                source,
+                "refusing to serve stale whitelist preconfirmation envelope"
+            );
+            self.state.remove_recent(&hash).await;
+            return Ok(None);
+        }
 
         self.state.insert_recent(envelope.clone()).await;
         self.publish_unsafe_response(envelope).await;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -40,12 +40,31 @@ pub(super) fn is_stale_at_confirmed_tip(block_number: u64, confirmed_tip: Option
 
 impl WhitelistPreconfirmationImporter {
     /// Cache a validated envelope and persist EOS epoch mapping when applicable.
+    ///
+    /// The admission-time staleness check is a best-effort filter: the authoritative
+    /// WLP-INV-003 boundary checks run again at cache drain, response serving, and driver
+    /// ingress. A transient confirmed-tip read failure therefore admits the envelope instead
+    /// of dropping it — gossipsub dedupe suppresses redelivery of the same message and a tip
+    /// or EOS envelope with no later child never triggers a parent request, so a dropped
+    /// envelope would be unrecoverable until L1 confirmation catches up.
     async fn ingest_validated_envelope(
         &mut self,
         envelope: Arc<WhitelistExecutionPayloadEnvelope>,
         ingress_source: &'static str,
-    ) -> Result<()> {
-        let confirmed_tip = self.head_l1_origin_block_id().await?;
+    ) {
+        let confirmed_tip = match self.head_l1_origin_block_id().await {
+            Ok(tip) => tip,
+            Err(err) => {
+                warn!(
+                    block_number = envelope.execution_payload.block_number,
+                    block_hash = %envelope.execution_payload.block_hash,
+                    ingress_source,
+                    error = %err,
+                    "confirmed-tip lookup failed at admission; admitting envelope for deferred stale checks"
+                );
+                None
+            }
+        };
         if is_stale_at_confirmed_tip(envelope.execution_payload.block_number, confirmed_tip) {
             debug!(
                 block_number = envelope.execution_payload.block_number,
@@ -54,14 +73,13 @@ impl WhitelistPreconfirmationImporter {
                 ingress_source,
                 "ignoring stale whitelist preconfirmation envelope"
             );
-            return Ok(());
+            return;
         }
 
         self.cache.insert(envelope.clone());
         self.update_pending_cache_gauge();
         self.state.insert_recent(envelope.clone()).await;
         self.record_eos_epoch_if_marked(&envelope, ingress_source).await;
-        Ok(())
     }
 
     /// Record the envelope block hash for its beacon epoch when `end_of_sequencing` is set.
@@ -129,7 +147,8 @@ impl WhitelistPreconfirmationImporter {
             envelope.execution_payload.timestamp,
             envelope.header_difficulty,
         )?;
-        self.ingest_validated_envelope(Arc::new(envelope), ingress_source).await
+        self.ingest_validated_envelope(Arc::new(envelope), ingress_source).await;
+        Ok(())
     }
 
     /// Serve an envelope by block hash from the recent cache or local L2 state,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -142,6 +142,17 @@ fn defers_cached_import_errors_for_engine_syncing_driver_error() {
 }
 
 #[test]
+fn defers_cached_import_errors_for_parent_mismatch() {
+    let err =
+        WhitelistPreconfirmationDriverError::Driver(driver::DriverError::PreconfParentMismatch {
+            block_number: 42,
+            expected: B256::from([0x11; 32]),
+            actual: B256::from([0x22; 32]),
+        });
+    assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Defer);
+}
+
+#[test]
 fn drops_cached_import_errors_for_invalid_block_driver_error() {
     let err =
         WhitelistPreconfirmationDriverError::Driver(driver::DriverError::PreconfInjectionFailed {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -16,6 +16,7 @@ use crate::{
 
 use super::{
     cache_import::{CachedImportDisposition, classify_cached_import_error},
+    ingress::is_stale_at_confirmed_tip,
     should_enable_preconf_imports,
     validation::{normalize_unsafe_payload_envelope, validate_execution_payload_for_preconf},
 };
@@ -23,6 +24,14 @@ use super::{
 const TEST_CHAIN_ID: u64 = 167;
 const NON_GOLDEN_SIGNER_PRIVATE_KEY: &str =
     "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+#[test]
+fn stale_envelope_requires_written_confirmed_tip() {
+    assert!(!is_stale_at_confirmed_tip(1, None));
+    assert!(is_stale_at_confirmed_tip(7, Some(7)));
+    assert!(is_stale_at_confirmed_tip(6, Some(7)));
+    assert!(!is_stale_at_confirmed_tip(8, Some(7)));
+}
 
 fn sample_execution_payload_with_transactions(
     transactions: Vec<Bytes>,

--- a/packages/taiko-client-rs/docs/agents/event-scan-reorg-and-preconf-flow.md
+++ b/packages/taiko-client-rs/docs/agents/event-scan-reorg-and-preconf-flow.md
@@ -69,7 +69,7 @@ Primary Rust behavior anchors:
   - Stale check is applied before enqueue and again during ingress processing.
 - `crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs`
   - Whitelist importer cached payloads at or below confirmed boundary are dropped.
-- `crates/whitelist-preconfirmation-driver/src/importer/response.rs`
+- `crates/whitelist-preconfirmation-driver/src/importer/ingress.rs`
   - Whitelist importer unsafe-response serving excludes blocks at or below confirmed boundary.
 
 Required interpretation:
@@ -108,7 +108,7 @@ Primary Rust behavior anchors:
 - `crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs`
   - Detects parent mismatches and requests missing parent/ancestor payloads.
   - Imports only contiguous parent-valid payload chains.
-- `crates/whitelist-preconfirmation-driver/src/importer/response.rs`
+- `crates/whitelist-preconfirmation-driver/src/importer/ingress.rs`
   - Publishes unsafe block requests/responses used for ancestry recovery.
 - `crates/driver/src/sync/event.rs`
   - Final preconf submission passes through strict ingress/stale gating.


### PR DESCRIPTION
## Summary

- bind every queued preconfirmation to the authenticated parent hash and reject canonical-parent changes before engine injection
- return explicit `Inserted`, `AlreadyMaterialized`, and `Stale` outcomes so stale races cannot advance local status or be logged as successful inserts
- defer cached parent-mismatch races into normal ancestry recovery instead of aborting the drain pass as a fatal error
- reject stale envelopes before cache/recent/EOS admission, and evict stale recent envelopes before serving P2P responses
- restore the Go-compatible `/status` key `highestUnsafeL2PayloadBlockID`

## Root cause

Preconfirmation validation and engine injection were separated by asynchronous queueing without carrying the validated parent identity into the production path. At the same time, stale submissions returned undifferentiated success, so callers could mutate local tracking after event sync had already confirmed the same block height. Incoming P2P envelopes also entered caches before consulting the confirmed tip, and the status field relied on generic camel-case serialization that emitted `Id` instead of Go's `ID`.

## Safety and compatibility

- strengthens WLP-INV-003 and WLP-INV-004 by enforcing `block_number <= head_l1_origin` at ingress, queue processing, cache admission, and response serving
- strengthens WLP-INV-009 by checking the authenticated parent again inside the serialized production path
- preserves WLP-INV-002 readiness gating
- restores WLP-INV-010 JSON compatibility
- preserves Go REST compatibility: block-insertion failures remain HTTP 500 with a JSON `error` body; Catalyst retries all non-success responses through the same path
- does not change gossipsub topics, SSZ encoding, message IDs, signature validation, or discovery behavior, so the driver remains compatible with the Go `taiko-client` preconfirmation network

## Verification

- `just fmt`
- `just clippy-fix` (workspace clippy with `-D warnings` passed)
- `just test` (299 passed, 0 skipped)

The Foundry deployment phase still emits its existing source-definition parsing warnings; deployment and the complete test run exit successfully.
