### PR TITLE
fix(taiko-client-rs): prevent preconfirmation timeout reorgs

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/error.rs
@@ -56,6 +56,13 @@ pub enum DriverError {
         existing_hash: B256,
     },
 
+    /// Block production was halted after an uncertain local preconfirmation finalization.
+    #[error("block production halted: {reason}")]
+    ProductionHalted {
+        /// Failure that forced production to stop until the process is restarted.
+        reason: String,
+    },
+
     /// Block not found on remote node.
     #[error("remote node missing block {0}")]
     BlockNotFound(u64),

--- a/packages/taiko-client-rs/crates/driver/src/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/error.rs
@@ -45,6 +45,17 @@ pub enum DriverError {
         actual: B256,
     },
 
+    /// A local block builder tried to replace an existing canonical block at the same height.
+    #[error(
+        "preconfirmation block {block_number} conflicts with existing canonical block {existing_hash}"
+    )]
+    PreconfCanonicalConflict {
+        /// L2 block number targeted by the preconfirmation.
+        block_number: u64,
+        /// Hash of the canonical block already materialized at that height.
+        existing_hash: B256,
+    },
+
     /// Block not found on remote node.
     #[error("remote node missing block {0}")]
     BlockNotFound(u64),

--- a/packages/taiko-client-rs/crates/driver/src/production/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/production/mod.rs
@@ -109,6 +109,8 @@ pub struct ProductionRouter {
     canonical: Arc<dyn BlockProductionPath + Send + Sync>,
     /// Path injecting preconfirmation payloads, present when preconfirmation is enabled.
     preconf: Option<Arc<dyn BlockProductionPath + Send + Sync>>,
+    /// Fail-closed latch set when local finalization can no longer safely release serialization.
+    halted_reason: Option<String>,
 }
 
 impl ProductionRouter {
@@ -117,7 +119,12 @@ impl ProductionRouter {
         canonical: Arc<dyn BlockProductionPath + Send + Sync>,
         preconf: Option<Arc<dyn BlockProductionPath + Send + Sync>>,
     ) -> Self {
-        Self { canonical, preconf }
+        Self { canonical, preconf, halted_reason: None }
+    }
+
+    /// Stop every production path after an uncertain local preconfirmation finalization.
+    pub(crate) fn halt(&mut self, reason: String) {
+        self.halted_reason.get_or_insert(reason);
     }
 
     /// Route input to the matching path based on the variant.
@@ -125,6 +132,9 @@ impl ProductionRouter {
         &self,
         input: ProductionInput,
     ) -> Result<Vec<EngineBlockOutcome>, DriverError> {
+        if let Some(reason) = &self.halted_reason {
+            return Err(DriverError::ProductionHalted { reason: reason.clone() })
+        }
         match &input {
             ProductionInput::L1ProposalLog(_) => self.canonical.produce(input).await,
             ProductionInput::Preconfirmation(_) => match &self.preconf {

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -23,7 +23,7 @@ use bindings::{anchor::Anchor::anchorV4Call, inbox::Inbox::Proposed};
 use event_scanner::{EventFilter, Notification, ScannerError, ScannerMessage};
 use tokio::{
     spawn,
-    sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot},
+    sync::{Mutex as AsyncMutex, Notify, OwnedMutexGuard, mpsc, oneshot},
     time::{MissedTickBehavior, interval, sleep, timeout},
 };
 use tokio_retry::{RetryIf, strategy::ExponentialBackoff};
@@ -458,7 +458,7 @@ pub struct PreconfJob {
     /// The preconfirmation payload to be processed.
     payload: Arc<PreconfPayload>,
     /// Oneshot channel to send the processing result back to the caller.
-    respond_to: oneshot::Sender<Result<PreconfSubmissionOutcome, DriverError>>,
+    respond_to: oneshot::Sender<Result<PreconfJobResponse, DriverError>>,
     /// Lifecycle shared with the submitter so a queued job can be abandoned without racing
     /// an engine injection that has already started.
     lifecycle: Arc<PreconfJobLifecycle>,
@@ -473,6 +473,60 @@ enum PreconfSubmissionPolicy {
     BranchCapable,
     /// Require the target height to be empty before a local block builder injects the payload.
     CanonicalExtensionOnly,
+}
+
+/// Result delivered by the serialized ingress loop to a preconfirmation submitter.
+enum PreconfJobResponse {
+    /// Terminal result for a branch-capable import after the router lock has been released.
+    Branch(PreconfSubmissionOutcome),
+    /// Local-builder result that retains the router lock through signature persistence.
+    Canonical(CanonicalPreconfSubmission),
+}
+
+impl PreconfJobResponse {
+    /// Extract a branch-capable outcome and reject an impossible policy mismatch.
+    fn into_branch(self) -> Result<PreconfSubmissionOutcome, DriverError> {
+        match self {
+            Self::Branch(outcome) => Ok(outcome),
+            Self::Canonical(_) => Err(DriverError::Other(anyhow!(
+                "canonical response returned for branch-capable preconfirmation"
+            ))),
+        }
+    }
+
+    /// Extract a canonical submission guard and reject an impossible policy mismatch.
+    fn into_canonical(self) -> Result<CanonicalPreconfSubmission, DriverError> {
+        match self {
+            Self::Canonical(submission) => Ok(submission),
+            Self::Branch(_) => Err(DriverError::Other(anyhow!(
+                "branch response returned for canonical preconfirmation"
+            ))),
+        }
+    }
+}
+
+/// Local preconfirmation result that keeps all block-production paths serialized until finalized.
+///
+/// The held router guard prevents event derivation or branch-capable imports from replacing the
+/// submitted block between hash-bound validation and `set_l1_origin_signature`. Callers should
+/// retain this value until the signature is durably written, then drop it to reopen production.
+pub struct CanonicalPreconfSubmission {
+    /// Exact terminal outcome observed inside the serialized production path.
+    outcome: PreconfSubmissionOutcome,
+    /// Router guard retained across the caller's hash-bound finalization steps.
+    _router_guard: OwnedMutexGuard<ProductionRouter>,
+}
+
+impl CanonicalPreconfSubmission {
+    /// Return the exact submission outcome while retaining the finalization guard.
+    pub const fn outcome(&self) -> PreconfSubmissionOutcome {
+        self.outcome
+    }
+
+    /// Halt all production before releasing the finalization guard.
+    pub fn halt(mut self, reason: impl Into<String>) {
+        self._router_guard.halt(reason.into());
+    }
 }
 
 /// Atomic lifecycle state for one queued preconfirmation job.
@@ -513,6 +567,11 @@ impl PreconfJobLifecycle {
             .is_ok()
     }
 
+    /// Return whether the submitter abandoned this job before engine production started.
+    fn is_abandoned(&self) -> bool {
+        self.state.load(Ordering::Acquire) == PreconfJobState::Abandoned as u8
+    }
+
     /// Commit a queued job to engine production unless its submitter already abandoned it.
     fn start_processing(&self) -> bool {
         self.state
@@ -545,10 +604,32 @@ impl Drop for PreconfSubmissionGuard {
 }
 
 impl PreconfJob {
-    /// Complete this job and best-effort deliver its terminal result to the submitter.
-    fn respond(self, result: Result<PreconfSubmissionOutcome, DriverError>) {
+    /// Complete this job and best-effort deliver an error to the submitter.
+    fn respond_error(self, error: DriverError) {
         self.lifecycle.complete();
-        let _ = self.respond_to.send(result);
+        let _ = self.respond_to.send(Err(error));
+    }
+
+    /// Deliver a successful outcome, retaining the router guard only for local finalization.
+    fn respond_outcome(
+        self,
+        outcome: PreconfSubmissionOutcome,
+        router_guard: OwnedMutexGuard<ProductionRouter>,
+    ) {
+        self.lifecycle.complete();
+        let response = match self.policy {
+            PreconfSubmissionPolicy::BranchCapable => {
+                drop(router_guard);
+                PreconfJobResponse::Branch(outcome)
+            }
+            PreconfSubmissionPolicy::CanonicalExtensionOnly => {
+                PreconfJobResponse::Canonical(CanonicalPreconfSubmission {
+                    outcome,
+                    _router_guard: router_guard,
+                })
+            }
+        };
+        let _ = self.respond_to.send(Ok(response));
     }
 }
 
@@ -618,6 +699,52 @@ async fn materialized_preconfirmation_block_hash(
     Ok(matches_base_fee.then_some(header.hash))
 }
 
+/// Return whether an engine submission error may have happened after the engine mutated state.
+fn preconf_error_may_have_materialized(err: &DriverError) -> bool {
+    matches!(
+        err,
+        DriverError::PreconfInjectionFailed {
+            source: EngineSubmissionError::Rpc(_) |
+                EngineSubmissionError::Provider(_) |
+                EngineSubmissionError::MissingInsertedBlock(_) |
+                EngineSubmissionError::InsertedBlockHashMismatch { .. },
+            ..
+        }
+    )
+}
+
+/// Reconcile an uncertain engine submission while production remains serialized.
+async fn reconcile_uncertain_canonical_preconfirmation(
+    rpc: &Client,
+    payload: &PreconfPayload,
+) -> Option<B256> {
+    const MAX_ATTEMPTS: usize = 6;
+    const INITIAL_DELAY: Duration = Duration::from_millis(100);
+    const MAX_DELAY: Duration = Duration::from_secs(1);
+
+    let mut retry_delay = INITIAL_DELAY;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match materialized_preconfirmation_block_hash(rpc, payload).await {
+            Ok(Some(block_hash)) => return Some(block_hash),
+            Ok(None) => debug!(
+                block_number = payload.block_number(),
+                attempt, "uncertain preconfirmation is not yet visible during reconciliation"
+            ),
+            Err(err) => warn!(
+                block_number = payload.block_number(),
+                attempt,
+                ?err,
+                "failed to read uncertain preconfirmation during reconciliation"
+            ),
+        }
+        if attempt < MAX_ATTEMPTS {
+            sleep(retry_delay).await;
+            retry_delay = retry_delay.saturating_mul(2).min(MAX_DELAY);
+        }
+    }
+    None
+}
+
 impl EventSyncer {
     /// Build the production router with the enabled paths.
     fn build_router(
@@ -660,9 +787,26 @@ impl EventSyncer {
             while let Some(job) = rx.recv().await {
                 // Track current backlog before processing this job.
                 DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
+                if job.lifecycle.is_abandoned() {
+                    debug!(
+                        block_number = job.payload.block_number(),
+                        "skipping abandoned preconfirmation before waiting for the router"
+                    );
+                    continue;
+                }
                 let start = Instant::now();
                 let block_number = job.payload.block_number();
-                let router_guard = router.lock().await;
+                let mut router_guard = Arc::clone(&router).lock_owned().await;
+                // A submitter may time out while this job waits behind a long proposal. Avoid
+                // running any RPC safety probes for work that can no longer enter the engine.
+                if job.lifecycle.is_abandoned() {
+                    debug!(
+                        block_number,
+                        "skipping abandoned preconfirmation after acquiring the router"
+                    );
+                    DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
+                    continue;
+                }
                 // Re-check ingress readiness under the router lock: the event loop closes the
                 // gate when the scanner drops into a replay window, and jobs that were already
                 // queued (or raced past the submit-side readiness check) must not inject
@@ -673,7 +817,7 @@ impl EventSyncer {
                         block_number,
                         "rejecting queued preconfirmation payload while ingress is closed"
                     );
-                    job.respond(Err(DriverError::PreconfIngressNotReady));
+                    job.respond_error(DriverError::PreconfIngressNotReady);
                     DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                     continue;
                 }
@@ -687,7 +831,7 @@ impl EventSyncer {
                     Ok(None) => 0,
                     Err(err) => {
                         error!(?err, block_number, "failed to read head_l1_origin in ingress loop");
-                        job.respond(Err(DriverError::Rpc(err)));
+                        job.respond_error(DriverError::Rpc(err));
                         DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                         continue;
                     }
@@ -700,7 +844,7 @@ impl EventSyncer {
                         head_l1_origin_block_id,
                         "dropping stale preconfirmation payload in ingress loop"
                     );
-                    job.respond(Ok(PreconfSubmissionOutcome::Stale));
+                    job.respond_outcome(PreconfSubmissionOutcome::Stale, router_guard);
                     DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                     continue;
                 }
@@ -715,9 +859,10 @@ impl EventSyncer {
                             %block_hash,
                             "preconfirmation payload is already materialized"
                         );
-                        job.respond(Ok(PreconfSubmissionOutcome::AlreadyMaterialized {
-                            block_hash,
-                        }));
+                        job.respond_outcome(
+                            PreconfSubmissionOutcome::AlreadyMaterialized { block_hash },
+                            router_guard,
+                        );
                         DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                         continue;
                     }
@@ -727,7 +872,7 @@ impl EventSyncer {
                             ?err,
                             block_number, "failed to check preconfirmation materialization state"
                         );
-                        job.respond(Err(err));
+                        job.respond_error(err);
                         DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                         continue;
                     }
@@ -747,7 +892,7 @@ impl EventSyncer {
                                 block_number,
                                 "failed to check canonical preconfirmation target height"
                             );
-                            job.respond(Err(err));
+                            job.respond_error(err);
                             DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                             continue;
                         }
@@ -759,10 +904,10 @@ impl EventSyncer {
                             %existing_hash,
                             "rejecting local preconfirmation that would replace a canonical block"
                         );
-                        job.respond(Err(DriverError::PreconfCanonicalConflict {
+                        job.respond_error(DriverError::PreconfCanonicalConflict {
                             block_number,
                             existing_hash,
-                        }));
+                        });
                         DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                         continue;
                     }
@@ -801,7 +946,10 @@ impl EventSyncer {
                                 "preconfirmation payload injected"
                             );
                             // Return the produced block identity to the original sender.
-                            job.respond(Ok(PreconfSubmissionOutcome::Inserted { block_hash }));
+                            job.respond_outcome(
+                                PreconfSubmissionOutcome::Inserted { block_hash },
+                                router_guard,
+                            );
                         }
                         // The preconfirmation path always yields exactly one outcome; treat an
                         // empty result as a missing block rather than fabricating an identity.
@@ -811,7 +959,7 @@ impl EventSyncer {
                                 block_number,
                                 duration_secs, "preconfirmation injection returned no block"
                             );
-                            job.respond(Err(DriverError::BlockNotFound(block_number)));
+                            job.respond_error(DriverError::BlockNotFound(block_number));
                         }
                     },
                     Err(err) => {
@@ -823,8 +971,36 @@ impl EventSyncer {
                             duration_secs,
                             "preconfirmation processing failed"
                         );
-                        // Surface the error to the original sender.
-                        job.respond(Err(err));
+                        if job.policy == PreconfSubmissionPolicy::CanonicalExtensionOnly &&
+                            preconf_error_may_have_materialized(&err)
+                        {
+                            if let Some(block_hash) = reconcile_uncertain_canonical_preconfirmation(
+                                &rpc,
+                                job.payload.as_ref(),
+                            )
+                            .await
+                            {
+                                warn!(
+                                    block_number,
+                                    %block_hash,
+                                    "recovered canonical preconfirmation after uncertain engine response"
+                                );
+                                job.respond_outcome(
+                                    PreconfSubmissionOutcome::AlreadyMaterialized { block_hash },
+                                    router_guard,
+                                );
+                            } else {
+                                let reason = format!(
+                                    "could not reconcile canonical preconfirmation block {block_number} after engine error: {err}"
+                                );
+                                router_guard.halt(reason.clone());
+                                job.respond_error(DriverError::ProductionHalted { reason });
+                            }
+                        } else {
+                            // Errors that prove no uncertain canonical mutation occurred can be
+                            // returned without poisoning the production router.
+                            job.respond_error(err);
+                        }
                     }
                 }
                 DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
@@ -1337,7 +1513,8 @@ impl EventSyncer {
             PreconfSubmissionPolicy::BranchCapable,
             PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT,
         )
-        .await
+        .await?
+        .into_branch()
     }
 
     /// Submit a branch-capable preconfirmation payload with an enqueue + response timeout.
@@ -1351,20 +1528,22 @@ impl EventSyncer {
             PreconfSubmissionPolicy::BranchCapable,
             timeout_duration,
         )
-        .await
+        .await?
+        .into_branch()
     }
 
     /// Submit a locally built preconfirmation without replacing a canonical same-height block.
     pub async fn submit_canonical_preconfirmation_payload(
         &self,
         payload: PreconfPayload,
-    ) -> Result<PreconfSubmissionOutcome, DriverError> {
+    ) -> Result<CanonicalPreconfSubmission, DriverError> {
         self.submit_preconfirmation_payload_with_policy_and_timeout(
             payload,
             PreconfSubmissionPolicy::CanonicalExtensionOnly,
             PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT,
         )
-        .await
+        .await?
+        .into_canonical()
     }
 
     /// Submit a preconfirmation using the requested branch policy and response deadline.
@@ -1373,7 +1552,7 @@ impl EventSyncer {
         payload: PreconfPayload,
         policy: PreconfSubmissionPolicy,
         timeout_duration: Duration,
-    ) -> Result<PreconfSubmissionOutcome, DriverError> {
+    ) -> Result<PreconfJobResponse, DriverError> {
         let tx = self.preconf_tx.as_ref().ok_or(DriverError::PreconfirmationDisabled)?;
 
         // Reject early if strict ingress gating is not satisfied yet.
@@ -1384,8 +1563,11 @@ impl EventSyncer {
         // Best-effort duplicate fast path outside the serialized loop: the returned outcome
         // carries the exact hash this check observed, so it stays self-consistent even if a
         // sibling becomes canonical afterwards.
-        let materialized_block_hash =
-            materialized_preconfirmation_block_hash(&self.rpc, &payload).await?;
+        let materialized_block_hash = if policy == PreconfSubmissionPolicy::BranchCapable {
+            materialized_preconfirmation_block_hash(&self.rpc, &payload).await?
+        } else {
+            None
+        };
         if let Some(block_hash) = materialized_block_hash {
             debug!(
                 block_number = payload.block_number(),
@@ -1402,17 +1584,21 @@ impl EventSyncer {
             Some(origin) => origin.block_id.to::<u64>(),
             None => 0,
         };
-        if is_stale_preconf(block_number, head_l1_origin_block_id) {
+        if is_stale_preconf(block_number, head_l1_origin_block_id) &&
+            policy == PreconfSubmissionPolicy::BranchCapable
+        {
             DriverMetrics::preconf_stale_dropped_total().inc();
             DriverMetrics::preconf_stale_dropped_before_enqueue_total().inc();
             warn!(
                 block_number,
                 head_l1_origin_block_id, "dropping stale preconfirmation payload before enqueue"
             );
-            return Ok(PreconfSubmissionOutcome::Stale);
+            return Ok(PreconfJobResponse::Branch(PreconfSubmissionOutcome::Stale));
         }
         if let Some(block_hash) = materialized_block_hash {
-            return Ok(PreconfSubmissionOutcome::AlreadyMaterialized { block_hash });
+            return Ok(PreconfJobResponse::Branch(PreconfSubmissionOutcome::AlreadyMaterialized {
+                block_hash,
+            }));
         }
 
         debug!(block_number, "submitting preconfirmation payload to queue");
@@ -1496,7 +1682,7 @@ impl EventSyncer {
 
         drop(submission_guard);
 
-        debug!(block_number, ?outcome, "preconfirmation payload processed successfully");
+        debug!(block_number, "preconfirmation payload processed successfully");
         Ok(outcome)
     }
 
@@ -2075,6 +2261,9 @@ mod tests {
         },
     };
 
+    /// Shared record of preconfirmation identities observed by a controllable path.
+    type SeenPreconfIdentities = StdArc<Mutex<Vec<(u64, u64, [u8; 8])>>>;
+
     /// Production path that exposes deterministic entry and release points to race tests.
     #[derive(Clone)]
     struct ControllablePreconfPath {
@@ -2083,7 +2272,7 @@ mod tests {
         /// Blocks `produce` until the test permits it to complete.
         release: StdArc<tokio::sync::Semaphore>,
         /// Payload identities observed by the production path.
-        seen: StdArc<Mutex<Vec<(u64, u64, [u8; 8])>>>,
+        seen: SeenPreconfIdentities,
     }
 
     impl ControllablePreconfPath {
@@ -2120,6 +2309,25 @@ mod tests {
             self.entered.add_permits(1);
             self.release.acquire().await.expect("release semaphore should remain open").forget();
             Ok(vec![sample_engine_outcome(payload.block_number())])
+        }
+    }
+
+    /// Production path that models an RPC failure after the engine may have mutated state.
+    struct UncertainPreconfPath;
+
+    #[async_trait]
+    impl BlockProductionPath for UncertainPreconfPath {
+        async fn produce(
+            &self,
+            input: ProductionInput,
+        ) -> Result<Vec<EngineBlockOutcome>, DriverError> {
+            let ProductionInput::Preconfirmation(payload) = input else {
+                return Err(anyhow!("expected preconfirmation input").into());
+            };
+            Err(DriverError::PreconfInjectionFailed {
+                block_number: payload.block_number(),
+                source: EngineSubmissionError::Provider("mock response lost".to_string()),
+            })
         }
     }
 
@@ -2926,7 +3134,8 @@ mod tests {
         timeout(Duration::from_secs(1), response)
             .await
             .expect("ingress loop should answer the queued job")
-            .expect("ingress loop should not drop the response channel")
+            .expect("ingress loop should not drop the response channel")?
+            .into_branch()
     }
 
     #[tokio::test]
@@ -2974,9 +3183,9 @@ mod tests {
     #[test_log::test(tokio::test(start_paused = true))]
     async fn timed_out_queued_preconf_is_abandoned_before_injection() {
         let l2_asserter = Asserter::new();
-        // Two submissions each perform a materialization + boundary read before enqueue, then
-        // the ingress loop repeats the boundary + materialization checks under the router lock.
-        for _ in 0..8 {
+        // Both submissions perform materialization + boundary reads before enqueue. The abandoned
+        // first job must consume no ingress RPCs; only the retry repeats the two locked checks.
+        for _ in 0..6 {
             l2_asserter.push_success(&Option::<RpcL1Origin>::None);
         }
         let path = MockProductionPath::default();
@@ -2993,7 +3202,7 @@ mod tests {
                 )
                 .await
         });
-        wait_for_rpc_queue_len(&l2_asserter, 6).await;
+        wait_for_rpc_queue_len(&l2_asserter, 4).await;
         tokio::time::advance(Duration::from_secs(13)).await;
         tokio::task::yield_now().await;
         assert!(matches!(
@@ -3010,7 +3219,7 @@ mod tests {
                 )
                 .await
         });
-        wait_for_rpc_queue_len(&l2_asserter, 4).await;
+        wait_for_rpc_queue_len(&l2_asserter, 2).await;
         drop(proposal_guard);
 
         assert!(matches!(
@@ -3018,6 +3227,10 @@ mod tests {
             Ok(PreconfSubmissionOutcome::Inserted { .. })
         ));
         assert_eq!(path.produced_blocks(), vec![1]);
+        assert!(
+            l2_asserter.read_q().is_empty(),
+            "the abandoned job must not consume ingress RPC responses"
+        );
     }
 
     #[test_log::test(tokio::test(start_paused = true))]
@@ -3055,9 +3268,102 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn canonical_preconfirmation_rejects_same_height_sibling() {
+    async fn canonical_preconf_submission_holds_router_until_caller_finishes_finalization() {
         let l2_asserter = Asserter::new();
         for _ in 0..4 {
+            l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        }
+        let path = MockProductionPath::default();
+        let (syncer, router) =
+            spawn_submission_test_ingress(l2_asserter, StdArc::new(path.clone())).await;
+
+        let submission = syncer
+            .submit_canonical_preconfirmation_payload(identified_preconf_payload(1, 100, 0xaa))
+            .await
+            .expect("canonical submission should be inserted");
+        assert!(matches!(submission.outcome(), PreconfSubmissionOutcome::Inserted { .. }));
+        assert!(
+            router.try_lock().is_err(),
+            "event and branch production must remain blocked until signature persistence"
+        );
+
+        drop(submission);
+        assert!(router.try_lock().is_ok(), "dropping the submission must reopen production");
+        assert_eq!(path.produced_blocks(), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn canonical_preconf_reconciles_materialized_block_after_uncertain_engine_error() {
+        let l2_asserter = Asserter::new();
+        for _ in 0..4 {
+            l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        }
+
+        let payload = identified_preconf_payload(1, 100, 0xaa);
+        let origin = payload.payload().l1_origin.clone();
+        let observed_block_hash = B256::from([0x66; 32]);
+        let mut block = RpcBlock::<TxEnvelope>::default();
+        block.header.hash = observed_block_hash;
+        block.header.parent_hash = payload.expected_parent_hash();
+        block.header.number = payload.block_number();
+        block.header.beneficiary = payload.payload().payload_attributes.suggested_fee_recipient;
+        block.header.mix_hash = payload.payload().payload_attributes.prev_randao;
+        block.header.gas_limit = payload.payload().block_metadata.gas_limit;
+        block.header.timestamp = payload.payload().payload_attributes.timestamp;
+        block.header.extra_data = payload.payload().block_metadata.extra_data.clone();
+        block.header.base_fee_per_gas = Some(0);
+        l2_asserter.push_success(&Some(origin));
+        l2_asserter.push_success(&Some(block));
+
+        let (syncer, router) =
+            spawn_submission_test_ingress(l2_asserter, StdArc::new(UncertainPreconfPath)).await;
+        let submission = syncer
+            .submit_canonical_preconfirmation_payload(payload)
+            .await
+            .expect("uncertain engine response should reconcile the materialized block");
+
+        assert_eq!(
+            submission.outcome(),
+            PreconfSubmissionOutcome::AlreadyMaterialized { block_hash: observed_block_hash }
+        );
+        assert!(router.try_lock().is_err(), "reconciled submission must retain the router lease");
+    }
+
+    #[tokio::test]
+    async fn fatal_canonical_finalization_halts_all_production_before_releasing_router() {
+        let l2_asserter = Asserter::new();
+        for _ in 0..4 {
+            l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        }
+        let path = MockProductionPath::default();
+        let (syncer, router) =
+            spawn_submission_test_ingress(l2_asserter, StdArc::new(path.clone())).await;
+        let submission = syncer
+            .submit_canonical_preconfirmation_payload(identified_preconf_payload(1, 100, 0xaa))
+            .await
+            .expect("canonical submission should be inserted");
+
+        submission.halt("mock finalization failure");
+        let result = router
+            .lock()
+            .await
+            .produce(ProductionInput::Preconfirmation(StdArc::new(identified_preconf_payload(
+                2, 112, 0xbb,
+            ))))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(DriverError::ProductionHalted { reason })
+                if reason == "mock finalization failure"
+        ));
+        assert_eq!(path.produced_blocks(), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn canonical_preconfirmation_rejects_same_height_sibling() {
+        let l2_asserter = Asserter::new();
+        for _ in 0..3 {
             l2_asserter.push_success(&Option::<RpcL1Origin>::None);
         }
         let existing_hash = B256::from([0x44; 32]);
@@ -3070,11 +3376,7 @@ mod tests {
         let (syncer, _) =
             spawn_submission_test_ingress(l2_asserter, StdArc::new(path.clone())).await;
         let result = syncer
-            .submit_preconfirmation_payload_with_policy_and_timeout(
-                identified_preconf_payload(1, 112, 0xbb),
-                PreconfSubmissionPolicy::CanonicalExtensionOnly,
-                Duration::from_secs(1),
-            )
+            .submit_canonical_preconfirmation_payload(identified_preconf_payload(1, 112, 0xbb))
             .await;
 
         assert!(matches!(

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashSet, VecDeque},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU8, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -459,6 +459,97 @@ pub struct PreconfJob {
     payload: Arc<PreconfPayload>,
     /// Oneshot channel to send the processing result back to the caller.
     respond_to: oneshot::Sender<Result<PreconfSubmissionOutcome, DriverError>>,
+    /// Lifecycle shared with the submitter so a queued job can be abandoned without racing
+    /// an engine injection that has already started.
+    lifecycle: Arc<PreconfJobLifecycle>,
+    /// Controls whether this submission may replace the canonical block at its target height.
+    policy: PreconfSubmissionPolicy,
+}
+
+/// Submission policy applied after exact-materialization and confirmed-boundary checks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PreconfSubmissionPolicy {
+    /// Permit a valid sibling branch, as required for P2P/cache imports.
+    BranchCapable,
+    /// Require the target height to be empty before a local block builder injects the payload.
+    CanonicalExtensionOnly,
+}
+
+/// Atomic lifecycle state for one queued preconfirmation job.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum PreconfJobState {
+    /// The job is queued or running non-mutating safety checks.
+    Queued = 0,
+    /// The job has committed to entering the engine production path.
+    Processing = 1,
+    /// The submitter stopped waiting before engine production started.
+    Abandoned = 2,
+    /// The ingress loop reached a terminal result.
+    Completed = 3,
+}
+
+/// Coordinates timeout/drop cancellation with the serialized ingress loop.
+struct PreconfJobLifecycle {
+    /// Current lifecycle state encoded as [`PreconfJobState`].
+    state: AtomicU8,
+}
+
+impl PreconfJobLifecycle {
+    /// Create a lifecycle in the queued state.
+    fn queued() -> Self {
+        Self { state: AtomicU8::new(PreconfJobState::Queued as u8) }
+    }
+
+    /// Abandon a job only while engine production has not started.
+    fn abandon_if_queued(&self) -> bool {
+        self.state
+            .compare_exchange(
+                PreconfJobState::Queued as u8,
+                PreconfJobState::Abandoned as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Commit a queued job to engine production unless its submitter already abandoned it.
+    fn start_processing(&self) -> bool {
+        self.state
+            .compare_exchange(
+                PreconfJobState::Queued as u8,
+                PreconfJobState::Processing as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Record that the ingress loop reached a terminal result.
+    fn complete(&self) {
+        self.state.store(PreconfJobState::Completed as u8, Ordering::Release);
+    }
+}
+
+/// Drop guard that prevents a disconnected submitter from leaving a queued injection behind.
+struct PreconfSubmissionGuard {
+    /// Lifecycle owned by the enqueued job.
+    lifecycle: Arc<PreconfJobLifecycle>,
+}
+
+impl Drop for PreconfSubmissionGuard {
+    /// Abandon the job when the submission future is dropped before engine production starts.
+    fn drop(&mut self) {
+        self.lifecycle.abandon_if_queued();
+    }
+}
+
+impl PreconfJob {
+    /// Complete this job and best-effort deliver its terminal result to the submitter.
+    fn respond(self, result: Result<PreconfSubmissionOutcome, DriverError>) {
+        self.lifecycle.complete();
+        let _ = self.respond_to.send(result);
+    }
 }
 
 /// Return the block hash of the local L2 block the provided preconfirmation payload already
@@ -582,7 +673,7 @@ impl EventSyncer {
                         block_number,
                         "rejecting queued preconfirmation payload while ingress is closed"
                     );
-                    let _ = job.respond_to.send(Err(DriverError::PreconfIngressNotReady));
+                    job.respond(Err(DriverError::PreconfIngressNotReady));
                     DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                     continue;
                 }
@@ -596,7 +687,7 @@ impl EventSyncer {
                     Ok(None) => 0,
                     Err(err) => {
                         error!(?err, block_number, "failed to read head_l1_origin in ingress loop");
-                        let _ = job.respond_to.send(Err(DriverError::Rpc(err)));
+                        job.respond(Err(DriverError::Rpc(err)));
                         DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                         continue;
                     }
@@ -609,7 +700,7 @@ impl EventSyncer {
                         head_l1_origin_block_id,
                         "dropping stale preconfirmation payload in ingress loop"
                     );
-                    let _ = job.respond_to.send(Ok(PreconfSubmissionOutcome::Stale));
+                    job.respond(Ok(PreconfSubmissionOutcome::Stale));
                     DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                     continue;
                 }
@@ -624,9 +715,9 @@ impl EventSyncer {
                             %block_hash,
                             "preconfirmation payload is already materialized"
                         );
-                        let _ = job
-                            .respond_to
-                            .send(Ok(PreconfSubmissionOutcome::AlreadyMaterialized { block_hash }));
+                        job.respond(Ok(PreconfSubmissionOutcome::AlreadyMaterialized {
+                            block_hash,
+                        }));
                         DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                         continue;
                     }
@@ -636,10 +727,57 @@ impl EventSyncer {
                             ?err,
                             block_number, "failed to check preconfirmation materialization state"
                         );
-                        let _ = job.respond_to.send(Err(err));
+                        job.respond(Err(err));
                         DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
                         continue;
                     }
+                }
+
+                if job.policy == PreconfSubmissionPolicy::CanonicalExtensionOnly {
+                    let canonical_block = match rpc
+                        .l2_provider
+                        .get_block_by_number(BlockNumberOrTag::Number(block_number))
+                        .await
+                    {
+                        Ok(block) => block,
+                        Err(err) => {
+                            let err = DriverError::Rpc(RpcClientError::Provider(err.to_string()));
+                            error!(
+                                ?err,
+                                block_number,
+                                "failed to check canonical preconfirmation target height"
+                            );
+                            job.respond(Err(err));
+                            DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
+                            continue;
+                        }
+                    };
+                    if let Some(block) = canonical_block {
+                        let existing_hash = block.header.hash;
+                        warn!(
+                            block_number,
+                            %existing_hash,
+                            "rejecting local preconfirmation that would replace a canonical block"
+                        );
+                        job.respond(Err(DriverError::PreconfCanonicalConflict {
+                            block_number,
+                            existing_hash,
+                        }));
+                        DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
+                        continue;
+                    }
+                }
+
+                // Linearize cancellation against engine mutation immediately before entering
+                // the production path. A timed-out or disconnected submitter may abandon only
+                // while this transition is still pending.
+                if !job.lifecycle.start_processing() {
+                    debug!(
+                        block_number,
+                        "skipping preconfirmation abandoned before engine production"
+                    );
+                    DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
+                    continue;
                 }
 
                 // Single-shot injection while holding router lock to avoid interleaving.
@@ -663,9 +801,7 @@ impl EventSyncer {
                                 "preconfirmation payload injected"
                             );
                             // Return the produced block identity to the original sender.
-                            let _ = job
-                                .respond_to
-                                .send(Ok(PreconfSubmissionOutcome::Inserted { block_hash }));
+                            job.respond(Ok(PreconfSubmissionOutcome::Inserted { block_hash }));
                         }
                         // The preconfirmation path always yields exactly one outcome; treat an
                         // empty result as a missing block rather than fabricating an identity.
@@ -675,8 +811,7 @@ impl EventSyncer {
                                 block_number,
                                 duration_secs, "preconfirmation injection returned no block"
                             );
-                            let _ =
-                                job.respond_to.send(Err(DriverError::BlockNotFound(block_number)));
+                            job.respond(Err(DriverError::BlockNotFound(block_number)));
                         }
                     },
                     Err(err) => {
@@ -689,7 +824,7 @@ impl EventSyncer {
                             "preconfirmation processing failed"
                         );
                         // Surface the error to the original sender.
-                        let _ = job.respond_to.send(Err(err));
+                        job.respond(Err(err));
                     }
                 }
                 DriverMetrics::preconf_queue_depth().set(rx.len() as f64);
@@ -1189,22 +1324,54 @@ impl EventSyncer {
         self.preconf_ingress_ready.load(Ordering::Acquire)
     }
 
-    /// Submit a preconfirmation payload and await the processing result.
+    /// Submit a branch-capable preconfirmation payload and await the processing result.
+    ///
+    /// This path is intended for authenticated P2P/cache imports, which must retain the ability
+    /// to materialize a valid sibling branch above the event-confirmed boundary.
     pub async fn submit_preconfirmation_payload(
         &self,
         payload: PreconfPayload,
     ) -> Result<PreconfSubmissionOutcome, DriverError> {
-        self.submit_preconfirmation_payload_with_timeout(
+        self.submit_preconfirmation_payload_with_policy_and_timeout(
             payload,
+            PreconfSubmissionPolicy::BranchCapable,
             PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT,
         )
         .await
     }
 
-    /// Submit a preconfirmation payload with a caller-provided timeout for enqueue + response.
+    /// Submit a branch-capable preconfirmation payload with an enqueue + response timeout.
     pub async fn submit_preconfirmation_payload_with_timeout(
         &self,
         payload: PreconfPayload,
+        timeout_duration: Duration,
+    ) -> Result<PreconfSubmissionOutcome, DriverError> {
+        self.submit_preconfirmation_payload_with_policy_and_timeout(
+            payload,
+            PreconfSubmissionPolicy::BranchCapable,
+            timeout_duration,
+        )
+        .await
+    }
+
+    /// Submit a locally built preconfirmation without replacing a canonical same-height block.
+    pub async fn submit_canonical_preconfirmation_payload(
+        &self,
+        payload: PreconfPayload,
+    ) -> Result<PreconfSubmissionOutcome, DriverError> {
+        self.submit_preconfirmation_payload_with_policy_and_timeout(
+            payload,
+            PreconfSubmissionPolicy::CanonicalExtensionOnly,
+            PRECONFIRMATION_PAYLOAD_SUBMIT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// Submit a preconfirmation using the requested branch policy and response deadline.
+    async fn submit_preconfirmation_payload_with_policy_and_timeout(
+        &self,
+        payload: PreconfPayload,
+        policy: PreconfSubmissionPolicy,
         timeout_duration: Duration,
     ) -> Result<PreconfSubmissionOutcome, DriverError> {
         let tx = self.preconf_tx.as_ref().ok_or(DriverError::PreconfirmationDisabled)?;
@@ -1251,11 +1418,18 @@ impl EventSyncer {
         debug!(block_number, "submitting preconfirmation payload to queue");
 
         // Create oneshot channel for receiving the processing result.
-        let (resp_tx, resp_rx) = oneshot::channel();
+        let (resp_tx, mut resp_rx) = oneshot::channel();
+        let lifecycle = Arc::new(PreconfJobLifecycle::queued());
+        let submission_guard = PreconfSubmissionGuard { lifecycle: Arc::clone(&lifecycle) };
         // Enqueue the preconfirmation job with timeout.
         let enqueue_result = timeout(
             timeout_duration,
-            tx.send(PreconfJob { payload: Arc::new(payload), respond_to: resp_tx }),
+            tx.send(PreconfJob {
+                payload: Arc::new(payload),
+                respond_to: resp_tx,
+                lifecycle: Arc::clone(&lifecycle),
+                policy,
+            }),
         )
         .await;
 
@@ -1280,17 +1454,32 @@ impl EventSyncer {
         }
 
         // Await the processing result with timeout.
-        let response_result = timeout(timeout_duration, resp_rx).await;
+        let response_result = timeout(timeout_duration, &mut resp_rx).await;
 
         let outcome = match response_result {
             Err(_) => {
                 DriverMetrics::preconf_response_timeouts_total().inc();
-                error!(
+                if lifecycle.abandon_if_queued() {
+                    error!(
+                        block_number,
+                        timeout_ms = timeout_duration.as_millis() as u64,
+                        "preconfirmation response timed out before engine production"
+                    );
+                    return Err(DriverError::PreconfResponseTimeout { waited: timeout_duration });
+                }
+                warn!(
                     block_number,
                     timeout_ms = timeout_duration.as_millis() as u64,
-                    "preconfirmation response timed out"
+                    "preconfirmation response deadline elapsed after engine production started; waiting for terminal result"
                 );
-                return Err(DriverError::PreconfResponseTimeout { waited: timeout_duration });
+                match resp_rx.await {
+                    Err(err) => {
+                        DriverMetrics::preconf_response_dropped_total().inc();
+                        error!(block_number, ?err, "preconfirmation response channel closed");
+                        return Err(DriverError::PreconfResponseDropped { recv_error: err });
+                    }
+                    Ok(inner_result) => inner_result?,
+                }
             }
             Ok(Err(err)) => {
                 DriverMetrics::preconf_response_dropped_total().inc();
@@ -1304,6 +1493,8 @@ impl EventSyncer {
                 inner_result?
             }
         };
+
+        drop(submission_guard);
 
         debug!(block_number, ?outcome, "preconfirmation payload processed successfully");
         Ok(outcome)
@@ -1872,6 +2063,7 @@ mod tests {
         transports::http::reqwest::Url,
     };
     use alloy_transport::mock::Asserter;
+    use async_trait::async_trait;
     use bindings::inbox::{IInbox::CoreState, Inbox::getCoreStateCall};
     use rpc::{SubscriptionSource, blob::BlobDataSource, client::ClientConfig};
 
@@ -1879,9 +2071,115 @@ mod tests {
         production::{BlockProductionPath, ProductionRouter},
         test_support::{
             MockProductionPath, mock_client_with_asserters, mock_client_with_l1_asserter,
-            sample_derivation_source, sample_payload,
+            sample_derivation_source, sample_engine_outcome, sample_payload,
         },
     };
+
+    /// Production path that exposes deterministic entry and release points to race tests.
+    #[derive(Clone)]
+    struct ControllablePreconfPath {
+        /// Signals that `produce` has started and the job is no longer cancellable.
+        entered: StdArc<tokio::sync::Semaphore>,
+        /// Blocks `produce` until the test permits it to complete.
+        release: StdArc<tokio::sync::Semaphore>,
+        /// Payload identities observed by the production path.
+        seen: StdArc<Mutex<Vec<(u64, u64, [u8; 8])>>>,
+    }
+
+    impl ControllablePreconfPath {
+        /// Create a blocked path with shared test controls.
+        fn new() -> Self {
+            Self {
+                entered: StdArc::new(tokio::sync::Semaphore::new(0)),
+                release: StdArc::new(tokio::sync::Semaphore::new(0)),
+                seen: StdArc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        /// Return payload identities observed by the path.
+        fn seen(&self) -> Vec<(u64, u64, [u8; 8])> {
+            self.seen.lock().expect("seen payloads mutex should not be poisoned").clone()
+        }
+    }
+
+    #[async_trait]
+    impl BlockProductionPath for ControllablePreconfPath {
+        /// Record and block one preconfirmation production call until released by the test.
+        async fn produce(
+            &self,
+            input: ProductionInput,
+        ) -> Result<Vec<EngineBlockOutcome>, DriverError> {
+            let ProductionInput::Preconfirmation(payload) = input else {
+                return Err(anyhow!("expected preconfirmation input").into());
+            };
+            self.seen.lock().expect("seen payloads mutex should not be poisoned").push((
+                payload.block_number(),
+                payload.payload().payload_attributes.timestamp,
+                payload.payload().l1_origin.build_payload_args_id,
+            ));
+            self.entered.add_permits(1);
+            self.release.acquire().await.expect("release semaphore should remain open").forget();
+            Ok(vec![sample_engine_outcome(payload.block_number())])
+        }
+    }
+
+    /// Build a preconfirmation payload with a distinct retry identity.
+    fn identified_preconf_payload(
+        block_number: u64,
+        timestamp: u64,
+        payload_id_byte: u8,
+    ) -> PreconfPayload {
+        let mut payload = sample_payload(block_number);
+        payload.payload_attributes.timestamp = timestamp;
+        payload.l1_origin.build_payload_args_id = [payload_id_byte; 8];
+        PreconfPayload::new(payload, B256::ZERO)
+    }
+
+    /// Spin until a mocked RPC queue reaches the expected length without advancing Tokio time.
+    async fn wait_for_rpc_queue_len(asserter: &Asserter, expected: usize) {
+        for _ in 0..1_000 {
+            if asserter.read_q().len() == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!(
+            "mocked RPC queue did not reach length {expected}; remaining: {}",
+            asserter.read_q().len()
+        );
+    }
+
+    /// Spawn a ready ingress loop over a caller-controlled production path.
+    async fn spawn_submission_test_ingress(
+        l2_asserter: Asserter,
+        path: StdArc<dyn BlockProductionPath + Send + Sync>,
+    ) -> (StdArc<EventSyncer>, StdArc<AsyncMutex<ProductionRouter>>) {
+        let rpc = mock_client_with_asserters(
+            Asserter::new(),
+            l2_asserter,
+            Asserter::new(),
+            Address::ZERO,
+        );
+        let syncer = StdArc::new(EventSyncer { rpc: rpc.clone(), ..build_syncer().await });
+        let rx = syncer
+            .preconf_rx
+            .lock()
+            .expect("preconfirmation receiver mutex should not be poisoned")
+            .take()
+            .expect("preconfirmation receiver should be available");
+        let router = StdArc::new(AsyncMutex::new(ProductionRouter::new(
+            StdArc::new(MockProductionPath::default()),
+            Some(path),
+        )));
+        syncer.spawn_preconf_ingress(
+            StdArc::clone(&router),
+            rx,
+            rpc,
+            StdArc::clone(&syncer.preconf_ingress_ready),
+        );
+        syncer.preconf_ingress_ready.store(true, Ordering::Release);
+        (syncer, router)
+    }
 
     async fn build_syncer() -> EventSyncer {
         let client_config = ClientConfig {
@@ -2619,6 +2917,8 @@ mod tests {
         tx.send(PreconfJob {
             payload: StdArc::new(PreconfPayload::new(sample_payload(block_number), B256::ZERO)),
             respond_to,
+            lifecycle: StdArc::new(PreconfJobLifecycle::queued()),
+            policy: PreconfSubmissionPolicy::BranchCapable,
         })
         .await
         .expect("ingress queue should accept the job");
@@ -2669,6 +2969,155 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(path.produced_blocks(), vec![1]);
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn timed_out_queued_preconf_is_abandoned_before_injection() {
+        let l2_asserter = Asserter::new();
+        // Two submissions each perform a materialization + boundary read before enqueue, then
+        // the ingress loop repeats the boundary + materialization checks under the router lock.
+        for _ in 0..8 {
+            l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        }
+        let path = MockProductionPath::default();
+        let (syncer, router) =
+            spawn_submission_test_ingress(l2_asserter.clone(), StdArc::new(path.clone())).await;
+        let proposal_guard = router.clone().lock_owned().await;
+
+        let first_syncer = StdArc::clone(&syncer);
+        let first = tokio::spawn(async move {
+            first_syncer
+                .submit_preconfirmation_payload_with_timeout(
+                    identified_preconf_payload(1, 100, 0xaa),
+                    Duration::from_secs(12),
+                )
+                .await
+        });
+        wait_for_rpc_queue_len(&l2_asserter, 6).await;
+        tokio::time::advance(Duration::from_secs(13)).await;
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            first.await.expect("first submission task should finish"),
+            Err(DriverError::PreconfResponseTimeout { .. })
+        ));
+
+        let retry_syncer = StdArc::clone(&syncer);
+        let retry = tokio::spawn(async move {
+            retry_syncer
+                .submit_preconfirmation_payload_with_timeout(
+                    identified_preconf_payload(1, 112, 0xbb),
+                    Duration::from_secs(12),
+                )
+                .await
+        });
+        wait_for_rpc_queue_len(&l2_asserter, 4).await;
+        drop(proposal_guard);
+
+        assert!(matches!(
+            retry.await.expect("retry submission task should finish"),
+            Ok(PreconfSubmissionOutcome::Inserted { .. })
+        ));
+        assert_eq!(path.produced_blocks(), vec![1]);
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn preconf_processing_started_before_deadline_waits_for_terminal_result() {
+        let l2_asserter = Asserter::new();
+        for _ in 0..4 {
+            l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        }
+        let path = ControllablePreconfPath::new();
+        let (syncer, _) =
+            spawn_submission_test_ingress(l2_asserter, StdArc::new(path.clone())).await;
+        let submission = tokio::spawn(async move {
+            syncer
+                .submit_preconfirmation_payload_with_timeout(
+                    identified_preconf_payload(1, 100, 0xaa),
+                    Duration::from_secs(12),
+                )
+                .await
+        });
+
+        path.entered.acquire().await.expect("entry semaphore should remain open").forget();
+        tokio::time::advance(Duration::from_secs(13)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !submission.is_finished(),
+            "a response deadline must not detach engine production already in flight"
+        );
+
+        path.release.add_permits(1);
+        assert!(matches!(
+            submission.await.expect("submission task should finish"),
+            Ok(PreconfSubmissionOutcome::Inserted { .. })
+        ));
+        assert_eq!(path.seen(), vec![(1, 100, [0xaa; 8])]);
+    }
+
+    #[tokio::test]
+    async fn canonical_preconfirmation_rejects_same_height_sibling() {
+        let l2_asserter = Asserter::new();
+        for _ in 0..4 {
+            l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        }
+        let existing_hash = B256::from([0x44; 32]);
+        let mut existing_block = RpcBlock::<TxEnvelope>::default();
+        existing_block.header.number = 1;
+        existing_block.header.hash = existing_hash;
+        l2_asserter.push_success(&Some(existing_block));
+
+        let path = MockProductionPath::default();
+        let (syncer, _) =
+            spawn_submission_test_ingress(l2_asserter, StdArc::new(path.clone())).await;
+        let result = syncer
+            .submit_preconfirmation_payload_with_policy_and_timeout(
+                identified_preconf_payload(1, 112, 0xbb),
+                PreconfSubmissionPolicy::CanonicalExtensionOnly,
+                Duration::from_secs(1),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(DriverError::PreconfCanonicalConflict {
+                block_number: 1,
+                existing_hash: hash,
+            }) if hash == existing_hash
+        ));
+        assert!(path.produced_blocks().is_empty());
+    }
+
+    #[tokio::test]
+    async fn branch_capable_preconfirmation_preserves_same_height_import_path() {
+        let l2_asserter = Asserter::new();
+        for _ in 0..4 {
+            l2_asserter.push_success(&Option::<RpcL1Origin>::None);
+        }
+        // This response would expose a canonical same-height block if the branch-capable path
+        // incorrectly inherited the local builder's canonical-extension-only lookup.
+        let mut existing_block = RpcBlock::<TxEnvelope>::default();
+        existing_block.header.number = 1;
+        existing_block.header.hash = B256::from([0x44; 32]);
+        l2_asserter.push_success(&Some(existing_block));
+
+        let path = MockProductionPath::default();
+        let (syncer, _) =
+            spawn_submission_test_ingress(l2_asserter.clone(), StdArc::new(path.clone())).await;
+        let outcome = syncer
+            .submit_preconfirmation_payload_with_timeout(
+                identified_preconf_payload(1, 112, 0xbb),
+                Duration::from_secs(1),
+            )
+            .await
+            .expect("branch-capable import should remain eligible for production");
+
+        assert!(matches!(outcome, PreconfSubmissionOutcome::Inserted { .. }));
+        assert_eq!(path.produced_blocks(), vec![1]);
+        assert_eq!(
+            l2_asserter.read_q().len(),
+            1,
+            "branch-capable imports must not query or reject the canonical target height"
+        );
     }
 
     #[tokio::test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
@@ -50,3 +50,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/http.rs
@@ -44,6 +44,9 @@ fn map_rest_error_status(err: &WhitelistPreconfirmationDriverError) -> StatusCod
         WhitelistPreconfirmationDriverError::Driver(driver::DriverError::EngineSyncing(_)) => {
             StatusCode::BAD_REQUEST
         }
+        WhitelistPreconfirmationDriverError::Driver(
+            driver::DriverError::PreconfCanonicalConflict { .. },
+        ) => StatusCode::CONFLICT,
         // The Go preconfirmation server maps block-insertion failures to 500. Keep parent
         // mismatches and other production-path failures in this catch-all for REST parity.
         _ => StatusCode::INTERNAL_SERVER_ERROR,
@@ -155,5 +158,24 @@ impl IntoResponse for ApiHttpError {
         }
 
         error_response(status, message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+
+    use super::*;
+
+    #[test]
+    fn canonical_preconfirmation_conflict_maps_to_http_conflict() {
+        let err = WhitelistPreconfirmationDriverError::Driver(
+            driver::DriverError::PreconfCanonicalConflict {
+                block_number: 42,
+                existing_hash: B256::from([0x44; 32]),
+            },
+        );
+
+        assert_eq!(map_rest_error_status(&err), StatusCode::CONFLICT);
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -3,6 +3,22 @@
 use super::*;
 
 impl WhitelistApiService {
+    /// Halt production and ask the runner to restart after an unsafe post-insert failure.
+    fn fail_closed_after_insert<T>(
+        &self,
+        submission: CanonicalPreconfSubmission,
+        block_number: u64,
+        step: &'static str,
+        err: impl Display,
+    ) -> Result<T> {
+        let reason = format!(
+            "failed to finalize locally inserted preconfirmation block {block_number} at {step}: {err}"
+        );
+        submission.halt(reason.clone());
+        self.report_fatal_build_failure(reason.clone());
+        Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(reason))
+    }
+
     /// Reject build requests when this node's own P2P signer is not a registered
     /// operator in the on-chain whitelist.
     ///
@@ -59,7 +75,6 @@ impl WhitelistApiService {
     async fn build_preconf_block_inner(
         &self,
         request: BuildPreconfBlockRequest,
-        _build_guard: OwnedMutexGuard<()>,
     ) -> Result<BuildPreconfBlockResponse> {
         let started_at = Instant::now();
         let BuildPreconfBlockRequest { executable_data, end_of_sequencing, is_forced_inclusion } =
@@ -98,14 +113,22 @@ impl WhitelistApiService {
         // obtain the canonical block hash before gossiping.
         let driver_payload =
             self.driver_payload_from_request(&data, is_forced_inclusion, prev_randao, [0u8; 65])?;
-        let submission_outcome = self
+        let canonical_submission = match self
             .event_syncer
             .submit_canonical_preconfirmation_payload(PreconfPayload::new(
                 driver_payload,
                 data.parent_hash,
             ))
-            .await?;
-        let bound_block_hash = match submission_outcome {
+            .await
+        {
+            Ok(submission) => submission,
+            Err(err @ driver::DriverError::ProductionHalted { .. }) => {
+                self.report_fatal_build_failure(err.to_string());
+                return Err(err.into())
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let bound_block_hash = match canonical_submission.outcome() {
             PreconfSubmissionOutcome::Inserted { block_hash } |
             PreconfSubmissionOutcome::AlreadyMaterialized { block_hash } => block_hash,
             PreconfSubmissionOutcome::Stale => {
@@ -119,36 +142,46 @@ impl WhitelistApiService {
         // Resolve the block by the hash bound to the submission outcome: a same-height sibling
         // can become canonical between submission and this read, and a height lookup would then
         // sign a hash that does not match the request's transactions.
-        let inserted_block = retry_post_insert_step(
-            data.block_number,
-            "read_and_validate_inserted_block",
-            || async {
-                let inserted_block = self
-                    .rpc
+        let inserted_block =
+            match retry_post_insert_step(data.block_number, "read_inserted_block", || async {
+                self.rpc
                     .l2_provider
                     .get_block_by_hash(bound_block_hash)
                     .await
                     .map_err(WhitelistPreconfirmationDriverError::provider)?
                     .ok_or(WhitelistPreconfirmationDriverError::MissingInsertedBlock(
                         data.block_number,
-                    ))?;
+                    ))
+            })
+            .await
+            {
+                Ok(block) => block,
+                Err(err) => {
+                    return self.fail_closed_after_insert(
+                        canonical_submission,
+                        data.block_number,
+                        "read_inserted_block",
+                        err,
+                    )
+                }
+            };
 
-                if inserted_block.header.parent_hash != data.parent_hash {
-                    return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                        "inserted block parent hash mismatch at block {}: expected {}, got {}",
-                        data.block_number, data.parent_hash, inserted_block.header.parent_hash
-                    )));
-                }
-                if inserted_block.header.number != data.block_number {
-                    return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                        "inserted block number mismatch: expected {}, got {}",
-                        data.block_number, inserted_block.header.number
-                    )));
-                }
-                Ok(inserted_block)
-            },
-        )
-        .await;
+        if inserted_block.header.parent_hash != data.parent_hash {
+            return self.fail_closed_after_insert(
+                canonical_submission,
+                data.block_number,
+                "validate_inserted_block_parent",
+                format!("expected {}, got {}", data.parent_hash, inserted_block.header.parent_hash),
+            )
+        }
+        if inserted_block.header.number != data.block_number {
+            return self.fail_closed_after_insert(
+                canonical_submission,
+                data.block_number,
+                "validate_inserted_block_number",
+                format!("expected {}, got {}", data.block_number, inserted_block.header.number),
+            )
+        }
 
         let block_hash = inserted_block.header.hash;
         let block_number = inserted_block.header.number;
@@ -156,22 +189,42 @@ impl WhitelistApiService {
         let base_fee_per_gas =
             inserted_block.header.base_fee_per_gas.unwrap_or(data.base_fee_per_gas);
         let block_hash_signature =
-            retry_post_insert_step(block_number, "sign_inserted_block", || async {
-                self.sign_digest(block_signing_hash(self.chain_id, block_hash.as_slice()))
-            })
-            .await;
+            match self.sign_digest(block_signing_hash(self.chain_id, block_hash.as_slice())) {
+                Ok(signature) => signature,
+                Err(err) => {
+                    return self.fail_closed_after_insert(
+                        canonical_submission,
+                        block_number,
+                        "sign_inserted_block",
+                        err,
+                    )
+                }
+            };
 
         // Persist per-block signature before gossip so RPC readers can immediately resolve
         // canonical origin signatures for the inserted block.
-        retry_post_insert_step(block_number, "persist_l1_origin_signature", || async {
-            self.rpc
-                .set_l1_origin_signature(
-                    U256::from(block_number),
-                    FixedBytes::<65>::from(block_hash_signature),
-                )
-                .await
-        })
-        .await;
+        if let Err(err) =
+            retry_post_insert_step(block_number, "persist_l1_origin_signature", || async {
+                self.rpc
+                    .set_l1_origin_signature(
+                        U256::from(block_number),
+                        FixedBytes::<65>::from(block_hash_signature),
+                    )
+                    .await
+            })
+            .await
+        {
+            return self.fail_closed_after_insert(
+                canonical_submission,
+                block_number,
+                "persist_l1_origin_signature",
+                err,
+            )
+        }
+        // Signature persistence is keyed by height in the current engine API. Retain the event
+        // syncer's router guard until this write completes so neither event derivation nor a
+        // branch-capable import can replace the canonical origin row with a same-height sibling.
+        drop(canonical_submission);
         self.state.record_inserted_block(block_number);
 
         let execution_payload = crate::payload::execution_payload_from_header(
@@ -258,9 +311,7 @@ impl WhitelistApi for WhitelistApiService {
         let service = self.clone();
         run_serialized_drop_resistant_build(
             Arc::clone(&self.build_preconf_lock),
-            move |build_guard| async move {
-                service.build_preconf_block_inner(request, build_guard).await
-            },
+            move || async move { service.build_preconf_block_inner(request).await },
         )
         .await
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/handlers.rs
@@ -54,18 +54,14 @@ fn log_build_preconf_block_entry(
     );
 }
 
-#[async_trait]
-impl WhitelistApi for WhitelistApiService {
-    /// Build, sign, publish, and return a preconfirmation block.
-    async fn build_preconf_block(
+impl WhitelistApiService {
+    /// Execute the serialized local build, signature persistence, cache, and gossip workflow.
+    async fn build_preconf_block_inner(
         &self,
         request: BuildPreconfBlockRequest,
+        _build_guard: OwnedMutexGuard<()>,
     ) -> Result<BuildPreconfBlockResponse> {
         let started_at = Instant::now();
-        // Record receipt before any validation so even rejected requests
-        // mark this pod as the active preconfer for shutdown purposes.
-        self.mark_preconf_request_received().await;
-
         let BuildPreconfBlockRequest { executable_data, end_of_sequencing, is_forced_inclusion } =
             request;
         let Some(data) = executable_data else {
@@ -74,8 +70,6 @@ impl WhitelistApi for WhitelistApiService {
             ));
         };
         log_build_preconf_block_entry(&data, end_of_sequencing, is_forced_inclusion);
-
-        let _build_guard = self.build_preconf_lock.lock().await;
 
         // Guard against building on a genuinely syncing node, but tolerate the false-
         // positive that taiko-geth emits on genesis chains (currentBlock == highestBlock
@@ -106,7 +100,10 @@ impl WhitelistApi for WhitelistApiService {
             self.driver_payload_from_request(&data, is_forced_inclusion, prev_randao, [0u8; 65])?;
         let submission_outcome = self
             .event_syncer
-            .submit_preconfirmation_payload(PreconfPayload::new(driver_payload, data.parent_hash))
+            .submit_canonical_preconfirmation_payload(PreconfPayload::new(
+                driver_payload,
+                data.parent_hash,
+            ))
             .await?;
         let bound_block_hash = match submission_outcome {
             PreconfSubmissionOutcome::Inserted { block_hash } |
@@ -122,26 +119,36 @@ impl WhitelistApi for WhitelistApiService {
         // Resolve the block by the hash bound to the submission outcome: a same-height sibling
         // can become canonical between submission and this read, and a height lookup would then
         // sign a hash that does not match the request's transactions.
-        let inserted_block = self
-            .rpc
-            .l2_provider
-            .get_block_by_hash(bound_block_hash)
-            .await
-            .map_err(WhitelistPreconfirmationDriverError::provider)?
-            .ok_or(WhitelistPreconfirmationDriverError::MissingInsertedBlock(data.block_number))?;
+        let inserted_block = retry_post_insert_step(
+            data.block_number,
+            "read_and_validate_inserted_block",
+            || async {
+                let inserted_block = self
+                    .rpc
+                    .l2_provider
+                    .get_block_by_hash(bound_block_hash)
+                    .await
+                    .map_err(WhitelistPreconfirmationDriverError::provider)?
+                    .ok_or(WhitelistPreconfirmationDriverError::MissingInsertedBlock(
+                        data.block_number,
+                    ))?;
 
-        if inserted_block.header.parent_hash != data.parent_hash {
-            return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                "inserted block parent hash mismatch at block {}: expected {}, got {}",
-                data.block_number, data.parent_hash, inserted_block.header.parent_hash
-            )));
-        }
-        if inserted_block.header.number != data.block_number {
-            return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
-                "inserted block number mismatch: expected {}, got {}",
-                data.block_number, inserted_block.header.number
-            )));
-        }
+                if inserted_block.header.parent_hash != data.parent_hash {
+                    return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
+                        "inserted block parent hash mismatch at block {}: expected {}, got {}",
+                        data.block_number, data.parent_hash, inserted_block.header.parent_hash
+                    )));
+                }
+                if inserted_block.header.number != data.block_number {
+                    return Err(WhitelistPreconfirmationDriverError::InvalidPayload(format!(
+                        "inserted block number mismatch: expected {}, got {}",
+                        data.block_number, inserted_block.header.number
+                    )));
+                }
+                Ok(inserted_block)
+            },
+        )
+        .await;
 
         let block_hash = inserted_block.header.hash;
         let block_number = inserted_block.header.number;
@@ -149,16 +156,22 @@ impl WhitelistApi for WhitelistApiService {
         let base_fee_per_gas =
             inserted_block.header.base_fee_per_gas.unwrap_or(data.base_fee_per_gas);
         let block_hash_signature =
-            self.sign_digest(block_signing_hash(self.chain_id, block_hash.as_slice()))?;
+            retry_post_insert_step(block_number, "sign_inserted_block", || async {
+                self.sign_digest(block_signing_hash(self.chain_id, block_hash.as_slice()))
+            })
+            .await;
 
         // Persist per-block signature before gossip so RPC readers can immediately resolve
         // canonical origin signatures for the inserted block.
-        self.rpc
-            .set_l1_origin_signature(
-                U256::from(block_number),
-                FixedBytes::<65>::from(block_hash_signature),
-            )
-            .await?;
+        retry_post_insert_step(block_number, "persist_l1_origin_signature", || async {
+            self.rpc
+                .set_l1_origin_signature(
+                    U256::from(block_number),
+                    FixedBytes::<65>::from(block_hash_signature),
+                )
+                .await
+        })
+        .await;
         self.state.record_inserted_block(block_number);
 
         let execution_payload = crate::payload::execution_payload_from_header(
@@ -228,6 +241,28 @@ impl WhitelistApi for WhitelistApiService {
         );
 
         Ok(BuildPreconfBlockResponse { block_header })
+    }
+}
+
+#[async_trait]
+impl WhitelistApi for WhitelistApiService {
+    /// Build, sign, publish, and return a preconfirmation block.
+    async fn build_preconf_block(
+        &self,
+        request: BuildPreconfBlockRequest,
+    ) -> Result<BuildPreconfBlockResponse> {
+        // Record receipt before any validation so even rejected requests
+        // mark this pod as the active preconfer for shutdown purposes.
+        self.mark_preconf_request_received().await;
+
+        let service = self.clone();
+        run_serialized_drop_resistant_build(
+            Arc::clone(&self.build_preconf_lock),
+            move |build_guard| async move {
+                service.build_preconf_block_inner(request, build_guard).await
+            },
+        )
+        .await
     }
 
     /// Return runtime status for the whitelist preconfirmation driver.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -1,6 +1,8 @@
 //! Whitelist preconfirmation API service implementation.
 
 use std::{
+    fmt::Display,
+    future::Future,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -15,8 +17,11 @@ use async_trait::async_trait;
 use driver::{PreconfPayload, PreconfSubmissionOutcome, sync::event::EventSyncer};
 use protocol::{shasta::calculate_shasta_mix_hash, signer::FixedKSigner};
 use rpc::{beacon::BeaconClient, client::Client};
-use tokio::sync::{Mutex, broadcast, mpsc};
-use tracing::{debug, warn};
+use tokio::{
+    sync::{Mutex, OwnedMutexGuard, broadcast, mpsc, oneshot},
+    time::sleep,
+};
+use tracing::{debug, error, warn};
 
 use crate::{
     api::{
@@ -72,6 +77,7 @@ fn can_shutdown_for(last_preconf_request: Option<Instant>) -> bool {
 }
 
 /// Implements whitelist preconfirmation API business logic.
+#[derive(Clone)]
 pub(crate) struct WhitelistApiService {
     /// Event syncer for L1 origin lookups.
     event_syncer: Arc<EventSyncer>,
@@ -86,7 +92,7 @@ pub(crate) struct WhitelistApiService {
     /// Channel to publish messages to the P2P network.
     network_command_tx: mpsc::Sender<NetworkCommand>,
     /// Serializes build requests to avoid concurrent insertion/signing races.
-    build_preconf_lock: Mutex<()>,
+    build_preconf_lock: Arc<Mutex<()>>,
     /// Lock-free shared set of whitelisted sequencer addresses; used to refuse
     /// build requests when this node's own P2P signer has been deregistered on-chain.
     operator_set: SharedOperatorSet,
@@ -97,7 +103,7 @@ pub(crate) struct WhitelistApiService {
     /// Wall-clock instant of the most recent `build_preconf_block` invocation,
     /// regardless of the request's outcome. `None` until the first request
     /// arrives. Read by `/status` to compute `can_shutdown`.
-    last_preconf_request_at: Mutex<Option<Instant>>,
+    last_preconf_request_at: Arc<Mutex<Option<Instant>>>,
 }
 
 /// Dependency bundle for constructing `WhitelistApiService`.
@@ -145,8 +151,8 @@ impl WhitelistApiService {
             state,
             eos_notification_tx,
             network_command_tx,
-            build_preconf_lock: Mutex::new(()),
-            last_preconf_request_at: Mutex::new(None),
+            build_preconf_lock: Arc::new(Mutex::new(())),
+            last_preconf_request_at: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -158,8 +164,95 @@ impl WhitelistApiService {
     }
 
     /// Returns `true` when no `build_preconf_block` request has been received
-    /// within the last `SHUTDOWN_BLOCK_WINDOW`.
+    /// within the last `SHUTDOWN_BLOCK_WINDOW` and no serialized build is active.
     pub(super) async fn compute_can_shutdown(&self) -> bool {
-        can_shutdown_for(*self.last_preconf_request_at.lock().await)
+        can_shutdown_for(*self.last_preconf_request_at.lock().await) &&
+            self.build_preconf_lock.try_lock().is_ok()
+    }
+}
+
+/// Run a local build workflow in a service-owned task that survives requester cancellation.
+///
+/// The detached task owns the entire build, signature persistence, cache, and gossip sequence.
+/// Dropping the caller only closes the response channel; it cannot leave an engine-inserted block
+/// without the metadata and envelope needed for peer recovery.
+async fn run_drop_resistant_build<T>(
+    build: impl Future<Output = Result<T>> + Send + 'static,
+) -> Result<T>
+where
+    T: Send + 'static,
+{
+    let (result_tx, result_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let result = build.await;
+        if let Err(orphaned_result) = result_tx.send(result) {
+            match orphaned_result {
+                Ok(_) => debug!("local preconfirmation build completed after requester dropped"),
+                Err(err) => error!(
+                    error = %err,
+                    "local preconfirmation build failed after requester dropped"
+                ),
+            }
+        }
+    });
+
+    result_rx.await.map_err(|_| {
+        WhitelistPreconfirmationDriverError::NodeTaskFailed(
+            "local preconfirmation build task exited without a result".to_string(),
+        )
+    })?
+}
+
+/// Wait for the shared build lock while caller cancellation is still allowed, then detach.
+///
+/// A requester dropped while waiting for the lock never creates a background build. Once the
+/// owned guard is acquired, the complete workflow becomes drop-resistant and retains the guard
+/// until it reaches a terminal result.
+async fn run_serialized_drop_resistant_build<T, F, Fut>(
+    build_lock: Arc<Mutex<()>>,
+    build: F,
+) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce(OwnedMutexGuard<()>) -> Fut + Send,
+    Fut: Future<Output = Result<T>> + Send + 'static,
+{
+    let build_guard = build_lock.lock_owned().await;
+    run_drop_resistant_build(build(build_guard)).await
+}
+
+/// Retry one post-insertion finalization step until local recovery metadata is durable.
+///
+/// Once the engine has accepted a block, returning a transient error would strand a canonical
+/// block without the signature/cache state peers need to recover it. Retrying under the serialized
+/// build guard fails closed: no same-height retry can race the unfinished finalization.
+async fn retry_post_insert_step<T, E, F, Fut>(
+    block_number: u64,
+    step: &'static str,
+    mut operation: F,
+) -> T
+where
+    E: Display,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = std::result::Result<T, E>>,
+{
+    const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+    let mut retry_delay = Duration::from_secs(1);
+    loop {
+        match operation().await {
+            Ok(value) => return value,
+            Err(err) => {
+                error!(
+                    block_number,
+                    step,
+                    error = %err,
+                    retry_delay_ms = retry_delay.as_millis() as u64,
+                    "post-insertion preconfirmation finalization failed; retrying"
+                );
+                sleep(retry_delay).await;
+                retry_delay = retry_delay.saturating_mul(2).min(MAX_RETRY_DELAY);
+            }
+        }
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -14,11 +14,14 @@ use alloy_provider::Provider;
 use alloy_rpc_types::SyncStatus;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
 use async_trait::async_trait;
-use driver::{PreconfPayload, PreconfSubmissionOutcome, sync::event::EventSyncer};
+use driver::{
+    PreconfPayload, PreconfSubmissionOutcome,
+    sync::event::{CanonicalPreconfSubmission, EventSyncer},
+};
 use protocol::{shasta::calculate_shasta_mix_hash, signer::FixedKSigner};
 use rpc::{beacon::BeaconClient, client::Client};
 use tokio::{
-    sync::{Mutex, OwnedMutexGuard, broadcast, mpsc, oneshot},
+    sync::{Mutex, broadcast, mpsc, oneshot},
     time::sleep,
 };
 use tracing::{debug, error, warn};
@@ -91,6 +94,8 @@ pub(crate) struct WhitelistApiService {
     beacon_client: Arc<BeaconClient>,
     /// Channel to publish messages to the P2P network.
     network_command_tx: mpsc::Sender<NetworkCommand>,
+    /// Notifies the runner when an inserted block cannot be finalized safely.
+    fatal_build_tx: mpsc::UnboundedSender<String>,
     /// Serializes build requests to avoid concurrent insertion/signing races.
     build_preconf_lock: Arc<Mutex<()>>,
     /// Lock-free shared set of whitelisted sequencer addresses; used to refuse
@@ -124,6 +129,8 @@ pub(crate) struct WhitelistApiServiceParams {
     pub(crate) state: SharedPreconfState,
     /// Network command sender for gossip publishing.
     pub(crate) network_command_tx: mpsc::Sender<NetworkCommand>,
+    /// Runner notification channel for fail-closed local build failures.
+    pub(crate) fatal_build_tx: mpsc::UnboundedSender<String>,
 }
 
 impl WhitelistApiService {
@@ -138,6 +145,7 @@ impl WhitelistApiService {
             operator_set,
             state,
             network_command_tx,
+            fatal_build_tx,
         }: WhitelistApiServiceParams,
     ) -> Self {
         let (eos_notification_tx, _) = broadcast::channel(EOS_NOTIFICATION_CHANNEL_CAPACITY);
@@ -151,6 +159,7 @@ impl WhitelistApiService {
             state,
             eos_notification_tx,
             network_command_tx,
+            fatal_build_tx,
             build_preconf_lock: Arc::new(Mutex::new(())),
             last_preconf_request_at: Arc::new(Mutex::new(None)),
         }
@@ -168,6 +177,18 @@ impl WhitelistApiService {
     pub(super) async fn compute_can_shutdown(&self) -> bool {
         can_shutdown_for(*self.last_preconf_request_at.lock().await) &&
             self.build_preconf_lock.try_lock().is_ok()
+    }
+
+    /// Wait until every serialized local build accepted before shutdown has finished.
+    pub(crate) async fn wait_for_active_build(&self) {
+        wait_for_serialized_build(Arc::clone(&self.build_preconf_lock)).await;
+    }
+
+    /// Ask the runner to restart after halting production on an unsafe finalization failure.
+    fn report_fatal_build_failure(&self, reason: String) {
+        if self.fatal_build_tx.send(reason.clone()).is_err() {
+            error!(%reason, "failed to notify runner about fatal local build failure");
+        }
     }
 }
 
@@ -214,14 +235,24 @@ async fn run_serialized_drop_resistant_build<T, F, Fut>(
 ) -> Result<T>
 where
     T: Send + 'static,
-    F: FnOnce(OwnedMutexGuard<()>) -> Fut + Send,
+    F: FnOnce() -> Fut + Send + 'static,
     Fut: Future<Output = Result<T>> + Send + 'static,
 {
     let build_guard = build_lock.lock_owned().await;
-    run_drop_resistant_build(build(build_guard)).await
+    run_drop_resistant_build(async move {
+        let result = build().await;
+        drop(build_guard);
+        result
+    })
+    .await
 }
 
-/// Retry one post-insertion finalization step until local recovery metadata is durable.
+/// Join the serialized build lane without cancelling a detached in-flight finalization task.
+async fn wait_for_serialized_build(build_lock: Arc<Mutex<()>>) {
+    drop(build_lock.lock_owned().await);
+}
+
+/// Retry one post-insertion finalization step for a bounded recovery window.
 ///
 /// Once the engine has accepted a block, returning a transient error would strand a canonical
 /// block without the signature/cache state peers need to recover it. Retrying under the serialized
@@ -229,30 +260,66 @@ where
 async fn retry_post_insert_step<T, E, F, Fut>(
     block_number: u64,
     step: &'static str,
-    mut operation: F,
-) -> T
+    operation: F,
+) -> std::result::Result<T, E>
 where
     E: Display,
     F: FnMut() -> Fut,
     Fut: Future<Output = std::result::Result<T, E>>,
 {
-    const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+    retry_post_insert_step_with_backoff(
+        block_number,
+        step,
+        Duration::from_secs(1),
+        Duration::from_secs(30),
+        6,
+        operation,
+    )
+    .await
+}
 
-    let mut retry_delay = Duration::from_secs(1);
-    loop {
+/// Retry a post-insertion step using caller-provided exponential-backoff bounds.
+async fn retry_post_insert_step_with_backoff<T, E, F, Fut>(
+    block_number: u64,
+    step: &'static str,
+    initial_retry_delay: Duration,
+    max_retry_delay: Duration,
+    max_attempts: usize,
+    mut operation: F,
+) -> std::result::Result<T, E>
+where
+    E: Display,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = std::result::Result<T, E>>,
+{
+    let mut retry_delay = initial_retry_delay;
+    assert!(max_attempts > 0, "post-insert retry requires at least one attempt");
+    for attempt in 1..=max_attempts {
         match operation().await {
-            Ok(value) => return value,
+            Ok(value) => return Ok(value),
             Err(err) => {
+                if attempt == max_attempts {
+                    error!(
+                        block_number,
+                        step,
+                        error = %err,
+                        attempt,
+                        "post-insertion preconfirmation finalization exhausted retries"
+                    );
+                    return Err(err)
+                }
                 error!(
                     block_number,
                     step,
                     error = %err,
+                    attempt,
                     retry_delay_ms = retry_delay.as_millis() as u64,
                     "post-insertion preconfirmation finalization failed; retrying"
                 );
                 sleep(retry_delay).await;
-                retry_delay = retry_delay.saturating_mul(2).min(MAX_RETRY_DELAY);
+                retry_delay = retry_delay.saturating_mul(2).min(max_retry_delay);
             }
         }
     }
+    unreachable!("positive retry attempt count must return from loop")
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -11,8 +11,8 @@ use flate2::{Compression, write::ZlibEncoder};
 
 use crate::{
     api::service::{
-        SHUTDOWN_BLOCK_WINDOW, can_shutdown_for, retry_post_insert_step,
-        run_serialized_drop_resistant_build,
+        SHUTDOWN_BLOCK_WINDOW, can_shutdown_for, retry_post_insert_step_with_backoff,
+        run_serialized_drop_resistant_build, wait_for_serialized_build,
     },
     cache::SharedPreconfState,
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, decompress_tx_list},
@@ -30,8 +30,8 @@ async fn drop_resistant_build_continues_after_requester_is_aborted() {
     let build_release = Arc::clone(&release);
     let build_completed = Arc::clone(&completed);
     let requester = tokio::spawn(run_serialized_drop_resistant_build(
-        build_lock,
-        move |_build_guard| async move {
+        Arc::clone(&build_lock),
+        move || async move {
             build_entered.add_permits(1);
             build_release.acquire().await.expect("release semaphore should remain open").forget();
             build_completed.add_permits(1);
@@ -43,12 +43,19 @@ async fn drop_resistant_build_continues_after_requester_is_aborted() {
     requester.abort();
     assert!(requester.await.expect_err("requester task should be cancelled").is_cancelled());
 
+    let mut drain = Box::pin(wait_for_serialized_build(Arc::clone(&build_lock)));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(10), &mut drain).await.is_err(),
+        "shutdown drain must wait for detached finalization"
+    );
+
     release.add_permits(1);
     tokio::time::timeout(Duration::from_secs(1), completed.acquire())
         .await
         .expect("detached build should finish after requester cancellation")
         .expect("completion semaphore should remain open")
         .forget();
+    drain.await;
 }
 
 #[tokio::test]
@@ -56,46 +63,89 @@ async fn build_waiting_for_serialization_lock_is_cancelled_with_requester() {
     let build_lock = Arc::new(tokio::sync::Mutex::new(()));
     let held_guard = Arc::clone(&build_lock).lock_owned().await;
     let started = Arc::new(AtomicBool::new(false));
+    let waiting = Arc::new(tokio::sync::Semaphore::new(0));
     let build_started = Arc::clone(&started);
+    let requester_waiting = Arc::clone(&waiting);
+    let requester_lock = Arc::clone(&build_lock);
 
-    let requester = tokio::spawn(run_serialized_drop_resistant_build(
-        build_lock,
-        move |_build_guard| async move {
+    let requester = tokio::spawn(async move {
+        requester_waiting.add_permits(1);
+        run_serialized_drop_resistant_build(requester_lock, move || async move {
             build_started.store(true, Ordering::Release);
             Ok::<_, WhitelistPreconfirmationDriverError>(())
-        },
-    ));
-    tokio::task::yield_now().await;
+        })
+        .await
+    });
+    waiting.acquire().await.expect("waiter semaphore should remain open").forget();
     requester.abort();
     assert!(requester.await.expect_err("requester task should be cancelled").is_cancelled());
 
     drop(held_guard);
-    tokio::task::yield_now().await;
+    drop(build_lock.lock().await);
     assert!(!started.load(Ordering::Acquire), "cancelled lock waiter must not detach a build");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn post_insert_finalization_retries_transient_failures() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let operation_attempts = Arc::clone(&attempts);
-    let finalization = tokio::spawn(retry_post_insert_step(42, "test_step", move || {
-        let operation_attempts = Arc::clone(&operation_attempts);
-        async move {
-            let attempt = operation_attempts.fetch_add(1, Ordering::AcqRel);
-            if attempt < 2 { Err("transient failure") } else { Ok(0x2au64) }
-        }
-    }));
+    let finalization = tokio::spawn(retry_post_insert_step_with_backoff(
+        42,
+        "test_step",
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+        4,
+        move || {
+            let operation_attempts = Arc::clone(&operation_attempts);
+            async move {
+                let attempt = operation_attempts.fetch_add(1, Ordering::AcqRel);
+                if attempt < 3 { Err("transient failure") } else { Ok(0x2au64) }
+            }
+        },
+    ));
 
     tokio::task::yield_now().await;
     assert_eq!(attempts.load(Ordering::Acquire), 1);
 
-    assert_eq!(
-        tokio::time::timeout(Duration::from_secs(4), finalization)
-            .await
-            .expect("retry task should finish after two transient failures")
-            .expect("retry task should not panic"),
-        0x2a
-    );
+    tokio::time::advance(Duration::from_millis(999)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(attempts.load(Ordering::Acquire), 1);
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(attempts.load(Ordering::Acquire), 2);
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(attempts.load(Ordering::Acquire), 3);
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+
+    assert_eq!(finalization.await.expect("retry task should not panic"), Ok(0x2a));
+    assert_eq!(attempts.load(Ordering::Acquire), 4);
+}
+
+#[tokio::test(start_paused = true)]
+async fn post_insert_finalization_stops_after_retry_budget() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let operation_attempts = Arc::clone(&attempts);
+    let finalization = tokio::spawn(retry_post_insert_step_with_backoff(
+        42,
+        "test_step",
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+        3,
+        move || {
+            let operation_attempts = Arc::clone(&operation_attempts);
+            async move {
+                operation_attempts.fetch_add(1, Ordering::AcqRel);
+                Err::<(), _>("permanent failure")
+            }
+        },
+    ));
+
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(3)).await;
+    assert_eq!(finalization.await.expect("retry task should not panic"), Err("permanent failure"));
     assert_eq!(attempts.load(Ordering::Acquire), 3);
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -1,16 +1,103 @@
 use std::{
     io::Write,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
     time::{Duration, Instant},
 };
 
 use flate2::{Compression, write::ZlibEncoder};
 
 use crate::{
-    api::service::{SHUTDOWN_BLOCK_WINDOW, can_shutdown_for},
+    api::service::{
+        SHUTDOWN_BLOCK_WINDOW, can_shutdown_for, retry_post_insert_step,
+        run_serialized_drop_resistant_build,
+    },
     cache::SharedPreconfState,
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, decompress_tx_list},
     error::WhitelistPreconfirmationDriverError,
 };
+
+#[tokio::test]
+async fn drop_resistant_build_continues_after_requester_is_aborted() {
+    let build_lock = Arc::new(tokio::sync::Mutex::new(()));
+    let entered = Arc::new(tokio::sync::Semaphore::new(0));
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let completed = Arc::new(tokio::sync::Semaphore::new(0));
+
+    let build_entered = Arc::clone(&entered);
+    let build_release = Arc::clone(&release);
+    let build_completed = Arc::clone(&completed);
+    let requester = tokio::spawn(run_serialized_drop_resistant_build(
+        build_lock,
+        move |_build_guard| async move {
+            build_entered.add_permits(1);
+            build_release.acquire().await.expect("release semaphore should remain open").forget();
+            build_completed.add_permits(1);
+            Ok::<_, WhitelistPreconfirmationDriverError>(())
+        },
+    ));
+
+    entered.acquire().await.expect("entry semaphore should remain open").forget();
+    requester.abort();
+    assert!(requester.await.expect_err("requester task should be cancelled").is_cancelled());
+
+    release.add_permits(1);
+    tokio::time::timeout(Duration::from_secs(1), completed.acquire())
+        .await
+        .expect("detached build should finish after requester cancellation")
+        .expect("completion semaphore should remain open")
+        .forget();
+}
+
+#[tokio::test]
+async fn build_waiting_for_serialization_lock_is_cancelled_with_requester() {
+    let build_lock = Arc::new(tokio::sync::Mutex::new(()));
+    let held_guard = Arc::clone(&build_lock).lock_owned().await;
+    let started = Arc::new(AtomicBool::new(false));
+    let build_started = Arc::clone(&started);
+
+    let requester = tokio::spawn(run_serialized_drop_resistant_build(
+        build_lock,
+        move |_build_guard| async move {
+            build_started.store(true, Ordering::Release);
+            Ok::<_, WhitelistPreconfirmationDriverError>(())
+        },
+    ));
+    tokio::task::yield_now().await;
+    requester.abort();
+    assert!(requester.await.expect_err("requester task should be cancelled").is_cancelled());
+
+    drop(held_guard);
+    tokio::task::yield_now().await;
+    assert!(!started.load(Ordering::Acquire), "cancelled lock waiter must not detach a build");
+}
+
+#[tokio::test]
+async fn post_insert_finalization_retries_transient_failures() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let operation_attempts = Arc::clone(&attempts);
+    let finalization = tokio::spawn(retry_post_insert_step(42, "test_step", move || {
+        let operation_attempts = Arc::clone(&operation_attempts);
+        async move {
+            let attempt = operation_attempts.fetch_add(1, Ordering::AcqRel);
+            if attempt < 2 { Err("transient failure") } else { Ok(0x2au64) }
+        }
+    }));
+
+    tokio::task::yield_now().await;
+    assert_eq!(attempts.load(Ordering::Acquire), 1);
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(4), finalization)
+            .await
+            .expect("retry task should finish after two transient failures")
+            .expect("retry task should not panic"),
+        0x2a
+    );
+    assert_eq!(attempts.load(Ordering::Acquire), 3);
+}
 
 fn compress(payload: &[u8]) -> Vec<u8> {
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -11,7 +11,7 @@ use driver::{
 };
 use protocol::signer::FixedKSigner;
 use rpc::beacon::BeaconClient;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     Result,
@@ -114,9 +114,11 @@ impl WhitelistPreconfirmationDriverRunner {
             .header
             .number;
         let state = SharedPreconfState::new(initial_l2_head);
+        let (fatal_build_tx, mut fatal_build_rx) = tokio::sync::mpsc::unbounded_channel();
 
         // Optionally start the REST/WS server when both rpc_listen_addr and p2p_signer_key
         // are configured.
+        let mut api_service = None;
         let mut rest_ws_server = if let (Some(listen_addr), Some(signer_key)) =
             (self.config.rpc_listen_addr, &self.config.p2p_signer_key)
         {
@@ -134,6 +136,7 @@ impl WhitelistPreconfirmationDriverRunner {
                 operator_set: operator_set.clone(),
                 state: state.clone(),
                 network_command_tx: network.command_tx.clone(),
+                fatal_build_tx,
             }));
             let server_config = WhitelistApiServerConfig {
                 listen_addr,
@@ -141,6 +144,7 @@ impl WhitelistPreconfirmationDriverRunner {
                 cors_origins: self.config.rpc_cors_origins.clone(),
             };
             let server = WhitelistApiServer::start(server_config, handler.clone()).await?;
+            api_service = Some(handler);
             info!(
                 addr = %server.local_addr(),
                 http_url = %server.http_url(),
@@ -174,7 +178,11 @@ impl WhitelistPreconfirmationDriverRunner {
         loop {
             tokio::select! {
                 result = &mut node_handle => {
-                    stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                    stop_sidecars(
+                        event_syncer_handle,
+                        &mut rest_ws_server,
+                        api_service.as_deref(),
+                    ).await;
                     return match result {
                         Ok(Ok(())) => Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
                             "whitelist preconfirmation network exited unexpectedly".to_string(),
@@ -186,14 +194,33 @@ impl WhitelistPreconfirmationDriverRunner {
                     };
                 }
                 result = &mut event_syncer_handle => {
+                    stop_sidecars(
+                        event_syncer_handle,
+                        &mut rest_ws_server,
+                        api_service.as_deref(),
+                    ).await;
                     let _ = command_tx.send(NetworkCommand::Shutdown).await;
                     node_handle.abort();
-                    stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
                     return map_event_syncer_exit(result).map_err(Into::into);
+                }
+                Some(reason) = fatal_build_rx.recv() => {
+                    error!(%reason, "fatal local preconfirmation finalization failure");
+                    stop_sidecars(
+                        event_syncer_handle,
+                        &mut rest_ws_server,
+                        api_service.as_deref(),
+                    ).await;
+                    let _ = command_tx.send(NetworkCommand::Shutdown).await;
+                    node_handle.abort();
+                    return Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(reason));
                 }
                 maybe_event = event_rx.recv() => {
                     let Some(event) = maybe_event else {
-                        stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
+                        stop_sidecars(
+                            event_syncer_handle,
+                            &mut rest_ws_server,
+                            api_service.as_deref(),
+                        ).await;
                         return Err(WhitelistPreconfirmationDriverError::NodeTaskFailed(
                             "whitelist preconfirmation event channel closed".to_string(),
                         ));
@@ -219,13 +246,17 @@ impl WhitelistPreconfirmationDriverRunner {
     }
 }
 
-/// Abort sidecar tasks and stop the REST server during shutdown.
+/// Stop accepting API requests, drain accepted builds, then abort event-sync sidecars.
 async fn stop_sidecars<T>(
     event_syncer_handle: &mut tokio::task::JoinHandle<T>,
     rest_ws_server: &mut Option<WhitelistApiServer>,
+    api_service: Option<&WhitelistApiService>,
 ) {
-    event_syncer_handle.abort();
     if let Some(server) = rest_ws_server.take() {
         server.stop().await;
     }
+    if let Some(service) = api_service {
+        service.wait_for_active_build().await;
+    }
+    event_syncer_handle.abort();
 }


### PR DESCRIPTION
## Summary

- abandon queued preconfirmation jobs when their response deadline expires, while waiting for already-processing engine work to reach a terminal result
- run the local block-building workflow in a service-owned task so client disconnects cannot cancel an accepted build
- reject same-height canonical conflicts from the local builder with HTTP 409 while preserving the branch-capable importer path
- retain the production-router lease through hash-bound block validation and signature persistence
- reconcile engine calls that may have materialized a block despite an RPC error; if reconciliation or bounded finalization retries fail, halt production and restart the runner instead of releasing an unsafe block-production lane

## Root cause

A preconfirmation response timeout only dropped the oneshot receiver; it did not remove or invalidate the queued job. If the local builder retried the same height with a new timestamp while event processing was delayed, both jobs could later reach the engine. The exact-materialization check did not match the changed payload, and the branch-capable path allowed the retry to inject a sibling block, producing a depth-1 reorg.

The post-insert workflow also remained tied to the HTTP request lifetime. In addition, signature persistence was keyed by height after the production-router lock was released, allowing a same-height sibling to become canonical before the signature write. An engine promotion whose response was lost could also leave a materialized block outside the normal signing path.

## Self-review follow-ups

- skip abandoned jobs before and after waiting for the production router
- bind local-builder finalization to the exact returned block hash and retain the router lease until its signature is persisted
- recover exact materialization after uncertain engine responses while still serialized
- bound transient post-insert retries; deterministic or exhausted failures halt the router and notify the runner to restart fail-closed
- drain detached accepted builds before event-sync shutdown
- strengthen cancellation, shutdown-drain, backoff, reconciliation, and halted-router tests

## Correctness

The change keeps the stale/confirmed boundary checks and importer branch semantics intact, preserving WLP-INV-003, WLP-INV-004, WLP-INV-009, and WLP-INV-010.

## Validation

- `just fmt`
- `just clippy-fix`
- `just clippy`
- `cargo test -p driver preconf -- --nocapture` — 27 passed
- `cargo test -p whitelist-preconfirmation-driver --lib` — 146 passed
- `just test` — 399 passed
- final self-review found no remaining actionable issues
