### PR TITLE
fix(taiko-client): harden L1 reorg recovery in reorg walk-back and proof submission

### DIFF
--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -576,11 +576,29 @@ func (c *Client) CheckL1Reorg(ctx context.Context, proposalID *big.Int) (*ReorgC
 		// 1. Check whether the last L2 block's corresponding L1 block which in L1Origin has been reorged.
 		l1Origin, err := c.L2Engine.LastL1OriginByBatchID(ctxWithTimeout, proposalID)
 		if err != nil {
-			// If the L2 EE is just synced through P2P, so there is no L1Origin information recorded in
-			// its local database, we skip this check.
 			if err.Error() == ethereum.NotFound.Error() || err.Error() == eth.ErrProposalLastBlockUncertain.Error() {
-				log.Info("L1Origin not found, the L2 execution engine has just synced from P2P network", "proposalID", proposalID)
-				return result, nil
+				// If no reorg has been detected yet, the L2 EE was just synced through P2P, and there is
+				// no L1Origin information recorded in its local database, so we skip this check.
+				if !result.IsReorged {
+					log.Info(
+						"L1Origin not found, the L2 execution engine has just synced from P2P network",
+						"proposalID", proposalID,
+					)
+					return result, nil
+				}
+
+				// A reorg was already detected at a newer proposal, so returning here without reset
+				// cursors would hand the caller an unusable result. Since this proposal's canonicality
+				// cannot be verified without its L1Origin, treat it as reorged as well and keep walking
+				// back until a verifiable proposal (or genesis) provides the reset cursors;
+				// over-rewinding is safe since re-derivation is idempotent.
+				log.Warn(
+					"L1Origin unavailable while walking back reorged proposals, continuing to the previous proposal",
+					"proposalID", proposalID,
+					"error", err,
+				)
+				proposalID = new(big.Int).Sub(proposalID, common.Big1)
+				continue
 			}
 
 			return nil, err

--- a/packages/taiko-client/prover/proof_submitter/interface.go
+++ b/packages/taiko-client/prover/proof_submitter/interface.go
@@ -3,6 +3,7 @@ package submitter
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 	proofProducer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
@@ -14,6 +15,27 @@ var (
 	ErrInvalidProof  = errors.New("invalid proof found")
 	ErrCacheNotFound = errors.New("cache not found")
 )
+
+// ReorgedProofsError is returned by BatchSubmitProofs when proofs were dropped from an
+// aggregation because their proposals' source L1 blocks are no longer in the canonical chain.
+// The caller must roll the proposal scan cursors back below the lowest dropped proposal, so
+// that the replacement proposal events are re-scanned and re-proven; otherwise the
+// already-advanced cursors would skip the re-proposed events forever.
+type ReorgedProofsError struct {
+	// LowestProposalID is the smallest dropped proposal ID in the aggregation.
+	LowestProposalID uint64
+	// LowestProposalMeta is the metadata of that proposal, from its stale pre-reorg event.
+	LowestProposalMeta metadata.TaikoProposalMetaData
+}
+
+// Error implements the error interface. The message embeds ErrInvalidProof's text, so callers
+// matching on that sentinel's text keep the previous drop behavior if they miss the typed error.
+func (e *ReorgedProofsError) Error() string {
+	return fmt.Sprintf("%s: proposal %d reorged out of the canonical L1 chain", ErrInvalidProof, e.LowestProposalID)
+}
+
+// Unwrap makes errors.Is(err, ErrInvalidProof) hold for this error.
+func (e *ReorgedProofsError) Unwrap() error { return ErrInvalidProof }
 
 const (
 	MaxNumSupportedZkTypes    = 2

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -379,7 +379,7 @@ func (s *ProofSubmitter) BatchSubmitProofs(ctx context.Context, batchProof *proo
 	}
 
 	// Check if there are any invalid proposal proofs in the aggregation, and ignore them.
-	invalidProposalIDs, err := s.validateBatchProofs(ctx, batchProof)
+	invalidProposalIDs, lowestReorged, err := s.validateBatchProofs(ctx, batchProof)
 	if err != nil {
 		return fmt.Errorf("failed to validate proposal proofs: %w", err)
 	}
@@ -387,6 +387,14 @@ func (s *ProofSubmitter) BatchSubmitProofs(ctx context.Context, batchProof *proo
 		// If there are invalid proposals in the aggregation, we ignore these proposals.
 		log.Warn("Invalid proposals in an aggregation, ignore these proposals", "proposalIDs", invalidProposalIDs)
 		proofBuffer.ClearItems(invalidProposalIDs...)
+		if lowestReorged != nil {
+			// Reorged proposals will be re-proposed under the same IDs by different L1 blocks, so
+			// the caller must roll the proposal scan cursors back to re-scan and re-prove them.
+			return &ReorgedProofsError{
+				LowestProposalID:   lowestReorged.BatchID.Uint64(),
+				LowestProposalMeta: lowestReorged.Meta,
+			}
+		}
 		return ErrInvalidProof
 	}
 	var (
@@ -526,21 +534,25 @@ func (s *ProofSubmitter) AggregateProofsByType(ctx context.Context, proofType pr
 }
 
 // validateBatchProofs validates the batch proofs before submitting them to the L1 chain,
-// returns the invalid proposal IDs.
+// returns the invalid proposal IDs and, when some of them were invalidated by an L1 reorg,
+// the dropped proposal proof with the smallest ID.
 func (s *ProofSubmitter) validateBatchProofs(
 	ctx context.Context,
 	batchProof *proofProducer.BatchProofs,
-) ([]uint64, error) {
-	var invalidProposalIDs []uint64
+) ([]uint64, *proofProducer.ProofResponse, error) {
+	var (
+		invalidProposalIDs []uint64
+		lowestReorged      *proofProducer.ProofResponse
+	)
 
 	if len(batchProof.ProofResponses) == 0 {
-		return nil, proofProducer.ErrInvalidLength
+		return nil, nil, proofProducer.ErrInvalidLength
 	}
 
 	// Fetch the latest verified proposal ID.
 	coreState, err := s.rpc.GetCoreState(&bind.CallOpts{Context: ctx})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get core state: %w", err)
+		return nil, nil, fmt.Errorf("failed to get core state: %w", err)
 	}
 	latestVerifiedID := coreState.LastFinalizedProposalId
 
@@ -548,28 +560,48 @@ func (s *ProofSubmitter) validateBatchProofs(
 	// if so, we skip this batch.
 	for _, proof := range batchProof.ProofResponses {
 		// Check if this proof is still needed to be submitted.
-		ok, err := s.ValidateProof(ctx, proof, latestVerifiedID)
+		valid, reorged, err := s.ValidateProof(ctx, proof, latestVerifiedID)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		proposalID := proof.BatchID
-		if !ok {
-			log.Error("A valid proof for this proposal has already been submitted", "proposalID", proposalID)
-			invalidProposalIDs = append(invalidProposalIDs, proposalID.Uint64())
+		if valid {
 			continue
 		}
+		proposalID := proof.BatchID
+		if reorged {
+			log.Warn("Proposal reorged out of the canonical L1 chain, dropping its proof", "proposalID", proposalID)
+			if lowestReorged == nil || proposalID.Cmp(lowestReorged.BatchID) < 0 {
+				lowestReorged = proof
+			}
+		} else {
+			log.Error("A valid proof for this proposal has already been submitted", "proposalID", proposalID)
+		}
+		invalidProposalIDs = append(invalidProposalIDs, proposalID.Uint64())
 	}
-	return invalidProposalIDs, nil
+	return invalidProposalIDs, lowestReorged, nil
 }
 
 // ValidateProof checks if the proof's corresponding L1 block is still in the canonical chain and if the
-// latest verified head is not ahead of this block proof.
+// latest verified head is not ahead of this block proof. The second return value reports whether an
+// invalid proof was invalidated by its source L1 block being reorged out of the canonical chain.
 func (s *ProofSubmitter) ValidateProof(
 	ctx context.Context,
 	proofResponse *proofProducer.ProofResponse,
 	latestVerifiedID *big.Int,
-) (bool, error) {
-	// 1. Check if the corresponding L1 block is still in the canonical chain.
+) (bool, bool, error) {
+	// 1. Check if the proposal is already finalized: its proof is no longer needed, no matter
+	// whether its source L1 block is still canonical, so this must be checked first to avoid
+	// classifying it as reorged and triggering an unnecessary cursor rollback.
+	if latestVerifiedID.Cmp(proofResponse.BatchID) >= 0 {
+		log.Info(
+			"Proposal is already finalized, skip current proof submission",
+			"proposalID", proofResponse.BatchID,
+			"latestVerifiedID", latestVerifiedID,
+		)
+		return false, false, nil
+	}
+
+	// 2. Check if the corresponding L1 block is still in the canonical chain.
 	l1Header, err := s.rpc.L1.HeaderByNumber(ctx, proofResponse.Meta.GetRawBlockHeight())
 	if err != nil {
 		log.Warn(
@@ -578,7 +610,7 @@ func (s *ProofSubmitter) ValidateProof(
 			"l1Height", proofResponse.Meta.GetRawBlockHeight(),
 			"error", err,
 		)
-		return false, err
+		return false, false, err
 	}
 	if l1Header.Hash() != proofResponse.Opts.GetRawBlockHash() {
 		log.Warn(
@@ -588,19 +620,10 @@ func (s *ProofSubmitter) ValidateProof(
 			"l1HashOld", proofResponse.Opts.GetRawBlockHash(),
 			"l1HashNew", l1Header.Hash(),
 		)
-		return false, nil
+		return false, true, nil
 	}
 
-	if latestVerifiedID.Cmp(proofResponse.BatchID) >= 0 {
-		log.Info(
-			"Proposal is already finalized, skip current proof submission",
-			"proposalID", proofResponse.BatchID,
-			"latestVerifiedID", latestVerifiedID,
-		)
-		return false, nil
-	}
-
-	return true, nil
+	return true, false, nil
 }
 
 // WaitTransitionVerified waits until the given transition ID is verified on L1.

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -2,6 +2,7 @@ package prover
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -314,6 +315,16 @@ func (p *Prover) submitProofAggregationOp(batchProof *proofProducer.BatchProofs)
 		return err
 	}
 	if err := submitter.BatchSubmitProofs(p.ctx, batchProof); err != nil {
+		var reorgedErr *proofSubmitter.ReorgedProofsError
+		if errors.As(err, &reorgedErr) {
+			log.Warn(
+				"Dropped proofs for reorged proposals in an aggregation, rolling back the proposal cursor",
+				"lowestReorgedProposalID", reorgedErr.LowestProposalID,
+				"proofType", batchProof.ProofType,
+				"error", err,
+			)
+			return p.rollbackProposalCursorForReorg(p.rpc, reorgedErr)
+		}
 		if strings.Contains(err.Error(), proofSubmitter.ErrInvalidProof.Error()) {
 			log.Warn(
 				"Detected proven proposals",
@@ -447,4 +458,89 @@ func (p *Prover) rollbackProposalCursorOnRetryExhaustion(
 		)
 		return nil
 	}
+}
+
+// reorgChecker is the subset of the RPC client used to resolve a canonical rollback anchor.
+type reorgChecker interface {
+	CheckL1Reorg(ctx context.Context, proposalID *big.Int) (*rpc.ReorgCheckResult, error)
+}
+
+// rollbackProposalCursorForReorg rolls the proposal scan cursors back below the lowest proposal
+// whose aggregated proof was dropped because its source L1 block was reorged out of the canonical
+// chain, so that the periodic proposal re-scan re-dispatches the replacement proposal events.
+// Without the rollback, the already-advanced cursors would skip the re-proposed events forever.
+func (p *Prover) rollbackProposalCursorForReorg(
+	checker reorgChecker,
+	reorgedErr *proofSubmitter.ReorgedProofsError,
+) error {
+	if p.ctx == nil {
+		return fmt.Errorf("missing prover context")
+	}
+	if p.ctx.Err() != nil {
+		return nil
+	}
+
+	resetID, resetHeader, err := resolveReorgRollbackAnchor(p.ctx, checker, reorgedErr)
+	if err != nil {
+		return err
+	}
+
+	if !p.sharedState.RollbackProposalCursor(p.ctx, resetID, resetHeader) {
+		return nil
+	}
+	log.Warn(
+		"Rolled back proposal cursor after dropping proofs for reorged proposals",
+		"lowestReorgedProposalID", reorgedErr.LowestProposalID,
+		"resetProposalID", resetID,
+		"resetL1Height", resetHeader.Number,
+	)
+	return nil
+}
+
+// resolveReorgRollbackAnchor picks the cursor targets for a reorg rollback: preferably the newest
+// canonical proposal at or below the dropped proposal's parent, resolved through CheckL1Reorg,
+// whose answers are proven against canonical block hashes at height. This covers replacement
+// events landing at a lower L1 height than the stale event. When that data is unavailable, it
+// falls back to the stale event's block height, which only covers replacements landing at or
+// above that height.
+func resolveReorgRollbackAnchor(
+	ctx context.Context,
+	checker reorgChecker,
+	reorgedErr *proofSubmitter.ReorgedProofsError,
+) (uint64, *types.Header, error) {
+	if reorgedErr == nil || reorgedErr.LowestProposalID == 0 {
+		return 0, nil, fmt.Errorf("invalid reorged proposal ID")
+	}
+
+	result, err := checker.CheckL1Reorg(ctx, new(big.Int).SetUint64(reorgedErr.LowestProposalID-1))
+	if err == nil && result != nil && result.L1CurrentToReset != nil {
+		var resetID uint64
+		if result.LastHandledProposalIDToReset != nil && result.LastHandledProposalIDToReset.IsUint64() {
+			resetID = result.LastHandledProposalIDToReset.Uint64()
+		}
+		return resetID, result.L1CurrentToReset, nil
+	}
+	if err != nil {
+		log.Warn(
+			"Failed to resolve a canonical rollback anchor, falling back to the stale event block height",
+			"lowestReorgedProposalID", reorgedErr.LowestProposalID,
+			"error", err,
+		)
+	} else {
+		log.Warn(
+			"No canonical rollback anchor available, falling back to the stale event block height",
+			"lowestReorgedProposalID", reorgedErr.LowestProposalID,
+		)
+	}
+
+	shastaMeta, ok := reorgedErr.LowestProposalMeta.(*metadata.TaikoProposalMetadataShasta)
+	if !ok || shastaMeta == nil || shastaMeta.GetEventData() == nil {
+		return 0, nil, fmt.Errorf("invalid metadata for reorged proposal %d", reorgedErr.LowestProposalID)
+	}
+	l1Height := shastaMeta.GetRawBlockHeight()
+	if l1Height == nil || l1Height.Sign() <= 0 || !l1Height.IsUint64() {
+		return 0, nil, fmt.Errorf("invalid L1 block height for reorged proposal %d", reorgedErr.LowestProposalID)
+	}
+
+	return reorgedErr.LowestProposalID - 1, &types.Header{Number: new(big.Int).Set(l1Height)}, nil
 }

--- a/packages/taiko-client/prover/prover_reorg_rollback_test.go
+++ b/packages/taiko-client/prover/prover_reorg_rollback_test.go
@@ -1,0 +1,191 @@
+package prover
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
+	shastaBindings "github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/shasta"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
+	proofSubmitter "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_submitter"
+	state "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/shared_state"
+)
+
+type stubReorgChecker struct {
+	result        *rpc.ReorgCheckResult
+	err           error
+	gotProposalID *big.Int
+}
+
+func (s *stubReorgChecker) CheckL1Reorg(_ context.Context, proposalID *big.Int) (*rpc.ReorgCheckResult, error) {
+	s.gotProposalID = proposalID
+	return s.result, s.err
+}
+
+func newReorgedProofsError(lowestID uint64, staleL1Height uint64) *proofSubmitter.ReorgedProofsError {
+	return &proofSubmitter.ReorgedProofsError{
+		LowestProposalID: lowestID,
+		LowestProposalMeta: metadata.NewTaikoProposalMetadataShasta(
+			&shastaBindings.ShastaInboxClientProposed{
+				Id:  new(big.Int).SetUint64(lowestID),
+				Raw: types.Log{BlockNumber: staleL1Height},
+			},
+			0,
+		),
+	}
+}
+
+func TestReorgRollbackAnchorPrefersCanonicalAnchor(t *testing.T) {
+	checker := &stubReorgChecker{
+		result: &rpc.ReorgCheckResult{
+			IsReorged:                    true,
+			L1CurrentToReset:             &types.Header{Number: big.NewInt(50)},
+			LastHandledProposalIDToReset: big.NewInt(17),
+		},
+	}
+
+	resetID, resetHeader, err := resolveReorgRollbackAnchor(context.Background(), checker, newReorgedProofsError(21, 88))
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(17), resetID)
+	require.Equal(t, uint64(50), resetHeader.Number.Uint64())
+	require.Equal(t, uint64(20), checker.gotProposalID.Uint64())
+}
+
+func TestReorgRollbackAnchorGenesisResult(t *testing.T) {
+	// CheckL1Reorg's genesis branches set IsReorged and L1CurrentToReset, but leave
+	// LastHandledProposalIDToReset nil.
+	checker := &stubReorgChecker{
+		result: &rpc.ReorgCheckResult{
+			IsReorged:        true,
+			L1CurrentToReset: &types.Header{Number: big.NewInt(0)},
+		},
+	}
+
+	resetID, resetHeader, err := resolveReorgRollbackAnchor(context.Background(), checker, newReorgedProofsError(1, 88))
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), resetID)
+	require.Equal(t, uint64(0), resetHeader.Number.Uint64())
+}
+
+func TestReorgRollbackAnchorFallsBackOnCheckerError(t *testing.T) {
+	checker := &stubReorgChecker{err: errors.New("RPC unavailable")}
+
+	resetID, resetHeader, err := resolveReorgRollbackAnchor(context.Background(), checker, newReorgedProofsError(21, 88))
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), resetID)
+	require.Equal(t, uint64(88), resetHeader.Number.Uint64())
+}
+
+func TestReorgRollbackAnchorFallsBackOnUnresolvedResult(t *testing.T) {
+	// A P2P-synced L2 EE without L1Origin data makes CheckL1Reorg skip its walk and return
+	// an empty result.
+	checker := &stubReorgChecker{result: new(rpc.ReorgCheckResult)}
+
+	resetID, resetHeader, err := resolveReorgRollbackAnchor(context.Background(), checker, newReorgedProofsError(21, 88))
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), resetID)
+	require.Equal(t, uint64(88), resetHeader.Number.Uint64())
+}
+
+func TestReorgRollbackAnchorRejectsInvalidInput(t *testing.T) {
+	checker := &stubReorgChecker{err: errors.New("RPC unavailable")}
+
+	_, _, err := resolveReorgRollbackAnchor(context.Background(), checker, nil)
+	require.Error(t, err)
+
+	_, _, err = resolveReorgRollbackAnchor(context.Background(), checker, newReorgedProofsError(0, 88))
+	require.Error(t, err)
+
+	// Fallback with unusable metadata must not fabricate an anchor.
+	_, _, err = resolveReorgRollbackAnchor(context.Background(), checker, &proofSubmitter.ReorgedProofsError{
+		LowestProposalID: 21,
+	})
+	require.Error(t, err)
+
+	_, _, err = resolveReorgRollbackAnchor(context.Background(), checker, newReorgedProofsError(21, 0))
+	require.Error(t, err)
+}
+
+func TestRollbackProposalCursorForReorgLowersCursors(t *testing.T) {
+	p := &Prover{
+		ctx:         context.Background(),
+		cfg:         &Config{},
+		sharedState: state.New(),
+	}
+	p.sharedState.SetLastHandledProposalID(42)
+	p.sharedState.SetL1Current(&types.Header{Number: big.NewInt(100)})
+	checker := &stubReorgChecker{
+		result: &rpc.ReorgCheckResult{
+			IsReorged:                    true,
+			L1CurrentToReset:             &types.Header{Number: big.NewInt(50)},
+			LastHandledProposalIDToReset: big.NewInt(17),
+		},
+	}
+
+	require.NoError(t, p.rollbackProposalCursorForReorg(checker, newReorgedProofsError(21, 88)))
+
+	require.Equal(t, uint64(17), p.sharedState.GetLastHandledProposalID())
+	require.Equal(t, uint64(50), p.sharedState.GetL1Current().Number.Uint64())
+}
+
+func TestRollbackProposalCursorForReorgNeverAdvancesCursors(t *testing.T) {
+	p := &Prover{
+		ctx:         context.Background(),
+		cfg:         &Config{},
+		sharedState: state.New(),
+	}
+	p.sharedState.SetLastHandledProposalID(10)
+	p.sharedState.SetL1Current(&types.Header{Number: big.NewInt(30)})
+	checker := &stubReorgChecker{
+		result: &rpc.ReorgCheckResult{
+			IsReorged:                    true,
+			L1CurrentToReset:             &types.Header{Number: big.NewInt(50)},
+			LastHandledProposalIDToReset: big.NewInt(17),
+		},
+	}
+
+	require.NoError(t, p.rollbackProposalCursorForReorg(checker, newReorgedProofsError(21, 88)))
+
+	require.Equal(t, uint64(10), p.sharedState.GetLastHandledProposalID())
+	require.Equal(t, uint64(30), p.sharedState.GetL1Current().Number.Uint64())
+}
+
+func TestRollbackProposalCursorForReorgNoopAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &Prover{
+		ctx:         ctx,
+		cfg:         &Config{},
+		sharedState: state.New(),
+	}
+	p.sharedState.SetLastHandledProposalID(42)
+	p.sharedState.SetL1Current(&types.Header{Number: big.NewInt(100)})
+	cancel()
+
+	require.NoError(t, p.rollbackProposalCursorForReorg(&stubReorgChecker{}, newReorgedProofsError(21, 88)))
+
+	require.Equal(t, uint64(42), p.sharedState.GetLastHandledProposalID())
+	require.Equal(t, uint64(100), p.sharedState.GetL1Current().Number.Uint64())
+}
+
+func TestReorgedProofsErrorMatchesInvalidProofSentinel(t *testing.T) {
+	err := error(&proofSubmitter.ReorgedProofsError{LowestProposalID: 21})
+
+	// The typed error must keep matching the legacy ErrInvalidProof checks, so callers
+	// missing the typed branch fall back to the previous drop behavior.
+	require.ErrorIs(t, err, proofSubmitter.ErrInvalidProof)
+	require.True(t, strings.Contains(err.Error(), proofSubmitter.ErrInvalidProof.Error()))
+
+	var reorgedErr *proofSubmitter.ReorgedProofsError
+	require.True(t, errors.As(err, &reorgedErr))
+	require.Equal(t, uint64(21), reorgedErr.LowestProposalID)
+}


### PR DESCRIPTION
## Summary

Two L1-reorg-recovery fixes, one in the shared `CheckL1Reorg` walk-back and one in the prover's proof-submission path. Both follow the same principle as #21950 on the Rust side: canonicality decisions must be proven against canonical hashes at height, and unresolved or reorged data must stay retryable instead of producing a terminal answer.

**1. `CheckL1Reorg` no longer returns an unusable result when L1Origin data is missing mid-walk.**

The walk-back loop returned as-is when `LastL1OriginByBatchID` reported `NotFound`/`ErrProposalLastBlockUncertain`. On the first iteration that is the intended P2P-sync skip, but once a prior iteration had set `IsReorged=true`, the early return handed the caller `{IsReorged: true, L1CurrentToReset: nil}`. The driver event syncer dereferences `L1CurrentToReset.Number` unguarded, so an L1 reorg whose walk-back crossed a proposal without L1Origin rows (P2P-synced region, or an uncertain batch boundary near the preconf tip) panicked the driver — and since the same walk re-runs after every restart, it crash-looped until the underlying state changed externally.

A proposal whose L1Origin cannot be resolved cannot be verified as canonical either, so the walk now treats it as reorged as well and keeps walking back until a verifiable proposal (or genesis) provides the reset cursors. The invariant "`IsReorged=true` ⇒ `L1CurrentToReset != nil`" is now structural. Over-rewinding is safe since re-derivation is idempotent, and the first-iteration P2P-sync skip is preserved exactly.

**2. Prover: proofs dropped for reorged proposals now roll the proposal scan cursors back.**

`ValidateProof` already detects — with canonical hash-at-height evidence — that a buffered proof's source L1 block was reorged out, but the consequence was terminal: `BatchSubmitProofs` cleared the items and returned `ErrInvalidProof`, which `submitProofAggregationOp` treats as success, so no rollback ran. Since `handleProposal` advances `lastHandledProposalID` before the proof outcome is known, the re-proposed event carrying the same proposal ID was then skipped forever by every prover that had scanned the stale event, stalling proof submission network-wide until a prover restarts. A transient canonical-hash mismatch from a lagging load-balanced L1 view triggered the same terminal drop for a still-canonical proposal.

`BatchSubmitProofs` now reports reorged drops with a typed `ReorgedProofsError` — it unwraps to and embeds the text of `ErrInvalidProof`, so any caller that only matches the legacy sentinel keeps the previous behavior — and the prover rolls the shared proposal cursors back below the lowest dropped proposal, so the periodic re-scan re-dispatches the replacement events. Already-finalized proposals in the same aggregation are still dropped without a rollback.

The rollback anchor is resolved through `CheckL1Reorg` (canonical, proven at height): this also covers replacement events landing at a **lower** L1 height than the stale event, which a stale-height anchor would silently miss because the proposal iterator's continuity check only guards within a single scanned batch. When that data is unavailable (e.g. a P2P-synced L2 EE without L1Origin rows), it falls back to the stale event's block height. `RollbackProposalCursor` is lower-only and idempotent, so concurrent or repeated rollbacks cannot advance the cursors.

## Testing

- New unit tests in `prover/prover_reorg_rollback_test.go` (same style as `prover_retry_test.go`): canonical-anchor preference, genesis result with nil reset ID, fallback on checker error / unresolved result, invalid-input rejection, cursor lowering, never-advance guarantee, ctx-cancel no-op, and the `ReorgedProofsError` ↔ `ErrInvalidProof` matching contract (`errors.Is`, `errors.As`, legacy `strings.Contains`).
- `go build ./...`, `go vet`, and `make lint` (golangci-lint, 0 issues) pass; all affected test packages compile; existing `TestProposalRetryExhaustion*` rollback tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)