### PR TITLE
chore(taiko-client-rs): expose FixedKSigner without the net feature

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/lib.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/lib.rs
@@ -8,12 +8,12 @@ pub mod codec;
 pub mod metrics;
 /// Shasta-specific protocol types, constants, and builders.
 pub mod shasta;
-/// Deterministic signer used by network protocol flows.
-#[cfg(feature = "net")]
+/// Deterministic fixed-k secp256k1 signer. Depends only on `alloy-primitives`/`k256`, so it is
+/// available without the `net` feature for zkVM guests (e.g. raiko2) that must regenerate the
+/// canonical golden-touch anchor signature.
 pub mod signer;
 /// Provider/event-scanner subscription source abstraction.
 #[cfg(feature = "net")]
 pub mod subscription_source;
 
-#[cfg(feature = "net")]
 pub use signer::{FixedKSigner, FixedKSignerError};


### PR DESCRIPTION
## Motivation

The cross-repo audit surfaced that the raiko2 guest does not enforce the canonical fixed-k anchor signature: it reuses the host-supplied anchor transaction, and the consensus validator only checks selector, gas, fees, and the recovered Golden Touch sender. Since the Golden Touch key is public, an alternate valid signature changes the transaction root and block hash while still passing the guest (and can perturb later `BLOCKHASH` reads in multi-block proposals).

The fix belongs in raiko2: regenerate the fixed-k signature over `anchor_tx.signature_hash()` and require exact equality. raiko2 already depends on this crate with `default-features = false` (`taiko-client-protocol` in its workspace manifest, consumed by `crates/protocol-shasta`) — the only blocker is that `FixedKSigner` sits behind the `net` feature and is invisible to that build.

## What this does

Removes the `#[cfg(feature = "net")]` gates on `pub mod signer` and the `FixedKSigner`/`FixedKSignerError` re-export.

The gate was added in #21605 because the signer needed `alloy/signers` at the time. The current implementation depends only on `alloy-primitives` and `k256`, both unconditional deps of the crate, so the gate is vestigial. Default builds are unchanged (`net` remains a default feature); no call sites move.

Exact-equality checking downstream is sound because `sign_with_predefined_k` is deterministic (k=1, then k=2) and the driver constructs anchors with this same routine (`shasta/anchor.rs`), so the canonical signature is canonical by construction.

## Verification

- `cargo check -p protocol --no-default-features` — passes (CI also guards this via `just check-features`)
- `cargo test -p protocol --no-default-features signer` — both Go-vector tests pass in the no-net config
- `cargo test -p protocol` — 50 tests pass
- both workspace clippy passes from the justfile (`-D warnings -D missing_docs ...`) — clean
- `cargo +nightly-2025-09-27 fmt --check` — clean

## Follow-ups (not in this PR)

- raiko2: bump the `taiko-client-protocol` rev and add the canonical-signature equality check in the guest; document as a soundness finding until deployed.
- Optionally add the same check to `validate_anchor_transaction` here (wpd importer admission), which currently has the same gap as the alethia-reth validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)