### PR TITLE
chore(protocol): set all foundry profiles to the osaka EVM

### DIFF
--- a/packages/protocol/foundry.toml
+++ b/packages/protocol/foundry.toml
@@ -7,7 +7,10 @@ optimizer_runs = 200
 ffi = true
 memory_limit = 4_294_967_296
 solc_version = "0.8.30"
-evm_version = "prague"
+# L1 (Ethereum) EVM version. Ethereum mainnet is on Osaka.
+# Taiko L2 is also on Osaka, but the two chains can fork independently again, so the L2 profiles
+# (layer2, shared, genesis) below set `evm_version` explicitly instead of inheriting this value.
+evm_version = "osaka"
 # Fuzzing configuration (updated for newer Foundry versions)
 fuzz = { runs = 200, show_logs = false }
 # Exclude genesis tests - they require special setup via genesis.test.sh
@@ -132,7 +135,9 @@ test = "test/layer2"
 script = "script/layer2"
 out = "out/layer2"
 cache_path = "cache/layer2"
-evm_version = "shanghai"
+# Taiko L2 EVM version. Kept explicit (rather than inherited from profile.default) so L2 can be
+# pinned to a different fork than L1 whenever the two chains diverge again.
+evm_version = "osaka"
 
 [profile.shared]
 src = "contracts/shared"
@@ -140,7 +145,9 @@ test = "test/shared"
 script = "script/shared"
 out = "out/shared"
 cache_path = "cache/shared"
-evm_version = "shanghai"
+# Shared contracts are deployed on both L1 and L2, so this must stay at the oldest fork of the two.
+# Both are on Osaka today; drop this back to the lagging chain's fork if they diverge again.
+evm_version = "osaka"
 
 [profile.genesis]
 src = "contracts/layer2"
@@ -148,4 +155,5 @@ test = "test/genesis"
 script = "script/layer2"
 out = "out/genesis"
 cache_path = "cache/genesis"
-evm_version = "shanghai"
+# Must match profile.layer2 — this profile builds the same L2 contracts into the genesis alloc.
+evm_version = "osaka"


### PR DESCRIPTION
## Summary

Ethereum mainnet and Taiko are both running the Osaka EVM now, so this updates `packages/protocol/foundry.toml` accordingly:

| Profile | Before | After |
| --- | --- | --- |
| `default` (inherited by `layer1` / `layer1o`) | `prague` | `osaka` |
| `layer2` | `shanghai` | `osaka` |
| `shared` | `shanghai` | `osaka` |
| `genesis` | `shanghai` | `osaka` |

The per-profile `evm_version` keys are deliberately **kept explicit** rather than collapsed into `profile.default`. The two chains can fork independently again, and leaving the L2 profiles inheriting from the L1 default would silently drag L2 along with the next L1 upgrade. Each key now carries a comment explaining which chain it tracks, including the note that `profile.shared` (contracts deployed on both L1 and L2) must stay at the older of the two forks if they diverge.

## Verification

Run locally with `foundry v1.4.2` (the version pinned in `packages/protocol/.tool-versions`) and `solc 0.8.30`, which lists `osaka` among its supported EVM versions.

**Resolved config** — all five profiles report `evm_version = "osaka"`.

**Builds** — `layer1`, `layer1o`, `layer2`, `shared`, `genesis` all compile cleanly (exit 0).

**Tests**

| Suite | Result |
| --- | --- |
| `layer1` | 374 passed, 0 failed |
| `layer2` | 12 passed, 0 failed |
| `shared` | 154 passed, 0 failed |

**Genesis (docker + geth v1.13.14)** — `pnpm genesis:test` completes successfully; geth initialises and mines against the regenerated alloc.

## Bytecode impact

Comparing runtime bytecode across EVM versions for the L2 contract set (metadata trailer stripped):

- `shanghai` → `cancun`: 31 of 74 runtime bytecodes change — this is the real codegen shift the L2 profiles are picking up.
- `cancun` → `prague` → `osaka`: no production contract bytecode changes. The only artifacts that differ are test/script contracts that embed other contracts' creation code, whose metadata hash encodes the `evmVersion` setting.

So on the L1 side (`prague` → `osaka`) deployed bytecode is unchanged, while the L2 genesis alloc does change as a result of moving off `shanghai`.

## Pre-existing issues noticed (not addressed here)

Two things surfaced while validating the genesis flow. Both reproduce identically on `main` with the original `shanghai` config, so neither is caused by this change — flagging them rather than fixing them, to keep this diff scoped:

1. The genesis assertion suite never runs in CI. `genesis.test.sh` invokes `forge test --match-path test/genesis/GenerateGenesis.g.sol`, but `no_match_path = "test/genesis/*"` in `profile.default` is inherited by `profile.genesis` and filters every test out. The script reports `No tests found in project!` and still exits 0.
2. Forcing that suite to run (by overriding `no_match_path`) gives 13 passed / 1 failed, with `testTaikoAnchor()` failing on `Function must be called through active proxy`. Identical result before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnwjNmjViuxbH8NaUJxo7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnwjNmjViuxbH8NaUJxo7v)_