### PR TITLE
ci(taiko-client-rs): enable signer recovery for net builds

### DIFF
--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -103,6 +103,12 @@ jobs:
         working-directory: packages/taiko-client-rs
         run: just fmt-check
 
+      - name: Check protocol feature isolation
+        working-directory: packages/taiko-client-rs
+        run: |
+          cargo check -p protocol --no-default-features --locked
+          cargo check -p protocol --locked
+
       - name: Check clippy
         working-directory: packages/taiko-client-rs
         run: just clippy

--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -103,12 +103,6 @@ jobs:
         working-directory: packages/taiko-client-rs
         run: just fmt-check
 
-      - name: Check protocol feature isolation
-        working-directory: packages/taiko-client-rs
-        run: |
-          cargo check -p protocol --no-default-features --locked
-          cargo check -p protocol --locked
-
       - name: Check clippy
         working-directory: packages/taiko-client-rs
         run: just clippy
@@ -241,6 +235,10 @@ jobs:
         uses: extractions/setup-just@v3
         with:
           just-version: 1.5.0
+
+      - name: Check protocol feature isolation
+        working-directory: packages/taiko-client-rs
+        run: just check-features
 
       - uses: taiki-e/install-action@nextest
 

--- a/packages/taiko-client-rs/crates/protocol/Cargo.toml
+++ b/packages/taiko-client-rs/crates/protocol/Cargo.toml
@@ -10,6 +10,7 @@ default = ["net"]
 net = [
     "alloy/default",
     "alloy/signers",
+    "alloy-consensus/k256",
     "bindings",
     "tokio",
     "tokio-stream",

--- a/packages/taiko-client-rs/justfile
+++ b/packages/taiko-client-rs/justfile
@@ -14,6 +14,10 @@ fmt-check:
   rustup toolchain install {{toolchain}} && \
   cargo +{{toolchain}} fmt --check
 
+check-features:
+  cargo check -p protocol --no-default-features --locked && \
+  cargo check -p protocol --locked
+
 clippy:
   cargo clippy --workspace --all-features --no-deps --exclude bindings --exclude test-harness -- -D warnings -D missing_docs -D clippy::missing_docs_in_private_items
 


### PR DESCRIPTION
## Why

- Standalone `protocol` builds with the default `net` feature fail because anchor validation calls `TxEnvelope::recover_signer()` without enabling Alloy's signer-recovery implementation.
- Workspace-wide feature unification can mask this failure, so downstream consumers such as raiko2 discover it only after updating their dependency pin.

## How

- Enable `alloy-consensus/k256` only through the `net` feature, preserving the no-default-features path used by zkVM guests.
- Check both default and no-default-features `protocol` builds independently in CI.

## Tests

- `cargo check -p protocol --no-default-features --locked` — passed
- `cargo check -p protocol --locked` — passed
- `just fmt-check` — passed
- `just clippy` — passed
- `just test` — 291 passed, 0 skipped

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
