### PR TITLE
fix(protocol): address review findings on Proposal0020

### DIFF
--- a/packages/protocol/script/layer1/governance/BuildDirectProposal.sol
+++ b/packages/protocol/script/layer1/governance/BuildDirectProposal.sol
@@ -35,6 +35,7 @@ abstract contract BuildDirectProposal is Script {
 
     error MissingEnv(string name);
     error CheckFailed(string what);
+    error InvalidMode(string mode);
 
     function run() external {
         string memory mode = vm.envString("MODE");
@@ -44,6 +45,7 @@ abstract contract BuildDirectProposal is Script {
             dryrunL1();
         } else {
             console2.log("Error: Invalid mode. Must be one of: print, l1dryrun");
+            revert InvalidMode(mode);
         }
     }
 
@@ -76,7 +78,10 @@ abstract contract BuildDirectProposal is Script {
             vm.toString(L1.DAO_STANDARD_MULTISIG),
             "`.\nThe UI pins the metadata and assembles `createProposal`; paste each action",
             " below into the\nUI's custom-action (calldata) form, in order. After creation,",
-            " run the `verify` mode\nagainst the new proposal id before approving.\n\n",
+            " compare the actions\nstored on-chain against this file before approving (the",
+            " `getProposal` command in\nProposal",
+            _proposalId,
+            ".md).\n\n",
             "- Destination plugin (set by the UI): `",
             vm.toString(L1.DAO_OPTIMISTIC_TOKEN_VOTING_PLUGIN),
             "`\n"

--- a/packages/protocol/script/layer1/governance/BuildDirectProposal.sol
+++ b/packages/protocol/script/layer1/governance/BuildDirectProposal.sol
@@ -33,10 +33,6 @@ abstract contract BuildDirectProposal is Script {
         bytes data;
     }
 
-    error MissingEnv(string name);
-    error CheckFailed(string what);
-    error InvalidMode(string mode);
-
     function run() external {
         string memory mode = vm.envString("MODE");
         if (keccak256(abi.encodePacked(mode)) == keccak256(abi.encodePacked("print"))) {
@@ -259,9 +255,17 @@ abstract contract BuildDirectProposal is Script {
         return "?";
     }
 
-    function readRaw(address _target, bytes memory _data) private view returns (bytes memory) {
+    function readRaw(address _target, bytes memory _data) internal view returns (bytes memory) {
         (bool ok, bytes memory ret) = _target.staticcall(_data);
         check(ok, "staticcall reverted");
         return ret;
     }
+
+    // ---------------------------------------------------------------
+    // Custom Errors
+    // ---------------------------------------------------------------
+
+    error MissingEnv(string name);
+    error CheckFailed(string what);
+    error InvalidMode(string mode);
 }

--- a/packages/protocol/script/layer1/governance/BuildDirectProposal.sol
+++ b/packages/protocol/script/layer1/governance/BuildDirectProposal.sol
@@ -264,6 +264,7 @@ abstract contract BuildDirectProposal is Script {
         returns (bytes memory)
     {
         (bool ok, bytes memory ret) = _target.staticcall(_data);
+        logIfReverted(ok, ret);
         check(ok, "staticcall reverted");
         return ret;
     }

--- a/packages/protocol/script/layer1/governance/BuildDirectProposal.sol
+++ b/packages/protocol/script/layer1/governance/BuildDirectProposal.sol
@@ -255,7 +255,14 @@ abstract contract BuildDirectProposal is Script {
         return "?";
     }
 
-    function readRaw(address _target, bytes memory _data) internal view returns (bytes memory) {
+    function readRaw(
+        address _target,
+        bytes memory _data
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
         (bool ok, bytes memory ret) = _target.staticcall(_data);
         check(ok, "staticcall reverted");
         return ret;

--- a/packages/protocol/script/layer1/proposals/Proposal0020.action.md
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.action.md
@@ -2,8 +2,9 @@
 
 Created via the Taiko DAO UI on the Standard Multisig `0xD7dA1C25E915438720692bC55eb3a7170cA90321`.
 The UI pins the metadata and assembles `createProposal`; paste each action below into the
-UI's custom-action (calldata) form, in order. After creation, run the `verify` mode
-against the new proposal id before approving.
+UI's custom-action (calldata) form, in order. After creation, compare the actions
+stored on-chain against this file before approving (the `getProposal` command in
+Proposal0020.md).
 
 - Destination plugin (set by the UI): `0x989E348275b659d36f8751ea1c10D146211650BE`
 

--- a/packages/protocol/script/layer1/proposals/Proposal0020.md
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.md
@@ -62,7 +62,9 @@ and committed as `Proposal0020.action.md`.
 Action 6 removes the delisted members from the registry's account enumeration only; their
 `appointerOf`/agent mappings persist. This is harmless — an unlisted appointer can never
 resolve for approvals — but their former agent addresses stay reserved and cannot be
-appointed by other seats.
+appointed by other seats. See `removeUnused()` in
+[EncryptionRegistry.sol](https://github.com/taikoxyz/dao-contracts/blob/main/src/EncryptionRegistry.sol);
+the dryrun's `checkPostState` asserts the pruning.
 
 Member addresses (from the on-chain SignerList census, cross-checked against
 `security-council-profiles.json` in `taikoxyz/dao-ui-mono`):

--- a/packages/protocol/script/layer1/proposals/Proposal0020.md
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.md
@@ -42,9 +42,10 @@ settings change and the 2025-06-02 / 2026-01-19 membership changes all executed 
 from the DAO). `allowFailureMap` is fixed to 0 by the multisig, so any reverting action
 aborts execution.
 
-Ordering is mandatory: Action 1 must precede Action 3 (`removeSigners` reverts if the list
-would drop below `minSignerListLength`, currently 8), and Actions 4–5 must follow Action 3
-(`minApprovals ≤ addresslistLength()` is checked against the then-current list).
+Ordering: the contract-enforced dependency is Action 1 before Action 3 (`removeSigners`
+reverts if the list would drop below `minSignerListLength`, currently 8). Actions 4–5 are
+placed after Action 3 defensively: `minApprovals ≤ addresslistLength()` is checked against
+the then-current list, which the new thresholds (3, 4) satisfy at every intermediate size.
 
 | #   | Target                                                          | Call                                                              |
 | --- | --------------------------------------------------------------- | ----------------------------------------------------------------- |
@@ -57,6 +58,11 @@ would drop below `minSignerListLength`, currently 8), and Actions 4–5 must fol
 
 The exact per-action calldata is produced by `Proposal0020.s.sol` (`P=0020 pnpm proposal`)
 and committed as `Proposal0020.action.md`.
+
+Action 6 removes the delisted members from the registry's account enumeration only; their
+`appointerOf`/agent mappings persist. This is harmless — an unlisted appointer can never
+resolve for approvals — but their former agent addresses stay reserved and cannot be
+appointed by other seats.
 
 Member addresses (from the on-chain SignerList census, cross-checked against
 `security-council-profiles.json` in `taikoxyz/dao-ui-mono`):
@@ -91,8 +97,9 @@ Member addresses (from the on-chain SignerList census, cross-checked against
 1. The new member EOA registers its encryption key via dao.taiko.xyz
    (`setOwnPublicKey`, only possible once listed); until then the seat can approve
    emergency proposals but cannot decrypt them.
-2. Taiko Labs' replacement agent registers its key the same way (rotation wiped the
-   stored key).
+2. Taiko Labs' replacement agent registers a new key for the seat via dao.taiko.xyz
+   (`setPublicKey`, callable only by the appointed agent — an agent is not listed, so
+   `setOwnPublicKey` does not apply; the rotation wiped the stored key).
 3. Update `security-council-profiles.json` in `taikoxyz/dao-ui-mono`; record execution in
    `deployments/mainnet-contract-logs-L1.md`.
 
@@ -120,7 +127,7 @@ SENDER=0x<member-or-agent> P=0020 pnpm proposal:dryrun:l1
 # 5. Submit, then confirm what landed on-chain matches this repo before approving —
 #    compare each stored action against Proposal0020.action.md (approvers should too):
 cast call 0xD7dA1C25E915438720692bC55eb3a7170cA90321 \
-  "getProposal(uint256)(bool,(uint16,uint64,uint64),bytes,(address,uint256,bytes)[],address)" \
+  "getProposal(uint256)(bool,uint16,(uint16,uint64,uint64),bytes,(address,uint256,bytes)[],address)" \
   <PROPOSAL_ID> --rpc-url <ETHEREUM_RPC>
 ```
 

--- a/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
@@ -209,6 +209,20 @@ contract Proposal0020 is BuildDirectProposal {
             );
         }
 
+        // Action 6 effect: every account still enumerated by the registry is a listed
+        // signer, i.e. the removed members were pruned (their appointerOf/agent mappings
+        // persist, as documented in Proposal0020.md).
+        address[] memory registered = abi.decode(
+            readRaw(L1.DAO_ENCRYPTION_REGISTRY, abi.encodeWithSignature("getRegisteredAccounts()")),
+            (address[])
+        );
+        for (uint256 i; i < registered.length; ++i) {
+            check(
+                readBool(L1.DAO_SIGNER_LIST, "isListed(address)", registered[i]),
+                "unlisted account still registered"
+            );
+        }
+
         // The invariant behind the mandatory rotation: once listed, SC_GUSTAVO_GONZALEZ must
         // not be any seat's appointed agent.
         check(

--- a/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
@@ -35,9 +35,10 @@ contract Proposal0020 is BuildDirectProposal {
     uint32 public constant DESTINATION_PROPOSAL_DURATION = 864_000; // 10-day veto period
     uint32 public constant PROPOSAL_EXPIRATION_PERIOD = 1_209_600; // 14 days
 
-    /// @dev Order is mandatory: the minSignerListLength floor (currently 8) must drop
-    /// before removeSigners, and the threshold updates must come after the list reaches
-    /// its final size (minApprovals is checked against the then-current list length).
+    /// @dev Contract-enforced ordering: the minSignerListLength floor (currently 8) must
+    /// drop before removeSigners, or action 3 reverts. Placing the threshold updates
+    /// after the list reaches its final size is defensive: the new minApprovals (3, 4)
+    /// satisfy the `<= addresslistLength()` check at every intermediate size.
     function buildDaoActions() internal pure override returns (Action[] memory actions_) {
         address[] memory toAdd = new address[](1);
         toAdd[0] = L1.SC_GUSTAVO_GONZALEZ;
@@ -92,7 +93,9 @@ contract Proposal0020 is BuildDirectProposal {
                 PROPOSAL_EXPIRATION_PERIOD
             )
         });
-        // Housekeeping: prunes the removed members' EncryptionRegistry entries.
+        // Housekeeping: prunes unlisted accounts from the EncryptionRegistry's account
+        // enumeration. Their appointerOf/agent mappings persist; harmless, as an unlisted
+        // appointer can never resolve for approvals.
         actions_[5] = Action({
             to: L1.DAO_ENCRYPTION_REGISTRY,
             value: 0,
@@ -160,6 +163,7 @@ contract Proposal0020 is BuildDirectProposal {
             !readBool(L1.DAO_SIGNER_LIST, "isListed(address)", L1.SC_GUSTAVO_GONZALEZ),
             "new member already listed"
         );
+        check(L1.SC_GUSTAVO_GONZALEZ.code.length == 0, "new member is not an EOA");
     }
 
     /// @dev Models the mandatory out-of-band step: Taiko Labs releases SC_GUSTAVO_GONZALEZ

--- a/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
@@ -219,7 +219,7 @@ contract Proposal0020 is BuildDirectProposal {
         for (uint256 i; i < registered.length; ++i) {
             check(
                 readBool(L1.DAO_SIGNER_LIST, "isListed(address)", registered[i]),
-                "unlisted account still registered"
+                string.concat("unlisted account still registered: ", vm.toString(registered[i]))
             );
         }
 


### PR DESCRIPTION
Applies the actionable findings from the [in-depth review of #22010](https://github.com/taikoxyz/taiko-mono/pull/22010#issuecomment-5278626312), stacked on `revamp-security-council`.

## Fixes

- **F1 — broken pre-approval verification command** (`Proposal0020.md`): the documented `getProposal` cast signature omitted the `uint16 approvals` return value, so the exact command approvers are told to run before approving failed with an ABI decode error. Corrected signature verified working against mainnet proposal 21.
- **F2 — stale `verify`-mode instruction**: `BuildDirectProposal.logProposalAction` still wrote "run the `verify` mode" (dropped in 6d57357) into every generated action file. The template now points at the `getProposal` comparison from the spec, and `Proposal0020.action.md` is regenerated — **all six action To/Value/Data fields are byte-identical**; only the instruction text changes.
- **F3 — silent invalid `MODE`**: `run()` now reverts with `InvalidMode(mode)` instead of logging and exiting 0.
- **F7 — EOA assumption**: `checkBaseline` now asserts `SC_GUSTAVO_GONZALEZ.code.length == 0`.
- **F4 — key-registration mechanism**: post-execution step 2 now names `setPublicKey` (the agent path) instead of implying `setOwnPublicKey`, which reverts `MustBeListed` for a non-listed agent.
- **F5 — `removeUnused()` accuracy**: the Action 6 comment and spec now state it prunes the account enumeration only; the removed members' `appointerOf`/agent mappings persist (harmlessly).
- **F6 — ordering precision**: spec and script comments now distinguish the contract-enforced dependency (Action 1 before Action 3) from the defensive placement of Actions 4–5.

## Verification

- Invalid mode: `MODE=bogus` now fails the script (`InvalidMode("bogus")`).
- `MODE=print` regeneration: committed `Proposal0020.action.md` matches; calldata diff vs the previous file is empty.
- `MODE=l1dryrun` on a mainnet fork: green end-to-end, including the new EOA baseline assertion.
- `forge fmt` with the repo config; no lines exceed 100 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXZ8HWv6KYVV3fgC6MGJiv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXZ8HWv6KYVV3fgC6MGJiv)_