### PR TITLE
fix(taiko-client-rs): trap shutdown signals and apply driver review cleanups

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -9118,6 +9118,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -9823,6 +9824,8 @@ dependencies = [
  "snap",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tokio-util",
  "tower-http",
  "tracing",
 ]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -27,6 +27,8 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3.0"
 tokio-stream = "0.1"
+tokio-tungstenite = "0.24"
+tokio-util = { version = "0.7", features = ["rt"] }
 
 # cli
 clap = { version = "4", features = ["derive", "env"] }

--- a/packages/taiko-client-rs/bin/client/src/cli.rs
+++ b/packages/taiko-client-rs/bin/client/src/cli.rs
@@ -39,14 +39,31 @@ impl Cli {
     /// Run the subcommand.
     pub fn run(self) -> Result<()> {
         match self.subcommand {
-            Commands::Proposer(proposer_cmd) => Self::run_until_ctrl_c(proposer_cmd.run()),
-            Commands::Driver(driver_cmd) => Self::run_until_ctrl_c(driver_cmd.run()),
-            Commands::WhitelistPreconfirmationDriver(cmd) => Self::run_until_ctrl_c(cmd.run()),
+            Commands::Proposer(proposer_cmd) => Self::run_until_shutdown_signal(proposer_cmd.run()),
+            Commands::Driver(driver_cmd) => Self::run_until_shutdown_signal(driver_cmd.run()),
+            // The whitelist runner installs its own signal handling so it can drain its REST
+            // server and sidecars before exiting; a second top-level handler would race it and
+            // cancel that teardown.
+            Commands::WhitelistPreconfirmationDriver(cmd) => Self::block_on(cmd.run()),
         }
     }
 
-    /// Run until ctrl-c is pressed.
-    pub fn run_until_ctrl_c<F>(fut: F) -> Result<()>
+    /// Run the future until it completes or the process receives a shutdown signal
+    /// (SIGINT/ctrl-c or SIGTERM).
+    pub fn run_until_shutdown_signal<F>(fut: F) -> Result<()>
+    where
+        F: Future<Output = Result<()>>,
+    {
+        Self::block_on(async {
+            tokio::select! {
+                res = fut => res,
+                _ = driver::shutdown::shutdown_signal() => Ok(()),
+            }
+        })
+    }
+
+    /// Drive the future to completion on a fresh multi-thread runtime.
+    pub fn block_on<F>(fut: F) -> Result<()>
     where
         F: Future<Output = Result<()>>,
     {

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/bundle.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/bundle.rs
@@ -12,7 +12,7 @@ pub(super) struct SourceManifestSegment {
 
 /// Fully decoded proposal payload containing all derivation sources.
 #[derive(Debug, Clone)]
-pub struct ShastaProposalBundle {
+pub(super) struct ShastaProposalBundle {
     /// Proposal-wide metadata derived from the log and L1 block.
     pub(super) meta: BundleMeta,
     /// Ordered source manifests included in the proposal.

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -53,10 +53,8 @@ mod payload;
 /// Parent-state tracking while deriving sequential blocks.
 mod state;
 
-use bundle::{BundleMeta, SourceManifestSegment};
+use bundle::{BundleMeta, ShastaProposalBundle, SourceManifestSegment};
 use state::ParentState;
-
-pub use bundle::ShastaProposalBundle;
 
 /// Query inbox core state at the provided L1 block hash and return the finalized proposal id.
 ///
@@ -224,7 +222,7 @@ pub struct ShastaDerivationPipeline {
     /// L2 chain ID for chain-aware derivation and validation rules.
     chain_id: u64,
     /// Initial proposal id used when bootstrapping event sync.
-    initial_proposal_id: U256,
+    initial_proposal_id: u64,
 }
 
 impl ShastaDerivationPipeline {
@@ -236,7 +234,7 @@ impl ShastaDerivationPipeline {
     pub async fn new(
         rpc: Client,
         blob_source: Arc<BlobDataSource>,
-        initial_proposal_id: U256,
+        initial_proposal_id: u64,
     ) -> Result<Self, DerivationError> {
         let source_manifest_fetcher = ShastaSourceManifestFetcher::new(blob_source.clone());
         let anchor_address = *rpc.shasta.anchor.address();
@@ -497,10 +495,10 @@ impl ShastaDerivationPipeline {
         applier: &(dyn PayloadApplier + Send + Sync),
     ) -> Result<Vec<EngineBlockOutcome>, DerivationError> {
         let ShastaProposalBundle { meta, sources, .. } = manifest;
-        if meta.proposal_id < self.initial_proposal_id.to() {
+        if meta.proposal_id < self.initial_proposal_id {
             info!(
                 proposal_id = meta.proposal_id,
-                initial_proposal_id = ?self.initial_proposal_id,
+                initial_proposal_id = self.initial_proposal_id,
                 "skipping proposal below initial proposal id"
             );
             DriverMetrics::event_proposals_skipped_total().inc();
@@ -893,7 +891,7 @@ mod tests {
             shasta_fork_timestamp: 0,
             min_base_fee_to_clamp: min_base_fee_for_chain(TAIKO_MAINNET_CHAIN_ID),
             chain_id: TAIKO_MAINNET_CHAIN_ID,
-            initial_proposal_id: U256::ZERO,
+            initial_proposal_id: 0,
         };
 
         let mut parent_block = RpcBlock::<TxEnvelope>::default();

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/payload.rs
@@ -12,7 +12,7 @@ use protocol::shasta::{
     PayloadAttributesInput, build_payload_attributes_with_id, calculate_shasta_mix_hash,
     encode_extra_data, encode_transactions,
     manifest::{BlockManifest, DerivationSourceManifest},
-    unzen_active_for_chain_timestamp,
+    payload_core_mismatch, unzen_active_for_chain_timestamp,
 };
 
 use crate::{
@@ -765,10 +765,15 @@ impl ShastaDerivationPipeline {
             return Ok(None);
         }
 
-        if block.header.beneficiary !=
-            derived_block.payload.payload_attributes.suggested_fee_recipient
+        // Shared with preconfirmation-materialization detection so both answers to "would these
+        // attributes produce this header" can never drift apart.
+        if let Some(mismatch) =
+            payload_core_mismatch(&block.header.inner, block_id, &derived_block.payload)
         {
-            debug!(proposal_id = meta.proposal_id, block_id, "coinbase mismatch");
+            debug!(
+                proposal_id = meta.proposal_id,
+                block_id, mismatch, "canonical block field mismatch"
+            );
             return Ok(None);
         }
 
@@ -829,44 +834,6 @@ impl ShastaDerivationPipeline {
                     proposal_id = meta.proposal_id,
                     block_id, "unexpected requests hash before Unzen"
                 );
-                return Ok(None);
-            }
-        }
-
-        if block.header.mix_hash != derived_block.payload.payload_attributes.prev_randao {
-            debug!(proposal_id = meta.proposal_id, block_id, "mix digest mismatch");
-            return Ok(None);
-        }
-
-        if block.header.number != block_id {
-            debug!(
-                proposal_id = meta.proposal_id,
-                block_id,
-                canonical = block.header.number,
-                "block number mismatch"
-            );
-            return Ok(None);
-        }
-
-        if block.header.gas_limit != derived_block.payload.block_metadata.gas_limit {
-            debug!(proposal_id = meta.proposal_id, block_id, "gas limit mismatch");
-            return Ok(None);
-        }
-
-        if block.header.timestamp != derived_block.payload.payload_attributes.timestamp {
-            debug!(proposal_id = meta.proposal_id, block_id, "timestamp mismatch");
-            return Ok(None);
-        }
-
-        if block.header.extra_data != derived_block.payload.block_metadata.extra_data {
-            debug!(proposal_id = meta.proposal_id, block_id, "extra data mismatch");
-            return Ok(None);
-        }
-
-        match block.header.base_fee_per_gas {
-            Some(base_fee) if U256::from(base_fee) == derived_block.payload.base_fee_per_gas => {}
-            _ => {
-                debug!(proposal_id = meta.proposal_id, block_id, "base fee mismatch");
                 return Ok(None);
             }
         }

--- a/packages/taiko-client-rs/crates/driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/error.rs
@@ -9,6 +9,32 @@ use tokio::sync::oneshot::error::RecvError;
 
 use crate::sync::{SyncError, error::EngineSubmissionError};
 
+/// RPC precheck phase that exhausted the total preconfirmation submission budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreconfPrecheckPhase {
+    /// Check whether the payload already materialized in local execution state.
+    Materialization,
+    /// Read the confirmed `head_l1_origin` boundary before enqueue.
+    HeadL1Origin,
+}
+
+impl PreconfPrecheckPhase {
+    /// Return the stable metric and log label for this phase.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Materialization => "materialization",
+            Self::HeadL1Origin => "head_l1_origin",
+        }
+    }
+}
+
+impl std::fmt::Display for PreconfPrecheckPhase {
+    /// Render the stable phase label.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Convenient result alias for driver operations.
 pub type Result<T> = StdResult<T, DriverError>;
 
@@ -51,6 +77,15 @@ pub enum DriverError {
         #[source]
         /// Underlying engine submission error.
         source: EngineSubmissionError,
+    },
+
+    /// Timed out during an RPC precheck before enqueueing a preconfirmation payload.
+    #[error("preconfirmation {phase} precheck timed out after {waited:?}")]
+    PreconfPrecheckTimeout {
+        /// RPC precheck that exhausted the total submission budget.
+        phase: PreconfPrecheckPhase,
+        /// Total configured submission budget.
+        waited: Duration,
     },
 
     /// Timed out while enqueuing a preconfirmation payload.

--- a/packages/taiko-client-rs/crates/driver/src/lib.rs
+++ b/packages/taiko-client-rs/crates/driver/src/lib.rs
@@ -30,6 +30,6 @@ pub mod sync;
 
 pub use config::DriverConfig;
 pub use driver::Driver;
-pub use error::DriverError;
+pub use error::{DriverError, PreconfPrecheckPhase};
 pub use production::PreconfPayload;
 pub use sync::{ConfirmedSyncSnapshot, SyncPipeline, SyncStage, event::EventSyncer};

--- a/packages/taiko-client-rs/crates/driver/src/lib.rs
+++ b/packages/taiko-client-rs/crates/driver/src/lib.rs
@@ -23,6 +23,8 @@ pub mod metrics;
 pub mod preconf_ingress_sync;
 /// Production path routing and payload wrappers.
 pub mod production;
+/// Cooperative OS shutdown-signal handling.
+pub mod shutdown;
 /// Synchronization stages and event scanning.
 pub mod sync;
 

--- a/packages/taiko-client-rs/crates/driver/src/metrics.rs
+++ b/packages/taiko-client-rs/crates/driver/src/metrics.rs
@@ -1,8 +1,10 @@
 //! Metrics exposed by the driver runtime.
 
 use once_cell::sync::Lazy;
-use prometheus::{Gauge, Histogram, IntCounter};
-use protocol::metrics::{DURATION_SECONDS_BUCKETS, counter, gauge, histogram};
+use prometheus::{Gauge, Histogram, IntCounter, IntCounterVec};
+use protocol::metrics::{DURATION_SECONDS_BUCKETS, counter, counter_vec, gauge, histogram};
+
+use crate::error::PreconfPrecheckPhase;
 
 /// Metric namespace for the driver.
 pub struct DriverMetrics;
@@ -103,6 +105,11 @@ impl DriverMetrics {
         &METRICS.preconf_queue_depth
     }
 
+    /// Increment the timeout counter for an RPC precheck phase.
+    pub(crate) fn inc_preconf_precheck_timeout(phase: PreconfPrecheckPhase) {
+        METRICS.preconf_precheck_timeouts_total.with_label_values(&[phase.as_str()]).inc();
+    }
+
     /// Return the preconfirmation enqueue timeout counter.
     pub(crate) fn preconf_enqueue_timeouts_total() -> &'static IntCounter {
         &METRICS.preconf_enqueue_timeouts_total
@@ -200,6 +207,8 @@ struct DriverMetricHandles {
     preconf_injection_duration_seconds: Histogram,
     /// Buffered preconfirmation jobs awaiting processing.
     preconf_queue_depth: Gauge,
+    /// Preconfirmation RPC precheck timeouts by phase.
+    preconf_precheck_timeouts_total: IntCounterVec,
     /// Preconfirmation enqueue timeouts.
     preconf_enqueue_timeouts_total: IntCounter,
     /// Preconfirmation enqueue failures.
@@ -300,6 +309,11 @@ impl DriverMetricHandles {
             preconf_queue_depth: gauge(
                 "driver_preconf_queue_depth",
                 "Buffered preconfirmation jobs awaiting processing",
+            ),
+            preconf_precheck_timeouts_total: counter_vec(
+                "driver_preconf_precheck_timeouts_total",
+                "Preconfirmation RPC prechecks that exhausted the total submission budget",
+                &["phase"],
             ),
             preconf_enqueue_timeouts_total: counter(
                 "driver_preconf_enqueue_timeouts_total",

--- a/packages/taiko-client-rs/crates/driver/src/shutdown.rs
+++ b/packages/taiko-client-rs/crates/driver/src/shutdown.rs
@@ -1,0 +1,49 @@
+//! Cooperative OS shutdown-signal handling shared by the client binaries and runners.
+//!
+//! Mirrors the Go client's signal trap (SIGINT/SIGTERM) so Kubernetes rollouts and operators
+//! terminate the client cooperatively instead of killing it mid-operation.
+
+use tracing::{error, info};
+
+/// Resolve when the process receives a shutdown signal (SIGINT/ctrl-c or SIGTERM).
+///
+/// If a signal handler cannot be installed the corresponding branch parks forever, leaving the
+/// default process disposition in place for that signal.
+#[cfg(unix)]
+pub async fn shutdown_signal() {
+    use tokio::signal::unix::SignalKind;
+
+    tokio::select! {
+        _ = wait_for_signal(SignalKind::interrupt(), "SIGINT") => {}
+        _ = wait_for_signal(SignalKind::terminate(), "SIGTERM") => {}
+    }
+}
+
+/// Resolve when the process receives a ctrl-c on targets without unix signals.
+#[cfg(not(unix))]
+pub async fn shutdown_signal() {
+    if let Err(err) = tokio::signal::ctrl_c().await {
+        error!(?err, "failed to install ctrl-c handler");
+        std::future::pending::<()>().await;
+    }
+    info!(signal = "ctrl-c", "received shutdown signal");
+}
+
+/// Wait for one occurrence of the given unix signal, logging when it arrives.
+#[cfg(unix)]
+async fn wait_for_signal(kind: tokio::signal::unix::SignalKind, label: &'static str) {
+    match tokio::signal::unix::signal(kind) {
+        Ok(mut stream) => {
+            if stream.recv().await.is_some() {
+                info!(signal = label, "received shutdown signal");
+            } else {
+                // The stream can no longer receive signals; park so the caller keeps running.
+                std::future::pending::<()>().await;
+            }
+        }
+        Err(err) => {
+            error!(signal = label, ?err, "failed to install signal handler");
+            std::future::pending::<()>().await;
+        }
+    }
+}

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -8,6 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use alethia_reth_primitives::decode_shasta_proposal_id;
 use alloy::{
     eips::{BlockId, BlockNumberOrTag, eip1898::RpcBlockHash},
     primitives::{Address, B256, U256},
@@ -20,10 +21,11 @@ use alloy_sol_types::SolCall;
 use anyhow::anyhow;
 use bindings::{anchor::Anchor::anchorV4Call, inbox::Inbox::Proposed};
 use event_scanner::{EventFilter, Notification, ScannerMessage};
+use protocol::shasta::payload_core_mismatch;
 use tokio::{
     spawn,
     sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot},
-    time::{sleep, timeout},
+    time::{sleep, timeout, timeout_at},
 };
 use tokio_retry::{Retry, strategy::ExponentialBackoff};
 use tokio_stream::StreamExt;
@@ -56,9 +58,10 @@ enum ProposalLogResult {
     SkippedOrphaned,
 }
 
-/// Default timeout for preconfirmation payload submission.
+/// Default total budget for preconfirmation payload submission.
 ///
-/// Covers both the enqueue operation and awaiting the processing response.
+/// Applied as one deadline spanning the materialization and staleness pre-checks, the enqueue
+/// operation, and awaiting the processing response.
 const PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT: Duration = Duration::from_secs(12);
 /// Timeout for best-effort `head_l1_origin` reset after an event-scanner reorg.
 const REORG_HEAD_L1_ORIGIN_RESET_TIMEOUT: Duration = Duration::from_secs(12);
@@ -295,29 +298,10 @@ async fn preconfirmation_payload_is_materialized(
     if origin.l2_block_hash != B256::ZERO && header.hash != origin.l2_block_hash {
         return Ok(false);
     }
-    if header.number != block_number {
-        return Ok(false);
-    }
-    if header.beneficiary != expected_payload.payload_attributes.suggested_fee_recipient {
-        return Ok(false);
-    }
-    if header.mix_hash != expected_payload.payload_attributes.prev_randao {
-        return Ok(false);
-    }
-    if header.gas_limit != expected_payload.block_metadata.gas_limit {
-        return Ok(false);
-    }
-    if header.timestamp != expected_payload.payload_attributes.timestamp {
-        return Ok(false);
-    }
-    if header.extra_data != expected_payload.block_metadata.extra_data {
-        return Ok(false);
-    }
 
-    Ok(matches!(
-        header.base_fee_per_gas,
-        Some(base_fee) if U256::from(base_fee) == expected_payload.base_fee_per_gas
-    ))
+    // Shared with canonical-proposal detection so both answers to "would these attributes
+    // produce this header" can never drift apart.
+    Ok(payload_core_mismatch(&header.inner, block_number, expected_payload).is_none())
 }
 
 impl EventSyncer {
@@ -797,12 +781,17 @@ impl EventSyncer {
         .await
     }
 
-    /// Submit a preconfirmation payload with a caller-provided timeout for enqueue + response.
+    /// Submit a preconfirmation payload with a caller-provided total submission budget.
+    ///
+    /// The budget is applied as one deadline spanning the materialization and staleness
+    /// pre-checks, the enqueue operation, and awaiting the processing response, so callers
+    /// never wait longer than `timeout_duration` in total.
     pub async fn submit_preconfirmation_payload_with_timeout(
         &self,
         payload: PreconfPayload,
         timeout_duration: Duration,
     ) -> Result<(), DriverError> {
+        let deadline = tokio::time::Instant::now() + timeout_duration;
         let tx = self.preconf_tx.as_ref().ok_or(DriverError::PreconfirmationDisabled)?;
 
         // Reject early if strict ingress gating is not satisfied yet.
@@ -810,22 +799,37 @@ impl EventSyncer {
             return Err(DriverError::PreconfIngressNotReady);
         }
 
-        if preconfirmation_payload_is_materialized(&self.rpc, &payload).await? {
+        let block_number = payload.block_number();
+        // Shared handler for every phase that exhausts the budget before the response wait.
+        let enqueue_timeout = |phase: &'static str| {
+            DriverMetrics::preconf_enqueue_timeouts_total().inc();
+            error!(
+                block_number,
+                timeout_ms = timeout_duration.as_millis() as u64,
+                phase,
+                "preconfirmation submission timed out"
+            );
+            DriverError::PreconfEnqueueTimeout { waited: timeout_duration }
+        };
+
+        if timeout_at(deadline, preconfirmation_payload_is_materialized(&self.rpc, &payload))
+            .await
+            .map_err(|_| enqueue_timeout("materialization pre-check"))??
+        {
             debug!(
-                block_number = payload.block_number(),
+                block_number,
                 build_payload_args_id = %PayloadId::new(payload.payload().l1_origin.build_payload_args_id),
                 "skipping already materialized preconfirmation payload"
             );
             return Ok(());
         }
 
-        let block_number = payload.block_number();
         // On genesis chains head_l1_origin is not yet written; default to 0 so
         // the staleness check passes for any block_number >= 1.
-        let head_l1_origin_block_id = match self.rpc.head_l1_origin().await? {
-            Some(origin) => origin.block_id.to::<u64>(),
-            None => 0,
-        };
+        let head_l1_origin_block_id = timeout_at(deadline, self.rpc.head_l1_origin())
+            .await
+            .map_err(|_| enqueue_timeout("head_l1_origin pre-check"))??
+            .map_or(0, |origin| origin.block_id.to::<u64>());
         if is_stale_preconf(block_number, head_l1_origin_block_id) {
             DriverMetrics::preconf_stale_dropped_total().inc();
             DriverMetrics::preconf_stale_dropped_before_enqueue_total().inc();
@@ -840,23 +844,15 @@ impl EventSyncer {
 
         // Create oneshot channel for receiving the processing result.
         let (resp_tx, resp_rx) = oneshot::channel();
-        // Enqueue the preconfirmation job with timeout.
-        let enqueue_result = timeout(
-            timeout_duration,
+        // Enqueue the preconfirmation job under the remaining budget.
+        let enqueue_result = timeout_at(
+            deadline,
             tx.send(PreconfJob { payload: Arc::new(payload), respond_to: resp_tx }),
         )
         .await;
 
         match enqueue_result {
-            Err(_) => {
-                DriverMetrics::preconf_enqueue_timeouts_total().inc();
-                error!(
-                    block_number,
-                    timeout_ms = timeout_duration.as_millis() as u64,
-                    "preconfirmation enqueue timed out"
-                );
-                return Err(DriverError::PreconfEnqueueTimeout { waited: timeout_duration });
-            }
+            Err(_) => return Err(enqueue_timeout("enqueue")),
             Ok(Err(err)) => {
                 DriverMetrics::preconf_enqueue_failures_total().inc();
                 error!(block_number, ?err, "preconfirmation enqueue failed");
@@ -867,8 +863,8 @@ impl EventSyncer {
             }
         }
 
-        // Await the processing result with timeout.
-        let response_result = timeout(timeout_duration, resp_rx).await;
+        // Await the processing result under the remaining budget.
+        let response_result = timeout_at(deadline, resp_rx).await;
 
         match response_result {
             Err(_) => {
@@ -1166,22 +1162,19 @@ impl EventSyncer {
 }
 
 /// Recover the proposal id from header extra data.
-/// Byte layout: basefeeSharingPctg (byte 0), proposalId uint48 (bytes 1..6, big-endian).
+///
+/// Delegates to the execution client's [`decode_shasta_proposal_id`] so the extra-data layout
+/// has a single source of truth shared with the engine and the proposer.
 fn decode_anchor_proposal_id(block: &RpcBlock<TxEnvelope>) -> Result<u64, SyncError> {
     if block.header.number == 0 {
         return Ok(0);
     }
-    let extra_data = block.header.extra_data.as_ref();
-    if extra_data.len() < 7 {
-        return Err(SyncError::MissingAnchorTransaction {
+    decode_shasta_proposal_id(block.header.extra_data.as_ref()).ok_or(
+        SyncError::MissingAnchorTransaction {
             block_number: block.header.number,
             reason: "extra_data too short for proposal id",
-        });
-    }
-    let mut buf = [0u8; 8];
-    // Zero-pad the upper two bytes so the uint48 (bytes 1..6) becomes a big-endian u64.
-    buf[2..8].copy_from_slice(&extra_data[1..7]);
-    Ok(u64::from_be_bytes(buf))
+        },
+    )
 }
 
 /// Parse the first transaction in `block` and recover the `anchorV4` call data.
@@ -1221,7 +1214,7 @@ impl SyncStage for EventSyncer {
         let derivation_pipeline = ShastaDerivationPipeline::new(
             self.rpc.clone(),
             self.blob_source.clone(),
-            U256::from(initial_proposal_id),
+            initial_proposal_id,
         )
         .await?;
         let derivation = Arc::new(derivation_pipeline);

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -39,7 +39,7 @@ use super::{
 use crate::{
     config::DriverConfig,
     derivation::ShastaDerivationPipeline,
-    error::DriverError,
+    error::{DriverError, PreconfPrecheckPhase},
     metrics::DriverMetrics,
     production::{
         BlockProductionPath, CanonicalL1ProductionPath, PreconfPayload, PreconfirmationPath,
@@ -800,21 +800,20 @@ impl EventSyncer {
         }
 
         let block_number = payload.block_number();
-        // Shared handler for every phase that exhausts the budget before the response wait.
-        let enqueue_timeout = |phase: &'static str| {
-            DriverMetrics::preconf_enqueue_timeouts_total().inc();
+        let precheck_timeout = |phase: PreconfPrecheckPhase| {
+            DriverMetrics::inc_preconf_precheck_timeout(phase);
             error!(
                 block_number,
                 timeout_ms = timeout_duration.as_millis() as u64,
-                phase,
-                "preconfirmation submission timed out"
+                phase = phase.as_str(),
+                "preconfirmation RPC precheck timed out"
             );
-            DriverError::PreconfEnqueueTimeout { waited: timeout_duration }
+            DriverError::PreconfPrecheckTimeout { phase, waited: timeout_duration }
         };
 
         if timeout_at(deadline, preconfirmation_payload_is_materialized(&self.rpc, &payload))
             .await
-            .map_err(|_| enqueue_timeout("materialization pre-check"))??
+            .map_err(|_| precheck_timeout(PreconfPrecheckPhase::Materialization))??
         {
             debug!(
                 block_number,
@@ -828,7 +827,7 @@ impl EventSyncer {
         // the staleness check passes for any block_number >= 1.
         let head_l1_origin_block_id = timeout_at(deadline, self.rpc.head_l1_origin())
             .await
-            .map_err(|_| enqueue_timeout("head_l1_origin pre-check"))??
+            .map_err(|_| precheck_timeout(PreconfPrecheckPhase::HeadL1Origin))??
             .map_or(0, |origin| origin.block_id.to::<u64>());
         if is_stale_preconf(block_number, head_l1_origin_block_id) {
             DriverMetrics::preconf_stale_dropped_total().inc();
@@ -852,7 +851,15 @@ impl EventSyncer {
         .await;
 
         match enqueue_result {
-            Err(_) => return Err(enqueue_timeout("enqueue")),
+            Err(_) => {
+                DriverMetrics::preconf_enqueue_timeouts_total().inc();
+                error!(
+                    block_number,
+                    timeout_ms = timeout_duration.as_millis() as u64,
+                    "preconfirmation enqueue timed out"
+                );
+                return Err(DriverError::PreconfEnqueueTimeout { waited: timeout_duration });
+            }
             Ok(Err(err)) => {
                 DriverMetrics::preconf_enqueue_failures_total().inc();
                 error!(block_number, ?err, "preconfirmation enqueue failed");

--- a/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
@@ -216,8 +216,7 @@ async fn known_canonical_fast_path(env: &mut ShastaEnv) -> Result<()> {
     // Re-process the same proposal via the derivation pipeline.
     let blob_source =
         Arc::new(BlobDataSource::new(Some(beacon_endpoint.clone()), None, false).await?);
-    let pipeline =
-        ShastaDerivationPipeline::new(driver_client.clone(), blob_source, U256::ZERO).await?;
+    let pipeline = ShastaDerivationPipeline::new(driver_client.clone(), blob_source, 0).await?;
     let applier: &(dyn PayloadApplier + Send + Sync) = &driver_client;
     let _outcomes = pipeline
         .process_proposal(&proposal_log, applier)

--- a/packages/taiko-client-rs/crates/driver/tests/shasta_event_sync.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/shasta_event_sync.rs
@@ -1,6 +1,5 @@
 use std::{sync::Arc, time::Duration};
 
-use alloy_primitives::U256;
 use alloy_provider::Provider;
 use alloy_rpc_types::Log;
 use anyhow::{Context, Result, ensure};
@@ -72,8 +71,7 @@ async fn syncs_shasta_proposal_into_l2(env: &mut ShastaEnv) -> Result<()> {
 
     let blob_source =
         Arc::new(BlobDataSource::new(Some(beacon_endpoint.clone()), None, false).await?);
-    let pipeline =
-        ShastaDerivationPipeline::new(driver_client.clone(), blob_source, U256::ZERO).await?;
+    let pipeline = ShastaDerivationPipeline::new(driver_client.clone(), blob_source, 0).await?;
 
     let l2_head_before = driver_client.l2_provider.get_block_number().await?;
 

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/mod.rs
@@ -20,5 +20,5 @@ pub use constants::{
 pub use error::{ProtocolError, Result};
 pub use payload_helpers::{
     PayloadAttributesInput, build_payload_attributes, build_payload_attributes_with_id,
-    calculate_shasta_mix_hash, encode_extra_data, encode_transactions,
+    calculate_shasta_mix_hash, encode_extra_data, encode_transactions, payload_core_mismatch,
 };

--- a/packages/taiko-client-rs/crates/protocol/src/shasta/payload_helpers.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/shasta/payload_helpers.rs
@@ -8,7 +8,7 @@ use alloy::{
     primitives::{Address, B256, Bytes, U256, keccak256},
     sol_types::SolValue,
 };
-use alloy_consensus::TxEnvelope;
+use alloy_consensus::{Header, TxEnvelope};
 use alloy_rlp::{BytesMut, encode_list};
 use alloy_rpc_types_engine_2::{PayloadAttributes as EthPayloadAttributes, PayloadId};
 
@@ -44,6 +44,42 @@ pub fn encode_extra_data(basefee_sharing_pctg: u8, proposal_id: u64) -> Bytes {
     let proposal_bytes = proposal_id.to_be_bytes();
     data[1..7].copy_from_slice(&proposal_bytes[2..8]);
     Bytes::from(data.to_vec())
+}
+
+/// Compare the execution-header fields that [`build_payload_attributes`] derives from
+/// [`TaikoPayloadAttributes`] against an observed header.
+///
+/// Returns the name of the first mismatching field, or `None` when the header matches the
+/// attributes. This is the single source of truth for "would these attributes produce this
+/// header"; callers layer context-specific checks (L1 origin records, anchor transactions,
+/// fork-specific header fields) on top.
+pub fn payload_core_mismatch(
+    header: &Header,
+    expected_block_number: u64,
+    attrs: &TaikoPayloadAttributes,
+) -> Option<&'static str> {
+    if header.number != expected_block_number {
+        return Some("block number");
+    }
+    if header.beneficiary != attrs.payload_attributes.suggested_fee_recipient {
+        return Some("coinbase");
+    }
+    if header.mix_hash != attrs.payload_attributes.prev_randao {
+        return Some("mix hash");
+    }
+    if header.gas_limit != attrs.block_metadata.gas_limit {
+        return Some("gas limit");
+    }
+    if header.timestamp != attrs.payload_attributes.timestamp {
+        return Some("timestamp");
+    }
+    if header.extra_data != attrs.block_metadata.extra_data {
+        return Some("extra data");
+    }
+    match header.base_fee_per_gas {
+        Some(base_fee) if U256::from(base_fee) == attrs.base_fee_per_gas => None,
+        _ => Some("base fee"),
+    }
 }
 
 /// Encode a list of transactions into the format expected by the execution engine.
@@ -156,4 +192,83 @@ pub fn build_payload_attributes_with_id(
     let payload_id = payload_id_taiko(parent_hash, &payload, PAYLOAD_ID_VERSION_V2);
     payload.l1_origin.build_payload_args_id = payload_id_to_bytes(payload_id);
     payload
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    /// Build a matching (header, attributes) pair sharing the same core field values.
+    fn matching_header_and_attrs() -> (Header, TaikoPayloadAttributes, u64) {
+        let block_number = 42u64;
+        let attrs = build_payload_attributes(PayloadAttributesInput {
+            beneficiary: address!("00000000000000000000000000000000000000aa"),
+            timestamp: 1_700_000_000,
+            mix_hash: B256::from([0x11; 32]),
+            gas_limit: 30_000_000,
+            tx_list: None,
+            extra_data: encode_extra_data(75, 7),
+            base_fee_per_gas: U256::from(1_000_000u64),
+            block_number,
+            l1_block_height: None,
+            l1_block_hash: None,
+            is_forced_inclusion: false,
+            signature: [0; 65],
+            parent_beacon_block_root: None,
+            anchor_transaction: None,
+        });
+        let header = Header {
+            number: block_number,
+            beneficiary: attrs.payload_attributes.suggested_fee_recipient,
+            mix_hash: attrs.payload_attributes.prev_randao,
+            gas_limit: attrs.block_metadata.gas_limit,
+            timestamp: attrs.payload_attributes.timestamp,
+            extra_data: attrs.block_metadata.extra_data.clone(),
+            base_fee_per_gas: Some(1_000_000),
+            ..Default::default()
+        };
+        (header, attrs, block_number)
+    }
+
+    #[test]
+    fn payload_core_mismatch_accepts_matching_header() {
+        let (header, attrs, block_number) = matching_header_and_attrs();
+        assert_eq!(payload_core_mismatch(&header, block_number, &attrs), None);
+    }
+
+    #[test]
+    fn payload_core_mismatch_reports_first_divergent_field() {
+        let (header, attrs, block_number) = matching_header_and_attrs();
+
+        assert_eq!(payload_core_mismatch(&header, block_number + 1, &attrs), Some("block number"));
+
+        let mut tweaked = header.clone();
+        tweaked.beneficiary = Address::ZERO;
+        assert_eq!(payload_core_mismatch(&tweaked, block_number, &attrs), Some("coinbase"));
+
+        let mut tweaked = header.clone();
+        tweaked.mix_hash = B256::ZERO;
+        assert_eq!(payload_core_mismatch(&tweaked, block_number, &attrs), Some("mix hash"));
+
+        let mut tweaked = header.clone();
+        tweaked.gas_limit += 1;
+        assert_eq!(payload_core_mismatch(&tweaked, block_number, &attrs), Some("gas limit"));
+
+        let mut tweaked = header.clone();
+        tweaked.timestamp += 1;
+        assert_eq!(payload_core_mismatch(&tweaked, block_number, &attrs), Some("timestamp"));
+
+        let mut tweaked = header.clone();
+        tweaked.extra_data = Bytes::from_static(&[0xde, 0xad]);
+        assert_eq!(payload_core_mismatch(&tweaked, block_number, &attrs), Some("extra data"));
+
+        let mut tweaked = header.clone();
+        tweaked.base_fee_per_gas = Some(999_999);
+        assert_eq!(payload_core_mismatch(&tweaked, block_number, &attrs), Some("base fee"));
+
+        let mut tweaked = header;
+        tweaked.base_fee_per_gas = None;
+        assert_eq!(payload_core_mismatch(&tweaked, block_number, &attrs), Some("base fee"));
+    }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
@@ -42,8 +42,10 @@ snap = { workspace = true }
 ssz = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true }
+tokio-tungstenite = { workspace = true }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/handlers.rs
@@ -42,20 +42,23 @@ pub(super) async fn handle_preconf_blocks(
     request: Request,
 ) -> Result<Response, ApiHttpError> {
     let started_at = Instant::now();
-    let result = async {
-        if !state.api.is_sync_ready() {
-            return Err(ApiHttpError::BadRequest(
-                "event sync is not ready to serve preconfBlocks".to_string(),
-            ));
-        }
+    let result = tokio::select! {
+        result = async {
+            if !state.api.is_sync_ready() {
+                return Err(ApiHttpError::BadRequest(
+                    "event sync is not ready to serve preconfBlocks".to_string(),
+                ));
+            }
 
-        let body = read_request_body(request.into_body(), PRECONF_BLOCKS_BODY_LIMIT_BYTES).await?;
-        let build_request: BuildPreconfBlockRequest = serde_json::from_slice(&body)?;
+            let body =
+                read_request_body(request.into_body(), PRECONF_BLOCKS_BODY_LIMIT_BYTES).await?;
+            let build_request: BuildPreconfBlockRequest = serde_json::from_slice(&body)?;
 
-        let response = state.api.build_preconf_block(build_request).await?;
-        Ok(json_response(http::StatusCode::OK, &response))
-    }
-    .await;
+            let response = state.api.build_preconf_block(build_request).await?;
+            Ok(json_response(http::StatusCode::OK, &response))
+        } => result,
+        _ = state.force_shutdown.cancelled() => Err(ApiHttpError::ShuttingDown),
+    };
 
     WhitelistPreconfirmationDriverMetrics::record_rpc(
         "preconfBlocks",
@@ -82,9 +85,14 @@ pub(super) async fn handle_websocket_upgrade(
     };
 
     let notifications = state.api.subscribe_end_of_sequencing();
+    let shutdown = state.websocket_shutdown.clone();
+    // Register before returning the upgrade response so shutdown cannot observe an empty tracker
+    // while Axum still owns a callback that has not started running yet.
+    let task_token = state.websocket_tasks.token();
     websocket_upgrade
         .on_upgrade(move |socket| async move {
-            serve_websocket_notifications(socket, notifications).await;
+            let _task_token = task_token;
+            serve_websocket_notifications(socket, notifications, shutdown).await;
         })
         .into_response()
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http.rs
@@ -106,6 +106,9 @@ pub(super) enum ApiHttpError {
     /// Explicit client error response with caller-provided message.
     #[error("{0}")]
     BadRequest(String),
+    /// Request processing was cancelled after the server drain deadline expired.
+    #[error("server is shutting down")]
+    ShuttingDown,
 }
 
 impl ApiHttpError {
@@ -116,6 +119,7 @@ impl ApiHttpError {
             Self::ReadBody(RequestBodyReadError::TooLarge { .. }) => StatusCode::PAYLOAD_TOO_LARGE,
             Self::ReadBody(_) | Self::ParseBody(_) => StatusCode::UNPROCESSABLE_ENTITY,
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::ShuttingDown => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 
@@ -129,6 +133,7 @@ impl ApiHttpError {
             Self::ReadBody(err) => format!("failed to read request body: {err}"),
             Self::ParseBody(err) => format!("failed to parse request body: {err}"),
             Self::BadRequest(message) => message.clone(),
+            Self::ShuttingDown => "server is shutting down".to_string(),
         }
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/mod.rs
@@ -1,6 +1,6 @@
 //! REST/WS server for the whitelist preconfirmation driver.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -10,6 +10,13 @@ use super::WhitelistApi;
 use crate::{
     Result, codec::MAX_COMPRESSED_TX_LIST_BYTES, error::WhitelistPreconfirmationDriverError,
 };
+
+/// Grace period for tracked WebSocket sessions to observe shutdown and flush their close frames
+/// before teardown proceeds without them.
+///
+/// A peer that has stopped reading its socket cannot be preempted mid-`send().await`, so the wait
+/// for outstanding sessions must be bounded — a single stalled subscriber must not hang shutdown.
+const WEBSOCKET_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 mod auth;
 mod handlers;
@@ -129,7 +136,12 @@ impl WhitelistApiServer {
                 warn!(error = %err, "whitelist preconfirmation REST/WS server terminated with error");
             }
             websocket_tasks_for_server.close();
-            websocket_tasks_for_server.wait().await;
+            if tokio::time::timeout(WEBSOCKET_DRAIN_TIMEOUT, websocket_tasks_for_server.wait())
+                .await
+                .is_err()
+            {
+                warn!("whitelist preconfirmation websocket drain timed out during shutdown");
+            }
         });
 
         info!(
@@ -196,7 +208,10 @@ impl WhitelistApiServer {
         self.force_shutdown.cancel();
         self.websocket_shutdown.cancel();
         self.websocket_tasks.close();
-        self.websocket_tasks.wait().await;
+        if tokio::time::timeout(WEBSOCKET_DRAIN_TIMEOUT, self.websocket_tasks.wait()).await.is_err()
+        {
+            warn!("whitelist preconfirmation websocket drain timed out during abort");
+        }
         self.task.abort();
         if let Err(err) = (&mut self.task).await &&
             !err.is_cancelled()

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/mod.rs
@@ -3,6 +3,7 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{info, warn};
 
 use super::WhitelistApi;
@@ -30,6 +31,12 @@ struct AppState {
     api: Arc<dyn WhitelistApi>,
     /// Optional shared JWT validator; `None` disables auth checks.
     jwt_auth: Option<Arc<auth::JwtAuth>>,
+    /// Force-cancellation signal for REST handlers after the drain deadline expires.
+    force_shutdown: CancellationToken,
+    /// Graceful cancellation signal for active WebSocket sessions.
+    websocket_shutdown: CancellationToken,
+    /// Tracks upgraded WebSocket sessions independently spawned by Axum.
+    websocket_tasks: TaskTracker,
 }
 
 /// Configuration for the whitelist preconfirmation REST/WS server.
@@ -65,6 +72,14 @@ pub struct WhitelistApiServer {
     shutdown_tx: Option<oneshot::Sender<()>>,
     /// Background task running the axum server.
     task: JoinHandle<()>,
+    /// Whether the task result has already been consumed.
+    joined: bool,
+    /// Force-cancellation signal retained for timeout fallback.
+    force_shutdown: CancellationToken,
+    /// Graceful cancellation signal retained for timeout fallback.
+    websocket_shutdown: CancellationToken,
+    /// Tracks upgraded WebSocket sessions until they exit.
+    websocket_tasks: TaskTracker,
 }
 
 impl WhitelistApiServer {
@@ -73,12 +88,18 @@ impl WhitelistApiServer {
         config: WhitelistApiServerConfig,
         api: Arc<dyn WhitelistApi>,
     ) -> Result<Self> {
+        let force_shutdown = CancellationToken::new();
+        let websocket_shutdown = CancellationToken::new();
+        let websocket_tasks = TaskTracker::new();
         let state = AppState {
             api: Arc::clone(&api),
             jwt_auth: config
                 .jwt_secret
                 .as_ref()
                 .map(|secret| Arc::new(auth::JwtAuth::new(secret.as_slice()))),
+            force_shutdown: force_shutdown.clone(),
+            websocket_shutdown: websocket_shutdown.clone(),
+            websocket_tasks: websocket_tasks.clone(),
         };
         let app = router::build_router(state, &config.cors_origins);
 
@@ -96,14 +117,19 @@ impl WhitelistApiServer {
         })?;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let websocket_shutdown_for_server = websocket_shutdown.clone();
+        let websocket_tasks_for_server = websocket_tasks.clone();
         let task = tokio::spawn(async move {
             let server = axum::serve(listener, app).with_graceful_shutdown(async move {
                 let _ = shutdown_rx.await;
+                websocket_shutdown_for_server.cancel();
             });
 
             if let Err(err) = server.await {
                 warn!(error = %err, "whitelist preconfirmation REST/WS server terminated with error");
             }
+            websocket_tasks_for_server.close();
+            websocket_tasks_for_server.wait().await;
         });
 
         info!(
@@ -115,7 +141,15 @@ impl WhitelistApiServer {
             "started whitelist preconfirmation REST/WS server"
         );
 
-        Ok(Self { addr, shutdown_tx: Some(shutdown_tx), task })
+        Ok(Self {
+            addr,
+            shutdown_tx: Some(shutdown_tx),
+            task,
+            joined: false,
+            force_shutdown,
+            websocket_shutdown,
+            websocket_tasks,
+        })
     }
 
     /// Return the bound socket address.
@@ -133,16 +167,48 @@ impl WhitelistApiServer {
         format!("ws://{}", self.addr)
     }
 
-    /// Stop the server gracefully.
-    pub async fn stop(mut self) {
+    /// Request graceful shutdown without relinquishing ownership of the server task.
+    pub fn request_shutdown(&mut self) {
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
             let _ = shutdown_tx.send(());
         }
+    }
 
-        if let Err(err) = self.task.await {
+    /// Wait for the server task to stop after graceful shutdown has been requested.
+    pub async fn wait_stopped(&mut self) {
+        if self.joined {
+            return;
+        }
+        if let Err(err) = (&mut self.task).await {
             warn!(error = %err, "whitelist preconfirmation REST/WS server task join failed");
         }
+        self.joined = true;
 
         info!("whitelist preconfirmation REST/WS server stopped");
+    }
+
+    /// Abort the server task and wait until cancellation has completed.
+    pub async fn abort(&mut self) {
+        if self.joined {
+            return;
+        }
+        self.request_shutdown();
+        self.force_shutdown.cancel();
+        self.websocket_shutdown.cancel();
+        self.websocket_tasks.close();
+        self.websocket_tasks.wait().await;
+        self.task.abort();
+        if let Err(err) = (&mut self.task).await &&
+            !err.is_cancelled()
+        {
+            warn!(error = %err, "whitelist preconfirmation REST/WS server abort failed");
+        }
+        self.joined = true;
+    }
+
+    /// Stop the server gracefully.
+    pub async fn stop(&mut self) {
+        self.request_shutdown();
+        self.wait_stopped().await;
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -12,7 +12,8 @@ use tokio::{
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 use super::{
-    PRECONF_BLOCKS_BODY_LIMIT_BYTES, WhitelistApiServer, WhitelistApiServerConfig,
+    PRECONF_BLOCKS_BODY_LIMIT_BYTES, WEBSOCKET_DRAIN_TIMEOUT, WhitelistApiServer,
+    WhitelistApiServerConfig,
     auth::JwtAuth,
     http::{RequestBodyReadError, read_request_body},
 };
@@ -258,6 +259,24 @@ async fn graceful_stop_closes_and_waits_for_websocket() {
     timeout(Duration::from_millis(100), server.wait_stopped())
         .await
         .expect("server should wait for websocket shutdown");
+}
+
+#[tokio::test]
+async fn abort_bounds_wait_on_stuck_websocket_session() {
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let mut server =
+        WhitelistApiServer::start(test_config(), api).await.expect("server should start");
+
+    // Simulate a websocket session that never finishes: a peer stuck mid-`send().await` cannot be
+    // preempted at the shutdown `select!`, so its tracker token never drops and an unbounded
+    // `wait()` would block teardown forever.
+    let _stuck_session = server.websocket_tasks.token();
+
+    // The force-abort fallback must stay bounded instead of hanging on the stuck session.
+    timeout(WEBSOCKET_DRAIN_TIMEOUT * 3, server.abort())
+        .await
+        .expect("abort must not hang when a websocket session never completes");
+    assert!(server.joined);
 }
 
 #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -1,10 +1,15 @@
 use bytes::Bytes;
+use futures::StreamExt;
 use http_body_util::Full;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
 };
-use tokio::sync::broadcast;
+use tokio::{
+    sync::{Mutex, Notify, broadcast, oneshot},
+    time::{Duration, timeout},
+};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 use super::{
     PRECONF_BLOCKS_BODY_LIMIT_BYTES, WhitelistApiServer, WhitelistApiServerConfig,
@@ -25,6 +30,64 @@ use alloy_primitives::{Address, B256, Bytes as RpcBytes};
 use async_trait::async_trait;
 
 struct MockApi;
+
+struct BlockingApi {
+    started: Mutex<Option<oneshot::Sender<()>>>,
+    release: Notify,
+}
+
+struct WebSocketApi {
+    notifications: broadcast::Sender<EndOfSequencingNotification>,
+}
+
+#[async_trait]
+impl WhitelistApi for WebSocketApi {
+    async fn build_preconf_block(
+        &self,
+        _request: BuildPreconfBlockRequest,
+    ) -> Result<BuildPreconfBlockResponse> {
+        unreachable!("websocket API only exercises notifications")
+    }
+
+    async fn get_status(&self) -> Result<ApiStatus> {
+        unreachable!("websocket API only exercises notifications")
+    }
+
+    fn is_sync_ready(&self) -> bool {
+        true
+    }
+
+    fn subscribe_end_of_sequencing(&self) -> broadcast::Receiver<EndOfSequencingNotification> {
+        self.notifications.subscribe()
+    }
+}
+
+#[async_trait]
+impl WhitelistApi for BlockingApi {
+    async fn build_preconf_block(
+        &self,
+        _request: BuildPreconfBlockRequest,
+    ) -> Result<BuildPreconfBlockResponse> {
+        if let Some(started) = self.started.lock().await.take() {
+            let _ = started.send(());
+        }
+        self.release.notified().await;
+        Ok(BuildPreconfBlockResponse { block_header: Default::default() })
+    }
+
+    async fn get_status(&self) -> Result<ApiStatus> {
+        unreachable!("blocking API only exercises preconfBlocks")
+    }
+
+    fn is_sync_ready(&self) -> bool {
+        true
+    }
+
+    fn subscribe_end_of_sequencing(&self) -> broadcast::Receiver<EndOfSequencingNotification> {
+        let (_tx, rx) = broadcast::channel(1);
+        rx
+    }
+}
 
 #[async_trait]
 impl WhitelistApi for MockApi {
@@ -127,12 +190,74 @@ async fn server_start_stop() {
     let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
 
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let mut server = WhitelistApiServer::start(config, api).await.expect("server should start");
     assert_eq!(server.local_addr().ip().to_string(), "127.0.0.1");
     assert_ne!(server.local_addr().port(), 0);
     assert!(server.http_url().starts_with("http://127.0.0.1:"));
     assert!(server.ws_url().starts_with("ws://127.0.0.1:"));
     server.stop().await;
+}
+
+#[tokio::test]
+async fn timed_out_stop_retains_server_task() {
+    let (started_tx, started_rx) = oneshot::channel();
+    let api =
+        Arc::new(BlockingApi { started: Mutex::new(Some(started_tx)), release: Notify::new() });
+    let mut server =
+        WhitelistApiServer::start(test_config(), api).await.expect("server should start");
+    let request = tokio::spawn({
+        let url = format!("{}/preconfBlocks", server.http_url());
+        async move {
+            reqwest::Client::new()
+                .post(url)
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(sample_preconf_request())
+                .send()
+                .await
+        }
+    });
+    started_rx.await.expect("request should enter blocking handler");
+
+    server.request_shutdown();
+    assert!(timeout(Duration::from_millis(10), server.wait_stopped()).await.is_err());
+    server.abort().await;
+    assert!(server.joined);
+    assert!(timeout(Duration::from_millis(100), request).await.is_ok());
+}
+
+#[tokio::test]
+async fn abort_after_graceful_wait_is_safe() {
+    let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
+    let mut server =
+        WhitelistApiServer::start(test_config(), api).await.expect("server should start");
+
+    server.request_shutdown();
+    server.wait_stopped().await;
+    server.abort().await;
+
+    assert!(server.joined);
+}
+
+#[tokio::test]
+async fn graceful_stop_closes_and_waits_for_websocket() {
+    let (notifications, _) = broadcast::channel(1);
+    let api: Arc<dyn WhitelistApi> = Arc::new(WebSocketApi { notifications });
+    let mut server =
+        WhitelistApiServer::start(test_config(), api).await.expect("server should start");
+    let (mut websocket, _) =
+        connect_async(format!("{}/ws", server.ws_url())).await.expect("websocket should connect");
+
+    server.request_shutdown();
+    let message = timeout(Duration::from_millis(100), websocket.next())
+        .await
+        .expect("websocket should close during graceful shutdown");
+    assert!(
+        matches!(message, Some(Ok(Message::Close(_))) | None),
+        "unexpected websocket shutdown message: {message:?}"
+    );
+    timeout(Duration::from_millis(100), server.wait_stopped())
+        .await
+        .expect("server should wait for websocket shutdown");
 }
 
 #[test]
@@ -151,7 +276,7 @@ async fn cors_layer_allows_configured_origin() {
     };
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
 
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let mut server = WhitelistApiServer::start(config, api).await.expect("server should start");
     let response = reqwest::Client::new()
         .get(format!("{}/status", server.http_url()))
         .header(reqwest::header::ORIGIN, "https://example.com")
@@ -179,7 +304,7 @@ async fn preconf_blocks_is_rejected_when_not_sync_ready() {
         ..test_config()
     };
     let api = SyncReadyApi { build_preconf_calls: build_preconf_calls.clone(), sync_ready: false };
-    let server =
+    let mut server =
         WhitelistApiServer::start(config, Arc::new(api)).await.expect("server should start");
 
     let response = reqwest::Client::new()
@@ -223,7 +348,7 @@ fn jwt_auth_rejects_missing_header() {
 
 #[tokio::test]
 async fn jwt_auth_is_required_when_secret_configured() {
-    let server = start_jwt_server().await;
+    let mut server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .post(format!("{}/preconfBlocks", server.http_url()))
@@ -241,7 +366,7 @@ async fn jwt_auth_is_required_when_secret_configured() {
 async fn websocket_route_rejects_non_upgrade_requests() {
     let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let mut server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
     let response = reqwest::Client::new()
         .get(format!("{}/ws", server.http_url()))
@@ -257,7 +382,7 @@ async fn websocket_route_rejects_non_upgrade_requests() {
 async fn preconf_blocks_enforces_body_limit() {
     let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let mut server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
     let oversized_body = vec![b'a'; PRECONF_BLOCKS_BODY_LIMIT_BYTES + 1];
     let response = reqwest::Client::new()
@@ -281,7 +406,7 @@ async fn preconf_blocks_enforces_body_limit() {
 async fn preconf_blocks_rejects_invalid_json() {
     let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let mut server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
     let response = reqwest::Client::new()
         .post(format!("{}/preconfBlocks", server.http_url()))
@@ -306,7 +431,7 @@ async fn preconf_blocks_rejects_invalid_json() {
 async fn get_status_returns_can_shutdown_field_in_camel_case() {
     let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let mut server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
     let response = reqwest::Client::new()
         .get(format!("{}/status", server.http_url()))
@@ -326,7 +451,7 @@ async fn get_status_returns_can_shutdown_field_in_camel_case() {
 
 #[tokio::test]
 async fn status_path_skips_jwt_when_secret_configured() {
-    let server = start_jwt_server().await;
+    let mut server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/status", server.http_url()))
@@ -344,7 +469,7 @@ async fn status_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn healthz_path_skips_jwt_when_secret_configured() {
-    let server = start_jwt_server().await;
+    let mut server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/healthz", server.http_url()))
@@ -358,7 +483,7 @@ async fn healthz_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn root_path_skips_jwt_when_secret_configured() {
-    let server = start_jwt_server().await;
+    let mut server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/", server.http_url()))
@@ -372,7 +497,7 @@ async fn root_path_skips_jwt_when_secret_configured() {
 
 #[tokio::test]
 async fn preconf_blocks_still_requires_jwt_when_configured() {
-    let server = start_jwt_server().await;
+    let mut server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .post(format!("{}/preconfBlocks", server.http_url()))
@@ -392,7 +517,7 @@ async fn preconf_blocks_still_requires_jwt_when_configured() {
 
 #[tokio::test]
 async fn ws_still_requires_jwt_when_configured() {
-    let server = start_jwt_server().await;
+    let mut server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/ws", server.http_url()))
@@ -410,7 +535,7 @@ async fn ws_still_requires_jwt_when_configured() {
 
 #[tokio::test]
 async fn unknown_path_requires_jwt_when_secret_configured() {
-    let server = start_jwt_server().await;
+    let mut server = start_jwt_server().await;
 
     let response = reqwest::Client::new()
         .get(format!("{}/this-route-does-not-exist", server.http_url()))
@@ -430,7 +555,7 @@ async fn unknown_path_requires_jwt_when_secret_configured() {
 async fn unknown_path_returns_not_found_when_no_jwt_secret() {
     let config = test_config();
     let api: Arc<dyn WhitelistApi> = Arc::new(MockApi);
-    let server = WhitelistApiServer::start(config, api).await.expect("server should start");
+    let mut server = WhitelistApiServer::start(config, api).await.expect("server should start");
 
     let response = reqwest::Client::new()
         .get(format!("{}/this-route-does-not-exist", server.http_url()))

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/websocket.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/websocket.rs
@@ -3,6 +3,7 @@
 use axum::extract::ws::{Message, WebSocket};
 use futures::StreamExt;
 use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use crate::api::types::EndOfSequencingNotification;
@@ -11,9 +12,14 @@ use crate::api::types::EndOfSequencingNotification;
 pub(super) async fn serve_websocket_notifications(
     mut websocket: WebSocket,
     mut notifications: broadcast::Receiver<EndOfSequencingNotification>,
+    shutdown: CancellationToken,
 ) {
     loop {
         tokio::select! {
+            _ = shutdown.cancelled() => {
+                let _ = websocket.send(Message::Close(None)).await;
+                break;
+            }
             result = notifications.recv() => {
                 if !handle_notification(&mut websocket, result).await {
                     break;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -232,6 +232,7 @@ fn classify_cached_driver_error(err: &driver::DriverError) -> CachedImportDispos
         driver::DriverError::EngineInvalidPayload(_) => CachedImportDisposition::Drop,
         driver::DriverError::EngineSyncing(_) |
         driver::DriverError::BlockNotFound(_) |
+        driver::DriverError::PreconfPrecheckTimeout { .. } |
         driver::DriverError::PreconfEnqueueTimeout { .. } |
         driver::DriverError::PreconfResponseTimeout { .. } => CachedImportDisposition::Defer,
         driver::DriverError::PreconfInjectionFailed { source, .. } => match source {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -180,6 +180,18 @@ fn defers_cached_import_errors_for_preconf_response_timeout() {
 }
 
 #[test]
+fn cached_import_defers_precheck_timeouts() {
+    for phase in
+        [driver::PreconfPrecheckPhase::Materialization, driver::PreconfPrecheckPhase::HeadL1Origin]
+    {
+        let err = WhitelistPreconfirmationDriverError::Driver(
+            driver::DriverError::PreconfPrecheckTimeout { phase, waited: Duration::from_secs(12) },
+        );
+        assert_eq!(classify_cached_import_error(&err), CachedImportDisposition::Defer);
+    }
+}
+
+#[test]
 fn validate_payload_rejects_missing_transactions_list() {
     let envelope = sample_execution_payload_with_transactions(Vec::new());
     let anchor_address = sample_anchor_address();

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -90,6 +90,9 @@ impl WhitelistPreconfirmationDriverRunner {
         )
         .await?;
         let operator_set = operator_poller.shared_set();
+        // Detached intentionally: the operator-set refresh is read-only L1 polling with no
+        // in-flight state to drain, so shutdown lets it exit with the process instead of
+        // tracking its handle for teardown.
         tokio::spawn(operator_poller.run_refresh_loop());
 
         let network = WhitelistNetwork::spawn(

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -186,7 +186,6 @@ impl WhitelistPreconfirmationDriverRunner {
             let iteration = async {
                 let outcome: Option<Result<()>> = tokio::select! {
                     result = &mut node_handle => {
-                        stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
                         Some(match result {
                             Ok(Ok(())) => Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
                                 "whitelist preconfirmation network exited unexpectedly".to_string(),
@@ -198,9 +197,6 @@ impl WhitelistPreconfirmationDriverRunner {
                         })
                     }
                     result = &mut event_syncer_handle => {
-                        let _ = command_tx.send(NetworkCommand::Shutdown).await;
-                        node_handle.abort();
-                        stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
                         Some(map_event_syncer_exit(result).map_err(Into::into))
                     }
                     maybe_event = event_rx.recv() => match maybe_event {
@@ -214,7 +210,6 @@ impl WhitelistPreconfirmationDriverRunner {
                             None
                         }
                         None => {
-                            stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
                             Some(Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
                                 "whitelist preconfirmation event channel closed".to_string(),
                             )))
@@ -234,7 +229,33 @@ impl WhitelistPreconfirmationDriverRunner {
             };
 
             match run_until_shutdown(shutdown.as_mut(), iteration).await {
-                Some(Some(result)) => return result,
+                Some(Some(result)) => {
+                    // Terminal task results must escape the signal-cancellable future before
+                    // cleanup starts. Otherwise a signal during REST draining can discard an
+                    // already-consumed JoinHandle result and later teardown may re-poll it.
+                    let cleanup = async {
+                        let _ = command_tx.send(NetworkCommand::Shutdown).await;
+                        node_handle.abort();
+                        stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                    };
+                    match complete_cleanup_or_timeout_on_shutdown(
+                        shutdown.as_mut(),
+                        &mut event_rx,
+                        cleanup,
+                        SHUTDOWN_DRAIN_TIMEOUT,
+                    )
+                    .await
+                    {
+                        ShutdownAwareCleanupOutcome::BeforeSignal => return result,
+                        ShutdownAwareCleanupOutcome::AfterSignal => return Ok(()),
+                        ShutdownAwareCleanupOutcome::TimedOut => {
+                            warn!("whitelist preconfirmation drain timed out; exiting anyway");
+                            node_handle.abort();
+                            event_syncer_handle.abort();
+                            return Ok(());
+                        }
+                    }
+                }
                 Some(None) => {}
                 None => {
                     info!("shutdown signal received; draining whitelist preconfirmation driver");
@@ -248,13 +269,82 @@ impl WhitelistPreconfirmationDriverRunner {
                         }
                         request_network_shutdown(&command_tx, &mut node_handle).await;
                     };
-                    if tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, teardown).await.is_err() {
+                    if tokio::time::timeout(
+                        SHUTDOWN_DRAIN_TIMEOUT,
+                        complete_while_draining(&mut event_rx, teardown),
+                    )
+                    .await
+                    .is_err()
+                    {
                         warn!("whitelist preconfirmation drain timed out; exiting anyway");
                         node_handle.abort();
                     }
                     event_syncer_handle.abort();
                     return Ok(());
                 }
+            }
+        }
+    }
+}
+
+/// Result of running terminal cleanup while still observing the process shutdown signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShutdownAwareCleanupOutcome {
+    /// Cleanup finished normally before a shutdown signal arrived.
+    BeforeSignal,
+    /// A shutdown signal arrived, and cleanup then finished within the shutdown deadline.
+    AfterSignal,
+    /// A shutdown signal arrived, but cleanup did not finish within the shutdown deadline.
+    TimedOut,
+}
+
+/// Run terminal cleanup while watching for shutdown, then bound the same in-progress cleanup
+/// future if a signal arrives.
+async fn complete_cleanup_or_timeout_on_shutdown<S, T, F>(
+    shutdown: Pin<&mut S>,
+    event_rx: &mut tokio::sync::mpsc::Receiver<T>,
+    cleanup: F,
+    shutdown_timeout: Duration,
+) -> ShutdownAwareCleanupOutcome
+where
+    S: Future<Output = ()>,
+    F: Future<Output = ()>,
+{
+    tokio::pin!(cleanup);
+    if run_until_shutdown(shutdown, complete_while_draining(event_rx, cleanup.as_mut()))
+        .await
+        .is_some()
+    {
+        return ShutdownAwareCleanupOutcome::BeforeSignal;
+    }
+
+    if tokio::time::timeout(shutdown_timeout, complete_while_draining(event_rx, cleanup.as_mut()))
+        .await
+        .is_err()
+    {
+        ShutdownAwareCleanupOutcome::TimedOut
+    } else {
+        ShutdownAwareCleanupOutcome::AfterSignal
+    }
+}
+
+/// Complete a future while discarding inbound events that could otherwise backpressure the
+/// network runtime and prevent it from consuming shutdown commands.
+async fn complete_while_draining<T, F>(
+    event_rx: &mut tokio::sync::mpsc::Receiver<T>,
+    future: F,
+) -> F::Output
+where
+    F: Future,
+{
+    tokio::pin!(future);
+    let mut event_rx_open = true;
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut future => return result,
+            event = event_rx.recv(), if event_rx_open => {
+                event_rx_open = event.is_some();
             }
         }
     }
@@ -277,6 +367,11 @@ async fn request_network_shutdown(
     command_tx: &tokio::sync::mpsc::Sender<NetworkCommand>,
     node_handle: &mut tokio::task::JoinHandle<Result<()>>,
 ) {
+    // A terminal select branch may already have consumed the task output before a concurrent
+    // signal redirects control into teardown. Re-polling that completed handle would panic.
+    if node_handle.is_finished() {
+        return;
+    }
     let _ = command_tx.send(NetworkCommand::Shutdown).await;
     let _ = node_handle.await;
 }
@@ -340,5 +435,70 @@ mod tests {
 
         allow_exit_tx.send(()).expect("network task should still be waiting");
         shutdown.await;
+    }
+
+    #[tokio::test]
+    async fn network_shutdown_does_not_repoll_a_consumed_node_handle() {
+        let (command_tx, _command_rx) = mpsc::channel(1);
+        let mut node_handle = tokio::spawn(async { Ok(()) });
+        let result = (&mut node_handle).await;
+        assert!(matches!(result, Ok(Ok(()))));
+
+        request_network_shutdown(&command_tx, &mut node_handle).await;
+    }
+
+    #[tokio::test]
+    async fn network_shutdown_drains_inbound_backpressure_before_exit() {
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        event_tx.send(()).await.expect("first inbound event should fill the channel");
+
+        let (command_tx, mut command_rx) = mpsc::channel(2);
+        command_tx
+            .send(NetworkCommand::PublishUnsafeRequest { hash: B256::ZERO })
+            .await
+            .expect("publish command should be queued before shutdown");
+
+        let mut node_handle = tokio::spawn(async move {
+            event_tx.send(()).await.expect("runner should drain inbound backpressure");
+            assert!(matches!(
+                command_rx.recv().await,
+                Some(NetworkCommand::PublishUnsafeRequest { hash: B256::ZERO })
+            ));
+            assert!(matches!(command_rx.recv().await, Some(NetworkCommand::Shutdown)));
+            Ok(())
+        });
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            complete_while_draining(
+                &mut event_rx,
+                request_network_shutdown(&command_tx, &mut node_handle),
+            ),
+        )
+        .await
+        .expect("network shutdown should make progress while inbound forwarding is backpressured");
+    }
+
+    #[tokio::test]
+    async fn terminal_cleanup_uses_shutdown_deadline_after_signal() {
+        let (cleanup_started_tx, cleanup_started_rx) = oneshot::channel();
+        let mut shutdown = Box::pin(async {
+            cleanup_started_rx.await.expect("cleanup should start before shutdown");
+        });
+        let (_event_tx, mut event_rx) = mpsc::channel::<()>(1);
+        let cleanup = async move {
+            cleanup_started_tx.send(()).expect("shutdown should still be waiting");
+            pending::<()>().await;
+        };
+
+        let outcome = complete_cleanup_or_timeout_on_shutdown(
+            shutdown.as_mut(),
+            &mut event_rx,
+            cleanup,
+            Duration::from_millis(10),
+        )
+        .await;
+
+        assert_eq!(outcome, ShutdownAwareCleanupOutcome::TimedOut);
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -1,6 +1,6 @@
 //! Whitelist preconfirmation runner orchestration.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::Address;
@@ -8,6 +8,7 @@ use alloy_provider::Provider;
 use driver::{
     DriverConfig,
     preconf_ingress_sync::{PreconfIngressSync, map_event_syncer_exit},
+    shutdown::shutdown_signal,
 };
 use protocol::signer::FixedKSigner;
 use rpc::beacon::BeaconClient;
@@ -25,6 +26,10 @@ use crate::{
     network::{NetworkCommand, NetworkConfig, WhitelistNetwork},
     operator_set::OperatorSetPoller,
 };
+
+/// Bound on draining the REST/WS server after a shutdown signal, mirroring the Go driver's
+/// bounded preconfirmation-server shutdown window.
+const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Configuration for the whitelist preconfirmation runner.
 #[derive(Clone, Debug)]
@@ -171,8 +176,28 @@ impl WhitelistPreconfirmationDriverRunner {
         let WhitelistNetwork { mut event_rx, command_tx, handle: mut node_handle, .. } = network;
         let mut event_syncer_handle = preconf_ingress_sync.handle_mut();
 
+        // Cooperative shutdown for the steady-state loop; pinned once so a signal arriving
+        // between loop iterations is not lost. Signals arriving before the first poll keep
+        // their default disposition (immediate exit), acceptable while nothing is in flight.
+        let shutdown = shutdown_signal();
+        tokio::pin!(shutdown);
+
         loop {
             tokio::select! {
+                _ = &mut shutdown => {
+                    info!("shutdown signal received; draining whitelist preconfirmation driver");
+                    let _ = command_tx.send(NetworkCommand::Shutdown).await;
+                    node_handle.abort();
+                    // Drain the REST server before killing the ingress loop so in-flight
+                    // submissions settle, bounded like the Go driver's shutdown window.
+                    if let Some(server) = rest_ws_server.take() &&
+                        tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, server.stop()).await.is_err()
+                    {
+                        warn!("whitelist REST/WS server drain timed out; exiting anyway");
+                    }
+                    event_syncer_handle.abort();
+                    return Ok(());
+                }
                 result = &mut node_handle => {
                     stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
                     return match result {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -1,6 +1,6 @@
 //! Whitelist preconfirmation runner orchestration.
 
-use std::{future::Future, net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
+use std::{future::Future, net::SocketAddr, pin::Pin, sync::Arc, task::Poll, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::Address;
@@ -75,6 +75,14 @@ impl WhitelistPreconfirmationDriverRunner {
         );
 
         preconf_ingress_sync.wait_preconf_ingress_ready().await?;
+
+        // Poll once before exposing P2P or REST so Tokio installs both OS signal streams. The
+        // pinned future then retains any signal arriving during the remaining startup sequence.
+        let shutdown = shutdown_signal();
+        tokio::pin!(shutdown);
+        if poll_shutdown_once(shutdown.as_mut()).await {
+            return Ok(());
+        }
 
         let operator_poller = OperatorSetPoller::new(
             self.config.whitelist_address,
@@ -176,12 +184,6 @@ impl WhitelistPreconfirmationDriverRunner {
         let WhitelistNetwork { mut event_rx, command_tx, handle: mut node_handle, .. } = network;
         let mut event_syncer_handle = preconf_ingress_sync.handle_mut();
 
-        // Cooperative shutdown for the steady-state loop; pinned once so a signal arriving
-        // between loop iterations is not lost. Signals arriving before the first poll keep
-        // their default disposition (immediate exit), acceptable while nothing is in flight.
-        let shutdown = shutdown_signal();
-        tokio::pin!(shutdown);
-
         loop {
             let iteration = async {
                 let outcome: Option<Result<()>> = tokio::select! {
@@ -235,7 +237,7 @@ impl WhitelistPreconfirmationDriverRunner {
                     // already-consumed JoinHandle result and later teardown may re-poll it.
                     let cleanup = async {
                         let _ = command_tx.send(NetworkCommand::Shutdown).await;
-                        node_handle.abort();
+                        abort_and_wait(&mut node_handle).await;
                         stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
                     };
                     match complete_cleanup_or_timeout_on_shutdown(
@@ -250,8 +252,12 @@ impl WhitelistPreconfirmationDriverRunner {
                         ShutdownAwareCleanupOutcome::AfterSignal => return Ok(()),
                         ShutdownAwareCleanupOutcome::TimedOut => {
                             warn!("whitelist preconfirmation drain timed out; exiting anyway");
-                            node_handle.abort();
-                            event_syncer_handle.abort();
+                            abort_remaining_tasks(
+                                &mut rest_ws_server,
+                                &mut node_handle,
+                                event_syncer_handle,
+                            )
+                            .await;
                             return Ok(());
                         }
                     }
@@ -264,7 +270,7 @@ impl WhitelistPreconfirmationDriverRunner {
                     // then ask the network to shut down and wait for queued commands to be
                     // consumed. One deadline bounds the whole sequence; abort only as fallback.
                     let teardown = async {
-                        if let Some(server) = rest_ws_server.take() {
+                        if let Some(server) = rest_ws_server.as_mut() {
                             server.stop().await;
                         }
                         request_network_shutdown(&command_tx, &mut node_handle).await;
@@ -277,14 +283,31 @@ impl WhitelistPreconfirmationDriverRunner {
                     .is_err()
                     {
                         warn!("whitelist preconfirmation drain timed out; exiting anyway");
-                        node_handle.abort();
+                        abort_remaining_tasks(
+                            &mut rest_ws_server,
+                            &mut node_handle,
+                            event_syncer_handle,
+                        )
+                        .await;
+                    } else {
+                        abort_and_wait(event_syncer_handle).await;
                     }
-                    event_syncer_handle.abort();
                     return Ok(());
                 }
             }
         }
     }
+}
+
+/// Poll a pinned shutdown future exactly once without consuming it when it remains pending.
+///
+/// Returns `true` when shutdown was already ready. A pending result leaves the same future ready
+/// for later steady-state polling after its signal handlers have been installed.
+async fn poll_shutdown_once<S>(mut shutdown: Pin<&mut S>) -> bool
+where
+    S: Future<Output = ()>,
+{
+    std::future::poll_fn(|cx| Poll::Ready(shutdown.as_mut().poll(cx).is_ready())).await
 }
 
 /// Result of running terminal cleanup while still observing the process shutdown signal.
@@ -376,25 +399,103 @@ async fn request_network_shutdown(
     let _ = node_handle.await;
 }
 
+/// Abort one task and wait until its cancellation has been observed.
+async fn abort_and_wait<T>(handle: &mut tokio::task::JoinHandle<T>) {
+    // A terminal select branch may already have consumed the handle result. Such a task is no
+    // longer live, and re-polling its completed handle would panic.
+    if handle.is_finished() {
+        return;
+    }
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Force-stop every owned component after the graceful shutdown deadline expires.
+async fn abort_remaining_tasks<T>(
+    rest_ws_server: &mut Option<WhitelistApiServer>,
+    node_handle: &mut tokio::task::JoinHandle<Result<()>>,
+    event_syncer_handle: &mut tokio::task::JoinHandle<T>,
+) {
+    if let Some(server) = rest_ws_server.as_mut() {
+        server.abort().await;
+    }
+    abort_and_wait(node_handle).await;
+    abort_and_wait(event_syncer_handle).await;
+}
+
 /// Abort sidecar tasks and stop the REST server during shutdown.
 async fn stop_sidecars<T>(
     event_syncer_handle: &mut tokio::task::JoinHandle<T>,
     rest_ws_server: &mut Option<WhitelistApiServer>,
 ) {
-    event_syncer_handle.abort();
-    if let Some(server) = rest_ws_server.take() {
+    abort_and_wait(event_syncer_handle).await;
+    if let Some(server) = rest_ws_server.as_mut() {
         server.stop().await;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::future::{pending, ready};
+    use std::{
+        future::{pending, poll_fn, ready},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        task::Poll,
+    };
 
     use alloy_primitives::B256;
     use tokio::sync::{mpsc, oneshot};
 
     use super::*;
+
+    struct DropSignal(Option<oneshot::Sender<()>>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn eager_shutdown_poll_installs_pending_handler() {
+        let polled = Arc::new(AtomicBool::new(false));
+        let mut shutdown = Box::pin(poll_fn({
+            let polled = Arc::clone(&polled);
+            move |_| {
+                polled.store(true, Ordering::SeqCst);
+                Poll::<()>::Pending
+            }
+        }));
+
+        assert!(!poll_shutdown_once(shutdown.as_mut()).await);
+        assert!(polled.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn eager_shutdown_poll_preserves_ready_signal() {
+        let mut shutdown = Box::pin(ready(()));
+
+        assert!(poll_shutdown_once(shutdown.as_mut()).await);
+    }
+
+    #[tokio::test]
+    async fn abort_and_wait_observes_task_cancellation() {
+        let (dropped_tx, dropped_rx) = oneshot::channel();
+        let mut handle = tokio::spawn(async move {
+            let _drop_signal = DropSignal(Some(dropped_tx));
+            pending::<()>().await;
+        });
+        tokio::task::yield_now().await;
+
+        abort_and_wait(&mut handle).await;
+
+        dropped_rx.await.expect("aborted task should drop before cleanup returns");
+        assert!(handle.is_finished());
+    }
 
     #[tokio::test]
     async fn shutdown_preempts_pending_steady_state_work() {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -27,8 +27,8 @@ use crate::{
     operator_set::OperatorSetPoller,
 };
 
-/// Bound on draining the REST/WS server after a shutdown signal, mirroring the Go driver's
-/// bounded preconfirmation-server shutdown window.
+/// Bound on the whole signal-teardown sequence (REST/WS drain plus the network shutdown
+/// command), mirroring the Go driver's bounded preconfirmation-server shutdown window.
 const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Configuration for the whitelist preconfirmation runner.
@@ -186,15 +186,20 @@ impl WhitelistPreconfirmationDriverRunner {
             tokio::select! {
                 _ = &mut shutdown => {
                     info!("shutdown signal received; draining whitelist preconfirmation driver");
-                    let _ = command_tx.send(NetworkCommand::Shutdown).await;
-                    node_handle.abort();
-                    // Drain the REST server before killing the ingress loop so in-flight
-                    // submissions settle, bounded like the Go driver's shutdown window.
-                    if let Some(server) = rest_ws_server.take() &&
-                        tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, server.stop()).await.is_err()
-                    {
-                        warn!("whitelist REST/WS server drain timed out; exiting anyway");
+                    // Drain the REST server first — with ingress and P2P still available — so
+                    // an in-flight build settles end to end (engine insert + gossip publish),
+                    // then ask the network to shut down. One deadline bounds the whole
+                    // teardown; the aborts below are synchronous and cannot block.
+                    let teardown = async {
+                        if let Some(server) = rest_ws_server.take() {
+                            server.stop().await;
+                        }
+                        let _ = command_tx.send(NetworkCommand::Shutdown).await;
+                    };
+                    if tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, teardown).await.is_err() {
+                        warn!("whitelist preconfirmation drain timed out; exiting anyway");
                     }
+                    node_handle.abort();
                     event_syncer_handle.abort();
                     return Ok(());
                 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -1,6 +1,6 @@
 //! Whitelist preconfirmation runner orchestration.
 
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{future::Future, net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::Address;
@@ -183,70 +183,102 @@ impl WhitelistPreconfirmationDriverRunner {
         tokio::pin!(shutdown);
 
         loop {
-            tokio::select! {
-                _ = &mut shutdown => {
+            let iteration = async {
+                let outcome: Option<Result<()>> = tokio::select! {
+                    result = &mut node_handle => {
+                        stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                        Some(match result {
+                            Ok(Ok(())) => Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
+                                "whitelist preconfirmation network exited unexpectedly".to_string(),
+                            )),
+                            Ok(Err(err)) => Err(err),
+                            Err(err) => Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
+                                err.to_string(),
+                            )),
+                        })
+                    }
+                    result = &mut event_syncer_handle => {
+                        let _ = command_tx.send(NetworkCommand::Shutdown).await;
+                        node_handle.abort();
+                        stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                        Some(map_event_syncer_exit(result).map_err(Into::into))
+                    }
+                    maybe_event = event_rx.recv() => match maybe_event {
+                        Some(event) => {
+                            if let Err(err) = importer.handle_event(event).await {
+                                warn!(
+                                    error = %err,
+                                    "failed to handle whitelist preconfirmation network event"
+                                );
+                            }
+                            None
+                        }
+                        None => {
+                            stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                            Some(Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
+                                "whitelist preconfirmation event channel closed".to_string(),
+                            )))
+                        }
+                    },
+                    _ = sync_ready_interval.tick() => {
+                        if let Err(err) = importer.maybe_import_from_cache().await {
+                            warn!(
+                                error = %err,
+                                "failed to import cached whitelist preconfirmation payloads on sync-ready poll"
+                            );
+                        }
+                        None
+                    }
+                };
+                outcome
+            };
+
+            match run_until_shutdown(shutdown.as_mut(), iteration).await {
+                Some(Some(result)) => return result,
+                Some(None) => {}
+                None => {
                     info!("shutdown signal received; draining whitelist preconfirmation driver");
                     // Drain the REST server first — with ingress and P2P still available — so
                     // an in-flight build settles end to end (engine insert + gossip publish),
-                    // then ask the network to shut down. One deadline bounds the whole
-                    // teardown; the aborts below are synchronous and cannot block.
+                    // then ask the network to shut down and wait for queued commands to be
+                    // consumed. One deadline bounds the whole sequence; abort only as fallback.
                     let teardown = async {
                         if let Some(server) = rest_ws_server.take() {
                             server.stop().await;
                         }
-                        let _ = command_tx.send(NetworkCommand::Shutdown).await;
+                        request_network_shutdown(&command_tx, &mut node_handle).await;
                     };
                     if tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, teardown).await.is_err() {
                         warn!("whitelist preconfirmation drain timed out; exiting anyway");
+                        node_handle.abort();
                     }
-                    node_handle.abort();
                     event_syncer_handle.abort();
                     return Ok(());
-                }
-                result = &mut node_handle => {
-                    stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
-                    return match result {
-                        Ok(Ok(())) => Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
-                            "whitelist preconfirmation network exited unexpectedly".to_string(),
-                        )),
-                        Ok(Err(err)) => Err(err),
-                        Err(err) => Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
-                            err.to_string(),
-                        )),
-                    };
-                }
-                result = &mut event_syncer_handle => {
-                    let _ = command_tx.send(NetworkCommand::Shutdown).await;
-                    node_handle.abort();
-                    stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
-                    return map_event_syncer_exit(result).map_err(Into::into);
-                }
-                maybe_event = event_rx.recv() => {
-                    let Some(event) = maybe_event else {
-                        stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
-                        return Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
-                            "whitelist preconfirmation event channel closed".to_string(),
-                        ));
-                    };
-
-                    if let Err(err) = importer.handle_event(event).await {
-                        warn!(
-                            error = %err,
-                            "failed to handle whitelist preconfirmation network event"
-                        );
-                    }
-                }
-                _ = sync_ready_interval.tick() => {
-                    if let Err(err) = importer.maybe_import_from_cache().await {
-                        warn!(
-                            error = %err,
-                            "failed to import cached whitelist preconfirmation payloads on sync-ready poll"
-                        );
-                    }
                 }
             }
         }
     }
+}
+
+/// Resolve with `None` as soon as shutdown wins, including while `work` is already in progress.
+async fn run_until_shutdown<S, W, T>(shutdown: Pin<&mut S>, work: W) -> Option<T>
+where
+    S: Future<Output = ()>,
+    W: Future<Output = T>,
+{
+    tokio::select! {
+        _ = shutdown => None,
+        result = work => Some(result),
+    }
+}
+
+/// Enqueue network shutdown and wait until the runtime consumes all preceding commands and exits.
+async fn request_network_shutdown(
+    command_tx: &tokio::sync::mpsc::Sender<NetworkCommand>,
+    node_handle: &mut tokio::task::JoinHandle<Result<()>>,
+) {
+    let _ = command_tx.send(NetworkCommand::Shutdown).await;
+    let _ = node_handle.await;
 }
 
 /// Abort sidecar tasks and stop the REST server during shutdown.
@@ -257,5 +289,56 @@ async fn stop_sidecars<T>(
     event_syncer_handle.abort();
     if let Some(server) = rest_ws_server.take() {
         server.stop().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::{pending, ready};
+
+    use alloy_primitives::B256;
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn shutdown_preempts_pending_steady_state_work() {
+        let mut shutdown = Box::pin(ready(()));
+
+        let result = run_until_shutdown(shutdown.as_mut(), pending::<()>()).await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn network_shutdown_waits_for_queued_commands_to_be_consumed() {
+        let (command_tx, mut command_rx) = mpsc::channel(2);
+        command_tx
+            .send(NetworkCommand::PublishUnsafeRequest { hash: B256::ZERO })
+            .await
+            .expect("publish command should be queued");
+
+        let (shutdown_received_tx, shutdown_received_rx) = oneshot::channel();
+        let (allow_exit_tx, allow_exit_rx) = oneshot::channel();
+        let mut node_handle = tokio::spawn(async move {
+            assert!(matches!(
+                command_rx.recv().await,
+                Some(NetworkCommand::PublishUnsafeRequest { hash: B256::ZERO })
+            ));
+            assert!(matches!(command_rx.recv().await, Some(NetworkCommand::Shutdown)));
+            shutdown_received_tx.send(()).expect("receiver should still be waiting");
+            allow_exit_rx.await.expect("test should release network task");
+            Ok(())
+        });
+
+        let shutdown = request_network_shutdown(&command_tx, &mut node_handle);
+        tokio::pin!(shutdown);
+        tokio::select! {
+            () = &mut shutdown => panic!("shutdown returned before the network task exited"),
+            result = shutdown_received_rx => result.expect("network task should observe shutdown"),
+        }
+
+        allow_exit_tx.send(()).expect("network task should still be waiting");
+        shutdown.await;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the shutdown gap found in the 2026-07-11 driver-crate review and applies the verified simplifications from the same review.

### 1. Shutdown-signal handling (the gap)

`run_until_ctrl_c` installed **no signal handler** — it only `block_on`'d the subcommand, so SIGTERM/SIGINT killed the process instantly and the whitelist runner's graceful teardown (`stop_sidecars`, REST server stop) never ran on a signal. The Go client traps SIGINT/SIGTERM/SIGQUIT (`cmd/utils/sub_command.go`) and drains the preconf server for a bounded 5s (`driver.go`).

- new `driver::shutdown::shutdown_signal()` (SIGINT + SIGTERM; non-unix falls back to ctrl-c)
- `driver`/`proposer` subcommands: top-level `select!` — exit cooperatively on signal (nothing to drain, matching Go)
- whitelist runner: a pinned signal arm in the steady-state loop — **drains the REST/WS server first, while both ingress and P2P stay available**, so an in-flight build settles end to end (engine insert + gossip publish), then sends P2P `Shutdown`; one 5s deadline (like Go) bounds the whole drain + network-shutdown sequence, and the node/syncer aborts that follow are synchronous (review follow-up: an earlier revision stopped P2P before the drain, which could strand an inserted-but-ungossiped block, and left the bounded command-channel send outside the deadline)
- the runner owns signal handling for the whitelist subcommand (no top-level select) so nothing races/cancels the drain

Signals arriving during startup (before the loop) keep today's immediate-exit behavior; nothing is in flight then. **Ops follow-up (separate repo):** mainnet StatefulSets also lack the `preconf-prestop.sh` / `canShutdown` preStop wiring that masaya/hoodi have — this PR is the in-process half.

### 2. Dedupe the consensus-relevant header-vs-attributes comparison

`preconfirmation_payload_is_materialized` (event.rs) and `verify_canonical_block` (payload.rs) independently answered “would these payload attributes produce this header” with 7 byte-identical field checks that could silently drift. Both now share `protocol::shasta::payload_core_mismatch(header, expected_block_number, attrs) -> Option<&'static str>`, which lives next to `build_payload_attributes` (the function that defines the mapping). Canonical verification keeps its superset checks (payload id, anchor tx, parent hash, ommers, Unzen fields, withdrawals) on top; unit tests cover match + first-mismatch reporting per field.

### 3. Preconf submit timeout applied as one deadline

`submit_preconfirmation_payload_with_timeout` applied its 12s budget **twice** (enqueue + response = 24s worst case) while the materialization/`head_l1_origin` pre-checks ran **outside any timeout**, contradicting the const's own doc. The budget is now a single `timeout_at` deadline spanning pre-checks → enqueue → response, so callers (whitelist REST handler) never wait longer than the stated budget. Pre-check expiry maps to a dedicated `PreconfPrecheckTimeout` variant (with a per-phase `driver_preconf_precheck_timeouts_total` metric), enqueue expiry to `PreconfEnqueueTimeout`, response expiry to `PreconfResponseTimeout` — all three keep the `Defer` disposition in the whitelist importer.

### 4. Extra-data decode: one source of truth

`decode_anchor_proposal_id` hand-rolled the inverse of `protocol::encode_extra_data`. It now delegates to `alethia_reth_primitives::decode_shasta_proposal_id` — the execution client's own decoder, already used by the proposer — with identical semantics (short extra-data still surfaces `MissingAnchorTransaction`).

### 5. Small cleanups

- `ShastaDerivationPipeline::initial_proposal_id`: `U256` → `u64` (only ever constructed from and compared as u64)
- `ShastaProposalBundle`: `pub` + re-export → `pub(super)` (no consumers outside its module)

### Deliberately not included

The review also found the derivation-path zlib inflate is unbounded on **both** clients (Rust `manifest.rs` `read_to_end`, Go `pkg/utils/compress.go` `io.ReadAll`). A cap changes when a manifest falls back to the default — i.e. derivation semantics — so it must land in Go + Rust (+ prover) together, not in a cleanup PR. Flagged for coordination.

## Verification

- `just fmt-check` / `just clippy` (`-D warnings -D missing_docs -D clippy::missing_docs_in_private_items`) clean
- `just test`: **293/293 passed** (unit + dockerized e2e), including `known_canonical_fast_path` (exercises the shared comparator on the canonical path) and the proposer→driver event-sync e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

