### PR TITLE
fix(taiko-client-rs): taiko-geth wire compat, proposer manifest fixes, and bounded event-sync retries

### DIFF
--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -137,6 +137,12 @@ rand_chacha.opt-level = 3
 rand_xorshift.opt-level = 3
 unarray.opt-level = 3
 
+[profile.release]
+# Blob and manifest parsing perform arithmetic on attacker-controlled inputs; a silent wrap in
+# production could turn a "reject payload" outcome into a wrong offset. The client is I/O-bound,
+# so the runtime cost of keeping the checks is negligible.
+overflow-checks = true
+
 [profile.debug-fast]
 inherits = "release"
 debug = true

--- a/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/engine.rs
@@ -178,7 +178,7 @@ async fn apply_payload_internal<R: EnginePayloadRpc>(
         finalized_block_hash: B256::ZERO,
     };
     let fc_response = rpc.forkchoice_updated_v2(forkchoice_state, Some(payload.clone())).await?;
-    ensure_valid_payload_status(
+    ensure_valid_forkchoice_status(
         payload.l1_origin.block_id.to::<u64>(),
         fc_response.payload_status.status,
     )?;
@@ -281,10 +281,13 @@ fn envelope_into_submission(
     (payload_input, sidecar, block_hash, block_number)
 }
 
-/// Map engine payload status into submission errors, accepting only VALID.
+/// Map `engine_newPayloadV2` status into submission errors, accepting only VALID.
 ///
 /// ACCEPTED means the engine stored the block on a side chain without executing it, so treating
-/// it as success would let the driver advance on a lineage the engine never validated.
+/// it as success would let the driver advance on a lineage the engine never validated. Only this
+/// mapping may produce [`EngineSubmissionError::InvalidBlock`]: a newPayload INVALID is the
+/// engine's deterministic verdict on the payload content itself, which downstream retry policies
+/// rely on when deciding to stop retrying.
 fn ensure_valid_payload_status(
     block_number: u64,
     status: PayloadStatusEnum,
@@ -298,6 +301,33 @@ fn ensure_valid_payload_status(
         PayloadStatusEnum::Syncing => Err(EngineSubmissionError::EngineSyncing(block_number)),
         PayloadStatusEnum::Invalid { validation_error } => {
             Err(EngineSubmissionError::InvalidBlock(block_number, validation_error))
+        }
+    }
+}
+
+/// Map `engine_forkchoiceUpdatedV2` status into submission errors, accepting only VALID.
+///
+/// Unlike [`ensure_valid_payload_status`], a non-VALID forkchoice status never maps to
+/// [`EngineSubmissionError::InvalidBlock`]: forkchoice INVALID reflects the engine's view of the
+/// referenced head (which can be unknown or temporarily unprocessable) rather than a
+/// deterministic verdict on the submitted payload's content, so callers must remain free to
+/// retry it.
+fn ensure_valid_forkchoice_status(
+    block_number: u64,
+    status: PayloadStatusEnum,
+) -> Result<(), EngineSubmissionError> {
+    match status {
+        PayloadStatusEnum::Valid => Ok(()),
+        PayloadStatusEnum::Syncing => Err(EngineSubmissionError::EngineSyncing(block_number)),
+        PayloadStatusEnum::Accepted => Err(EngineSubmissionError::UnexpectedPayloadStatus(
+            block_number,
+            "forkchoice ACCEPTED".to_string(),
+        )),
+        PayloadStatusEnum::Invalid { validation_error } => {
+            Err(EngineSubmissionError::UnexpectedPayloadStatus(
+                block_number,
+                format!("forkchoice INVALID: {validation_error}"),
+            ))
         }
     }
 }
@@ -357,7 +387,7 @@ async fn submit_payload_to_engine<R: EnginePayloadRpc>(
 
     let promoted_state = promotion_forkchoice_state(block_hash, finalized_block_hash);
     let promotion = rpc.forkchoice_updated_v2(promoted_state, None).await?;
-    ensure_valid_payload_status(block_number, promotion.payload_status.status)?;
+    ensure_valid_forkchoice_status(block_number, promotion.payload_status.status)?;
 
     let block = fetch_block_by_number(rpc, block_number).await?;
     ensure_inserted_block_hash(block_number, block_hash, block.header.hash)?;
@@ -517,6 +547,34 @@ mod tests {
             err,
             EngineSubmissionError::InvalidBlock(7, ref reason) if reason == "bad block"
         ));
+    }
+
+    #[test]
+    fn forkchoice_invalid_status_never_maps_to_invalid_block() {
+        // Forkchoice INVALID can reflect an unknown or temporarily unprocessable head, so it
+        // must not be conflated with the engine's deterministic newPayload content verdict.
+        let err = ensure_valid_forkchoice_status(
+            7,
+            PayloadStatusEnum::Invalid { validation_error: "bad head".to_string() },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            EngineSubmissionError::UnexpectedPayloadStatus(7, ref reason)
+                if reason == "forkchoice INVALID: bad head"
+        ));
+
+        let err = ensure_valid_forkchoice_status(7, PayloadStatusEnum::Accepted).unwrap_err();
+        assert!(matches!(
+            err,
+            EngineSubmissionError::UnexpectedPayloadStatus(7, ref reason)
+                if reason == "forkchoice ACCEPTED"
+        ));
+
+        let err = ensure_valid_forkchoice_status(7, PayloadStatusEnum::Syncing).unwrap_err();
+        assert!(matches!(err, EngineSubmissionError::EngineSyncing(7)));
+
+        assert!(ensure_valid_forkchoice_status(7, PayloadStatusEnum::Valid).is_ok());
     }
 
     /// Which engine RPC a scripted call hit, in production sequence order.
@@ -832,7 +890,8 @@ mod tests {
 
         assert!(matches!(
             err,
-            EngineSubmissionError::InvalidBlock(7, ref reason) if reason == "bad head"
+            EngineSubmissionError::UnexpectedPayloadStatus(7, ref reason)
+                if reason == "forkchoice INVALID: bad head"
         ));
         assert_eq!(
             engine.calls(),

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -25,7 +25,7 @@ use tokio::{
     sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot},
     time::{sleep, timeout},
 };
-use tokio_retry::{Retry, strategy::ExponentialBackoff};
+use tokio_retry::{RetryIf, strategy::ExponentialBackoff};
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -33,10 +33,11 @@ use super::{
     FINALIZED_BLOCK_NOT_FOUND, SyncError, SyncStage,
     checkpoint_resume_head::CheckpointResumeHead,
     confirmed_sync::{ConfirmedSyncSnapshot, build_confirmed_sync_snapshot},
+    error::EngineSubmissionError,
 };
 use crate::{
     config::DriverConfig,
-    derivation::ShastaDerivationPipeline,
+    derivation::{DerivationError, ShastaDerivationPipeline},
     error::DriverError,
     metrics::DriverMetrics,
     production::{
@@ -209,6 +210,22 @@ fn resolve_reconnect_start_block(
 #[inline]
 fn is_stale_preconf(block_number: u64, confirmed_tip: u64) -> bool {
     block_number <= confirmed_tip
+}
+
+/// Return whether a proposal-processing failure is a deterministic engine verdict.
+///
+/// `INVALID` and other non-`VALID` payload statuses are the engine's judgement on the payload
+/// content itself: resubmitting the identical payload cannot change the answer, so retrying
+/// forever would stall event sync silently. Everything else (RPC transport failures, engine
+/// syncing, missing data) stays retryable.
+fn is_fatal_proposal_processing_error(err: &DriverError) -> bool {
+    matches!(
+        err,
+        DriverError::Sync(SyncError::Derivation(DerivationError::Engine(
+            EngineSubmissionError::InvalidBlock(..) |
+                EngineSubmissionError::UnexpectedPayloadStatus(..)
+        )))
+    )
 }
 
 /// Responsible for following inbox events and updating the L2 execution engine accordingly.
@@ -626,63 +643,82 @@ impl EventSyncer {
                 });
             };
 
-            // Retry proposal processing on transient errors.
+            // Retry proposal processing on transient errors; deterministic engine verdicts
+            // abort immediately once the source log is proven canonical.
             let retry_strategy =
                 ExponentialBackoff::from_millis(10).max_delay(Duration::from_secs(12));
 
             let syncer = self;
             let router = router.clone();
             let proposal_log = log.clone();
-            let processing = Retry::spawn(retry_strategy, move || {
-                let router = router.clone();
-                let log = proposal_log.clone();
-                async move {
-                    let router_call = {
-                        // Lock router so L1 proposals and preconf inputs cannot interleave.
-                        let router_guard = router.lock().await;
-                        router_guard.produce(ProductionInput::L1ProposalLog(log.clone())).await
-                    };
+            let processing = RetryIf::spawn(
+                retry_strategy,
+                move || {
+                    let router = router.clone();
+                    let log = proposal_log.clone();
+                    async move {
+                        let router_call = {
+                            // Lock router so L1 proposals and preconf inputs cannot interleave.
+                            let router_guard = router.lock().await;
+                            router_guard.produce(ProductionInput::L1ProposalLog(log.clone())).await
+                        };
 
-                    match router_call {
-                        Ok(outcomes) => Ok(ProposalLogResult::Processed(outcomes)),
-                        Err(err) => match syncer
-                            .is_permanently_orphaned_proposal_log(block_hash, log.block_number)
-                            .await
-                        {
-                            Ok(true) => {
-                                DriverMetrics::event_orphaned_proposal_logs_total().inc();
-                                warn!(
-                                    ?err,
-                                    block_number = log.block_number,
-                                    block_hash = ?block_hash,
-                                    transaction_hash = ?log.transaction_hash,
-                                    "skipping permanently orphaned proposal log",
-                                );
-                                Ok(ProposalLogResult::SkippedOrphaned)
-                            }
-                            Ok(false) => {
-                                warn!(
-                                    ?err,
-                                    tx_hash = ?log.transaction_hash,
-                                    block_number = log.block_number,
-                                    "proposal derivation failed; retrying"
-                                );
-                                Err(err)
-                            }
-                            Err(recheck_err) => {
-                                warn!(
-                                    ?err,
-                                    ?recheck_err,
-                                    tx_hash = ?log.transaction_hash,
-                                    block_number = log.block_number,
-                                    "proposal derivation failed and orphaned-log recheck errored; retrying"
-                                );
-                                Err(err)
-                            }
-                        },
+                        match router_call {
+                            Ok(outcomes) => Ok(ProposalLogResult::Processed(outcomes)),
+                            Err(err) => match syncer
+                                .is_permanently_orphaned_proposal_log(block_hash, log.block_number)
+                                .await
+                            {
+                                Ok(true) => {
+                                    DriverMetrics::event_orphaned_proposal_logs_total().inc();
+                                    warn!(
+                                        ?err,
+                                        block_number = log.block_number,
+                                        block_hash = ?block_hash,
+                                        transaction_hash = ?log.transaction_hash,
+                                        "skipping permanently orphaned proposal log",
+                                    );
+                                    Ok(ProposalLogResult::SkippedOrphaned)
+                                }
+                                Ok(false) => {
+                                    if is_fatal_proposal_processing_error(&err) {
+                                        error!(
+                                            ?err,
+                                            tx_hash = ?log.transaction_hash,
+                                            block_number = log.block_number,
+                                            "proposal derivation hit a deterministic engine \
+                                             verdict on a canonical log; aborting"
+                                        );
+                                    } else {
+                                        warn!(
+                                            ?err,
+                                            tx_hash = ?log.transaction_hash,
+                                            block_number = log.block_number,
+                                            "proposal derivation failed; retrying"
+                                        );
+                                    }
+                                    Err(err)
+                                }
+                                Err(recheck_err) => {
+                                    warn!(
+                                        ?err,
+                                        ?recheck_err,
+                                        tx_hash = ?log.transaction_hash,
+                                        block_number = log.block_number,
+                                        "proposal derivation failed and orphaned-log recheck errored; retrying"
+                                    );
+                                    // Surface the retryable recheck error instead of the
+                                    // original failure: a fatal verdict may only abort after
+                                    // the log is proven canonical, never while orphanhood is
+                                    // still unresolved.
+                                    Err(DriverError::Sync(recheck_err))
+                                }
+                            },
+                        }
                     }
-                }
-            })
+                },
+                |err: &DriverError| !is_fatal_proposal_processing_error(err),
+            )
             .await
             .map_err(|err| match err {
                 DriverError::Sync(sync_err) => sync_err,
@@ -1749,6 +1785,45 @@ mod tests {
         }
     }
 
+    /// Production path that always fails with a deterministic engine verdict.
+    #[derive(Clone)]
+    struct MockFatalBatchPath {
+        seen_tx_hashes: StdArc<Mutex<Vec<B256>>>,
+    }
+
+    impl MockFatalBatchPath {
+        fn new() -> Self {
+            Self { seen_tx_hashes: StdArc::new(Mutex::new(Vec::new())) }
+        }
+
+        fn seen_tx_hashes(&self) -> Vec<B256> {
+            self.seen_tx_hashes.lock().expect("seen tx hashes mutex should not be poisoned").clone()
+        }
+    }
+
+    #[async_trait]
+    impl BlockProductionPath for MockFatalBatchPath {
+        async fn produce(
+            &self,
+            input: ProductionInput,
+        ) -> Result<Vec<EngineBlockOutcome>, DriverError> {
+            let ProductionInput::L1ProposalLog(log) = input else {
+                panic!("mock fatal batch path only supports L1 proposal logs");
+            };
+
+            let tx_hash =
+                log.transaction_hash.expect("test proposal log should always include tx hash");
+            self.seen_tx_hashes
+                .lock()
+                .expect("seen tx hashes mutex should not be poisoned")
+                .push(tx_hash);
+
+            Err(DriverError::Sync(SyncError::Derivation(DerivationError::Engine(
+                EngineSubmissionError::InvalidBlock(1, "mock invalid payload".to_string()),
+            ))))
+        }
+    }
+
     fn mock_client_with_l1_asserter(l1_asserter: Asserter) -> Client {
         mock_client_with_asserters(l1_asserter, Asserter::new())
     }
@@ -1943,6 +2018,64 @@ mod tests {
             "recheck rpc errors should keep the log retryable until a later attempt succeeds",
         );
         assert_eq!(path.seen_tx_hashes(), vec![retry_tx_hash, retry_tx_hash]);
+    }
+
+    #[test]
+    fn fatal_proposal_processing_errors_are_deterministic_engine_verdicts_only() {
+        assert!(is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Derivation(
+            DerivationError::Engine(EngineSubmissionError::InvalidBlock(1, "invalid".into()))
+        ))));
+        assert!(is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Derivation(
+            DerivationError::Engine(EngineSubmissionError::UnexpectedPayloadStatus(
+                1,
+                "ACCEPTED".into()
+            ))
+        ))));
+        // Transient shapes must stay retryable.
+        assert!(!is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Derivation(
+            DerivationError::Engine(EngineSubmissionError::EngineSyncing(1))
+        ))));
+        assert!(!is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Rpc(
+            RpcClientError::Provider("boom".into())
+        ))));
+        assert!(!is_fatal_proposal_processing_error(&DriverError::Other(anyhow!("boom"))));
+    }
+
+    #[tokio::test]
+    async fn process_log_batch_aborts_without_retry_on_fatal_engine_verdict() {
+        let fatal_block_hash = B256::from([0x71; 32]);
+        let fatal_tx_hash = B256::from([0x81; 32]);
+        let asserter = Asserter::new();
+        // Orphan recheck resolves the source block as still canonical, so the deterministic
+        // engine verdict must abort instead of retrying forever.
+        asserter.push_success(&Some(RpcBlock::<TxEnvelope>::default()));
+
+        let syncer =
+            EventSyncer { rpc: mock_client_with_l1_asserter(asserter), ..build_syncer().await };
+        let path = MockFatalBatchPath::new();
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let result = timeout(
+            Duration::from_millis(250),
+            syncer.process_log_batch(
+                router,
+                vec![sample_proposed_log(1, fatal_block_hash, fatal_tx_hash)],
+            ),
+        )
+        .await;
+
+        let err = result
+            .expect("fatal verdict should abort immediately instead of exhausting the timeout")
+            .expect_err("fatal engine verdict on a canonical log should surface as an error");
+        assert!(matches!(
+            err,
+            SyncError::Derivation(DerivationError::Engine(EngineSubmissionError::InvalidBlock(..)))
+        ));
+        assert_eq!(
+            path.seen_tx_hashes(),
+            vec![fatal_tx_hash],
+            "a deterministic engine verdict must not be retried"
+        );
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -57,6 +57,27 @@ enum ProposalLogResult {
     SkippedOrphaned,
 }
 
+/// Retry decision attached to a failed proposal-processing attempt.
+///
+/// The decision is made where the full context is available (error class plus the canonical
+/// proof of the source log), so the retry predicate never has to re-derive it: only `Abort`
+/// stops the retry loop.
+enum ProposalRetryError {
+    /// Deterministic failure on a proven-canonical log; retrying cannot change the outcome.
+    Abort(DriverError),
+    /// Transient or unproven failure; the attempt should be retried.
+    Retry(DriverError),
+}
+
+impl ProposalRetryError {
+    /// Unwrap the underlying driver error regardless of the retry decision.
+    fn into_inner(self) -> DriverError {
+        match self {
+            ProposalRetryError::Abort(err) | ProposalRetryError::Retry(err) => err,
+        }
+    }
+}
+
 /// Default timeout for preconfirmation payload submission.
 ///
 /// Covers both the enqueue operation and awaiting the processing response.
@@ -214,16 +235,18 @@ fn is_stale_preconf(block_number: u64, confirmed_tip: u64) -> bool {
 
 /// Return whether a proposal-processing failure is a deterministic engine verdict.
 ///
-/// `INVALID` and other non-`VALID` payload statuses are the engine's judgement on the payload
-/// content itself: resubmitting the identical payload cannot change the answer, so retrying
-/// forever would stall event sync silently. Everything else (RPC transport failures, engine
-/// syncing, missing data) stays retryable.
+/// Only a newPayload `INVALID` qualifies: it is the engine's judgement on the payload content
+/// itself, so resubmitting the identical payload cannot change the answer and retrying forever
+/// would stall event sync silently. `ACCEPTED` is excluded because taiko-geth returns it while
+/// the parent state is temporarily unavailable, and forkchoice `INVALID` is excluded because it
+/// can reflect an unknown or unprocessable head rather than the payload content (the engine
+/// layer keeps both away from `InvalidBlock`). RPC transport failures, engine syncing, and
+/// missing data stay retryable.
 fn is_fatal_proposal_processing_error(err: &DriverError) -> bool {
     matches!(
         err,
         DriverError::Sync(SyncError::Derivation(DerivationError::Engine(
-            EngineSubmissionError::InvalidBlock(..) |
-                EngineSubmissionError::UnexpectedPayloadStatus(..)
+            EngineSubmissionError::InvalidBlock(..)
         )))
     )
 }
@@ -538,6 +561,90 @@ impl EventSyncer {
         Ok(chain_head >= log_block_number)
     }
 
+    /// Prove that a proposal log's source block is canonical on L1.
+    ///
+    /// The proof compares the canonical block hash at the log's height against the log's block
+    /// hash. It deliberately avoids by-hash lookups, whose semantics diverge between node
+    /// families (geth keeps serving reorged-out blocks by hash while reth does not); the
+    /// by-number canonical view is the one both answer identically. Missing data — no log
+    /// height, or no canonical block at that height yet — leaves the proof unestablished.
+    #[instrument(skip(self), level = "debug")]
+    async fn is_proposal_log_proven_canonical(
+        &self,
+        block_hash: B256,
+        log_block_number: Option<u64>,
+    ) -> Result<bool, SyncError> {
+        let Some(log_block_number) = log_block_number else {
+            return Ok(false);
+        };
+
+        let canonical_block = self
+            .rpc
+            .l1_provider
+            .get_block_by_number(BlockNumberOrTag::Number(log_block_number))
+            .await
+            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
+
+        Ok(canonical_block.is_some_and(|block| block.header.hash == block_hash))
+    }
+
+    /// Decide whether a failed attempt on a non-orphaned proposal log aborts or keeps retrying.
+    ///
+    /// Aborting requires both a deterministic engine verdict on the payload content and an
+    /// explicit canonical proof of the source log. The orphan recheck alone cannot stand in for
+    /// the proof: geth-like L1 nodes keep serving reorged-out blocks by hash, so a stale log can
+    /// pass the recheck while no longer being canonical. Unproven canonicality and proof
+    /// failures keep the attempt retryable.
+    async fn classify_proposal_processing_failure(
+        &self,
+        err: DriverError,
+        log: &Log,
+        block_hash: B256,
+    ) -> ProposalRetryError {
+        if !is_fatal_proposal_processing_error(&err) {
+            warn!(
+                ?err,
+                tx_hash = ?log.transaction_hash,
+                block_number = log.block_number,
+                "proposal derivation failed; retrying"
+            );
+            return ProposalRetryError::Retry(err);
+        }
+
+        match self.is_proposal_log_proven_canonical(block_hash, log.block_number).await {
+            Ok(true) => {
+                error!(
+                    ?err,
+                    tx_hash = ?log.transaction_hash,
+                    block_number = log.block_number,
+                    "proposal derivation hit a deterministic engine verdict on a \
+                     proven-canonical log; aborting"
+                );
+                ProposalRetryError::Abort(err)
+            }
+            Ok(false) => {
+                warn!(
+                    ?err,
+                    tx_hash = ?log.transaction_hash,
+                    block_number = log.block_number,
+                    "deterministic engine verdict but source log is not proven canonical; \
+                     retrying"
+                );
+                ProposalRetryError::Retry(err)
+            }
+            Err(proof_err) => {
+                warn!(
+                    ?err,
+                    ?proof_err,
+                    tx_hash = ?log.transaction_hash,
+                    block_number = log.block_number,
+                    "deterministic engine verdict but the canonical proof errored; retrying"
+                );
+                ProposalRetryError::Retry(err)
+            }
+        }
+    }
+
     /// Best-effort reset of `head_l1_origin` to the latest canonical proposal's last L2 block at
     /// the stable post-reorg boundary. If the L2 EE's confirmed boundary is left ahead of the
     /// post-reorg canonical chain, preconf and chain-syncer guards reject incoming blocks until
@@ -643,8 +750,8 @@ impl EventSyncer {
                 });
             };
 
-            // Retry proposal processing on transient errors; deterministic engine verdicts
-            // abort immediately once the source log is proven canonical.
+            // Retry proposal processing on transient errors; a deterministic engine verdict
+            // aborts only once the source log is proven canonical on L1.
             let retry_strategy =
                 ExponentialBackoff::from_millis(10).max_delay(Duration::from_secs(12));
 
@@ -680,25 +787,9 @@ impl EventSyncer {
                                     );
                                     Ok(ProposalLogResult::SkippedOrphaned)
                                 }
-                                Ok(false) => {
-                                    if is_fatal_proposal_processing_error(&err) {
-                                        error!(
-                                            ?err,
-                                            tx_hash = ?log.transaction_hash,
-                                            block_number = log.block_number,
-                                            "proposal derivation hit a deterministic engine \
-                                             verdict on a canonical log; aborting"
-                                        );
-                                    } else {
-                                        warn!(
-                                            ?err,
-                                            tx_hash = ?log.transaction_hash,
-                                            block_number = log.block_number,
-                                            "proposal derivation failed; retrying"
-                                        );
-                                    }
-                                    Err(err)
-                                }
+                                Ok(false) => Err(syncer
+                                    .classify_proposal_processing_failure(err, &log, block_hash)
+                                    .await),
                                 Err(recheck_err) => {
                                     warn!(
                                         ?err,
@@ -711,15 +802,16 @@ impl EventSyncer {
                                     // original failure: a fatal verdict may only abort after
                                     // the log is proven canonical, never while orphanhood is
                                     // still unresolved.
-                                    Err(DriverError::Sync(recheck_err))
+                                    Err(ProposalRetryError::Retry(DriverError::Sync(recheck_err)))
                                 }
                             },
                         }
                     }
                 },
-                |err: &DriverError| !is_fatal_proposal_processing_error(err),
+                |err: &ProposalRetryError| matches!(err, ProposalRetryError::Retry(_)),
             )
             .await
+            .map_err(ProposalRetryError::into_inner)
             .map_err(|err| match err {
                 DriverError::Sync(sync_err) => sync_err,
                 DriverError::Rpc(rpc_err) => SyncError::Rpc(rpc_err),
@@ -2020,18 +2112,32 @@ mod tests {
         assert_eq!(path.seen_tx_hashes(), vec![retry_tx_hash, retry_tx_hash]);
     }
 
+    /// Build an RPC block whose header hash matches the given hash, for canonical-proof stubs.
+    fn rpc_block_with_hash(hash: B256) -> RpcBlock<TxEnvelope> {
+        let mut block = RpcBlock::<TxEnvelope>::default();
+        block.header.hash = hash;
+        block
+    }
+
     #[test]
-    fn fatal_proposal_processing_errors_are_deterministic_engine_verdicts_only() {
+    fn fatal_proposal_processing_errors_are_newpayload_invalid_only() {
         assert!(is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Derivation(
             DerivationError::Engine(EngineSubmissionError::InvalidBlock(1, "invalid".into()))
         ))));
-        assert!(is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Derivation(
+        // ACCEPTED is transient on taiko-geth (returned while parent state is unavailable) and
+        // forkchoice INVALID can reflect an unknown head; both must stay retryable.
+        assert!(!is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Derivation(
             DerivationError::Engine(EngineSubmissionError::UnexpectedPayloadStatus(
                 1,
                 "ACCEPTED".into()
             ))
         ))));
-        // Transient shapes must stay retryable.
+        assert!(!is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Derivation(
+            DerivationError::Engine(EngineSubmissionError::UnexpectedPayloadStatus(
+                1,
+                "forkchoice INVALID: bad head".into()
+            ))
+        ))));
         assert!(!is_fatal_proposal_processing_error(&DriverError::Sync(SyncError::Derivation(
             DerivationError::Engine(EngineSubmissionError::EngineSyncing(1))
         ))));
@@ -2046,9 +2152,11 @@ mod tests {
         let fatal_block_hash = B256::from([0x71; 32]);
         let fatal_tx_hash = B256::from([0x81; 32]);
         let asserter = Asserter::new();
-        // Orphan recheck resolves the source block as still canonical, so the deterministic
-        // engine verdict must abort instead of retrying forever.
+        // Orphan recheck (by hash) still resolves the source block, so the log is not skipped.
         asserter.push_success(&Some(RpcBlock::<TxEnvelope>::default()));
+        // Canonical proof (by number) returns the log's own hash: the log is proven canonical,
+        // so the deterministic engine verdict must abort instead of retrying forever.
+        asserter.push_success(&Some(rpc_block_with_hash(fatal_block_hash)));
 
         let syncer =
             EventSyncer { rpc: mock_client_with_l1_asserter(asserter), ..build_syncer().await };
@@ -2066,7 +2174,7 @@ mod tests {
 
         let err = result
             .expect("fatal verdict should abort immediately instead of exhausting the timeout")
-            .expect_err("fatal engine verdict on a canonical log should surface as an error");
+            .expect_err("fatal engine verdict on a proven-canonical log should surface an error");
         assert!(matches!(
             err,
             SyncError::Derivation(DerivationError::Engine(EngineSubmissionError::InvalidBlock(..)))
@@ -2074,7 +2182,45 @@ mod tests {
         assert_eq!(
             path.seen_tx_hashes(),
             vec![fatal_tx_hash],
-            "a deterministic engine verdict must not be retried"
+            "a deterministic engine verdict on a proven-canonical log must not be retried"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_log_batch_keeps_retrying_fatal_verdict_without_canonical_proof() {
+        let stale_block_hash = B256::from([0x72; 32]);
+        let stale_tx_hash = B256::from([0x82; 32]);
+        let asserter = Asserter::new();
+        // Two attempts' worth of responses. The by-hash recheck resolves the block (geth-like
+        // L1 nodes keep serving reorged-out blocks by hash), but the canonical block at the
+        // log's height carries a different hash — the proof fails, so the fatal verdict must
+        // keep retrying instead of terminating event sync on a possibly-reorged log.
+        for _ in 0..2 {
+            asserter.push_success(&Some(RpcBlock::<TxEnvelope>::default()));
+            asserter.push_success(&Some(rpc_block_with_hash(B256::from([0x99; 32]))));
+        }
+
+        let syncer =
+            EventSyncer { rpc: mock_client_with_l1_asserter(asserter), ..build_syncer().await };
+        let path = MockFatalBatchPath::new();
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let result = timeout(
+            Duration::from_millis(250),
+            syncer.process_log_batch(
+                router,
+                vec![sample_proposed_log(1, stale_block_hash, stale_tx_hash)],
+            ),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "an unproven fatal verdict must keep retrying rather than abort the batch"
+        );
+        assert!(
+            path.seen_tx_hashes().len() >= 2,
+            "the proposal should be retried while canonicality stays unproven"
         );
     }
 

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -276,9 +276,6 @@ fn is_fatal_proposal_processing_error(err: &DriverError) -> bool {
     )
 }
 
-/// Return whether a scanner stream error breaks event continuity and requires dropping the
-/// subscription so the reconnect path can replay from a safe overlap.
-///
 /// Responsible for following inbox events and updating the L2 execution engine accordingly.
 pub struct EventSyncer {
     /// RPC client shared with derivation pipeline.

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -57,6 +57,17 @@ enum ProposalLogResult {
     SkippedOrphaned,
 }
 
+/// Finalized-ancestry proof state for a proposal log's source L1 block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProposalLogCanonicality {
+    /// The log block hash matches the ancestor at its height on the finalized chain.
+    Canonical,
+    /// The finalized chain contains a different block hash at the log's height.
+    Orphaned,
+    /// Finality or ancestry data is insufficient to make a permanent decision.
+    Unproven,
+}
+
 /// Retry decision attached to a failed proposal-processing attempt.
 ///
 /// The decision is made where the full context is available (error class plus the canonical
@@ -612,14 +623,17 @@ impl EventSyncer {
         drop(router.lock().await);
     }
 
-    /// Return whether a failed proposal log is permanently orphaned because its source L1 block
-    /// is proven not to be an ancestor of the finalized L1 block.
+    /// Resolve a proposal log's source block against finalized L1 ancestry.
+    ///
+    /// A permanent decision is returned only when finality has reached the log height and every
+    /// required content-addressed ancestry hop is available and height-consistent. Mutable head
+    /// views, missing data, and capped walks remain [`ProposalLogCanonicality::Unproven`].
     #[instrument(skip(self), level = "debug")]
-    async fn is_permanently_orphaned_proposal_log(
+    async fn proposal_log_canonicality(
         &self,
         block_hash: B256,
         log_block_number: Option<u64>,
-    ) -> Result<bool, SyncError> {
+    ) -> Result<ProposalLogCanonicality, SyncError> {
         let block = self
             .rpc
             .l1_provider
@@ -632,7 +646,7 @@ impl EventSyncer {
         // row to compare against, so no mismatch can be proven and the log stays retryable;
         // mined logs always carry a block number, making this fallback effectively unreachable.
         let Some(block_number) = block.map(|block| block.header.number).or(log_block_number) else {
-            return Ok(false);
+            return Ok(ProposalLogCanonicality::Unproven);
         };
 
         // A canonical row is only immutable once its height is finalized. Above the finalized
@@ -647,10 +661,10 @@ impl EventSyncer {
                 Err(err) => return Err(SyncError::Rpc(RpcClientError::Provider(err.to_string()))),
             };
         let Some(finalized_block) = finalized_block else {
-            return Ok(false);
+            return Ok(ProposalLogCanonicality::Unproven);
         };
         if finalized_block.header.number < block_number {
-            return Ok(false);
+            return Ok(ProposalLogCanonicality::Unproven);
         }
 
         // The canonical hash at the log height is derived from the finalized block's own
@@ -666,7 +680,7 @@ impl EventSyncer {
                 finalized_block_number = finalized_block.header.number,
                 "orphan-proof ancestry walk exceeds cap; keeping proposal log retryable"
             );
-            return Ok(false);
+            return Ok(ProposalLogCanonicality::Unproven);
         }
         let mut cursor = finalized_block;
         while cursor.header.number > block_number.saturating_add(1) {
@@ -678,12 +692,12 @@ impl EventSyncer {
                 .await
                 .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
             let Some(parent) = parent else {
-                return Ok(false);
+                return Ok(ProposalLogCanonicality::Unproven);
             };
             // Content addressing fixes the parent's height on honest data; treat anything else
             // as unproven rather than risking a non-terminating walk.
             if parent.header.number != parent_number {
-                return Ok(false);
+                return Ok(ProposalLogCanonicality::Unproven);
             }
             cursor = parent;
         }
@@ -693,50 +707,23 @@ impl EventSyncer {
             cursor.header.parent_hash
         };
 
-        // Only a hash mismatch anchored into the finalized chain classifies the log as
-        // permanently orphaned.
-        Ok(canonical_hash_at_height != block_hash)
+        Ok(if canonical_hash_at_height == block_hash {
+            ProposalLogCanonicality::Canonical
+        } else {
+            ProposalLogCanonicality::Orphaned
+        })
     }
 
-    /// Prove that a proposal log's source block is canonical on L1.
-    ///
-    /// The proof compares the canonical block hash at the log's height against the log's block
-    /// hash. It deliberately avoids by-hash lookups, whose semantics diverge between node
-    /// families (geth keeps serving reorged-out blocks by hash while reth does not); the
-    /// by-number canonical view is the one both answer identically. Missing data — no log
-    /// height, or no canonical block at that height yet — leaves the proof unestablished.
-    #[instrument(skip(self), level = "debug")]
-    async fn is_proposal_log_proven_canonical(
-        &self,
-        block_hash: B256,
-        log_block_number: Option<u64>,
-    ) -> Result<bool, SyncError> {
-        let Some(log_block_number) = log_block_number else {
-            return Ok(false);
-        };
-
-        let canonical_block = self
-            .rpc
-            .l1_provider
-            .get_block_by_number(BlockNumberOrTag::Number(log_block_number))
-            .await
-            .map_err(|err| SyncError::Rpc(RpcClientError::Provider(err.to_string())))?;
-
-        Ok(canonical_block.is_some_and(|block| block.header.hash == block_hash))
-    }
-
-    /// Decide whether a failed attempt on a non-orphaned proposal log aborts or keeps retrying.
+    /// Decide whether a failed attempt on a proposal log aborts or keeps retrying.
     ///
     /// Aborting requires both a deterministic engine verdict on the payload content and an
-    /// explicit canonical proof of the source log. The orphan recheck alone cannot stand in for
-    /// the proof: geth-like L1 nodes keep serving reorged-out blocks by hash, so a stale log can
-    /// pass the recheck while no longer being canonical. Unproven canonicality and proof
-    /// failures keep the attempt retryable.
-    async fn classify_proposal_processing_failure(
+    /// explicit finalized-ancestry proof of the source log. Unproven canonicality keeps the
+    /// attempt retryable so event-side reorg processing can eventually skip a losing-fork log.
+    fn classify_proposal_processing_failure(
         &self,
         err: DriverError,
         log: &Log,
-        block_hash: B256,
+        canonicality: ProposalLogCanonicality,
     ) -> ProposalRetryError {
         if !is_fatal_proposal_processing_error(&err) {
             warn!(
@@ -748,8 +735,8 @@ impl EventSyncer {
             return ProposalRetryError::Retry(err);
         }
 
-        match self.is_proposal_log_proven_canonical(block_hash, log.block_number).await {
-            Ok(true) => {
+        match canonicality {
+            ProposalLogCanonicality::Canonical => {
                 error!(
                     ?err,
                     tx_hash = ?log.transaction_hash,
@@ -759,23 +746,15 @@ impl EventSyncer {
                 );
                 ProposalRetryError::Abort(err)
             }
-            Ok(false) => {
+            ProposalLogCanonicality::Orphaned | ProposalLogCanonicality::Unproven => {
                 warn!(
                     ?err,
+                    ?canonicality,
                     tx_hash = ?log.transaction_hash,
                     block_number = log.block_number,
-                    "deterministic engine verdict but source log is not proven canonical; \
+                    "deterministic engine verdict but finalized ancestry does not prove the \
+                     source log canonical; \
                      retrying"
-                );
-                ProposalRetryError::Retry(err)
-            }
-            Err(proof_err) => {
-                warn!(
-                    ?err,
-                    ?proof_err,
-                    tx_hash = ?log.transaction_hash,
-                    block_number = log.block_number,
-                    "deterministic engine verdict but the canonical proof errored; retrying"
                 );
                 ProposalRetryError::Retry(err)
             }
@@ -910,10 +889,10 @@ impl EventSyncer {
                         match router_call {
                             Ok(outcomes) => Ok(ProposalLogResult::Processed(outcomes)),
                             Err(err) => match syncer
-                                .is_permanently_orphaned_proposal_log(block_hash, log.block_number)
+                                .proposal_log_canonicality(block_hash, log.block_number)
                                 .await
                             {
-                                Ok(true) => {
+                                Ok(ProposalLogCanonicality::Orphaned) => {
                                     DriverMetrics::event_orphaned_proposal_logs_total().inc();
                                     warn!(
                                         ?err,
@@ -924,9 +903,8 @@ impl EventSyncer {
                                     );
                                     Ok(ProposalLogResult::SkippedOrphaned)
                                 }
-                                Ok(false) => Err(syncer
-                                    .classify_proposal_processing_failure(err, &log, block_hash)
-                                    .await),
+                                Ok(canonicality) => Err(syncer
+                                    .classify_proposal_processing_failure(err, &log, canonicality)),
                                 Err(recheck_err) => {
                                     warn!(
                                         ?err,
@@ -1859,7 +1837,10 @@ mod tests {
     ) -> Result<bool, SyncError> {
         let syncer =
             EventSyncer { rpc: mock_client_with_l1_asserter(asserter), ..build_syncer().await };
-        syncer.is_permanently_orphaned_proposal_log(block_hash, log_block_number).await
+        syncer
+            .proposal_log_canonicality(block_hash, log_block_number)
+            .await
+            .map(|canonicality| canonicality == ProposalLogCanonicality::Orphaned)
     }
 
     fn sample_event_log_with_block_hash(block_hash: B256) -> Log {
@@ -2355,7 +2336,7 @@ mod tests {
 
         let log = sample_event_log_with_block_hash(B256::from([3u8; 32]));
         let err = syncer
-            .is_permanently_orphaned_proposal_log(
+            .proposal_log_canonicality(
                 log.block_hash.expect("test log should include block hash"),
                 log.block_number,
             )
@@ -2482,12 +2463,9 @@ mod tests {
         let fatal_block_hash = B256::from([0x71; 32]);
         let fatal_tx_hash = B256::from([0x81; 32]);
         let asserter = Asserter::new();
-        // Orphan recheck resolves the source block and proves it belongs to the finalized chain,
-        // so the log is not skipped.
+        // Finalized ancestry resolves the source block as canonical, so the deterministic engine
+        // verdict must abort instead of retrying forever.
         asserter.push_success(&l1_block_at(1, fatal_block_hash, B256::ZERO));
-        asserter.push_success(&l1_block_at(1, fatal_block_hash, B256::ZERO));
-        // Canonical proof (by number) returns the log's own hash: the log is proven canonical,
-        // so the deterministic engine verdict must abort instead of retrying forever.
         asserter.push_success(&l1_block_at(1, fatal_block_hash, B256::ZERO));
 
         let syncer =
@@ -2524,13 +2502,11 @@ mod tests {
         let stale_tx_hash = B256::from([0x82; 32]);
         let asserter = Asserter::new();
         // Two attempts' worth of responses. The by-hash recheck resolves the block, but L1
-        // finality has not reached the log height, so orphanhood remains unproven. The canonical
-        // block at the log's height carries a different hash, so the fatal verdict must keep
-        // retrying instead of terminating event sync on a possibly-reorged log.
+        // finality has not reached the log height, so canonicality remains unproven and the fatal
+        // verdict must keep retrying instead of terminating event sync on a possibly-reorged log.
         for _ in 0..2 {
             asserter.push_success(&l1_block_at(1, stale_block_hash, B256::ZERO));
             asserter.push_success(&l1_block_at(0, B256::ZERO, B256::ZERO));
-            asserter.push_success(&l1_block_at(1, B256::from([0x99; 32]), B256::ZERO));
         }
 
         let syncer =
@@ -2554,6 +2530,43 @@ mod tests {
         assert!(
             path.seen_tx_hashes().len() >= 2,
             "the proposal should be retried while canonicality stays unproven"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_log_batch_keeps_retrying_fatal_verdict_on_unfinalized_matching_view() {
+        let stale_block_hash = B256::from([0x73; 32]);
+        let stale_tx_hash = B256::from([0x83; 32]);
+        let asserter = Asserter::new();
+        // Two attempts' worth of responses. A lagging by-number backend still reports the log's
+        // block hash, but the finalized height has not reached the log. That mutable view cannot
+        // prove canonicality strongly enough to terminate event sync.
+        for _ in 0..2 {
+            asserter.push_success(&l1_block_at(1, stale_block_hash, B256::ZERO));
+            asserter.push_success(&l1_block_at(0, B256::ZERO, B256::ZERO));
+        }
+
+        let syncer =
+            EventSyncer { rpc: mock_client_with_l1_asserter(asserter), ..build_syncer().await };
+        let path = MockFatalBatchPath::new();
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let result = timeout(
+            Duration::from_millis(250),
+            syncer.process_log_batch(
+                router,
+                vec![sample_proposed_log(1, stale_block_hash, stale_tx_hash)],
+            ),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a matching but unfinalized backend view must not abort the proposal batch"
+        );
+        assert!(
+            path.seen_tx_hashes().len() >= 2,
+            "the proposal should keep retrying until finalized ancestry proves canonicality"
         );
     }
 

--- a/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/proposer_driver_e2e.rs
@@ -14,7 +14,10 @@ use driver::{
     derivation::ShastaDerivationPipeline,
     sync::{SyncStage, engine::PayloadApplier, event::EventSyncer},
 };
-use proposer::transaction_builder::{BuiltProposalTx, ShastaProposalTransactionBuilder};
+use proposer::{
+    proposer::EngineBuildContext,
+    transaction_builder::{BuiltProposalTx, ShastaProposalTransactionBuilder},
+};
 use rpc::{blob::BlobDataSource, client::Client};
 use serial_test::serial;
 use test_context::test_context;
@@ -107,7 +110,8 @@ async fn proposer_to_driver_event_sync(env: &mut ShastaEnv) -> Result<()> {
     // Build a proposal and inject its sidecar into the beacon stub.
     let builder =
         ShastaProposalTransactionBuilder::new(proposer.clone(), env.l2_suggested_fee_recipient);
-    let request = builder.build(vec![Vec::new()], None).await?;
+    let (build_ctx, _) = EngineBuildContext::from_chain_heads(&proposer).await?;
+    let request = builder.build(vec![Vec::new()], build_ctx).await?;
     beacon_stub.set_default_blob_sidecar(built_proposal_sidecar(&request));
 
     // Start event syncer before submitting the proposal.
@@ -169,7 +173,8 @@ async fn known_canonical_fast_path(env: &mut ShastaEnv) -> Result<()> {
 
     let builder =
         ShastaProposalTransactionBuilder::new(proposer.clone(), env.l2_suggested_fee_recipient);
-    let request = builder.build(vec![Vec::new()], None).await?;
+    let (build_ctx, _) = EngineBuildContext::from_chain_heads(&proposer).await?;
+    let request = builder.build(vec![Vec::new()], build_ctx).await?;
     beacon_stub.set_default_blob_sidecar(built_proposal_sidecar(&request));
 
     let driver_config = DriverConfig::new(
@@ -255,7 +260,8 @@ async fn multiple_proposals_event_sync(env: &mut ShastaEnv) -> Result<()> {
     // Build a proposal once and inject its sidecar into the beacon stub.
     let builder =
         ShastaProposalTransactionBuilder::new(proposer.clone(), env.l2_suggested_fee_recipient);
-    let request = builder.build(vec![Vec::new()], None).await?;
+    let (build_ctx, _) = EngineBuildContext::from_chain_heads(&proposer).await?;
+    let request = builder.build(vec![Vec::new()], build_ctx).await?;
     beacon_stub.set_default_blob_sidecar(built_proposal_sidecar(&request));
 
     let driver_config = DriverConfig::new(

--- a/packages/taiko-client-rs/crates/driver/tests/shasta_event_sync.rs
+++ b/packages/taiko-client-rs/crates/driver/tests/shasta_event_sync.rs
@@ -7,7 +7,9 @@ use anyhow::{Context, Result, ensure};
 use driver::{
     Driver, DriverConfig, derivation::ShastaDerivationPipeline, sync::engine::PayloadApplier,
 };
-use proposer::transaction_builder::ShastaProposalTransactionBuilder;
+use proposer::{
+    proposer::EngineBuildContext, transaction_builder::ShastaProposalTransactionBuilder,
+};
 use rpc::{blob::BlobDataSource, client::Client};
 use serial_test::serial;
 use test_context::test_context;
@@ -25,7 +27,8 @@ async fn syncs_shasta_proposal_into_l2(env: &mut ShastaEnv) -> Result<()> {
     );
 
     // Build a proposal with an empty transaction list to force an anchor-only block.
-    let request = builder.build(vec![Vec::new()], None).await?;
+    let (build_ctx, _) = EngineBuildContext::from_chain_heads(&proposer_client).await?;
+    let request = builder.build(vec![Vec::new()], build_ctx).await?;
     let sidecar = request.blob_sidecar();
 
     // Start beacon stub and inject the blob sidecar.

--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -26,22 +26,21 @@ use protocol::shasta::{
     AnchorTxConstructor, AnchorV4Input, PayloadAttributesInput, build_payload_attributes,
     calculate_shasta_mix_hash,
     constants::{
-        MIN_BLOCK_GAS_LIMIT, PROPOSAL_MAX_BLOB_BYTES,
-        calculate_next_block_eip4396_base_fee_for_parent, min_base_fee_for_chain,
+        PROPOSAL_MAX_BLOB_BYTES, calculate_next_block_eip4396_base_fee_for_parent,
+        min_base_fee_for_chain,
     },
     encode_extra_data,
 };
 use rpc::{RpcClientError, client::Client};
 use serde_json::from_value;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::time::interval;
+use tokio::time::{MissedTickBehavior, interval};
 use tracing::{error, info, instrument, warn};
 
 use crate::{
     config::ProposerConfigs,
     error::{ProposerError, Result},
     metrics::ProposerMetrics,
-    transaction_builder::ShastaProposalTransactionBuilder,
+    transaction_builder::{ShastaProposalTransactionBuilder, manifest_gas_limit},
     tx_manager_adapter::{build_tx_manager, proposal_candidate},
 };
 
@@ -140,6 +139,9 @@ impl Proposer {
     /// Start the proposer main loop.
     pub async fn start(&self) -> Result<()> {
         let mut interval = interval(self.cfg.propose_interval);
+        // A slow confirmation must not replay the missed ticks as an immediate burst afterwards:
+        // the inbox accepts at most one proposal per L1 block, so burst ticks only revert.
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         let mut epoch = 0;
 
         loop {
@@ -292,15 +294,26 @@ impl Proposer {
 
     /// Fetch transaction pool content from the L2 execution engine.
     async fn fetch_pool_content(&self) -> Result<TransactionLists> {
-        let base_fee_u64 = u64::try_from(self.calculate_next_shasta_block_base_fee().await?)
-            .map_err(|_| ProposerError::BaseFeeOverflow)?;
+        let parent = self
+            .rpc_provider
+            .l2_provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await?
+            .ok_or(ProposerError::LatestBlockNotFound)?;
+
+        let base_fee_u64 =
+            u64::try_from(self.calculate_next_shasta_block_base_fee_for_parent(&parent).await?)
+                .map_err(|_| ProposerError::BaseFeeOverflow)?;
 
         let pool_content = self
             .rpc_provider
             .tx_pool_content_with_min_tip(rpc::TxPoolContentParams {
                 beneficiary: self.cfg.l2_suggested_fee_recipient,
                 base_fee: Some(base_fee_u64),
-                block_max_gas_limit: MIN_BLOCK_GAS_LIMIT,
+                // Fill up to the gas limit the manifest will actually declare (parent limit
+                // minus the anchor-gas discount) instead of the protocol minimum, which
+                // under-filled every list to 10M while blocks advertise ~45M.
+                block_max_gas_limit: manifest_gas_limit(parent.number(), parent.header.gas_limit),
                 max_bytes_per_tx_list: PROPOSAL_MAX_BLOB_BYTES as u64,
                 locals: vec![],
                 max_transactions_lists: 1,
@@ -325,19 +338,6 @@ impl Proposer {
             .collect::<Result<Vec<Vec<_>>>>()?;
 
         Ok(txs_lists)
-    }
-
-    /// Calculate the base fee for the next L2 block using EIP-4396 rules.
-    async fn calculate_next_shasta_block_base_fee(&self) -> Result<U256> {
-        // Get the latest block to calculate the next base fee.
-        let parent = self
-            .rpc_provider
-            .l2_provider
-            .get_block_by_number(BlockNumberOrTag::Latest)
-            .await?
-            .ok_or(ProposerError::LatestBlockNotFound)?;
-
-        self.calculate_next_shasta_block_base_fee_for_parent(&parent).await
     }
 
     /// Calculate the base fee for the next L2 block from a specific parent snapshot.
@@ -410,7 +410,6 @@ impl Proposer {
         parent: &Block,
     ) -> Result<(TaikoPayloadAttributes, EngineBuildContext)> {
         let block_number = parent.number() + 1;
-        let timestamp = current_unix_timestamp();
 
         // Get basefee sharing percentage from inbox config.
         let inbox_config = self.rpc_provider.shasta.inbox.getConfig().call().await?;
@@ -430,6 +429,10 @@ impl Proposer {
             .await?
             .ok_or(ProposerError::LatestBlockNotFound)?;
         let anchor_block_number = l1_block.header.number;
+        // Stamp the payload with the L1 head timestamp instead of the local wall clock: the
+        // manifest timestamp must not exceed the proposal's L1 inclusion timestamp, or driver
+        // validation degrades the whole manifest to the default empty block.
+        let timestamp = l1_block.header.timestamp;
 
         // Build anchor transaction.
         let anchor_tx = self
@@ -647,11 +650,6 @@ fn forced_inclusion_is_permissionless(
     l1_timestamp > permissionless_timestamp
 }
 
-/// Returns the current UNIX timestamp in seconds.
-pub(crate) fn current_unix_timestamp() -> u64 {
-    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
-}
-
 /// Derive the next proposal id from the parent block header.
 ///
 /// Shasta stores the previous proposal id in the parent block extra data. On a fresh chain the
@@ -714,28 +712,16 @@ mod tests {
     };
     use base_tx_manager::TxManagerError;
 
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     use super::{
-        calculate_next_shasta_block_base_fee_from_parent, current_unix_timestamp,
-        forced_inclusion_is_permissionless, is_operational_loop_error, next_shasta_proposal_id,
-        record_submission_attempt, record_submission_receipt, should_increment_loop_failure_metric,
+        calculate_next_shasta_block_base_fee_from_parent, forced_inclusion_is_permissionless,
+        is_operational_loop_error, next_shasta_proposal_id, record_submission_attempt,
+        record_submission_receipt, should_increment_loop_failure_metric,
     };
     use crate::{error::ProposerError, metrics::ProposerMetrics};
     use protocol::shasta::{
         constants::calculate_next_block_eip4396_base_fee_from_parent_values, encode_extra_data,
     };
     use rpc::RpcClientError;
-
-    #[test]
-    fn current_unix_timestamp_tracks_system_time() {
-        let before = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-        let timestamp = current_unix_timestamp();
-        let after = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-
-        assert!(timestamp >= before);
-        assert!(timestamp <= after);
-    }
 
     #[test]
     fn submission_attempt_increments_sent_metric() {

--- a/packages/taiko-client-rs/crates/proposer/src/proposer.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/proposer.rs
@@ -47,8 +47,10 @@ use crate::{
 /// Type alias for batches of transaction lists fetched from the txpool.
 pub type TransactionLists = Vec<Vec<Transaction>>;
 
-/// Parameters captured from engine mode payload building.
-/// These ensure consistency between the anchor transaction and the block manifest.
+/// Chain-state snapshot a proposal is built against.
+/// Captured once per proposal attempt — from engine-mode payload building or from the
+/// proposer's own L1/L2 reads in pool mode — so transaction selection, the anchor transaction,
+/// and the block manifest all describe the same parent and L1 head.
 #[derive(Debug, Clone, Copy)]
 pub struct EngineBuildContext {
     /// The L1 block number used for the anchor transaction.
@@ -59,6 +61,37 @@ pub struct EngineBuildContext {
     pub timestamp: u64,
     /// The gas limit for the block.
     pub gas_limit: u64,
+}
+
+impl EngineBuildContext {
+    /// Capture a build context, together with the L2 parent block it derives from, off the
+    /// current L1/L2 chain heads.
+    ///
+    /// The timestamp is taken from the L1 head rather than the local wall clock: driver
+    /// validation rejects any manifest block stamped above the proposal's L1 inclusion
+    /// timestamp, degrading the whole manifest to the default empty block.
+    pub async fn from_chain_heads(rpc: &Client) -> Result<(Self, Block)> {
+        let parent = rpc
+            .l2_provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await?
+            .ok_or(ProposerError::LatestBlockNotFound)?;
+
+        let l1_head = rpc
+            .l1_provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await?
+            .ok_or(ProposerError::LatestBlockNotFound)?;
+
+        let context = Self {
+            anchor_block_number: l1_head.header.number,
+            parent_block_number: parent.number(),
+            timestamp: l1_head.header.timestamp,
+            gas_limit: parent.header.gas_limit,
+        };
+
+        Ok((context, parent))
+    }
 }
 
 /// Proposer loop that builds and submits Shasta proposals at a fixed interval.
@@ -198,13 +231,12 @@ impl Proposer {
 
     /// Fetch L2 EE mempool and propose a new proposal to protocol inbox.
     pub async fn fetch_and_propose(&self) -> Result<TransactionReceipt> {
-        // Fetch transactions based on mode.
-        // Engine mode also returns the parameters used for the anchor transaction.
-        let (pool_content, engine_params) = if self.cfg.use_engine_mode {
-            let (txs, params) = self.fetch_payload_transactions().await?;
-            (txs, Some(params))
+        // Fetch transactions based on mode. Both modes capture the chain-state snapshot the
+        // transactions were selected against, so the manifest is built from the same snapshot.
+        let (pool_content, build_ctx) = if self.cfg.use_engine_mode {
+            self.fetch_payload_transactions().await?
         } else {
-            (self.fetch_pool_content().await?, None)
+            self.fetch_pool_content().await?
         };
 
         // Record number of transactions in the pool
@@ -214,11 +246,11 @@ impl Proposer {
             txs_lists = pool_content.len(),
             tx_count,
             engine_mode = self.cfg.use_engine_mode,
-            ?engine_params,
+            ?build_ctx,
             "fetched transaction pool content"
         );
 
-        let mut proposal_tx = self.transaction_builder.build(pool_content, engine_params).await?;
+        let mut proposal_tx = self.transaction_builder.build(pool_content, build_ctx).await?;
 
         // Set gas limit if configured, otherwise let the provider estimate it.
         if let Some(gas_limit) = self.cfg.gas_limit {
@@ -292,14 +324,10 @@ impl Proposer {
         ))
     }
 
-    /// Fetch transaction pool content from the L2 execution engine.
-    async fn fetch_pool_content(&self) -> Result<TransactionLists> {
-        let parent = self
-            .rpc_provider
-            .l2_provider
-            .get_block_by_number(BlockNumberOrTag::Latest)
-            .await?
-            .ok_or(ProposerError::LatestBlockNotFound)?;
+    /// Fetch transaction pool content from the L2 execution engine, together with the
+    /// chain-state snapshot the selection ran against.
+    async fn fetch_pool_content(&self) -> Result<(TransactionLists, EngineBuildContext)> {
+        let (build_ctx, parent) = EngineBuildContext::from_chain_heads(&self.rpc_provider).await?;
 
         let base_fee_u64 =
             u64::try_from(self.calculate_next_shasta_block_base_fee_for_parent(&parent).await?)
@@ -312,8 +340,12 @@ impl Proposer {
                 base_fee: Some(base_fee_u64),
                 // Fill up to the gas limit the manifest will actually declare (parent limit
                 // minus the anchor-gas discount) instead of the protocol minimum, which
-                // under-filled every list to 10M while blocks advertise ~45M.
-                block_max_gas_limit: manifest_gas_limit(parent.number(), parent.header.gas_limit),
+                // under-filled every list to 10M while blocks advertise ~45M. Derived from the
+                // same snapshot the manifest is built against.
+                block_max_gas_limit: manifest_gas_limit(
+                    build_ctx.parent_block_number,
+                    build_ctx.gas_limit,
+                ),
                 max_bytes_per_tx_list: PROPOSAL_MAX_BLOB_BYTES as u64,
                 locals: vec![],
                 max_transactions_lists: 1,
@@ -337,7 +369,7 @@ impl Proposer {
             })
             .collect::<Result<Vec<Vec<_>>>>()?;
 
-        Ok(txs_lists)
+        Ok((txs_lists, build_ctx))
     }
 
     /// Calculate the base fee for the next L2 block from a specific parent snapshot.

--- a/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
@@ -3,13 +3,11 @@
 use alethia_reth_consensus::validation::ANCHOR_V3_V4_GAS_LIMIT;
 use alloy::{
     consensus::{BlobTransactionSidecar, BlobTransactionSidecarVariant, SidecarBuilder},
-    eips::BlockNumberOrTag,
     network::TransactionBuilder4844,
     primitives::{
         Address, Bytes, U256,
         aliases::{U24, U48},
     },
-    providers::Provider,
     rpc::types::{TransactionInput, TransactionRequest},
 };
 use bindings::inbox::{IInbox::ProposeInput, LibBlobs::BlobReference};
@@ -96,43 +94,18 @@ impl ShastaProposalTransactionBuilder {
 
     /// Build a Shasta `propose` transaction with the given L2 transactions.
     ///
-    /// If `engine_params` is provided (engine mode), those parameters will be used directly.
-    /// Otherwise, the current L1 head, current timestamp, and latest canonical parent gas limit are
-    /// used.
+    /// The caller supplies the [`EngineBuildContext`] snapshot (L1 anchor, timestamp base, and
+    /// the L2 parent's gas limit) so that transaction selection and manifest construction always
+    /// describe the same chain state; the builder performs no chain reads of its own besides the
+    /// propose-input encoding.
     pub async fn build(
         &self,
         txs_lists: TransactionLists,
-        engine_params: Option<EngineBuildContext>,
+        ctx: EngineBuildContext,
     ) -> Result<BuiltProposalTx> {
-        // Use provided engine params or derive defaults.
-        let (anchor_block_number, timestamp, gas_limit) = match engine_params {
-            Some(params) => (
-                params.anchor_block_number,
-                params.timestamp,
-                manifest_gas_limit(params.parent_block_number, params.gas_limit),
-            ),
-            None => {
-                let latest_parent = self
-                    .rpc_provider
-                    .l2_provider
-                    .get_block_by_number(BlockNumberOrTag::Latest)
-                    .await?
-                    .ok_or(ProposerError::LatestBlockNotFound)?;
-                let gas_limit =
-                    manifest_gas_limit(latest_parent.number(), latest_parent.header.gas_limit);
-                // Anchor the manifest timestamps to the L1 head rather than the local wall
-                // clock: driver validation rejects any block timestamp above the proposal's L1
-                // inclusion timestamp and degrades the whole manifest to the default empty
-                // block, so a fast local clock would silently drop every proposed transaction.
-                let l1_head = self
-                    .rpc_provider
-                    .l1_provider
-                    .get_block_by_number(BlockNumberOrTag::Latest)
-                    .await?
-                    .ok_or(ProposerError::LatestBlockNotFound)?;
-                (l1_head.header.number, l1_head.header.timestamp, gas_limit)
-            }
-        };
+        let anchor_block_number = ctx.anchor_block_number;
+        let timestamp = ctx.timestamp;
+        let gas_limit = manifest_gas_limit(ctx.parent_block_number, ctx.gas_limit);
 
         // Proposer intentionally keeps the stricter Shasta cap. It is below the
         // Unzen derivation-source cap, so proposals that pass here are safe there.
@@ -151,7 +124,10 @@ impl ShastaProposalTransactionBuilder {
                 .map(|(index, txs)| {
                     // Driver validation requires strictly increasing block timestamps
                     // (parent + 1 lower bound), so stagger multi-block manifests by index
-                    // exactly like the Go proposer does.
+                    // exactly like the Go proposer does (`l1Head.Time + i`). Shared ceiling
+                    // with Go: blocks whose index exceeds the proposal's actual L1 inclusion
+                    // delay trip the driver's upper bound (timestamp <= inclusion timestamp),
+                    // which cannot be known at build time.
                     let block_timestamp = timestamp + index as u64;
                     info!(
                         block_index = index,
@@ -219,7 +195,7 @@ pub(crate) fn manifest_gas_limit(parent_block_number: u64, gas_limit: u64) -> u6
 mod tests {
     use super::{ShastaProposalTransactionBuilder, manifest_gas_limit};
     use alloy::{
-        consensus::{BlobTransactionSidecar, Header as ConsensusHeader, TxEnvelope},
+        consensus::BlobTransactionSidecar,
         eips::eip4844::Blob,
         network::TransactionBuilder4844,
         primitives::{Address, Bytes},
@@ -233,16 +209,11 @@ mod tests {
         transports::{TransportError, TransportFut},
     };
     use alloy_provider::ProviderBuilder;
-    use alloy_rpc_types::eth::{Block as RpcBlock, Header as RpcHeader};
     use bindings::{anchor::Anchor::AnchorInstance, inbox::Inbox::InboxInstance};
     use protocol::shasta::{BlobCoder, manifest::DerivationSourceManifest};
     use rpc::client::{Client, ShastaProtocolInstance};
-    use std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
-    };
 
-    use crate::transaction_builder::BuiltProposalTx;
+    use crate::{proposer::EngineBuildContext, transaction_builder::BuiltProposalTx};
 
     impl BuiltProposalTx {
         /// Build a proposal transaction from raw blobs for crate-local tests.
@@ -281,133 +252,23 @@ mod tests {
         );
     }
 
+    /// Minimal transport for builder tests: serves the propose-input `eth_call` and
+    /// `eth_chainId`. The builder performs no other chain reads — its inputs arrive via
+    /// [`EngineBuildContext`].
     #[derive(Clone, Debug)]
     struct ManifestTestTransport {
-        l1_block_number: u64,
         call_result: Bytes,
-        latest_block: Option<RpcBlock<TxEnvelope>>,
-        genesis_block: Option<RpcBlock<TxEnvelope>>,
-        requests: Arc<Mutex<Vec<String>>>,
-        saw_latest_block: Arc<AtomicBool>,
-        saw_genesis_block: Arc<AtomicBool>,
     }
 
     impl ManifestTestTransport {
-        fn l1(l1_block_number: u64, l1_timestamp: u64, call_result: Bytes) -> Self {
-            let l1_head = RpcBlock::<TxEnvelope> {
-                header: RpcHeader {
-                    hash: Default::default(),
-                    inner: ConsensusHeader {
-                        number: l1_block_number,
-                        timestamp: l1_timestamp,
-                        ..Default::default()
-                    },
-                    total_difficulty: None,
-                    size: None,
-                },
-                ..Default::default()
-            };
-            Self {
-                l1_block_number,
-                call_result,
-                latest_block: Some(l1_head),
-                genesis_block: None,
-                requests: Arc::new(Mutex::new(Vec::new())),
-                saw_latest_block: Arc::new(AtomicBool::new(false)),
-                saw_genesis_block: Arc::new(AtomicBool::new(false)),
-            }
-        }
-
-        fn l2(latest_block: RpcBlock<TxEnvelope>, genesis_block: RpcBlock<TxEnvelope>) -> Self {
-            Self {
-                l1_block_number: 0,
-                call_result: Bytes::new(),
-                latest_block: Some(latest_block),
-                genesis_block: Some(genesis_block),
-                requests: Arc::new(Mutex::new(Vec::new())),
-                saw_latest_block: Arc::new(AtomicBool::new(false)),
-                saw_genesis_block: Arc::new(AtomicBool::new(false)),
-            }
-        }
-
-        fn seen_latest_block_request(&self) -> bool {
-            self.saw_latest_block.load(Ordering::SeqCst)
-        }
-
-        fn seen_genesis_block_request(&self) -> bool {
-            self.saw_genesis_block.load(Ordering::SeqCst)
-        }
-
-        fn request_log(&self) -> Vec<String> {
-            self.requests.lock().expect("request log should not be poisoned").clone()
-        }
-
         fn handle_request(
             &self,
             request: SerializedRequest,
         ) -> Response<Box<serde_json::value::RawValue>> {
-            let method = request.method().to_string();
-            let params = request.params().map(|params| params.get().to_string());
-            self.requests
-                .lock()
-                .expect("request log should not be poisoned")
-                .push(format!("{method} {}", params.as_deref().unwrap_or("")));
-
-            match method.as_str() {
-                "eth_blockNumber" => success_u64(request.id().clone(), self.l1_block_number),
+            match request.method() {
                 "eth_call" => success_bytes(request.id().clone(), &self.call_result),
-                "eth_getBlockByNumber" => {
-                    self.handle_get_block_by_number(request.id().clone(), params.as_deref())
-                }
                 "eth_chainId" => success_u64(request.id().clone(), 1),
                 _ => success_null(request.id().clone()),
-            }
-        }
-
-        fn handle_get_block_by_number(
-            &self,
-            id: Id,
-            params: Option<&str>,
-        ) -> Response<Box<serde_json::value::RawValue>> {
-            let parsed_params: serde_json::Value = params
-                .and_then(|raw| serde_json::from_str(raw).ok())
-                .unwrap_or(serde_json::Value::Null);
-            let requested_block = parsed_params.as_array().and_then(|items| items.first());
-
-            match requested_block {
-                Some(serde_json::Value::String(tag)) if tag == "latest" => {
-                    self.saw_latest_block.store(true, Ordering::SeqCst);
-                    success_block(
-                        id,
-                        self.latest_block
-                            .as_ref()
-                            .expect("latest block fixture should be configured"),
-                    )
-                }
-                Some(serde_json::Value::String(tag))
-                    if tag == "0x0" || tag == "0x00" || tag == "0" =>
-                {
-                    self.saw_genesis_block.store(true, Ordering::SeqCst);
-                    success_block(
-                        id,
-                        self.genesis_block
-                            .as_ref()
-                            .expect("genesis block fixture should be configured"),
-                    )
-                }
-                Some(serde_json::Value::Number(number)) if number.as_u64() == Some(0) => {
-                    self.saw_genesis_block.store(true, Ordering::SeqCst);
-                    success_block(
-                        id,
-                        self.genesis_block
-                            .as_ref()
-                            .expect("genesis block fixture should be configured"),
-                    )
-                }
-                _ => success_block(
-                    id,
-                    self.latest_block.as_ref().expect("latest block fixture should be configured"),
-                ),
             }
         }
     }
@@ -461,20 +322,12 @@ mod tests {
         success_json(id, serde_json::to_string(value).expect("test response should serialize"))
     }
 
-    fn success_block(
-        id: Id,
-        value: &RpcBlock<TxEnvelope>,
-    ) -> Response<Box<serde_json::value::RawValue>> {
-        success_json(id, serde_json::to_string(value).expect("test response should serialize"))
-    }
-
-    fn test_rpc_client(
-        l1_transport: ManifestTestTransport,
-        l2_transport: ManifestTestTransport,
-    ) -> Client {
-        let l1_provider = ProviderBuilder::new().connect_client(RpcClient::new(l1_transport, true));
+    fn test_rpc_client(call_result: Bytes) -> Client {
+        let transport = ManifestTestTransport { call_result };
+        let l1_provider =
+            ProviderBuilder::new().connect_client(RpcClient::new(transport.clone(), true));
         let l2_provider =
-            ProviderBuilder::default().connect_client(RpcClient::new(l2_transport, true));
+            ProviderBuilder::default().connect_client(RpcClient::new(transport, true));
         let l2_auth_provider = l2_provider.clone();
         let inbox = InboxInstance::new(Address::ZERO, l1_provider.clone());
         let anchor = AnchorInstance::new(Address::ZERO, l2_auth_provider.clone());
@@ -494,113 +347,63 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_manifest_gas_limit_uses_latest_parent_block_in_non_engine_mode()
-    -> crate::error::Result<()> {
-        let latest_parent = RpcBlock::<TxEnvelope> {
-            header: RpcHeader {
-                hash: Default::default(),
-                inner: ConsensusHeader { number: 42, gas_limit: 46_000_000, ..Default::default() },
-                total_difficulty: None,
-                size: None,
-            },
-            ..Default::default()
-        };
-        let genesis_parent = RpcBlock::<TxEnvelope> {
-            header: RpcHeader {
-                hash: Default::default(),
-                inner: ConsensusHeader { number: 0, gas_limit: 47_000_000, ..Default::default() },
-                total_difficulty: None,
-                size: None,
-            },
-            ..Default::default()
-        };
+    async fn build_applies_anchor_gas_discount_from_context() -> crate::error::Result<()> {
         let call_result = Bytes::from(Bytes::from_static(b"proposal-encoded-bytes").abi_encode());
-        let l1_transport = ManifestTestTransport::l1(1, 1_000, call_result);
-        let l2_transport = ManifestTestTransport::l2(latest_parent, genesis_parent);
-        let rpc_provider = test_rpc_client(l1_transport.clone(), l2_transport.clone());
-        let builder =
-            ShastaProposalTransactionBuilder::new(rpc_provider, Address::repeat_byte(0x11));
+        let builder = ShastaProposalTransactionBuilder::new(
+            test_rpc_client(call_result),
+            Address::repeat_byte(0x11),
+        );
+        let ctx = EngineBuildContext {
+            anchor_block_number: 77,
+            parent_block_number: 42,
+            timestamp: 1_000,
+            gas_limit: 46_000_000,
+        };
 
-        let built_tx = builder.build(vec![vec![]], None).await?;
-        let manifest_payload =
-            BlobCoder::decode_blob(&built_tx.blobs()[0]).expect("manifest blob should decode");
-        let manifest = DerivationSourceManifest::decompress_and_decode(&manifest_payload, 0)
-            .expect("manifest should decode from blob sidecar");
+        let built_tx = builder.build(vec![vec![]], ctx).await?;
+        let manifest = decode_built_manifest(&built_tx);
 
         assert_eq!(manifest.blocks.len(), 1);
         assert_eq!(manifest.blocks[0].gas_limit, 45_000_000);
-        assert!(
-            l2_transport.seen_latest_block_request(),
-            "build should query eth_getBlockByNumber latest"
-        );
-        assert!(
-            !l2_transport.seen_genesis_block_request(),
-            "build should not query the genesis block in non-engine mode"
-        );
-        assert!(
-            l2_transport
-                .request_log()
-                .iter()
-                .any(|entry| entry.contains("eth_getBlockByNumber") && entry.contains("latest")),
-            "request log should include an eth_getBlockByNumber latest lookup"
-        );
+        assert_eq!(manifest.blocks[0].anchor_block_number, 77);
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn build_stamps_l1_head_timestamp_and_staggers_blocks_in_non_engine_mode()
-    -> crate::error::Result<()> {
-        let latest_parent = RpcBlock::<TxEnvelope> {
-            header: RpcHeader {
-                hash: Default::default(),
-                inner: ConsensusHeader { number: 42, gas_limit: 46_000_000, ..Default::default() },
-                total_difficulty: None,
-                size: None,
-            },
-            ..Default::default()
-        };
-        let genesis_parent = RpcBlock::<TxEnvelope> {
-            header: RpcHeader {
-                hash: Default::default(),
-                inner: ConsensusHeader { number: 0, gas_limit: 47_000_000, ..Default::default() },
-                total_difficulty: None,
-                size: None,
-            },
-            ..Default::default()
-        };
-        let l1_head_number = 77;
-        let l1_head_timestamp = 1_234_567;
+    async fn build_stamps_context_timestamp_and_staggers_blocks() -> crate::error::Result<()> {
         let call_result = Bytes::from(Bytes::from_static(b"proposal-encoded-bytes").abi_encode());
-        let l1_transport =
-            ManifestTestTransport::l1(l1_head_number, l1_head_timestamp, call_result);
-        let l2_transport = ManifestTestTransport::l2(latest_parent, genesis_parent);
-        let rpc_provider = test_rpc_client(l1_transport.clone(), l2_transport.clone());
-        let builder =
-            ShastaProposalTransactionBuilder::new(rpc_provider, Address::repeat_byte(0x11));
+        let builder = ShastaProposalTransactionBuilder::new(
+            test_rpc_client(call_result),
+            Address::repeat_byte(0x11),
+        );
+        let ctx = EngineBuildContext {
+            anchor_block_number: 77,
+            parent_block_number: 42,
+            timestamp: 1_234_567,
+            gas_limit: 46_000_000,
+        };
 
         // Two tx lists: driver validation requires strictly increasing timestamps across the
         // manifest blocks, so identical stamps would void the whole proposal.
-        let built_tx = builder.build(vec![vec![], vec![]], None).await?;
-        let manifest_payload =
-            BlobCoder::decode_blob(&built_tx.blobs()[0]).expect("manifest blob should decode");
-        let manifest = DerivationSourceManifest::decompress_and_decode(&manifest_payload, 0)
-            .expect("manifest should decode from blob sidecar");
+        let built_tx = builder.build(vec![vec![], vec![]], ctx).await?;
+        let manifest = decode_built_manifest(&built_tx);
 
         assert_eq!(manifest.blocks.len(), 2);
-        // The base timestamp comes from the L1 head (never above the proposal's L1 inclusion
-        // timestamp), not from the local wall clock.
-        assert_eq!(manifest.blocks[0].timestamp, l1_head_timestamp);
-        assert_eq!(manifest.blocks[1].timestamp, l1_head_timestamp + 1);
-        assert_eq!(manifest.blocks[0].anchor_block_number, l1_head_number);
-        assert!(
-            l1_transport
-                .request_log()
-                .iter()
-                .any(|entry| entry.contains("eth_getBlockByNumber") && entry.contains("latest")),
-            "builder should fetch the L1 head block instead of eth_blockNumber"
-        );
+        // The base timestamp comes from the caller's L1-head snapshot (never above the
+        // proposal's L1 inclusion timestamp), not from the local wall clock.
+        assert_eq!(manifest.blocks[0].timestamp, 1_234_567);
+        assert_eq!(manifest.blocks[1].timestamp, 1_234_568);
+        assert_eq!(manifest.blocks[0].anchor_block_number, 77);
 
         Ok(())
+    }
+
+    /// Decode the manifest back out of the built transaction's first blob.
+    fn decode_built_manifest(built_tx: &BuiltProposalTx) -> DerivationSourceManifest {
+        let manifest_payload =
+            BlobCoder::decode_blob(&built_tx.blobs()[0]).expect("manifest blob should decode");
+        DerivationSourceManifest::decompress_and_decode(&manifest_payload, 0)
+            .expect("manifest should decode from blob sidecar")
     }
 }

--- a/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
+++ b/packages/taiko-client-rs/crates/proposer/src/transaction_builder.rs
@@ -23,7 +23,7 @@ use tracing::info;
 
 use crate::{
     error::{ProposerError, Result},
-    proposer::{EngineBuildContext, TransactionLists, current_unix_timestamp},
+    proposer::{EngineBuildContext, TransactionLists},
 };
 
 /// A proposer-owned proposal transaction prepared for adapter-backed submission.
@@ -120,11 +120,17 @@ impl ShastaProposalTransactionBuilder {
                     .ok_or(ProposerError::LatestBlockNotFound)?;
                 let gas_limit =
                     manifest_gas_limit(latest_parent.number(), latest_parent.header.gas_limit);
-                (
-                    self.rpc_provider.l1_provider.get_block_number().await?,
-                    current_unix_timestamp(),
-                    gas_limit,
-                )
+                // Anchor the manifest timestamps to the L1 head rather than the local wall
+                // clock: driver validation rejects any block timestamp above the proposal's L1
+                // inclusion timestamp and degrades the whole manifest to the default empty
+                // block, so a fast local clock would silently drop every proposed transaction.
+                let l1_head = self
+                    .rpc_provider
+                    .l1_provider
+                    .get_block_by_number(BlockNumberOrTag::Latest)
+                    .await?
+                    .ok_or(ProposerError::LatestBlockNotFound)?;
+                (l1_head.header.number, l1_head.header.timestamp, gas_limit)
             }
         };
 
@@ -143,17 +149,21 @@ impl ShastaProposalTransactionBuilder {
                 .iter()
                 .enumerate()
                 .map(|(index, txs)| {
+                    // Driver validation requires strictly increasing block timestamps
+                    // (parent + 1 lower bound), so stagger multi-block manifests by index
+                    // exactly like the Go proposer does.
+                    let block_timestamp = timestamp + index as u64;
                     info!(
                         block_index = index,
                         tx_count = txs.len(),
-                        timestamp,
+                        timestamp = block_timestamp,
                         anchor_block_number,
                         gas_limit,
                         coinbase = ?self.l2_suggested_fee_recipient,
                         "setting up derivation source manifest block"
                     );
                     BlockManifest {
-                        timestamp,
+                        timestamp: block_timestamp,
                         coinbase: self.l2_suggested_fee_recipient,
                         anchor_block_number,
                         gas_limit,
@@ -197,7 +207,7 @@ impl ShastaProposalTransactionBuilder {
 ///
 /// The genesis parent (block number 0) keeps its gas limit unchanged; all later parents apply the
 /// anchor-gas discount expected by the driver-side validation.
-fn manifest_gas_limit(parent_block_number: u64, gas_limit: u64) -> u64 {
+pub(crate) fn manifest_gas_limit(parent_block_number: u64, gas_limit: u64) -> u64 {
     if parent_block_number == 0 {
         gas_limit
     } else {
@@ -283,11 +293,24 @@ mod tests {
     }
 
     impl ManifestTestTransport {
-        fn l1(l1_block_number: u64, call_result: Bytes) -> Self {
+        fn l1(l1_block_number: u64, l1_timestamp: u64, call_result: Bytes) -> Self {
+            let l1_head = RpcBlock::<TxEnvelope> {
+                header: RpcHeader {
+                    hash: Default::default(),
+                    inner: ConsensusHeader {
+                        number: l1_block_number,
+                        timestamp: l1_timestamp,
+                        ..Default::default()
+                    },
+                    total_difficulty: None,
+                    size: None,
+                },
+                ..Default::default()
+            };
             Self {
                 l1_block_number,
                 call_result,
-                latest_block: None,
+                latest_block: Some(l1_head),
                 genesis_block: None,
                 requests: Arc::new(Mutex::new(Vec::new())),
                 saw_latest_block: Arc::new(AtomicBool::new(false)),
@@ -492,7 +515,7 @@ mod tests {
             ..Default::default()
         };
         let call_result = Bytes::from(Bytes::from_static(b"proposal-encoded-bytes").abi_encode());
-        let l1_transport = ManifestTestTransport::l1(1, call_result);
+        let l1_transport = ManifestTestTransport::l1(1, 1_000, call_result);
         let l2_transport = ManifestTestTransport::l2(latest_parent, genesis_parent);
         let rpc_provider = test_rpc_client(l1_transport.clone(), l2_transport.clone());
         let builder =
@@ -520,6 +543,62 @@ mod tests {
                 .iter()
                 .any(|entry| entry.contains("eth_getBlockByNumber") && entry.contains("latest")),
             "request log should include an eth_getBlockByNumber latest lookup"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_stamps_l1_head_timestamp_and_staggers_blocks_in_non_engine_mode()
+    -> crate::error::Result<()> {
+        let latest_parent = RpcBlock::<TxEnvelope> {
+            header: RpcHeader {
+                hash: Default::default(),
+                inner: ConsensusHeader { number: 42, gas_limit: 46_000_000, ..Default::default() },
+                total_difficulty: None,
+                size: None,
+            },
+            ..Default::default()
+        };
+        let genesis_parent = RpcBlock::<TxEnvelope> {
+            header: RpcHeader {
+                hash: Default::default(),
+                inner: ConsensusHeader { number: 0, gas_limit: 47_000_000, ..Default::default() },
+                total_difficulty: None,
+                size: None,
+            },
+            ..Default::default()
+        };
+        let l1_head_number = 77;
+        let l1_head_timestamp = 1_234_567;
+        let call_result = Bytes::from(Bytes::from_static(b"proposal-encoded-bytes").abi_encode());
+        let l1_transport =
+            ManifestTestTransport::l1(l1_head_number, l1_head_timestamp, call_result);
+        let l2_transport = ManifestTestTransport::l2(latest_parent, genesis_parent);
+        let rpc_provider = test_rpc_client(l1_transport.clone(), l2_transport.clone());
+        let builder =
+            ShastaProposalTransactionBuilder::new(rpc_provider, Address::repeat_byte(0x11));
+
+        // Two tx lists: driver validation requires strictly increasing timestamps across the
+        // manifest blocks, so identical stamps would void the whole proposal.
+        let built_tx = builder.build(vec![vec![], vec![]], None).await?;
+        let manifest_payload =
+            BlobCoder::decode_blob(&built_tx.blobs()[0]).expect("manifest blob should decode");
+        let manifest = DerivationSourceManifest::decompress_and_decode(&manifest_payload, 0)
+            .expect("manifest should decode from blob sidecar");
+
+        assert_eq!(manifest.blocks.len(), 2);
+        // The base timestamp comes from the L1 head (never above the proposal's L1 inclusion
+        // timestamp), not from the local wall clock.
+        assert_eq!(manifest.blocks[0].timestamp, l1_head_timestamp);
+        assert_eq!(manifest.blocks[1].timestamp, l1_head_timestamp + 1);
+        assert_eq!(manifest.blocks[0].anchor_block_number, l1_head_number);
+        assert!(
+            l1_transport
+                .request_log()
+                .iter()
+                .any(|entry| entry.contains("eth_getBlockByNumber") && entry.contains("latest")),
+            "builder should fetch the L1 head block instead of eth_blockNumber"
         );
 
         Ok(())

--- a/packages/taiko-client-rs/crates/protocol/src/subscription_source.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/subscription_source.rs
@@ -19,6 +19,18 @@ use thiserror::Error;
 /// Poll HTTP L1 providers frequently enough to keep the local harness responsive.
 const HTTP_SUBSCRIPTION_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
+/// Total per-request timeout for HTTP providers, mirroring the rpc crate's
+/// `DEFAULT_HTTP_TIMEOUT`. Without it a black-holed endpoint stalls every caller forever.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(12);
+
+/// Build a reqwest HTTP client with a bounded total request timeout.
+fn http_client_with_timeout() -> alloy::transports::http::reqwest::Client {
+    alloy::transports::http::reqwest::Client::builder()
+        .timeout(HTTP_REQUEST_TIMEOUT)
+        .build()
+        .expect("http client")
+}
+
 /// Convenience alias for the recommended filler stack with a wallet.
 pub type JoinedRecommendedFillersWithWallet =
     JoinFill<JoinedRecommendedFillers, WalletFiller<EthereumWallet>>;
@@ -80,7 +92,9 @@ impl SubscriptionSource {
         let builder = ProviderBuilder::new();
         let provider =
             match self {
-                SubscriptionSource::Http(url) => builder.connect_http(url.clone()),
+                SubscriptionSource::Http(url) => {
+                    builder.connect_reqwest(http_client_with_timeout(), url.clone())
+                }
                 SubscriptionSource::Ws(url) => builder
                     .connect_ws(WsConnect::new(url.as_str()))
                     .await
@@ -104,7 +118,9 @@ impl SubscriptionSource {
         let builder = ProviderBuilder::new().wallet(wallet);
         let provider =
             match self {
-                SubscriptionSource::Http(url) => builder.connect_http(url.clone()),
+                SubscriptionSource::Http(url) => {
+                    builder.connect_reqwest(http_client_with_timeout(), url.clone())
+                }
                 SubscriptionSource::Ws(url) => builder
                     .connect_ws(WsConnect::new(url.as_str()))
                     .await

--- a/packages/taiko-client-rs/crates/rpc/src/auth.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/auth.rs
@@ -56,8 +56,13 @@ struct EngineNewPayloadV2Request<'a> {
     /// Withdrawals root hash tracked by the Taiko sidecar.
     withdrawals_hash: B256,
     /// Optional hash-relevant header difficulty restored for Unzen blocks.
+    ///
+    /// Serialized as a decimal JSON number: taiko-geth deserializes this field as a bare
+    /// `*big.Int`, which rejects the quoted hex encoding alloy uses for `U256`, while
+    /// alethia-reth's `U256` accepts numbers and hex strings alike. The value carries the
+    /// block's zk gas, which is bounded well below `u64::MAX` by the node-side schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
-    header_difficulty: Option<U256>,
+    header_difficulty: Option<u64>,
     /// Optional marker flag indicating that the payload is Taiko-specific.
     #[serde(skip_serializing_if = "Option::is_none")]
     taiko_block: Option<bool>,
@@ -68,11 +73,23 @@ fn engine_new_payload_v2_value(
     payload: &ExecutionPayloadInputV2,
     sidecar: &TaikoExecutionDataSidecar,
 ) -> Result<Value> {
+    let header_difficulty = sidecar
+        .header_difficulty
+        .map(|difficulty| {
+            u64::try_from(difficulty).map_err(|_| {
+                RpcClientError::Other(anyhow!(
+                    "header difficulty {difficulty} exceeds the u64 range supported by the \
+                     engine_newPayloadV2 wire encoding"
+                ))
+            })
+        })
+        .transpose()?;
+
     serde_json::to_value(EngineNewPayloadV2Request {
         payload,
         tx_hash: sidecar.tx_hash,
         withdrawals_hash: sidecar.withdrawals_hash.unwrap_or_default(),
-        header_difficulty: sidecar.header_difficulty,
+        header_difficulty,
         taiko_block: sidecar.taiko_block,
     })
     .map_err(|err| RpcClientError::Other(anyhow!(err)))
@@ -325,7 +342,13 @@ mod tests {
         let value = engine_new_payload_v2_value(&payload, &sidecar).unwrap();
         let obj = value.as_object().expect("payload should serialize to a JSON object");
 
-        assert_eq!(obj.get("headerDifficulty"), Some(&serde_json::json!("0x7")));
+        // taiko-geth unmarshals `headerDifficulty` into a bare `*big.Int`, which only accepts
+        // decimal JSON numbers — a quoted hex string fails the whole newPayload request there.
+        assert_eq!(obj.get("headerDifficulty"), Some(&serde_json::json!(7)));
+        assert!(
+            obj.get("headerDifficulty").is_some_and(serde_json::Value::is_u64),
+            "headerDifficulty must serialize as a JSON number, not a string"
+        );
         assert_eq!(
             obj.get("txHash"),
             Some(&serde_json::json!(format!("{:#066x}", sidecar.tx_hash)))
@@ -336,6 +359,40 @@ mod tests {
         );
         assert_eq!(obj.get("taikoBlock"), Some(&serde_json::json!(true)));
         assert!(!obj.contains_key("withdrawals"));
+    }
+
+    #[test]
+    fn engine_new_payload_v2_value_rejects_header_difficulty_beyond_u64() {
+        let payload = ExecutionPayloadInputV2 {
+            execution_payload: ExecutionPayloadV1 {
+                parent_hash: B256::from(U256::from(10u64)),
+                fee_recipient: Address::from([1u8; 20]),
+                state_root: B256::from(U256::from(2u64)),
+                receipts_root: B256::from(U256::from(3u64)),
+                logs_bloom: Default::default(),
+                prev_randao: B256::from(U256::from(4u64)),
+                block_number: 7,
+                gas_limit: 30_000_000,
+                gas_used: 0,
+                timestamp: 123,
+                extra_data: Bytes::new(),
+                base_fee_per_gas: U256::from(1u64),
+                block_hash: B256::from(U256::from(42u64)),
+                transactions: vec![],
+            },
+            withdrawals: None,
+        };
+
+        let sidecar = TaikoExecutionDataSidecar {
+            tx_hash: B256::ZERO,
+            withdrawals_hash: None,
+            header_difficulty: Some(U256::from(u64::MAX) + U256::from(1u64)),
+            taiko_block: Some(true),
+        };
+
+        let err = engine_new_payload_v2_value(&payload, &sidecar)
+            .expect_err("difficulty beyond u64 has no lossless wire encoding and must error");
+        assert!(err.to_string().contains("exceeds the u64 range"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the highest-priority findings from the 2026-07-13 full-module review of `taiko-client-rs` (driver / proposer / protocol / rpc, cross-checked against the Go client, taiko-geth, and alethia-reth). Five independent fixes, one commit each:

**1. `headerDifficulty` was wire-incompatible with taiko-geth (`rpc/src/auth.rs`).**
The `engine_newPayloadV2` request serialized the field as a quoted hex string (alloy `U256` default), but taiko-geth deserializes it into a bare `*big.Int` — the only `ExecutableData` field without a `hexutil` override — which rejects quoted hex. The field is populated for every post-Unzen payload, so the geth lane would fail on each `newPayload` exactly at Unzen activation; the reth-only Docker e2e stack could not catch it because ruint accepts both encodings. Now encoded as a decimal JSON number (the Go client's wire form, accepted by both nodes), with a loud error for values beyond `u64` (the value carries block zk gas, which the node-side schedule bounds far below that).

**2. Proposer manifest timestamps could silently void whole proposals (`proposer`).**
Both build paths stamped `BlockManifest.timestamp` from the local wall clock, and every block of a multi-list manifest got the same value. Driver validation rejects any block timestamp above the proposal's L1 inclusion timestamp **and** requires strictly increasing timestamps, degrading a rejected manifest to the default empty block — so clock skew (or any future multi-list proposal) dropped all user transactions while still paying for the blob. Timestamps now come from the L1 head (never above the inclusion timestamp) staggered by block index, matching Go's `l1Head.Time + uint64(i)`.

**3. Pool selection capped at 10M gas while manifests declare ~45M (`proposer`).**
`taikoAuth_txPoolContentWithMinTip` was called with `block_max_gas_limit = MIN_BLOCK_GAS_LIMIT` (10M) while the manifest advertises the parent-derived limit (~45M − anchor gas), losing ~4x throughput under load. The pool cap now reuses `manifest_gas_limit(parent)` — the same value the driver validates blocks against.

**4. Deterministic engine verdicts retried forever in event sync (`driver/src/sync/event.rs`).**
The per-proposal retry loop had no attempt bound and retried every non-orphaned failure, including the typed verdicts introduced by #21949 — resubmitting an identical payload cannot change the engine's answer, so a deterministic rejection became a silent every-12s retry loop (chain stall with only WARN logs). The loop now aborts on deterministic verdicts under the conditions described in review round 1 below. (Re-lands the retry-abort portion of the closed #21952 as a minimal, self-contained change.)

**5. The L1 HTTP provider had no request timeout (`protocol/src/subscription_source.rs`).**
All proposer/driver L1 reads (inbox `getConfig`, core state, block lookups, `encodeProposeInput`) went through a provider with no total timeout, so a black-holed endpoint stalled the calling loop forever, silently. The HTTP arm now uses a reqwest client with the same 12s bound the L2 and engine providers already have.

Plus two one-liners: the propose interval sets `MissedTickBehavior::Delay` (a slow confirmation no longer replays a burst of ticks that each revert against the one-proposal-per-L1-block inbox rule), and release builds enable `overflow-checks` (the #21948 class of attacker-controlled arithmetic panics instead of wrapping in production; the client is I/O-bound so the cost is negligible).

## Review round 1

- **Retry aborts are now gated on an explicit canonical proof, node-family agnostic.** The orphan recheck's "block still resolvable by hash" does not prove the log is canonical — geth-like L1 nodes keep serving reorged-out blocks by hash, while reth-like nodes do not serve them at all, so neither by-hash answer is usable as an abort precondition. The abort decision now requires a canonical-hash-at-height match (`eth_getBlockByNumber`, the one view both node families answer identically) on top of the fatal error class. The decision is made inside the retry closure as an explicit `Abort`/`Retry` wrapper where the full context is available; the retry predicate merely follows it, so a fatal error can never leak out of an unproven attempt. Unproven canonicality, proof failures, and recheck failures all keep retrying.
- **The fatal classification no longer includes transient engine states.** `ensure_valid_payload_status` served both `newPayloadV2` and the two `forkchoiceUpdatedV2` sites, so forkchoice INVALID (possibly an unknown/unprocessable head) surfaced as `InvalidBlock`, and `UnexpectedPayloadStatus` meant ACCEPTED — which taiko-geth returns while parent state is temporarily unavailable (`eth/catalyst/api.go`). Forkchoice statuses now map through a dedicated `ensure_valid_forkchoice_status` that never produces `InvalidBlock`; only a newPayload INVALID — the engine's deterministic verdict on payload content — classifies as fatal.
- **Proposals are built from a single chain-state snapshot.** Pool selection and manifest construction each fetched their own "latest" blocks, so a block landing in between could make the selected transactions and the declared gas budget disagree. `EngineBuildContext::from_chain_heads` captures the snapshot once per attempt and threads it through selection, base-fee calculation, and the builder, which no longer reads the chain beyond the propose-input encoding call.
- **Multi-block timestamp ceiling: acknowledged and documented, deliberately not "fixed".** With `base + index` stamping, blocks whose index exceeds the proposal's actual L1 inclusion delay trip the driver's upper bound. That bound cannot be known at build time, and the stamping is byte-identical to the Go proposer's `l1Head.Time + uint64(i)` — a shared, documented ceiling. Deviating unilaterally would trade it for operational asymmetry between the two proposers; if it needs raising, it should change in Go and Rust together. A comment at the stagger site records this.

## Not included (tracked separately)

- The full typed-error refactor and graceful-shutdown work from the closed #21952 / #21954.
- `event.rs` changes are kept away from the regions #21950 rewrites (scanner loop, orphan check, ingress gate); the two PRs touch different hunks of the file but should be sequenced at merge time.

## Testing

- New regression tests: `headerDifficulty` decimal-number encoding + beyond-u64 rejection; context timestamp + per-block staggering (decoded back out of the built blob); fatal-verdict classification (newPayload INVALID only; forkchoice INVALID and ACCEPTED stay retryable); `process_log_batch` aborts after exactly one attempt on `InvalidBlock` with a canonically-proven source log, and keeps retrying when the canonical proof fails; forkchoice-status mapping never produces `InvalidBlock`.
- `cargo nextest run` (lib): driver + proposer + rpc + protocol 190/190; whitelist-preconfirmation-driver 105/105.
- `just fmt`, `just clippy` (deny warnings, deny missing docs), and `just check-features` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)