### PR TITLE
feat(taiko-client): add ZK-only proof mode for provers without a TEE leg

### DIFF
--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -94,7 +94,9 @@ var (
 	ZkOnlyProofs = &cli.BoolFlag{
 		Name: "prover.zkOnlyProofs",
 		Usage: "Prove every proposal with both RISC0 and SP1 proofs and submit the [RISC0, SP1] sub-proof pair, " +
-			"instead of pairing a single ZK proof with an SGX_GETH proof. Requires --raiko.host.zkvm. " +
+			"instead of pairing a single ZK proof with an SGX_GETH proof. Requires --raiko.host.zkvm, and the " +
+			"inbox's proof verifier must accept the [RISC0, SP1] pair — i.e. ZkRequiredVerifier, live with the " +
+			"Unzen hardfork; on the pre-Unzen MainnetVerifier every submission reverts. " +
 			"Intended for provers running without a TEE (sgx-geth) service or during SGX outages; " +
 			"note that it generates proofs on both ZKVMs for every proposal. " +
 			"When set, --prover.forceSP1Proof and --prover.maxRisc0ProofProposalDistance are ignored. " +

--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -17,9 +17,9 @@ var (
 		EnvVars:  []string{"L1_PROVER_PRIV_KEY"},
 	}
 	RaikoHostEndpoint = &cli.StringFlag{
-		Name:     "raiko.host",
-		Usage:    "RPC endpoint of a Raiko host service for post Shasta fork",
-		Required: true,
+		Name: "raiko.host",
+		Usage: "RPC endpoint of a Raiko host service for post Shasta fork " +
+			"(required unless --prover.zkOnlyProofs is set)",
 		Category: proverCategory,
 		EnvVars:  []string{"RAIKO_HOST"},
 	}

--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -86,10 +86,22 @@ var (
 		Name: "prover.forceSP1Proof",
 		Usage: "Always request SP1 proofs from the ZKVM proof producer instead of trying RISC0 first. " +
 			"If no ZKVM proof producer is configured, the prover keeps using the base proof producer. " +
-			"Post Shasta fork only.",
+			"Ignored when --prover.zkOnlyProofs is set. Post Shasta fork only.",
 		Value:    false,
 		Category: proverCategory,
 		EnvVars:  []string{"PROVER_FORCE_SP1_PROOF"},
+	}
+	ZkOnlyProofs = &cli.BoolFlag{
+		Name: "prover.zkOnlyProofs",
+		Usage: "Prove every proposal with both RISC0 and SP1 proofs and submit the [RISC0, SP1] sub-proof pair, " +
+			"instead of pairing a single ZK proof with an SGX_GETH proof. Requires --raiko.host.zkvm. " +
+			"Intended for provers running without a TEE (sgx-geth) service or during SGX outages; " +
+			"note that it generates proofs on both ZKVMs for every proposal. " +
+			"When set, --prover.forceSP1Proof and --prover.maxRisc0ProofProposalDistance are ignored. " +
+			"Post Shasta fork only.",
+		Value:    false,
+		Category: proverCategory,
+		EnvVars:  []string{"PROVER_ZK_ONLY_PROOFS"},
 	}
 	// Special flags for testing.
 	Dummy = &cli.BoolFlag{
@@ -171,4 +183,5 @@ var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	ProposalWindowSize,
 	MaxRisc0ProofProposalDistance,
 	ForceSP1Proof,
+	ZkOnlyProofs,
 }, opsigner.CLIFlags("PROVER", proverCategory), TxmgrFlags)

--- a/packages/taiko-client/cmd/flags/prover_test.go
+++ b/packages/taiko-client/cmd/flags/prover_test.go
@@ -1,0 +1,41 @@
+package flags
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestProverFlagsAllowZkOnlyModeWithoutRaikoHost(t *testing.T) {
+	oldRaikoHost, hadRaikoHost := os.LookupEnv("RAIKO_HOST")
+	require.NoError(t, os.Unsetenv("RAIKO_HOST"))
+	t.Cleanup(func() {
+		if hadRaikoHost {
+			require.NoError(t, os.Setenv("RAIKO_HOST", oldRaikoHost))
+		}
+	})
+
+	app := cli.NewApp()
+	app.Flags = ProverFlags
+	actionCalled := false
+	app.Action = func(*cli.Context) error {
+		actionCalled = true
+		return nil
+	}
+
+	err := app.Run([]string{
+		"prover",
+		"--" + InboxAddress.Name, "0x0000000000000000000000000000000000000001",
+		"--" + TaikoAnchorAddress.Name, "0x0000000000000000000000000000000000000002",
+		"--" + L2AuthEndpoint.Name, "http://localhost:8551",
+		"--" + JWTSecret.Name, "jwt-secret.txt",
+		"--" + L1ProverPrivKey.Name, "0x01",
+		"--" + ZkOnlyProofs.Name,
+		"--" + RaikoZKVMHostEndpoint.Name, "http://raiko.zkvm",
+	})
+
+	require.NoError(t, err)
+	require.True(t, actionCalled)
+}

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	ProposalWindowSize            uint64
 	MaxRisc0ProofProposalDistance uint64
 	ForceSP1Proof                 bool
+	ZkOnlyProofs                  bool
 }
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
@@ -84,6 +85,16 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid ApiKey secret file: %w", err)
 		}
+	}
+
+	// The ZK-only mode generates both ZK proofs from the ZKVM raiko host, so it cannot
+	// run without one configured.
+	if c.Bool(flags.ZkOnlyProofs.Name) && len(c.String(flags.RaikoZKVMHostEndpoint.Name)) == 0 {
+		return nil, fmt.Errorf(
+			"--%s requires --%s to be set",
+			flags.ZkOnlyProofs.Name,
+			flags.RaikoZKVMHostEndpoint.Name,
+		)
 	}
 
 	var localProposerAddresses []common.Address
@@ -120,6 +131,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			flags.MaxRisc0ProofProposalDistance.Name,
 		),
 		ForceSP1Proof:          c.Bool(flags.ForceSP1Proof.Name),
+		ZkOnlyProofs:           c.Bool(flags.ZkOnlyProofs.Name),
 		RPCTimeout:             c.Duration(flags.RPCTimeout.Name),
 		ProveBatchesGasLimit:   c.Uint64(flags.TxGasLimit.Name),
 		LocalProposerAddresses: localProposerAddresses,

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -88,12 +88,21 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	}
 
 	// The ZK-only mode generates both ZK proofs from the ZKVM raiko host, so it cannot
-	// run without one configured.
-	if c.Bool(flags.ZkOnlyProofs.Name) && len(c.String(flags.RaikoZKVMHostEndpoint.Name)) == 0 {
+	// run without one configured. Other modes still need the base raiko host for the
+	// SGX_GETH companion proof.
+	zkOnlyProofs := c.Bool(flags.ZkOnlyProofs.Name)
+	if zkOnlyProofs && len(c.String(flags.RaikoZKVMHostEndpoint.Name)) == 0 {
 		return nil, fmt.Errorf(
 			"--%s requires --%s to be set",
 			flags.ZkOnlyProofs.Name,
 			flags.RaikoZKVMHostEndpoint.Name,
+		)
+	}
+	if !zkOnlyProofs && len(c.String(flags.RaikoHostEndpoint.Name)) == 0 {
+		return nil, fmt.Errorf(
+			"--%s is required unless --%s is set",
+			flags.RaikoHostEndpoint.Name,
+			flags.ZkOnlyProofs.Name,
 		)
 	}
 
@@ -131,7 +140,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			flags.MaxRisc0ProofProposalDistance.Name,
 		),
 		ForceSP1Proof:          c.Bool(flags.ForceSP1Proof.Name),
-		ZkOnlyProofs:           c.Bool(flags.ZkOnlyProofs.Name),
+		ZkOnlyProofs:           zkOnlyProofs,
 		RPCTimeout:             c.Duration(flags.RPCTimeout.Name),
 		ProveBatchesGasLimit:   c.Uint64(flags.TxGasLimit.Name),
 		LocalProposerAddresses: localProposerAddresses,

--- a/packages/taiko-client/prover/config_test.go
+++ b/packages/taiko-client/prover/config_test.go
@@ -104,6 +104,30 @@ func TestNewConfigFromCliContextForceSP1Proof(t *testing.T) {
 	})
 }
 
+func TestNewConfigFromCliContextZkOnlyProofs(t *testing.T) {
+	t.Run("uses default value", func(t *testing.T) {
+		cfg := newTestConfigFromCLI(t)
+
+		require.False(t, cfg.ZkOnlyProofs)
+	})
+
+	t.Run("requires the ZKVM raiko host", func(t *testing.T) {
+		err := runTestConfigFromCLI(t, "--"+flags.ZkOnlyProofs.Name)
+
+		require.ErrorContains(t, err, "--"+flags.RaikoZKVMHostEndpoint.Name)
+	})
+
+	t.Run("uses flag value with the ZKVM raiko host", func(t *testing.T) {
+		cfg := newTestConfigFromCLI(
+			t,
+			"--"+flags.ZkOnlyProofs.Name,
+			"--"+flags.RaikoZKVMHostEndpoint.Name, "http://raiko.zkvm",
+		)
+
+		require.True(t, cfg.ZkOnlyProofs)
+	})
+}
+
 func (s *ProverTestSuite) TestNewConfigFromCliContextProverKeyError() {
 	app := s.SetupApp()
 
@@ -178,6 +202,8 @@ func runTestConfigFromCLIWithConfig(t *testing.T, cfg **Config, extraArgs ...str
 			Value:   flags.MaxRisc0ProofProposalDistance.Value,
 		},
 		&cli.BoolFlag{Name: flags.ForceSP1Proof.Name},
+		&cli.BoolFlag{Name: flags.ZkOnlyProofs.Name},
+		&cli.StringFlag{Name: flags.RaikoZKVMHostEndpoint.Name},
 	}
 
 	app.Action = func(ctx *cli.Context) error {

--- a/packages/taiko-client/prover/config_test.go
+++ b/packages/taiko-client/prover/config_test.go
@@ -120,12 +120,20 @@ func TestNewConfigFromCliContextZkOnlyProofs(t *testing.T) {
 	t.Run("uses flag value with the ZKVM raiko host", func(t *testing.T) {
 		cfg := newTestConfigFromCLI(
 			t,
+			"--"+flags.RaikoHostEndpoint.Name, "",
 			"--"+flags.ZkOnlyProofs.Name,
 			"--"+flags.RaikoZKVMHostEndpoint.Name, "http://raiko.zkvm",
 		)
 
 		require.True(t, cfg.ZkOnlyProofs)
+		require.Empty(t, cfg.RaikoHostEndpoint)
 	})
+}
+
+func TestNewConfigFromCliContextRequiresRaikoHostOutsideZkOnlyMode(t *testing.T) {
+	err := runTestConfigFromCLI(t, "--"+flags.RaikoHostEndpoint.Name, "")
+
+	require.ErrorContains(t, err, "--"+flags.RaikoHostEndpoint.Name)
 }
 
 func (s *ProverTestSuite) TestNewConfigFromCliContextProverKeyError() {
@@ -203,6 +211,7 @@ func runTestConfigFromCLIWithConfig(t *testing.T, cfg **Config, extraArgs ...str
 		},
 		&cli.BoolFlag{Name: flags.ForceSP1Proof.Name},
 		&cli.BoolFlag{Name: flags.ZkOnlyProofs.Name},
+		&cli.StringFlag{Name: flags.RaikoHostEndpoint.Name},
 		&cli.StringFlag{Name: flags.RaikoZKVMHostEndpoint.Name},
 	}
 
@@ -220,6 +229,7 @@ func runTestConfigFromCLIWithConfig(t *testing.T, cfg **Config, extraArgs ...str
 		"--" + flags.TaikoAnchorAddress.Name, common.HexToAddress("0x00000000000000000000000000000000000000bb").Hex(),
 		"--" + flags.L1ProverPrivKey.Name, encoding.GoldenTouchPrivKey,
 		"--" + flags.JWTSecret.Name, jwtSecret,
+		"--" + flags.RaikoHostEndpoint.Name, "http://raiko.host",
 	}
 	args = append(args, extraArgs...)
 

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -34,6 +34,24 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 		err error
 	)
 
+	// A ZK-only prover can only finalize against a proof verifier that accepts the
+	// [RISC0, SP1] sub-proof pair (ZkRequiredVerifier, live with the Unzen hardfork).
+	// That is not checkable on-chain (areVerifiersSufficient is internal), so surface the
+	// configured verifier loudly for the operator to check: on the pre-Unzen
+	// MainnetVerifier every ZK-only submission reverts with CV_VERIFIERS_INSUFFICIENT.
+	if p.cfg.ZkOnlyProofs {
+		if inboxConfig, err := p.rpc.ShastaClients.Inbox.GetConfig(&bind.CallOpts{Context: ctx}); err != nil {
+			log.Warn("ZK-only proof mode is enabled, but fetching the inbox's proof verifier failed", "error", err)
+		} else {
+			log.Warn(
+				"ZK-only proof mode is enabled: the inbox's proof verifier must accept the [RISC0, SP1] "+
+					"sub-proof pair (ZkRequiredVerifier, live with the Unzen hardfork), "+
+					"otherwise every proof submission will revert",
+				"proofVerifier", inboxConfig.ProofVerifier,
+			)
+		}
+	}
+
 	sgxGethProducer := &producer.SgxGethProofProducer{
 		RaikoHostEndpoint:   p.cfg.RaikoHostEndpoint,
 		VerifierID:          sgxGethVerifierID,

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -70,6 +70,7 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 			ApiKey:              p.cfg.RaikoApiKey,
 			RaikoRequestTimeout: p.cfg.RaikoRequestTimeout,
 			ProofType:           producer.ProofTypeZKR0,
+			ZkOnly:              p.cfg.ZkOnlyProofs,
 			Dummy:               p.cfg.Dummy,
 		}
 	}
@@ -117,6 +118,7 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 		new(big.Int).SetUint64(p.cfg.ProposalWindowSize),
 		new(big.Int).SetUint64(p.cfg.MaxRisc0ProofProposalDistance),
 		p.cfg.ForceSP1Proof,
+		p.cfg.ZkOnlyProofs,
 	); err != nil {
 		return fmt.Errorf("failed to initialize proof submitter: %w", err)
 	}

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
@@ -415,9 +415,15 @@ func validateRaikoProofResponse(
 			err,
 		)
 	}
+	if output.ProofType != proofType {
+		return nil, fmt.Errorf(
+			"unexpected proof type from raiko: requested %s, got %s",
+			proofType,
+			output.ProofType,
+		)
+	}
 
 	if !alreadyGenerated {
-		proofType = output.ProofType
 		log.Info(
 			"Batch proof generated",
 			"isAggregation", isAggregation,

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer.go
@@ -48,7 +48,11 @@ type ComposeProofProducer struct {
 	ApiKey              string // ApiKey provided by Raiko
 	SgxGethProducer     *SgxGethProofProducer
 	ProofType           ProofType
-	Dummy               bool
+	// ZkOnly pairs the primary SP1 proof with a RISC0 companion proof instead of an
+	// SGX_GETH proof, producing the [RISC0_RETH, SP1_RETH] combination that
+	// ZkRequiredVerifier accepts without any TEE leg.
+	ZkOnly bool
+	Dummy  bool
 	DummyProofProducer
 }
 
@@ -61,7 +65,11 @@ func (s *ComposeProofProducer) RequestProof(
 	requestAt time.Time,
 ) (*ProofResponse, error) {
 	requestProofType := s.ProofType
-	if opts.ProposalOptions().ProofType != "" {
+	if s.ZkOnly {
+		// In ZK-only mode SP1 is always the primary proof lane, and the RISC0 proof is
+		// requested as the companion leg alongside it.
+		requestProofType = ProofTypeZKSP1
+	} else if opts.ProposalOptions().ProofType != "" {
 		requestProofType = opts.ProposalOptions().ProofType
 	}
 
@@ -114,6 +122,9 @@ func (s *ComposeProofProducer) RequestProof(
 	})
 
 	g.Go(func() error {
+		if s.ZkOnly {
+			return s.requestRisc0CompanionProof(ctx, opts, meta, requestAt)
+		}
 		if _, err := s.SgxGethProducer.RequestProof(ctx, opts, proposalID, meta, requestAt); err != nil {
 			return err
 		} else {
@@ -164,27 +175,42 @@ func (s *ComposeProofProducer) Aggregate(
 		"time", time.Since(requestAt),
 	)
 	var (
-		sgxGethBatchProofs *BatchProofs
-		batchProofs        []byte
-		batchIDs           = make([]*big.Int, 0, len(items))
-		opts               = make([]ProofRequestOptions, 0, len(items))
-		metas              = make([]metadata.TaikoProposalMetaData, 0, len(items))
-		g                  = new(errgroup.Group)
-		err                error
+		companionBatchProof []byte
+		companionVerifierID uint8
+		batchProofs         []byte
+		batchIDs            = make([]*big.Int, 0, len(items))
+		opts                = make([]ProofRequestOptions, 0, len(items))
+		metas               = make([]metadata.TaikoProposalMetaData, 0, len(items))
+		g                   = new(errgroup.Group)
 	)
+	if s.ZkOnly {
+		if companionVerifierID, exist = s.VerifierIDs[ProofTypeZKR0]; !exist {
+			return nil, fmt.Errorf("no verifier ID for the %s companion proof", ProofTypeZKR0)
+		}
+	}
 	for _, item := range items {
 		opts = append(opts, item.Opts)
 		metas = append(metas, item.Meta)
 		batchIDs = append(batchIDs, item.Meta.GetProposalID())
 	}
 	g.Go(func() error {
-		if sgxGethBatchProofs, err = s.SgxGethProducer.Aggregate(ctx, items, requestAt); err != nil {
-			return err
-		} else {
-			// Note: we mark `GethProofAggregationGenerated` in the first item with true.
-			items[0].Opts.ProposalOptions().GethProofAggregationGenerated = true
+		if s.ZkOnly {
+			proof, err := s.aggregateRisc0CompanionProofs(ctx, opts, metas, items, requestAt)
+			if err != nil {
+				return err
+			}
+			companionBatchProof = proof
 			return nil
 		}
+		sgxGethBatchProofs, err := s.SgxGethProducer.Aggregate(ctx, items, requestAt)
+		if err != nil {
+			return err
+		}
+		// Note: we mark `GethProofAggregationGenerated` in the first item with true.
+		items[0].Opts.ProposalOptions().GethProofAggregationGenerated = true
+		companionBatchProof = sgxGethBatchProofs.BatchProof
+		companionVerifierID = sgxGethBatchProofs.VerifierID
+		return nil
 	})
 	g.Go(func() error {
 		if s.Dummy {
@@ -214,16 +240,73 @@ func (s *ComposeProofProducer) Aggregate(
 	}
 
 	return &BatchProofs{
-		ProofResponses:       items,
-		BatchProof:           batchProofs,
-		BatchIDs:             batchIDs,
-		ProofType:            proofType,
-		Verifier:             verifier,
-		VerifierID:           verifierID,
-		SgxGethBatchProof:    sgxGethBatchProofs.BatchProof,
-		SgxGethProofVerifier: sgxGethBatchProofs.Verifier,
-		SgxGethVerifierID:    sgxGethBatchProofs.VerifierID,
+		ProofResponses:      items,
+		BatchProof:          batchProofs,
+		BatchIDs:            batchIDs,
+		ProofType:           proofType,
+		Verifier:            verifier,
+		VerifierID:          verifierID,
+		CompanionBatchProof: companionBatchProof,
+		CompanionVerifierID: companionVerifierID,
 	}, nil
+}
+
+// requestRisc0CompanionProof requests the RISC0 companion proof for the given proposal in
+// ZK-only mode, taking the place of the SGX_GETH leg. Like that leg, only the generation
+// status matters here: the proof bytes submitted on-chain come from the aggregation.
+func (s *ComposeProofProducer) requestRisc0CompanionProof(
+	ctx context.Context,
+	opts ProofRequestOptions,
+	meta metadata.TaikoProposalMetaData,
+	requestAt time.Time,
+) error {
+	if s.Dummy {
+		return nil
+	}
+	if _, err := s.requestBatchProof(
+		ctx,
+		[]ProofRequestOptions{opts},
+		[]metadata.TaikoProposalMetaData{meta},
+		false,
+		ProofTypeZKR0,
+		requestAt,
+		opts.ProposalOptions().Risc0CompanionProofGenerated,
+	); err != nil {
+		return err
+	}
+	// Note: we mark `Risc0CompanionProofGenerated` with true to record if it is the first time generated.
+	opts.ProposalOptions().Risc0CompanionProofGenerated = true
+	return nil
+}
+
+// aggregateRisc0CompanionProofs aggregates the RISC0 companion proofs of the given items in
+// ZK-only mode, taking the place of the SGX_GETH aggregation leg.
+func (s *ComposeProofProducer) aggregateRisc0CompanionProofs(
+	ctx context.Context,
+	opts []ProofRequestOptions,
+	metas []metadata.TaikoProposalMetaData,
+	items []*ProofResponse,
+	requestAt time.Time,
+) ([]byte, error) {
+	if s.Dummy {
+		resp, _ := s.DummyProofProducer.RequestBatchProofs(items, ProofTypeZKR0)
+		return resp.BatchProof, nil
+	}
+	resp, err := s.requestBatchProof(
+		ctx,
+		opts,
+		metas,
+		true,
+		ProofTypeZKR0,
+		requestAt,
+		items[0].Opts.ProposalOptions().Risc0CompanionProofAggregationGenerated,
+	)
+	if err != nil {
+		return nil, err
+	}
+	// Note: we mark `Risc0CompanionProofAggregationGenerated` in the first item with true.
+	items[0].Opts.ProposalOptions().Risc0CompanionProofAggregationGenerated = true
+	return common.Hex2Bytes(resp.Data.Proof[2:]), nil
 }
 
 // requestBatchProof poll the proof aggregation service to get the aggregated proof.

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer_test.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer_test.go
@@ -167,9 +167,10 @@ func TestComposeProducerZkOnlyAggregateRequiresRisc0VerifierID(t *testing.T) {
 // raikoRequestRecorder records the proof requests a test raiko server receives and answers
 // each with the given per-proof-type proof hex string.
 type raikoRequestRecorder struct {
-	mu       sync.Mutex
-	requests []RaikoRequestProofBodyV4
-	proofs   map[ProofType]string
+	mu                sync.Mutex
+	requests          []RaikoRequestProofBodyV4
+	proofs            map[ProofType]string
+	responseProofType ProofType
 }
 
 func (r *raikoRequestRecorder) handler() http.HandlerFunc {
@@ -188,8 +189,12 @@ func (r *raikoRequestRecorder) handler() http.HandlerFunc {
 		r.requests = append(r.requests, body)
 		r.mu.Unlock()
 
+		responseProofType := body.ProofType
+		if r.responseProofType != "" {
+			responseProofType = r.responseProofType
+		}
 		_ = json.NewEncoder(w).Encode(&RaikoRequestProofBodyResponse{
-			ProofType: body.ProofType,
+			ProofType: responseProofType,
 			Data:      &RaikoProofData{Proof: r.proofs[body.ProofType]},
 		})
 	}
@@ -297,4 +302,80 @@ func TestComposeProducerZkOnlyAggregateRequestsBothZkAggregations(t *testing.T) 
 	require.True(t, opts.RethProofAggregationGenerated)
 	require.True(t, opts.Risc0CompanionProofAggregationGenerated)
 	require.False(t, opts.GethProofAggregationGenerated)
+}
+
+func TestComposeProducerZkOnlyRequestProofRejectsMismatchedCompanionType(t *testing.T) {
+	recorder := &raikoRequestRecorder{
+		proofs: map[ProofType]string{
+			ProofTypeZKSP1: "",
+			ProofTypeZKR0:  "0xff01",
+		},
+		responseProofType: ProofTypeZKSP1,
+	}
+	server := httptest.NewServer(recorder.handler())
+	defer server.Close()
+
+	producer := &ComposeProofProducer{
+		VerifierIDs: map[ProofType]uint8{
+			ProofTypeZKR0:  5,
+			ProofTypeZKSP1: 6,
+		},
+		ZkOnly:              true,
+		RaikoHostEndpoint:   server.URL,
+		RaikoRequestTimeout: time.Second,
+	}
+	opts := &ProposalProofRequestOptions{L2BlockNums: []*big.Int{common.Big1}}
+
+	_, err := producer.RequestProof(
+		context.Background(),
+		opts,
+		common.Big1,
+		metadata.NewTaikoProposalMetadataShasta(&shastaBindings.ShastaInboxClientProposed{Id: common.Big1}, 0),
+		time.Now(),
+	)
+
+	require.ErrorContains(t, err, "requested risc0, got sp1")
+	require.False(t, opts.Risc0CompanionProofGenerated)
+}
+
+func TestComposeProducerZkOnlyAggregateRejectsMismatchedCompanionType(t *testing.T) {
+	recorder := &raikoRequestRecorder{
+		proofs: map[ProofType]string{
+			ProofTypeZKSP1: "0xaaaa",
+			ProofTypeZKR0:  "0xbbbb",
+		},
+		responseProofType: ProofTypeZKSP1,
+	}
+	server := httptest.NewServer(recorder.handler())
+	defer server.Close()
+
+	producer := &ComposeProofProducer{
+		VerifierIDs: map[ProofType]uint8{
+			ProofTypeZKR0:  5,
+			ProofTypeZKSP1: 6,
+		},
+		ZkOnly:              true,
+		RaikoHostEndpoint:   server.URL,
+		RaikoRequestTimeout: time.Second,
+	}
+	opts := &ProposalProofRequestOptions{L2BlockNums: []*big.Int{common.Big1}}
+
+	_, err := producer.Aggregate(
+		context.Background(),
+		[]*ProofResponse{
+			{
+				BatchID:   common.Big1,
+				ProofType: ProofTypeZKSP1,
+				Meta: metadata.NewTaikoProposalMetadataShasta(
+					&shastaBindings.ShastaInboxClientProposed{Id: common.Big1},
+					0,
+				),
+				Opts: opts,
+			},
+		},
+		time.Now(),
+	)
+
+	require.ErrorContains(t, err, "requested risc0, got sp1")
+	require.False(t, opts.Risc0CompanionProofAggregationGenerated)
 }

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer_test.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer_test.go
@@ -2,6 +2,11 @@ package producer
 
 import (
 	"context"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -63,4 +68,233 @@ func TestComposeProducerAggregateUsesItemProofType(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, ProofTypeZKSP1, result.ProofType)
+}
+
+// TestComposeProducerZkOnlyRequestProofDummy ensures the ZK-only path never touches the
+// SGX_GETH leg (a nil SgxGethProducer would panic otherwise) and pins the primary proof
+// type to SP1.
+func TestComposeProducerZkOnlyRequestProofDummy(t *testing.T) {
+	var (
+		producer = &ComposeProofProducer{
+			ZkOnly:             true,
+			Dummy:              true,
+			DummyProofProducer: DummyProofProducer{},
+			ProofType:          ProofTypeZKR0,
+		}
+		blockID = common.Big32
+		opts    = &ProposalProofRequestOptions{}
+	)
+	res, err := producer.RequestProof(
+		context.Background(),
+		opts,
+		blockID,
+		metadata.NewTaikoProposalMetadataShasta(&shastaBindings.ShastaInboxClientProposed{Id: blockID}, 0),
+		time.Now(),
+	)
+	require.Nil(t, err)
+
+	require.Equal(t, res.BatchID, blockID)
+	require.Equal(t, ProofTypeZKSP1, res.ProofType)
+	require.NotEmpty(t, res.Proof)
+}
+
+// TestComposeProducerZkOnlyAggregateDummy ensures the ZK-only aggregation pairs the primary
+// proof with a RISC0 companion proof instead of an SGX_GETH one.
+func TestComposeProducerZkOnlyAggregateDummy(t *testing.T) {
+	producer := &ComposeProofProducer{
+		VerifierIDs: map[ProofType]uint8{
+			ProofTypeZKR0:  5,
+			ProofTypeZKSP1: 6,
+		},
+		ZkOnly:             true,
+		Dummy:              true,
+		DummyProofProducer: DummyProofProducer{},
+	}
+
+	result, err := producer.Aggregate(
+		context.Background(),
+		[]*ProofResponse{
+			{
+				BatchID:   common.Big1,
+				ProofType: ProofTypeZKSP1,
+				Meta: metadata.NewTaikoProposalMetadataShasta(
+					&shastaBindings.ShastaInboxClientProposed{Id: common.Big1},
+					0,
+				),
+				Opts: &ProposalProofRequestOptions{},
+			},
+		},
+		time.Now(),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, ProofTypeZKSP1, result.ProofType)
+	require.Equal(t, uint8(6), result.VerifierID)
+	require.Equal(t, uint8(5), result.CompanionVerifierID)
+	require.NotEmpty(t, result.BatchProof)
+	require.NotEmpty(t, result.CompanionBatchProof)
+}
+
+func TestComposeProducerZkOnlyAggregateRequiresRisc0VerifierID(t *testing.T) {
+	producer := &ComposeProofProducer{
+		VerifierIDs: map[ProofType]uint8{
+			ProofTypeZKSP1: 6,
+		},
+		ZkOnly:             true,
+		Dummy:              true,
+		DummyProofProducer: DummyProofProducer{},
+	}
+
+	_, err := producer.Aggregate(
+		context.Background(),
+		[]*ProofResponse{
+			{
+				BatchID:   common.Big1,
+				ProofType: ProofTypeZKSP1,
+				Meta: metadata.NewTaikoProposalMetadataShasta(
+					&shastaBindings.ShastaInboxClientProposed{Id: common.Big1},
+					0,
+				),
+				Opts: &ProposalProofRequestOptions{},
+			},
+		},
+		time.Now(),
+	)
+
+	require.ErrorContains(t, err, "no verifier ID")
+}
+
+// raikoRequestRecorder records the proof requests a test raiko server receives and answers
+// each with the given per-proof-type proof hex string.
+type raikoRequestRecorder struct {
+	mu       sync.Mutex
+	requests []RaikoRequestProofBodyV4
+	proofs   map[ProofType]string
+}
+
+func (r *raikoRequestRecorder) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost || req.URL.Path != "/v4/proof/proposal" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		var body RaikoRequestProofBodyV4
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		r.mu.Lock()
+		r.requests = append(r.requests, body)
+		r.mu.Unlock()
+
+		_ = json.NewEncoder(w).Encode(&RaikoRequestProofBodyResponse{
+			ProofType: body.ProofType,
+			Data:      &RaikoProofData{Proof: r.proofs[body.ProofType]},
+		})
+	}
+}
+
+func (r *raikoRequestRecorder) requestedTypes() map[ProofType]int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	types := make(map[ProofType]int, len(r.requests))
+	for _, req := range r.requests {
+		types[req.ProofType]++
+	}
+	return types
+}
+
+func TestComposeProducerZkOnlyRequestProofRequestsBothZkProofs(t *testing.T) {
+	recorder := &raikoRequestRecorder{proofs: map[ProofType]string{
+		// A single SP1 proof from raiko is null, only the RISC0 companion carries bytes.
+		ProofTypeZKSP1: "",
+		ProofTypeZKR0:  "0xff01",
+	}}
+	server := httptest.NewServer(recorder.handler())
+	defer server.Close()
+
+	var (
+		producer = &ComposeProofProducer{
+			VerifierIDs: map[ProofType]uint8{
+				ProofTypeZKR0:  5,
+				ProofTypeZKSP1: 6,
+			},
+			ZkOnly:              true,
+			RaikoHostEndpoint:   server.URL,
+			RaikoRequestTimeout: time.Second,
+			ProofType:           ProofTypeZKR0,
+		}
+		opts = &ProposalProofRequestOptions{L2BlockNums: []*big.Int{common.Big1}}
+	)
+
+	res, err := producer.RequestProof(
+		context.Background(),
+		opts,
+		common.Big1,
+		metadata.NewTaikoProposalMetadataShasta(&shastaBindings.ShastaInboxClientProposed{Id: common.Big1}, 0),
+		time.Now(),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, ProofTypeZKSP1, res.ProofType)
+	require.Equal(t, map[ProofType]int{ProofTypeZKSP1: 1, ProofTypeZKR0: 1}, recorder.requestedTypes())
+	for _, req := range recorder.requests {
+		require.False(t, req.Aggregate)
+	}
+	require.True(t, opts.RethProofGenerated)
+	require.True(t, opts.Risc0CompanionProofGenerated)
+	require.False(t, opts.GethProofGenerated)
+}
+
+func TestComposeProducerZkOnlyAggregateRequestsBothZkAggregations(t *testing.T) {
+	recorder := &raikoRequestRecorder{proofs: map[ProofType]string{
+		ProofTypeZKSP1: "0xaaaa",
+		ProofTypeZKR0:  "0xbbbb",
+	}}
+	server := httptest.NewServer(recorder.handler())
+	defer server.Close()
+
+	var (
+		producer = &ComposeProofProducer{
+			VerifierIDs: map[ProofType]uint8{
+				ProofTypeZKR0:  5,
+				ProofTypeZKSP1: 6,
+			},
+			ZkOnly:              true,
+			RaikoHostEndpoint:   server.URL,
+			RaikoRequestTimeout: time.Second,
+		}
+		opts = &ProposalProofRequestOptions{L2BlockNums: []*big.Int{common.Big1}}
+	)
+
+	result, err := producer.Aggregate(
+		context.Background(),
+		[]*ProofResponse{
+			{
+				BatchID:   common.Big1,
+				ProofType: ProofTypeZKSP1,
+				Meta: metadata.NewTaikoProposalMetadataShasta(
+					&shastaBindings.ShastaInboxClientProposed{Id: common.Big1},
+					0,
+				),
+				Opts: opts,
+			},
+		},
+		time.Now(),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, ProofTypeZKSP1, result.ProofType)
+	require.Equal(t, map[ProofType]int{ProofTypeZKSP1: 1, ProofTypeZKR0: 1}, recorder.requestedTypes())
+	for _, req := range recorder.requests {
+		require.True(t, req.Aggregate)
+	}
+	require.Equal(t, uint8(6), result.VerifierID)
+	require.Equal(t, common.Hex2Bytes("aaaa"), result.BatchProof)
+	require.Equal(t, uint8(5), result.CompanionVerifierID)
+	require.Equal(t, common.Hex2Bytes("bbbb"), result.CompanionBatchProof)
+	require.True(t, opts.RethProofAggregationGenerated)
+	require.True(t, opts.Risc0CompanionProofAggregationGenerated)
+	require.False(t, opts.GethProofAggregationGenerated)
 }

--- a/packages/taiko-client/prover/proof_producer/interface.go
+++ b/packages/taiko-client/prover/proof_producer/interface.go
@@ -49,11 +49,16 @@ type ProposalProofRequestOptions struct {
 	GethProofAggregationGenerated bool
 	RethProofGenerated            bool
 	RethProofAggregationGenerated bool
-	ProofType                     ProofType
-	L2BlockNums                   []*big.Int
-	DesignatedProver              common.Address
-	Checkpoint                    *Checkpoint
-	LastAnchorBlockNumber         *big.Int
+	// Risc0CompanionProofGenerated / Risc0CompanionProofAggregationGenerated record whether
+	// the RISC0 companion proof has been generated in ZK-only mode, where it takes the
+	// place of the SGX_GETH leg.
+	Risc0CompanionProofGenerated            bool
+	Risc0CompanionProofAggregationGenerated bool
+	ProofType                               ProofType
+	L2BlockNums                             []*big.Int
+	DesignatedProver                        common.Address
+	Checkpoint                              *Checkpoint
+	LastAnchorBlockNumber                   *big.Int
 }
 
 // ProposalOptions implements the ProofRequestOptions interface.

--- a/packages/taiko-client/prover/proof_producer/proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_producer.go
@@ -35,15 +35,16 @@ type ProofResponse struct {
 
 // BatchProofs represents a response of a batch proof request.
 type BatchProofs struct {
-	ProofResponses       []*ProofResponse
-	BatchProof           []byte
-	BatchIDs             []*big.Int
-	ProofType            ProofType
-	Verifier             common.Address
-	VerifierID           uint8
-	SgxGethBatchProof    []byte
-	SgxGethProofVerifier common.Address
-	SgxGethVerifierID    uint8
+	ProofResponses []*ProofResponse
+	BatchProof     []byte
+	BatchIDs       []*big.Int
+	ProofType      ProofType
+	Verifier       common.Address
+	VerifierID     uint8
+	// The companion sub-proof submitted alongside BatchProof: the SGX_GETH proof by
+	// default, or the RISC0 proof in ZK-only mode.
+	CompanionBatchProof []byte
+	CompanionVerifierID uint8
 }
 
 // ProofProducer is an interface that contains all methods to generate a proof.

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -59,6 +59,7 @@ type ProofSubmitter struct {
 	proposalWindowSize            *big.Int
 	maxRisc0ProofProposalDistance *big.Int
 	forceSP1Proof                 bool
+	zkOnlyProofs                  bool
 	// RISC0-to-SP1 fallback state machine (see risc0_sp1_fallback.go).
 	risc0Backlog proofProducer.Risc0BacklogController
 	sp1Fallback  sp1Fallback
@@ -85,7 +86,11 @@ func NewProofSubmitter(
 	proposalWindowSize *big.Int,
 	maxRisc0ProofProposalDistance *big.Int,
 	forceSP1Proof bool,
+	zkOnlyProofs bool,
 ) (*ProofSubmitter, error) {
+	if zkOnlyProofs && zkvmProofProducer == nil {
+		return nil, fmt.Errorf("ZK-only proof mode requires a ZKVM proof producer")
+	}
 	proofSubmitter := &ProofSubmitter{
 		rpc:                    senderOpts.RPCClient,
 		baseLevelProofProducer: baseLevelProofProducer,
@@ -109,6 +114,7 @@ func NewProofSubmitter(
 		proposalWindowSize:            proposalWindowSize,
 		maxRisc0ProofProposalDistance: maxRisc0ProofProposalDistance,
 		forceSP1Proof:                 forceSP1Proof,
+		zkOnlyProofs:                  zkOnlyProofs,
 		ctx:                           ctx,
 	}
 
@@ -285,7 +291,14 @@ func (s *ProofSubmitter) requestProposalProof(
 		return proofResponse, nil
 	}
 
-	proofType := s.decideZKProofType(ctx, proposalID, lastFinalizedProposalID)
+	// In ZK-only mode every proposal needs both ZK proofs: SP1 is the primary lane and the
+	// producer requests RISC0 as the companion leg, so the RISC0/SP1 selection machine (and
+	// its backlog-clearing side effects, which would cancel RISC0 tasks this mode depends
+	// on) must not run.
+	proofType := proofProducer.ProofTypeZKSP1
+	if !s.zkOnlyProofs {
+		proofType = s.decideZKProofType(ctx, proposalID, lastFinalizedProposalID)
+	}
 	opts.ProposalOptions().ProofType = proofType
 
 	proofResponse, err := s.zkvmProofProducer.RequestProof(ctx, opts, proposalID, meta, startAt)

--- a/packages/taiko-client/prover/proof_submitter/transaction/builder.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/builder.go
@@ -121,16 +121,13 @@ func (a *ProveBatchesTxBuilder) BuildProveBatchesShasta(
 		}
 		log.Info(
 			"Verifier information",
-			"GethVerifierID", batchProof.SgxGethVerifierID,
-			"GethProof", common.Bytes2Hex(batchProof.SgxGethBatchProof),
+			"companionVerifierID", batchProof.CompanionVerifierID,
+			"companionProof", common.Bytes2Hex(batchProof.CompanionBatchProof),
 			"VerifierID", batchProof.VerifierID,
 			"Proof", common.Bytes2Hex(batchProof.BatchProof),
 		)
 
-		encodedSubProofs, err := encoding.EncodeBatchesSubProofs([]encoding.SubProofShasta{
-			{VerifierId: batchProof.SgxGethVerifierID, Proof: batchProof.SgxGethBatchProof},
-			{VerifierId: batchProof.VerifierID, Proof: batchProof.BatchProof},
-		})
+		encodedSubProofs, err := encoding.EncodeBatchesSubProofs(orderedSubProofs(batchProof))
 		if err != nil {
 			return nil, err
 		}
@@ -148,4 +145,17 @@ func (a *ProveBatchesTxBuilder) BuildProveBatchesShasta(
 			Value:    txOpts.Value,
 		}, nil
 	}
+}
+
+// orderedSubProofs returns the batch's companion and primary sub-proofs in ascending
+// verifier ID order, as required by ComposeVerifier.
+func orderedSubProofs(batchProof *proofProducer.BatchProofs) []encoding.SubProofShasta {
+	subProofs := []encoding.SubProofShasta{
+		{VerifierId: batchProof.CompanionVerifierID, Proof: batchProof.CompanionBatchProof},
+		{VerifierId: batchProof.VerifierID, Proof: batchProof.BatchProof},
+	}
+	if subProofs[0].VerifierId > subProofs[1].VerifierId {
+		subProofs[0], subProofs[1] = subProofs[1], subProofs[0]
+	}
+	return subProofs
 }

--- a/packages/taiko-client/prover/proof_submitter/transaction/builder_order_test.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/builder_order_test.go
@@ -1,0 +1,46 @@
+package transaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/encoding"
+	producer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
+)
+
+func TestOrderedSubProofsAscendingVerifierIDs(t *testing.T) {
+	// Default mode: SGX_GETH companion (1) + ZK primary (5/6), already ascending.
+	require.Equal(t, []encoding.SubProofShasta{
+		{VerifierId: 1, Proof: []byte{0x01}},
+		{VerifierId: 6, Proof: []byte{0x06}},
+	}, orderedSubProofs(&producer.BatchProofs{
+		CompanionVerifierID: 1,
+		CompanionBatchProof: []byte{0x01},
+		VerifierID:          6,
+		BatchProof:          []byte{0x06},
+	}))
+
+	// ZK-only mode: RISC0 companion (5) + SP1 primary (6), already ascending.
+	require.Equal(t, []encoding.SubProofShasta{
+		{VerifierId: 5, Proof: []byte{0x05}},
+		{VerifierId: 6, Proof: []byte{0x06}},
+	}, orderedSubProofs(&producer.BatchProofs{
+		CompanionVerifierID: 5,
+		CompanionBatchProof: []byte{0x05},
+		VerifierID:          6,
+		BatchProof:          []byte{0x06},
+	}))
+
+	// A companion with a higher verifier ID than the primary proof must be swapped, since
+	// ComposeVerifier rejects sub-proofs in descending verifier ID order.
+	require.Equal(t, []encoding.SubProofShasta{
+		{VerifierId: 5, Proof: []byte{0x05}},
+		{VerifierId: 6, Proof: []byte{0x06}},
+	}, orderedSubProofs(&producer.BatchProofs{
+		CompanionVerifierID: 6,
+		CompanionBatchProof: []byte{0x06},
+		VerifierID:          5,
+		BatchProof:          []byte{0x05},
+	}))
+}

--- a/packages/taiko-client/prover/proof_submitter/zk_only_test.go
+++ b/packages/taiko-client/prover/proof_submitter/zk_only_test.go
@@ -1,0 +1,66 @@
+package submitter
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
+	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
+	proofProducer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
+)
+
+func TestRequestProposalProofZkOnlyPinsSP1AndSkipsSelection(t *testing.T) {
+	base := &recordingProofProducer{proofType: proofProducer.ProofTypeSgx}
+	zkvm := &recordingProofProducer{proofType: proofProducer.ProofTypeZKR0}
+	submitter := &ProofSubmitter{
+		baseLevelProofProducer:        base,
+		zkvmProofProducer:             zkvm,
+		maxRisc0ProofProposalDistance: big.NewInt(30),
+		zkOnlyProofs:                  true,
+	}
+
+	// The proposal is within the RISC0 distance, so the RISC0/SP1 selection would pick
+	// RISC0; ZK-only mode must pin SP1 as the primary lane regardless.
+	resp, err := submitter.requestProposalProof(
+		context.Background(),
+		&proofProducer.ProposalProofRequestOptions{ProposalID: big.NewInt(40)},
+		big.NewInt(40),
+		metadata.NewTaikoProposalMetadataShasta(&shastaBindings.ShastaInboxClientProposed{Id: big.NewInt(40)}, 0),
+		time.Now(),
+		big.NewInt(10),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, proofProducer.ProofTypeZKSP1, resp.ProofType)
+	require.Equal(t, 1, zkvm.requests)
+	require.Equal(t, []proofProducer.ProofType{proofProducer.ProofTypeZKSP1}, zkvm.requestedTypes)
+	require.Zero(t, base.requests)
+}
+
+func TestNewProofSubmitterZkOnlyRequiresZKVMProducer(t *testing.T) {
+	_, err := NewProofSubmitter(
+		context.Background(),
+		&recordingProofProducer{proofType: proofProducer.ProofTypeSgx},
+		nil,
+		nil,
+		nil,
+		nil,
+		&SenderOptions{},
+		nil,
+		0,
+		nil,
+		0,
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		true,
+	)
+
+	require.ErrorContains(t, err, "ZK-only proof mode requires a ZKVM proof producer")
+}


### PR DESCRIPTION
## Why

Post-Unzen (#21924 / #21935 / #21945), `ZkRequiredVerifier` accepts `[RISC0_RETH, SP1_RETH]` — a proof pair with **no TEE leg**. But the prover cannot produce it: `ComposeProofProducer` hardwires SGX_GETH as the companion sub-proof in both `RequestProof` and `Aggregate`, and a failure of that leg fails the whole request. If gaiko halts (enclave expiry, attestation issue, another MRSIGNER incident forcing an untrust), proving halts with it — even though the protocol deliberately keeps a TEE-free finalization path open (#21945: "if SGX instance registration is somehow still pending at execution, proving continues on RISC0+SP1"). This PR gives the client that lane.

## What

A new opt-in flag, **`--prover.zkOnlyProofs`** (`PROVER_ZK_ONLY_PROOFS`), requires `--raiko.host.zkvm`:

- **Submitter** pins SP1 as the primary proof lane instead of running `decideZKProofType`. The bypass is load-bearing, not cosmetic: the RISC0→SP1 fallback machine's side effect (`POST /v3/prover/clear`) would cancel the very RISC0 tasks this mode depends on.
- **`ComposeProofProducer`** gets a `ZkOnly` field: the companion goroutine requests a RISC0 proof from the ZKVM raiko host in place of the SGX_GETH proof (single-shot in `RequestProof`, aggregation in `Aggregate`). Buffering, aggregation triggers, and revert-resend all reuse the existing SP1 lane unchanged.
- **`BatchProofs.SgxGeth*` → `Companion*`** since the slot now carries either the SGX_GETH or the RISC0 leg (the never-read `SgxGethProofVerifier` field is dropped).
- **Tx builder** orders the two sub-proofs by ascending verifier ID (`orderedSubProofs`), as `ComposeVerifier` requires; RISC0(5) + SP1(6) packs as `[5, 6]`, exactly the `ZkRequiredVerifier` combination.
- New `Risc0CompanionProofGenerated` / `...AggregationGenerated` markers mirror the existing Geth/Reth ones so proving metrics aren't double-counted across retries.

Default behavior (flag unset) is byte-identical to today: `[SGX_GETH, RISC0|SP1]`.

## Compatibility

`[RISC0, SP1]` is only sufficient for `ZkRequiredVerifier`, which goes live with the Unzen hardfork (Proposal0019, #21935). The live mainnet inbox still reports the legacy `MainnetVerifier` (`0x71808449…`), which requires a TEE leg in every accepted pair — enabling this flag before Proposal0019 executes would generate both ZK proofs and then revert every submission with `CV_VERIFIERS_INSUFFICIENT`. A hard startup guard is not possible (`areVerifiersSufficient` is internal and cannot be probed without valid sub-proofs), so the flag usage text states the requirement and the prover logs a prominent startup warning with the inbox's configured proof verifier address.

## Design notes

- **Static mode over automatic fallback**: a gaiko outage is an incident-scale event, and this mode doubles ZK proving cost per proposal (both zkVMs), so flipping it should be an operator decision — same posture as the Unzen raiko endpoint switch. An automatic latch (N consecutive sgxGeth failures → ZK-only → probe → back) can be layered on later; it needs batch-coherence handling (an aggregation must have both legs for every proposal in it), so it's deliberately out of scope here.
- **SP1 as primary, RISC0 as companion**: the primary type keys buffers/metrics; SP1's null-single-proof quirk is already handled on the primary path, and companion(5) < primary(6) keeps the packing naturally ascending.
- **Assumption for raiko reviewers**: the ZKVM host serves both `risc0` and `sp1` tasks for the same proposal concurrently (it already serves both types today, chosen alternately by the selection machine — this mode just requests both).

## Out of scope / follow-ups

- `DevnetVerifier` accepts only `SGX_GETH + X`, so devnet e2e can't exercise `[RISC0, SP1]`; coverage here is unit-level (dummy + httptest against the raiko API surface). Extending `DevnetVerifier` with the RISC0+SP1 combo would enable an integration lane.
- Automatic sgxGeth-failure fallback (above).
- Fail-fast when `--raiko.host.zkvm` is unset entirely (the guaranteed post-Unzen revert loop) — separate concern, separate PR.

## Test plan

- `go build ./...`, `go vet`, `make lint` — clean.
- `go test -race ./prover/proof_producer/` — new: ZK-only RequestProof/Aggregate in dummy mode (nil `SgxGethProducer` proves the SGX leg is never touched), httptest-backed tests asserting exactly one `sp1` + one `risc0` request per proposal (and per aggregation) with no `sgxgeth` request, missing-RISC0-verifier-ID error.
- `go test -race ./prover/proof_submitter/` — ZK-only pins SP1 within RISC0 distance (selection bypassed); constructor rejects ZK-only without a ZKVM producer.
- `go test -race ./prover/proof_submitter/transaction/` — `orderedSubProofs` ascending for `[1,6]`, `[5,6]`, and the swap case.
- `go test -race ./prover/ -run TestNewConfigFromCliContext` — flag default, ZKVM-host requirement, happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
