### PR TITLE
refactor(protocol): move security council seat addresses to LibL1Addrs

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
+++ b/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
@@ -15,18 +15,18 @@ library LibL1Addrs {
 
     // Security Council seats (members of DAO_SIGNER_LIST)
     // Seats retained by Proposal0020
-    address public constant TAIKO_LABS = 0xb47fE76aC588101BFBdA9E68F66433bA51E8029a;
-    address public constant L2BEAT = 0xf1cF63589A1e012F9124182c9eAa36B5333e5f06;
-    address public constant ARAGON = 0xb284810536C0dAB6A8e48153B58588A9B9e0F701;
-    address public constant NETHERMIND = 0x5353c607e6eca6C63FEC5c6C0F5CC3a5348d5c95;
+    address public constant SC_TAIKO_LABS = 0xb47fE76aC588101BFBdA9E68F66433bA51E8029a;
+    address public constant SC_L2BEAT = 0xf1cF63589A1e012F9124182c9eAa36B5333e5f06;
+    address public constant SC_ARAGON = 0xb284810536C0dAB6A8e48153B58588A9B9e0F701;
+    address public constant SC_NETHERMIND = 0x5353c607e6eca6C63FEC5c6C0F5CC3a5348d5c95;
     // Independent seat (EOA) added by Proposal0020
-    address public constant GUSTAVO_GONZALEZ = 0xAC5898b0FFFd23F4Ef09F0E50Fa1bC4896eF7163;
+    address public constant SC_GUSTAVO_GONZALEZ = 0xAC5898b0FFFd23F4Ef09F0E50Fa1bC4896eF7163;
     // Seats removed by Proposal0020
-    address public constant CHAINBOUND = 0x436a1075099A145417EBFc74BBaC9605e3e4f1A7;
-    address public constant HALBORN = 0x0F40268Ec0Dc8D88CF2f22E227A29a0b478b6351;
-    address public constant DREW_VAN_DER_WERFF = 0x25d3E89bAcE2040Ed3aF7c4c7B505cfBB72fD6f1;
-    address public constant TONI_WAHRSTATTER = 0xa384E224A3F3D664F43eBE33395eF0DCcE67e894;
-    address public constant GATTACA = 0x6268d189E011Aa53A2f09A1FE159445BeB3d878E;
+    address public constant SC_CHAINBOUND = 0x436a1075099A145417EBFc74BBaC9605e3e4f1A7;
+    address public constant SC_HALBORN = 0x0F40268Ec0Dc8D88CF2f22E227A29a0b478b6351;
+    address public constant SC_DREW_VAN_DER_WERFF = 0x25d3E89bAcE2040Ed3aF7c4c7B505cfBB72fD6f1;
+    address public constant SC_TONI_WAHRSTATTER = 0xa384E224A3F3D664F43eBE33395eF0DCcE67e894;
+    address public constant SC_GATTACA = 0x6268d189E011Aa53A2f09A1FE159445BeB3d878E;
 
     address public constant FORCED_INCLUSION_STORE = 0x05d88855361808fA1d7fc28084Ef3fCa191c4e03;
     // Kept for legacy governance scripts (e.g. Proposal0009)

--- a/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
+++ b/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
@@ -13,6 +13,21 @@ library LibL1Addrs {
     address public constant DAO_OPTIMISTIC_TOKEN_VOTING_PLUGIN =
         0x989E348275b659d36f8751ea1c10D146211650BE;
 
+    // Security Council seats (members of DAO_SIGNER_LIST)
+    // Seats retained by Proposal0020
+    address public constant TAIKO_LABS = 0xb47fE76aC588101BFBdA9E68F66433bA51E8029a;
+    address public constant L2BEAT = 0xf1cF63589A1e012F9124182c9eAa36B5333e5f06;
+    address public constant ARAGON = 0xb284810536C0dAB6A8e48153B58588A9B9e0F701;
+    address public constant NETHERMIND = 0x5353c607e6eca6C63FEC5c6C0F5CC3a5348d5c95;
+    // Independent seat (EOA) added by Proposal0020
+    address public constant GUSTAVO_GONZALEZ = 0xAC5898b0FFFd23F4Ef09F0E50Fa1bC4896eF7163;
+    // Seats removed by Proposal0020
+    address public constant CHAINBOUND = 0x436a1075099A145417EBFc74BBaC9605e3e4f1A7;
+    address public constant HALBORN = 0x0F40268Ec0Dc8D88CF2f22E227A29a0b478b6351;
+    address public constant DREW_VAN_DER_WERFF = 0x25d3E89bAcE2040Ed3aF7c4c7B505cfBB72fD6f1;
+    address public constant TONI_WAHRSTATTER = 0xa384E224A3F3D664F43eBE33395eF0DCcE67e894;
+    address public constant GATTACA = 0x6268d189E011Aa53A2f09A1FE159445BeB3d878E;
+
     address public constant FORCED_INCLUSION_STORE = 0x05d88855361808fA1d7fc28084Ef3fCa191c4e03;
     // Kept for legacy governance scripts (e.g. Proposal0009)
     address public constant TAIKO_WRAPPER = 0x9F9D2fC7abe74C79f86F0D1212107692430eef72;

--- a/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
+++ b/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
@@ -13,7 +13,7 @@ library LibL1Addrs {
     address public constant DAO_OPTIMISTIC_TOKEN_VOTING_PLUGIN =
         0x989E348275b659d36f8751ea1c10D146211650BE;
 
-    // Security Council seats (members of DAO_SIGNER_LIST)
+    // Security Council seat addresses (DAO_SIGNER_LIST membership before/after Proposal0020)
     // Seats retained by Proposal0020
     address public constant SC_TAIKO_LABS = 0xb47fE76aC588101BFBdA9E68F66433bA51E8029a;
     address public constant SC_L2BEAT = 0xf1cF63589A1e012F9124182c9eAa36B5333e5f06;

--- a/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
@@ -10,11 +10,11 @@ import "../governance/BuildDirectProposal.sol";
 // To dryrun the proposal on an L1 fork: `SENDER=<a member or agent> P=0020 pnpm proposal:dryrun:l1`
 contract Proposal0020 is BuildDirectProposal {
     // All seat addresses live in LibL1Addrs ("Security Council seats" section): the new
-    // independent seat L1.GUSTAVO_GONZALEZ (EOA); the removed L1.CHAINBOUND, L1.HALBORN,
-    // L1.DREW_VAN_DER_WERFF, L1.TONI_WAHRSTATTER, L1.GATTACA; and the retained
-    // L1.TAIKO_LABS, L1.L2BEAT, L1.ARAGON, L1.NETHERMIND (dryrun assertions only).
+    // independent seat L1.SC_GUSTAVO_GONZALEZ (EOA); the removed L1.SC_CHAINBOUND, L1.SC_HALBORN,
+    // L1.SC_DREW_VAN_DER_WERFF, L1.SC_TONI_WAHRSTATTER, L1.SC_GATTACA; and the retained
+    // L1.SC_TAIKO_LABS, L1.SC_L2BEAT, L1.SC_ARAGON, L1.SC_NETHERMIND (dryrun assertions only).
     //
-    // IMPORTANT: GUSTAVO_GONZALEZ is currently the encryption agent appointed by the
+    // IMPORTANT: SC_GUSTAVO_GONZALEZ is currently the encryption agent appointed by the
     // Taiko Labs seat. Before this proposal EXECUTES, Taiko Labs must appoint a
     // replacement agent (EncryptionRegistry.appointAgent from the Taiko Labs Safe). If it
     // is still appointed at execution time, the Taiko Labs seat is left without a valid
@@ -40,14 +40,14 @@ contract Proposal0020 is BuildDirectProposal {
     /// its final size (minApprovals is checked against the then-current list length).
     function buildDaoActions() internal pure override returns (Action[] memory actions_) {
         address[] memory toAdd = new address[](1);
-        toAdd[0] = L1.GUSTAVO_GONZALEZ;
+        toAdd[0] = L1.SC_GUSTAVO_GONZALEZ;
 
         address[] memory toRemove = new address[](5);
-        toRemove[0] = L1.CHAINBOUND;
-        toRemove[1] = L1.HALBORN;
-        toRemove[2] = L1.DREW_VAN_DER_WERFF;
-        toRemove[3] = L1.TONI_WAHRSTATTER;
-        toRemove[4] = L1.GATTACA;
+        toRemove[0] = L1.SC_CHAINBOUND;
+        toRemove[1] = L1.SC_HALBORN;
+        toRemove[2] = L1.SC_DREW_VAN_DER_WERFF;
+        toRemove[3] = L1.SC_TONI_WAHRSTATTER;
+        toRemove[4] = L1.SC_GATTACA;
 
         actions_ = new Action[](6);
         actions_[0] = Action({
@@ -140,15 +140,15 @@ contract Proposal0020 is BuildDirectProposal {
         );
 
         address[9] memory current = [
-            L1.TAIKO_LABS,
-            L1.L2BEAT,
-            L1.ARAGON,
-            L1.NETHERMIND,
-            L1.CHAINBOUND,
-            L1.HALBORN,
-            L1.DREW_VAN_DER_WERFF,
-            L1.TONI_WAHRSTATTER,
-            L1.GATTACA
+            L1.SC_TAIKO_LABS,
+            L1.SC_L2BEAT,
+            L1.SC_ARAGON,
+            L1.SC_NETHERMIND,
+            L1.SC_CHAINBOUND,
+            L1.SC_HALBORN,
+            L1.SC_DREW_VAN_DER_WERFF,
+            L1.SC_TONI_WAHRSTATTER,
+            L1.SC_GATTACA
         ];
         for (uint256 i; i < current.length; ++i) {
             check(
@@ -157,20 +157,20 @@ contract Proposal0020 is BuildDirectProposal {
             );
         }
         check(
-            !readBool(L1.DAO_SIGNER_LIST, "isListed(address)", L1.GUSTAVO_GONZALEZ),
+            !readBool(L1.DAO_SIGNER_LIST, "isListed(address)", L1.SC_GUSTAVO_GONZALEZ),
             "new member already listed"
         );
     }
 
-    /// @dev Models the mandatory out-of-band step: Taiko Labs releases GUSTAVO_GONZALEZ
+    /// @dev Models the mandatory out-of-band step: Taiko Labs releases SC_GUSTAVO_GONZALEZ
     /// as its encryption agent before the DAO executes the actions (the real rotation
     /// appoints a replacement agent instead of un-appointing).
     function simulatePreExecution() internal override {
         address appointer =
-            readAddr(L1.DAO_ENCRYPTION_REGISTRY, "appointerOf(address)", L1.GUSTAVO_GONZALEZ);
+            readAddr(L1.DAO_ENCRYPTION_REGISTRY, "appointerOf(address)", L1.SC_GUSTAVO_GONZALEZ);
         if (appointer != address(0)) {
             console2.log(
-                "simulating agent rotation: releasing GUSTAVO_GONZALEZ, appointer:", appointer
+                "simulating agent rotation: releasing SC_GUSTAVO_GONZALEZ, appointer:", appointer
             );
             vm.prank(appointer);
             (bool ok,) = L1.DAO_ENCRYPTION_REGISTRY
@@ -182,16 +182,22 @@ contract Proposal0020 is BuildDirectProposal {
     function checkPostState() internal view override {
         check(readUint(L1.DAO_SIGNER_LIST, "addresslistLength()") == 5, "expected 5 members");
 
-        address[5] memory listed =
-            [L1.TAIKO_LABS, L1.L2BEAT, L1.ARAGON, L1.NETHERMIND, L1.GUSTAVO_GONZALEZ];
+        address[5] memory listed = [
+            L1.SC_TAIKO_LABS, L1.SC_L2BEAT, L1.SC_ARAGON, L1.SC_NETHERMIND, L1.SC_GUSTAVO_GONZALEZ
+        ];
         for (uint256 i; i < listed.length; ++i) {
             check(
                 readBool(L1.DAO_SIGNER_LIST, "isListed(address)", listed[i]),
                 "retained/new member not listed"
             );
         }
-        address[5] memory removed =
-            [L1.CHAINBOUND, L1.HALBORN, L1.DREW_VAN_DER_WERFF, L1.TONI_WAHRSTATTER, L1.GATTACA];
+        address[5] memory removed = [
+            L1.SC_CHAINBOUND,
+            L1.SC_HALBORN,
+            L1.SC_DREW_VAN_DER_WERFF,
+            L1.SC_TONI_WAHRSTATTER,
+            L1.SC_GATTACA
+        ];
         for (uint256 i; i < removed.length; ++i) {
             check(
                 !readBool(L1.DAO_SIGNER_LIST, "isListed(address)", removed[i]),
@@ -199,12 +205,12 @@ contract Proposal0020 is BuildDirectProposal {
             );
         }
 
-        // The invariant behind the mandatory rotation: once listed, GUSTAVO_GONZALEZ must
+        // The invariant behind the mandatory rotation: once listed, SC_GUSTAVO_GONZALEZ must
         // not be any seat's appointed agent.
         check(
-            readAddr(L1.DAO_ENCRYPTION_REGISTRY, "appointerOf(address)", L1.GUSTAVO_GONZALEZ)
+            readAddr(L1.DAO_ENCRYPTION_REGISTRY, "appointerOf(address)", L1.SC_GUSTAVO_GONZALEZ)
                 == address(0),
-            "GUSTAVO_GONZALEZ still appointed as an agent; Taiko Labs must rotate before execution"
+            "SC_GUSTAVO_GONZALEZ still an appointed agent; Taiko Labs must rotate before execution"
         );
 
         (address encryptionRegistry, uint16 minSignerListLength) = readSignerListSettings();

--- a/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
@@ -9,30 +9,20 @@ import "../governance/BuildDirectProposal.sol";
 // To print the actions to paste into the DAO UI: `P=0020 pnpm proposal`
 // To dryrun the proposal on an L1 fork: `SENDER=<a member or agent> P=0020 pnpm proposal:dryrun:l1`
 contract Proposal0020 is BuildDirectProposal {
-    // New member: Gustavo Gonzalez, independent seat (EOA).
+    // All seat addresses live in LibL1Addrs ("Security Council seats" section): the new
+    // independent seat L1.GUSTAVO_GONZALEZ (EOA); the removed L1.CHAINBOUND, L1.HALBORN,
+    // L1.DREW_VAN_DER_WERFF, L1.TONI_WAHRSTATTER, L1.GATTACA; and the retained
+    // L1.TAIKO_LABS, L1.L2BEAT, L1.ARAGON, L1.NETHERMIND (dryrun assertions only).
     //
-    // IMPORTANT: this address is currently the encryption agent appointed by the Taiko
-    // Labs seat. Before this proposal EXECUTES, Taiko Labs must appoint a replacement
-    // agent (EncryptionRegistry.appointAgent from the Taiko Labs Safe). If it is still
-    // appointed at execution time, the Taiko Labs seat is left without a valid approver
-    // until Taiko Labs rotates: only the appointed agent may approve for a seat, and once
-    // this address is listed as its own seat, its approvals credit that seat instead.
-    // The dryrun simulates the rotation between creation and execution; approvals on
-    // in-flight proposals are unaffected (approvals are recorded per seat owner).
-    address public constant NEW_MEMBER = 0xAC5898b0FFFd23F4Ef09F0E50Fa1bC4896eF7163;
-
-    // Members removed by this proposal.
-    address public constant CHAINBOUND = 0x436a1075099A145417EBFc74BBaC9605e3e4f1A7;
-    address public constant HALBORN = 0x0F40268Ec0Dc8D88CF2f22E227A29a0b478b6351;
-    address public constant DREW_VAN_DER_WERFF = 0x25d3E89bAcE2040Ed3aF7c4c7B505cfBB72fD6f1;
-    address public constant TONI_WAHRSTATTER = 0xa384E224A3F3D664F43eBE33395eF0DCcE67e894;
-    address public constant GATTACA = 0x6268d189E011Aa53A2f09A1FE159445BeB3d878E;
-
-    // Members retained (used by the dryrun assertions only).
-    address public constant TAIKO_LABS = 0xb47fE76aC588101BFBdA9E68F66433bA51E8029a;
-    address public constant L2BEAT = 0xf1cF63589A1e012F9124182c9eAa36B5333e5f06;
-    address public constant ARAGON = 0xb284810536C0dAB6A8e48153B58588A9B9e0F701;
-    address public constant NETHERMIND = 0x5353c607e6eca6C63FEC5c6C0F5CC3a5348d5c95;
+    // IMPORTANT: GUSTAVO_GONZALEZ is currently the encryption agent appointed by the
+    // Taiko Labs seat. Before this proposal EXECUTES, Taiko Labs must appoint a
+    // replacement agent (EncryptionRegistry.appointAgent from the Taiko Labs Safe). If it
+    // is still appointed at execution time, the Taiko Labs seat is left without a valid
+    // approver until Taiko Labs rotates: only the appointed agent may approve for a seat,
+    // and once this address is listed as its own seat, its approvals credit that seat
+    // instead. The dryrun simulates the rotation between creation and execution;
+    // approvals on in-flight proposals are unaffected (approvals are recorded per seat
+    // owner).
 
     // New thresholds. minSignerListLength must stay >= the emergency minApprovals (see
     // SignerList.Settings NatSpec); 4 preserves the current one-removal headroom pattern.
@@ -50,14 +40,14 @@ contract Proposal0020 is BuildDirectProposal {
     /// its final size (minApprovals is checked against the then-current list length).
     function buildDaoActions() internal pure override returns (Action[] memory actions_) {
         address[] memory toAdd = new address[](1);
-        toAdd[0] = NEW_MEMBER;
+        toAdd[0] = L1.GUSTAVO_GONZALEZ;
 
         address[] memory toRemove = new address[](5);
-        toRemove[0] = CHAINBOUND;
-        toRemove[1] = HALBORN;
-        toRemove[2] = DREW_VAN_DER_WERFF;
-        toRemove[3] = TONI_WAHRSTATTER;
-        toRemove[4] = GATTACA;
+        toRemove[0] = L1.CHAINBOUND;
+        toRemove[1] = L1.HALBORN;
+        toRemove[2] = L1.DREW_VAN_DER_WERFF;
+        toRemove[3] = L1.TONI_WAHRSTATTER;
+        toRemove[4] = L1.GATTACA;
 
         actions_ = new Action[](6);
         actions_[0] = Action({
@@ -150,15 +140,15 @@ contract Proposal0020 is BuildDirectProposal {
         );
 
         address[9] memory current = [
-            TAIKO_LABS,
-            L2BEAT,
-            ARAGON,
-            NETHERMIND,
-            CHAINBOUND,
-            HALBORN,
-            DREW_VAN_DER_WERFF,
-            TONI_WAHRSTATTER,
-            GATTACA
+            L1.TAIKO_LABS,
+            L1.L2BEAT,
+            L1.ARAGON,
+            L1.NETHERMIND,
+            L1.CHAINBOUND,
+            L1.HALBORN,
+            L1.DREW_VAN_DER_WERFF,
+            L1.TONI_WAHRSTATTER,
+            L1.GATTACA
         ];
         for (uint256 i; i < current.length; ++i) {
             check(
@@ -167,18 +157,21 @@ contract Proposal0020 is BuildDirectProposal {
             );
         }
         check(
-            !readBool(L1.DAO_SIGNER_LIST, "isListed(address)", NEW_MEMBER),
+            !readBool(L1.DAO_SIGNER_LIST, "isListed(address)", L1.GUSTAVO_GONZALEZ),
             "new member already listed"
         );
     }
 
-    /// @dev Models the mandatory out-of-band step: Taiko Labs releases NEW_MEMBER as its
-    /// encryption agent before the DAO executes the actions (the real rotation appoints a
-    /// replacement agent instead of un-appointing).
+    /// @dev Models the mandatory out-of-band step: Taiko Labs releases GUSTAVO_GONZALEZ
+    /// as its encryption agent before the DAO executes the actions (the real rotation
+    /// appoints a replacement agent instead of un-appointing).
     function simulatePreExecution() internal override {
-        address appointer = readAddr(L1.DAO_ENCRYPTION_REGISTRY, "appointerOf(address)", NEW_MEMBER);
+        address appointer =
+            readAddr(L1.DAO_ENCRYPTION_REGISTRY, "appointerOf(address)", L1.GUSTAVO_GONZALEZ);
         if (appointer != address(0)) {
-            console2.log("simulating agent rotation: releasing NEW_MEMBER, appointer:", appointer);
+            console2.log(
+                "simulating agent rotation: releasing GUSTAVO_GONZALEZ, appointer:", appointer
+            );
             vm.prank(appointer);
             (bool ok,) = L1.DAO_ENCRYPTION_REGISTRY
                 .call(abi.encodeWithSignature("appointAgent(address)", appointer));
@@ -189,7 +182,8 @@ contract Proposal0020 is BuildDirectProposal {
     function checkPostState() internal view override {
         check(readUint(L1.DAO_SIGNER_LIST, "addresslistLength()") == 5, "expected 5 members");
 
-        address[5] memory listed = [TAIKO_LABS, L2BEAT, ARAGON, NETHERMIND, NEW_MEMBER];
+        address[5] memory listed =
+            [L1.TAIKO_LABS, L1.L2BEAT, L1.ARAGON, L1.NETHERMIND, L1.GUSTAVO_GONZALEZ];
         for (uint256 i; i < listed.length; ++i) {
             check(
                 readBool(L1.DAO_SIGNER_LIST, "isListed(address)", listed[i]),
@@ -197,7 +191,7 @@ contract Proposal0020 is BuildDirectProposal {
             );
         }
         address[5] memory removed =
-            [CHAINBOUND, HALBORN, DREW_VAN_DER_WERFF, TONI_WAHRSTATTER, GATTACA];
+            [L1.CHAINBOUND, L1.HALBORN, L1.DREW_VAN_DER_WERFF, L1.TONI_WAHRSTATTER, L1.GATTACA];
         for (uint256 i; i < removed.length; ++i) {
             check(
                 !readBool(L1.DAO_SIGNER_LIST, "isListed(address)", removed[i]),
@@ -205,11 +199,12 @@ contract Proposal0020 is BuildDirectProposal {
             );
         }
 
-        // The invariant behind the mandatory rotation: once listed, NEW_MEMBER must not
-        // be any seat's appointed agent.
+        // The invariant behind the mandatory rotation: once listed, GUSTAVO_GONZALEZ must
+        // not be any seat's appointed agent.
         check(
-            readAddr(L1.DAO_ENCRYPTION_REGISTRY, "appointerOf(address)", NEW_MEMBER) == address(0),
-            "NEW_MEMBER still appointed as an agent; Taiko Labs must rotate before execution"
+            readAddr(L1.DAO_ENCRYPTION_REGISTRY, "appointerOf(address)", L1.GUSTAVO_GONZALEZ)
+                == address(0),
+            "GUSTAVO_GONZALEZ still appointed as an agent; Taiko Labs must rotate before execution"
         );
 
         (address encryptionRegistry, uint16 minSignerListLength) = readSignerListSettings();


### PR DESCRIPTION
Follow-up to #22010, stacked on `revamp-security-council`.

## What this does

- Adds a **Security Council seats** section to `LibL1Addrs.sol` with all current and post-Proposal0020 member addresses, grouped by disposition (retained / added / removed by Proposal0020).
- Points `Proposal0020.s.sol` at those constants instead of declaring its own copies.
- Renames the new independent seat's constant from `NEW_MEMBER` to `GUSTAVO_GONZALEZ`.

## Verification (no behavioral change)

- `MODE=print` regenerates a **byte-identical** `Proposal0020.action.md` — the six action calldatas are unchanged.
- `MODE=l1dryrun` against a mainnet fork still passes end-to-end: baseline checks, `createProposal`, simulated agent rotation, all six actions executed as the DAO, and all post-state assertions.
- `grep` confirms no stale `NEW_MEMBER` references remain; `forge fmt` run with the repo's config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXZ8HWv6KYVV3fgC6MGJiv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXZ8HWv6KYVV3fgC6MGJiv)_