### PR TITLE
fix(taiko-client-rs): enforce strict engine status checks in driver payload submission

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
@@ -112,10 +112,13 @@ trait EnginePayloadRpc: Sync {
 
 #[async_trait]
 impl EnginePayloadRpc for Client {
+    /// Return the chain id cached on the client at construction time.
     fn chain_id(&self) -> u64 {
         self.chain_id
     }
 
+    /// Delegate to `engine_forkchoiceUpdatedV2` on the authenticated engine endpoint,
+    /// mapping RPC/transport failures into [`EngineSubmissionError::Rpc`].
     async fn forkchoice_updated_v2(
         &self,
         state: ForkchoiceState,
@@ -124,6 +127,8 @@ impl EnginePayloadRpc for Client {
         Ok(self.engine_forkchoice_updated_v2(state, attrs).await?)
     }
 
+    /// Delegate to `engine_getPayloadV2` on the authenticated engine endpoint, mapping
+    /// RPC/transport failures into [`EngineSubmissionError::Rpc`].
     async fn get_payload_v2(
         &self,
         payload_id: PayloadId,
@@ -131,6 +136,8 @@ impl EnginePayloadRpc for Client {
         Ok(self.engine_get_payload_v2(payload_id).await?)
     }
 
+    /// Delegate to `engine_newPayloadV2` on the authenticated engine endpoint, mapping
+    /// RPC/transport failures into [`EngineSubmissionError::Rpc`].
     async fn new_payload_v2(
         &self,
         payload: &ExecutionPayloadInputV2,
@@ -139,6 +146,9 @@ impl EnginePayloadRpc for Client {
         Ok(self.engine_new_payload_v2(payload, sidecar).await?)
     }
 
+    /// Fetch the block at the given height from the public L2 provider, converting its
+    /// transactions into [`TxEnvelope`]s; provider failures map into
+    /// [`EngineSubmissionError::Provider`], while an unknown height yields `Ok(None)`.
     async fn block_by_number(
         &self,
         number: u64,
@@ -512,11 +522,11 @@ mod tests {
     /// Which engine RPC a scripted call hit, in production sequence order.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum EngineCall {
-        ForkchoiceWithAttributes,
-        GetPayload,
-        NewPayload,
-        PromotionForkchoice,
-        BlockByNumber,
+        ForkchoiceWithAttributes { head: B256, attrs_block_number: u64 },
+        GetPayload { payload_id: PayloadId },
+        NewPayload { block_hash: B256 },
+        PromotionForkchoice { head: B256, safe: B256, finalized: B256 },
+        BlockByNumber { number: u64 },
     }
 
     /// Scripted [`EnginePayloadRpc`] double that records the call sequence and replays the
@@ -554,16 +564,23 @@ mod tests {
 
         async fn forkchoice_updated_v2(
             &self,
-            _state: ForkchoiceState,
+            state: ForkchoiceState,
             attrs: Option<TaikoPayloadAttributes>,
         ) -> Result<ForkchoiceUpdated, EngineSubmissionError> {
-            if attrs.is_some() {
-                self.record(EngineCall::ForkchoiceWithAttributes);
+            if let Some(attrs) = attrs {
+                self.record(EngineCall::ForkchoiceWithAttributes {
+                    head: state.head_block_hash,
+                    attrs_block_number: attrs.l1_origin.block_id.to::<u64>(),
+                });
                 self.attributes_forkchoice
                     .clone()
                     .ok_or_else(|| Self::unscripted("forkchoiceUpdated with attributes"))
             } else {
-                self.record(EngineCall::PromotionForkchoice);
+                self.record(EngineCall::PromotionForkchoice {
+                    head: state.head_block_hash,
+                    safe: state.safe_block_hash,
+                    finalized: state.finalized_block_hash,
+                });
                 self.promotion_forkchoice
                     .clone()
                     .ok_or_else(|| Self::unscripted("promotion forkchoiceUpdated"))
@@ -572,26 +589,28 @@ mod tests {
 
         async fn get_payload_v2(
             &self,
-            _payload_id: PayloadId,
+            payload_id: PayloadId,
         ) -> Result<ExecutionPayloadEnvelopeV2, EngineSubmissionError> {
-            self.record(EngineCall::GetPayload);
+            self.record(EngineCall::GetPayload { payload_id });
             self.envelope.clone().ok_or_else(|| Self::unscripted("getPayload"))
         }
 
         async fn new_payload_v2(
             &self,
-            _payload: &ExecutionPayloadInputV2,
+            payload: &ExecutionPayloadInputV2,
             _sidecar: &TaikoExecutionDataSidecar,
         ) -> Result<PayloadStatus, EngineSubmissionError> {
-            self.record(EngineCall::NewPayload);
+            self.record(EngineCall::NewPayload {
+                block_hash: payload.execution_payload.block_hash,
+            });
             self.new_payload.clone().ok_or_else(|| Self::unscripted("newPayload"))
         }
 
         async fn block_by_number(
             &self,
-            _number: u64,
+            number: u64,
         ) -> Result<Option<RpcBlock<TxEnvelope>>, EngineSubmissionError> {
-            self.record(EngineCall::BlockByNumber);
+            self.record(EngineCall::BlockByNumber { number });
             Ok(self.readback_block.clone())
         }
     }
@@ -635,6 +654,35 @@ mod tests {
         block
     }
 
+    /// Expected attribute-forkchoice log entry for the sample sequence (parent is zero).
+    fn attrs_call() -> EngineCall {
+        EngineCall::ForkchoiceWithAttributes { head: B256::ZERO, attrs_block_number: 7 }
+    }
+
+    /// Expected getPayload log entry: the id handed back by the attribute forkchoice.
+    fn get_payload_call() -> EngineCall {
+        EngineCall::GetPayload { payload_id: PayloadId::new([0; 8]) }
+    }
+
+    /// Expected newPayload log entry: the block hash advertised by getPayload.
+    fn new_payload_call() -> EngineCall {
+        EngineCall::NewPayload { block_hash: sample_block_hash() }
+    }
+
+    /// Expected promotion log entry: head at the built hash, safe/finalized zeroed.
+    fn promotion_call() -> EngineCall {
+        EngineCall::PromotionForkchoice {
+            head: sample_block_hash(),
+            safe: B256::ZERO,
+            finalized: B256::ZERO,
+        }
+    }
+
+    /// Expected readback log entry at the built block's height.
+    fn readback_call() -> EngineCall {
+        EngineCall::BlockByNumber { number: 7 }
+    }
+
     /// A scripted engine primed for the full happy-path sequence.
     fn scripted_happy_engine() -> ScriptedEngine {
         ScriptedEngine {
@@ -662,7 +710,7 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, EngineSubmissionError::EngineSyncing(7)));
-        assert_eq!(engine.calls(), vec![EngineCall::ForkchoiceWithAttributes]);
+        assert_eq!(engine.calls(), vec![attrs_call()]);
     }
 
     #[tokio::test]
@@ -681,11 +729,7 @@ mod tests {
         assert!(matches!(err, EngineSubmissionError::UnexpectedPayloadStatus(7, _)));
         assert_eq!(
             engine.calls(),
-            vec![
-                EngineCall::ForkchoiceWithAttributes,
-                EngineCall::GetPayload,
-                EngineCall::NewPayload,
-            ],
+            vec![attrs_call(), get_payload_call(), new_payload_call()],
             "no promotion or readback may happen after a non-VALID newPayload"
         );
     }
@@ -711,12 +755,7 @@ mod tests {
         ));
         assert_eq!(
             engine.calls(),
-            vec![
-                EngineCall::ForkchoiceWithAttributes,
-                EngineCall::GetPayload,
-                EngineCall::NewPayload,
-                EngineCall::PromotionForkchoice,
-            ],
+            vec![attrs_call(), get_payload_call(), new_payload_call(), promotion_call()],
             "no readback may happen after a failed promotion"
         );
     }
@@ -736,6 +775,16 @@ mod tests {
             err,
             EngineSubmissionError::InsertedBlockHashMismatch { block_number: 7, .. }
         ));
+        assert_eq!(
+            engine.calls(),
+            vec![
+                attrs_call(),
+                get_payload_call(),
+                new_payload_call(),
+                promotion_call(),
+                readback_call(),
+            ]
+        );
     }
 
     #[tokio::test]
@@ -751,11 +800,11 @@ mod tests {
         assert_eq!(
             engine.calls(),
             vec![
-                EngineCall::ForkchoiceWithAttributes,
-                EngineCall::GetPayload,
-                EngineCall::NewPayload,
-                EngineCall::PromotionForkchoice,
-                EngineCall::BlockByNumber,
+                attrs_call(),
+                get_payload_call(),
+                new_payload_call(),
+                promotion_call(),
+                readback_call(),
             ]
         );
     }

--- a/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
@@ -522,11 +522,32 @@ mod tests {
     /// Which engine RPC a scripted call hit, in production sequence order.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum EngineCall {
-        ForkchoiceWithAttributes { head: B256, attrs_block_number: u64 },
-        GetPayload { payload_id: PayloadId },
-        NewPayload { block_hash: B256 },
-        PromotionForkchoice { head: B256, safe: B256, finalized: B256 },
-        BlockByNumber { number: u64 },
+        ForkchoiceWithAttributes {
+            head: B256,
+            safe: B256,
+            finalized: B256,
+            attrs_block_number: u64,
+            attrs_payload_id: [u8; 8],
+        },
+        GetPayload {
+            payload_id: PayloadId,
+        },
+        NewPayload {
+            block_hash: B256,
+            block_number: u64,
+            tx_hash: B256,
+            withdrawals_hash: Option<B256>,
+            header_difficulty: Option<U256>,
+            taiko_block: Option<bool>,
+        },
+        PromotionForkchoice {
+            head: B256,
+            safe: B256,
+            finalized: B256,
+        },
+        BlockByNumber {
+            number: u64,
+        },
     }
 
     /// Scripted [`EnginePayloadRpc`] double that records the call sequence and replays the
@@ -570,7 +591,10 @@ mod tests {
             if let Some(attrs) = attrs {
                 self.record(EngineCall::ForkchoiceWithAttributes {
                     head: state.head_block_hash,
+                    safe: state.safe_block_hash,
+                    finalized: state.finalized_block_hash,
                     attrs_block_number: attrs.l1_origin.block_id.to::<u64>(),
+                    attrs_payload_id: attrs.l1_origin.build_payload_args_id,
                 });
                 self.attributes_forkchoice
                     .clone()
@@ -598,10 +622,15 @@ mod tests {
         async fn new_payload_v2(
             &self,
             payload: &ExecutionPayloadInputV2,
-            _sidecar: &TaikoExecutionDataSidecar,
+            sidecar: &TaikoExecutionDataSidecar,
         ) -> Result<PayloadStatus, EngineSubmissionError> {
             self.record(EngineCall::NewPayload {
                 block_hash: payload.execution_payload.block_hash,
+                block_number: payload.execution_payload.block_number,
+                tx_hash: sidecar.tx_hash,
+                withdrawals_hash: sidecar.withdrawals_hash,
+                header_difficulty: sidecar.header_difficulty,
+                taiko_block: sidecar.taiko_block,
             });
             self.new_payload.clone().ok_or_else(|| Self::unscripted("newPayload"))
         }
@@ -617,7 +646,7 @@ mod tests {
 
     /// Payload attributes for block 7, matching [`sample_envelope_v1`]'s block number.
     fn sample_attributes() -> TaikoPayloadAttributes {
-        build_payload_attributes(PayloadAttributesInput {
+        let mut attributes = build_payload_attributes(PayloadAttributesInput {
             beneficiary: Address::from([1u8; 20]),
             timestamp: 1,
             mix_hash: B256::ZERO,
@@ -632,7 +661,9 @@ mod tests {
             signature: [0; 65],
             parent_beacon_block_root: None,
             anchor_transaction: None,
-        })
+        });
+        attributes.l1_origin.build_payload_args_id = *expected_payload_id().0;
+        attributes
     }
 
     fn forkchoice_response(
@@ -647,6 +678,26 @@ mod tests {
         B256::from(U256::from(42u64))
     }
 
+    /// Parent hash supplied to the attribute forkchoice.
+    fn sample_parent_hash() -> B256 {
+        B256::from(U256::from(10u64))
+    }
+
+    /// Finalized hash supplied to the promotion forkchoice.
+    fn sample_finalized_hash() -> B256 {
+        B256::from(U256::from(20u64))
+    }
+
+    /// Payload id derived by the driver before contacting the engine.
+    fn expected_payload_id() -> PayloadId {
+        PayloadId::new([0x11; 8])
+    }
+
+    /// Distinct payload id returned by the engine and used for getPayload/outcome wiring.
+    fn engine_payload_id() -> PayloadId {
+        PayloadId::new([0x22; 8])
+    }
+
     fn sample_readback_block(hash: B256) -> RpcBlock<TxEnvelope> {
         let mut block = RpcBlock::<TxEnvelope>::default();
         block.header.hash = hash;
@@ -654,27 +705,42 @@ mod tests {
         block
     }
 
-    /// Expected attribute-forkchoice log entry for the sample sequence (parent is zero).
+    /// Expected attribute-forkchoice log entry for the sample sequence.
     fn attrs_call() -> EngineCall {
-        EngineCall::ForkchoiceWithAttributes { head: B256::ZERO, attrs_block_number: 7 }
+        EngineCall::ForkchoiceWithAttributes {
+            head: sample_parent_hash(),
+            safe: sample_parent_hash(),
+            finalized: B256::ZERO,
+            attrs_block_number: 7,
+            attrs_payload_id: *expected_payload_id().0,
+        }
     }
 
     /// Expected getPayload log entry: the id handed back by the attribute forkchoice.
     fn get_payload_call() -> EngineCall {
-        EngineCall::GetPayload { payload_id: PayloadId::new([0; 8]) }
+        EngineCall::GetPayload { payload_id: engine_payload_id() }
     }
 
     /// Expected newPayload log entry: the block hash advertised by getPayload.
     fn new_payload_call() -> EngineCall {
-        EngineCall::NewPayload { block_hash: sample_block_hash() }
+        let (_, sidecar, block_hash, block_number) =
+            envelope_into_submission(TAIKO_DEVNET_CHAIN_ID, sample_envelope_v1(0, U256::ZERO));
+        EngineCall::NewPayload {
+            block_hash,
+            block_number,
+            tx_hash: sidecar.tx_hash,
+            withdrawals_hash: sidecar.withdrawals_hash,
+            header_difficulty: sidecar.header_difficulty,
+            taiko_block: sidecar.taiko_block,
+        }
     }
 
-    /// Expected promotion log entry: head at the built hash, safe/finalized zeroed.
+    /// Expected promotion log entry: head at the built hash, safe/finalized at the checkpoint.
     fn promotion_call() -> EngineCall {
         EngineCall::PromotionForkchoice {
             head: sample_block_hash(),
-            safe: B256::ZERO,
-            finalized: B256::ZERO,
+            safe: sample_finalized_hash(),
+            finalized: sample_finalized_hash(),
         }
     }
 
@@ -688,7 +754,7 @@ mod tests {
         ScriptedEngine {
             attributes_forkchoice: Some(forkchoice_response(
                 PayloadStatusEnum::Valid,
-                Some(PayloadId::new([0; 8])),
+                Some(engine_payload_id()),
             )),
             envelope: Some(sample_envelope_v1(0, U256::ZERO)),
             new_payload: Some(PayloadStatus::from_status(PayloadStatusEnum::Valid)),
@@ -705,9 +771,14 @@ mod tests {
             ..Default::default()
         };
 
-        let err = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
-            .await
-            .unwrap_err();
+        let err = apply_payload_internal(
+            &engine,
+            &sample_attributes(),
+            sample_parent_hash(),
+            Some(sample_finalized_hash()),
+        )
+        .await
+        .unwrap_err();
 
         assert!(matches!(err, EngineSubmissionError::EngineSyncing(7)));
         assert_eq!(engine.calls(), vec![attrs_call()]);
@@ -722,9 +793,14 @@ mod tests {
             ..scripted_happy_engine()
         };
 
-        let err = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
-            .await
-            .unwrap_err();
+        let err = apply_payload_internal(
+            &engine,
+            &sample_attributes(),
+            sample_parent_hash(),
+            Some(sample_finalized_hash()),
+        )
+        .await
+        .unwrap_err();
 
         assert!(matches!(err, EngineSubmissionError::UnexpectedPayloadStatus(7, _)));
         assert_eq!(
@@ -745,9 +821,14 @@ mod tests {
             ..scripted_happy_engine()
         };
 
-        let err = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
-            .await
-            .unwrap_err();
+        let err = apply_payload_internal(
+            &engine,
+            &sample_attributes(),
+            sample_parent_hash(),
+            Some(sample_finalized_hash()),
+        )
+        .await
+        .unwrap_err();
 
         assert!(matches!(
             err,
@@ -767,9 +848,14 @@ mod tests {
             ..scripted_happy_engine()
         };
 
-        let err = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
-            .await
-            .unwrap_err();
+        let err = apply_payload_internal(
+            &engine,
+            &sample_attributes(),
+            sample_parent_hash(),
+            Some(sample_finalized_hash()),
+        )
+        .await
+        .unwrap_err();
 
         assert!(matches!(
             err,
@@ -791,12 +877,18 @@ mod tests {
     async fn apply_payload_returns_hash_verified_outcome_for_valid_sequence() {
         let engine = scripted_happy_engine();
 
-        let outcome = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
-            .await
-            .expect("valid sequence must succeed");
+        let outcome = apply_payload_internal(
+            &engine,
+            &sample_attributes(),
+            sample_parent_hash(),
+            Some(sample_finalized_hash()),
+        )
+        .await
+        .expect("valid sequence must succeed");
 
         assert_eq!(outcome.block_hash(), sample_block_hash());
         assert_eq!(outcome.block_number(), 7);
+        assert_eq!(outcome.payload_id, engine_payload_id());
         assert_eq!(
             engine.calls(),
             vec![

--- a/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
@@ -14,7 +14,7 @@ use alloy_rpc_types::{Transaction as RpcTransaction, eth::Block as RpcBlock};
 use alloy_rpc_types_engine::ExecutionPayloadV1;
 use alloy_rpc_types_engine::{
     ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ExecutionPayloadInputV2, ForkchoiceState,
-    PayloadId, PayloadStatusEnum,
+    ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum,
 };
 use async_trait::async_trait;
 use protocol::shasta::unzen_active_for_chain_timestamp;
@@ -76,11 +76,87 @@ impl PayloadApplier for Client {
     }
 }
 
+/// Minimal engine/provider surface used to materialise payload attributes into blocks, letting
+/// the submission orchestration be exercised against a scripted engine in tests.
+#[async_trait]
+trait EnginePayloadRpc: Sync {
+    /// Chain id used to normalise Unzen payload envelopes.
+    fn chain_id(&self) -> u64;
+
+    /// Send `engine_forkchoiceUpdatedV2`, optionally carrying payload attributes.
+    async fn forkchoice_updated_v2(
+        &self,
+        state: ForkchoiceState,
+        attrs: Option<TaikoPayloadAttributes>,
+    ) -> Result<ForkchoiceUpdated, EngineSubmissionError>;
+
+    /// Fetch a built payload envelope via `engine_getPayloadV2`.
+    async fn get_payload_v2(
+        &self,
+        payload_id: PayloadId,
+    ) -> Result<ExecutionPayloadEnvelopeV2, EngineSubmissionError>;
+
+    /// Submit an execution payload via `engine_newPayloadV2`.
+    async fn new_payload_v2(
+        &self,
+        payload: &ExecutionPayloadInputV2,
+        sidecar: &TaikoExecutionDataSidecar,
+    ) -> Result<PayloadStatus, EngineSubmissionError>;
+
+    /// Fetch a block by number from the execution client's public RPC.
+    async fn block_by_number(
+        &self,
+        number: u64,
+    ) -> Result<Option<RpcBlock<TxEnvelope>>, EngineSubmissionError>;
+}
+
+#[async_trait]
+impl EnginePayloadRpc for Client {
+    fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
+    async fn forkchoice_updated_v2(
+        &self,
+        state: ForkchoiceState,
+        attrs: Option<TaikoPayloadAttributes>,
+    ) -> Result<ForkchoiceUpdated, EngineSubmissionError> {
+        Ok(self.engine_forkchoice_updated_v2(state, attrs).await?)
+    }
+
+    async fn get_payload_v2(
+        &self,
+        payload_id: PayloadId,
+    ) -> Result<ExecutionPayloadEnvelopeV2, EngineSubmissionError> {
+        Ok(self.engine_get_payload_v2(payload_id).await?)
+    }
+
+    async fn new_payload_v2(
+        &self,
+        payload: &ExecutionPayloadInputV2,
+        sidecar: &TaikoExecutionDataSidecar,
+    ) -> Result<PayloadStatus, EngineSubmissionError> {
+        Ok(self.engine_new_payload_v2(payload, sidecar).await?)
+    }
+
+    async fn block_by_number(
+        &self,
+        number: u64,
+    ) -> Result<Option<RpcBlock<TxEnvelope>>, EngineSubmissionError> {
+        Ok(self
+            .l2_provider
+            .get_block_by_number(BlockNumberOrTag::Number(number))
+            .await
+            .map_err(|err| EngineSubmissionError::Provider(err.to_string()))?
+            .map(|block| block.map_transactions(|tx: RpcTransaction| tx.into())))
+    }
+}
+
 /// Submit the provided payload attributes to the execution engine, building canonical L2
 /// blocks.
 #[instrument(skip(rpc, payload), fields(payload_id = tracing::field::Empty))]
-async fn apply_payload_internal(
-    rpc: &Client,
+async fn apply_payload_internal<R: EnginePayloadRpc>(
+    rpc: &R,
     payload: &TaikoPayloadAttributes,
     parent_hash: B256,
     finalized_block_hash: Option<B256>,
@@ -91,8 +167,7 @@ async fn apply_payload_internal(
         safe_block_hash: parent_hash,
         finalized_block_hash: B256::ZERO,
     };
-    let fc_response =
-        rpc.engine_forkchoice_updated_v2(forkchoice_state, Some(payload.clone())).await?;
+    let fc_response = rpc.forkchoice_updated_v2(forkchoice_state, Some(payload.clone())).await?;
     ensure_valid_payload_status(
         payload.l1_origin.block_id.to::<u64>(),
         fc_response.payload_status.status,
@@ -111,9 +186,9 @@ async fn apply_payload_internal(
     }
 
     // Fetch the constructed payload and normalise it into the `engine_newPayloadV2` input shape.
-    let envelope = rpc.engine_get_payload_v2(payload_id).await?;
+    let envelope = rpc.get_payload_v2(payload_id).await?;
     let (payload_input, sidecar, block_hash, block_number) =
-        envelope_into_submission(rpc.chain_id, envelope);
+        envelope_into_submission(rpc.chain_id(), envelope);
 
     debug!(
         block_number,
@@ -247,22 +322,19 @@ fn ensure_inserted_block_hash(
     }
 }
 
-/// Fetch the inserted block by number and map provider errors into submission errors.
-async fn fetch_block_by_number(
-    rpc: &Client,
+/// Fetch the inserted block by number, mapping absence into a submission error.
+async fn fetch_block_by_number<R: EnginePayloadRpc>(
+    rpc: &R,
     block_number: u64,
 ) -> Result<RpcBlock<TxEnvelope>, EngineSubmissionError> {
-    rpc.l2_provider
-        .get_block_by_number(BlockNumberOrTag::Number(block_number))
-        .await
-        .map_err(|err| EngineSubmissionError::Provider(err.to_string()))?
-        .map(|block| block.map_transactions(|tx: RpcTransaction| tx.into()))
+    rpc.block_by_number(block_number)
+        .await?
         .ok_or(EngineSubmissionError::MissingInsertedBlock(block_number))
 }
 
 /// Common flow to submit a payload to the engine, promote forkchoice, and read back the block.
-async fn submit_payload_to_engine(
-    rpc: &Client,
+async fn submit_payload_to_engine<R: EnginePayloadRpc>(
+    rpc: &R,
     payload_input: &ExecutionPayloadInputV2,
     sidecar: &TaikoExecutionDataSidecar,
     block_hash: B256,
@@ -270,11 +342,11 @@ async fn submit_payload_to_engine(
     finalized_block_hash: Option<B256>,
     payload_id: PayloadId,
 ) -> Result<EngineBlockOutcome, EngineSubmissionError> {
-    let status = rpc.engine_new_payload_v2(payload_input, sidecar).await?;
+    let status = rpc.new_payload_v2(payload_input, sidecar).await?;
     ensure_valid_payload_status(block_number, status.status)?;
 
     let promoted_state = promotion_forkchoice_state(block_hash, finalized_block_hash);
-    let promotion = rpc.engine_forkchoice_updated_v2(promoted_state, None).await?;
+    let promotion = rpc.forkchoice_updated_v2(promoted_state, None).await?;
     ensure_valid_payload_status(block_number, promotion.payload_status.status)?;
 
     let block = fetch_block_by_number(rpc, block_number).await?;
@@ -291,7 +363,10 @@ mod tests {
     use alloy_eips::eip4895::Withdrawal;
     use alloy_primitives::bytes::BufMut;
     use alloy_rpc_types_engine::ExecutionPayloadV2;
-    use protocol::shasta::constants::{TAIKO_DEVNET_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID};
+    use protocol::shasta::{
+        PayloadAttributesInput, build_payload_attributes,
+        constants::{TAIKO_DEVNET_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID},
+    };
 
     fn sample_payload(timestamp: u64) -> ExecutionPayloadV1 {
         ExecutionPayloadV1 {
@@ -432,6 +507,257 @@ mod tests {
             err,
             EngineSubmissionError::InvalidBlock(7, ref reason) if reason == "bad block"
         ));
+    }
+
+    /// Which engine RPC a scripted call hit, in production sequence order.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum EngineCall {
+        ForkchoiceWithAttributes,
+        GetPayload,
+        NewPayload,
+        PromotionForkchoice,
+        BlockByNumber,
+    }
+
+    /// Scripted [`EnginePayloadRpc`] double that records the call sequence and replays the
+    /// configured responses; unscripted calls return an error so a regression that keeps
+    /// calling after a failure surfaces as both a wrong call log and a wrong error.
+    #[derive(Default)]
+    struct ScriptedEngine {
+        calls: std::sync::Mutex<Vec<EngineCall>>,
+        attributes_forkchoice: Option<ForkchoiceUpdated>,
+        envelope: Option<ExecutionPayloadEnvelopeV2>,
+        new_payload: Option<PayloadStatus>,
+        promotion_forkchoice: Option<ForkchoiceUpdated>,
+        readback_block: Option<RpcBlock<TxEnvelope>>,
+    }
+
+    impl ScriptedEngine {
+        fn record(&self, call: EngineCall) {
+            self.calls.lock().expect("call log lock").push(call);
+        }
+
+        fn calls(&self) -> Vec<EngineCall> {
+            self.calls.lock().expect("call log lock").clone()
+        }
+
+        fn unscripted(call: &str) -> EngineSubmissionError {
+            EngineSubmissionError::Provider(format!("unscripted engine call: {call}"))
+        }
+    }
+
+    #[async_trait]
+    impl EnginePayloadRpc for ScriptedEngine {
+        fn chain_id(&self) -> u64 {
+            TAIKO_DEVNET_CHAIN_ID
+        }
+
+        async fn forkchoice_updated_v2(
+            &self,
+            _state: ForkchoiceState,
+            attrs: Option<TaikoPayloadAttributes>,
+        ) -> Result<ForkchoiceUpdated, EngineSubmissionError> {
+            if attrs.is_some() {
+                self.record(EngineCall::ForkchoiceWithAttributes);
+                self.attributes_forkchoice
+                    .clone()
+                    .ok_or_else(|| Self::unscripted("forkchoiceUpdated with attributes"))
+            } else {
+                self.record(EngineCall::PromotionForkchoice);
+                self.promotion_forkchoice
+                    .clone()
+                    .ok_or_else(|| Self::unscripted("promotion forkchoiceUpdated"))
+            }
+        }
+
+        async fn get_payload_v2(
+            &self,
+            _payload_id: PayloadId,
+        ) -> Result<ExecutionPayloadEnvelopeV2, EngineSubmissionError> {
+            self.record(EngineCall::GetPayload);
+            self.envelope.clone().ok_or_else(|| Self::unscripted("getPayload"))
+        }
+
+        async fn new_payload_v2(
+            &self,
+            _payload: &ExecutionPayloadInputV2,
+            _sidecar: &TaikoExecutionDataSidecar,
+        ) -> Result<PayloadStatus, EngineSubmissionError> {
+            self.record(EngineCall::NewPayload);
+            self.new_payload.clone().ok_or_else(|| Self::unscripted("newPayload"))
+        }
+
+        async fn block_by_number(
+            &self,
+            _number: u64,
+        ) -> Result<Option<RpcBlock<TxEnvelope>>, EngineSubmissionError> {
+            self.record(EngineCall::BlockByNumber);
+            Ok(self.readback_block.clone())
+        }
+    }
+
+    /// Payload attributes for block 7, matching [`sample_envelope_v1`]'s block number.
+    fn sample_attributes() -> TaikoPayloadAttributes {
+        build_payload_attributes(PayloadAttributesInput {
+            beneficiary: Address::from([1u8; 20]),
+            timestamp: 1,
+            mix_hash: B256::ZERO,
+            gas_limit: 30_000_000,
+            tx_list: Some(Bytes::new()),
+            extra_data: Bytes::new(),
+            base_fee_per_gas: U256::from(1u64),
+            block_number: 7,
+            l1_block_height: Some(U256::from(100u64)),
+            l1_block_hash: Some(B256::ZERO),
+            is_forced_inclusion: false,
+            signature: [0; 65],
+            parent_beacon_block_root: None,
+            anchor_transaction: None,
+        })
+    }
+
+    fn forkchoice_response(
+        status: PayloadStatusEnum,
+        payload_id: Option<PayloadId>,
+    ) -> ForkchoiceUpdated {
+        ForkchoiceUpdated { payload_status: PayloadStatus::from_status(status), payload_id }
+    }
+
+    /// The block hash produced by [`sample_payload`], i.e. what getPayload advertises.
+    fn sample_block_hash() -> B256 {
+        B256::from(U256::from(42u64))
+    }
+
+    fn sample_readback_block(hash: B256) -> RpcBlock<TxEnvelope> {
+        let mut block = RpcBlock::<TxEnvelope>::default();
+        block.header.hash = hash;
+        block.header.inner.number = 7;
+        block
+    }
+
+    /// A scripted engine primed for the full happy-path sequence.
+    fn scripted_happy_engine() -> ScriptedEngine {
+        ScriptedEngine {
+            attributes_forkchoice: Some(forkchoice_response(
+                PayloadStatusEnum::Valid,
+                Some(PayloadId::new([0; 8])),
+            )),
+            envelope: Some(sample_envelope_v1(0, U256::ZERO)),
+            new_payload: Some(PayloadStatus::from_status(PayloadStatusEnum::Valid)),
+            promotion_forkchoice: Some(forkchoice_response(PayloadStatusEnum::Valid, None)),
+            readback_block: Some(sample_readback_block(sample_block_hash())),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_payload_stops_when_attribute_forkchoice_is_not_valid() {
+        let engine = ScriptedEngine {
+            attributes_forkchoice: Some(forkchoice_response(PayloadStatusEnum::Syncing, None)),
+            ..Default::default()
+        };
+
+        let err = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, EngineSubmissionError::EngineSyncing(7)));
+        assert_eq!(engine.calls(), vec![EngineCall::ForkchoiceWithAttributes]);
+    }
+
+    #[tokio::test]
+    async fn apply_payload_stops_when_new_payload_is_accepted() {
+        let engine = ScriptedEngine {
+            promotion_forkchoice: None,
+            readback_block: None,
+            new_payload: Some(PayloadStatus::from_status(PayloadStatusEnum::Accepted)),
+            ..scripted_happy_engine()
+        };
+
+        let err = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, EngineSubmissionError::UnexpectedPayloadStatus(7, _)));
+        assert_eq!(
+            engine.calls(),
+            vec![
+                EngineCall::ForkchoiceWithAttributes,
+                EngineCall::GetPayload,
+                EngineCall::NewPayload,
+            ],
+            "no promotion or readback may happen after a non-VALID newPayload"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_payload_stops_when_promotion_forkchoice_is_not_valid() {
+        let engine = ScriptedEngine {
+            readback_block: None,
+            promotion_forkchoice: Some(forkchoice_response(
+                PayloadStatusEnum::Invalid { validation_error: "bad head".to_string() },
+                None,
+            )),
+            ..scripted_happy_engine()
+        };
+
+        let err = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            EngineSubmissionError::InvalidBlock(7, ref reason) if reason == "bad head"
+        ));
+        assert_eq!(
+            engine.calls(),
+            vec![
+                EngineCall::ForkchoiceWithAttributes,
+                EngineCall::GetPayload,
+                EngineCall::NewPayload,
+                EngineCall::PromotionForkchoice,
+            ],
+            "no readback may happen after a failed promotion"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_payload_rejects_mismatched_readback_hash() {
+        let engine = ScriptedEngine {
+            readback_block: Some(sample_readback_block(B256::from(U256::from(43u64)))),
+            ..scripted_happy_engine()
+        };
+
+        let err = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            EngineSubmissionError::InsertedBlockHashMismatch { block_number: 7, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn apply_payload_returns_hash_verified_outcome_for_valid_sequence() {
+        let engine = scripted_happy_engine();
+
+        let outcome = apply_payload_internal(&engine, &sample_attributes(), B256::ZERO, None)
+            .await
+            .expect("valid sequence must succeed");
+
+        assert_eq!(outcome.block_hash(), sample_block_hash());
+        assert_eq!(outcome.block_number(), 7);
+        assert_eq!(
+            engine.calls(),
+            vec![
+                EngineCall::ForkchoiceWithAttributes,
+                EngineCall::GetPayload,
+                EngineCall::NewPayload,
+                EngineCall::PromotionForkchoice,
+                EngineCall::BlockByNumber,
+            ]
+        );
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
@@ -93,6 +93,10 @@ async fn apply_payload_internal(
     };
     let fc_response =
         rpc.engine_forkchoice_updated_v2(forkchoice_state, Some(payload.clone())).await?;
+    ensure_valid_payload_status(
+        payload.l1_origin.block_id.to::<u64>(),
+        fc_response.payload_status.status,
+    )?;
 
     let payload_id = fc_response.payload_id.ok_or(EngineSubmissionError::MissingPayloadId)?;
     tracing::Span::current().record("payload_id", format_args!("{payload_id}"));
@@ -192,13 +196,20 @@ fn envelope_into_submission(
     (payload_input, sidecar, block_hash, block_number)
 }
 
-/// Map engine payload status into submission errors, rejecting syncing/invalid statuses.
+/// Map engine payload status into submission errors, accepting only VALID.
+///
+/// ACCEPTED means the engine stored the block on a side chain without executing it, so treating
+/// it as success would let the driver advance on a lineage the engine never validated.
 fn ensure_valid_payload_status(
     block_number: u64,
     status: PayloadStatusEnum,
 ) -> Result<(), EngineSubmissionError> {
     match status {
-        PayloadStatusEnum::Valid | PayloadStatusEnum::Accepted => Ok(()),
+        PayloadStatusEnum::Valid => Ok(()),
+        PayloadStatusEnum::Accepted => Err(EngineSubmissionError::UnexpectedPayloadStatus(
+            block_number,
+            PayloadStatusEnum::Accepted.as_str().to_string(),
+        )),
         PayloadStatusEnum::Syncing => Err(EngineSubmissionError::EngineSyncing(block_number)),
         PayloadStatusEnum::Invalid { validation_error } => {
             Err(EngineSubmissionError::InvalidBlock(block_number, validation_error))
@@ -216,6 +227,23 @@ fn promotion_forkchoice_state(
         head_block_hash: block_hash,
         safe_block_hash: resolved_finalized_hash,
         finalized_block_hash: resolved_finalized_hash,
+    }
+}
+
+/// Verify the canonical block read back after promotion matches the submitted payload hash.
+///
+/// A mismatch means the forkchoice update did not take effect (or another actor moved the head
+/// between promotion and readback); advancing on the mismatched block would silently desync the
+/// driver's parent state from the engine's canonical chain.
+fn ensure_inserted_block_hash(
+    block_number: u64,
+    expected: B256,
+    actual: B256,
+) -> Result<(), EngineSubmissionError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(EngineSubmissionError::InsertedBlockHashMismatch { block_number, expected, actual })
     }
 }
 
@@ -246,9 +274,11 @@ async fn submit_payload_to_engine(
     ensure_valid_payload_status(block_number, status.status)?;
 
     let promoted_state = promotion_forkchoice_state(block_hash, finalized_block_hash);
-    rpc.engine_forkchoice_updated_v2(promoted_state, None).await?;
+    let promotion = rpc.engine_forkchoice_updated_v2(promoted_state, None).await?;
+    ensure_valid_payload_status(block_number, promotion.payload_status.status)?;
 
     let block = fetch_block_by_number(rpc, block_number).await?;
+    ensure_inserted_block_hash(block_number, block_hash, block.header.hash)?;
 
     Ok(EngineBlockOutcome { block, payload_id })
 }
@@ -369,5 +399,59 @@ mod tests {
         let (_, sidecar, _, _) = envelope_into_submission(TAIKO_DEVNET_CHAIN_ID, envelope);
 
         assert_eq!(sidecar.header_difficulty, Some(U256::from(42u64)));
+    }
+
+    #[test]
+    fn valid_payload_status_is_ok() {
+        assert!(ensure_valid_payload_status(7, PayloadStatusEnum::Valid).is_ok());
+    }
+
+    #[test]
+    fn accepted_payload_status_is_rejected() {
+        let err = ensure_valid_payload_status(7, PayloadStatusEnum::Accepted).unwrap_err();
+        assert!(matches!(
+            err,
+            EngineSubmissionError::UnexpectedPayloadStatus(7, ref status) if status == "ACCEPTED"
+        ));
+    }
+
+    #[test]
+    fn syncing_payload_status_maps_to_engine_syncing() {
+        let err = ensure_valid_payload_status(7, PayloadStatusEnum::Syncing).unwrap_err();
+        assert!(matches!(err, EngineSubmissionError::EngineSyncing(7)));
+    }
+
+    #[test]
+    fn invalid_payload_status_maps_to_invalid_block() {
+        let err = ensure_valid_payload_status(
+            7,
+            PayloadStatusEnum::Invalid { validation_error: "bad block".to_string() },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            EngineSubmissionError::InvalidBlock(7, ref reason) if reason == "bad block"
+        ));
+    }
+
+    #[test]
+    fn matching_readback_hash_is_ok() {
+        let hash = B256::from(U256::from(1u64));
+        assert!(ensure_inserted_block_hash(7, hash, hash).is_ok());
+    }
+
+    #[test]
+    fn mismatched_readback_hash_is_rejected() {
+        let expected = B256::from(U256::from(1u64));
+        let actual = B256::from(U256::from(2u64));
+        let err = ensure_inserted_block_hash(7, expected, actual).unwrap_err();
+        assert!(matches!(
+            err,
+            EngineSubmissionError::InsertedBlockHashMismatch {
+                block_number: 7,
+                expected: e,
+                actual: a,
+            } if e == expected && a == actual
+        ));
     }
 }

--- a/packages/taiko-client-rs/crates/driver/src/sync/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/error.rs
@@ -100,10 +100,23 @@ pub enum EngineSubmissionError {
     /// Execution engine rejected the block payload.
     #[error("execution engine rejected block {0}: {1}")]
     InvalidBlock(u64, String),
+    /// Execution engine returned a status other than VALID for a canonical insert.
+    #[error("execution engine returned unexpected payload status for block {0}: {1}")]
+    UnexpectedPayloadStatus(u64, String),
     /// Engine did not return a payload identifier after forkchoice update.
     #[error("forkchoice update returned no payload id")]
     MissingPayloadId,
     /// Execution engine failed to return the inserted block via RPC.
     #[error("inserted block {0} not found via rpc provider")]
     MissingInsertedBlock(u64),
+    /// The canonical block read back after promotion does not match the submitted payload.
+    #[error("inserted block {block_number} hash mismatch: expected {expected}, got {actual}")]
+    InsertedBlockHashMismatch {
+        /// Number of the block that was submitted to the engine.
+        block_number: u64,
+        /// Block hash of the payload the engine was asked to insert.
+        expected: B256,
+        /// Block hash the provider returned at that height after promotion.
+        actual: B256,
+    },
 }

--- a/packages/taiko-client-rs/crates/proposer/src/config.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/config.rs
@@ -23,12 +23,12 @@ pub struct ProposerConfigs {
     /// Whether to use Engine API mode for payload building.
     /// When true, uses FCU + get_payload instead of tx_pool_content_with_min_tip.
     ///
-    /// WARNING: unsafe against current alethia-reth. The build-only FCU persists `l1_origin`,
-    /// `head_l1_origin`, and `batch_to_last_block` rows on the node before the previewed block
-    /// is ever imported or canonicalized, so every proposal cycle leaves ghost rows describing
-    /// blocks that do not exist on the canonical chain (the preview is never submitted via
-    /// `newPayload`). Keep this disabled until alethia-reth defers custom-table persistence to
-    /// canonical promotion.
+    /// WARNING: requires an execution client that defers L1-origin persistence to canonical
+    /// promotion (taikoxyz/alethia-reth#219). On older alethia-reth nodes, the build-only FCU
+    /// preview persists `l1_origin`, `head_l1_origin`, and `batch_to_last_block` rows before
+    /// the previewed block is ever imported or canonicalized, so every proposal cycle leaves
+    /// ghost rows describing blocks that do not exist on the canonical chain (the preview is
+    /// never submitted via `newPayload`).
     pub use_engine_mode: bool,
     /// Interval between tx-manager resubmissions when a proposal transaction remains
     /// unconfirmed.

--- a/packages/taiko-client-rs/crates/proposer/src/config.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/config.rs
@@ -22,6 +22,13 @@ pub struct ProposerConfigs {
     pub gas_limit: Option<u64>,
     /// Whether to use Engine API mode for payload building.
     /// When true, uses FCU + get_payload instead of tx_pool_content_with_min_tip.
+    ///
+    /// WARNING: unsafe against current alethia-reth. The build-only FCU persists `l1_origin`,
+    /// `head_l1_origin`, and `batch_to_last_block` rows on the node before the previewed block
+    /// is ever imported or canonicalized, so every proposal cycle leaves ghost rows describing
+    /// blocks that do not exist on the canonical chain (the preview is never submitted via
+    /// `newPayload`). Keep this disabled until alethia-reth defers custom-table persistence to
+    /// canonical promotion.
     pub use_engine_mode: bool,
     /// Interval between tx-manager resubmissions when a proposal transaction remains
     /// unconfirmed.

--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -108,6 +108,13 @@ impl Proposer {
 
         // Initialize anchor transaction constructor only for engine mode.
         let anchor_constructor = if cfg.use_engine_mode {
+            warn!(
+                "engine mode is enabled: the build-only FCU preview persists l1_origin, \
+                 head_l1_origin, and batch_to_last_block rows on the L2 node before (and \
+                 regardless of whether) the previewed block becomes canonical, leaving ghost \
+                 rows every proposal cycle; keep it disabled in production until alethia-reth \
+                 defers custom-table persistence to canonical promotion"
+            );
             Some(
                 AnchorTxConstructor::new(
                     rpc_provider.l2_provider.clone(),

--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -109,11 +109,11 @@ impl Proposer {
         // Initialize anchor transaction constructor only for engine mode.
         let anchor_constructor = if cfg.use_engine_mode {
             warn!(
-                "engine mode is enabled: the build-only FCU preview persists l1_origin, \
-                 head_l1_origin, and batch_to_last_block rows on the L2 node before (and \
-                 regardless of whether) the previewed block becomes canonical, leaving ghost \
-                 rows every proposal cycle; keep it disabled in production until alethia-reth \
-                 defers custom-table persistence to canonical promotion"
+                "engine mode is enabled: on execution clients without deferred L1-origin \
+                 persistence (taikoxyz/alethia-reth#219), the build-only FCU preview persists \
+                 l1_origin, head_l1_origin, and batch_to_last_block rows for blocks that never \
+                 become canonical, leaving ghost rows every proposal cycle; verify the \
+                 connected node includes that fix before using engine mode in production"
             );
             Some(
                 AnchorTxConstructor::new(
@@ -757,8 +757,14 @@ mod tests {
         assert_eq!(ProposerMetrics::proposals_success().get(), before + 1);
     }
 
+    /// Serializes tests that snapshot and assert on the process-global proposal-failure
+    /// counter, which would otherwise race each other under the parallel test runner.
+    static PROPOSALS_FAILED_METRIC_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn reverted_submission_receipt_becomes_failed_proposal_error() {
+        let _metric_guard =
+            PROPOSALS_FAILED_METRIC_GUARD.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let receipt = receipt_with_status(false);
         let tx_hash = receipt.transaction_hash;
         let before = ProposerMetrics::proposals_failed().get();
@@ -832,6 +838,8 @@ mod tests {
 
     #[test]
     fn loop_failure_metric_not_double_counted_for_reverted_receipts() {
+        let _metric_guard =
+            PROPOSALS_FAILED_METRIC_GUARD.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let before = ProposerMetrics::proposals_failed().get();
 
         let reverted_err =

--- a/packages/taiko-client-rs/crates/test-harness/src/shasta/helpers.rs
+++ b/packages/taiko-client-rs/crates/test-harness/src/shasta/helpers.rs
@@ -107,7 +107,9 @@ pub(crate) async fn create_snapshot(
 }
 
 fn payload_status_is_ok(status: &PayloadStatusEnum) -> bool {
-    matches!(status, PayloadStatusEnum::Valid | PayloadStatusEnum::Accepted)
+    // Canonical insertion requires strict VALID, matching production submission: ACCEPTED
+    // means the engine stored the block on a side chain without executing it.
+    matches!(status, PayloadStatusEnum::Valid)
 }
 
 /// Reset the L2 chain head to the base block (height 1) using the engine API.


### PR DESCRIPTION
## Problem

Engine build, canonicalization, and custom-table persistence are not atomic, and the Rust driver could not detect a mid-sequence failure. In the insert sequence `FCU(attrs) → getPayload → newPayload → FCU(promote) → readback`:

- `newPayload` returning **ACCEPTED** (side-chain insert, block never executed) was treated as success ([engine.rs](https://github.com/taikoxyz/taiko-mono/blob/main/packages/taiko-client-rs/crates/driver/src/sync/engine.rs) `ensure_valid_payload_status`)
- the **attribute FCU**'s payload status was never checked (only `payload_id` was extracted)
- the **promotion FCU**'s payload status was discarded entirely (`?` only caught transport errors)
- the inserted block was **read back by number without comparing its hash** to the submitted payload's hash

Since alethia-reth commits `l1_origin` / `head_l1_origin` / `batch_to_last_block` at *build* time (inside the attribute FCU, before `newPayload`/promotion), any silent mid-sequence failure leaves those tables describing blocks that never became canonical, while the driver advances `ParentState` on whatever block happens to sit at that height. Restart-time checkpoint resume reads exactly these tables (`MissingExecutionBlockForBatch` family).

The Go driver checks all of these statuses; this brings the Rust driver to parity plus a hash-verified readback.

## Changes

- `ensure_valid_payload_status` now accepts only `VALID`; `ACCEPTED` maps to a new `UnexpectedPayloadStatus` error
- the attribute FCU and the promotion FCU payload statuses are both enforced with the same helper
- new `ensure_inserted_block_hash` verifies the post-promotion readback returns the exact submitted block hash (new `InsertedBlockHashMismatch` error)
- beacon sync is intentionally untouched: its checkpoint-import path has its own status semantics where `SYNCING`/`ACCEPTED` are expected during backfill
- proposer: documented and `warn!`-ed that `use_engine_mode` ghost-writes the custom tables on the node every proposal cycle (its FCU+getPayload preview is never imported); the warning is qualified by execution-client behavior: engine mode requires a node with deferred L1-origin persistence (taikoxyz/alethia-reth#219)

## Testing

- TDD: new unit tests written first and watched fail (ACCEPTED-as-success, missing hash check), then implementation
- `cargo test -p driver --lib`: 93 passed; `cargo test -p proposer --lib`: 33 passed
- `cargo clippy --workspace --all-features --no-deps --exclude bindings --exclude test-harness -- -D warnings -D missing_docs -D clippy::missing_docs_in_private_items`: clean
- `cargo +nightly-2025-09-27 fmt`: applied

Companion PRs: taikoxyz/alethia-reth#219 and taikoxyz/taiko-geth#597 (persist L1-origin tables only on canonical promotion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Follow-up commit:** also serializes the two proposer tests that snapshot/assert the process-global `proposals_failed` counter — they raced each other under the parallel test runner and failed intermittently on unmodified `main` (reproduced at the base commit).


**Follow-up commit — orchestration regression coverage:** the submission orchestration now runs behind a minimal `EnginePayloadRpc` trait (implemented by `Client` with identical behavior) and is tested with a scripted, call-recording engine double: non-VALID at each of the three status-bearing calls stops immediately with the right error and no later engine calls; ACCEPTED from newPayload prevents promotion; a failed promotion prevents readback; a mismatched readback hash returns `InsertedBlockHashMismatch`; the happy path returns a hash-verified outcome. Each call-site check was mutation-tested — deleting it fails exactly its test. The integration harness's canonical-insertion helper now also requires strict VALID instead of tolerating ACCEPTED.

