### PR TITLE
feat(taiko-client): add forced SGX proof mode

### DIFF
--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -84,6 +84,17 @@ var (
 		Category: proverCategory,
 		EnvVars:  []string{"PROVER_FORCE_SP1_PROOF"},
 	}
+	ForceSGXProof = &cli.BoolFlag{
+		Name: "prover.forceSGXProof",
+		Usage: "Always request SGX_RETH proofs from the Raiko proof producer instead of using the " +
+			"RISC0-to-SP1 selection and fallback flow. Ignored when --prover.zkOnlyProofs is set. " +
+			"The inbox's proof verifier must accept the [SGX_GETH, SGX_RETH] sub-proof pair. " +
+			"When set, --prover.forceSP1Proof and --prover.maxRisc0ProofProposalDistance are ignored. " +
+			"Post Shasta fork only.",
+		Value:    false,
+		Category: proverCategory,
+		EnvVars:  []string{"PROVER_FORCE_SGX_PROOF"},
+	}
 	ZkOnlyProofs = &cli.BoolFlag{
 		Name: "prover.zkOnlyProofs",
 		Usage: "Prove every proposal with both RISC0 and SP1 proofs and submit the [RISC0, SP1] sub-proof pair, " +
@@ -168,5 +179,6 @@ var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	ProposalWindowSize,
 	MaxRisc0ProofProposalDistance,
 	ForceSP1Proof,
+	ForceSGXProof,
 	ZkOnlyProofs,
 }, opsigner.CLIFlags("PROVER", proverCategory), TxmgrFlags)

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	ProposalWindowSize            uint64
 	MaxRisc0ProofProposalDistance uint64
 	ForceSP1Proof                 bool
+	ForceSGXProof                 bool
 	ZkOnlyProofs                  bool
 }
 
@@ -127,6 +128,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			flags.MaxRisc0ProofProposalDistance.Name,
 		),
 		ForceSP1Proof:          c.Bool(flags.ForceSP1Proof.Name),
+		ForceSGXProof:          c.Bool(flags.ForceSGXProof.Name),
 		ZkOnlyProofs:           zkOnlyProofs,
 		RPCTimeout:             c.Duration(flags.RPCTimeout.Name),
 		ProveBatchesGasLimit:   c.Uint64(flags.TxGasLimit.Name),

--- a/packages/taiko-client/prover/config_test.go
+++ b/packages/taiko-client/prover/config_test.go
@@ -101,6 +101,20 @@ func TestNewConfigFromCliContextForceSP1Proof(t *testing.T) {
 	})
 }
 
+func TestNewConfigFromCliContextForceSGXProof(t *testing.T) {
+	t.Run("uses default value", func(t *testing.T) {
+		cfg := newTestConfigFromCLI(t)
+
+		require.False(t, cfg.ForceSGXProof)
+	})
+
+	t.Run("uses flag value", func(t *testing.T) {
+		cfg := newTestConfigFromCLI(t, "--"+flags.ForceSGXProof.Name)
+
+		require.True(t, cfg.ForceSGXProof)
+	})
+}
+
 func TestNewConfigFromCliContextZkOnlyProofs(t *testing.T) {
 	t.Run("uses default value", func(t *testing.T) {
 		cfg := newTestConfigFromCLI(t)
@@ -211,6 +225,7 @@ func runTestConfigFromCLIWithConfig(t *testing.T, cfg **Config, extraArgs ...str
 			Value:   flags.MaxRisc0ProofProposalDistance.Value,
 		},
 		&cli.BoolFlag{Name: flags.ForceSP1Proof.Name},
+		&cli.BoolFlag{Name: flags.ForceSGXProof.Name},
 		&cli.BoolFlag{Name: flags.ZkOnlyProofs.Name},
 		&cli.StringFlag{Name: flags.RaikoHostEndpoint.Name},
 	}

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -16,18 +16,35 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_submitter/transaction"
 )
 
+const (
+	sgxGethVerifierID   uint8 = 1
+	sgxRethVerifierID   uint8 = 4
+	risc0RethVerifierID uint8 = 5
+	sp1RethVerifierID   uint8 = 6
+)
+
+func verifierIDsByProofType() map[producer.ProofType]uint8 {
+	return map[producer.ProofType]uint8{
+		producer.ProofTypeSgxGeth: sgxGethVerifierID,
+		producer.ProofTypeSgx:     sgxRethVerifierID,
+		producer.ProofTypeZKR0:    risc0RethVerifierID,
+		producer.ProofTypeZKSP1:   sp1RethVerifierID,
+	}
+}
+
+func enabledProofTypes(forceSGXProof bool, zkOnlyProofs bool) []producer.ProofType {
+	if forceSGXProof && !zkOnlyProofs {
+		return []producer.ProofType{producer.ProofTypeSgx}
+	}
+	return []producer.ProofType{producer.ProofTypeZKR0, producer.ProofTypeZKSP1}
+}
+
 // initProofSubmitter initializes the proof submitter from the non-zero verifier addresses set in protocol.
 func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.ProveBatchesTxBuilder) error {
 	var (
 		// All activated proof types in protocol.
-		proofTypes = make([]producer.ProofType, 0, proofSubmitter.MaxNumSupportedProofTypes)
-
-		// VerifierIDs
-		sgxGethVerifierID   uint8 = 1
-		risc0RethVerifierID uint8 = 5
-		sp1RethVerifierID   uint8 = 6
-
-		err error
+		proofTypes = enabledProofTypes(p.cfg.ForceSGXProof, p.cfg.ZkOnlyProofs)
+		err        error
 	)
 
 	// A ZK-only prover can only finalize against a proof verifier that accepts the
@@ -47,14 +64,20 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 			)
 		}
 	}
-
-	// Initialize the zk verifiers and zkvm proof producers.
-	verifierIDs := map[producer.ProofType]uint8{
-		producer.ProofTypeSgxGeth: sgxGethVerifierID,
-		producer.ProofTypeZKR0:    risc0RethVerifierID,
-		producer.ProofTypeZKSP1:   sp1RethVerifierID,
+	if p.cfg.ForceSGXProof && !p.cfg.ZkOnlyProofs {
+		if inboxConfig, err := p.rpc.ShastaClients.Inbox.GetConfig(&bind.CallOpts{Context: ctx}); err != nil {
+			log.Warn("Force SGX proof mode is enabled, but fetching the inbox's proof verifier failed", "error", err)
+		} else {
+			log.Warn(
+				"Force SGX proof mode is enabled: the inbox's proof verifier must accept the "+
+					"[SGX_GETH, SGX_RETH] sub-proof pair, otherwise every proof submission will revert",
+				"proofVerifier", inboxConfig.ProofVerifier,
+			)
+		}
 	}
-	proofTypes = append(proofTypes, producer.ProofTypeZKR0, producer.ProofTypeZKSP1)
+
+	// Initialize proof verifier IDs and the Raiko proof producer.
+	verifierIDs := verifierIDsByProofType()
 
 	zkvmProducer := &producer.ComposeProofProducer{
 		VerifierIDs:         verifierIDs,
@@ -76,7 +99,7 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 	for _, proofType := range proofTypes {
 		cacheMaps[proofType] = cmap.New[*producer.ProofResponse]()
 		switch proofType {
-		case producer.ProofTypeZKR0, producer.ProofTypeZKSP1:
+		case producer.ProofTypeSgx, producer.ProofTypeZKR0, producer.ProofTypeZKSP1:
 			proofBuffers[proofType] = producer.NewProofBuffer(p.cfg.ZKVMProofBufferSize)
 		default:
 			return fmt.Errorf("unexpected proof type: %s", proofType)
@@ -104,6 +127,7 @@ func (p *Prover) initProofSubmitter(ctx context.Context, txBuilder *transaction.
 		new(big.Int).SetUint64(p.cfg.ProposalWindowSize),
 		new(big.Int).SetUint64(p.cfg.MaxRisc0ProofProposalDistance),
 		p.cfg.ForceSP1Proof,
+		p.cfg.ForceSGXProof,
 		p.cfg.ZkOnlyProofs,
 	); err != nil {
 		return fmt.Errorf("failed to initialize proof submitter: %w", err)

--- a/packages/taiko-client/prover/init_test.go
+++ b/packages/taiko-client/prover/init_test.go
@@ -1,5 +1,39 @@
 package prover
 
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	producer "github.com/taikoxyz/taiko-mono/packages/taiko-client/prover/proof_producer"
+)
+
 func (s *ProverTestSuite) TestInitUsesShastaSubmitterOnly() {
 	s.NotNil(s.p.proofSubmitter)
+}
+
+func TestVerifierIDsByProofTypeUsesSGXRethVerifierID(t *testing.T) {
+	require.Equal(t, uint8(4), verifierIDsByProofType()[producer.ProofTypeSgx])
+}
+
+func TestEnabledProofTypes(t *testing.T) {
+	t.Run("default supports RISC0 and SP1", func(t *testing.T) {
+		require.Equal(
+			t,
+			[]producer.ProofType{producer.ProofTypeZKR0, producer.ProofTypeZKSP1},
+			enabledProofTypes(false, false),
+		)
+	})
+
+	t.Run("force SGX replaces RISC0 and SP1 selection", func(t *testing.T) {
+		require.Equal(t, []producer.ProofType{producer.ProofTypeSgx}, enabledProofTypes(true, false))
+	})
+
+	t.Run("ZK-only takes precedence over force SGX", func(t *testing.T) {
+		require.Equal(
+			t,
+			[]producer.ProofType{producer.ProofTypeZKR0, producer.ProofTypeZKSP1},
+			enabledProofTypes(true, true),
+		)
+	})
 }

--- a/packages/taiko-client/prover/proof_producer/compose_proof_producer_test.go
+++ b/packages/taiko-client/prover/proof_producer/compose_proof_producer_test.go
@@ -78,6 +78,41 @@ func TestComposeProducerAggregateUsesItemProofType(t *testing.T) {
 	require.True(t, opts.CompanionProofAggregationGenerated)
 }
 
+func TestComposeProducerAggregateUsesSGXRethVerifierID(t *testing.T) {
+	producer := &ComposeProofProducer{
+		VerifierIDs: map[ProofType]uint8{
+			ProofTypeSgxGeth: 1,
+			ProofTypeSgx:     4,
+		},
+		Dummy:              true,
+		DummyProofProducer: DummyProofProducer{},
+	}
+
+	result, err := producer.Aggregate(
+		context.Background(),
+		[]*ProofResponse{
+			{
+				BatchID:   common.Big1,
+				ProofType: ProofTypeSgx,
+				Meta: metadata.NewTaikoProposalMetadataShasta(
+					&shastaBindings.ShastaInboxClientProposed{Id: common.Big1},
+					0,
+				),
+				Opts: &ProposalProofRequestOptions{
+					ProofType:          ProofTypeSgx,
+					CompanionProofType: ProofTypeSgxGeth,
+				},
+			},
+		},
+		time.Now(),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, ProofTypeSgx, result.ProofType)
+	require.Equal(t, uint8(4), result.VerifierID)
+	require.Equal(t, uint8(1), result.CompanionVerifierID)
+}
+
 func TestComposeProducerAggregateRejectsInconsistentCompanionProofTypes(t *testing.T) {
 	producer := &ComposeProofProducer{
 		VerifierIDs: map[ProofType]uint8{
@@ -255,6 +290,38 @@ func (r *raikoRequestRecorder) requestedTypes() map[ProofType]int {
 		types[req.ProofType]++
 	}
 	return types
+}
+
+func TestComposeProducerRequestProofRequestsSGXRethAndSgxGethCompanion(t *testing.T) {
+	recorder := &raikoRequestRecorder{proofs: map[ProofType]string{
+		ProofTypeSgx:     "0xaaaa",
+		ProofTypeSgxGeth: "0xbbbb",
+	}}
+	server := httptest.NewServer(recorder.handler())
+	defer server.Close()
+
+	producer := &ComposeProofProducer{
+		RaikoHostEndpoint:   server.URL,
+		RaikoRequestTimeout: time.Second,
+	}
+	opts := &ProposalProofRequestOptions{
+		ProofType:          ProofTypeSgx,
+		CompanionProofType: ProofTypeSgxGeth,
+		L2BlockNums:        []*big.Int{common.Big1},
+	}
+
+	result, err := producer.RequestProof(
+		context.Background(),
+		opts,
+		common.Big1,
+		metadata.NewTaikoProposalMetadataShasta(&shastaBindings.ShastaInboxClientProposed{Id: common.Big1}, 0),
+		time.Now(),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, ProofTypeSgx, result.ProofType)
+	require.Equal(t, common.Hex2Bytes("aaaa"), result.Proof)
+	require.Equal(t, map[ProofType]int{ProofTypeSgx: 1, ProofTypeSgxGeth: 1}, recorder.requestedTypes())
 }
 
 func TestComposeProducerRequestProofRequestsPrimaryAndSgxGethCompanion(t *testing.T) {

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -58,6 +58,7 @@ type ProofSubmitter struct {
 	proposalWindowSize            *big.Int
 	maxRisc0ProofProposalDistance *big.Int
 	forceSP1Proof                 bool
+	forceSGXProof                 bool
 	zkOnlyProofs                  bool
 	// RISC0-to-SP1 fallback state machine (see risc0_sp1_fallback.go).
 	risc0Backlog proofProducer.Risc0BacklogController
@@ -84,6 +85,7 @@ func NewProofSubmitter(
 	proposalWindowSize *big.Int,
 	maxRisc0ProofProposalDistance *big.Int,
 	forceSP1Proof bool,
+	forceSGXProof bool,
 	zkOnlyProofs bool,
 ) (*ProofSubmitter, error) {
 	if zkvmProofProducer == nil {
@@ -111,6 +113,7 @@ func NewProofSubmitter(
 		proposalWindowSize:            proposalWindowSize,
 		maxRisc0ProofProposalDistance: maxRisc0ProofProposalDistance,
 		forceSP1Proof:                 forceSP1Proof,
+		forceSGXProof:                 forceSGXProof,
 		zkOnlyProofs:                  zkOnlyProofs,
 		ctx:                           ctx,
 	}
@@ -284,7 +287,9 @@ func (s *ProofSubmitter) requestProposalProof(
 	// its backlog-clearing side effects, which would cancel RISC0 tasks this mode depends
 	// on) must not run.
 	proofType := proofProducer.ProofTypeZKSP1
-	if !s.zkOnlyProofs {
+	if s.forceSGXProof && !s.zkOnlyProofs {
+		proofType = proofProducer.ProofTypeSgx
+	} else if !s.zkOnlyProofs {
 		proofType = s.decideZKProofType(ctx, proposalID, lastFinalizedProposalID)
 	}
 	companionProofType := proofProducer.ProofTypeSgxGeth
@@ -475,7 +480,7 @@ func (s *ProofSubmitter) AggregateProofsByType(ctx context.Context, proofType pr
 	// nolint:exhaustive
 	// We deliberately handle only known proof types and catch others in default case
 	switch proofType {
-	case proofProducer.ProofTypeZKR0, proofProducer.ProofTypeZKSP1:
+	case proofProducer.ProofTypeSgx, proofProducer.ProofTypeZKR0, proofProducer.ProofTypeZKSP1:
 	default:
 		return fmt.Errorf("unknown proof type: %s", proofType)
 	}

--- a/packages/taiko-client/prover/proof_submitter/risc0_sp1_selection_test.go
+++ b/packages/taiko-client/prover/proof_submitter/risc0_sp1_selection_test.go
@@ -126,6 +126,34 @@ func TestRequestProposalProofForceSP1UsesSP1WithinRisc0Distance(t *testing.T) {
 	require.Equal(t, []proofProducer.ProofType{proofProducer.ProofTypeZKSP1}, risc0.requestedTypes)
 }
 
+func TestRequestProposalProofForceSGXUsesSGXReth(t *testing.T) {
+	producer := &recordingProofProducer{proofType: proofProducer.ProofTypeZKR0}
+	submitter := &ProofSubmitter{
+		zkvmProofProducer:             producer,
+		maxRisc0ProofProposalDistance: big.NewInt(30),
+		forceSP1Proof:                 true,
+		forceSGXProof:                 true,
+	}
+
+	resp, err := submitter.requestProposalProof(
+		context.Background(),
+		&proofProducer.ProposalProofRequestOptions{ProposalID: big.NewInt(40)},
+		big.NewInt(40),
+		metadata.NewTaikoProposalMetadataShasta(&shastaBindings.ShastaInboxClientProposed{Id: big.NewInt(40)}, 0),
+		time.Now(),
+		big.NewInt(10),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, proofProducer.ProofTypeSgx, resp.ProofType)
+	require.Equal(t, []proofProducer.ProofType{proofProducer.ProofTypeSgx}, producer.requestedTypes)
+	require.Equal(
+		t,
+		[]proofProducer.ProofType{proofProducer.ProofTypeSgxGeth},
+		producer.requestedCompanionTypes,
+	)
+}
+
 func TestRequestProposalProofErrorsOnNilZKVMResponse(t *testing.T) {
 	risc0 := &recordingProofProducer{proofType: proofProducer.ProofTypeZKR0, nilResponse: true}
 	submitter := &ProofSubmitter{
@@ -165,7 +193,7 @@ func TestRequestProposalProofRejectsMissingZKVMProducer(t *testing.T) {
 	require.Nil(t, resp)
 }
 
-func TestAggregateProofsByTypeRejectsNonZKProofType(t *testing.T) {
+func TestAggregateProofsByTypeSupportsSGXProofType(t *testing.T) {
 	submitter := &ProofSubmitter{
 		zkvmProofProducer: &recordingProofProducer{proofType: proofProducer.ProofTypeZKR0},
 		proofBuffers: map[proofProducer.ProofType]*proofProducer.ProofBuffer{
@@ -175,5 +203,5 @@ func TestAggregateProofsByTypeRejectsNonZKProofType(t *testing.T) {
 
 	err := submitter.AggregateProofsByType(context.Background(), proofProducer.ProofTypeSgx)
 
-	require.ErrorContains(t, err, "unknown proof type: sgx")
+	require.NoError(t, err)
 }

--- a/packages/taiko-client/prover/proof_submitter/zk_only_test.go
+++ b/packages/taiko-client/prover/proof_submitter/zk_only_test.go
@@ -19,6 +19,7 @@ func TestRequestProposalProofZkOnlyPinsSP1AndSkipsSelection(t *testing.T) {
 	submitter := &ProofSubmitter{
 		zkvmProofProducer:             zkvm,
 		maxRisc0ProofProposalDistance: big.NewInt(30),
+		forceSGXProof:                 true,
 		zkOnlyProofs:                  true,
 		risc0Backlog:                  backlog,
 		ctx:                           context.Background(),
@@ -68,6 +69,7 @@ func TestNewProofSubmitterRequiresZKVMProducer(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		false,
 		false,
 		false,
 	)


### PR DESCRIPTION
## Summary

- add `--prover.forceSGXProof` and `PROVER_FORCE_SGX_PROOF` for forcing SGX_RETH proposal proofs
- bypass the RISC0-to-SP1 selection and fallback flow while the new mode is enabled
- map SGX_RETH to verifier ID 4 and initialize SGX proof buffers, caches, and aggregation support
- preserve `zkOnlyProofs` precedence and warn operators about verifier compatibility

## Behavior

When `--prover.forceSGXProof` is enabled outside ZK-only mode, the prover requests this sub-proof pair:

- companion: SGX_GETH (`sgxgeth`, verifier ID 1)
- primary: SGX_RETH (`sgx`, verifier ID 4)

The flag takes precedence over `--prover.forceSP1Proof` and `--prover.maxRisc0ProofProposalDistance`. `--prover.zkOnlyProofs` keeps its existing higher priority.

The configured inbox proof verifier must accept the `[SGX_GETH, SGX_RETH]` pair. The current `ZkRequiredVerifier` does not accept this TEE-only combination.

## Validation

- `make lint`
- `go test ./cmd/flags ./prover/proof_producer ./prover/proof_submitter -count=1`
- targeted `go test` coverage for config, mode selection, Raiko request proof types, aggregation, verifier IDs, and ZK-only precedence
- targeted `go test -race` for the new producer and submitter paths
- `go vet ./prover/...`
- `go test ./prover/... -run TestDoesNotExist -count=1`
- `go build -o /private/tmp/taiko-client-force-sgx ./cmd`
