### PR TITLE
fix(taiko-client-rs): prevent derivation panic on oversized manifest size field

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/shasta/manifest.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/manifest.rs
@@ -162,15 +162,20 @@ fn decode_manifest_payload(bytes: &[u8], offset: usize) -> Result<Vec<u8>> {
         ProtocolError::InvalidPayload(format!("size field exceeds usize range: {size_u64}"))
     })?;
 
-    if bytes.len() < offset + 64 + size {
+    // Bound the compressed slice `[start, start + size)` with subtraction so a hostile `size`
+    // (attacker-controlled up to `u64::MAX` in a forced-inclusion blob) cannot overflow the
+    // `start + size` addition and panic. The header check above guarantees `start <= bytes.len()`,
+    // so `bytes.len() - start` never underflows, and `size <= remaining` keeps `start + size`
+    // within bounds. Mirrors the Go reference `DerivationSourceFetcher.manifestFromBlobBytes`.
+    let start = offset + 64;
+    let remaining = bytes.len() - start;
+    if remaining < size {
         return Err(ProtocolError::InvalidPayload(format!(
-            "payload too short for compressed data: expected {} bytes, got {}",
-            offset + 64 + size,
-            bytes.len()
+            "payload too short for compressed data: need {size} bytes after offset {start}, got {remaining}"
         )));
     }
 
-    let compressed = &bytes[offset + 64..offset + 64 + size];
+    let compressed = &bytes[start..start + size];
     let mut decoder = ZlibDecoder::new(compressed);
     let mut decoded = Vec::new();
     decoder
@@ -380,5 +385,49 @@ mod tests {
 
         let decoded = DerivationSourceManifest::decompress_and_decode(&encoded, 0).unwrap();
         assert_eq!(decoded.blocks.len(), manifest.blocks.len());
+    }
+
+    #[test]
+    fn test_decode_manifest_payload_size_u64_max_returns_err() {
+        // A forced-inclusion blob can set the size word to u64::MAX. The bounds check must reject
+        // it with an error instead of overflowing `offset + 64 + size` and panicking (which would
+        // bypass the default-manifest fallback and crash derivation).
+        let mut payload = vec![0u8; 64];
+        payload[31] = SHASTA_PAYLOAD_VERSION;
+        payload[56..64].fill(0xFF); // size word low 64 bits = u64::MAX
+
+        let result = decode_manifest_payload(&payload, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("payload too short for compressed data"));
+    }
+
+    #[test]
+    fn test_decompress_and_decode_size_u64_max_returns_default() {
+        // The overflow-triggering payload must degrade to the default manifest via the decode
+        // fallback, matching Go, rather than panicking the derivation pipeline.
+        let mut payload = vec![0u8; 64];
+        payload[31] = SHASTA_PAYLOAD_VERSION;
+        payload[56..64].fill(0xFF);
+
+        let decoded = DerivationSourceManifest::decompress_and_decode(&payload, 0)
+            .expect("hostile size must fall back to default, not return a hard error");
+        assert_eq!(decoded.blocks.len(), DerivationSourceManifest::default().blocks.len());
+        assert_eq!(
+            decoded.blocks[0].gas_limit,
+            DerivationSourceManifest::default().blocks[0].gas_limit
+        );
+    }
+
+    #[test]
+    fn test_decode_manifest_payload_size_exceeds_remaining_returns_err() {
+        // A `size` larger than the bytes available after the header (without overflowing) must be
+        // rejected so the compressed slice never reads out of bounds.
+        let mut payload = vec![0u8; 66]; // 64-byte header + 2 trailing bytes
+        payload[31] = SHASTA_PAYLOAD_VERSION;
+        payload[63] = 100; // size = 100, but only 2 bytes remain after the header
+
+        let result = decode_manifest_payload(&payload, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("payload too short for compressed data"));
     }
 }


### PR DESCRIPTION
## Problem

A public **forced-inclusion blob can panic canonical Rust derivation.** The `size` word in a Shasta derivation-source manifest is attacker-controlled — any party can post a forced-inclusion blob whose bytes are arbitrary — so it can be set to `u64::MAX`.

`decode_manifest_payload` in `crates/protocol/src/shasta/manifest.rs` computed `offset + 64 + size` as **unchecked `usize` arithmetic**:

- **Debug:** `offset + 64 + size` overflows → panic *"attempt to add with overflow"*.
- **Release:** `64 + usize::MAX` wraps to `63`, the bounds check `bytes.len() < 63` passes, then the slice `&bytes[64..63]` panics *"slice index starts at 64 but ends at 63"*.

The panic unwinds **past the default-manifest fallback**, which only catches `Err`. So a single crafted blob crashes derivation on every Rust-driver node — a liveness/consensus divergence from the Go client (forced inclusions are permissionless and live on mainnet post-Unzen).

The Go reference avoids this with a subtractive bounds check in `DerivationSourceFetcher.manifestFromBlobBytes` (`driver/chain_syncer/event/derivation/source_fetcher.go`):

```go
start := offset + 64
if start > len(b) || uint64(len(b)-start) < size {
    return defaultPayload, nil
}
```

## Fix

Bound the compressed slice `[start, start + size)` with subtraction so the addition can never overflow:

```rust
let start = offset + 64;
let remaining = bytes.len() - start; // no underflow: header check guarantees start <= bytes.len()
if remaining < size {                // no overflow: pure subtraction, mirrors Go
    return Err(/* payload too short */);
}
let compressed = &bytes[start..start + size]; // size <= remaining ⇒ start + size <= bytes.len()
```

An oversized `size` now returns `Err`, which the existing fallback (`decompress_and_decode_with_max_blocks`) turns into the default payload — **identical behavior to Go**.

## Alignment audit

The size-bounds check was the **only** divergence in this decode path. Everything else already matches Go: the offset upper-bound guard (`is_source_offset_valid` vs `Fetch`; `offset` is a `uint24`, so its `.to()` conversions can't panic), `uint32` version truncation, low-64-bit size, `decode_exact` trailing-byte rejection, forced-inclusion single-block rule, and the max-blocks cap.

## Tests

Added regression tests (pass in **both debug and release**):
- `test_decode_manifest_payload_size_u64_max_returns_err` — `u64::MAX` size returns `Err` instead of panicking.
- `test_decompress_and_decode_size_u64_max_returns_default` — the same payload degrades to the default manifest.
- `test_decode_manifest_payload_size_exceeds_remaining_returns_err` — non-overflow `size > remaining` is rejected.

Verified: `cargo +nightly fmt`, `cargo clippy -p protocol` (clean), `cargo test -p protocol shasta::manifest` in debug and release (15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)