### PR TITLE
feat(relayer): judge after-transacting profitability against actual payout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -163,6 +163,7 @@ require (
 	github.com/koron/go-ssdp v0.0.5 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.2.3 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.2.0 // indirect

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -519,7 +519,7 @@ func (p *Processor) relayerFeeFromReceipt(
 	var stats *bridge.BridgeProcessingStats
 
 	for _, receiptLog := range receipt.Logs {
-		if receiptLog.Address != p.cfg.DestBridgeAddress || len(receiptLog.Topics) < 2 ||
+		if receiptLog == nil || receiptLog.Address != p.cfg.DestBridgeAddress || len(receiptLog.Topics) < 2 ||
 			receiptLog.Topics[0] != messageProcessed.ID || receiptLog.Topics[1] != common.Hash(event.MsgHash) {
 			continue
 		}
@@ -552,6 +552,9 @@ func (p *Processor) relayerFeeFromReceipt(
 	if !stats.ProcessedByRelayer {
 		return new(big.Int).SetUint64(event.Message.Fee), nil
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.ethClientTimeout)
+	defer cancel()
 
 	minedHeader, err := p.destEthClient.HeaderByHash(ctx, receipt.BlockHash)
 	if err != nil {
@@ -630,7 +633,7 @@ func (p *Processor) saveMessageStatusChangedEvent(
 	m := make(map[string]interface{})
 
 	for _, log := range receipt.Logs {
-		if len(log.Topics) == 0 {
+		if log == nil || len(log.Topics) == 0 {
 			continue
 		}
 

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -465,9 +465,13 @@ func (p *Processor) sendProcessMessageCall(
 			"srcTxHash", event.Raw.TxHash.Hex(),
 			"actualCost", cost,
 			"estimatedMaxCost", estimatedMaxCost,
+			"processingFee", event.Message.Fee,
 		)
 
-		if cost > estimatedMaxCost {
+		// Compare against the fee the relayer actually receives, not the
+		// pre-send estimate: a cost above the estimate (e.g. after tx manager
+		// fee bumps) is still profitable as long as the fee covers it.
+		if cost > event.Message.Fee {
 			relayer.UnprofitableMessageAfterTransacting.Inc()
 		} else {
 			relayer.ProfitableMessageAfterTransacting.Inc()

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -462,6 +462,7 @@ func (p *Processor) sendProcessMessageCall(
 
 	if p.profitableOnly {
 		if receipt.EffectiveGasPrice == nil {
+			relayer.AfterTransactingProfitabilityEvaluationErrors.Inc()
 			slog.Warn("missing effective gas price; skipping after-transacting profitability",
 				"txHash", hex.EncodeToString(receipt.TxHash.Bytes()),
 				"srcTxHash", event.Raw.TxHash.Hex(),
@@ -471,6 +472,7 @@ func (p *Processor) sendProcessMessageCall(
 
 			relayerFee, err := p.relayerFeeFromReceipt(ctx, receipt, event)
 			if err != nil {
+				relayer.AfterTransactingProfitabilityEvaluationErrors.Inc()
 				slog.Warn("failed to determine relayer fee; skipping after-transacting profitability",
 					"txHash", hex.EncodeToString(receipt.TxHash.Bytes()),
 					"srcTxHash", event.Raw.TxHash.Hex(),
@@ -551,16 +553,12 @@ func (p *Processor) relayerFeeFromReceipt(
 		return new(big.Int).SetUint64(event.Message.Fee), nil
 	}
 
-	if receipt.BlockNumber == nil {
-		return nil, errors.New("receipt block number is missing")
-	}
-
-	minedBlock, err := p.destEthClient.BlockByNumber(ctx, receipt.BlockNumber)
+	minedHeader, err := p.destEthClient.HeaderByHash(ctx, receipt.BlockHash)
 	if err != nil {
-		return nil, errors.Wrap(err, "get mined block")
+		return nil, errors.Wrap(err, "get mined block header")
 	}
 
-	if minedBlock == nil || minedBlock.BaseFee() == nil {
+	if minedHeader == nil || minedHeader.BaseFee == nil {
 		return nil, errors.New("mined block base fee is missing")
 	}
 
@@ -577,7 +575,7 @@ func (p *Processor) relayerFeeFromReceipt(
 
 	maxFee := new(big.Int).Mul(gasCharged, new(big.Int).SetUint64(event.Message.Fee))
 	maxFee.Div(maxFee, new(big.Int).SetUint64(uint64(event.Message.GasLimit)))
-	baseFee := new(big.Int).Mul(gasCharged, minedBlock.BaseFee())
+	baseFee := new(big.Int).Mul(gasCharged, minedHeader.BaseFee)
 
 	var paidFee *big.Int
 	if baseFee.Cmp(maxFee) >= 0 {

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -32,6 +32,8 @@ var (
 	errAlreadyProcessing = errors.New("already processing txHash")
 )
 
+const gasRefundPerCacheOperation uint64 = 20_000
+
 // eventStatusFromMsgHash will check the event's msgHash/signal, and
 // get its on-chain current status.
 func (p *Processor) eventStatusFromMsgHash(
@@ -459,22 +461,39 @@ func (p *Processor) sendProcessMessageCall(
 	relayer.MessageSentEventsProcessed.Inc()
 
 	if p.profitableOnly {
-		cost := receipt.GasUsed * receipt.EffectiveGasPrice.Uint64()
-
-		slog.Info("tx cost", "txHash", hex.EncodeToString(receipt.TxHash.Bytes()),
-			"srcTxHash", event.Raw.TxHash.Hex(),
-			"actualCost", cost,
-			"estimatedMaxCost", estimatedMaxCost,
-			"processingFee", event.Message.Fee,
-		)
-
-		// Compare against the fee the relayer actually receives, not the
-		// pre-send estimate: a cost above the estimate (e.g. after tx manager
-		// fee bumps) is still profitable as long as the fee covers it.
-		if cost > event.Message.Fee {
-			relayer.UnprofitableMessageAfterTransacting.Inc()
+		if receipt.EffectiveGasPrice == nil {
+			slog.Warn("missing effective gas price; skipping after-transacting profitability",
+				"txHash", hex.EncodeToString(receipt.TxHash.Bytes()),
+				"srcTxHash", event.Raw.TxHash.Hex(),
+			)
 		} else {
-			relayer.ProfitableMessageAfterTransacting.Inc()
+			cost := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), receipt.EffectiveGasPrice)
+
+			relayerFee, err := p.relayerFeeFromReceipt(ctx, receipt, event)
+			if err != nil {
+				slog.Warn("failed to determine relayer fee; skipping after-transacting profitability",
+					"txHash", hex.EncodeToString(receipt.TxHash.Bytes()),
+					"srcTxHash", event.Raw.TxHash.Hex(),
+					"actualCost", cost,
+					"estimatedMaxCost", estimatedMaxCost,
+					"processingFee", event.Message.Fee,
+					"error", err,
+				)
+			} else {
+				slog.Info("tx cost", "txHash", hex.EncodeToString(receipt.TxHash.Bytes()),
+					"srcTxHash", event.Raw.TxHash.Hex(),
+					"actualCost", cost,
+					"estimatedMaxCost", estimatedMaxCost,
+					"processingFee", event.Message.Fee,
+					"relayerFee", relayerFee,
+				)
+
+				if cost.Cmp(relayerFee) > 0 {
+					relayer.UnprofitableMessageAfterTransacting.Inc()
+				} else {
+					relayer.ProfitableMessageAfterTransacting.Inc()
+				}
+			}
 		}
 	}
 
@@ -483,6 +502,96 @@ func (p *Processor) sendProcessMessageCall(
 	}
 
 	return receipt, nil
+}
+
+func (p *Processor) relayerFeeFromReceipt(
+	ctx context.Context,
+	receipt *types.Receipt,
+	event *bridge.BridgeMessageSent,
+) (*big.Int, error) {
+	messageProcessed, ok := encoding.BridgeABI.Events[relayer.EventNameMessageProcessed]
+	if !ok {
+		return nil, errors.New("MessageProcessed ABI event not found")
+	}
+
+	var stats *bridge.BridgeProcessingStats
+
+	for _, receiptLog := range receipt.Logs {
+		if receiptLog.Address != p.cfg.DestBridgeAddress || len(receiptLog.Topics) < 2 ||
+			receiptLog.Topics[0] != messageProcessed.ID || receiptLog.Topics[1] != common.Hash(event.MsgHash) {
+			continue
+		}
+
+		decoded := struct {
+			Message bridge.IBridgeMessage
+			Stats   bridge.BridgeProcessingStats
+		}{}
+		if err := encoding.BridgeABI.UnpackIntoInterface(
+			&decoded,
+			relayer.EventNameMessageProcessed,
+			receiptLog.Data,
+		); err != nil {
+			return nil, errors.Wrap(err, "unpack MessageProcessed event")
+		}
+
+		stats = &decoded.Stats
+
+		break
+	}
+
+	if stats == nil {
+		return nil, errors.New("MessageProcessed event not found in receipt")
+	}
+
+	if event.Message.GasLimit == 0 {
+		return nil, errors.New("message gas limit is zero")
+	}
+
+	if !stats.ProcessedByRelayer {
+		return new(big.Int).SetUint64(event.Message.Fee), nil
+	}
+
+	if receipt.BlockNumber == nil {
+		return nil, errors.New("receipt block number is missing")
+	}
+
+	minedBlock, err := p.destEthClient.BlockByNumber(ctx, receipt.BlockNumber)
+	if err != nil {
+		return nil, errors.Wrap(err, "get mined block")
+	}
+
+	if minedBlock == nil || minedBlock.BaseFee() == nil {
+		return nil, errors.New("mined block base fee is missing")
+	}
+
+	refund := new(big.Int).Mul(
+		new(big.Int).SetUint64(uint64(stats.NumCacheOps)),
+		new(big.Int).SetUint64(gasRefundPerCacheOperation),
+	)
+	gasUsedInFeeCalc := new(big.Int).SetUint64(uint64(stats.GasUsedInFeeCalc))
+	gasCharged := new(big.Int)
+
+	if gasUsedInFeeCalc.Cmp(refund) > 0 {
+		gasCharged.Sub(gasUsedInFeeCalc, refund)
+	}
+
+	maxFee := new(big.Int).Mul(gasCharged, new(big.Int).SetUint64(event.Message.Fee))
+	maxFee.Div(maxFee, new(big.Int).SetUint64(uint64(event.Message.GasLimit)))
+	baseFee := new(big.Int).Mul(gasCharged, minedBlock.BaseFee())
+
+	var paidFee *big.Int
+	if baseFee.Cmp(maxFee) >= 0 {
+		paidFee = maxFee
+	} else {
+		paidFee = new(big.Int).Rsh(new(big.Int).Add(maxFee, baseFee), 1)
+	}
+
+	feeCap := new(big.Int).SetUint64(event.Message.Fee)
+	if paidFee.Cmp(feeCap) > 0 {
+		return feeCap, nil
+	}
+
+	return paidFee, nil
 }
 
 // retrieve the balance of the relayer and set Prometheus

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -85,86 +85,97 @@ func messageProcessedLog(
 		Data:    data,
 	}
 }
+func newProcessMessageEvent(fee uint64) *bridge.BridgeMessageSent {
+	return &bridge.BridgeMessageSent{
+		MsgHash: mock.SuccessMsgHash,
+		Message: bridge.IBridgeMessage{
+			Id:          1,
+			From:        common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+			DestChainId: mock.MockChainID.Uint64(),
+			SrcChainId:  mock.MockChainID.Uint64(),
+			SrcOwner:    common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+			DestOwner:   common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+			To:          common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+			Value:       big.NewInt(0),
+			Fee:         fee,
+			GasLimit:    100000,
+			Data:        []byte{},
+		},
+		Raw: types.Log{
+			Address: relayer.ZeroAddress,
+			Topics: []common.Hash{
+				relayer.ZeroHash,
+			},
+			Data: []byte{0xff},
+		},
+	}
+}
 
 func Test_sendProcessMessageCall_afterTransactingProfitability(t *testing.T) {
-	newEvent := func(fee uint64) *bridge.BridgeMessageSent {
-		return &bridge.BridgeMessageSent{
-			MsgHash: mock.SuccessMsgHash,
-			Message: bridge.IBridgeMessage{
-				Id:          1,
-				From:        common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
-				DestChainId: mock.MockChainID.Uint64(),
-				SrcChainId:  mock.MockChainID.Uint64(),
-				SrcOwner:    common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
-				DestOwner:   common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
-				To:          common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
-				Value:       big.NewInt(0),
-				Fee:         fee,
-				GasLimit:    100000,
-				Data:        []byte{},
-			},
-			Raw: types.Log{
-				Address: relayer.ZeroAddress,
-				Topics: []common.Hash{
-					relayer.ZeroHash,
-				},
-				Data: []byte{0xff},
-			},
-		}
-	}
-
 	tests := []struct {
-		name              string
-		fee               uint64
-		baseFee           int64
-		gasUsedInFeeCalc  uint32
-		gasUsed           uint64
-		effectiveGasPrice int64
-		wantProfitable    bool
+		name                  string
+		fee                   uint64
+		latestBaseFee         int64
+		canonicalBlockBaseFee int64
+		receiptBlockBaseFee   int64
+		gasUsedInFeeCalc      uint32
+		gasUsed               uint64
+		effectiveGasPrice     int64
+		wantProfitable        bool
 	}{
 		{
 			// The actual cost exceeds the pre-send estimate, but the Bridge's
 			// 1_500_000 wei relayer payout covers it.
-			name:              "relayer fee covers actual cost",
-			fee:               200_000_000,
-			baseFee:           1_000,
-			gasUsedInFeeCalc:  1_000,
-			gasUsed:           1_500,
-			effectiveGasPrice: 1_000,
-			wantProfitable:    true,
+			name:                  "relayer fee covers actual cost",
+			fee:                   200_000_000,
+			latestBaseFee:         1_000,
+			canonicalBlockBaseFee: 1_000,
+			receiptBlockBaseFee:   1_000,
+			gasUsedInFeeCalc:      1_000,
+			gasUsed:               1_500,
+			effectiveGasPrice:     1_000,
+			wantProfitable:        true,
 		},
 		{
 			// The Bridge pays (maxFee + baseFee) / 2 =
 			// (1_000_000 + 100_000) / 2 = 550_000 wei. That is less than
 			// the 1_000_000 wei transaction cost even though the fee cap covers it.
-			name:              "fee cap covers actual cost but relayer fee does not",
-			fee:               100_000_000,
-			baseFee:           100,
-			gasUsedInFeeCalc:  1_000,
-			gasUsed:           1_000,
-			effectiveGasPrice: 1_000,
-			wantProfitable:    false,
+			// The canonical block at the same number has a different base fee,
+			// modeling a reorg between receipt retrieval and profitability evaluation.
+			name:                  "fee cap covers actual cost but relayer fee does not",
+			fee:                   100_000_000,
+			latestBaseFee:         100,
+			canonicalBlockBaseFee: 1_000,
+			receiptBlockBaseFee:   100,
+			gasUsedInFeeCalc:      1_000,
+			gasUsed:               1_000,
+			effectiveGasPrice:     1_000,
+			wantProfitable:        false,
 		},
 		{
 			// The transaction cost is larger than uint64. It must remain
 			// unprofitable instead of wrapping below the relayer fee.
-			name:              "actual cost exceeds uint64",
-			fee:               ^uint64(0),
-			baseFee:           1,
-			gasUsedInFeeCalc:  ^uint32(0),
-			gasUsed:           ^uint64(0),
-			effectiveGasPrice: 2,
-			wantProfitable:    false,
+			name:                  "actual cost exceeds uint64",
+			fee:                   ^uint64(0),
+			latestBaseFee:         1,
+			canonicalBlockBaseFee: 1,
+			receiptBlockBaseFee:   1,
+			gasUsedInFeeCalc:      ^uint32(0),
+			gasUsed:               ^uint64(0),
+			effectiveGasPrice:     2,
+			wantProfitable:        false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			event := newEvent(tt.fee)
+			event := newProcessMessageEvent(tt.fee)
+			receiptBlockHash := common.HexToHash("0x1234")
 			receipt := &types.Receipt{
 				Status:            types.ReceiptStatusSuccessful,
 				GasUsed:           tt.gasUsed,
 				EffectiveGasPrice: big.NewInt(tt.effectiveGasPrice),
+				BlockHash:         receiptBlockHash,
 				BlockNumber:       big.NewInt(1),
 			}
 			receipt.Logs = []*types.Log{messageProcessedLog(t, event.Message, bridge.BridgeProcessingStats{
@@ -173,9 +184,18 @@ func Test_sendProcessMessageCall_afterTransactingProfitability(t *testing.T) {
 			})}
 
 			p := newTestProcessor(true)
-			p.destEthClient = &blockByNumberEthClient{
-				EthClient: &mock.EthClient{},
-				block:     processorBlockWithBaseFee(big.NewInt(tt.baseFee)),
+			p.destEthClient = &profitabilityEthClient{
+				EthClient:        &mock.EthClient{},
+				receiptBlockHash: receiptBlockHash,
+				latestBlock: processorBlockWithBaseFee(
+					big.NewInt(tt.latestBaseFee),
+				),
+				canonicalBlock: processorBlockWithBaseFee(
+					big.NewInt(tt.canonicalBlockBaseFee),
+				),
+				receiptBlockHeader: processorHeaderWithBaseFee(
+					big.NewInt(tt.receiptBlockBaseFee),
+				),
 			}
 			p.txmgr = &receiptTxManager{receipt: receipt}
 
@@ -195,6 +215,45 @@ func Test_sendProcessMessageCall_afterTransactingProfitability(t *testing.T) {
 				assert.Equal(t, float64(0), profDelta)
 				assert.Equal(t, float64(1), unprofDelta)
 			}
+		})
+	}
+}
+
+func Test_sendProcessMessageCall_afterTransactingProfitabilityEvaluationErrors(t *testing.T) {
+	tests := []struct {
+		name              string
+		effectiveGasPrice *big.Int
+	}{
+		{
+			name: "missing effective gas price",
+		},
+		{
+			name:              "missing MessageProcessed event",
+			effectiveGasPrice: big.NewInt(1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestProcessor(true)
+			p.txmgr = &receiptTxManager{receipt: &types.Receipt{
+				Status:            types.ReceiptStatusSuccessful,
+				GasUsed:           1,
+				EffectiveGasPrice: tt.effectiveGasPrice,
+			}}
+
+			before := testutil.ToFloat64(relayer.AfterTransactingProfitabilityEvaluationErrors)
+
+			_, err := p.sendProcessMessageCall(
+				context.Background(),
+				1,
+				newProcessMessageEvent(100_000_000),
+				[]byte{},
+			)
+			require.NoError(t, err)
+
+			after := testutil.ToFloat64(relayer.AfterTransactingProfitabilityEvaluationErrors)
+			assert.Equal(t, float64(1), after-before)
 		})
 	}
 }
@@ -394,13 +453,41 @@ type blockByNumberEthClient struct {
 	block *types.Block
 }
 
+type profitabilityEthClient struct {
+	*mock.EthClient
+	latestBlock        *types.Block
+	canonicalBlock     *types.Block
+	receiptBlockHash   common.Hash
+	receiptBlockHeader *types.Header
+}
+
+func (c *profitabilityEthClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	if number == nil {
+		return c.latestBlock, nil
+	}
+
+	return c.canonicalBlock, nil
+}
+
+func (c *profitabilityEthClient) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	if hash != c.receiptBlockHash {
+		return nil, errors.New("unexpected receipt block hash")
+	}
+
+	return c.receiptBlockHeader, nil
+}
+
 func (c *blockByNumberEthClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	return c.block, nil
 }
 
 func processorBlockWithBaseFee(baseFee *big.Int) *types.Block {
+	return types.NewBlockWithHeader(processorHeaderWithBaseFee(baseFee))
+}
+
+func processorHeaderWithBaseFee(baseFee *big.Int) *types.Header {
 	header := *mock.Header
 	header.BaseFee = baseFee
 
-	return types.NewBlockWithHeader(&header)
+	return &header
 }

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
@@ -49,6 +51,99 @@ func Test_sendProcessMessageCall(t *testing.T) {
 		}, []byte{})
 
 	assert.Equal(t, err, errUnprocessable)
+}
+
+// receiptTxManager is a mock.TxManager whose Send returns a fixed receipt,
+// letting tests control the actual on-chain cost of a processed message.
+type receiptTxManager struct {
+	mock.TxManager
+	receipt *types.Receipt
+}
+
+func (t *receiptTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (*types.Receipt, error) {
+	return t.receipt, nil
+}
+
+func Test_sendProcessMessageCall_afterTransactingProfitability(t *testing.T) {
+	newEvent := func(fee uint64) *bridge.BridgeMessageSent {
+		return &bridge.BridgeMessageSent{
+			MsgHash: mock.SuccessMsgHash,
+			Message: bridge.IBridgeMessage{
+				Id:          1,
+				From:        common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+				DestChainId: mock.MockChainID.Uint64(),
+				SrcChainId:  mock.MockChainID.Uint64(),
+				SrcOwner:    common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+				DestOwner:   common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+				To:          common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+				Value:       big.NewInt(0),
+				Fee:         fee,
+				GasLimit:    100000,
+				Data:        []byte{},
+			},
+			Raw: types.Log{
+				Address: relayer.ZeroAddress,
+				Topics: []common.Hash{
+					relayer.ZeroHash,
+				},
+				Data: []byte{0xff},
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		fee               uint64
+		gasUsed           uint64
+		effectiveGasPrice int64
+		wantProfitable    bool
+	}{
+		{
+			// The actual cost exceeds the pre-send estimate (the mocks
+			// estimate ~a few hundred wei), but the message fee still covers
+			// it: the relayer earned money, so the message is profitable.
+			name:              "fee covers actual cost",
+			fee:               100_000_000,
+			gasUsed:           1000,
+			effectiveGasPrice: 1000,
+			wantProfitable:    true,
+		},
+		{
+			name:              "actual cost exceeds fee",
+			fee:               100_000_000,
+			gasUsed:           1000,
+			effectiveGasPrice: 1_000_000,
+			wantProfitable:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestProcessor(true)
+			p.txmgr = &receiptTxManager{receipt: &types.Receipt{
+				Status:            types.ReceiptStatusSuccessful,
+				GasUsed:           tt.gasUsed,
+				EffectiveGasPrice: big.NewInt(tt.effectiveGasPrice),
+			}}
+
+			profBefore := testutil.ToFloat64(relayer.ProfitableMessageAfterTransacting)
+			unprofBefore := testutil.ToFloat64(relayer.UnprofitableMessageAfterTransacting)
+
+			_, err := p.sendProcessMessageCall(context.Background(), 1, newEvent(tt.fee), []byte{})
+			assert.Nil(t, err)
+
+			profDelta := testutil.ToFloat64(relayer.ProfitableMessageAfterTransacting) - profBefore
+			unprofDelta := testutil.ToFloat64(relayer.UnprofitableMessageAfterTransacting) - unprofBefore
+
+			if tt.wantProfitable {
+				assert.Equal(t, float64(1), profDelta)
+				assert.Equal(t, float64(0), unprofDelta)
+			} else {
+				assert.Equal(t, float64(0), profDelta)
+				assert.Equal(t, float64(1), unprofDelta)
+			}
+		})
+	}
 }
 
 func TestGetBaseFee_Layer2UsesHeaderBaseFee(t *testing.T) {

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -258,6 +258,53 @@ func Test_sendProcessMessageCall_afterTransactingProfitabilityEvaluationErrors(t
 	}
 }
 
+func Test_sendProcessMessageCall_afterTransactingProfitabilitySkipsNilReceiptLogs(t *testing.T) {
+	p := newTestProcessor(true)
+	p.txmgr = &receiptTxManager{receipt: &types.Receipt{
+		Status:            types.ReceiptStatusSuccessful,
+		GasUsed:           1,
+		EffectiveGasPrice: big.NewInt(1),
+		Logs:              []*types.Log{nil},
+	}}
+
+	before := testutil.ToFloat64(relayer.AfterTransactingProfitabilityEvaluationErrors)
+
+	_, err := p.sendProcessMessageCall(
+		context.Background(),
+		1,
+		newProcessMessageEvent(100_000_000),
+		[]byte{},
+	)
+	require.NoError(t, err)
+
+	after := testutil.ToFloat64(relayer.AfterTransactingProfitabilityEvaluationErrors)
+	assert.Equal(t, float64(1), after-before)
+}
+
+func Test_relayerFeeFromReceipt_timesOutHeaderLookup(t *testing.T) {
+	event := newProcessMessageEvent(100_000_000)
+	receipt := &types.Receipt{
+		BlockHash: common.HexToHash("0x1234"),
+		Logs: []*types.Log{messageProcessedLog(t, event.Message, bridge.BridgeProcessingStats{
+			GasUsedInFeeCalc:   1,
+			ProcessedByRelayer: true,
+		})},
+	}
+
+	p := newTestProcessor(true)
+	p.ethClientTimeout = 10 * time.Millisecond
+	p.destEthClient = &blockingHeaderEthClient{EthClient: &mock.EthClient{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watchdog := time.AfterFunc(250*time.Millisecond, cancel)
+	defer watchdog.Stop()
+
+	_, err := p.relayerFeeFromReceipt(ctx, receipt, event)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func TestGetBaseFee_Layer2UsesHeaderBaseFee(t *testing.T) {
 	p := newTestProcessor(false)
 	p.taikoL2 = &taikol2.TaikoL2{}
@@ -459,6 +506,16 @@ type profitabilityEthClient struct {
 	canonicalBlock     *types.Block
 	receiptBlockHash   common.Hash
 	receiptBlockHeader *types.Header
+}
+
+type blockingHeaderEthClient struct {
+	*mock.EthClient
+}
+
+func (c *blockingHeaderEthClient) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	<-ctx.Done()
+
+	return nil, ctx.Err()
 }
 
 func (c *profitabilityEthClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/taikol2"
@@ -64,6 +65,27 @@ func (t *receiptTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate
 	return t.receipt, nil
 }
 
+func messageProcessedLog(
+	t *testing.T,
+	message bridge.IBridgeMessage,
+	stats bridge.BridgeProcessingStats,
+) *types.Log {
+	t.Helper()
+
+	bridgeABI, err := bridge.BridgeMetaData.GetAbi()
+	require.NoError(t, err)
+
+	messageProcessed := bridgeABI.Events["MessageProcessed"]
+	data, err := messageProcessed.Inputs.NonIndexed().Pack(message, stats)
+	require.NoError(t, err)
+
+	return &types.Log{
+		Address: common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+		Topics:  []common.Hash{messageProcessed.ID, common.Hash(mock.SuccessMsgHash)},
+		Data:    data,
+	}
+}
+
 func Test_sendProcessMessageCall_afterTransactingProfitability(t *testing.T) {
 	newEvent := func(fee uint64) *bridge.BridgeMessageSent {
 		return &bridge.BridgeMessageSent{
@@ -94,43 +116,74 @@ func Test_sendProcessMessageCall_afterTransactingProfitability(t *testing.T) {
 	tests := []struct {
 		name              string
 		fee               uint64
+		baseFee           int64
+		gasUsedInFeeCalc  uint32
 		gasUsed           uint64
 		effectiveGasPrice int64
 		wantProfitable    bool
 	}{
 		{
-			// The actual cost exceeds the pre-send estimate (the mocks
-			// estimate ~a few hundred wei), but the message fee still covers
-			// it: the relayer earned money, so the message is profitable.
-			name:              "fee covers actual cost",
-			fee:               100_000_000,
-			gasUsed:           1000,
-			effectiveGasPrice: 1000,
+			// The actual cost exceeds the pre-send estimate, but the Bridge's
+			// 1_500_000 wei relayer payout covers it.
+			name:              "relayer fee covers actual cost",
+			fee:               200_000_000,
+			baseFee:           1_000,
+			gasUsedInFeeCalc:  1_000,
+			gasUsed:           1_500,
+			effectiveGasPrice: 1_000,
 			wantProfitable:    true,
 		},
 		{
-			name:              "actual cost exceeds fee",
+			// The Bridge pays (maxFee + baseFee) / 2 =
+			// (1_000_000 + 100_000) / 2 = 550_000 wei. That is less than
+			// the 1_000_000 wei transaction cost even though the fee cap covers it.
+			name:              "fee cap covers actual cost but relayer fee does not",
 			fee:               100_000_000,
-			gasUsed:           1000,
-			effectiveGasPrice: 1_000_000,
+			baseFee:           100,
+			gasUsedInFeeCalc:  1_000,
+			gasUsed:           1_000,
+			effectiveGasPrice: 1_000,
+			wantProfitable:    false,
+		},
+		{
+			// The transaction cost is larger than uint64. It must remain
+			// unprofitable instead of wrapping below the relayer fee.
+			name:              "actual cost exceeds uint64",
+			fee:               ^uint64(0),
+			baseFee:           1,
+			gasUsedInFeeCalc:  ^uint32(0),
+			gasUsed:           ^uint64(0),
+			effectiveGasPrice: 2,
 			wantProfitable:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newTestProcessor(true)
-			p.txmgr = &receiptTxManager{receipt: &types.Receipt{
+			event := newEvent(tt.fee)
+			receipt := &types.Receipt{
 				Status:            types.ReceiptStatusSuccessful,
 				GasUsed:           tt.gasUsed,
 				EffectiveGasPrice: big.NewInt(tt.effectiveGasPrice),
-			}}
+				BlockNumber:       big.NewInt(1),
+			}
+			receipt.Logs = []*types.Log{messageProcessedLog(t, event.Message, bridge.BridgeProcessingStats{
+				GasUsedInFeeCalc:   tt.gasUsedInFeeCalc,
+				ProcessedByRelayer: true,
+			})}
+
+			p := newTestProcessor(true)
+			p.destEthClient = &blockByNumberEthClient{
+				EthClient: &mock.EthClient{},
+				block:     processorBlockWithBaseFee(big.NewInt(tt.baseFee)),
+			}
+			p.txmgr = &receiptTxManager{receipt: receipt}
 
 			profBefore := testutil.ToFloat64(relayer.ProfitableMessageAfterTransacting)
 			unprofBefore := testutil.ToFloat64(relayer.UnprofitableMessageAfterTransacting)
 
-			_, err := p.sendProcessMessageCall(context.Background(), 1, newEvent(tt.fee), []byte{})
-			assert.Nil(t, err)
+			_, err := p.sendProcessMessageCall(context.Background(), 1, event, []byte{})
+			require.NoError(t, err)
 
 			profDelta := testutil.ToFloat64(relayer.ProfitableMessageAfterTransacting) - profBefore
 			unprofDelta := testutil.ToFloat64(relayer.UnprofitableMessageAfterTransacting) - unprofBefore

--- a/packages/relayer/prometheus.go
+++ b/packages/relayer/prometheus.go
@@ -122,6 +122,10 @@ var (
 		Name: "unprofitable_message_after_transacting_ops_total",
 		Help: "The total number of processed events that ended up unprofitable",
 	})
+	AfterTransactingProfitabilityEvaluationErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "after_transacting_profitability_evaluation_errors_ops_total",
+		Help: "The total number of errors evaluating profitability after transacting",
+	})
 	MessageSentEventsAfterRetryErrorCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "message_sent_events_after_retry_error_count",
 		Help: "The total number of errors logged for MessageSent events after retries",


### PR DESCRIPTION
## Why

unprofitable_message_after_transacting_ops_total compared actual transaction cost against the pre-send estimate, so fee-bumped transactions could trigger the alert even when they remained profitable.

The message fee cannot be used directly as revenue either: the Bridge defines Message.Fee as a maximum and refunds the unpaid portion to destOwner. Profitability must therefore use the amount the Bridge actually pays the relayer.

## What

- Parse the matching MessageProcessed event from the successful receipt.
- Reproduce the Bridge payout calculation using its processing stats and the mined block base fee.
- Fetch the mined header by receipt block hash, avoiding full transaction retrieval and number-based reorg ambiguity.
- Compare GasUsed × EffectiveGasPrice against the calculated relayer payout using overflow-safe big integers.
- Keep estimatedMaxCost and processingFee in logs, and add relayerFee.
- Increment after_transacting_profitability_evaluation_errors_ops_total when receipt data or RPC results prevent the profitability evaluation, without failing an already-mined message.
- Cover profitable, fee-cap-covers-cost-but-payout-does-not, uint64-overflow, reorg, and evaluation-error cases.

## Verification

- CI-equivalent relayer unit test suite
- Focused race-enabled profitability tests
- golangci-lint
