### PR TITLE
fix(taiko-client): roll back proposal cursors so failed proposals are re-scanned

### DIFF
--- a/packages/taiko-client/prover/event_handler/proposal.go
+++ b/packages/taiko-client/prover/event_handler/proposal.go
@@ -105,7 +105,20 @@ func (h *ProposalEventHandler) handleProposal(
 				ctx,
 			),
 		); err != nil {
-			log.Error("Handle proposed event error", "error", err)
+			if ctx.Err() != nil {
+				return
+			}
+			// Roll the cursors back, so that the periodic proposal re-scan can pick this
+			// proposal up again, otherwise it would be skipped forever.
+			if !h.sharedState.RollbackProposalCursor(ctx, proposalID.Uint64()-1, newL1Current) {
+				return
+			}
+			log.Error(
+				"Handle proposed event error, rolled back the proposal cursor for a re-scan",
+				"proposalID", proposalID,
+				"l1Height", newL1Current.Number,
+				"error", err,
+			)
 		}
 	}()
 

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
@@ -245,13 +246,19 @@ func (p *Prover) eventLoop() {
 				func() error { return p.clearProofBuffer(batchProof, true) },
 			)
 		case req := <-p.proofSubmissionCh:
-			p.withRetry(func() error { return p.requestProofOp(req.Meta) }, nil)
+			p.withRetry(
+				func() error { return p.requestProofOp(req.Meta) },
+				p.rollbackProposalCursorOnRetryExhaustion(req.Meta),
+			)
 		case proofType := <-p.batchesAggregationNotify:
 			p.withRetry(func() error { return p.aggregateOp(proofType) }, nil)
 		case proofType := <-p.flushCacheNotify:
 			p.withRetry(func() error { return p.proofSubmitter.FlushCache(p.ctx, proofType) }, nil)
 		case m := <-p.assignmentExpiredCh:
-			p.withRetry(func() error { return p.eventHandlers.assignmentExpiredHandler.Handle(p.ctx, m) }, nil)
+			p.withRetry(
+				func() error { return p.eventHandlers.assignmentExpiredHandler.Handle(p.ctx, m) },
+				p.rollbackProposalCursorOnRetryExhaustion(m),
+			)
 		case <-proposedCh:
 			reqProving()
 		case e := <-provedCh:
@@ -269,18 +276,20 @@ func (p *Prover) Close(_ context.Context) {
 
 // proveOp iterates through Proposed events.
 func (p *Prover) proveOp() error {
-	iter, err := eventIterator.NewProposalIterator(p.ctx, &eventIterator.ProposalIteratorConfig{
-		RpcClient:          p.rpc,
-		StartHeight:        new(big.Int).SetUint64(p.sharedState.GetL1Current().Number.Uint64()),
-		OnProposalEvent:    p.eventHandlers.proposalHandler.Handle,
-		BlockConfirmations: &p.cfg.BlockConfirmations,
-	})
-	if err != nil {
-		log.Error("Failed to start proposal iterator", "error", err)
-		return err
-	}
+	return p.sharedState.WithProposalCursor(func() error {
+		iter, err := eventIterator.NewProposalIterator(p.ctx, &eventIterator.ProposalIteratorConfig{
+			RpcClient:          p.rpc,
+			StartHeight:        new(big.Int).SetUint64(p.sharedState.GetL1Current().Number.Uint64()),
+			OnProposalEvent:    p.eventHandlers.proposalHandler.Handle,
+			BlockConfirmations: &p.cfg.BlockConfirmations,
+		})
+		if err != nil {
+			log.Error("Failed to start proposal iterator", "error", err)
+			return err
+		}
 
-	return iter.Iter()
+		return iter.Iter()
+	})
 }
 
 // aggregateOp aggregates all proofs in buffer.
@@ -395,4 +404,47 @@ func (p *Prover) withRetry(f func() error, callback func() error) {
 			log.Error("Operation failed", "error", err)
 		}
 	}()
+}
+
+func (p *Prover) rollbackProposalCursorOnRetryExhaustion(
+	meta metadata.TaikoProposalMetaData,
+) func() error {
+	return func() error {
+		if p.ctx == nil {
+			return fmt.Errorf("missing prover context")
+		}
+		if p.ctx.Err() != nil {
+			return nil
+		}
+
+		shastaMeta, ok := meta.(*metadata.TaikoProposalMetadataShasta)
+		if !ok || shastaMeta == nil || shastaMeta.GetEventData() == nil {
+			return fmt.Errorf("invalid proposal metadata")
+		}
+
+		proposalID := shastaMeta.GetProposalID()
+		if proposalID == nil || proposalID.Sign() <= 0 || !proposalID.IsUint64() {
+			return fmt.Errorf("invalid proposal ID")
+		}
+
+		l1Height := shastaMeta.GetRawBlockHeight()
+		if l1Height == nil || l1Height.Sign() <= 0 || !l1Height.IsUint64() {
+			return fmt.Errorf("invalid proposal L1 block height")
+		}
+
+		rollbackHeight := new(big.Int).Set(l1Height)
+		if !p.sharedState.RollbackProposalCursor(
+			p.ctx,
+			proposalID.Uint64()-1,
+			&types.Header{Number: rollbackHeight},
+		) {
+			return nil
+		}
+		log.Warn(
+			"Rolled back proposal cursor after retry exhaustion",
+			"proposalID", proposalID,
+			"l1Height", rollbackHeight,
+		)
+		return nil
+	}
 }

--- a/packages/taiko-client/prover/prover_retry_test.go
+++ b/packages/taiko-client/prover/prover_retry_test.go
@@ -1,0 +1,113 @@
+package prover
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
+	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
+	state "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/shared_state"
+)
+
+func TestProposalRetryExhaustionRollsBackCursor(t *testing.T) {
+	ctx := context.Background()
+	p := &Prover{
+		ctx:         ctx,
+		cfg:         &Config{},
+		sharedState: state.New(),
+	}
+	p.sharedState.SetLastHandledProposalID(42)
+	p.sharedState.SetL1Current(&types.Header{Number: big.NewInt(100)})
+	meta := metadata.NewTaikoProposalMetadataShasta(
+		&shastaBindings.ShastaInboxClientProposed{
+			Id:  big.NewInt(21),
+			Raw: types.Log{BlockNumber: 88},
+		},
+		0,
+	)
+
+	p.withRetry(
+		func() error { return errors.New("RPC unavailable") },
+		p.rollbackProposalCursorOnRetryExhaustion(meta),
+	)
+	p.wg.Wait()
+
+	require.Equal(t, uint64(20), p.sharedState.GetLastHandledProposalID())
+	require.Equal(t, uint64(88), p.sharedState.GetL1Current().Number.Uint64())
+}
+
+func TestProposalRetryExhaustionDoesNotRollBackAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &Prover{
+		ctx:         ctx,
+		cfg:         &Config{},
+		sharedState: state.New(),
+	}
+	p.sharedState.SetLastHandledProposalID(42)
+	p.sharedState.SetL1Current(&types.Header{Number: big.NewInt(100)})
+	meta := metadata.NewTaikoProposalMetadataShasta(
+		&shastaBindings.ShastaInboxClientProposed{
+			Id:  big.NewInt(21),
+			Raw: types.Log{BlockNumber: 88},
+		},
+		0,
+	)
+	cancel()
+
+	p.withRetry(
+		func() error { return errors.New("RPC unavailable") },
+		p.rollbackProposalCursorOnRetryExhaustion(meta),
+	)
+	p.wg.Wait()
+
+	require.Equal(t, uint64(42), p.sharedState.GetLastHandledProposalID())
+	require.Equal(t, uint64(100), p.sharedState.GetL1Current().Number.Uint64())
+}
+
+func TestProposalRetryExhaustionRejectsInvalidMetadata(t *testing.T) {
+	var typedNil *metadata.TaikoProposalMetadataShasta
+	tests := []struct {
+		name string
+		meta metadata.TaikoProposalMetaData
+	}{
+		{name: "nil", meta: nil},
+		{name: "typed nil", meta: typedNil},
+		{
+			name: "zero proposal ID",
+			meta: metadata.NewTaikoProposalMetadataShasta(
+				&shastaBindings.ShastaInboxClientProposed{
+					Id:  new(big.Int),
+					Raw: types.Log{BlockNumber: 88},
+				},
+				0,
+			),
+		},
+		{
+			name: "zero L1 height",
+			meta: metadata.NewTaikoProposalMetadataShasta(
+				&shastaBindings.ShastaInboxClientProposed{Id: big.NewInt(21)},
+				0,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Prover{
+				ctx:         context.Background(),
+				sharedState: state.New(),
+			}
+			p.sharedState.SetLastHandledProposalID(42)
+			p.sharedState.SetL1Current(&types.Header{Number: big.NewInt(100)})
+
+			require.Error(t, p.rollbackProposalCursorOnRetryExhaustion(tt.meta)())
+			require.Equal(t, uint64(42), p.sharedState.GetLastHandledProposalID())
+			require.Equal(t, uint64(100), p.sharedState.GetL1Current().Number.Uint64())
+		})
+	}
+}

--- a/packages/taiko-client/prover/shared_state/state.go
+++ b/packages/taiko-client/prover/shared_state/state.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"context"
+	"sync"
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -10,6 +12,7 @@ import (
 type SharedState struct {
 	lastHandledProposalID atomic.Uint64
 	l1Current             atomic.Value
+	proposalCursorMu      sync.Mutex
 }
 
 // New creates a new prover shared state instance.
@@ -27,6 +30,56 @@ func (s *SharedState) SetLastHandledProposalID(proposalID uint64) {
 	s.lastHandledProposalID.Store(proposalID)
 }
 
+// WithProposalCursor runs fn while holding the proposal cursor lock.
+func (s *SharedState) WithProposalCursor(fn func() error) error {
+	s.proposalCursorMu.Lock()
+	defer s.proposalCursorMu.Unlock()
+
+	return fn()
+}
+
+// RollbackProposalCursor rolls both proposal cursors back atomically relative to
+// a proposal scan. It never advances either cursor and returns false if the
+// context is canceled before the cursors are mutated.
+func (s *SharedState) RollbackProposalCursor(
+	ctx context.Context,
+	proposalID uint64,
+	header *types.Header,
+) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
+	rolledBack := false
+	_ = s.WithProposalCursor(func() error {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		s.lowerLastHandledProposalID(proposalID)
+		s.lowerL1Current(header)
+		rolledBack = true
+		return nil
+	})
+
+	return rolledBack
+}
+
+// LowerLastHandledProposalID rolls the last handled proposal ID back to the given
+// value, it never advances the cursor.
+func (s *SharedState) LowerLastHandledProposalID(proposalID uint64) {
+	s.lowerLastHandledProposalID(proposalID)
+}
+
+func (s *SharedState) lowerLastHandledProposalID(proposalID uint64) {
+	for {
+		current := s.lastHandledProposalID.Load()
+		if current <= proposalID || s.lastHandledProposalID.CompareAndSwap(current, proposalID) {
+			return
+		}
+	}
+}
+
 // GetL1Current returns the current L1 header cursor.
 func (s *SharedState) GetL1Current() *types.Header {
 	if val := s.l1Current.Load(); val != nil {
@@ -38,4 +91,25 @@ func (s *SharedState) GetL1Current() *types.Header {
 // SetL1Current sets the current L1 header cursor.
 func (s *SharedState) SetL1Current(header *types.Header) {
 	s.l1Current.Store(header)
+}
+
+// LowerL1Current rolls the L1 cursor back to the given header, it never advances
+// the cursor.
+func (s *SharedState) LowerL1Current(header *types.Header) {
+	s.lowerL1Current(header)
+}
+
+func (s *SharedState) lowerL1Current(header *types.Header) {
+	for {
+		val := s.l1Current.Load()
+		if val == nil {
+			// atomic.Value.CompareAndSwap panics on a nil old value, and the cursor
+			// is always initialized before event handlers run, so a plain store is fine.
+			s.l1Current.Store(header)
+			return
+		}
+		if val.(*types.Header).Number.Cmp(header.Number) <= 0 || s.l1Current.CompareAndSwap(val, header) {
+			return
+		}
+	}
 }

--- a/packages/taiko-client/prover/shared_state/state_test.go
+++ b/packages/taiko-client/prover/shared_state/state_test.go
@@ -1,12 +1,27 @@
 package state
 
 import (
+	"context"
+	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/suite"
 )
+
+type errSignalingContext struct {
+	context.Context
+	errCalled chan struct{}
+	once      sync.Once
+}
+
+func (c *errSignalingContext) Err() error {
+	err := c.Context.Err()
+	c.once.Do(func() { close(c.errCalled) })
+	return err
+}
 
 type ProverSharedStateTestSuite struct {
 	suite.Suite
@@ -29,6 +44,109 @@ func (s *ProverSharedStateTestSuite) TestL1Current() {
 	s.NotEqual(newL1Current, s.state.GetL1Current())
 	s.state.SetL1Current(newL1Current)
 	s.Equal(newL1Current.Hash(), s.state.GetL1Current().Hash())
+}
+
+func (s *ProverSharedStateTestSuite) TestLowerLastHandledProposalID() {
+	s.state.SetLastHandledProposalID(10)
+
+	s.state.LowerLastHandledProposalID(5)
+	s.Equal(uint64(5), s.state.GetLastHandledProposalID())
+
+	// Lowering to a value above the current cursor must not advance it.
+	s.state.LowerLastHandledProposalID(8)
+	s.Equal(uint64(5), s.state.GetLastHandledProposalID())
+
+	s.state.LowerLastHandledProposalID(5)
+	s.Equal(uint64(5), s.state.GetLastHandledProposalID())
+}
+
+func (s *ProverSharedStateTestSuite) TestLowerL1Current() {
+	s.state.SetL1Current(&types.Header{Number: big.NewInt(100)})
+
+	s.state.LowerL1Current(&types.Header{Number: big.NewInt(90)})
+	s.Equal(uint64(90), s.state.GetL1Current().Number.Uint64())
+
+	// Lowering to a header above the current cursor must not advance it.
+	s.state.LowerL1Current(&types.Header{Number: big.NewInt(95)})
+	s.Equal(uint64(90), s.state.GetL1Current().Number.Uint64())
+}
+
+func (s *ProverSharedStateTestSuite) TestLowerL1CurrentUnset() {
+	s.Nil(s.state.GetL1Current())
+
+	s.state.LowerL1Current(&types.Header{Number: big.NewInt(42)})
+	s.Equal(uint64(42), s.state.GetL1Current().Number.Uint64())
+}
+
+func (s *ProverSharedStateTestSuite) TestRollbackProposalCursor() {
+	s.state.SetLastHandledProposalID(10)
+	s.state.SetL1Current(&types.Header{Number: big.NewInt(100)})
+
+	s.True(s.state.RollbackProposalCursor(context.Background(), 5, &types.Header{Number: big.NewInt(90)}))
+	s.Equal(uint64(5), s.state.GetLastHandledProposalID())
+	s.Equal(uint64(90), s.state.GetL1Current().Number.Uint64())
+
+	// Rolling back to values above the current cursors must not advance them.
+	s.True(s.state.RollbackProposalCursor(context.Background(), 8, &types.Header{Number: big.NewInt(95)}))
+	s.Equal(uint64(5), s.state.GetLastHandledProposalID())
+	s.Equal(uint64(90), s.state.GetL1Current().Number.Uint64())
+}
+
+func (s *ProverSharedStateTestSuite) TestRollbackProposalCursorCanceledWhileWaitingForLock() {
+	s.state.SetLastHandledProposalID(10)
+	s.state.SetL1Current(&types.Header{Number: big.NewInt(100)})
+
+	lockAcquired := make(chan struct{})
+	releaseLock := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- s.state.WithProposalCursor(func() error {
+			close(lockAcquired)
+			<-releaseLock
+			return nil
+		})
+	}()
+	<-lockAcquired
+
+	ctx, cancel := context.WithCancel(context.Background())
+	instrumentedCtx := &errSignalingContext{Context: ctx, errCalled: make(chan struct{})}
+	rollbackDone := make(chan bool, 1)
+	go func() {
+		rollbackDone <- s.state.RollbackProposalCursor(
+			instrumentedCtx,
+			5,
+			&types.Header{Number: big.NewInt(90)},
+		)
+	}()
+
+	<-instrumentedCtx.errCalled
+	cancel()
+	close(releaseLock)
+
+	s.NoError(<-lockDone)
+	s.False(<-rollbackDone)
+	s.Equal(uint64(10), s.state.GetLastHandledProposalID())
+	s.Equal(uint64(100), s.state.GetL1Current().Number.Uint64())
+}
+
+func (s *ProverSharedStateTestSuite) TestWithProposalCursorLocksDuringScan() {
+	s.state.SetLastHandledProposalID(10)
+	s.state.SetL1Current(&types.Header{Number: big.NewInt(100)})
+
+	s.NoError(s.state.WithProposalCursor(func() error {
+		acquired := s.state.proposalCursorMu.TryLock()
+		if acquired {
+			s.state.proposalCursorMu.Unlock()
+		}
+		s.False(acquired, "proposal cursor lock was not held during the scan")
+
+		s.state.SetLastHandledProposalID(20)
+		s.state.SetL1Current(&types.Header{Number: big.NewInt(200)})
+		return nil
+	}))
+
+	s.Equal(uint64(20), s.state.GetLastHandledProposalID())
+	s.Equal(uint64(200), s.state.GetL1Current().Number.Uint64())
 }
 
 func TestProverSharedStateTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

The prover advances its proposal cursors (`lastHandledProposalID` + `L1Current`) **before** the async proof-status check / proof request for that proposal has succeeded. If that work then fails — the `handleProposal` goroutine errors, or the proof request / assignment-expiration op exhausts its retries (~10 minutes of L1 RPC errors with default flags) — the proposal is only logged: the periodic force-proving re-scan finds the event again but skips it at the `lastHandledProposalID` check. A designated prover permanently misses its own proposal until process restart.

### Fix

Roll both cursors back on failure so the next re-scan re-delivers the event, wired in at the three failure points: `handleProposal`'s goroutine error path, and retry exhaustion of `requestProofOp` / `assignmentExpiredHandler` in the event loop.

- `SharedState.RollbackProposalCursor` lowers `lastHandledProposalID` + `L1Current` together, serialized against in-flight proposal scans (`proveOp` now runs under the same `WithProposalCursor` lock), so a rollback can't interleave with a scan advancing the cursors.
- Cursors are lower-only (CAS loops): a late rollback can't clobber progress made by concurrent handlers, and re-scanning already-handled proposals is idempotent (verified proposals are skipped; raiko deduplicates in-flight batch requests).
- Rollback is skipped once the prover context is canceled, so shutdown doesn't trigger spurious rollbacks.

## Testing

- New unit tests: `SharedState` lower-cursor semantics (rollback, never-advance, unset cursor, cancellation while waiting on the lock, scan/rollback serialization) and `TestProposalRetryExhaustion*` (rollback on exhaustion, no rollback after shutdown, invalid-metadata rejection).
- `go build ./...`, `go vet ./prover/...`, `gofmt`, and `golangci-lint run` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
