### PR TITLE
ci: bind vercel workflow inputs via env before shell

### DIFF
--- a/.github/workflows/repo--vercel-deploy.yml
+++ b/.github/workflows/repo--vercel-deploy.yml
@@ -43,10 +43,19 @@ jobs:
         run: pnpm add --global vercel@53.3.2
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.vercel_token }}
+        env:
+          VERCEL_ENVIRONMENT: ${{ inputs.environment }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: vercel pull --yes --environment="$VERCEL_ENVIRONMENT" --token="$VERCEL_TOKEN"
 
       - name: Build Project Artifacts
-        run: vercel build ${{ inputs.flags }} --token=${{ secrets.vercel_token }}
+        env:
+          VERCEL_FLAGS: ${{ inputs.flags }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: vercel build $VERCEL_FLAGS --token="$VERCEL_TOKEN"
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt ${{ inputs.flags }} --force --token=${{ secrets.vercel_token }}
+        env:
+          VERCEL_FLAGS: ${{ inputs.flags }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: vercel deploy --prebuilt $VERCEL_FLAGS --force --token="$VERCEL_TOKEN"


### PR DESCRIPTION
## Summary
- Bind `inputs.environment` / `inputs.flags` (and the Vercel token) through `env:` before the pull/build/deploy shell steps.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Vercel pull still targets the requested environment
- [ ] Build/deploy still forward caller-provided flags unchanged for trusted inputs


Made with [Cursor](https://cursor.com)