### PR TITLE
chore(taiko-client-rs): use standard preconfirmation signer

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -10140,6 +10140,8 @@ dependencies = [
  "alloy-rpc-types 1.8.3",
  "alloy-rpc-types-engine 1.8.3",
  "alloy-rpc-types-engine 2.2.0",
+ "alloy-signer",
+ "alloy-signer-local",
  "arc-swap",
  "async-trait",
  "axum",

--- a/packages/taiko-client-rs/crates/protocol/src/signer.rs
+++ b/packages/taiko-client-rs/crates/protocol/src/signer.rs
@@ -45,7 +45,7 @@ pub enum FixedKSignerError {
     SigningFailed,
 }
 
-/// Deterministic secp256k1 signer.
+/// Deterministic secp256k1 signer for golden-touch anchor transactions.
 #[derive(Debug, Clone)]
 pub struct FixedKSigner {
     /// Secp256k1 private scalar used for fixed-k signing.
@@ -57,7 +57,7 @@ pub struct FixedKSigner {
 impl FixedKSigner {
     /// Instantiate a signer from a hex-encoded private key (with or without `0x`).
     #[instrument(skip(private_key_hex))]
-    pub fn new(private_key_hex: &str) -> Result<Self, FixedKSignerError> {
+    fn new(private_key_hex: &str) -> Result<Self, FixedKSignerError> {
         let trimmed = private_key_hex.strip_prefix("0x").unwrap_or(private_key_hex);
         let bytes = hex::decode_to_array::<_, 32>(trimmed)
             .map_err(|_| FixedKSignerError::InvalidPrivateKey)?;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/Cargo.toml
@@ -15,6 +15,8 @@ alloy-provider = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-rpc-types-engine = { workspace = true, features = ["ssz"] }
 alloy-rpc-types-engine-2 = { workspace = true }
+alloy-signer = { workspace = true }
+alloy-signer-local = { workspace = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/mod.rs
@@ -11,9 +11,11 @@ use alloy_primitives::{B256, Bloom, FixedBytes, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::SyncStatus;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
 use async_trait::async_trait;
 use driver::{PreconfPayload, PreconfSubmissionOutcome, sync::event::EventSyncer};
-use protocol::{shasta::calculate_shasta_mix_hash, signer::FixedKSigner};
+use protocol::shasta::calculate_shasta_mix_hash;
 use rpc::{beacon::BeaconClient, client::Client};
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tracing::{debug, warn};
@@ -101,8 +103,8 @@ pub(crate) struct WhitelistApiService {
     rpc: Client,
     /// Chain ID for signature domain separation.
     chain_id: u64,
-    /// Deterministic signer for block signing.
-    signer: FixedKSigner,
+    /// Standard secp256k1 signer for block signing.
+    signer: PrivateKeySigner,
     /// Beacon client used to derive current epoch values for EOS requests.
     beacon_client: Arc<BeaconClient>,
     /// Channel to publish messages to the P2P network.
@@ -131,7 +133,7 @@ pub(crate) struct WhitelistApiServiceParams {
     /// Chain ID used for signing and payload hashing.
     pub(crate) chain_id: u64,
     /// Signer used for block signing operations.
-    pub(crate) signer: FixedKSigner,
+    pub(crate) signer: PrivateKeySigner,
     /// Beacon client used for epoch calculations.
     pub(crate) beacon_client: Arc<BeaconClient>,
     /// Shared operator set used to gate the build API on the node's own whitelist status.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/payload_build.rs
@@ -46,16 +46,12 @@ impl WhitelistApiService {
 
     /// Build a 65-byte signature from a digest.
     pub(super) fn sign_digest(&self, digest: B256) -> Result<[u8; 65]> {
-        let sig_result = self
+        let signature = self
             .signer
-            .sign_with_predefined_k(digest.as_ref())
+            .sign_hash_sync(&digest)
             .map_err(|e| WhitelistPreconfirmationDriverError::Signing(e.to_string()))?;
 
-        let mut sig_bytes = [0u8; 65];
-        sig_bytes[..32].copy_from_slice(&sig_result.signature.r().to_be_bytes::<32>());
-        sig_bytes[32..64].copy_from_slice(&sig_result.signature.s().to_be_bytes::<32>());
-        sig_bytes[64] = sig_result.recovery_id;
-        Ok(sig_bytes)
+        Ok(signature.as_rsy())
     }
 
     /// Derive the mix-hash / prev-randao from the parent block.

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -3,12 +3,13 @@ use std::{
     time::{Duration, Instant},
 };
 
+use alloy_signer_local::PrivateKeySigner;
 use flate2::{Compression, write::ZlibEncoder};
 
 use crate::{
     api::service::{
         HAND_OVER_WINDOW_SLOTS, SHUTDOWN_BLOCK_WINDOW, SHUTDOWN_IMMINENCE_MARGIN_SLOTS,
-        can_shutdown_for,
+        WhitelistApiService, can_shutdown_for,
     },
     cache::SharedPreconfState,
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, decompress_tx_list},
@@ -26,6 +27,17 @@ const IMMINENCE_BAND_START: u64 =
 /// A slot comfortably outside the imminence band, so activity-focused tests
 /// exercise only the request-recency rule.
 const MID_EPOCH_SLOT: u64 = 2;
+
+#[test]
+fn whitelist_service_uses_standard_signer() {
+    fn assert_standard_signer(_: &PrivateKeySigner) {}
+
+    fn check_service_signer(service: &WhitelistApiService) {
+        assert_standard_signer(&service.signer);
+    }
+
+    let _ = check_service_signer as fn(&WhitelistApiService);
+}
 
 fn compress(payload: &[u8]) -> Vec<u8> {
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/tests.rs
@@ -7,6 +7,8 @@ use alloy_consensus::{
 use alloy_eips::{Encodable2718, eip2930::AccessList};
 use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
 use alloy_rpc_types_engine::ExecutionPayloadV1;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
 use protocol::{FixedKSigner, codec::ZlibTxListCodec};
 
 use crate::{
@@ -113,6 +115,29 @@ fn signed_anchor_tx_bytes(
 
     let envelope =
         TxEnvelope::new_unhashed(EthereumTypedTransaction::Eip1559(tx), signature.signature);
+    envelope.encoded_2718().to_vec()
+}
+
+fn standard_signed_anchor_tx_bytes(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    anchor_address: Address,
+    selector: [u8; 4],
+) -> Vec<u8> {
+    let tx = TxEip1559 {
+        chain_id,
+        nonce: 0,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 0,
+        gas_limit: 210_000,
+        to: alloy_primitives::TxKind::Call(anchor_address),
+        value: U256::ZERO,
+        access_list: AccessList::default(),
+        input: Bytes::from(selector.to_vec()),
+    };
+
+    let signature = signer.sign_hash_sync(&tx.signature_hash()).expect("sign anchor transaction");
+    let envelope = TxEnvelope::new_unhashed(EthereumTypedTransaction::Eip1559(tx), signature);
     envelope.encoded_2718().to_vec()
 }
 
@@ -470,9 +495,14 @@ fn validate_payload_rejects_anchor_with_wrong_recipient() {
 #[test]
 fn validate_payload_rejects_anchor_with_wrong_sender() {
     let anchor_address = sample_anchor_address();
-    let signer = FixedKSigner::new(NON_GOLDEN_SIGNER_PRIVATE_KEY).expect("non-golden signer key");
-    let tx_bytes =
-        signed_anchor_tx_bytes(&signer, TEST_CHAIN_ID, anchor_address, *ANCHOR_V4_SELECTOR);
+    let signer =
+        NON_GOLDEN_SIGNER_PRIVATE_KEY.parse::<PrivateKeySigner>().expect("non-golden signer key");
+    let tx_bytes = standard_signed_anchor_tx_bytes(
+        &signer,
+        TEST_CHAIN_ID,
+        anchor_address,
+        *ANCHOR_V4_SELECTOR,
+    );
     let envelope =
         sample_execution_payload_with_transactions(vec![encode_compressed_tx_list(vec![tx_bytes])]);
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -5,11 +5,11 @@ use std::{net::SocketAddr, sync::Arc};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::Address;
 use alloy_provider::Provider;
+use alloy_signer_local::PrivateKeySigner;
 use driver::{
     DriverConfig,
     preconf_ingress_sync::{PreconfIngressSync, map_event_syncer_exit},
 };
-use protocol::signer::FixedKSigner;
 use rpc::beacon::BeaconClient;
 use tracing::{info, warn};
 
@@ -120,7 +120,7 @@ impl WhitelistPreconfirmationDriverRunner {
         let mut rest_ws_server = if let (Some(listen_addr), Some(signer_key)) =
             (self.config.rpc_listen_addr, &self.config.p2p_signer_key)
         {
-            let signer = FixedKSigner::new(signer_key).map_err(|e| {
+            let signer = signer_key.parse::<PrivateKeySigner>().map_err(|e| {
                 WhitelistPreconfirmationDriverError::Signing(format!(
                     "failed to create P2P signer: {e}"
                 ))


### PR DESCRIPTION
## Summary

- replace the Rust whitelist preconfirmation driver's fixed-k signer with Alloy's standard `PrivateKeySigner`
- keep the existing preconfirmation signing domain and `r || s || yParity` wire encoding
- restrict `FixedKSigner` construction to the public golden-touch key used by `anchorV4`
- update the wrong-anchor-sender test to use a normal signer and add a regression guard for the whitelist service signer type

## Root cause

`FixedKSigner` uses the public, predefined nonce candidates `k = 1` and `k = 2`. That is acceptable for golden-touch anchor transactions because the golden-touch private key is public. It is unsafe for the secret whitelist operator key: one observed signature and its digest are sufficient to recover the private key.

The Go preconfirmation path already uses standard `crypto.Sign`; this change restores Rust/Go parity.

## Impact

Rust whitelist preconfirmation block-hash and gossip-envelope signatures now use standard RFC6979 secp256k1 signing. Signature verification and wire compatibility are unchanged.

This affects `WLP-INV-010` cross-implementation parity only. Ingress gating, stale boundaries, reorg handling, and execution-engine custom-table behavior are unchanged.

## Validation

- `just fmt`
- `just clippy-fix`
- `just unit`: 382 workspace tests and 43 `protocol --no-default-features` tests passed
- `cargo test -p whitelist-preconfirmation-driver --lib`: 146 passed
- `just test` was attempted but stopped before tests because Docker could not refresh the local `gcloud` credentials while pulling `us-docker.pkg.dev/evmchain/images/alethia-reth:main`
