### PR TITLE
chore(taiko-client,taiko-client-rs): refuse shutdown ahead of imminent sequencing windows

### DIFF
--- a/packages/taiko-client-rs/crates/rpc/src/beacon.rs
+++ b/packages/taiko-client-rs/crates/rpc/src/beacon.rs
@@ -348,6 +348,19 @@ impl BeaconClient {
     pub const fn genesis_time(&self) -> u64 {
         self.genesis_time
     }
+
+    /// Return the number of slots per beacon epoch.
+    ///
+    /// Fetched from `/eth/v1/config/spec` (`SLOTS_PER_EPOCH`) during client construction.
+    pub const fn slots_per_epoch(&self) -> u64 {
+        self.slots_per_epoch
+    }
+
+    /// Return the current slot's index within its beacon epoch, based on local
+    /// wall-clock time.
+    pub fn current_slot_in_epoch(&self) -> u64 {
+        self.current_slot() % self.slots_per_epoch
+    }
 }
 
 impl BeaconBlockResponse {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -60,15 +60,37 @@ const SECONDS_PER_SLOT: u64 = 12;
 const SHUTDOWN_BLOCK_WINDOW: Duration =
     Duration::from_secs(HAND_OVER_WINDOW_SLOTS * SECONDS_PER_SLOT * 3 / 2);
 
-/// Pure helper deciding whether the pod is safe to shut down given the time
-/// of the most recent `build_preconf_block` invocation. Returns `true` when
-/// no invocation has been recorded or when the elapsed time meets or exceeds
-/// `SHUTDOWN_BLOCK_WINDOW`.
-fn can_shutdown_for(last_preconf_request: Option<Instant>) -> bool {
-    match last_preconf_request {
-        None => true,
-        Some(at) => at.elapsed() >= SHUTDOWN_BLOCK_WINDOW,
-    }
+/// Number of L1 slots ahead of the hand-over window during which shutdown is
+/// refused even without recent build requests. `can_shutdown_for` blocks from
+/// this margin before the hand-over boundary through the end of the epoch, so
+/// a restart triggered just before a hand-over cannot leave the upcoming
+/// preconfer without its driver while its window opens: replacing the pod
+/// (rescheduling plus execution-client and driver boot) takes ~30-60s, which
+/// the activity-based `SHUTDOWN_BLOCK_WINDOW` cannot see because it only
+/// looks backwards at requests already received.
+const SHUTDOWN_IMMINENCE_MARGIN_SLOTS: u64 = 8;
+
+/// Pure helper deciding whether the pod is safe to shut down.
+///
+/// Returns `false` (refuse shutdown) when either:
+/// - a `build_preconf_block` request was received within `SHUTDOWN_BLOCK_WINDOW`: the preconfer
+///   this driver serves is actively sequencing, or
+/// - `slot_in_epoch` is within `SHUTDOWN_IMMINENCE_MARGIN_SLOTS` of the hand-over boundary or past
+///   it: a preconfer taking over at the next hand-over would find its driver still booting. This
+///   driver has no lookahead, so the guard applies to every epoch tail regardless of which operator
+///   is due next.
+fn can_shutdown_for(
+    last_preconf_request: Option<Instant>,
+    slot_in_epoch: u64,
+    slots_per_epoch: u64,
+) -> bool {
+    let recently_active =
+        matches!(last_preconf_request, Some(at) if at.elapsed() < SHUTDOWN_BLOCK_WINDOW);
+
+    let handover_start = slots_per_epoch.saturating_sub(HAND_OVER_WINDOW_SLOTS);
+    let handover_imminent = slot_in_epoch + SHUTDOWN_IMMINENCE_MARGIN_SLOTS >= handover_start;
+
+    !recently_active && !handover_imminent
 }
 
 /// Implements whitelist preconfirmation API business logic.
@@ -158,8 +180,13 @@ impl WhitelistApiService {
     }
 
     /// Returns `true` when no `build_preconf_block` request has been received
-    /// within the last `SHUTDOWN_BLOCK_WINDOW`.
+    /// within the last `SHUTDOWN_BLOCK_WINDOW` and no hand-over boundary is
+    /// imminent (see `can_shutdown_for`).
     pub(super) async fn compute_can_shutdown(&self) -> bool {
-        can_shutdown_for(*self.last_preconf_request_at.lock().await)
+        can_shutdown_for(
+            *self.last_preconf_request_at.lock().await,
+            self.beacon_client.current_slot_in_epoch(),
+            self.beacon_client.slots_per_epoch(),
+        )
     }
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -6,11 +6,26 @@ use std::{
 use flate2::{Compression, write::ZlibEncoder};
 
 use crate::{
-    api::service::{SHUTDOWN_BLOCK_WINDOW, can_shutdown_for},
+    api::service::{
+        HAND_OVER_WINDOW_SLOTS, SHUTDOWN_BLOCK_WINDOW, SHUTDOWN_IMMINENCE_MARGIN_SLOTS,
+        can_shutdown_for,
+    },
     cache::SharedPreconfState,
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, decompress_tx_list},
     error::WhitelistPreconfirmationDriverError,
 };
+
+/// Mainnet slots-per-epoch used by the shutdown tests.
+const SLOTS_PER_EPOCH: u64 = 32;
+
+/// First slot of the epoch at which the imminence guard starts refusing
+/// shutdown: the hand-over boundary minus the imminence margin.
+const IMMINENCE_BAND_START: u64 =
+    SLOTS_PER_EPOCH - HAND_OVER_WINDOW_SLOTS - SHUTDOWN_IMMINENCE_MARGIN_SLOTS;
+
+/// A slot comfortably outside the imminence band, so activity-focused tests
+/// exercise only the request-recency rule.
+const MID_EPOCH_SLOT: u64 = 2;
 
 fn compress(payload: &[u8]) -> Vec<u8> {
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
@@ -52,12 +67,12 @@ fn decompress_tx_list_accepts_non_empty_payload_within_limits() {
 
 #[test]
 fn can_shutdown_returns_true_when_no_request_received() {
-    assert!(can_shutdown_for(None));
+    assert!(can_shutdown_for(None, MID_EPOCH_SLOT, SLOTS_PER_EPOCH));
 }
 
 #[test]
 fn can_shutdown_returns_false_for_request_just_now() {
-    assert!(!can_shutdown_for(Some(Instant::now())));
+    assert!(!can_shutdown_for(Some(Instant::now()), MID_EPOCH_SLOT, SLOTS_PER_EPOCH));
 }
 
 #[test]
@@ -65,7 +80,7 @@ fn can_shutdown_returns_true_after_full_window_has_elapsed() {
     let well_past = Instant::now()
         .checked_sub(SHUTDOWN_BLOCK_WINDOW + Duration::from_secs(1))
         .expect("test platform must support subtracting from Instant::now");
-    assert!(can_shutdown_for(Some(well_past)));
+    assert!(can_shutdown_for(Some(well_past), MID_EPOCH_SLOT, SLOTS_PER_EPOCH));
 }
 
 #[test]
@@ -73,7 +88,27 @@ fn can_shutdown_returns_false_just_before_window_boundary() {
     let almost = Instant::now()
         .checked_sub(SHUTDOWN_BLOCK_WINDOW - Duration::from_secs(1))
         .expect("test platform must support subtracting from Instant::now");
-    assert!(!can_shutdown_for(Some(almost)));
+    assert!(!can_shutdown_for(Some(almost), MID_EPOCH_SLOT, SLOTS_PER_EPOCH));
+}
+
+#[test]
+fn can_shutdown_allows_just_before_imminence_band() {
+    assert!(can_shutdown_for(None, IMMINENCE_BAND_START - 1, SLOTS_PER_EPOCH));
+}
+
+#[test]
+fn can_shutdown_blocks_at_imminence_band_start() {
+    assert!(!can_shutdown_for(None, IMMINENCE_BAND_START, SLOTS_PER_EPOCH));
+}
+
+#[test]
+fn can_shutdown_blocks_through_epoch_tail() {
+    assert!(!can_shutdown_for(None, SLOTS_PER_EPOCH - 1, SLOTS_PER_EPOCH));
+}
+
+#[test]
+fn can_shutdown_allows_at_epoch_start() {
+    assert!(can_shutdown_for(None, 0, SLOTS_PER_EPOCH));
 }
 
 #[test]

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -49,6 +49,16 @@ const requestSyncMargin = uint64(128) // Margin for requesting sync, to avoid re
 // monitorLatestProposalOnChainInterval defines how often we reconcile the cached proposal with on-chain state.
 const monitorLatestProposalOnChainInterval = 10 * time.Second
 
+// shutdownImminenceMarginSlots is the number of upcoming L1 slots CanShutdown
+// treats as already in-window: shutdown is refused not only while the current
+// slot is inside one of this operator's sequencing ranges, but also when a
+// range starts within this many slots. The margin must cover replacing the
+// pod (rescheduling plus execution-client and driver boot, observed 30-60s)
+// and the preconfer client's own reconnect time, so a restart triggered just
+// before a hand-over cannot leave the operator unable to sequence when its
+// window opens. Eight 12s slots ≈ 96s.
+const shutdownImminenceMarginSlots = uint64(8)
+
 // preconfBlockChainSyncer is an interface for preconfirmation block chain syncer.
 type preconfBlockChainSyncer interface {
 	InsertPreconfBlocksFromEnvelopes(context.Context, []*preconf.Envelope, bool) ([]*types.Header, error)
@@ -1079,17 +1089,22 @@ func (s *PreconfBlockAPIServer) CanShutdown(globalSlot uint64) bool {
 
 // canShutdownLocked is the lock-held variant of CanShutdown for callers that
 // already hold s.lookaheadMutex.
+//
+// A range blocks shutdown from shutdownImminenceMarginSlots before its start
+// until its end: a SIGTERM landing just before a sequencing window would
+// otherwise take the driver down for the pod-replacement time and leave the
+// operator dark when the window opens.
 func (s *PreconfBlockAPIServer) canShutdownLocked(globalSlot uint64) bool {
 	if s.lookahead == nil || s.rpc.L1Beacon == nil {
 		return true
 	}
 	for _, r := range s.lookahead.CurrRanges {
-		if globalSlot >= r.Start && globalSlot < r.End {
+		if globalSlot+shutdownImminenceMarginSlots >= r.Start && globalSlot < r.End {
 			return false
 		}
 	}
 	for _, r := range s.lookahead.NextRanges {
-		if globalSlot >= r.Start && globalSlot < r.End {
+		if globalSlot+shutdownImminenceMarginSlots >= r.Start && globalSlot < r.End {
 			return false
 		}
 	}

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -101,11 +101,20 @@ func (s *PreconfBlockAPIServerTestSuite) TestCanShutdown() {
 		NextRanges:   []SlotRange{{Start: 24, End: 32}},
 		UpdatedAt:    time.Now().UTC(),
 	}
+	// Ranges entirely in the future, to exercise the imminence margin.
+	laFuture := &Lookahead{
+		CurrOperator: curr,
+		NextOperator: next,
+		CurrRanges:   []SlotRange{{Start: 100, End: 124}},
+		NextRanges:   []SlotRange{{Start: 200, End: 208}},
+		UpdatedAt:    time.Now().UTC(),
+	}
 
 	tests := []struct {
 		name         string
 		setLookahead bool
 		setBeacon    bool
+		lookahead    *Lookahead
 		globalSlot   uint64
 		want         bool
 	}{
@@ -123,12 +132,43 @@ func (s *PreconfBlockAPIServerTestSuite) TestCanShutdown() {
 			setLookahead: true, setBeacon: true, globalSlot: 31, want: false,
 		},
 		{name: "slot outside both ranges → safe", setLookahead: true, setBeacon: true, globalSlot: 50, want: true},
+		{
+			name:         "curr range starts beyond margin → safe",
+			setLookahead: true, setBeacon: true, lookahead: laFuture,
+			globalSlot: 100 - shutdownImminenceMarginSlots - 1, want: true,
+		},
+		{
+			name:         "curr range starts exactly at margin → unsafe",
+			setLookahead: true, setBeacon: true, lookahead: laFuture,
+			globalSlot: 100 - shutdownImminenceMarginSlots, want: false,
+		},
+		{
+			name:         "slot just before curr range start → unsafe",
+			setLookahead: true, setBeacon: true, lookahead: laFuture, globalSlot: 99, want: false,
+		},
+		{
+			name:         "next range starts exactly at margin → unsafe",
+			setLookahead: true, setBeacon: true, lookahead: laFuture,
+			globalSlot: 200 - shutdownImminenceMarginSlots, want: false,
+		},
+		{
+			name:         "between ranges, both beyond margin → safe",
+			setLookahead: true, setBeacon: true, lookahead: laFuture, globalSlot: 150, want: true,
+		},
+		{
+			name:         "past all ranges → safe",
+			setLookahead: true, setBeacon: true, lookahead: laFuture, globalSlot: 208, want: true,
+		},
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			if tt.setLookahead {
-				s.s.lookahead = la
+				if tt.lookahead != nil {
+					s.s.lookahead = tt.lookahead
+				} else {
+					s.s.lookahead = la
+				}
 			} else {
 				s.s.lookahead = nil
 			}


### PR DESCRIPTION
## Why

On 2026-07-31 the hoodi preconfer `0x75141CD0…` was ejected from the whitelist. Root cause chain:

1. GKE preempted `l2-node-nethermind-reth-0` (the sequencer's reth + driver pod) at 21:43:23 UTC — **61 seconds before** the operator's hand-over window.
2. The pod's preStop hook polled the driver's `/status`, got `"canShutdown": true` (the *current* slot was outside all sequencing ranges), and let SIGTERM through immediately.
3. Pod replacement took ~30s, the Catalyst preconfer's L2 WS connection died in the meantime, and the operator produced zero blocks in its window → the ejector removed it after 48s.

`canShutdown` is a point-in-time membership test. Its own doc comment already promises *"not the active **or imminent** preconfer"* — but the imminent half was never implemented, so any restart landing within ~1–2 slots of a window start strands the operator.

## What changed

**taiko-client (Go, whitelist lookahead driver)**
- `canShutdownLocked` now treats a range as blocking from `shutdownImminenceMarginSlots` (8 slots ≈ 96s) *before* its start until its end, covering pod rescheduling + EL/driver boot + preconfer reconnect.
- Extended `TestCanShutdown` with margin boundary cases (runs in CI's devnet suite).

**taiko-client-rs (Rust, whitelist preconfirmation driver)**
- This driver has no lookahead — `can_shutdown` was purely backward-looking (no `build_preconf_block` request within 144s), which is blind to a *first* request that hasn't arrived yet. `can_shutdown_for` now additionally refuses shutdown from `SHUTDOWN_IMMINENCE_MARGIN_SLOTS` (8) before the hand-over boundary through the end of the epoch, so a preconfer taking over at the next hand-over can't find its driver mid-boot. Conservative by design (applies to every epoch tail regardless of which operator is next); the k8s preStop budget (550s) comfortably absorbs the worst-case ~3 min wait.
- Added `slots_per_epoch()` / `current_slot_in_epoch()` accessors to `BeaconClient`.
- Unit tests for the imminence band; all 145 crate tests pass, clippy + nightly rustfmt clean.

## Notes for reviewers

- Margin size (8 slots) is a judgment call: it must cover pod replacement (observed 30–60s on Autopilot, longer when scheduling is tight) and the serving preconfer's reconnect time. Happy to tune.
- The Go margin only extends ranges *backward*; behavior inside/after ranges is unchanged, and existing test expectations still hold.
- Ops-side follow-ups tracked separately in k8s-configs: PriorityClass for chain-critical pods (prevents the preemption trigger itself) and preconfer WS reconnect resilience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
