### PR TITLE
chore(taiko-client-rs): surface async dial failures for configured whitelist peers

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/network/runtime.rs
@@ -262,6 +262,7 @@ impl WhitelistNetwork {
             event_tx,
             command_rx,
             connected_configured_addrs: HashSet::new(),
+            failing_configured_addrs: HashSet::new(),
             configured_peer_addrs,
             peer_retry_interval: delayed_interval(CONFIGURED_PEER_RETRY_INTERVAL),
             peer_status_log_interval: delayed_interval(PEER_STATUS_LOG_INTERVAL),
@@ -427,6 +428,8 @@ struct NetworkRuntime {
     command_rx: mpsc::Receiver<NetworkCommand>,
     /// Connected configured addresses used to prevent duplicate direct dials.
     connected_configured_addrs: HashSet<Multiaddr>,
+    /// Configured addresses whose latest dial attempt failed, for edge-triggered logging.
+    failing_configured_addrs: HashSet<Multiaddr>,
     /// Configured static peer and bootnode addresses retried for connectivity.
     configured_peer_addrs: Vec<ConfiguredPeerAddr>,
     /// Periodic timer for retrying configured peer dials.
@@ -635,8 +638,15 @@ impl NetworkRuntime {
                 debug!(%address, "whitelist preconfirmation network listening");
             }
             libp2p::swarm::SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
-                self.track_configured_connection(endpoint.get_remote_address());
-                debug!(%peer_id, remote_addr = %endpoint.get_remote_address(), "peer connected");
+                let remote_addr = endpoint.get_remote_address();
+                if self.failing_configured_addrs.remove(remote_addr) {
+                    info!(%peer_id, %remote_addr, "configured peer address recovered");
+                }
+                self.track_configured_connection(remote_addr);
+                debug!(%peer_id, %remote_addr, "peer connected");
+            }
+            libp2p::swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                self.handle_outgoing_connection_error(peer_id, error);
             }
             libp2p::swarm::SwarmEvent::ConnectionClosed {
                 peer_id,
@@ -661,6 +671,49 @@ impl NetworkRuntime {
     fn track_configured_connection(&mut self, remote_addr: &Multiaddr) {
         if self.configured_peer_addrs.iter().any(|peer| &peer.addr == remote_addr) {
             self.connected_configured_addrs.insert(remote_addr.clone());
+        }
+    }
+
+    /// Surface asynchronous outgoing dial failures.
+    ///
+    /// `dial_addr` only observes errors `Swarm::dial` returns synchronously; connect
+    /// timeouts and refusals arrive later as `OutgoingConnectionError` events, so without
+    /// this handler a dead configured peer fails every retry tick with no log line or
+    /// metric. Configured addresses warn only when transitioning into the failing state
+    /// (cleared again on `ConnectionEstablished`), so a peer that stays down produces one
+    /// warning per outage instead of one per retry tick.
+    fn handle_outgoing_connection_error(&mut self, peer_id: Option<PeerId>, error: DialError) {
+        let DialError::Transport(failed) = &error else {
+            WhitelistPreconfirmationDriverMetrics::inc_network_dial_attempt(
+                "unknown",
+                "connect_failed",
+            );
+            debug!(?peer_id, %error, "outgoing connection attempt failed");
+            return;
+        };
+
+        for (addr, transport_error) in failed {
+            let (source, first_failure) = note_dial_failure(
+                &self.configured_peer_addrs,
+                &mut self.failing_configured_addrs,
+                addr,
+            );
+            WhitelistPreconfirmationDriverMetrics::inc_network_dial_attempt(
+                source,
+                "connect_failed",
+            );
+
+            if first_failure {
+                warn!(
+                    %addr,
+                    source,
+                    error = %transport_error,
+                    retry_interval = ?CONFIGURED_PEER_RETRY_INTERVAL,
+                    "configured peer dial failed; further failures logged at debug until it recovers"
+                );
+            } else {
+                debug!(%addr, source, error = %transport_error, "outgoing connection attempt failed");
+            }
         }
     }
 
@@ -875,6 +928,25 @@ fn format_peer_ids(peers: &[PeerId]) -> String {
     peers.iter().map(ToString::to_string).collect::<Vec<_>>().join(",")
 }
 
+/// Record one failed dial address against the failing-address set.
+///
+/// Returns the configured source label (`"unknown"` for unconfigured addresses) and
+/// whether this is the address's first failure since it last connected. Unconfigured
+/// addresses are not tracked and never report a first failure.
+fn note_dial_failure(
+    configured_peer_addrs: &[ConfiguredPeerAddr],
+    failing_configured_addrs: &mut HashSet<Multiaddr>,
+    addr: &Multiaddr,
+) -> (&'static str, bool) {
+    let source =
+        configured_peer_addrs.iter().find(|peer| &peer.addr == addr).map(|peer| peer.source);
+
+    match source {
+        Some(source) => (source, failing_configured_addrs.insert(addr.clone())),
+        None => ("unknown", false),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -1029,6 +1101,33 @@ mod tests {
         let listen_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 30303));
 
         assert_eq!(advertised_enode_url(&local_key, listen_addr, None), None);
+    }
+
+    #[test]
+    fn note_dial_failure_reports_first_failure_only_until_recovery() {
+        let addr: Multiaddr = "/ip4/10.0.0.1/tcp/4001".parse().expect("valid multiaddr");
+        let configured = vec![ConfiguredPeerAddr { addr: addr.clone(), source: "bootnode" }];
+        let mut failing = HashSet::new();
+
+        assert_eq!(note_dial_failure(&configured, &mut failing, &addr), ("bootnode", true));
+        assert_eq!(note_dial_failure(&configured, &mut failing, &addr), ("bootnode", false));
+
+        // Recovery clears the failing state, so the next outage warns again.
+        failing.remove(&addr);
+        assert_eq!(note_dial_failure(&configured, &mut failing, &addr), ("bootnode", true));
+    }
+
+    #[test]
+    fn note_dial_failure_ignores_unconfigured_addresses() {
+        let configured = vec![ConfiguredPeerAddr {
+            addr: "/ip4/10.0.0.1/tcp/4001".parse().expect("valid multiaddr"),
+            source: "static peer",
+        }];
+        let mut failing = HashSet::new();
+        let unknown: Multiaddr = "/ip4/10.0.0.2/tcp/4001".parse().expect("valid multiaddr");
+
+        assert_eq!(note_dial_failure(&configured, &mut failing, &unknown), ("unknown", false));
+        assert!(failing.is_empty());
     }
 }
 


### PR DESCRIPTION
## Motivation

While investigating why the hoodi `l2-node-reth` rs-driver sat at exactly 1 gossip peer for a week, we found its second configured bootnode (Chainbound, `35.239.142.239:4001`) has been dead the whole time — and nothing in logs or metrics showed it. The whitelist preconfirmation network runtime only observes errors `Swarm::dial` returns synchronously; connect timeouts/refusals arrive later as `OutgoingConnectionError` swarm events, which fell into the ignored catch-all. Result: ~16.4k dial timeouts over 5d17h (one per 30s retry tick), zero log lines, zero failure metrics. The only trace was `connected_configured_addr_count=1` in the periodic peer-status line.

Since the whitelist driver has no peer discovery (removed in #21913), the configured peers are the entire connectivity mechanism — a silently-dead configured peer is a silently-lost redundancy path, which showed up downstream as preconf response timeouts and ingestion gaps whenever the single remaining peer hiccuped.

## Changes

- Handle `SwarmEvent::OutgoingConnectionError` in the network runtime:
  - resolve each failed transport address to its configured source label (`bootnode` / `static peer`, else `unknown`),
  - count it under `whitelist_preconf_driver_network_dial_attempts_total{result="connect_failed"}`,
  - **warn once per outage** — edge-triggered via a `failing_configured_addrs` set so a peer that stays down produces one warning, not one per 30s tick; repeats log at debug,
  - log an info line when a previously-failing configured address connects again.
- Extract the bookkeeping into a pure `note_dial_failure` helper with unit tests, matching the module's existing test style.

## Testing

- `cargo test -p whitelist-preconfirmation-driver --lib` — 107 passed (2 new: first-failure edge-trigger + recovery re-arm, unconfigured addresses ignored)
- `just clippy` (workspace, `-D warnings -D missing_docs -D clippy::missing_docs_in_private_items`) — clean
- `cargo +nightly-2025-09-27 fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)