### PR TITLE
chore(taiko-client-rs): improve whitelist preconfirmation driver

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
@@ -22,13 +22,17 @@ impl JwtAuth {
     /// Build a validator from a shared secret.
     pub(super) fn new(secret: &[u8]) -> Self {
         let mut validation = Validation::new(Algorithm::HS256);
-        // Claims stay optional (no claim is required to be present), but `exp`
-        // and `nbf` are validated whenever present with zero leeway — matching
-        // the Go client's echo-jwt defaults, which refuse expired tokens.
+        // The library layer only verifies the signature; temporal claims are
+        // checked by `validate_temporal_claims` with golang-jwt v5 semantics
+        // (present-but-malformed rejected, `exp == now` already expired),
+        // because jsonwebtoken treats malformed claims as absent and keeps
+        // `exp == now` valid. `aud` is not validated: the Go client's echo-jwt
+        // defaults only check an audience when one is configured, while
+        // jsonwebtoken would reject every token carrying an `aud` claim.
         validation.required_spec_claims.clear();
-        validation.validate_exp = true;
-        validation.validate_nbf = true;
-        validation.leeway = 0;
+        validation.validate_exp = false;
+        validation.validate_nbf = false;
+        validation.validate_aud = false;
         Self { decoding_key: DecodingKey::from_secret(secret), validation }
     }
 
@@ -45,9 +49,51 @@ impl JwtAuth {
             .strip_prefix("Bearer ")
             .ok_or_else(|| "authorization header must use bearer token".to_string())?;
 
-        decode::<serde_json::Value>(token, &self.decoding_key, &self.validation)
+        let token_data = decode::<serde_json::Value>(token, &self.decoding_key, &self.validation)
             .map_err(|err| format!("invalid bearer token: {err}"))?;
-        Ok(())
+        validate_temporal_claims(&token_data.claims)
+    }
+}
+
+/// Validate `exp`/`nbf` with the Go client's golang-jwt v5 semantics: claims are
+/// optional, but a present claim must be a numeric date, a token is expired once
+/// `now >= exp`, and not yet valid while `now < nbf` (no leeway).
+fn validate_temporal_claims(claims: &serde_json::Value) -> std::result::Result<(), String> {
+    // Backstop only: jsonwebtoken's own claim parsing already rejects
+    // non-object payloads today. Kept so a library change cannot silently turn
+    // the temporal checks below into no-ops (Go's MapClaims also rejects).
+    if !claims.is_object() {
+        return Err("token claims must be a JSON object".to_string());
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|err| format!("system clock before unix epoch: {err}"))?
+        .as_secs_f64();
+
+    if let Some(exp) = numeric_date_claim(claims, "exp")? &&
+        now >= exp
+    {
+        return Err("token has expired".to_string());
+    }
+    if let Some(nbf) = numeric_date_claim(claims, "nbf")? &&
+        now < nbf
+    {
+        return Err("token is not valid yet".to_string());
+    }
+    Ok(())
+}
+
+/// Read an optional numeric-date claim, rejecting present-but-non-numeric values.
+fn numeric_date_claim(
+    claims: &serde_json::Value,
+    name: &str,
+) -> std::result::Result<Option<f64>, String> {
+    match claims.get(name) {
+        None => Ok(None),
+        Some(value) => {
+            value.as_f64().map(Some).ok_or_else(|| format!("claim {name} must be a numeric date"))
+        }
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
@@ -85,6 +85,11 @@ fn validate_temporal_claims(claims: &serde_json::Value) -> std::result::Result<(
 }
 
 /// Read an optional numeric-date claim, rejecting present-but-non-numeric values.
+///
+/// A numeric value of zero is treated as an absent claim: golang-jwt v5's
+/// `MapClaims.parseNumericDate` returns nil for a zero float64 (a holdover
+/// from v4's struct zero-value semantics), so the Go client accepts `exp: 0`.
+/// `-0.0 == 0.0` on both sides, so negative zero follows the same rule.
 fn numeric_date_claim(
     claims: &serde_json::Value,
     name: &str,
@@ -92,7 +97,9 @@ fn numeric_date_claim(
     match claims.get(name) {
         None => Ok(None),
         Some(value) => {
-            value.as_f64().map(Some).ok_or_else(|| format!("claim {name} must be a numeric date"))
+            let seconds =
+                value.as_f64().ok_or_else(|| format!("claim {name} must be a numeric date"))?;
+            Ok((seconds != 0.0).then_some(seconds))
         }
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
@@ -22,10 +22,13 @@ impl JwtAuth {
     /// Build a validator from a shared secret.
     pub(super) fn new(secret: &[u8]) -> Self {
         let mut validation = Validation::new(Algorithm::HS256);
-        // Validate signatures while keeping claims like `exp` optional.
+        // Claims stay optional (no claim is required to be present), but `exp`
+        // and `nbf` are validated whenever present with zero leeway — matching
+        // the Go client's echo-jwt defaults, which refuse expired tokens.
         validation.required_spec_claims.clear();
-        validation.validate_exp = false;
-        validation.validate_nbf = false;
+        validation.validate_exp = true;
+        validation.validate_nbf = true;
+        validation.leeway = 0;
         Self { decoding_key: DecodingKey::from_secret(secret), validation }
     }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
@@ -59,17 +59,24 @@ impl JwtAuth {
 /// optional, but a present claim must be a numeric date, a token is expired once
 /// `now >= exp`, and not yet valid while `now < nbf` (no leeway).
 fn validate_temporal_claims(claims: &serde_json::Value) -> std::result::Result<(), String> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|err| format!("system clock before unix epoch: {err}"))?
+        .as_secs_f64();
+    validate_temporal_claims_at(claims, now)
+}
+
+/// Validate temporal claims against `now`, expressed as fractional Unix seconds.
+pub(super) fn validate_temporal_claims_at(
+    claims: &serde_json::Value,
+    now: f64,
+) -> std::result::Result<(), String> {
     // Backstop only: jsonwebtoken's own claim parsing already rejects
     // non-object payloads today. Kept so a library change cannot silently turn
     // the temporal checks below into no-ops (Go's MapClaims also rejects).
     if !claims.is_object() {
         return Err("token claims must be a JSON object".to_string());
     }
-
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|err| format!("system clock before unix epoch: {err}"))?
-        .as_secs_f64();
 
     if let Some(exp) = numeric_date_claim(claims, "exp")? &&
         now >= exp
@@ -84,7 +91,8 @@ fn validate_temporal_claims(claims: &serde_json::Value) -> std::result::Result<(
     Ok(())
 }
 
-/// Read an optional numeric-date claim, rejecting present-but-non-numeric values.
+/// Read an optional numeric-date claim at golang-jwt's default one-second
+/// precision, rejecting present-but-non-numeric values.
 ///
 /// A numeric value of zero is treated as an absent claim: golang-jwt v5's
 /// `MapClaims.parseNumericDate` returns nil for a zero float64 (a holdover
@@ -99,7 +107,7 @@ fn numeric_date_claim(
         Some(value) => {
             let seconds =
                 value.as_f64().ok_or_else(|| format!("claim {name} must be a numeric date"))?;
-            Ok((seconds != 0.0).then_some(seconds))
+            Ok((seconds != 0.0).then_some(seconds.floor()))
         }
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/auth.rs
@@ -36,19 +36,51 @@ impl JwtAuth {
         Self { decoding_key: DecodingKey::from_secret(secret), validation }
     }
 
-    /// Validate `Authorization: Bearer <jwt>`.
+    /// Validate `Authorization: Bearer <jwt>` headers.
+    ///
+    /// Mirrors the Go server's echo-jwt v4 extraction: every `Authorization`
+    /// value is considered (up to echo-jwt's extractor limit of 20), the
+    /// `Bearer ` scheme prefix is matched case-insensitively with a non-empty
+    /// remainder, and the request is authorized when any candidate token
+    /// validates. ASCII case folding is exact here because `to_str` only
+    /// admits visible-ASCII header values.
     pub(super) fn validate_headers(
         &self,
         headers: &http::HeaderMap,
     ) -> std::result::Result<(), String> {
-        let header = headers
-            .get(AUTHORIZATION)
-            .and_then(|value| value.to_str().ok())
-            .ok_or_else(|| "missing bearer authorization header".to_string())?;
-        let token = header
-            .strip_prefix("Bearer ")
-            .ok_or_else(|| "authorization header must use bearer token".to_string())?;
+        const BEARER_PREFIX: &str = "Bearer ";
+        /// echo-jwt caps how many header values its extractor considers. This
+        /// counts candidates where echo-jwt counts header indices — divergent
+        /// only for requests carrying more than 20 `Authorization` values.
+        const EXTRACTOR_LIMIT: usize = 20;
 
+        let tokens = headers
+            .get_all(AUTHORIZATION)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .filter(|value| {
+                value.len() > BEARER_PREFIX.len() &&
+                    value[..BEARER_PREFIX.len()].eq_ignore_ascii_case(BEARER_PREFIX)
+            })
+            .map(|value| &value[BEARER_PREFIX.len()..])
+            .take(EXTRACTOR_LIMIT)
+            .collect::<Vec<_>>();
+        if tokens.is_empty() {
+            return Err("missing bearer authorization header".to_string());
+        }
+
+        let mut last_error = String::new();
+        for token in tokens {
+            match self.validate_token(token) {
+                Ok(()) => return Ok(()),
+                Err(err) => last_error = err,
+            }
+        }
+        Err(last_error)
+    }
+
+    /// Decode one candidate token and validate its temporal claims.
+    fn validate_token(&self, token: &str) -> std::result::Result<(), String> {
         let token_data = decode::<serde_json::Value>(token, &self.decoding_key, &self.validation)
             .map_err(|err| format!("invalid bearer token: {err}"))?;
         validate_temporal_claims(&token_data.claims)

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -8,7 +8,7 @@ use tokio::sync::broadcast;
 
 use super::{
     PRECONF_BLOCKS_BODY_LIMIT_BYTES, WhitelistApiServer, WhitelistApiServerConfig,
-    auth::JwtAuth,
+    auth::{JwtAuth, validate_temporal_claims_at},
     http::{RequestBodyReadError, read_request_body},
 };
 use crate::{
@@ -251,6 +251,22 @@ fn unix_now() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .expect("clock after epoch")
         .as_secs()
+}
+
+#[test]
+fn jwt_auth_truncates_fractional_temporal_claims_to_seconds() {
+    let now = 1_000.1;
+    let fractional_boundary = 1_000.9;
+
+    // golang-jwt's default TimePrecision truncates NumericDates to seconds,
+    // so this becomes `exp == current second` and is already expired.
+    let err = validate_temporal_claims_at(&serde_json::json!({ "exp": fractional_boundary }), now)
+        .expect_err("fractional exp must be truncated");
+    assert!(err.contains("token has expired"), "unexpected error: {err}");
+
+    // The same truncation makes this `nbf == current second`, so it is valid.
+    validate_temporal_claims_at(&serde_json::json!({ "nbf": fractional_boundary }), now)
+        .expect("fractional nbf must be truncated");
 }
 
 #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -221,6 +221,61 @@ fn jwt_auth_rejects_missing_header() {
     assert!(err.contains("missing bearer authorization header"));
 }
 
+/// Build an `Authorization: Bearer <jwt>` header map for the given claims.
+fn bearer_headers(secret: &[u8], claims: &serde_json::Value) -> http::HeaderMap {
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+        claims,
+        &jsonwebtoken::EncodingKey::from_secret(secret),
+    )
+    .expect("token should encode");
+    let mut headers = http::HeaderMap::new();
+    headers.insert(
+        http::header::AUTHORIZATION,
+        format!("Bearer {token}").parse().expect("valid header value"),
+    );
+    headers
+}
+
+#[test]
+fn jwt_auth_accepts_token_without_claims() {
+    let secret = b"test-secret";
+    let auth = JwtAuth::new(secret);
+    let headers = bearer_headers(secret, &serde_json::json!({}));
+    auth.validate_headers(&headers).expect("claimless token is accepted");
+}
+
+#[test]
+fn jwt_auth_rejects_expired_token() {
+    let secret = b"test-secret";
+    let auth = JwtAuth::new(secret);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_secs();
+
+    let headers = bearer_headers(secret, &serde_json::json!({ "exp": now - 60 }));
+    let err = auth.validate_headers(&headers).expect_err("expired token must fail");
+    assert!(err.contains("invalid bearer token"));
+
+    let headers = bearer_headers(secret, &serde_json::json!({ "exp": now + 600 }));
+    auth.validate_headers(&headers).expect("unexpired token is accepted");
+}
+
+#[test]
+fn jwt_auth_rejects_premature_token() {
+    let secret = b"test-secret";
+    let auth = JwtAuth::new(secret);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_secs();
+
+    let headers = bearer_headers(secret, &serde_json::json!({ "nbf": now + 600 }));
+    let err = auth.validate_headers(&headers).expect_err("not-yet-valid token must fail");
+    assert!(err.contains("invalid bearer token"));
+}
+
 #[tokio::test]
 async fn jwt_auth_is_required_when_secret_configured() {
     let server = start_jwt_server().await;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -221,14 +221,19 @@ fn jwt_auth_rejects_missing_header() {
     assert!(err.contains("missing bearer authorization header"));
 }
 
-/// Build an `Authorization: Bearer <jwt>` header map for the given claims.
-fn bearer_headers(secret: &[u8], claims: &serde_json::Value) -> http::HeaderMap {
-    let token = jsonwebtoken::encode(
+/// Encode a signed HS256 token for the given claims.
+fn signed_token(secret: &[u8], claims: &serde_json::Value) -> String {
+    jsonwebtoken::encode(
         &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
         claims,
         &jsonwebtoken::EncodingKey::from_secret(secret),
     )
-    .expect("token should encode");
+    .expect("token should encode")
+}
+
+/// Build an `Authorization: Bearer <jwt>` header map for the given claims.
+fn bearer_headers(secret: &[u8], claims: &serde_json::Value) -> http::HeaderMap {
+    let token = signed_token(secret, claims);
     let mut headers = http::HeaderMap::new();
     headers.insert(
         http::header::AUTHORIZATION,
@@ -243,6 +248,54 @@ fn jwt_auth_accepts_token_without_claims() {
     let auth = JwtAuth::new(secret);
     let headers = bearer_headers(secret, &serde_json::json!({}));
     auth.validate_headers(&headers).expect("claimless token is accepted");
+}
+
+#[test]
+fn jwt_auth_matches_bearer_scheme_case_insensitively() {
+    // echo-jwt extracts the token with `strings.EqualFold` on the `Bearer `
+    // prefix, so the Go server accepts any casing of the scheme.
+    let secret = b"test-secret";
+    let auth = JwtAuth::new(secret);
+    let token = signed_token(secret, &serde_json::json!({}));
+    for scheme in ["bearer", "BEARER", "BeArEr"] {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::AUTHORIZATION,
+            format!("{scheme} {token}").parse().expect("valid header value"),
+        );
+        auth.validate_headers(&headers).expect("case-folded bearer scheme is accepted");
+    }
+}
+
+#[test]
+fn jwt_auth_tries_every_authorization_header_value() {
+    // echo-jwt collects candidates from every `Authorization` value and
+    // authorizes when any one of them validates.
+    let secret = b"test-secret";
+    let auth = JwtAuth::new(secret);
+    let mut headers = http::HeaderMap::new();
+    headers.append(http::header::AUTHORIZATION, "Bearer not-a-jwt".parse().expect("valid header"));
+    headers.append(
+        http::header::AUTHORIZATION,
+        format!("Bearer {}", signed_token(secret, &serde_json::json!({})))
+            .parse()
+            .expect("valid header value"),
+    );
+    auth.validate_headers(&headers).expect("any validating candidate authorizes the request");
+}
+
+#[test]
+fn jwt_auth_treats_non_bearer_headers_as_missing() {
+    // A present `Authorization` value with no extractable `Bearer ` candidate is
+    // a missing token in echo-jwt, and an empty remainder is not a candidate
+    // (`len(value) > len(prefix)`).
+    let auth = JwtAuth::new(b"test-secret");
+    for value in ["Basic abc123", "Bearer", "Bearer "] {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::AUTHORIZATION, value.parse().expect("valid header value"));
+        let err = auth.validate_headers(&headers).expect_err("no bearer candidate must fail");
+        assert!(err.contains("missing bearer authorization header"), "unexpected error: {err}");
+    }
 }
 
 /// Current unix time in whole seconds, for minting test claims.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -245,35 +245,98 @@ fn jwt_auth_accepts_token_without_claims() {
     auth.validate_headers(&headers).expect("claimless token is accepted");
 }
 
+/// Current unix time in whole seconds, for minting test claims.
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_secs()
+}
+
 #[test]
 fn jwt_auth_rejects_expired_token() {
     let secret = b"test-secret";
     let auth = JwtAuth::new(secret);
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("clock after epoch")
-        .as_secs();
+    let now = unix_now();
 
     let headers = bearer_headers(secret, &serde_json::json!({ "exp": now - 60 }));
     let err = auth.validate_headers(&headers).expect_err("expired token must fail");
-    assert!(err.contains("invalid bearer token"));
+    assert!(err.contains("token has expired"));
+
+    // golang-jwt requires `now < exp`, so a token expiring exactly now is
+    // already expired.
+    let headers = bearer_headers(secret, &serde_json::json!({ "exp": now }));
+    let err = auth.validate_headers(&headers).expect_err("exp == now must fail");
+    assert!(err.contains("token has expired"));
+
+    // Negative numeric dates parse like Go NumericDates, and are long expired.
+    let headers = bearer_headers(secret, &serde_json::json!({ "exp": -100 }));
+    let err = auth.validate_headers(&headers).expect_err("negative exp must fail");
+    assert!(err.contains("token has expired"));
 
     let headers = bearer_headers(secret, &serde_json::json!({ "exp": now + 600 }));
     auth.validate_headers(&headers).expect("unexpired token is accepted");
+
+    // Fractional numeric dates are valid per RFC 7519.
+    let headers = bearer_headers(secret, &serde_json::json!({ "exp": now as f64 + 600.5 }));
+    auth.validate_headers(&headers).expect("fractional exp is accepted");
 }
 
 #[test]
 fn jwt_auth_rejects_premature_token() {
     let secret = b"test-secret";
     let auth = JwtAuth::new(secret);
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("clock after epoch")
-        .as_secs();
+    let now = unix_now();
 
     let headers = bearer_headers(secret, &serde_json::json!({ "nbf": now + 600 }));
     let err = auth.validate_headers(&headers).expect_err("not-yet-valid token must fail");
-    assert!(err.contains("invalid bearer token"));
+    assert!(err.contains("token is not valid yet"));
+
+    let headers = bearer_headers(secret, &serde_json::json!({ "nbf": now - 60 }));
+    auth.validate_headers(&headers).expect("past nbf is accepted");
+}
+
+#[test]
+fn jwt_auth_rejects_malformed_temporal_claims() {
+    let secret = b"test-secret";
+    let auth = JwtAuth::new(secret);
+
+    for claims in [
+        serde_json::json!({ "exp": "soon" }),
+        serde_json::json!({ "exp": serde_json::Value::Null }),
+        serde_json::json!({ "nbf": true }),
+    ] {
+        let headers = bearer_headers(secret, &claims);
+        let err = auth
+            .validate_headers(&headers)
+            .expect_err("present-but-malformed temporal claim must fail");
+        assert!(err.contains("must be a numeric date"), "unexpected error: {err}");
+    }
+
+    // Composite claim values abort claim parsing inside jsonwebtoken itself,
+    // so they are refused at decode rather than by the manual check.
+    let headers = bearer_headers(secret, &serde_json::json!({ "exp": [1, 2] }));
+    let err = auth.validate_headers(&headers).expect_err("array exp must fail");
+    assert!(err.contains("invalid bearer token"), "unexpected error: {err}");
+
+    // Non-object claim payloads are refused at decode, like golang-jwt's
+    // MapClaims parse.
+    let headers = bearer_headers(secret, &serde_json::json!("not-an-object"));
+    let err = auth.validate_headers(&headers).expect_err("non-object claims must fail");
+    assert!(err.contains("invalid bearer token"), "unexpected error: {err}");
+}
+
+#[test]
+fn jwt_auth_ignores_audience_when_none_configured() {
+    // echo-jwt only checks `aud` when an expected audience is configured;
+    // jsonwebtoken's default would reject every token carrying the claim.
+    let secret = b"test-secret";
+    let auth = JwtAuth::new(secret);
+    let headers = bearer_headers(
+        secret,
+        &serde_json::json!({ "aud": "taiko-preconf", "exp": unix_now() + 600 }),
+    );
+    auth.validate_headers(&headers).expect("audience-bearing token is accepted");
 }
 
 #[tokio::test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -274,6 +274,11 @@ fn jwt_auth_rejects_expired_token() {
     let err = auth.validate_headers(&headers).expect_err("negative exp must fail");
     assert!(err.contains("token has expired"));
 
+    // A numeric-date value of zero is an absent claim in golang-jwt v5
+    // (`MapClaims.parseNumericDate` returns nil for a zero float64).
+    let headers = bearer_headers(secret, &serde_json::json!({ "exp": 0 }));
+    auth.validate_headers(&headers).expect("zero exp is treated as absent");
+
     let headers = bearer_headers(secret, &serde_json::json!({ "exp": now + 600 }));
     auth.validate_headers(&headers).expect("unexpired token is accepted");
 
@@ -294,6 +299,10 @@ fn jwt_auth_rejects_premature_token() {
 
     let headers = bearer_headers(secret, &serde_json::json!({ "nbf": now - 60 }));
     auth.validate_headers(&headers).expect("past nbf is accepted");
+
+    // Zero follows the same absent-claim rule as `exp: 0`.
+    let headers = bearer_headers(secret, &serde_json::json!({ "nbf": 0 }));
+    auth.validate_headers(&headers).expect("zero nbf is treated as absent");
 }
 
 #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -199,10 +199,12 @@ impl WhitelistApi for WhitelistApiService {
         )
         .await?;
 
-        // If end-of-sequencing, record the epoch marker and notify `/ws` subscribers. The
-        // envelope gossiped above already carries the EOS flag; incoming sequencers that
-        // missed it request it themselves on the EOS request topic, which the importer
-        // serves from the recent-envelope cache.
+        // If end-of-sequencing, record the epoch marker. No `/ws` notification here:
+        // matching the Go client, subscribers are only notified when an EOS block
+        // arrives via P2P gossip (the builder already learns its own EOS block from
+        // this endpoint's response). Incoming sequencers that missed the gossip
+        // request it on the EOS request topic, which the importer serves from the
+        // recent-envelope cache.
         if end_of_sequencing.unwrap_or(false) {
             let epoch = self.beacon_client.timestamp_to_epoch(data.timestamp).map_err(|e| {
                 WhitelistPreconfirmationDriverError::InvalidPayload(format!(
@@ -211,16 +213,6 @@ impl WhitelistApi for WhitelistApiService {
                 ))
             })?;
             self.state.record_end_of_sequencing(epoch, block_hash).await;
-            if let Err(err) = self
-                .eos_notification_tx
-                .send(EndOfSequencingNotification { current_epoch: epoch, end_of_sequencing: true })
-            {
-                warn!(
-                    error = %err,
-                    current_epoch = epoch,
-                    "failed to deliver end-of-sequencing websocket notification"
-                );
-            }
         }
 
         crate::metrics::WhitelistPreconfirmationDriverMetrics::observe_build_preconf_block_duration(

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -200,8 +200,8 @@ impl WhitelistApi for WhitelistApiService {
         .await?;
 
         // If end-of-sequencing, record the epoch marker. No `/ws` notification here:
-        // matching the Go client, subscribers are only notified when an EOS block
-        // arrives via P2P gossip (the builder already learns its own EOS block from
+        // matching the Go client, subscribers are only notified when a gossiped EOS
+        // block is imported (the builder already learns its own EOS block from
         // this endpoint's response). Incoming sequencers that missed the gossip
         // request it on the EOS request topic, which the importer serves from the
         // recent-envelope cache.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -206,13 +206,12 @@ impl WhitelistApi for WhitelistApiService {
         // request it on the EOS request topic, which the importer serves from the
         // recent-envelope cache.
         if end_of_sequencing.unwrap_or(false) {
-            let epoch = self.beacon_client.timestamp_to_epoch(data.timestamp).map_err(|e| {
-                WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                    "failed to derive epoch from block timestamp {}: {e}",
-                    data.timestamp
-                ))
-            })?;
-            self.state.record_end_of_sequencing(epoch, block_hash).await;
+            // Key the marker by the wall-clock epoch at record time (Go's build
+            // path uses `CurrentEpoch()`), matching how the requesting operator
+            // looks the marker up at handover.
+            self.state
+                .record_end_of_sequencing(self.beacon_client.current_epoch(), block_hash)
+                .await;
         }
 
         crate::metrics::WhitelistPreconfirmationDriverMetrics::observe_build_preconf_block_duration(

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -41,9 +41,6 @@ mod status;
 #[cfg(test)]
 mod tests;
 
-/// Maximum number of pending EOS notifications retained for `/ws` subscribers.
-const EOS_NOTIFICATION_CHANNEL_CAPACITY: usize = 128;
-
 /// Number of L1 slots in the preconfer hand-over window. Doubled relative to
 /// the Go client's default `handover_slots = 4` because the Rust whitelist
 /// driver lacks lookahead-aware logic and must rely on a coarser time-based
@@ -92,8 +89,6 @@ pub(crate) struct WhitelistApiService {
     operator_set: SharedOperatorSet,
     /// Shared driver state (recent envelopes, EOS markers, last reported L2 head).
     state: SharedPreconfState,
-    /// Broadcast channel for API `/ws` end-of-sequencing notifications.
-    eos_notification_tx: broadcast::Sender<EndOfSequencingNotification>,
     /// Wall-clock instant of the most recent `build_preconf_block` invocation,
     /// regardless of the request's outcome. `None` until the first request
     /// arrives. Read by `/status` to compute `can_shutdown`.
@@ -134,7 +129,6 @@ impl WhitelistApiService {
             network_command_tx,
         }: WhitelistApiServiceParams,
     ) -> Self {
-        let (eos_notification_tx, _) = broadcast::channel(EOS_NOTIFICATION_CHANNEL_CAPACITY);
         Self {
             event_syncer,
             rpc,
@@ -143,7 +137,6 @@ impl WhitelistApiService {
             beacon_client,
             operator_set,
             state,
-            eos_notification_tx,
             network_command_tx,
             build_preconf_lock: Mutex::new(()),
             last_preconf_request_at: Mutex::new(None),

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -41,6 +41,6 @@ impl WhitelistApiService {
     pub(super) fn subscribe_end_of_sequencing_notifications(
         &self,
     ) -> broadcast::Receiver<EndOfSequencingNotification> {
-        self.eos_notification_tx.subscribe()
+        self.state.subscribe_end_of_sequencing()
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -259,6 +259,44 @@ impl RequestThrottle {
     }
 }
 
+/// Bounded set of block hashes whose end-of-sequencing flag arrived on the
+/// wire-signed payload topic and still awaits its `/ws` notification.
+///
+/// The flag must be captured at admission rather than read from the pending
+/// envelope cache at import time: that cache overwrites same-hash entries, and
+/// a later response-topic envelope — whose embedded signature covers only the
+/// block hash, leaving the EOS flag unauthenticated — could otherwise flip the
+/// flag in either direction (spoofing a handover, or suppressing a real one)
+/// before the block imports. Entries for blocks that never import age out by
+/// capacity.
+#[derive(Debug)]
+pub(crate) struct PayloadEosTracker {
+    /// Marked hashes in insertion order, oldest first.
+    hashes: LinkedHashMap<B256, ()>,
+    /// Maximum number of hashes retained.
+    capacity: usize,
+}
+
+impl PayloadEosTracker {
+    /// Create a tracker retaining at most `capacity` pending hashes.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self { hashes: LinkedHashMap::new(), capacity }
+    }
+
+    /// Record an operator-authenticated EOS block hash from the payload topic.
+    pub(crate) fn mark(&mut self, hash: B256) {
+        self.hashes.insert(hash, ());
+        while self.hashes.len() > self.capacity {
+            let _ = self.hashes.pop_front();
+        }
+    }
+
+    /// Consume the pending notification for a hash, returning whether one existed.
+    pub(crate) fn take(&mut self, hash: &B256) -> bool {
+        self.hashes.remove(hash).is_some()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -430,5 +468,48 @@ mod tests {
     #[test]
     fn notify_without_subscribers_is_a_no_op() {
         SharedPreconfState::new(0).notify_end_of_sequencing(7);
+    }
+
+    #[test]
+    fn payload_eos_tracker_takes_marked_hashes_once() {
+        let mut tracker = PayloadEosTracker::with_capacity(4);
+        let marked = B256::from([0x01u8; 32]);
+        let unmarked = B256::from([0x02u8; 32]);
+
+        tracker.mark(marked);
+
+        // A hash never marked by the payload topic (e.g. response-sourced EOS)
+        // has no pending notification.
+        assert!(!tracker.take(&unmarked));
+        assert!(tracker.take(&marked));
+        assert!(!tracker.take(&marked), "a notification is consumed exactly once");
+    }
+
+    #[test]
+    fn payload_eos_tracker_remark_is_idempotent() {
+        let mut tracker = PayloadEosTracker::with_capacity(4);
+        let hash = B256::from([0x03u8; 32]);
+
+        // Duplicate gossip deliveries of the same payload envelope re-mark the
+        // same hash; that must still yield a single pending notification.
+        tracker.mark(hash);
+        tracker.mark(hash);
+
+        assert!(tracker.take(&hash));
+        assert!(!tracker.take(&hash));
+    }
+
+    #[test]
+    fn payload_eos_tracker_evicts_oldest_beyond_capacity() {
+        let mut tracker = PayloadEosTracker::with_capacity(2);
+        let hashes: Vec<B256> = (1u8..=3).map(|byte| B256::from([byte; 32])).collect();
+
+        for hash in &hashes {
+            tracker.mark(*hash);
+        }
+
+        assert!(!tracker.take(&hashes[0]), "oldest entry is evicted at capacity");
+        assert!(tracker.take(&hashes[1]));
+        assert!(tracker.take(&hashes[2]));
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -267,8 +267,8 @@ impl RequestThrottle {
 /// a later response-topic envelope — whose embedded signature covers only the
 /// block hash, leaving the EOS flag unauthenticated — could otherwise flip the
 /// flag in either direction (spoofing a handover, or suppressing a real one)
-/// before the block imports. Entries for blocks that never import age out by
-/// capacity.
+/// before the block imports. Terminally removed envelopes discard their marks;
+/// any remaining entries for blocks that never return age out by capacity.
 #[derive(Debug)]
 pub(crate) struct PayloadEosTracker {
     /// Marked hashes in insertion order, oldest first.
@@ -294,6 +294,11 @@ impl PayloadEosTracker {
     /// Consume the pending notification for a hash, returning whether one existed.
     pub(crate) fn take(&mut self, hash: &B256) -> bool {
         self.hashes.remove(hash).is_some()
+    }
+
+    /// Discard a terminal envelope's pending notification without sending it.
+    pub(crate) fn discard(&mut self, hash: &B256) {
+        self.hashes.remove(hash);
     }
 }
 
@@ -511,5 +516,22 @@ mod tests {
         assert!(!tracker.take(&hashes[0]), "oldest entry is evicted at capacity");
         assert!(tracker.take(&hashes[1]));
         assert!(tracker.take(&hashes[2]));
+    }
+
+    #[test]
+    fn payload_eos_tracker_discards_terminal_hash_without_evicting_pending_hash() {
+        let mut tracker = PayloadEosTracker::with_capacity(2);
+        let pending = B256::from([0x01u8; 32]);
+        let terminal = B256::from([0x02u8; 32]);
+        let newer = B256::from([0x03u8; 32]);
+
+        tracker.mark(pending);
+        tracker.mark(terminal);
+        tracker.discard(&terminal);
+        tracker.mark(newer);
+
+        assert!(tracker.take(&pending), "terminal cleanup must preserve pending provenance");
+        assert!(!tracker.take(&terminal));
+        assert!(tracker.take(&newer));
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -72,13 +72,15 @@ impl SharedPreconfState {
         self.eos_notification_tx.subscribe()
     }
 
-    /// Notify `/ws` subscribers that the epoch's end-of-sequencing block was observed.
+    /// Notify `/ws` subscribers that an end-of-sequencing block has materialized.
     ///
+    /// `current_epoch` is the wall-clock epoch at push time (the Go client
+    /// re-reads `CurrentEpoch()` when pushing, ignoring the block's own epoch).
     /// A send error only means no subscriber is currently connected, which is normal.
-    pub(crate) fn notify_end_of_sequencing(&self, epoch: u64) {
+    pub(crate) fn notify_end_of_sequencing(&self, current_epoch: u64) {
         let _ = self
             .eos_notification_tx
-            .send(EndOfSequencingNotification { current_epoch: epoch, end_of_sequencing: true });
+            .send(EndOfSequencingNotification { current_epoch, end_of_sequencing: true });
     }
 
     /// Record an EOS hash for the given epoch with bounded cache size.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -98,6 +98,16 @@ impl SharedPreconfState {
         self.end_of_sequencing_by_epoch.lock().await.get(&epoch).copied()
     }
 
+    /// Whether any recorded per-epoch EOS marker points at this block hash.
+    ///
+    /// Markers are only recorded from authenticated sites (payload-topic
+    /// ingress and the local build path), so this is the trustworthy source for
+    /// an envelope's EOS flag — the Go server derives the flag for rebuilt
+    /// responses by scanning the same marker cache.
+    pub(crate) async fn is_end_of_sequencing_hash(&self, hash: &B256) -> bool {
+        self.end_of_sequencing_by_epoch.lock().await.values().any(|marked| marked == hash)
+    }
+
     /// Insert a validated envelope into the recent cache and refresh its gauge.
     pub(crate) async fn insert_recent(&self, envelope: Arc<WhitelistExecutionPayloadEnvelope>) {
         let mut recent = self.recent_envelopes.lock().await;
@@ -446,6 +456,8 @@ mod tests {
         state.record_end_of_sequencing(42, hash).await;
         assert_eq!(state.end_of_sequencing_for_epoch(42).await, Some(hash));
         assert_eq!(state.end_of_sequencing_for_epoch(43).await, None);
+        assert!(state.is_end_of_sequencing_hash(&hash).await);
+        assert!(!state.is_end_of_sequencing_hash(&B256::from([0x78u8; 32])).await);
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -11,14 +11,17 @@ use std::{
 
 use alloy_primitives::B256;
 use hashlink::LinkedHashMap;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, broadcast};
 
 use crate::{
-    codec::WhitelistExecutionPayloadEnvelope, metrics::WhitelistPreconfirmationDriverMetrics,
+    api::types::EndOfSequencingNotification, codec::WhitelistExecutionPayloadEnvelope,
+    metrics::WhitelistPreconfirmationDriverMetrics,
 };
 
 /// Maximum number of recently validated envelopes retained for serving responses.
 const RECENT_ENVELOPE_CAPACITY: usize = 1024;
+/// Maximum number of pending EOS notifications retained for `/ws` subscribers.
+const EOS_NOTIFICATION_CHANNEL_CAPACITY: usize = 128;
 /// Maximum number of pending envelopes retained while waiting for parents.
 pub(crate) const PENDING_ENVELOPE_CAPACITY: usize = 768;
 /// Maximum number of EOS cache entries retained.
@@ -43,18 +46,39 @@ pub(crate) struct SharedPreconfState {
     /// Most recent L2 head observed by `/status` or advanced by locally inserted blocks,
     /// reported as a fallback when the head is unreadable. Seeded with the head at startup.
     last_reported_l2_head: Arc<AtomicU64>,
+    /// Broadcast channel feeding `/ws` end-of-sequencing notifications; the importer
+    /// sends when an EOS block arrives via the payload topic, the API server subscribes.
+    eos_notification_tx: broadcast::Sender<EndOfSequencingNotification>,
 }
 
 impl SharedPreconfState {
     /// Create shared state seeded with the current L2 head block number.
     pub(crate) fn new(initial_l2_head: u64) -> Self {
+        let (eos_notification_tx, _) = broadcast::channel(EOS_NOTIFICATION_CHANNEL_CAPACITY);
         Self {
             end_of_sequencing_by_epoch: Arc::new(Mutex::new(LinkedHashMap::new())),
             recent_envelopes: Arc::new(Mutex::new(EnvelopeCache::with_capacity(
                 RECENT_ENVELOPE_CAPACITY,
             ))),
             last_reported_l2_head: Arc::new(AtomicU64::new(initial_l2_head)),
+            eos_notification_tx,
         }
+    }
+
+    /// Subscribe to end-of-sequencing `/ws` notifications.
+    pub(crate) fn subscribe_end_of_sequencing(
+        &self,
+    ) -> broadcast::Receiver<EndOfSequencingNotification> {
+        self.eos_notification_tx.subscribe()
+    }
+
+    /// Notify `/ws` subscribers that the epoch's end-of-sequencing block was observed.
+    ///
+    /// A send error only means no subscriber is currently connected, which is normal.
+    pub(crate) fn notify_end_of_sequencing(&self, epoch: u64) {
+        let _ = self
+            .eos_notification_tx
+            .send(EndOfSequencingNotification { current_epoch: epoch, end_of_sequencing: true });
     }
 
     /// Record an EOS hash for the given epoch with bounded cache size.
@@ -387,5 +411,22 @@ mod tests {
 
         assert!(state.remove_recent(&hash).await.is_some());
         assert!(state.get_recent(&hash).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn shared_state_notifies_eos_subscribers() {
+        let state = SharedPreconfState::new(0);
+        let mut subscriber = state.subscribe_end_of_sequencing();
+
+        state.notify_end_of_sequencing(42);
+
+        let notification = subscriber.recv().await.expect("notification delivered");
+        assert_eq!(notification.current_epoch, 42);
+        assert!(notification.end_of_sequencing);
+    }
+
+    #[test]
+    fn notify_without_subscribers_is_a_no_op() {
+        SharedPreconfState::new(0).notify_end_of_sequencing(7);
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
@@ -80,9 +80,14 @@ pub(crate) fn block_signing_hash(chain_id: u64, signing_payload: &[u8]) -> B256 
 
 /// Recover signer address from a signature and prehash.
 pub(crate) fn recover_signer(prehash: B256, signature: &[u8; SIGNATURE_LEN]) -> Result<Address> {
-    // Go peers (geth `crypto.SigToPub`) only accept recovery ids 0/1, while alloy
-    // would also normalize 27/28/35+; accepting those here would import messages
-    // every Go node rejects.
+    // Decision-equivalent to Go peers (geth `crypto.SigToPub`), not
+    // mechanism-identical: geth rejects recovery ids >= 4 outright and attempts
+    // recovery for 2/3, but a 2/3 recovery only succeeds when r < p - n (~2^129
+    // of a ~2^256 space) and crafting such a signature that recovers to an
+    // *allowlisted* address is cryptographically unreachable — so geth also
+    // rejects every feasible v > 1 message. Alloy alone would additionally
+    // normalize 27/28/35+, which geth genuinely rejects, so the pre-check is
+    // required either way.
     if signature[SIGNATURE_LEN - 1] > 1 {
         return Err(WhitelistPreconfirmationDriverError::InvalidSignature(format!(
             "invalid recovery id: {}",

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/codec.rs
@@ -15,8 +15,19 @@ const SIGNATURE_LEN: usize = 65;
 const ENVELOPE_HEADER_LEN: usize = 34;
 /// Maximum allowed size after snappy decompression, bounded by gossip limits.
 const MAX_DECOMPRESSED_GOSSIP_BYTES: usize = kona_gossip::MAX_GOSSIP_SIZE;
+/// Usable bytes of one EIP-4844 blob after field-element encoding, mirroring the
+/// Go client's `eth.MaxBlobDataSize`.
+const MAX_BLOB_DATA_SIZE: usize = (4 * 31 + 3) * 1024 - 4;
+/// Maximum number of blobs per blob-carrying transaction, mirroring the Go
+/// client's `eth.MaxBlobsPerBlobTx`.
+const MAX_BLOBS_PER_BLOB_TX: usize = 6;
 /// Maximum compressed tx-list size accepted from a preconfirmation payload.
-pub(crate) const MAX_COMPRESSED_TX_LIST_BYTES: usize = 131_072 * 6;
+///
+/// Must equal the Go client's `eth.MaxBlobDataSize * eth.MaxBlobsPerBlobTx`
+/// cap (`server.go` `ValidateExecutionPayload`): a larger local cap would let
+/// this node import payloads every Go node rejects, splitting the preconf
+/// head on mixed fleets.
+pub(crate) const MAX_COMPRESSED_TX_LIST_BYTES: usize = MAX_BLOB_DATA_SIZE * MAX_BLOBS_PER_BLOB_TX;
 /// Maximum decompressed tx-list size accepted from a preconfirmation payload.
 ///
 /// Aligned with the preconfirmation tx-list cap to prevent zlib bomb expansion
@@ -69,6 +80,16 @@ pub(crate) fn block_signing_hash(chain_id: u64, signing_payload: &[u8]) -> B256 
 
 /// Recover signer address from a signature and prehash.
 pub(crate) fn recover_signer(prehash: B256, signature: &[u8; SIGNATURE_LEN]) -> Result<Address> {
+    // Go peers (geth `crypto.SigToPub`) only accept recovery ids 0/1, while alloy
+    // would also normalize 27/28/35+; accepting those here would import messages
+    // every Go node rejects.
+    if signature[SIGNATURE_LEN - 1] > 1 {
+        return Err(WhitelistPreconfirmationDriverError::InvalidSignature(format!(
+            "invalid recovery id: {}",
+            signature[SIGNATURE_LEN - 1]
+        )));
+    }
+
     let signature = Signature::from_raw_array(signature).map_err(|err| {
         WhitelistPreconfirmationDriverError::InvalidSignature(format!(
             "invalid signature bytes: {err}"
@@ -454,6 +475,39 @@ mod tests {
             err,
             WhitelistPreconfirmationDriverError::InvalidPayload(msg)
                 if msg.contains("too large after decompression")
+        ));
+    }
+
+    #[test]
+    fn compressed_tx_list_cap_matches_go_client() {
+        // Go: `eth.MaxBlobDataSize * eth.MaxBlobsPerBlobTx` = 130,044 * 6.
+        assert_eq!(MAX_COMPRESSED_TX_LIST_BYTES, 780_264);
+    }
+
+    #[test]
+    fn recover_signer_accepts_raw_recovery_ids_only() {
+        let signer = protocol::signer::FixedKSigner::new(
+            "0x0101010101010101010101010101010101010101010101010101010101010101",
+        )
+        .expect("valid private key");
+        let prehash = block_signing_hash(167_000, b"payload bytes");
+        let signed = signer.sign_with_predefined_k(prehash.as_ref()).expect("signing succeeds");
+
+        let mut signature = [0u8; SIGNATURE_LEN];
+        signature[..32].copy_from_slice(&signed.signature.r().to_be_bytes::<32>());
+        signature[32..64].copy_from_slice(&signed.signature.s().to_be_bytes::<32>());
+        signature[64] = signed.recovery_id;
+        recover_signer(prehash, &signature).expect("raw recovery id is accepted");
+
+        // The same signature with a legacy 27/28 v byte must be rejected: geth's
+        // `crypto.SigToPub` (used by Go peers) only accepts recovery ids 0/1.
+        signature[64] = signed.recovery_id + 27;
+        let err =
+            recover_signer(prehash, &signature).expect_err("legacy recovery id must be rejected");
+        assert!(matches!(
+            err,
+            WhitelistPreconfirmationDriverError::InvalidSignature(msg)
+                if msg.contains("invalid recovery id")
         ));
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -3,10 +3,12 @@
 use std::time::Instant;
 
 use alethia_reth_primitives::payload::attributes::TaikoPayloadAttributes;
+use alloy_primitives::B256;
 use driver::{PreconfPayload, PreconfSubmissionOutcome};
 use tracing::{debug, info, warn};
 
 use crate::{
+    cache::{EnvelopeCache, PayloadEosTracker},
     codec::{WhitelistExecutionPayloadEnvelope, decompress_tx_list},
     error::{Result, WhitelistPreconfirmationDriverError},
     metrics::WhitelistPreconfirmationDriverMetrics,
@@ -30,6 +32,16 @@ fn driver_payload_from_envelope(
         envelope.is_forced_inclusion.unwrap_or(false),
         envelope.signature.unwrap_or([0u8; 65]),
     ))
+}
+
+/// Remove a terminal pending envelope and retire any unsent EOS notification provenance.
+pub(super) fn remove_terminal_cached_envelope(
+    cache: &mut EnvelopeCache,
+    payload_eos_tracker: &mut PayloadEosTracker,
+    hash: &B256,
+) {
+    payload_eos_tracker.discard(hash);
+    cache.remove(hash);
 }
 
 impl WhitelistPreconfirmationImporter {
@@ -68,7 +80,15 @@ impl WhitelistPreconfirmationImporter {
                         WhitelistPreconfirmationDriverMetrics::inc_cache_import_result(
                             "progressed",
                         );
-                        self.cache.remove(&hash);
+                        // Every `Ok(true)` outcome is terminal for this cache entry. A
+                        // matching insertion already consumed and notified its marker;
+                        // stale, already-materialized, and invalid outcomes must discard
+                        // theirs so they cannot evict provenance for live deferred EOS blocks.
+                        remove_terminal_cached_envelope(
+                            &mut self.cache,
+                            &mut self.payload_eos_tracker,
+                            &hash,
+                        );
                         progressed = true;
                     }
                     Ok(false) => {
@@ -94,7 +114,11 @@ impl WhitelistPreconfirmationImporter {
                                 error = %err,
                                 "dropping cached whitelist preconfirmation payload after invalid import"
                             );
-                            self.cache.remove(&hash);
+                            remove_terminal_cached_envelope(
+                                &mut self.cache,
+                                &mut self.payload_eos_tracker,
+                                &hash,
+                            );
                             progressed = true;
                         }
                         CachedImportDisposition::Propagate => {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -197,11 +197,15 @@ impl WhitelistPreconfirmationImporter {
                     // block has materialized, with the wall-clock epoch at push
                     // time — both matching the Go client, whose only push site
                     // runs after `TryImportingPayload` succeeds and re-reads
-                    // `CurrentEpoch()`. Deliberate superset of Go: this also
-                    // fires for deferred imports and response-topic envelopes
-                    // (Go's envelope cache drops the EOS flag, silently losing
-                    // those notifications).
-                    if end_of_sequencing {
+                    // `CurrentEpoch()`. The tracker holds hashes whose EOS flag
+                    // arrived wire-signed on the payload topic; the flag on the
+                    // cached envelope is deliberately not consulted, since a
+                    // response-topic envelope (embedded signature covers only
+                    // the block hash) could have overwritten it in either
+                    // direction. Deliberate superset of Go in one respect only:
+                    // deferred payload-topic imports still notify, where Go's
+                    // envelope cache drops the EOS flag and loses them.
+                    if self.payload_eos_tracker.take(&block_hash) {
                         self.state.notify_end_of_sequencing(self.beacon_client.current_epoch());
                     }
                 } else {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -44,6 +44,33 @@ pub(super) fn remove_terminal_cached_envelope(
     cache.remove(hash);
 }
 
+/// Whether a submission outcome consumes the pending payload-topic EOS
+/// notification for the envelope's operator-signed block hash.
+///
+/// Only an `Inserted` outcome whose produced hash matches the envelope hash
+/// notifies, and only when the flag arrived wire-signed on the payload topic
+/// (a tracker mark). The tracker is consulted instead of the cached envelope's
+/// own flag because the pending cache overwrites same-hash entries — a
+/// response-topic envelope, whose embedded signature covers only the block
+/// hash, could have flipped the flag unauthenticated in either direction.
+/// Hash-mismatched insertions are deliberately stricter than Go, whose push
+/// site never compares hashes: the operator-signed EOS block never
+/// materialized, so the notification is withheld and the mark left for
+/// terminal cleanup to discard. `AlreadyMaterialized` and `Stale` never notify
+/// (Go's push site is gated on a fresh insert). Deliberate superset of Go in
+/// one respect only: deferred payload-topic imports still notify, where Go's
+/// envelope cache drops the EOS flag and loses them.
+pub(super) fn eos_notification_due(
+    tracker: &mut PayloadEosTracker,
+    outcome: &PreconfSubmissionOutcome,
+    envelope_block_hash: B256,
+) -> bool {
+    matches!(
+        outcome,
+        PreconfSubmissionOutcome::Inserted { block_hash } if *block_hash == envelope_block_hash
+    ) && tracker.take(&envelope_block_hash)
+}
+
 impl WhitelistPreconfirmationImporter {
     /// Attempt to import cached envelopes if sync is ready.
     pub(crate) async fn maybe_import_from_cache(&mut self) -> Result<()> {
@@ -119,6 +146,11 @@ impl WhitelistPreconfirmationImporter {
                                 &mut self.payload_eos_tracker,
                                 &hash,
                             );
+                            // Stop re-serving an envelope the driver rejected as
+                            // invalid, matching the hash-mismatch purge in
+                            // `try_import_cached` (Go only ever serves imported
+                            // blocks).
+                            self.state.remove_recent(&hash).await;
                             progressed = true;
                         }
                         CachedImportDisposition::Propagate => {
@@ -207,7 +239,16 @@ impl WhitelistPreconfirmationImporter {
             if submit_result.is_ok() { "success" } else { "failure" },
             submit_start.elapsed().as_secs_f64(),
         );
-        match submit_result? {
+        let outcome = submit_result?;
+        // Notify `/ws` subscribers only once the end-of-sequencing block has
+        // materialized, with the wall-clock epoch at push time — both matching
+        // the Go client, whose only push site runs after `TryImportingPayload`
+        // succeeds and re-reads `CurrentEpoch()`. See `eos_notification_due`
+        // for which outcomes qualify.
+        if eos_notification_due(&mut self.payload_eos_tracker, &outcome, block_hash) {
+            self.state.notify_end_of_sequencing(self.beacon_client.current_epoch());
+        }
+        match outcome {
             PreconfSubmissionOutcome::Inserted { block_hash: inserted_block_hash } => {
                 if inserted_block_hash == block_hash {
                     info!(
@@ -217,21 +258,6 @@ impl WhitelistPreconfirmationImporter {
                         end_of_sequencing,
                         "inserted whitelist preconfirmation block"
                     );
-                    // Notify `/ws` subscribers only once the end-of-sequencing
-                    // block has materialized, with the wall-clock epoch at push
-                    // time — both matching the Go client, whose only push site
-                    // runs after `TryImportingPayload` succeeds and re-reads
-                    // `CurrentEpoch()`. The tracker holds hashes whose EOS flag
-                    // arrived wire-signed on the payload topic; the flag on the
-                    // cached envelope is deliberately not consulted, since a
-                    // response-topic envelope (embedded signature covers only
-                    // the block hash) could have overwritten it in either
-                    // direction. Deliberate superset of Go in one respect only:
-                    // deferred payload-topic imports still notify, where Go's
-                    // envelope cache drops the EOS flag and loses them.
-                    if self.payload_eos_tracker.take(&block_hash) {
-                        self.state.notify_end_of_sequencing(self.beacon_client.current_epoch());
-                    }
                 } else {
                     // The operator-signed hash does not match the block its own payload
                     // produces; stop re-serving the inconsistent envelope to peers. The

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -193,6 +193,17 @@ impl WhitelistPreconfirmationImporter {
                         end_of_sequencing,
                         "inserted whitelist preconfirmation block"
                     );
+                    // Notify `/ws` subscribers only once the end-of-sequencing
+                    // block has materialized, with the wall-clock epoch at push
+                    // time — both matching the Go client, whose only push site
+                    // runs after `TryImportingPayload` succeeds and re-reads
+                    // `CurrentEpoch()`. Deliberate superset of Go: this also
+                    // fires for deferred imports and response-topic envelopes
+                    // (Go's envelope cache drops the EOS flag, silently losing
+                    // those notifications).
+                    if end_of_sequencing {
+                        self.state.notify_end_of_sequencing(self.beacon_client.current_epoch());
+                    }
                 } else {
                     // The operator-signed hash does not match the block its own payload
                     // produces; stop re-serving the inconsistent envelope to peers. The

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -104,14 +104,12 @@ impl WhitelistPreconfirmationImporter {
                 ingress_source,
                 "recording end-of-sequencing envelope for epoch"
             );
+            // Record the marker at admission (before import) so EOS catch-up
+            // requests can be served immediately. The `/ws` notification is
+            // deliberately NOT sent here: it fires only once the block has
+            // materialized, in `try_import_cached`, matching the Go client
+            // (which pushes only after `TryImportingPayload` succeeds).
             self.state.record_end_of_sequencing(epoch, envelope.execution_payload.block_hash).await;
-            // Notify `/ws` subscribers about EOS blocks observed on the payload
-            // topic, mirroring the Go client (`OnUnsafeL2Payload` is its only
-            // push site): the incoming sequencer learns the outgoing operator's
-            // end-of-sequencing block from gossip, not from its own build API.
-            if ingress_source == "payload" {
-                self.state.notify_end_of_sequencing(epoch);
-            }
         }
     }
 
@@ -172,13 +170,16 @@ impl WhitelistPreconfirmationImporter {
         hash: B256,
         mark_end_of_sequencing: bool,
     ) -> Result<Option<&'static str>> {
-        // Envelopes without an embedded signature are never servable: response
-        // receivers verify that signature against the block hash and reject its
-        // absence, so fall through to the L2 rebuild (which declines on a zero
-        // L1-origin signature, matching the Go client).
+        // Envelopes without a non-zero embedded signature are never servable:
+        // response receivers verify that signature against the block hash, so
+        // an absent or all-zero signature (which the wire format can carry) is
+        // rejected by every peer. Fall through to the L2 rebuild, which
+        // declines on a zero L1-origin signature — matching the Go client,
+        // which only ever serves from L2 state under the same zero check.
         let (envelope, source) = if let Some(envelope) =
-            self.state.get_recent(&hash).await.filter(|envelope| envelope.signature.is_some())
-        {
+            self.state.get_recent(&hash).await.filter(|envelope| {
+                envelope.signature.is_some_and(|signature| signature != [0u8; 65])
+            }) {
             (envelope, "cache_hit")
         } else if let Some(mut envelope) = self.build_response_envelope_from_l2(hash).await? {
             if mark_end_of_sequencing {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -35,6 +35,36 @@ pub(super) fn is_stale_at_confirmed_tip(block_number: u64, confirmed_tip: Option
     confirmed_tip.is_some_and(|tip| block_number <= tip)
 }
 
+/// Which gossip topic an inbound envelope arrived on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IngressSource {
+    /// `preconfBlocks` — the wire signature covers the whole SSZ envelope.
+    Payload,
+    /// `responsePreconfBlocks` — the embedded signature covers only the block hash.
+    Response,
+}
+
+impl IngressSource {
+    /// Static label used in logs and metrics.
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Payload => "payload",
+            Self::Response => "response",
+        }
+    }
+
+    /// Whether the envelope's EOS flag is operator-authenticated on this source.
+    ///
+    /// Only the payload topic signs the flag bytes (the wire signature covers
+    /// the whole SSZ envelope); on the response topic the embedded signature
+    /// covers only the block hash, so any peer could set the flag on an
+    /// otherwise-valid response. The Go client likewise never ingests EOS
+    /// state from responses.
+    pub(super) fn authenticates_eos_flag(self) -> bool {
+        matches!(self, Self::Payload)
+    }
+}
+
 /// Apply the trusted EOS-request marker to an envelope selected for response serving.
 pub(super) fn apply_response_eos_marker(
     envelope: Arc<WhitelistExecutionPayloadEnvelope>,
@@ -61,7 +91,7 @@ impl WhitelistPreconfirmationImporter {
     async fn ingest_validated_envelope(
         &mut self,
         envelope: Arc<WhitelistExecutionPayloadEnvelope>,
-        ingress_source: &'static str,
+        ingress_source: IngressSource,
     ) {
         let confirmed_tip = match self.head_l1_origin_block_id().await {
             Ok(tip) => tip,
@@ -69,7 +99,7 @@ impl WhitelistPreconfirmationImporter {
                 warn!(
                     block_number = envelope.execution_payload.block_number,
                     block_hash = %envelope.execution_payload.block_hash,
-                    ingress_source,
+                    ingress_source = ingress_source.label(),
                     error = %err,
                     "confirmed-tip lookup failed at admission; admitting envelope for deferred stale checks"
                 );
@@ -81,7 +111,7 @@ impl WhitelistPreconfirmationImporter {
                 block_number = envelope.execution_payload.block_number,
                 block_hash = %envelope.execution_payload.block_hash,
                 ?confirmed_tip,
-                ingress_source,
+                ingress_source = ingress_source.label(),
                 "ignoring stale whitelist preconfirmation envelope"
             );
             return;
@@ -93,51 +123,39 @@ impl WhitelistPreconfirmationImporter {
         self.record_eos_epoch_if_marked(&envelope, ingress_source).await;
     }
 
-    /// Record the envelope block hash for its beacon epoch when `end_of_sequencing` is set.
+    /// Record the envelope block hash as this epoch's EOS marker when `end_of_sequencing`
+    /// is set and the source authenticates the flag.
     async fn record_eos_epoch_if_marked(
         &mut self,
         envelope: &WhitelistExecutionPayloadEnvelope,
-        ingress_source: &'static str,
+        ingress_source: IngressSource,
     ) {
-        if !envelope.end_of_sequencing.unwrap_or(false) {
+        if !envelope.end_of_sequencing.unwrap_or(false) || !ingress_source.authenticates_eos_flag()
+        {
             return;
         }
 
-        // The EOS flag is only trusted from the payload topic, where the wire
-        // signature covers the whole SSZ envelope including the flag bytes. On
-        // the response topic the embedded signature covers only the block
-        // hash, so the flag is unauthenticated: any peer could set it on an
-        // otherwise-valid response. Ignoring it matches the Go client, which
-        // never ingests EOS state from responses.
-        if ingress_source != "payload" {
-            return;
-        }
-
-        let timestamp = envelope.execution_payload.timestamp;
-        if let Ok(epoch) = self.beacon_client.timestamp_to_epoch(timestamp).inspect_err(|err| {
-            tracing::warn!(
-                timestamp,
-                ingress_source,
-                error = %err,
-                "failed to derive epoch from envelope timestamp for EOS recording"
-            );
-        }) {
-            debug!(
-                epoch,
-                hash = %envelope.execution_payload.block_hash,
-                ingress_source,
-                "recording end-of-sequencing envelope for epoch"
-            );
-            // Record the marker at admission (before import) so EOS catch-up
-            // requests can be served immediately. The `/ws` notification is
-            // deliberately NOT sent here: it fires once the block has
-            // materialized, in `try_import_cached`. The hash is remembered in
-            // the tracker rather than re-read from the pending cache at import
-            // time, because that cache overwrites same-hash entries — a later
-            // response envelope could otherwise rewrite the flag unauthenticated.
-            self.state.record_end_of_sequencing(epoch, envelope.execution_payload.block_hash).await;
-            self.payload_eos_tracker.mark(envelope.execution_payload.block_hash);
-        }
+        // Key the marker by the wall-clock epoch at record time, not the block
+        // timestamp's epoch: both Go record sites use `CurrentEpoch()`, and the
+        // requesting operator looks the marker up with its own wall-clock epoch
+        // at handover — timestamp keying would miss an EOS block delivered just
+        // across an epoch boundary.
+        let epoch = self.beacon_client.current_epoch();
+        debug!(
+            epoch,
+            hash = %envelope.execution_payload.block_hash,
+            ingress_source = ingress_source.label(),
+            "recording end-of-sequencing envelope for epoch"
+        );
+        // Record the marker at admission (before import) so EOS catch-up
+        // requests can be served immediately. The `/ws` notification is
+        // deliberately NOT sent here: it fires once the block has
+        // materialized, in `try_import_cached`. The hash is remembered in
+        // the tracker rather than re-read from the pending cache at import
+        // time, because that cache overwrites same-hash entries — a later
+        // response envelope could otherwise rewrite the flag unauthenticated.
+        self.state.record_end_of_sequencing(epoch, envelope.execution_payload.block_hash).await;
+        self.payload_eos_tracker.mark(envelope.execution_payload.block_hash);
     }
 
     /// Handle an incoming unsafe payload from the `preconfBlocks` topic.
@@ -152,7 +170,7 @@ impl WhitelistPreconfirmationImporter {
         &mut self,
         payload: DecodedUnsafePayload,
     ) -> Result<()> {
-        self.validate_and_ingest(payload.envelope, "payload").await
+        self.validate_and_ingest(payload.envelope, IngressSource::Payload).await
     }
 
     /// Handle an incoming unsafe response from the `responsePreconfBlocks` topic.
@@ -160,7 +178,7 @@ impl WhitelistPreconfirmationImporter {
         &mut self,
         envelope: WhitelistExecutionPayloadEnvelope,
     ) -> Result<()> {
-        self.validate_and_ingest(envelope, "response").await
+        self.validate_and_ingest(envelope, IngressSource::Response).await
     }
 
     /// Run payload-level validation and ingest the envelope, tagged with its ingress source.
@@ -170,7 +188,7 @@ impl WhitelistPreconfirmationImporter {
     async fn validate_and_ingest(
         &mut self,
         envelope: WhitelistExecutionPayloadEnvelope,
-        ingress_source: &'static str,
+        ingress_source: IngressSource,
     ) -> Result<()> {
         validate_execution_payload_for_preconf(
             &envelope.execution_payload,
@@ -296,11 +314,12 @@ impl WhitelistPreconfirmationImporter {
             )
         })?;
 
-        let end_of_sequencing = self
-            .cache
-            .get(&hash)
-            .and_then(|envelope| envelope.end_of_sequencing)
-            .filter(|&enabled| enabled);
+        // Derive the flag from the per-epoch marker map — populated only from
+        // authenticated sites (payload-topic ingress, local builds) — the way
+        // the Go server scans its marker cache for rebuilt responses. The
+        // pending envelope cache is deliberately not consulted: a response-topic
+        // envelope could have planted an unauthenticated flag there.
+        let end_of_sequencing = self.state.is_end_of_sequencing_hash(&hash).await.then_some(true);
         let base_fee = block.header.base_fee_per_gas.ok_or_else(|| {
             WhitelistPreconfirmationDriverError::invalid_payload(format!(
                 "request-response block {} missing base fee",

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -27,10 +27,7 @@ use crate::{
 
 use super::{
     WhitelistPreconfirmationImporter,
-    validation::{
-        normalize_unsafe_payload_envelope, validate_envelope_header_difficulty,
-        validate_execution_payload_for_preconf,
-    },
+    validation::{validate_envelope_header_difficulty, validate_execution_payload_for_preconf},
 };
 
 /// Return whether an envelope is at or below a written event-confirmed tip.
@@ -108,16 +105,29 @@ impl WhitelistPreconfirmationImporter {
                 "recording end-of-sequencing envelope for epoch"
             );
             self.state.record_end_of_sequencing(epoch, envelope.execution_payload.block_hash).await;
+            // Notify `/ws` subscribers about EOS blocks observed on the payload
+            // topic, mirroring the Go client (`OnUnsafeL2Payload` is its only
+            // push site): the incoming sequencer learns the outgoing operator's
+            // end-of-sequencing block from gossip, not from its own build API.
+            if ingress_source == "payload" {
+                self.state.notify_end_of_sequencing(epoch);
+            }
         }
     }
 
     /// Handle an incoming unsafe payload from the `preconfBlocks` topic.
+    ///
+    /// The wire signature is deliberately NOT copied into the envelope's embedded
+    /// signature slot when the latter is absent: the wire signature signs the SSZ
+    /// envelope bytes while the embedded slot is verified against the block hash
+    /// (a different domain), so a substituted signature would be persisted to the
+    /// L1 origin and served in responses every peer rejects. The Go client keeps
+    /// the slot empty and declines to serve such blocks; match that.
     pub(super) async fn handle_unsafe_payload(
         &mut self,
         payload: DecodedUnsafePayload,
     ) -> Result<()> {
-        let envelope = normalize_unsafe_payload_envelope(payload.envelope, payload.wire_signature);
-        self.validate_and_ingest(envelope, "payload").await
+        self.validate_and_ingest(payload.envelope, "payload").await
     }
 
     /// Handle an incoming unsafe response from the `responsePreconfBlocks` topic.
@@ -162,7 +172,13 @@ impl WhitelistPreconfirmationImporter {
         hash: B256,
         mark_end_of_sequencing: bool,
     ) -> Result<Option<&'static str>> {
-        let (envelope, source) = if let Some(envelope) = self.state.get_recent(&hash).await {
+        // Envelopes without an embedded signature are never servable: response
+        // receivers verify that signature against the block hash and reject its
+        // absence, so fall through to the L2 rebuild (which declines on a zero
+        // L1-origin signature, matching the Go client).
+        let (envelope, source) = if let Some(envelope) =
+            self.state.get_recent(&hash).await.filter(|envelope| envelope.signature.is_some())
+        {
             (envelope, "cache_hit")
         } else if let Some(mut envelope) = self.build_response_envelope_from_l2(hash).await? {
             if mark_end_of_sequencing {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -35,6 +35,20 @@ pub(super) fn is_stale_at_confirmed_tip(block_number: u64, confirmed_tip: Option
     confirmed_tip.is_some_and(|tip| block_number <= tip)
 }
 
+/// Apply the trusted EOS-request marker to an envelope selected for response serving.
+pub(super) fn apply_response_eos_marker(
+    envelope: Arc<WhitelistExecutionPayloadEnvelope>,
+    mark_end_of_sequencing: bool,
+) -> Arc<WhitelistExecutionPayloadEnvelope> {
+    if !mark_end_of_sequencing || envelope.end_of_sequencing == Some(true) {
+        return envelope;
+    }
+
+    let mut marked = (*envelope).clone();
+    marked.end_of_sequencing = Some(true);
+    Arc::new(marked)
+}
+
 impl WhitelistPreconfirmationImporter {
     /// Cache a validated envelope and persist EOS epoch mapping when applicable.
     ///
@@ -176,8 +190,8 @@ impl WhitelistPreconfirmationImporter {
     /// publishing it on the response topic.
     ///
     /// Returns the source label of the served envelope, or `None` when the hash
-    /// is not servable. `mark_end_of_sequencing` tags envelopes rebuilt from L2
-    /// so EOS catch-up responses carry the marker.
+    /// is not servable. `mark_end_of_sequencing` tags the selected envelope so
+    /// EOS catch-up responses carry the marker regardless of cache provenance.
     pub(super) async fn serve_envelope_by_hash(
         &mut self,
         hash: B256,
@@ -194,14 +208,12 @@ impl WhitelistPreconfirmationImporter {
                 envelope.signature.is_some_and(|signature| signature != [0u8; 65])
             }) {
             (envelope, "cache_hit")
-        } else if let Some(mut envelope) = self.build_response_envelope_from_l2(hash).await? {
-            if mark_end_of_sequencing {
-                envelope.end_of_sequencing = Some(true);
-            }
+        } else if let Some(envelope) = self.build_response_envelope_from_l2(hash).await? {
             (Arc::new(envelope), "l2_hit")
         } else {
             return Ok(None);
         };
+        let envelope = apply_response_eos_marker(envelope, mark_end_of_sequencing);
 
         let confirmed_tip = self.head_l1_origin_block_id().await?;
         if is_stale_at_confirmed_tip(envelope.execution_payload.block_number, confirmed_tip) {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -81,11 +81,21 @@ impl WhitelistPreconfirmationImporter {
 
     /// Record the envelope block hash for its beacon epoch when `end_of_sequencing` is set.
     async fn record_eos_epoch_if_marked(
-        &self,
+        &mut self,
         envelope: &WhitelistExecutionPayloadEnvelope,
         ingress_source: &'static str,
     ) {
         if !envelope.end_of_sequencing.unwrap_or(false) {
+            return;
+        }
+
+        // The EOS flag is only trusted from the payload topic, where the wire
+        // signature covers the whole SSZ envelope including the flag bytes. On
+        // the response topic the embedded signature covers only the block
+        // hash, so the flag is unauthenticated: any peer could set it on an
+        // otherwise-valid response. Ignoring it matches the Go client, which
+        // never ingests EOS state from responses.
+        if ingress_source != "payload" {
             return;
         }
 
@@ -106,10 +116,13 @@ impl WhitelistPreconfirmationImporter {
             );
             // Record the marker at admission (before import) so EOS catch-up
             // requests can be served immediately. The `/ws` notification is
-            // deliberately NOT sent here: it fires only once the block has
-            // materialized, in `try_import_cached`, matching the Go client
-            // (which pushes only after `TryImportingPayload` succeeds).
+            // deliberately NOT sent here: it fires once the block has
+            // materialized, in `try_import_cached`. The hash is remembered in
+            // the tracker rather than re-read from the pending cache at import
+            // time, because that cache overwrites same-hash entries — a later
+            // response envelope could otherwise rewrite the flag unauthenticated.
             self.state.record_end_of_sequencing(epoch, envelope.execution_payload.block_hash).await;
+            self.payload_eos_tracker.mark(envelope.execution_payload.block_hash);
         }
     }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -10,7 +10,10 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use crate::{
-    cache::{EnvelopeCache, PENDING_ENVELOPE_CAPACITY, RequestThrottle, SharedPreconfState},
+    cache::{
+        EnvelopeCache, PENDING_ENVELOPE_CAPACITY, PayloadEosTracker, RequestThrottle,
+        SharedPreconfState,
+    },
     error::{Result, WhitelistPreconfirmationDriverError},
     metrics::WhitelistPreconfirmationDriverMetrics,
     network::{NetworkCommand, NetworkEvent},
@@ -62,6 +65,8 @@ pub(crate) struct WhitelistPreconfirmationImporter {
     beacon_client: Arc<BeaconClient>,
     /// Out-of-order payload cache waiting for parent availability.
     cache: EnvelopeCache,
+    /// Payload-topic EOS hashes with a `/ws` notification pending materialization.
+    payload_eos_tracker: PayloadEosTracker,
     /// Cooldown gate for repeated missing-parent requests.
     request_throttle: RequestThrottle,
     /// Command channel used to publish P2P requests/responses.
@@ -100,6 +105,7 @@ impl WhitelistPreconfirmationImporter {
             state,
             beacon_client,
             cache: EnvelopeCache::with_capacity(PENDING_ENVELOPE_CAPACITY),
+            payload_eos_tracker: PayloadEosTracker::with_capacity(PENDING_ENVELOPE_CAPACITY),
             request_throttle: RequestThrottle::default(),
             network_command_tx,
             sync_ready: false,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -18,7 +18,7 @@ use super::{
     cache_import::{CachedImportDisposition, classify_cached_import_error},
     ingress::is_stale_at_confirmed_tip,
     should_enable_preconf_imports,
-    validation::{normalize_unsafe_payload_envelope, validate_execution_payload_for_preconf},
+    validation::validate_execution_payload_for_preconf,
 };
 
 const TEST_CHAIN_ID: u64 = 167;
@@ -59,14 +59,6 @@ fn sample_execution_payload_with_transactions(
         },
         signature: Some([0x22u8; 65]),
     }
-}
-
-fn sample_unsigned_execution_payload_with_transactions(
-    transactions: Vec<Bytes>,
-) -> WhitelistExecutionPayloadEnvelope {
-    let mut envelope = sample_execution_payload_with_transactions(transactions);
-    envelope.signature = None;
-    envelope
 }
 
 fn compress(data: &[u8]) -> Bytes {
@@ -508,26 +500,6 @@ fn validate_payload_rejects_anchor_with_wrong_method() {
         WhitelistPreconfirmationDriverError::InvalidPayload(msg)
             if msg.contains("invalid anchor transaction method")
     ));
-}
-
-#[test]
-fn normalizes_unsafe_payload_envelope_adds_missing_signature() {
-    let wire_signature = [0xabu8; 65];
-    let envelope = sample_unsigned_execution_payload_with_transactions(vec![compress(b"valid")]);
-    let normalized = normalize_unsafe_payload_envelope(envelope, wire_signature);
-
-    assert_eq!(normalized.signature, Some(wire_signature));
-}
-
-#[test]
-fn normalizes_unsafe_payload_envelope_keeps_existing_signature() {
-    let embedded = [0x11u8; 65];
-    let wire_signature = [0xabu8; 65];
-    let mut envelope = sample_execution_payload_with_transactions(vec![compress(b"valid")]);
-    envelope.signature = Some(embedded);
-    let normalized = normalize_unsafe_payload_envelope(envelope, wire_signature);
-
-    assert_eq!(normalized.signature, Some(embedded));
 }
 
 #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -19,7 +19,7 @@ use super::{
     cache_import::{
         CachedImportDisposition, classify_cached_import_error, remove_terminal_cached_envelope,
     },
-    ingress::is_stale_at_confirmed_tip,
+    ingress::{apply_response_eos_marker, is_stale_at_confirmed_tip},
     should_enable_preconf_imports,
     validation::validate_execution_payload_for_preconf,
 };
@@ -34,6 +34,16 @@ fn stale_envelope_requires_written_confirmed_tip() {
     assert!(is_stale_at_confirmed_tip(7, Some(7)));
     assert!(is_stale_at_confirmed_tip(6, Some(7)));
     assert!(!is_stale_at_confirmed_tip(8, Some(7)));
+}
+
+#[test]
+fn eos_catch_up_marker_overrides_cached_response_flag() {
+    let mut envelope = sample_execution_payload_with_transactions(Vec::new());
+    envelope.end_of_sequencing = Some(false);
+
+    let response = apply_response_eos_marker(Arc::new(envelope), true);
+
+    assert_eq!(response.end_of_sequencing, Some(true));
 }
 
 #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use alethia_reth_consensus::validation::ANCHOR_V4_SELECTOR;
 use alloy_consensus::{
@@ -10,12 +10,15 @@ use alloy_rpc_types_engine::ExecutionPayloadV1;
 use protocol::{FixedKSigner, codec::ZlibTxListCodec};
 
 use crate::{
+    cache::{EnvelopeCache, PayloadEosTracker},
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, WhitelistExecutionPayloadEnvelope},
     error::WhitelistPreconfirmationDriverError,
 };
 
 use super::{
-    cache_import::{CachedImportDisposition, classify_cached_import_error},
+    cache_import::{
+        CachedImportDisposition, classify_cached_import_error, remove_terminal_cached_envelope,
+    },
     ingress::is_stale_at_confirmed_tip,
     should_enable_preconf_imports,
     validation::validate_execution_payload_for_preconf,
@@ -31,6 +34,29 @@ fn stale_envelope_requires_written_confirmed_tip() {
     assert!(is_stale_at_confirmed_tip(7, Some(7)));
     assert!(is_stale_at_confirmed_tip(6, Some(7)));
     assert!(!is_stale_at_confirmed_tip(8, Some(7)));
+}
+
+#[test]
+fn terminal_cache_removal_discards_eos_provenance() {
+    let pending = B256::from([0x01u8; 32]);
+    let terminal = B256::from([0x02u8; 32]);
+    let newer = B256::from([0x03u8; 32]);
+    let mut envelope = sample_execution_payload_with_transactions(Vec::new());
+    envelope.execution_payload.block_hash = terminal;
+
+    let mut cache = EnvelopeCache::with_capacity(2);
+    cache.insert(Arc::new(envelope));
+    let mut tracker = PayloadEosTracker::with_capacity(2);
+    tracker.mark(pending);
+    tracker.mark(terminal);
+
+    remove_terminal_cached_envelope(&mut cache, &mut tracker, &terminal);
+    tracker.mark(newer);
+
+    assert!(cache.get(&terminal).is_none());
+    assert!(tracker.take(&pending), "terminal cleanup must preserve pending provenance");
+    assert!(!tracker.take(&terminal));
+    assert!(tracker.take(&newer));
 }
 
 fn sample_execution_payload_with_transactions(

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -17,9 +17,10 @@ use crate::{
 
 use super::{
     cache_import::{
-        CachedImportDisposition, classify_cached_import_error, remove_terminal_cached_envelope,
+        CachedImportDisposition, classify_cached_import_error, eos_notification_due,
+        remove_terminal_cached_envelope,
     },
-    ingress::{apply_response_eos_marker, is_stale_at_confirmed_tip},
+    ingress::{IngressSource, apply_response_eos_marker, is_stale_at_confirmed_tip},
     should_enable_preconf_imports,
     validation::validate_execution_payload_for_preconf,
 };
@@ -67,6 +68,70 @@ fn terminal_cache_removal_discards_eos_provenance() {
     assert!(tracker.take(&pending), "terminal cleanup must preserve pending provenance");
     assert!(!tracker.take(&terminal));
     assert!(tracker.take(&newer));
+}
+
+#[test]
+fn eos_flag_is_authenticated_only_on_the_payload_topic() {
+    // The wire signature on `preconfBlocks` covers the whole SSZ envelope
+    // including the flag bytes; the response topic's embedded signature covers
+    // only the block hash, leaving the flag attacker-controlled there.
+    assert!(IngressSource::Payload.authenticates_eos_flag());
+    assert!(!IngressSource::Response.authenticates_eos_flag());
+}
+
+#[test]
+fn eos_notification_fires_once_for_a_hash_matching_insert() {
+    let mut tracker = PayloadEosTracker::with_capacity(4);
+    let hash = B256::from([0x01u8; 32]);
+    tracker.mark(hash);
+    let outcome = driver::PreconfSubmissionOutcome::Inserted { block_hash: hash };
+
+    assert!(eos_notification_due(&mut tracker, &outcome, hash));
+    assert!(
+        !eos_notification_due(&mut tracker, &outcome, hash),
+        "a re-import of the same block must not notify twice"
+    );
+}
+
+#[test]
+fn eos_notification_never_fires_for_unmarked_hashes() {
+    // A hash never marked by the payload topic — e.g. a response-topic envelope
+    // whose unauthenticated flag claimed EOS — has no pending notification.
+    let mut tracker = PayloadEosTracker::with_capacity(4);
+    let hash = B256::from([0x02u8; 32]);
+    let outcome = driver::PreconfSubmissionOutcome::Inserted { block_hash: hash };
+
+    assert!(!eos_notification_due(&mut tracker, &outcome, hash));
+}
+
+#[test]
+fn eos_notification_withheld_on_hash_mismatched_insert_leaving_mark_for_cleanup() {
+    let mut tracker = PayloadEosTracker::with_capacity(4);
+    let envelope_hash = B256::from([0x03u8; 32]);
+    let produced_hash = B256::from([0x04u8; 32]);
+    tracker.mark(envelope_hash);
+    let outcome = driver::PreconfSubmissionOutcome::Inserted { block_hash: produced_hash };
+
+    // Stricter than Go (whose push site never compares hashes): the signed EOS
+    // block never materialized, so no notification fires.
+    assert!(!eos_notification_due(&mut tracker, &outcome, envelope_hash));
+    assert!(tracker.take(&envelope_hash), "the mark must survive for terminal cleanup to discard");
+}
+
+#[test]
+fn eos_notification_never_fires_for_already_materialized_or_stale_outcomes() {
+    let hash = B256::from([0x05u8; 32]);
+    for outcome in [
+        driver::PreconfSubmissionOutcome::AlreadyMaterialized { block_hash: hash },
+        driver::PreconfSubmissionOutcome::Stale,
+    ] {
+        let mut tracker = PayloadEosTracker::with_capacity(4);
+        tracker.mark(hash);
+        assert!(
+            !eos_notification_due(&mut tracker, &outcome, hash),
+            "only a fresh matching insert may notify (Go parity), got {outcome:?}"
+        );
+    }
 }
 
 fn sample_execution_payload_with_transactions(

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/validation.rs
@@ -9,10 +9,7 @@ use protocol::{
 };
 
 use crate::{
-    codec::{
-        MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES,
-        WhitelistExecutionPayloadEnvelope,
-    },
+    codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES},
     error::{Result, WhitelistPreconfirmationDriverError},
 };
 
@@ -89,17 +86,6 @@ pub(crate) fn validate_execution_payload_for_preconf(
     })?;
 
     Ok(())
-}
-
-/// Ensure unsafe payload envelopes carry an embedded signature for response-topic compatibility.
-pub(super) fn normalize_unsafe_payload_envelope(
-    mut envelope: WhitelistExecutionPayloadEnvelope,
-    wire_signature: [u8; 65],
-) -> WhitelistExecutionPayloadEnvelope {
-    if envelope.signature.is_none() {
-        envelope.signature = Some(wire_signature);
-    }
-    envelope
 }
 
 /// Reject envelopes whose `header_difficulty` presence contradicts the Unzen


### PR DESCRIPTION
## Summary

A review of `crates/whitelist-preconfirmation-driver` against the Go client's preconf block server (`driver/preconf_blocks` + the pinned `taikoxyz/optimism` p2p fork) found five behavioral divergences. Each one can make a Rust node accept what every Go node rejects (or vice versa), splitting the preconf head on a mixed fleet, or silently break the API contract Catalyst-side tooling expects. This PR fixes all five; wire-format parity (topics, message-id, SSZ envelope layout, signing hash, validation ordering) was checked and needed no changes. An independent verification round against the Go/geth/echo-jwt sources then confirmed each fix and produced the tightenings in "Review follow-ups" below.

### 1. Compressed tx-list cap: 786,432 → 780,264 (`codec.rs`)

The cap was `131_072 * 6`, but Go checks `eth.MaxBlobDataSize * eth.MaxBlobsPerBlobTx` = `((4*31+3)*1024 − 4) * 6` = 780,264 (`server.go` `ValidateExecutionPayload`). A payload whose compressed list lands in the 6,168-byte gap was accepted and imported here while every Go node dropped it. The constant is now derived the same way Go derives it, with a test pinning the value.

### 2. Drop the wire-signature → embedded-signature substitution (`importer/validation.rs`, `importer/ingress.rs`)

`normalize_unsafe_payload_envelope` copied the wire signature (which signs the **SSZ envelope bytes**) into the envelope's embedded-signature slot (which peers verify against the **block hash** — a different domain) whenever the slot was empty. The substituted value was persisted to the L1 origin, passed the non-zero "can attest" check, and got served in response envelopes that **every** receiving peer rejects (the recovered address is never an operator). The Go client keeps the slot empty and declines to serve such blocks. Now: unsigned envelopes stay unsigned, `serve_envelope_by_hash` skips them in the recent cache (falling through to the L2 rebuild, which already declines on a zero L1-origin signature), and the L1 origin records a zero signature — all matching Go.

### 3. Reject recovery ids > 1 (`codec.rs`)

`recover_signer` parsed via alloy `Signature::from_raw_array`, which accepts and normalizes v ∈ {0, 1, 27, 28, 35+} — so anyone re-publishing a valid envelope with v=27 could make Rust and Go nodes disagree on acceptance at will. geth's `crypto.SigToPub` (what Go peers use) rejects v ≥ 4 outright and, for v ∈ {2, 3}, attempts a recovery that can only succeed when r < p − n (≈2^129 of a ~2^256 space); crafting such a signature that also recovers to an *allowlisted* address is cryptographically unreachable, so Go nodes reject every feasible v > 1 message too. Checking the v byte before parsing is therefore decision-equivalent to geth — not mechanism-identical, which an in-code comment now spells out — while closing the real 27/28/35+ divergence. (High-s signatures remain accepted, which matches Go's `Ecrecover` exactly.)

### 4. Validate JWT `exp`/`nbf` when present (`api/server/auth.rs`)

`validate_exp` was `false`, so an expired token stayed valid forever. The Go server (echo-jwt → golang-jwt v5 defaults) validates `exp`/`nbf` whenever present, with claims otherwise optional and zero leeway. jsonwebtoken's built-in validator cannot reproduce those semantics exactly — it treats present-but-malformed claims as absent, keeps `exp == now` valid, and rejects any token carrying an `aud` claim by default — so the library layer now verifies only the signature, and a manual `validate_temporal_claims` replicates golang-jwt v5: present claims must be numeric dates, truncated to whole seconds, expired once `now >= exp`, not yet valid while `now < nbf`, no leeway, and a numeric date of `0` counts as absent (golang-jwt's `parseNumericDate` returns nil for a zero float64). Tokens without claims continue to work.

### 5. Push `/ws` EOS notifications when a gossiped EOS block materializes, not on local build (`cache.rs`, `importer/*`, `api/service/*`)

The only notification site was the **API build path** — i.e. the node that built the EOS block notified its own subscriber, who already has the block from the 200 response. The Go client's only push site is the opposite: an EOS block received from the payload topic (`server.go` `OnUnsafeL2Payload`), pushed after `TryImportingPayload` succeeds — the signal the *incoming* sequencer actually needs.

Now: the EOS flag is trusted **only from the payload topic**, whose wire signature covers the whole SSZ envelope including the flag bytes. On the response topic the embedded signature covers only the block hash, so the flag is unauthenticated there — and Go's `OnUnsafeL2Response` has no EOS handling at all, so response-topic envelopes now contribute nothing to EOS state. A bounded `PayloadEosTracker` captures the flag at admission (the pending cache overwrites same-hash entries, so a later response envelope could otherwise flip it in either direction), and the `/ws` notification fires once the block **materializes** (`Inserted` with the operator-signed hash), carrying the wall-clock epoch at push time. The build path only records the epoch marker.

Two deliberate deviations from Go inside this fix, both local-API-only (no gossip effect):

- **Deferred imports still notify.** An EOS payload-topic block imported later (missing parent, or received while the node catches up) notifies on materialization. Go cannot: `envelopeFromMessage` drops the `EndOfSequencing` flag when caching and its push site is gated on an immediate fresh insert, so a Go sidecar silently misses those handovers.
- **Hash-mismatched insertions withhold the notification** (Go's push site never compares the envelope hash to its inserted block): the operator-signed EOS block never materialized, so notifying would announce a block peers cannot fetch.

## Review follow-ups (second round)

- **EOS markers are keyed by the wall-clock epoch at record time** at both record sites (payload-topic ingress and the build path), matching Go's `CurrentEpoch()`. The requesting operator looks the marker up with *its* wall-clock epoch at handover, so the previous block-timestamp keying missed an EOS block delivered just across an epoch boundary. Since `current_epoch()` is infallible, this also removes the build path's only post-insert failure mode (epoch derivation erroring after the block was already inserted and gossiped) — Go's build path cannot fail there either.
- **Rebuilt request-topic responses derive their EOS flag from the marker map** (`SharedPreconfState::is_end_of_sequencing_hash` — the same value scan Go runs over `sequencingEndedForEpochCache`) instead of the pending envelope cache, which a response-topic envelope could taint.
- **Envelopes whose import was rejected as invalid are purged from the recent serve cache**, matching the existing hash-mismatch purge; Go only ever serves imported blocks.
- **JWT extraction mirrors echo-jwt v4**: every `Authorization` value is considered (up to echo-jwt's 20-entry extractor cap; ours counts candidates where echo-jwt counts header indices, divergent only for requests with more than 20 `Authorization` values), the `Bearer ` prefix matches case-insensitively with a non-empty remainder, and any validating candidate authorizes. Verified against the pinned echo-jwt v4.4.0 that both missing and invalid tokens map to 401 there (`ErrJWTMissing` is `StatusUnauthorized`), so the middleware's existing single-401 behavior already matched and stays.
- **The ingress source is a two-variant enum** (`Payload`/`Response`), so a future ingress path cannot silently skip the EOS authentication gate, and the notify decision is an extracted, directly tested function (`eos_notification_due`).

## Not in scope (deliberate divergences left as-is)

- `/status` field set (`lookahead`/`totalCached` absent) and `canShutdown` semantics — consequences of the Catalyst-owns-handover architecture, worth documenting rather than changing.
- The Rust-only 8 MiB decompressed tx-list bound (zlib-bomb protection). Accurate risk statement: Go's `utils.Decompress` is unbounded, and a gas-legal block heavy in zero bytes (~11 MB decompressed at 4 gas per zero byte) can compress far under the 780,264 cap — Go imports such a block while Rust rejects it, stalling the Rust side of a mixed fleet on that head until L1 confirmation. Only an operator-signed payload can trigger this, so the bound is kept and the divergence is tracked as operator-signed-only rather than claimed "stricter is safer".

## Testing

- `cargo nextest run -p whitelist-preconfirmation-driver`: 127/127 pass.
- New tests across both rounds: cap value pinned to 780,264; recovery-id 27 rejected / 0-1 accepted (real `FixedKSigner` signature); expired-`exp` and future-`nbf` tokens rejected while claimless tokens pass, `exp: 0` treated as absent, fractional claims truncated to whole seconds, malformed present claims rejected; case-folded `bearer` schemes accepted, every `Authorization` value tried, candidate-free headers classed as missing; `SharedPreconfState` EOS notify/subscribe round-trip and marker-hash lookup; `eos_notification_due` composite decisions (notifies exactly once on a matching insert; never for unmarked hashes, mismatched insertions, `AlreadyMaterialized`, or `Stale`); `PayloadEosTracker` mark/take/discard/eviction semantics.
- `cargo clippy -p whitelist-preconfirmation-driver --all-targets`: no new warnings (the pre-existing `items_after_test_module` warning in `network/runtime.rs` is untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
