### PR TITLE
chore(taiko-client-rs): bump execution client dependencies

### DIFF
--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.3.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=11973e70335247d104eec634d96db772b20976c8#11973e70335247d104eec634d96db772b20976c8"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=298b37cbd0b06df6090da987b9705006af61b529#298b37cbd0b06df6090da987b9705006af61b529"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.2.0",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.3.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=11973e70335247d104eec634d96db772b20976c8#11973e70335247d104eec634d96db772b20976c8"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=298b37cbd0b06df6090da987b9705006af61b529#298b37cbd0b06df6090da987b9705006af61b529"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.2.0",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.3.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=11973e70335247d104eec634d96db772b20976c8#11973e70335247d104eec634d96db772b20976c8"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=298b37cbd0b06df6090da987b9705006af61b529#298b37cbd0b06df6090da987b9705006af61b529"
 dependencies = [
  "alloy-consensus 2.2.0",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.3.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=11973e70335247d104eec634d96db772b20976c8#11973e70335247d104eec634d96db772b20976c8"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=298b37cbd0b06df6090da987b9705006af61b529#298b37cbd0b06df6090da987b9705006af61b529"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3006,7 +3006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3818,7 +3818,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -6354,7 +6354,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6392,9 +6392,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8213,7 +8213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8271,7 +8271,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9073,7 +9073,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10215,7 +10215,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/taiko-client-rs/Cargo.lock
+++ b/packages/taiko-client-rs/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-chainspec"
 version = "1.3.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=298b37cbd0b06df6090da987b9705006af61b529#298b37cbd0b06df6090da987b9705006af61b529"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=54e9abbbc827dc8f6625813d131f20aa8f40636f#54e9abbbc827dc8f6625813d131f20aa8f40636f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.2.0",
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-consensus"
 version = "1.3.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=298b37cbd0b06df6090da987b9705006af61b529#298b37cbd0b06df6090da987b9705006af61b529"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=54e9abbbc827dc8f6625813d131f20aa8f40636f#54e9abbbc827dc8f6625813d131f20aa8f40636f"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-consensus 2.2.0",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-primitives"
 version = "1.3.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=298b37cbd0b06df6090da987b9705006af61b529#298b37cbd0b06df6090da987b9705006af61b529"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=54e9abbbc827dc8f6625813d131f20aa8f40636f#54e9abbbc827dc8f6625813d131f20aa8f40636f"
 dependencies = [
  "alloy-consensus 2.2.0",
  "alloy-primitives",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "alethia-reth-rpc-types"
 version = "1.3.0"
-source = "git+https://github.com/taikoxyz/alethia-reth?rev=298b37cbd0b06df6090da987b9705006af61b529#298b37cbd0b06df6090da987b9705006af61b529"
+source = "git+https://github.com/taikoxyz/alethia-reth?rev=54e9abbbc827dc8f6625813d131f20aa8f40636f#54e9abbbc827dc8f6625813d131f20aa8f40636f"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3818,7 +3818,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -6354,7 +6354,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6392,7 +6392,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -75,12 +75,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "11973e70335247d104eec634d96db772b20976c8", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "11973e70335247d104eec634d96db772b20976c8", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "11973e70335247d104eec634d96db772b20976c8", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "298b37cbd0b06df6090da987b9705006af61b529", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "298b37cbd0b06df6090da987b9705006af61b529", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "298b37cbd0b06df6090da987b9705006af61b529", default-features = false, features = [
     "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "11973e70335247d104eec634d96db772b20976c8" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "298b37cbd0b06df6090da987b9705006af61b529" }
 
 # networking
 arc-swap = "1.7"

--- a/packages/taiko-client-rs/Cargo.toml
+++ b/packages/taiko-client-rs/Cargo.toml
@@ -75,12 +75,12 @@ k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 robust-provider = "1.0.1"
 
 # taiko
-alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "298b37cbd0b06df6090da987b9705006af61b529", default-features = false }
-alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "298b37cbd0b06df6090da987b9705006af61b529", default-features = false }
-alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "298b37cbd0b06df6090da987b9705006af61b529", default-features = false, features = [
+alethia-reth-chainspec = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-chainspec", rev = "54e9abbbc827dc8f6625813d131f20aa8f40636f", default-features = false }
+alethia-reth-consensus = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-consensus", rev = "54e9abbbc827dc8f6625813d131f20aa8f40636f", default-features = false }
+alethia-reth-primitives = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-primitives", rev = "54e9abbbc827dc8f6625813d131f20aa8f40636f", default-features = false, features = [
     "serde",
 ] }
-alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "298b37cbd0b06df6090da987b9705006af61b529" }
+alethia-reth-rpc-types = { git = "https://github.com/taikoxyz/alethia-reth", package = "alethia-reth-rpc-types", rev = "54e9abbbc827dc8f6625813d131f20aa8f40636f" }
 
 # networking
 arc-swap = "1.7"


### PR DESCRIPTION
## Summary

- confirm the existing `taiko-geth` replacement already targets the latest `taiko` revision (`ca164c06e00ceb2b1cc25ae2a141ee57b6a1cd18`)
- pin all four direct `alethia-reth` dependencies to the latest `main` revision (`54e9abbbc827dc8f6625813d131f20aa8f40636f`)
- refresh the Cargo lockfile for resolver-required related dependency edges

## Impact

The Go execution-client dependency is unchanged because it was already current. The Rust client now builds against the latest `alethia-reth` main branch through an immutable commit pin.

## Validation

- `go mod verify`
- `go test -run '^$' ./packages/taiko-client/...`
- `PULL_POLICY=missing just fmt && just clippy-fix && just test` (394 tests passed)

## Notes

A standalone `go test ./packages/taiko-client/...` sweep was attempted, but integration-style suites timed out waiting for an unavailable local L1 WebSocket endpoint at `localhost:62925`. The Go module graph is unchanged, and the compile-only package pass above completed successfully.