### PR TITLE
ci(repo): run README link checks on pull requests

### DIFF
--- a/.github/workflows/repo--check-links.yml
+++ b/.github/workflows/repo--check-links.yml
@@ -1,9 +1,20 @@
 name: Check links
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**/README.md"
   push:
     paths:
       - "**/README.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-links-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-links:
@@ -12,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2


### PR DESCRIPTION


Run the README link-check workflow for pull requests that modify README files,  so broken links can be caught before the changes are merged.

Also tighten the workflow by setting read-only contents permissions, cancelling  superseded runs for the same ref, and disabling persisted checkout credentials.