### PR TITLE
chore(repo): consolidate codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,23 +1,23 @@
 # Root level files and workflows
-.github/CODEOWNERS              @dantaik @ggonzalez94 @davidtaikocha
-.github/workflows/*             @ggonzalez94 @YoGhurt111 @davidtaikocha @RogerLamTd
+.github/CODEOWNERS              @dantaik @davidtaikocha @smtmfft
+.github/workflows/*             @davidtaikocha @smtmfft
 
 # Protocol
-/packages/protocol/**           @ggonzalez94 @davidtaikocha
-/packages/protocol/contracts/**/*Verifier*.sol @smtmfft @ggonzalez94 @davidtaikocha
-/packages/protocol/contracts/layer1/preconf/** @AnshuJalan @ggonzalez94 @davidtaikocha
+/packages/protocol/**           @dantaik @davidtaikocha @smtmfft
+/packages/protocol/contracts/**/*Verifier*.sol @dantaik @davidtaikocha @smtmfft
+/packages/protocol/contracts/layer1/preconf/** @dantaik @davidtaikocha @smtmfft
 
 # Client services
-/packages/taiko-client/**       @YoGhurt111 @davidtaikocha
-/packages/taiko-client-rs/**    @YoGhurt111 @davidtaikocha
-/packages/eventindexer/**       @YoGhurt111 @davidtaikocha
-/packages/relayer/**            @YoGhurt111 @davidtaikocha
+/packages/taiko-client/**       @davidtaikocha @smtmfft
+/packages/taiko-client-rs/**    @davidtaikocha @smtmfft
+/packages/eventindexer/**       @davidtaikocha @smtmfft
+/packages/relayer/**            @davidtaikocha @smtmfft
 
 # Frontend applications
-/packages/bridge-ui/**          @RogerLamTd @ggonzalez94
+/packages/bridge-ui/**          @davidtaikocha @smtmfft
 
 # Infrastructure and tools
-/packages/balance-monitor/**    @YoGhurt111 @davidtaikocha @RogerLamTd
-/packages/ejector/**            @YoGhurt111 @davidtaikocha @RogerLamTd
-/packages/fork-diff/**          @YoGhurt111 @davidtaikocha @RogerLamTd
-/packages/geth-rpc-gateway/**   @YoGhurt111 @davidtaikocha
+/packages/balance-monitor/**    @davidtaikocha @smtmfft
+/packages/ejector/**            @davidtaikocha @smtmfft
+/packages/fork-diff/**          @davidtaikocha @smtmfft
+/packages/geth-rpc-gateway/**   @davidtaikocha @smtmfft


### PR DESCRIPTION
## Summary

Consolidates `.github/CODEOWNERS` so every rule is owned by @davidtaikocha and @smtmfft.

- All existing rules now list **@davidtaikocha @smtmfft**.
- **@dantaik** is kept on `.github/CODEOWNERS` (as before) and added to the three `/packages/protocol/**` rules.
- @ggonzalez94, @YoGhurt111, @RogerLamTd and @AnshuJalan are removed as owners.

## Notes

Two pre-existing quirks are left untouched in this PR, but worth flagging:

- The two narrower protocol rules (`**/*Verifier*.sol` and `layer1/preconf/**`) now carry exactly the same owners as `/packages/protocol/**`, so they are effectively redundant under CODEOWNERS' last-match-wins semantics. Happy to drop them if we'd rather keep the file minimal.
- `/packages/geth-rpc-gateway/**` no longer exists in the repo; the rule is dead but kept for a minimal diff.
- There is still no `*` fallback rule, so paths outside the listed packages (repo root config, `packages/monitors`, `nfts`, `snaefell-ui`, `supplementary-contracts`, `taikoon-ui`, `tools`, `ui-lib`, `whitepaper`) have no code owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)