### PR TITLE
chore(repo): add cargo ecosystem and group security updates in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,28 @@
 # Dependabot configuration for automated dependency updates.
 # This file is the single source of truth and overrides any GitHub repo settings.
 #
-# Key features:
-# - Monthly updates scheduled for Saturday 04:20 ET
-# - Dependencies are grouped by ecosystem to minimize PR noise
-# - Each group has designated reviewers and single PR limit
-# - To ignore updates for a dependency, add to ecosystem's ignore field (and open
-#   a GitHub issue if needed for tracking):
+# Two independent update streams reach this repo:
+#
+#   1. Version updates  — driven entirely by this file. Honour `schedule`,
+#      `open-pull-requests-limit`, `directories` and `groups`.
+#   2. Security updates — driven by Dependabot alerts (Settings -> Code security).
+#      They ignore `open-pull-requests-limit` entirely and, unless a group is
+#      explicitly marked `applies-to: security-updates`, they ignore `groups`
+#      too. That is why every ecosystem below declares BOTH a version-update
+#      group and a security-update group: without the latter, a batch of alerts
+#      lands as one PR per package.
+#
+# To ignore updates for a dependency, add to the ecosystem's ignore field (and
+# open a GitHub issue if needed for tracking):
 #   ignore:
 #     - dependency-name: "golang.org/x/crypto"  # skip all crypto updates
 
 version: 2
 updates:
+  # ---------------------------------------------------------------------------
+  # Go — one root module (github.com/taikoxyz/taiko-mono) covers taiko-client,
+  # relayer, eventindexer and the shared packages.
+  # ---------------------------------------------------------------------------
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -19,12 +30,20 @@ updates:
       day: "saturday"
       time: "04:20"
       timezone: "America/New_York"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     groups:
       go-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      go-security:
+        applies-to: security-updates
         patterns:
           - "*"
 
+  # ---------------------------------------------------------------------------
+  # GitHub Actions
+  # ---------------------------------------------------------------------------
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -32,21 +51,76 @@ updates:
       day: "saturday"
       time: "04:20"
       timezone: "America/New_York"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     groups:
       github-actions-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"
 
-  - package-ecosystem: "npm"
-    directory: "/"
+  # ---------------------------------------------------------------------------
+  # Rust — previously absent, so taiko-client-rs and ejector received version
+  # updates from nobody and only ever saw security PRs.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "cargo"
+    directories:
+      - "/packages/taiko-client-rs"
+      - "/packages/ejector"
     schedule:
       interval: "monthly"
       day: "saturday"
       time: "04:20"
       timezone: "America/New_York"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     groups:
-      npm-updates:
+      cargo-updates:
+        applies-to: version-updates
         patterns:
           - "*"
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # npm / pnpm — only actively maintained workspace members are listed. The
+  # dormant ones (nfts, snaefell-ui, taikoon-ui, ui-lib, supplementary-contracts)
+  # have had no commits in over six months; version-bump PRs against them have no
+  # reviewer. Note this does NOT stop security PRs on those packages — security
+  # updates work off the dependency graph, not off `directories`. Suppress those
+  # by dismissing the alerts in the Security tab, or by retiring the packages.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/bridge-ui"
+      - "/packages/protocol"
+      - "/packages/relayer"
+      - "/packages/eventindexer"
+      - "/packages/taiko-client"
+      - "/packages/fork-diff"
+    schedule:
+      interval: "monthly"
+      day: "saturday"
+      time: "04:20"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    groups:
+      npm-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      # Majors are handled by hand. Left to Dependabot they rot: svelte 4->5,
+      # eslint 8->9, vite 5->6 and vitest 1->3 all sat open for months before
+      # being closed unmerged.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,22 +87,32 @@ updates:
           - "*"
 
   # ---------------------------------------------------------------------------
-  # npm / pnpm — only actively maintained workspace members are listed. The
-  # dormant ones (nfts, snaefell-ui, taikoon-ui, ui-lib, supplementary-contracts)
-  # have had no commits in over six months; version-bump PRs against them have no
-  # reviewer. Note this does NOT stop security PRs on those packages — security
-  # updates work off the dependency graph, not off `directories`. Suppress those
-  # by dismissing the alerts in the Security tab, or by retiring the packages.
+  # npm / pnpm — a single root entry is all that is needed. Dependabot's npm
+  # fetcher reads pnpm-workspace.yaml and glob-expands `packages/*` itself, so
+  # `directory: "/"` already pulls in every member manifest; listing members
+  # explicitly is redundant. See dependabot-core npm_and_yarn/file_fetcher.rb:
+  # fetch_files -> pnpm_files -> fetch_pnpm_workspace_package_jsons.
+  #
+  # `exclude-paths` is how members are actually dropped — it is checked inside
+  # fetch_package_json_if_present, the same helper the pnpm workspace expansion
+  # calls. The five packages below have had no commits in over six months, so
+  # version-bump PRs against them have no reviewer.
+  #
+  # Two caveats worth keeping in mind:
+  #   - `exclude-paths` is version-updates only. It does NOT stop security PRs
+  #     on these packages: security updates work off the dependency graph. Those
+  #     have to be dismissed in the Security tab, or the packages retired.
+  #   - Patterns are relative to `directory`, and a bare directory name prefix-
+  #     matches everything beneath it, so `packages/nfts` covers its manifest.
   # ---------------------------------------------------------------------------
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/packages/bridge-ui"
-      - "/packages/protocol"
-      - "/packages/relayer"
-      - "/packages/eventindexer"
-      - "/packages/taiko-client"
-      - "/packages/fork-diff"
+    directory: "/"
+    exclude-paths:
+      - "packages/nfts"
+      - "packages/snaefell-ui"
+      - "packages/taikoon-ui"
+      - "packages/ui-lib"
+      - "packages/supplementary-contracts"
     schedule:
       interval: "monthly"
       day: "saturday"


### PR DESCRIPTION
## Context

The repo had **39 open Dependabot PRs**, the oldest from 2024-12-23. I closed 24 of them (stale, conflicting, superseded, or targeting packages that no longer exist); 15 mergeable ones remain. This PR fixes the config that let the backlog build up.

The key finding: **only 2 of those 39 PRs came from `dependabot.yml` at all.** Everything else was a Dependabot *security* update, which is a separate stream that ignores `open-pull-requests-limit` outright and ignores `groups` unless a group is explicitly marked `applies-to: security-updates`.

Proof that the two streams are distinct: `cargo` was not in `dependabot.yml`, yet #21713 and #22003 exist as `cargo group` PRs.

## Changes

| Change | Why |
|---|---|
| Add the `cargo` ecosystem (`packages/taiko-client-rs`, `packages/ejector`) | Both were getting zero version updates. `taiko-client-rs` has 129 commits in the last 6 months and runs in production. Two separate workspace roots, no root `Cargo.toml`, so both must be listed. |
| Add an `applies-to: security-updates` group to every ecosystem | The actual noise fix. Without it, a batch of alerts lands as one PR per package — ten were opened on 2026-05-14 alone (#21679–#21688). |
| Mark existing groups `applies-to: version-updates` | Previously implicit; making it explicit is what allows the paired security group to exist. |
| npm: keep `directory: "/"`, add `exclude-paths` for the 5 dormant packages | `nfts`, `snaefell-ui`, `taikoon-ui`, `ui-lib`, `supplementary-contracts` have 0 commits in 6 months; version-bump PRs against them have no reviewer. See the note below on why `exclude-paths` rather than a `directories:` list. |
| npm: ignore `version-update:semver-major` | Majors rot when left to Dependabot. svelte 4→5, eslint 8→9, vite 5→6, vitest 1→3 all sat open for months and were closed unmerged. |
| `open-pull-requests-limit` 1 → 3 | At 1, a single stuck group PR blocks its ecosystem for a whole cycle. Worth stating plainly: this setting never applied to security updates, so it was not what was holding PR count down. |

Cadence stays **monthly** — the version-update stream was not the noisy one. `go-updates` and `github-actions-updates` have merged 20 times on that rhythm.

## Why `exclude-paths` and not a `directories:` list

An earlier revision of this PR listed the six active workspace members under `directories:`. That was wrong twice over, and the correction is worth recording:

Dependabot's npm fetcher parses `pnpm-workspace.yaml` and glob-expands `packages/*` on its own, so `directory: "/"` already loads **every** member manifest:

```
fetch_files                              # npm_and_yarn/file_fetcher.rb:83
  -> pnpm_files                          # :136 (gated on pnpm_version, satisfied by the root pnpm-lock.yaml)
  -> fetch_pnpm_workspace_package_jsons  # :641
  -> workspace_paths(pnpm-workspace.yaml["packages"])   # glob-expands packages/*
  -> fetch_package_json_if_present(workspace)           # :725
```

So the six explicit entries were redundant, **and the dormant packages were never excluded** — the config's own comment claimed an exclusion it did not perform.

`exclude-paths` is the mechanism that actually works here, because it is checked inside `fetch_package_json_if_present` (`:728`) — the same helper the workspace expansion calls.

Two caveats, both now recorded inline in the config:

- `exclude-paths` is **version-updates only** (so marked in the [options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#exclude-paths)). It will not stop security PRs on the dormant packages; those still need dismissing in the Security tab, or the packages retiring.
- In dependabot-core the npm `exclude-paths` checks sit behind the experiment flag `enable_exclude_paths_subdirectory_manifest_files`. The option is publicly documented, so it is presumably enabled in production, but that is not verifiable from outside.

## Open question for a maintainer — please read

The npm version-update lane has **never produced a single PR**. Exact-phrase search across all PR states:

```
"the npm-updates group" in:title  →  0
"the go-updates group"  in:title  →  20
```

This is *not* explained by directory scoping — as established above, `directory: "/"` was already reaching the whole workspace. And the root manifest alone has been updatable this entire time:

| Dependency | `package.json` | `pnpm-lock.yaml` | Latest |
|---|---|---|---|
| `prettier` | `^3.2.5` | 3.2.5 | 3.9.6 (in-range) |
| `lefthook` | `^1.6.10` | 1.6.10 | 2.1.10 (major) |

An in-range `prettier` bump should have been proposed long ago. It was not — which points at the npm updater job **erroring out**, and nothing in this PR would fix that.

Dependabot job logs are not exposed via the API, so I could not confirm it. Someone with admin access should check **Insights → Dependency graph → Dependabot** for the npm ecosystem's last run.

One lead worth checking there: `pnpm-workspace.yaml` uses `onlyBuiltDependencies`, a **pnpm 10** key, while CI pins **pnpm 9** (`.github/actions/install-pnpm-dependencies/action.yml`, `taiko-client-rs--test.yml`) and there is no `packageManager` field in the root `package.json` for Dependabot to read. I deliberately left `package.json` untouched here — pinning `packageManager` affects CI and belongs in its own PR.

## Verification

- YAML parses; all 4 ecosystems carry both a version-update and a security-update group.
- Every declared directory has its manifest committed: `go.mod`, both `Cargo.toml`, root `package.json`.
- `exclude-paths` patterns checked against a faithful port of `Dependabot::FileFiltering.exclude_path?`: all 11 workspace members classify as intended (5 excluded, 6 kept) and the root manifest survives.
- Config-only change; no build or runtime impact.

Left as draft pending the Dependabot job-log check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
