### PR TITLE
chore: pin pnpm 9.15.9

### DIFF
--- a/.github/actions/install-pnpm-dependencies/action.yml
+++ b/.github/actions/install-pnpm-dependencies/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 9.15.9
         run_install: false
 
     - name: Install Node.js

--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 9
+          version: 9.15.9
           run_install: false
 
       - name: Install Node.js

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "taiko-mono",
   "version": "0.23.0",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "postinstall": "bash scripts/setup-local-ignores.sh",
     "setup:ignores": "bash scripts/setup-local-ignores.sh",


### PR DESCRIPTION
## Summary

- pin the workspace package manager to pnpm 9.15.9
- align both CI pnpm setup sites with the same exact version

## Root cause

The lockfile was generated by pnpm 9 and contains Git-hosted dependency keys that pnpm 11.14 rejects under its stricter dependency-alias validation. Local installs could accidentally run a globally installed pnpm 11 because the root manifest did not declare the repository's pnpm version, while CI already used pnpm 9.

## Impact

Running `pnpm install` now delegates to the repository's pnpm 9 toolchain, preventing `ERR_PNPM_INVALID_DEPENDENCY_NAME` and keeping local and CI installs consistent.

## Validation

- confirmed the global pnpm entrypoint delegates to pnpm 9.15.9 in a clean workspace
- ran `pnpm install --frozen-lockfile --ignore-scripts` in that clean workspace (2,290 packages, exit 0)
- passed the repository pre-commit hook
