### PR TITLE
perf(protocol): avoid redundant fixed-k scalar multiplication

### DIFF
--- a/packages/taiko-client-rs/crates/protocol/src/signer.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/signer.rs
@@ -95,11 +95,17 @@ impl FixedKSigner {
         &self,
         hash: &[u8; 32],
     ) -> Result<SignatureWithRecoveryId, FixedKSignerError> {
-        for candidate in [Scalar::ONE, Scalar::from(2u64)] {
-            if let Ok(signature) = self.sign_with_specific_k(candidate, hash) {
-                debug!(?candidate, "generated signature with fixed k");
-                return Ok(signature);
-            }
+        if let Ok(signature) =
+            self.sign_with_k_components(AffinePoint::GENERATOR, Scalar::ONE, hash)
+        {
+            debug!(candidate = ?Scalar::ONE, "generated signature with fixed k");
+            return Ok(signature);
+        }
+
+        let candidate = Scalar::from(2u64);
+        if let Ok(signature) = self.sign_with_specific_k(candidate, hash) {
+            debug!(?candidate, "generated signature with fixed k");
+            return Ok(signature);
         }
         Err(FixedKSignerError::SigningFailed)
     }
@@ -113,15 +119,25 @@ impl FixedKSigner {
     ) -> Result<SignatureWithRecoveryId, FixedKSignerError> {
         // Calculate k * G in affine coordinates.
         let k_point: AffinePoint = ProjectivePoint::mul_by_generator(&k).to_affine();
+        let kinv =
+            Option::<Scalar>::from(k.invert()).ok_or(FixedKSignerError::NonInvertibleScalar)?;
+
+        self.sign_with_k_components(k_point, kinv, hash)
+    }
+
+    /// Finish signing from the affine nonce point and inverse nonce scalar.
+    fn sign_with_k_components(
+        &self,
+        k_point: AffinePoint,
+        kinv: Scalar,
+        hash: &[u8; 32],
+    ) -> Result<SignatureWithRecoveryId, FixedKSignerError> {
         let x_bytes = k_point.x();
         let y_is_odd = bool::from(k_point.y_is_odd());
 
         let raw_r = Scalar::from_repr(x_bytes);
         let overflow = !bool::from(raw_r.is_some());
         let r = raw_r.unwrap_or_else(|| <Scalar as Reduce<ScalarModulus>>::reduce_bytes(&x_bytes));
-
-        let kinv =
-            Option::<Scalar>::from(k.invert()).ok_or(FixedKSignerError::NonInvertibleScalar)?;
 
         // s = k^{-1} (hash + r * priv)
         let hash_bytes: FieldBytes = (*hash).into();
@@ -217,13 +233,30 @@ mod tests {
             "0x663d210fa6dba171546498489de1ba024b89db49e21662f91bf83cdffe788820",
         )
         .unwrap();
-        let k1_sig = signer.sign_with_specific_k(Scalar::ONE, &payload).ok();
-        let k2_sig =
-            signer.sign_with_specific_k(Scalar::from(2u64), &payload).expect("k=2 signature");
-        let actual =
-            signer.sign_with_predefined_k(&payload).expect("predefined k signature").signature;
-        let matches_k1 = k1_sig.as_ref().map(|sig| sig.signature == actual).unwrap_or(false);
-        let matches_k2 = k2_sig.signature == actual;
-        assert!(matches_k1 || matches_k2, "predefined-k result matches neither k=1 nor k=2 output");
+        let expected = signer.sign_with_specific_k(Scalar::ONE, &payload).expect("k=1 signature");
+        let actual = signer.sign_with_predefined_k(&payload).expect("predefined k signature");
+
+        assert_eq!(actual.signature, expected.signature);
+        assert_eq!(actual.recovery_id, expected.recovery_id);
+    }
+
+    #[test]
+    fn sign_with_predefined_k_falls_back_when_k1_produces_zero_s() {
+        let signer = FixedKSigner::golden_touch().expect("golden touch key");
+        let r = Option::<Scalar>::from(Scalar::from_repr(AffinePoint::GENERATOR.x()))
+            .expect("generator x coordinate is canonical");
+        let payload: [u8; 32] = (-(r * signer.secret_scalar)).to_bytes().into();
+
+        assert!(matches!(
+            signer.sign_with_specific_k(Scalar::ONE, &payload),
+            Err(FixedKSignerError::ZeroSignatureComponent)
+        ));
+        let expected = signer
+            .sign_with_specific_k(Scalar::from(2u64), &payload)
+            .expect("k=2 fallback signature");
+        let actual = signer.sign_with_predefined_k(&payload).expect("predefined k signature");
+
+        assert_eq!(actual.signature, expected.signature);
+        assert_eq!(actual.recovery_id, expected.recovery_id);
     }
 }

--- a/packages/taiko-client-rs/crates/protocol/src/signer.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/signer.rs
@@ -6,6 +6,7 @@ use k256::{
     elliptic_curve::{
         bigint::U256 as ScalarModulus,
         ff::PrimeField,
+        group::prime::PrimeCurveAffine,
         ops::{MulByGenerator, Reduce},
         point::AffineCoordinates,
         scalar::IsHigh,
@@ -95,8 +96,10 @@ impl FixedKSigner {
         &self,
         hash: &[u8; 32],
     ) -> Result<SignatureWithRecoveryId, FixedKSignerError> {
+        // For k = 1, kG is the generator and k^-1 is one, so skip the generic
+        // scalar multiplication and inversion path.
         if let Ok(signature) =
-            self.sign_with_k_components(AffinePoint::GENERATOR, Scalar::ONE, hash)
+            self.sign_with_k_components(AffinePoint::generator(), Scalar::ONE, hash)
         {
             debug!(candidate = ?Scalar::ONE, "generated signature with fixed k");
             return Ok(signature);
@@ -126,6 +129,8 @@ impl FixedKSigner {
     }
 
     /// Finish signing from the affine nonce point and inverse nonce scalar.
+    ///
+    /// `k_point` and `kinv` must be derived from the same non-zero nonce scalar.
     fn sign_with_k_components(
         &self,
         k_point: AffinePoint,


### PR DESCRIPTION
## Summary
- use the known generator point and inverse scalar directly for the fixed k=1 signing attempt
- preserve the existing k=2 fallback through the generic path
- add coverage for both the normal k=1 result and the zero-s fallback case
- use the affine generator API supported by both standard k256 and the SP1-patched implementation

## Motivation
Taiko anchor transaction reconstruction intentionally uses fixed k=1. Running that known constant through generic secp256k1 generator multiplication and inversion is especially expensive inside zkVM guests. On a 192-block Shasta proposal, this change reduced RISC0 user cycles by another 801M after the KZG setup optimization, with identical guest output.

## Verification
- rustfmt +1.94.1 --edition 2024 --check packages/taiko-client-rs/crates/protocol/src/signer.rs
- cargo test -p protocol signer::tests -- --nocapture
- raiko2: just build-guest risc0 --force
- raiko2: just build-guest sp1 --bench --force
- raiko2: RISC0 and SP1 execution on proposal 23077 produced identical public output