### PR TITLE
fix(taiko-client-rs): abort event sync when the execution engine rewinds below derived state

### DIFF
--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/error.rs
@@ -25,6 +25,12 @@ pub enum DerivationError {
     /// The required L2 block has not been produced yet.
     #[error("l2 block {0} not yet available")]
     BlockUnavailable(u64),
+    /// The proposal's L1 source block is missing from the L1 provider's current view.
+    ///
+    /// Kept distinct from [`Self::BlockUnavailable`] (an L2 number) so retry classification can
+    /// never confuse a lagging L1 backend with an L2 execution-engine rewind.
+    #[error("l1 source block {0} not available from the l1 provider")]
+    SourceBlockUnavailable(u64),
     /// Failure decoding the L1 proposal event payload.
     #[error(transparent)]
     ProposalDecode(#[from] SolTypeError),

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -348,7 +348,7 @@ impl ShastaDerivationPipeline {
             .l1_provider
             .get_block_by_hash(l1_block_hash)
             .await?
-            .ok_or(DerivationError::BlockUnavailable(l1_block_number))?;
+            .ok_or(DerivationError::SourceBlockUnavailable(l1_block_number))?;
 
         let l1_timestamp = l1_block.header.timestamp;
 

--- a/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
+++ b/packages/taiko-client-rs/crates/driver/src/derivation/pipeline/shasta/pipeline/mod.rs
@@ -871,6 +871,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn decode_log_reports_missing_l1_source_block() {
+        let l1_asserter = Asserter::new();
+        l1_asserter.push_success(&Option::<RpcBlock<TxEnvelope>>::None);
+        let l2_asserter = Asserter::new();
+        l2_asserter.push_success(&TAIKO_MAINNET_CHAIN_ID);
+        let anchor_address = Address::ZERO;
+        let client =
+            mock_client_with_asserters(l1_asserter, l2_asserter, Asserter::new(), anchor_address);
+        let blob_source = Arc::new(
+            BlobDataSource::new(None, None, true)
+                .await
+                .expect("blob data source should initialise"),
+        );
+        let anchor_constructor =
+            AnchorTxConstructor::new(client.l2_provider.clone(), anchor_address)
+                .await
+                .expect("anchor constructor should initialise");
+        let pipeline = ShastaDerivationPipeline {
+            rpc: client,
+            anchor_constructor,
+            derivation_source_manifest_fetcher: ShastaSourceManifestFetcher::new(blob_source),
+            shasta_fork_timestamp: 0,
+            min_base_fee_to_clamp: min_base_fee_for_chain(TAIKO_MAINNET_CHAIN_ID),
+            chain_id: TAIKO_MAINNET_CHAIN_ID,
+            initial_proposal_id: U256::ZERO,
+        };
+        let l1_block_hash = B256::from([0x61; 32]);
+        let log = Log {
+            inner: alloy::primitives::Log::new_from_event_unchecked(
+                Address::ZERO,
+                sample_event_context().event,
+            )
+            .reserialize(),
+            block_hash: Some(l1_block_hash),
+            block_number: Some(10),
+            block_timestamp: None,
+            transaction_hash: Some(B256::from([0x71; 32])),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        };
+
+        let err = pipeline
+            .decode_log_to_event_context(&log)
+            .await
+            .expect_err("missing source block should fail event decoding");
+
+        assert!(matches!(err, DerivationError::SourceBlockUnavailable(10)));
+    }
+
+    #[tokio::test]
     async fn finalized_proposal_id_at_block_returns_some_on_success() {
         let asserter = Asserter::new();
         let client = mock_client_with_l1_asserter(asserter.clone());

--- a/packages/taiko-client-rs/crates/driver/src/metrics.rs
+++ b/packages/taiko-client-rs/crates/driver/src/metrics.rs
@@ -63,6 +63,11 @@ impl DriverMetrics {
         &METRICS.event_orphaned_proposal_logs_total
     }
 
+    /// Return the execution-rewind abort counter.
+    pub(crate) fn event_execution_rewind_aborts_total() -> &'static IntCounter {
+        &METRICS.event_execution_rewind_aborts_total
+    }
+
     /// Return the derived event block counter.
     pub(crate) fn event_derived_blocks_total() -> &'static IntCounter {
         &METRICS.event_derived_blocks_total
@@ -184,6 +189,8 @@ struct DriverMetricHandles {
     event_proposals_skipped_total: IntCounter,
     /// Orphaned proposal logs skipped after L1 reorg detection.
     event_orphaned_proposal_logs_total: IntCounter,
+    /// Event sync aborts triggered by an execution-engine rewind below derived state.
+    event_execution_rewind_aborts_total: IntCounter,
     /// Derived or confirmed L2 blocks per proposal.
     event_derived_blocks_total: IntCounter,
     /// Proposals resolved entirely via canonical chain detection.
@@ -267,6 +274,10 @@ impl DriverMetricHandles {
             event_orphaned_proposal_logs_total: counter(
                 "driver_event_orphaned_proposal_logs_total",
                 "Proposal logs skipped because their source L1 block was reorged away",
+            ),
+            event_execution_rewind_aborts_total: counter(
+                "driver_event_execution_rewind_aborts_total",
+                "Event sync aborts after the execution engine rewound below derived state",
             ),
             event_derived_blocks_total: counter(
                 "driver_event_derived_blocks_total",

--- a/packages/taiko-client-rs/crates/driver/src/sync/error.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/error.rs
@@ -39,6 +39,21 @@ pub enum SyncError {
         number: u64,
     },
 
+    /// Event sync: the execution engine's canonical head sits below a block derivation already
+    /// produced, so the missing parent can never reappear through retries — event derivation is
+    /// the only producer of that range and it is stuck behind this proposal (post-crash rewind).
+    #[error(
+        "execution engine rewound below derived state: derivation needs block {missing_block} but \
+         the execution head is {execution_head}; aborting event sync so the restart re-resolves a \
+         safe resume head"
+    )]
+    ExecutionEngineRewound {
+        /// Block number derivation failed to load from the execution engine.
+        missing_block: u64,
+        /// Execution engine canonical head observed while that block was missing.
+        execution_head: u64,
+    },
+
     /// Event sync: failed to locate the expected anchor transaction for deriving resume point.
     #[error("anchor transaction missing in l2 block {block_number}: {reason}")]
     MissingAnchorTransaction {

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashSet, VecDeque},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -162,6 +162,26 @@ impl ProposalRetryError {
         }
     }
 }
+
+/// Verdict from probing a `BlockUnavailable` failure against the execution engine's live head.
+enum ExecutionRewindVerdict {
+    /// The above-head streak reached [`EXECUTION_REWIND_ABORT_THRESHOLD`]: abort event sync.
+    Abort {
+        /// Block number derivation failed to load from the execution engine.
+        missing_block: u64,
+        /// Execution engine canonical head observed while that block was missing.
+        execution_head: u64,
+    },
+    /// Above-head observation below the threshold: retry without further classification.
+    Observed,
+}
+
+/// Consecutive above-head `BlockUnavailable` observations required before event sync aborts.
+///
+/// A short streak filters head-probe races around an in-flight insert; a genuine post-crash
+/// rewind holds the condition indefinitely, so a few consecutive observations are enough to
+/// conclude the missing parent cannot reappear on its own.
+const EXECUTION_REWIND_ABORT_THRESHOLD: u32 = 3;
 
 /// Default timeout for preconfirmation payload submission.
 ///
@@ -894,6 +914,70 @@ impl EventSyncer {
         }
     }
 
+    /// Probe a proposal-processing failure for an execution-engine rewind below derived state.
+    ///
+    /// Applies only to [`DerivationError::BlockUnavailable`] failures. When the missing block
+    /// sits strictly ABOVE the execution engine's live head, the engine has rewound (post-crash)
+    /// below state derivation already produced — retrying can never heal it, because event
+    /// derivation itself is the only producer of that range and it is stuck behind this
+    /// proposal. After [`EXECUTION_REWIND_ABORT_THRESHOLD`] consecutive observations the
+    /// verdict escalates to an abort so the driver restarts and re-resolves a safe resume head
+    /// (checkpoint-synced, or the minimum of the head and `head_l1_origin`).
+    ///
+    /// Returns `None` when the ordinary retry/canonicality classification should stay in
+    /// charge: the failure is not `BlockUnavailable`, the block exists at or below the head
+    /// (streak resets), or the head probe itself failed (missing evidence must not abort).
+    async fn probe_execution_rewind(
+        &self,
+        err: &DriverError,
+        rewind_streak: &AtomicU32,
+    ) -> Option<ExecutionRewindVerdict> {
+        let DriverError::Sync(SyncError::Derivation(DerivationError::BlockUnavailable(
+            missing_block,
+        ))) = err
+        else {
+            return None;
+        };
+        let missing_block = *missing_block;
+
+        let execution_head = match self.rpc.l2_provider.get_block_number().await {
+            Ok(head) => head,
+            Err(probe_err) => {
+                warn!(
+                    missing_block,
+                    %probe_err,
+                    "failed to probe the execution head after BlockUnavailable; retrying"
+                );
+                return None;
+            }
+        };
+        if missing_block <= execution_head {
+            rewind_streak.store(0, Ordering::Relaxed);
+            return None;
+        }
+
+        let streak = rewind_streak.fetch_add(1, Ordering::Relaxed) + 1;
+        if streak >= EXECUTION_REWIND_ABORT_THRESHOLD {
+            error!(
+                missing_block,
+                execution_head,
+                streak,
+                "derivation needs a block above the execution head; aborting event sync so a \
+                 restart re-resolves the resume head"
+            );
+            Some(ExecutionRewindVerdict::Abort { missing_block, execution_head })
+        } else {
+            warn!(
+                missing_block,
+                execution_head,
+                streak,
+                "derivation needs a block above the execution head; execution engine may have \
+                 rewound"
+            );
+            Some(ExecutionRewindVerdict::Observed)
+        }
+    }
+
     /// Best-effort reset of `head_l1_origin` to the latest canonical proposal's last L2 block at
     /// the stable post-reorg boundary. If the L2 EE's confirmed boundary is left ahead of the
     /// post-reorg canonical chain, preconf and chain-syncer guards reject incoming blocks until
@@ -1007,11 +1091,15 @@ impl EventSyncer {
             let syncer = self;
             let router = router.clone();
             let proposal_log = log.clone();
+            // Consecutive above-head `BlockUnavailable` observations for THIS log; a fresh log
+            // starts a fresh streak.
+            let rewind_streak = Arc::new(AtomicU32::new(0));
             let processing = RetryIf::spawn(
                 retry_strategy,
                 move || {
                     let router = router.clone();
                     let log = proposal_log.clone();
+                    let rewind_streak = rewind_streak.clone();
                     async move {
                         let router_call = {
                             // Lock router so L1 proposals and preconf inputs cannot interleave.
@@ -1021,38 +1109,68 @@ impl EventSyncer {
 
                         match router_call {
                             Ok(outcomes) => Ok(ProposalLogResult::Processed(outcomes)),
-                            Err(err) => match syncer
-                                .proposal_log_canonicality(block_hash, log.block_number)
-                                .await
-                            {
-                                Ok(ProposalLogCanonicality::Orphaned) => {
-                                    DriverMetrics::event_orphaned_proposal_logs_total().inc();
-                                    warn!(
-                                        ?err,
-                                        block_number = log.block_number,
-                                        block_hash = ?block_hash,
-                                        transaction_hash = ?log.transaction_hash,
-                                        "skipping permanently orphaned proposal log",
-                                    );
-                                    Ok(ProposalLogResult::SkippedOrphaned)
+                            Err(err) => {
+                                // A rewound execution engine can never satisfy this retry on
+                                // its own (derivation is the sole producer of the missing
+                                // range), so the rewind probe runs before any L1-side
+                                // classification.
+                                match syncer.probe_execution_rewind(&err, &rewind_streak).await {
+                                    Some(ExecutionRewindVerdict::Abort {
+                                        missing_block,
+                                        execution_head,
+                                    }) => {
+                                        DriverMetrics::event_execution_rewind_aborts_total().inc();
+                                        return Err(ProposalRetryError::Abort(DriverError::Sync(
+                                            SyncError::ExecutionEngineRewound {
+                                                missing_block,
+                                                execution_head,
+                                            },
+                                        )));
+                                    }
+                                    Some(ExecutionRewindVerdict::Observed) => {
+                                        return Err(ProposalRetryError::Retry(err));
+                                    }
+                                    None => {}
                                 }
-                                Ok(canonicality) => Err(syncer
-                                    .classify_proposal_processing_failure(err, &log, canonicality)),
-                                Err(recheck_err) => {
-                                    warn!(
-                                        ?err,
-                                        ?recheck_err,
-                                        tx_hash = ?log.transaction_hash,
-                                        block_number = log.block_number,
-                                        "proposal derivation failed and orphaned-log recheck errored; retrying"
-                                    );
-                                    // Surface the retryable recheck error instead of the
-                                    // original failure: a fatal verdict may only abort after
-                                    // the log is proven canonical, never while orphanhood is
-                                    // still unresolved.
-                                    Err(ProposalRetryError::Retry(DriverError::Sync(recheck_err)))
+                                match syncer
+                                    .proposal_log_canonicality(block_hash, log.block_number)
+                                    .await
+                                {
+                                    Ok(ProposalLogCanonicality::Orphaned) => {
+                                        DriverMetrics::event_orphaned_proposal_logs_total().inc();
+                                        warn!(
+                                            ?err,
+                                            block_number = log.block_number,
+                                            block_hash = ?block_hash,
+                                            transaction_hash = ?log.transaction_hash,
+                                            "skipping permanently orphaned proposal log",
+                                        );
+                                        Ok(ProposalLogResult::SkippedOrphaned)
+                                    }
+                                    Ok(canonicality) => Err(syncer
+                                        .classify_proposal_processing_failure(
+                                            err,
+                                            &log,
+                                            canonicality,
+                                        )),
+                                    Err(recheck_err) => {
+                                        warn!(
+                                            ?err,
+                                            ?recheck_err,
+                                            tx_hash = ?log.transaction_hash,
+                                            block_number = log.block_number,
+                                            "proposal derivation failed and orphaned-log recheck errored; retrying"
+                                        );
+                                        // Surface the retryable recheck error instead of the
+                                        // original failure: a fatal verdict may only abort
+                                        // after the log is proven canonical, never while
+                                        // orphanhood is still unresolved.
+                                        Err(ProposalRetryError::Retry(DriverError::Sync(
+                                            recheck_err,
+                                        )))
+                                    }
                                 }
-                            },
+                            }
                         }
                     }
                 },
@@ -1868,7 +1986,7 @@ mod tests {
     use super::*;
     use alethia_reth_primitives::payload::attributes::RpcL1Origin;
     use alloy::{
-        primitives::{Address, B256, Bytes, FixedBytes, U256, aliases::U48},
+        primitives::{Address, B256, Bytes, FixedBytes, U64, U256, aliases::U48},
         transports::http::reqwest::Url,
     };
     use alloy_transport::mock::Asserter;
@@ -2530,6 +2648,112 @@ mod tests {
             vec![fatal_tx_hash],
             "a deterministic engine verdict on a proven-canonical log must not be retried"
         );
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn process_log_batch_aborts_after_persistent_block_unavailable_above_execution_head() {
+        let block_hash = B256::from([0x73; 32]);
+        let tx_hash = B256::from([0x83; 32]);
+        let l2_asserter = Asserter::new();
+        // One execution-head probe per failed attempt; three consecutive above-head
+        // observations prove a rewind and must abort instead of retrying forever.
+        for _ in 0..3 {
+            l2_asserter.push_success(&U64::from(40u64));
+        }
+
+        let syncer = EventSyncer {
+            rpc: mock_client_with_asserters(
+                Asserter::new(),
+                l2_asserter,
+                Asserter::new(),
+                Address::ZERO,
+            ),
+            ..build_syncer().await
+        };
+        let path = MockProductionPath::unavailable_for([tx_hash], 100);
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let result = timeout(
+            Duration::from_secs(120),
+            syncer.process_log_batch(router, vec![sample_proposed_log(1, block_hash, tx_hash)]),
+        )
+        .await
+        .expect("a persistent rewind must abort the batch instead of retrying forever");
+
+        let err = result
+            .expect_err("BlockUnavailable persistently above the execution head should abort");
+        assert!(
+            matches!(
+                err,
+                SyncError::ExecutionEngineRewound { missing_block: 100, execution_head: 40 }
+            ),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(path.calls(), 3, "abort must fire at the consecutive-rewind threshold");
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn process_log_batch_keeps_retrying_block_unavailable_at_or_below_execution_head() {
+        let block_hash = B256::from([0x74; 32]);
+        let tx_hash = B256::from([0x84; 32]);
+        let l2_asserter = Asserter::new();
+        // Execution head at the missing block: the parent exists, so this is not a rewind and
+        // the ordinary retry path must stay in charge.
+        l2_asserter.push_success(&U64::from(100u64));
+
+        let syncer = EventSyncer {
+            rpc: mock_client_with_asserters(
+                Asserter::new(),
+                l2_asserter,
+                Asserter::new(),
+                Address::ZERO,
+            ),
+            ..build_syncer().await
+        };
+        let path = MockProductionPath::unavailable_once_for([tx_hash], 100);
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let result = timeout(
+            Duration::from_secs(120),
+            syncer.process_log_batch(router, vec![sample_proposed_log(1, block_hash, tx_hash)]),
+        )
+        .await
+        .expect("the retry loop should finish once production succeeds");
+
+        assert!(result.is_ok(), "at-or-below-head unavailability stays retryable: {result:?}");
+        assert_eq!(path.calls(), 2, "one failed attempt, then the retry succeeds");
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn process_log_batch_keeps_retrying_when_execution_head_probe_fails() {
+        let block_hash = B256::from([0x75; 32]);
+        let tx_hash = B256::from([0x85; 32]);
+        let l2_asserter = Asserter::new();
+        // A failing head probe proves nothing about a rewind; the ordinary retry path must
+        // stay in charge rather than aborting on missing evidence.
+        l2_asserter.push_failure_msg("execution head probe unavailable");
+
+        let syncer = EventSyncer {
+            rpc: mock_client_with_asserters(
+                Asserter::new(),
+                l2_asserter,
+                Asserter::new(),
+                Address::ZERO,
+            ),
+            ..build_syncer().await
+        };
+        let path = MockProductionPath::unavailable_once_for([tx_hash], 100);
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let result = timeout(
+            Duration::from_secs(120),
+            syncer.process_log_batch(router, vec![sample_proposed_log(1, block_hash, tx_hash)]),
+        )
+        .await
+        .expect("the retry loop should finish once production succeeds");
+
+        assert!(result.is_ok(), "an unprovable rewind stays retryable: {result:?}");
+        assert_eq!(path.calls(), 2, "one failed attempt, then the retry succeeds");
     }
 
     #[test_log::test(tokio::test(start_paused = true))]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashSet, VecDeque},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicU32, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -182,6 +182,38 @@ enum ExecutionRewindVerdict {
 /// rewind holds the condition indefinitely, so a few consecutive observations are enough to
 /// conclude the missing parent cannot reappear on its own.
 const EXECUTION_REWIND_ABORT_THRESHOLD: u32 = 3;
+
+/// Identity-keyed streak of above-head `BlockUnavailable` observations.
+///
+/// Escalation requires the SAME missing block to stay above the execution head across
+/// conclusive probes: a different missing block restarts the count (derivation progressed, so
+/// earlier evidence is stale). Inconclusive attempts (failed head probe, unrelated errors)
+/// deliberately leave the streak untouched instead of resetting it — a genuine rewind
+/// interleaved with a flaky probe must still escalate.
+#[derive(Default)]
+struct RewindStreak {
+    /// Missing block the current streak is counting.
+    missing_block: u64,
+    /// Conclusive above-head observations of `missing_block` so far.
+    count: u32,
+}
+
+impl RewindStreak {
+    /// Record an above-head observation of `missing_block`, returning the updated count.
+    fn observe(&mut self, missing_block: u64) -> u32 {
+        if self.missing_block != missing_block {
+            self.missing_block = missing_block;
+            self.count = 0;
+        }
+        self.count += 1;
+        self.count
+    }
+
+    /// Clear the streak after evidence that the missing block exists at or below the head.
+    fn clear(&mut self) {
+        self.count = 0;
+    }
+}
 
 /// Default timeout for preconfirmation payload submission.
 ///
@@ -916,21 +948,28 @@ impl EventSyncer {
 
     /// Probe a proposal-processing failure for an execution-engine rewind below derived state.
     ///
-    /// Applies only to [`DerivationError::BlockUnavailable`] failures. When the missing block
-    /// sits strictly ABOVE the execution engine's live head, the engine has rewound (post-crash)
-    /// below state derivation already produced — retrying can never heal it, because event
-    /// derivation itself is the only producer of that range and it is stuck behind this
-    /// proposal. After [`EXECUTION_REWIND_ABORT_THRESHOLD`] consecutive observations the
-    /// verdict escalates to an abort so the driver restarts and re-resolves a safe resume head
+    /// Applies only to [`DerivationError::BlockUnavailable`] failures, which by contract carry
+    /// an L2 block number — a missing L1 source block surfaces as
+    /// [`DerivationError::SourceBlockUnavailable`] precisely so a lagging L1 backend can never
+    /// masquerade as a rewind here. When the missing L2 block sits strictly ABOVE the execution
+    /// engine's live head, the engine has rewound (post-crash) below state derivation already
+    /// produced — retrying can never heal it, because event derivation itself is the only
+    /// producer of that range and it is stuck behind this proposal. After
+    /// [`EXECUTION_REWIND_ABORT_THRESHOLD`] consecutive same-block observations the verdict
+    /// escalates to an abort so the driver restarts and re-resolves a safe resume head
     /// (checkpoint-synced, or the minimum of the head and `head_l1_origin`).
     ///
-    /// Returns `None` when the ordinary retry/canonicality classification should stay in
-    /// charge: the failure is not `BlockUnavailable`, the block exists at or below the head
-    /// (streak resets), or the head probe itself failed (missing evidence must not abort).
+    /// The caller settles orphanhood BEFORE this probe, so a finalized-orphaned log is skipped
+    /// and never accumulates rewind evidence.
+    ///
+    /// Returns `None` when the ordinary retry classification should stay in charge: the failure
+    /// is not `BlockUnavailable`, the block exists at or below the head (streak clears), or the
+    /// head probe itself failed (missing evidence must not abort, and deliberately leaves the
+    /// streak intact so a flaky probe cannot indefinitely postpone escape from a real rewind).
     async fn probe_execution_rewind(
         &self,
         err: &DriverError,
-        rewind_streak: &AtomicU32,
+        rewind_streak: &Mutex<RewindStreak>,
     ) -> Option<ExecutionRewindVerdict> {
         let DriverError::Sync(SyncError::Derivation(DerivationError::BlockUnavailable(
             missing_block,
@@ -952,11 +991,14 @@ impl EventSyncer {
             }
         };
         if missing_block <= execution_head {
-            rewind_streak.store(0, Ordering::Relaxed);
+            rewind_streak.lock().expect("rewind streak mutex should not be poisoned").clear();
             return None;
         }
 
-        let streak = rewind_streak.fetch_add(1, Ordering::Relaxed) + 1;
+        let streak = rewind_streak
+            .lock()
+            .expect("rewind streak mutex should not be poisoned")
+            .observe(missing_block);
         if streak >= EXECUTION_REWIND_ABORT_THRESHOLD {
             error!(
                 missing_block,
@@ -1091,9 +1133,9 @@ impl EventSyncer {
             let syncer = self;
             let router = router.clone();
             let proposal_log = log.clone();
-            // Consecutive above-head `BlockUnavailable` observations for THIS log; a fresh log
-            // starts a fresh streak.
-            let rewind_streak = Arc::new(AtomicU32::new(0));
+            // Above-head `BlockUnavailable` observations for THIS log, keyed by the missing
+            // block; a fresh log starts a fresh streak.
+            let rewind_streak = Arc::new(Mutex::new(RewindStreak::default()));
             let processing = RetryIf::spawn(
                 retry_strategy,
                 move || {
@@ -1110,28 +1152,6 @@ impl EventSyncer {
                         match router_call {
                             Ok(outcomes) => Ok(ProposalLogResult::Processed(outcomes)),
                             Err(err) => {
-                                // A rewound execution engine can never satisfy this retry on
-                                // its own (derivation is the sole producer of the missing
-                                // range), so the rewind probe runs before any L1-side
-                                // classification.
-                                match syncer.probe_execution_rewind(&err, &rewind_streak).await {
-                                    Some(ExecutionRewindVerdict::Abort {
-                                        missing_block,
-                                        execution_head,
-                                    }) => {
-                                        DriverMetrics::event_execution_rewind_aborts_total().inc();
-                                        return Err(ProposalRetryError::Abort(DriverError::Sync(
-                                            SyncError::ExecutionEngineRewound {
-                                                missing_block,
-                                                execution_head,
-                                            },
-                                        )));
-                                    }
-                                    Some(ExecutionRewindVerdict::Observed) => {
-                                        return Err(ProposalRetryError::Retry(err));
-                                    }
-                                    None => {}
-                                }
                                 match syncer
                                     .proposal_log_canonicality(block_hash, log.block_number)
                                     .await
@@ -1147,12 +1167,40 @@ impl EventSyncer {
                                         );
                                         Ok(ProposalLogResult::SkippedOrphaned)
                                     }
-                                    Ok(canonicality) => Err(syncer
-                                        .classify_proposal_processing_failure(
-                                            err,
-                                            &log,
-                                            canonicality,
-                                        )),
+                                    Ok(canonicality) => {
+                                        // Orphanhood is settled, so rewind evidence may now
+                                        // accumulate: a rewound execution engine can never
+                                        // satisfy this retry on its own — derivation is the
+                                        // sole producer of the missing range.
+                                        match syncer
+                                            .probe_execution_rewind(&err, &rewind_streak)
+                                            .await
+                                        {
+                                            Some(ExecutionRewindVerdict::Abort {
+                                                missing_block,
+                                                execution_head,
+                                            }) => {
+                                                DriverMetrics::event_execution_rewind_aborts_total(
+                                                )
+                                                .inc();
+                                                Err(ProposalRetryError::Abort(DriverError::Sync(
+                                                    SyncError::ExecutionEngineRewound {
+                                                        missing_block,
+                                                        execution_head,
+                                                    },
+                                                )))
+                                            }
+                                            Some(ExecutionRewindVerdict::Observed) => {
+                                                Err(ProposalRetryError::Retry(err))
+                                            }
+                                            None => Err(syncer
+                                                .classify_proposal_processing_failure(
+                                                    err,
+                                                    &log,
+                                                    canonicality,
+                                                )),
+                                        }
+                                    }
                                     Err(recheck_err) => {
                                         warn!(
                                             ?err,
@@ -2654,16 +2702,20 @@ mod tests {
     async fn process_log_batch_aborts_after_persistent_block_unavailable_above_execution_head() {
         let block_hash = B256::from([0x73; 32]);
         let tx_hash = B256::from([0x83; 32]);
+        let l1_asserter = Asserter::new();
         let l2_asserter = Asserter::new();
-        // One execution-head probe per failed attempt; three consecutive above-head
+        // Each failed attempt settles canonicality first (Unproven: finality below the log
+        // height), then probes the execution head once; three consecutive above-head
         // observations prove a rewind and must abort instead of retrying forever.
         for _ in 0..3 {
+            l1_asserter.push_success(&l1_block_at(1, block_hash, B256::ZERO));
+            l1_asserter.push_success(&l1_block_at(0, B256::ZERO, B256::ZERO));
             l2_asserter.push_success(&U64::from(40u64));
         }
 
         let syncer = EventSyncer {
             rpc: mock_client_with_asserters(
-                Asserter::new(),
+                l1_asserter,
                 l2_asserter,
                 Asserter::new(),
                 Address::ZERO,
@@ -2696,6 +2748,10 @@ mod tests {
     async fn process_log_batch_keeps_retrying_block_unavailable_at_or_below_execution_head() {
         let block_hash = B256::from([0x74; 32]);
         let tx_hash = B256::from([0x84; 32]);
+        let l1_asserter = Asserter::new();
+        // The failed attempt settles canonicality first (Unproven), then probes the head.
+        l1_asserter.push_success(&l1_block_at(1, block_hash, B256::ZERO));
+        l1_asserter.push_success(&l1_block_at(0, B256::ZERO, B256::ZERO));
         let l2_asserter = Asserter::new();
         // Execution head at the missing block: the parent exists, so this is not a rewind and
         // the ordinary retry path must stay in charge.
@@ -2703,7 +2759,7 @@ mod tests {
 
         let syncer = EventSyncer {
             rpc: mock_client_with_asserters(
-                Asserter::new(),
+                l1_asserter,
                 l2_asserter,
                 Asserter::new(),
                 Address::ZERO,
@@ -2728,6 +2784,10 @@ mod tests {
     async fn process_log_batch_keeps_retrying_when_execution_head_probe_fails() {
         let block_hash = B256::from([0x75; 32]);
         let tx_hash = B256::from([0x85; 32]);
+        let l1_asserter = Asserter::new();
+        // The failed attempt settles canonicality first (Unproven), then probes the head.
+        l1_asserter.push_success(&l1_block_at(1, block_hash, B256::ZERO));
+        l1_asserter.push_success(&l1_block_at(0, B256::ZERO, B256::ZERO));
         let l2_asserter = Asserter::new();
         // A failing head probe proves nothing about a rewind; the ordinary retry path must
         // stay in charge rather than aborting on missing evidence.
@@ -2735,7 +2795,7 @@ mod tests {
 
         let syncer = EventSyncer {
             rpc: mock_client_with_asserters(
-                Asserter::new(),
+                l1_asserter,
                 l2_asserter,
                 Asserter::new(),
                 Address::ZERO,
@@ -2754,6 +2814,99 @@ mod tests {
 
         assert!(result.is_ok(), "an unprovable rewind stays retryable: {result:?}");
         assert_eq!(path.calls(), 2, "one failed attempt, then the retry succeeds");
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn process_log_batch_skips_finalized_orphan_before_rewind_escalation() {
+        let orphaned_block_hash = B256::from([0x76; 32]);
+        let tx_hash = B256::from([0x86; 32]);
+        let l1_asserter = Asserter::new();
+        // By-hash lookup misses (the log's source block is gone) and finalized ancestry proves
+        // a different canonical hash at the log height: a finalized orphan. It must be skipped
+        // even though derivation reports its parent above the execution head — orphanhood
+        // settles first, rewind evidence never accumulates.
+        l1_asserter.push_success(&Option::<RpcBlock<TxEnvelope>>::None);
+        l1_asserter.push_success(&l1_block_at(1, B256::from([0x66; 32]), B256::ZERO));
+        let l2_asserter = Asserter::new();
+        l2_asserter.push_success(&U64::from(40u64));
+
+        let syncer = EventSyncer {
+            rpc: mock_client_with_asserters(
+                l1_asserter,
+                l2_asserter,
+                Asserter::new(),
+                Address::ZERO,
+            ),
+            ..build_syncer().await
+        };
+        let path = MockProductionPath::unavailable_for([tx_hash], 100);
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let result = timeout(
+            Duration::from_secs(120),
+            syncer.process_log_batch(
+                router,
+                vec![sample_proposed_log(1, orphaned_block_hash, tx_hash)],
+            ),
+        )
+        .await
+        .expect("the orphan skip should finish the batch");
+
+        assert!(matches!(result, Ok(())), "finalized orphan should be skipped: {result:?}");
+        assert_eq!(
+            path.calls(),
+            1,
+            "a finalized orphan must be skipped on first classification, not escalated"
+        );
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
+    async fn process_log_batch_never_escalates_missing_l1_source_blocks() {
+        let block_hash = B256::from([0x77; 32]);
+        let tx_hash = B256::from([0x87; 32]);
+        // The proposal's L1 source height sits far above the L2 head, as on young L2 chains.
+        // A lagging L1 backend must stay retryable — never terminate the driver.
+        let l2_asserter = Asserter::new();
+        for _ in 0..4 {
+            l2_asserter.push_success(&U64::from(40u64));
+        }
+
+        let syncer = EventSyncer {
+            rpc: mock_client_with_asserters(
+                Asserter::new(),
+                l2_asserter,
+                Asserter::new(),
+                Address::ZERO,
+            ),
+            ..build_syncer().await
+        };
+        let path = MockProductionPath::source_unavailable_for([tx_hash], 3_369_822);
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let result = timeout(
+            Duration::from_secs(90),
+            syncer.process_log_batch(router, vec![sample_proposed_log(1, block_hash, tx_hash)]),
+        )
+        .await;
+
+        assert!(result.is_err(), "missing L1 source blocks must keep retrying, not abort");
+        assert!(
+            path.calls() > 3,
+            "retries must continue past the rewind threshold, saw {}",
+            path.calls()
+        );
+    }
+
+    #[test]
+    fn rewind_streak_counts_only_consecutive_matching_blocks() {
+        let mut streak = RewindStreak::default();
+        assert_eq!(streak.observe(100), 1);
+        assert_eq!(streak.observe(100), 2);
+        // Derivation progressed to a different missing parent: stale evidence restarts.
+        assert_eq!(streak.observe(101), 1);
+        assert_eq!(streak.observe(101), 2);
+        streak.clear();
+        assert_eq!(streak.observe(101), 1);
     }
 
     #[test_log::test(tokio::test(start_paused = true))]

--- a/packages/taiko-client-rs/crates/driver/src/sync/event.rs
+++ b/packages/taiko-client-rs/crates/driver/src/sync/event.rs
@@ -188,8 +188,7 @@ const EXECUTION_REWIND_ABORT_THRESHOLD: u32 = 3;
 /// Escalation requires the SAME missing block to stay above the execution head across
 /// conclusive probes: a different missing block restarts the count (derivation progressed, so
 /// earlier evidence is stale). Inconclusive attempts (failed head probe, unrelated errors)
-/// deliberately leave the streak untouched instead of resetting it — a genuine rewind
-/// interleaved with a flaky probe must still escalate.
+/// clear the streak so escalation always rests on consecutive complete observations.
 #[derive(Default)]
 struct RewindStreak {
     /// Missing block the current streak is counting.
@@ -209,7 +208,7 @@ impl RewindStreak {
         self.count
     }
 
-    /// Clear the streak after evidence that the missing block exists at or below the head.
+    /// Clear the streak after an attempt fails to provide matching above-head evidence.
     fn clear(&mut self) {
         self.count = 0;
     }
@@ -963,9 +962,9 @@ impl EventSyncer {
     /// and never accumulates rewind evidence.
     ///
     /// Returns `None` when the ordinary retry classification should stay in charge: the failure
-    /// is not `BlockUnavailable`, the block exists at or below the head (streak clears), or the
-    /// head probe itself failed (missing evidence must not abort, and deliberately leaves the
-    /// streak intact so a flaky probe cannot indefinitely postpone escape from a real rewind).
+    /// is not `BlockUnavailable`, the block exists at or below the head, or the head probe itself
+    /// failed. Every such inconclusive attempt clears the streak so only consecutive complete
+    /// observations can trigger an abort.
     async fn probe_execution_rewind(
         &self,
         err: &DriverError,
@@ -975,6 +974,7 @@ impl EventSyncer {
             missing_block,
         ))) = err
         else {
+            rewind_streak.lock().expect("rewind streak mutex should not be poisoned").clear();
             return None;
         };
         let missing_block = *missing_block;
@@ -982,6 +982,7 @@ impl EventSyncer {
         let execution_head = match self.rpc.l2_provider.get_block_number().await {
             Ok(head) => head,
             Err(probe_err) => {
+                rewind_streak.lock().expect("rewind streak mutex should not be poisoned").clear();
                 warn!(
                     missing_block,
                     %probe_err,
@@ -1202,6 +1203,10 @@ impl EventSyncer {
                                         }
                                     }
                                     Err(recheck_err) => {
+                                        rewind_streak
+                                            .lock()
+                                            .expect("rewind streak mutex should not be poisoned")
+                                            .clear();
                                         warn!(
                                             ?err,
                                             ?recheck_err,
@@ -2817,6 +2822,52 @@ mod tests {
     }
 
     #[test_log::test(tokio::test(start_paused = true))]
+    async fn process_log_batch_resets_rewind_streak_after_failed_head_probe() {
+        let block_hash = B256::from([0x78; 32]);
+        let tx_hash = B256::from([0x88; 32]);
+        let l1_asserter = Asserter::new();
+        let l2_asserter = Asserter::new();
+        // Every attempt proves the source log is not a finalized orphan before probing the
+        // execution head. The failed third probe must invalidate the first two observations.
+        for _ in 0..6 {
+            l1_asserter.push_success(&l1_block_at(1, block_hash, B256::ZERO));
+            l1_asserter.push_success(&l1_block_at(0, B256::ZERO, B256::ZERO));
+        }
+        l2_asserter.push_success(&U64::from(40u64));
+        l2_asserter.push_success(&U64::from(40u64));
+        l2_asserter.push_failure_msg("execution head probe unavailable");
+        for _ in 0..3 {
+            l2_asserter.push_success(&U64::from(40u64));
+        }
+
+        let syncer = EventSyncer {
+            rpc: mock_client_with_asserters(
+                l1_asserter,
+                l2_asserter,
+                Asserter::new(),
+                Address::ZERO,
+            ),
+            ..build_syncer().await
+        };
+        let path = MockProductionPath::unavailable_for([tx_hash], 100);
+        let router = Arc::new(AsyncMutex::new(ProductionRouter::new(Arc::new(path.clone()), None)));
+
+        let err = timeout(
+            Duration::from_secs(120),
+            syncer.process_log_batch(router, vec![sample_proposed_log(1, block_hash, tx_hash)]),
+        )
+        .await
+        .expect("a renewed three-observation streak must eventually abort")
+        .expect_err("persistent above-head unavailability should abort after the renewed streak");
+
+        assert!(matches!(
+            err,
+            SyncError::ExecutionEngineRewound { missing_block: 100, execution_head: 40 }
+        ));
+        assert_eq!(path.calls(), 6, "the failed probe must reset the first two observations");
+    }
+
+    #[test_log::test(tokio::test(start_paused = true))]
     async fn process_log_batch_skips_finalized_orphan_before_rewind_escalation() {
         let orphaned_block_hash = B256::from([0x76; 32]);
         let tx_hash = B256::from([0x86; 32]);
@@ -2866,14 +2917,18 @@ mod tests {
         let tx_hash = B256::from([0x87; 32]);
         // The proposal's L1 source height sits far above the L2 head, as on young L2 chains.
         // A lagging L1 backend must stay retryable — never terminate the driver.
+        let l1_asserter = Asserter::new();
         let l2_asserter = Asserter::new();
         for _ in 0..4 {
+            // Settle canonicality as Unproven so each attempt reaches rewind classification.
+            l1_asserter.push_success(&l1_block_at(1, block_hash, B256::ZERO));
+            l1_asserter.push_success(&l1_block_at(0, B256::ZERO, B256::ZERO));
             l2_asserter.push_success(&U64::from(40u64));
         }
 
         let syncer = EventSyncer {
             rpc: mock_client_with_asserters(
-                Asserter::new(),
+                l1_asserter,
                 l2_asserter,
                 Asserter::new(),
                 Address::ZERO,

--- a/packages/taiko-client-rs/crates/driver/src/test_support.rs
+++ b/packages/taiko-client-rs/crates/driver/src/test_support.rs
@@ -136,6 +136,10 @@ pub(crate) enum MockProductionBehavior {
     FailOnceFor(Mutex<HashSet<B256>>),
     /// Always fail with a deterministic engine verdict.
     Fatal,
+    /// Always fail with [`DerivationError::BlockUnavailable`] for the given transaction hashes.
+    UnavailableFor(HashSet<B256>, u64),
+    /// Fail with [`DerivationError::BlockUnavailable`] once per transaction hash, then succeed.
+    UnavailableOnceFor(Mutex<HashSet<B256>>, u64),
 }
 
 /// Configurable [`BlockProductionPath`] mock recording every input it produces.
@@ -171,6 +175,28 @@ impl MockProductionPath {
     /// Mock that always fails proposal logs with a deterministic engine verdict.
     pub(crate) fn fatal() -> Self {
         Self::with_behavior(MockProductionBehavior::Fatal)
+    }
+
+    /// Mock that always fails the given proposal logs with `BlockUnavailable(missing_block)`.
+    pub(crate) fn unavailable_for(
+        tx_hashes: impl IntoIterator<Item = B256>,
+        missing_block: u64,
+    ) -> Self {
+        Self::with_behavior(MockProductionBehavior::UnavailableFor(
+            tx_hashes.into_iter().collect(),
+            missing_block,
+        ))
+    }
+
+    /// Mock that fails each given proposal log once with `BlockUnavailable(missing_block)`.
+    pub(crate) fn unavailable_once_for(
+        tx_hashes: impl IntoIterator<Item = B256>,
+        missing_block: u64,
+    ) -> Self {
+        Self::with_behavior(MockProductionBehavior::UnavailableOnceFor(
+            Mutex::new(tx_hashes.into_iter().collect()),
+            missing_block,
+        ))
     }
 
     /// Mock with the given proposal-log behavior and fresh recording state.
@@ -249,6 +275,26 @@ impl BlockProductionPath for MockProductionPath {
                                 "mock invalid payload".to_string(),
                             )),
                         )));
+                    }
+                    MockProductionBehavior::UnavailableFor(tx_hashes, missing_block) => {
+                        if log.transaction_hash.is_some_and(|tx_hash| tx_hashes.contains(&tx_hash))
+                        {
+                            return Err(DriverError::Sync(SyncError::Derivation(
+                                DerivationError::BlockUnavailable(*missing_block),
+                            )));
+                        }
+                    }
+                    MockProductionBehavior::UnavailableOnceFor(tx_hashes, missing_block) => {
+                        if let Some(tx_hash) = log.transaction_hash &&
+                            tx_hashes
+                                .lock()
+                                .expect("unavailable-once tx hashes mutex should not be poisoned")
+                                .remove(&tx_hash)
+                        {
+                            return Err(DriverError::Sync(SyncError::Derivation(
+                                DerivationError::BlockUnavailable(*missing_block),
+                            )));
+                        }
                     }
                 }
 

--- a/packages/taiko-client-rs/crates/driver/src/test_support.rs
+++ b/packages/taiko-client-rs/crates/driver/src/test_support.rs
@@ -140,6 +140,9 @@ pub(crate) enum MockProductionBehavior {
     UnavailableFor(HashSet<B256>, u64),
     /// Fail with [`DerivationError::BlockUnavailable`] once per transaction hash, then succeed.
     UnavailableOnceFor(Mutex<HashSet<B256>>, u64),
+    /// Always fail the given transaction hashes the way `decode_log_to_event_context` fails
+    /// when the proposal's L1 source block is missing from the L1 provider view.
+    SourceUnavailableFor(HashSet<B256>, u64),
 }
 
 /// Configurable [`BlockProductionPath`] mock recording every input it produces.
@@ -196,6 +199,17 @@ impl MockProductionPath {
         Self::with_behavior(MockProductionBehavior::UnavailableOnceFor(
             Mutex::new(tx_hashes.into_iter().collect()),
             missing_block,
+        ))
+    }
+
+    /// Mock that always fails the given proposal logs the way a missing L1 source block does.
+    pub(crate) fn source_unavailable_for(
+        tx_hashes: impl IntoIterator<Item = B256>,
+        l1_block_number: u64,
+    ) -> Self {
+        Self::with_behavior(MockProductionBehavior::SourceUnavailableFor(
+            tx_hashes.into_iter().collect(),
+            l1_block_number,
         ))
     }
 
@@ -293,6 +307,16 @@ impl BlockProductionPath for MockProductionPath {
                         {
                             return Err(DriverError::Sync(SyncError::Derivation(
                                 DerivationError::BlockUnavailable(*missing_block),
+                            )));
+                        }
+                    }
+                    MockProductionBehavior::SourceUnavailableFor(tx_hashes, l1_block_number) => {
+                        if log.transaction_hash.is_some_and(|tx_hash| tx_hashes.contains(&tx_hash))
+                        {
+                            // Mirrors `decode_log_to_event_context` when the L1 provider's view
+                            // is missing the proposal's source block.
+                            return Err(DriverError::Sync(SyncError::Derivation(
+                                DerivationError::SourceBlockUnavailable(*l1_block_number),
                             )));
                         }
                     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -189,7 +189,7 @@ impl WhitelistPreconfirmationDriverRunner {
                     let _ = command_tx.send(NetworkCommand::Shutdown).await;
                     node_handle.abort();
                     stop_sidecars(event_syncer_handle, &mut rest_ws_server).await;
-                    return map_event_syncer_exit(result).map_err(Into::into);
+                    return map_runner_event_syncer_exit(result);
                 }
                 maybe_event = event_rx.recv() => {
                     let Some(event) = maybe_event else {
@@ -219,6 +219,13 @@ impl WhitelistPreconfirmationDriverRunner {
     }
 }
 
+/// Convert event syncer task termination into the whitelist runner's error type.
+fn map_runner_event_syncer_exit(
+    result: driver::preconf_ingress_sync::EventSyncJoinResult,
+) -> Result<()> {
+    map_event_syncer_exit(result).map_err(Into::into)
+}
+
 /// Abort sidecar tasks and stop the REST server during shutdown.
 async fn stop_sidecars<T>(
     event_syncer_handle: &mut tokio::task::JoinHandle<T>,
@@ -227,5 +234,31 @@ async fn stop_sidecars<T>(
     event_syncer_handle.abort();
     if let Some(server) = rest_ws_server.take() {
         server.stop().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_rewind_exit_propagates_as_sync_error() {
+        let err = map_runner_event_syncer_exit(Ok(Err(driver::DriverError::Sync(
+            driver::sync::SyncError::ExecutionEngineRewound {
+                missing_block: 100,
+                execution_head: 40,
+            },
+        ))))
+        .expect_err("execution rewind must stop the whitelist runner");
+
+        assert!(matches!(
+            err,
+            WhitelistPreconfirmationDriverError::Sync(
+                driver::sync::SyncError::ExecutionEngineRewound {
+                    missing_block: 100,
+                    execution_head: 40,
+                }
+            )
+        ));
     }
 }

--- a/packages/taiko-client-rs/docs/superpowers/specs/2026-08-07-finalized-forkchoice-and-rewind-recovery-design.md
+++ b/packages/taiko-client-rs/docs/superpowers/specs/2026-08-07-finalized-forkchoice-and-rewind-recovery-design.md
@@ -1,0 +1,214 @@
+# Finalized Forkchoice Propagation and Execution-Rewind Recovery
+
+**Status:** Design approved; written specification pending review
+**Date:** 2026-08-07
+**Scope:** `packages/taiko-client-rs`
+
+## Context
+
+The Hoodi Rust-driver Reth node exposed two independent driver defects during the same incident.
+
+First, whitelist preconfirmation insertion currently calls the payload applier without a finalized
+block hash. Canonical proposal processing can advance finality, but its known-canonical fast path
+returns after updating origin metadata and does not issue a forkchoice update. Reth therefore can
+keep its finalized head stale while accepting thousands of unsafe blocks. The affected Alethia-Reth
+revision retains one changeset-cache entry per block above finalized, so stale driver finality
+amplifies memory growth into an OOM.
+
+Second, an execution-layer restart can discard its unpersisted canonical tail while Alethia-Reth
+custom origin and batch mappings still reference blocks in that tail. The running Rust driver then
+loads the stale mapped parent, receives `BlockUnavailable`, and retries the same proposal forever.
+The safe beacon-checkpoint and resume-head selection path runs only at driver startup, so it is not
+re-entered until the driver restarts.
+
+On 2026-08-07, Reth moved from block 16,211,455 back to 16,211,327, an exact 128-block rewind. The
+driver retried `BlockUnavailable(16211429)` 1,105 times for the same proposal from 08:18:54Z until
+the pod was deleted at 12:40:46Z. Restarting the driver reran beacon sync, selected a new checkpoint
+resume head, and restored progress.
+
+## Goals
+
+1. Propagate a recent proof-finalized L2 checkpoint through both preconfirmation and canonical
+   forkchoice updates.
+2. Cover the known-canonical proposal fast path, where no payload is submitted.
+3. Escape the proposal retry loop when the execution engine has demonstrably rewound below a
+   required L2 parent.
+4. Reuse the existing startup beacon-sync recovery path instead of introducing another recovery
+   state machine.
+5. Preserve proposal canonicality, L1 reorg, confirmed-boundary, and preconfirmation ordering
+   invariants.
+
+## Non-goals
+
+- Fixing Alethia-Reth changeset-cache ownership, custom-table persistence, or startup
+  reconciliation.
+- Adding a periodic finality task or a second driver supervisor loop.
+- Changing Kubernetes CPU or memory resources, probes, or restart policy.
+- Treating every missing block, RPC failure, or EL restart as a confirmed execution rewind.
+- Changing protocol finalization semantics.
+
+## Design
+
+### 1. Finalized checkpoint sources
+
+Use one checkpoint value type across production paths:
+
+```text
+FinalizedCheckpoint {
+    proposal_id: u64,
+    block_hash: B256,
+}
+```
+
+Both paths read `Inbox.getCoreState()` and use the returned `lastFinalizedProposalId` and
+`lastFinalizedBlockHash` directly. This avoids resolving the finalized block through Alethia-Reth
+custom batch tables, which may legitimately be absent after checkpoint sync.
+
+Canonical proposal processing reads CoreState at the proposal log's L1 block and stores the pair in
+the proposal bundle metadata. This event-scoped snapshot preserves replay ordering: a checkpoint
+from a newer L1 block must not be attached to an older canonical proposal because it could place
+safe/finalized ahead of the forkchoice head.
+
+Preconfirmation processing uses a small shared cache sourced from CoreState at a finalized L1
+block. It uses a three-minute TTL, matching the Go driver's checkpoint-cache cadence:
+
+- the first lookup refreshes synchronously;
+- a fresh value is returned immediately;
+- a stale value is returned immediately while one background refresh runs;
+- concurrent stale readers do not start duplicate refreshes;
+- a failed refresh retains the last valid value;
+- proposal IDs may advance but never regress;
+- a zero hash is rejected;
+- the same proposal ID with a different hash is rejected and logged.
+
+There is no timer-driven task. Refresh work is triggered only by canonical or preconfirmation
+production activity.
+
+On a cold-cache refresh failure, preconfirmation receives no checkpoint, keeps its current
+availability behavior, and submits without a finalized hash; a later production input retries the
+refresh. A canonical CoreState lookup retains its existing error propagation because its snapshot
+is part of deriving that proposal.
+
+### 2. Forkchoice propagation
+
+Preconfirmation production obtains the cached checkpoint before applying a payload. When present,
+the existing payload-promotion forkchoice state uses the new block as head and the checkpoint hash
+as both safe and finalized. When absent, it preserves the current `None` behavior.
+
+Canonical payload production uses the event-scoped checkpoint in bundle metadata instead of
+resolving finality through `last_block_id_by_batch_id`. All blocks in one proposal use the same
+checkpoint snapshot. The checkpoint proposal ID must not exceed the proposal being processed.
+
+The known-canonical proposal fast path performs no payload insertion, but it must still send a
+no-payload `forkchoiceUpdated` call after validating the canonical proposal. Its head is the
+detected canonical proposal tip; safe and finalized are the event-scoped checkpoint. Origin
+metadata is updated only as already permitted by the canonical-path invariants.
+
+The engine abstraction gains only the minimal no-payload forkchoice operation needed by this fast
+path. It reuses the existing `VALID` status validation and does not introduce payload attributes.
+
+### 3. Execution-rewind escape
+
+Give a missing L1 source block a distinct derivation error so it cannot enter execution-rewind
+classification. A missing L2 parent remains retryable initially. Before retrying it, event sync
+reads the current execution head and records consecutive rewind observations. It promotes the
+failure to `SyncError::ExecutionEngineRewound` only when all of the following hold:
+
+1. derivation failed to load the required parent block;
+2. the execution head query succeeded; and
+3. the required block number is above the current execution head; and
+4. the same missing block has produced that result on three consecutive attempts.
+
+The error records both `missing_block` and `execution_head`. If the head cannot be queried, or it is
+not below the missing block, the consecutive observation count resets and existing retry and
+proposal-canonicality behavior remains unchanged. A different missing block starts a new count.
+Permanently orphaned L1 proposal logs are still skipped before rewind classification.
+
+`ExecutionEngineRewound` exits the event-sync task instead of entering `RetryIf` again. The existing
+whitelist runner already propagates event-sync termination, shuts down its network sidecars, and
+returns an error from the command. Under Kubernetes, the driver container then restarts and executes
+the existing sequence:
+
+```text
+beacon checkpoint sync -> safe resume-head resolution -> fresh derivation pipeline -> event sync
+```
+
+This intentionally uses process restart as the recovery boundary. An in-process supervisor would
+need to reset ingress tasks, router state, processed-log caches, and derivation state, duplicating
+the startup lifecycle for no additional Kubernetes availability benefit.
+
+## Error handling and safety
+
+- Finalized checkpoint refresh failures never discard a previously validated checkpoint.
+- Preconfirmation checkpoints never regress within one process.
+- A preconfirmation checkpoint is sourced from finalized L1 state, not an unsafe latest-state
+  observation.
+- A canonical checkpoint is tied to the proposal's L1 block and cannot be newer than its
+  forkchoice head.
+- The rewind escape cannot trigger merely because an L1 block is temporarily unavailable.
+- A confirmed execution rewind fails visibly and restarts the driver rather than remaining Ready
+  while silently retrying one proposal.
+- Existing deterministic engine-verdict and finalized-L1 canonicality rules remain unchanged.
+- No recovery path crosses below the confirmed/finalized boundary selected by startup beacon sync.
+
+## Test strategy
+
+Add focused tests for:
+
+1. preconfirmation checkpoint cold load, fresh hit, stale-while-refresh, singleflight refresh,
+   refresh failure, zero hash rejection, and monotonic non-regression;
+2. preconfirmation payload promotion with and without a cached finalized hash;
+3. canonical payload production using the event-scoped CoreState hash directly, including
+   rejection of a checkpoint ahead of the proposal;
+4. known-canonical proposal processing issuing one no-payload forkchoice update;
+5. the same missing derivation parent above the execution head escaping after three consecutive
+   classified attempts;
+6. a missing block at or below the head remaining on the existing retry path;
+7. an execution-head query failure remaining retryable;
+8. a missing L1 source block never entering execution-rewind classification;
+9. an orphaned proposal log being skipped rather than classified as a rewind; and
+10. event-sync failure propagation through the whitelist runner.
+
+The implementation plan must preserve RED/GREEN evidence for the finalized-propagation and
+execution-rewind regression seams independently. Final verification is:
+
+```text
+just fmt
+just clippy-fix
+just test
+```
+
+from `packages/taiko-client-rs`, plus a final merge-base diff review.
+
+## Documentation impact
+
+Update the following invariant references when code anchors move:
+
+- `docs/agents/whitelist-preconfirmation-invariants.md`
+- `docs/agents/event-scan-reorg-and-preconf-flow.md`
+- `docs/agents/alethia-reth-custom-tables-and-beacon-sync-gaps.md`
+- `docs/agents/reference-map.md`
+
+The documentation must keep the two remediations distinct:
+
+- finalized propagation prevents stale-finality resource amplification;
+- rewind escape restores availability after a separately triggered EL rollback.
+
+## Rejected alternatives
+
+### Strict Go parity only
+
+Updating finalized only during preconfirmation insertion would leave the canonical known-block fast
+path uncovered and would preserve dependence on potentially missing custom batch mappings.
+
+### Independent periodic finality loop
+
+A timer would advance finality during completely idle production periods, but adds task lifecycle,
+shutdown, and engine-call concurrency for little benefit. Event-driven three-minute refresh is
+sufficient for the observed workload.
+
+### In-process rewind supervisor
+
+Looping beacon and event stages inside the same process could avoid a container restart, but requires
+careful teardown and reconstruction of ingress and network state. Exiting through the existing
+runner is smaller, observable, and already supervised in the deployed environment.


### PR DESCRIPTION
## The bug

After an unclean execution-engine restart (OOMKill), reth rewinds to its last persisted block, losing the in-memory tail — while `head_l1_origin` still points above the new head. The running event syncer then retries the same proposal forever:

```
WARN proposal derivation failed; retrying err=Sync(Derivation(BlockUnavailable(16211429)))
WARN orphan-proof ancestry walk exceeds cap; keeping proposal log retryable
```

The missing parent can never reappear on its own — event derivation is the only producer of that range and it is stuck behind this proposal; gossip drops the gap blocks as stale, and the safe resume-head resolution (`resolve_resume_head_block_number`, checkpoint path) only runs at driver **startup**. The node freezes silently (and keeps reporting Ready) until an operator restarts the pod.

Two production incidents on hoodi `l2-node-reth-0`: 2026-08-02 (~14.5h frozen) and 2026-08-07 (~4.5h frozen, chain head alert), both ended by a manual pod delete. The rewind trigger (an alethia-reth memory leak on sub-5-CPU nodes) is being removed by taikoxyz/k8s-configs#1478, but any future EL rewind under a running driver reproduces the freeze.

## The fix

When a proposal fails with `BlockUnavailable(n)`, probe the execution head. Three consecutive observations of `n` strictly above the live head classify the failure as a rewind: abort the event-sync run (`SyncError::ExecutionEngineRewound`) instead of retrying. The whitelist runner already treats an event-syncer exit as fatal, so the driver process exits and restarts (k8s restarts only the driver container — the EL is untouched), re-resolves a safe resume head (checkpoint-synced, or `min(head, head_l1_origin)`), and re-derives the lost range. This is exactly the manual remedy from both incidents, automated.

Deliberately out of scope: re-resolving the resume head in-place. Startup resolution is the single tested authority for choosing a safe resume point; duplicating it mid-run would fork that logic. The abort-and-restart path reuses it wholesale.

Conservative by construction:
- a failed head probe proves nothing → ordinary retry stays in charge;
- `BlockUnavailable` at/below the head is not a rewind → streak resets, existing retry/canonicality classification untouched;
- the three-observation streak filters head-probe races around an in-flight insert (~1s of backoff).

Adds `driver_event_execution_rewind_aborts_total`.

## Tests

TDD: the abort test was written first and failed on `main` by looping exactly like production (virtual-clock timeout with the same retry warns), then the fix made it pass.

- `process_log_batch_aborts_after_persistent_block_unavailable_above_execution_head` — bounded abort at the threshold with `ExecutionEngineRewound { missing_block, execution_head }`
- `process_log_batch_keeps_retrying_block_unavailable_at_or_below_execution_head` — boundary guard (not a rewind → retry then succeed)
- `process_log_batch_keeps_retrying_when_execution_head_probe_fails` — missing evidence must not abort

`cargo test -p driver --lib`: 129 passed. Both CI clippy passes clean; nightly rustfmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)