### PR TITLE
docs(protocol): disclose Daniel Wang's Taiko affiliation and council composition in Proposal0020

### DIFF
--- a/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
+++ b/packages/protocol/contracts/layer1/mainnet/LibL1Addrs.sol
@@ -20,7 +20,7 @@ library LibL1Addrs {
     address public constant SC_ARAGON = 0xb284810536C0dAB6A8e48153B58588A9B9e0F701;
     // Independent seat (EOA) added by Proposal0020
     address public constant SC_GUSTAVO_GONZALEZ = 0xe63E61BbB3aa1b82d44471AbcAb490102C17c986;
-    // Daniel Wang's seat (EOA) added by Proposal0020
+    // Taiko-affiliated seat (EOA; Daniel Wang, Taiko co-founder) added by Proposal0020
     address public constant SC_DANIEL_WANG = 0xF74F2bBaEd41e3e4AbAcbA24563a5Ce5aB071C8A;
     // Seats removed by Proposal0020
     address public constant SC_NETHERMIND = 0x5353c607e6eca6C63FEC5c6C0F5CC3a5348d5c95;

--- a/packages/protocol/script/layer1/proposals/Proposal0020.md
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.md
@@ -8,12 +8,17 @@ This proposal restructures the Security Council:
   Nethermind
 - **Retained (3):** Taiko Labs, L2BEAT, Aragon
 - **Added (2):** Gustavo Gonzalez (independent member), seat
-  `0xe63E61BbB3aa1b82d44471AbcAb490102C17c986` (EOA); Daniel Wang, seat
-  `0xF74F2bBaEd41e3e4AbAcbA24563a5Ce5aB071C8A` (EOA)
+  `0xe63E61BbB3aa1b82d44471AbcAb490102C17c986` (EOA); Daniel Wang (Taiko co-founder),
+  seat `0xF74F2bBaEd41e3e4AbAcbA24563a5Ce5aB071C8A` (EOA)
 - **Standard proposal threshold:** 5/9 → **3/5**
 - **Emergency proposal threshold:** 7/9 → **4/5**
 - **SignerList `minSignerListLength`:** 8 → **4** (contract-documented floor: must be ≥ the
   emergency `minApprovals`; 4 preserves the current one-removal headroom pattern)
+- **Resulting composition:** two of the five seats are Taiko-affiliated — the Taiko Labs
+  seat and Daniel Wang (Taiko co-founder). This is intentional; the Taiko-affiliated
+  seats alone meet neither threshold. The other three seats (L2BEAT, Aragon, Gustavo
+  Gonzalez) can meet the standard 3/5 threshold on their own; the emergency 4/5 threshold
+  requires approvals from both groups.
 
 ## Prerequisites
 
@@ -80,7 +85,7 @@ Member addresses (from the on-chain SignerList census, cross-checked against
 | L2BEAT                         | `0xf1cF63589A1e012F9124182c9eAa36B5333e5f06`       | retained    |
 | Aragon                         | `0xb284810536C0dAB6A8e48153B58588A9B9e0F701`       | retained    |
 | Gustavo Gonzalez (independent) | `0xe63E61BbB3aa1b82d44471AbcAb490102C17c986` (EOA) | added       |
-| Daniel Wang                    | `0xF74F2bBaEd41e3e4AbAcbA24563a5Ce5aB071C8A` (EOA) | added       |
+| Daniel Wang (Taiko co-founder) | `0xF74F2bBaEd41e3e4AbAcbA24563a5Ce5aB071C8A` (EOA) | added       |
 | Nethermind                     | `0x5353c607e6eca6C63FEC5c6C0F5CC3a5348d5c95`       | removed     |
 | Chainbound                     | `0x436a1075099A145417EBFc74BBaC9605e3e4f1A7`       | removed     |
 | Halborn                        | `0x0F40268Ec0Dc8D88CF2f22E227A29a0b478b6351`       | removed     |
@@ -160,7 +165,9 @@ Council and, during the veto window, TAIKO holders read. Paste them exactly:
 - **Description:** Removes Chainbound, Halborn, Drew Van der Werff, Toni Wahrstätter,
   Gattaca and Nethermind; retains Taiko Labs, L2BEAT and Aragon; adds Gustavo Gonzalez as
   an independent member (seat `0xe63E61BbB3aa1b82d44471AbcAb490102C17c986`) and Daniel
-  Wang (seat `0xF74F2bBaEd41e3e4AbAcbA24563a5Ce5aB071C8A`). Lowers the SignerList
+  Wang, Taiko co-founder (seat `0xF74F2bBaEd41e3e4AbAcbA24563a5Ce5aB071C8A`) — two of the
+  five resulting seats are thus Taiko-affiliated (the Taiko Labs seat and Daniel Wang),
+  and they alone meet neither approval threshold. Lowers the SignerList
   `minSignerListLength` from 8 to 4, the standard multisig `minApprovals` from 5 to 3,
   and the emergency multisig `minApprovals` from 7 to 4. All other settings (the 10-day
   veto duration and 14-day proposal expiration) are unchanged. Full technical

--- a/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
+++ b/packages/protocol/script/layer1/proposals/Proposal0020.s.sol
@@ -17,10 +17,11 @@ import {
 // To dryrun the proposal on an L1 fork: `SENDER=<a member or agent> P=0020 pnpm proposal:dryrun:l1`
 contract Proposal0020 is BuildDirectProposal {
     // All seat addresses live in LibL1Addrs ("Security Council seats" section): the new
-    // seats L1.SC_GUSTAVO_GONZALEZ (independent, EOA) and L1.SC_DANIEL_WANG (EOA); the
-    // removed L1.SC_CHAINBOUND, L1.SC_HALBORN, L1.SC_DREW_VAN_DER_WERFF,
-    // L1.SC_TONI_WAHRSTATTER, L1.SC_GATTACA, L1.SC_NETHERMIND; and the retained
-    // L1.SC_TAIKO_LABS, L1.SC_L2BEAT, L1.SC_ARAGON (dryrun assertions only).
+    // seats L1.SC_GUSTAVO_GONZALEZ (independent, EOA) and L1.SC_DANIEL_WANG (Taiko
+    // co-founder, EOA); the removed L1.SC_CHAINBOUND, L1.SC_HALBORN,
+    // L1.SC_DREW_VAN_DER_WERFF, L1.SC_TONI_WAHRSTATTER, L1.SC_GATTACA, L1.SC_NETHERMIND;
+    // and the retained L1.SC_TAIKO_LABS, L1.SC_L2BEAT, L1.SC_ARAGON (dryrun assertions
+    // only).
     //
     // IMPORTANT: neither SC_GUSTAVO_GONZALEZ nor SC_DANIEL_WANG may be any seat's
     // appointed encryption agent when this proposal EXECUTES: only the appointed agent


### PR DESCRIPTION
## What

Addresses the two remaining (presentation-level) items from the automated review on #22040, which that PR's author-side reply left open for the proposal author to decide. Stacks directly on #22040's head branch.

Both items came down to the same gap: the Gustavo Gonzalez seat is explicitly labeled *independent*, while the new Daniel Wang seat carried no affiliation label, leaving the resulting 2-of-5 Taiko-affiliated composition implicit.

## Changes

- **`LibL1Addrs.sol`** — the `SC_DANIEL_WANG` comment now reads "Taiko-affiliated seat (EOA; Daniel Wang, Taiko co-founder)", mirroring the "Independent seat (EOA)" label on `SC_GUSTAVO_GONZALEZ`.
- **`Proposal0020.s.sol`** — the header seat roster labels `L1.SC_DANIEL_WANG` as "(Taiko co-founder, EOA)" alongside `L1.SC_GUSTAVO_GONZALEZ` "(independent, EOA)".
- **`Proposal0020.md`**
  - Executive summary: the "Added (2)" bullet labels the seat, and a new **Resulting composition** bullet states that two of the five seats are Taiko-affiliated (Taiko Labs + Daniel Wang), that this is intentional, and what it means against the thresholds — the two Taiko-affiliated seats meet neither threshold alone; the other three (L2BEAT, Aragon, Gustavo Gonzalez) can meet the standard 3/5 on their own, while the emergency 4/5 needs approvals from both groups.
  - Member census table: the row reads "Daniel Wang (Taiko co-founder)".
  - **DAO UI fields → Description**: the same disclosure, since this is the metadata pinned to IPFS that the Security Council and TAIKO holders actually read during the veto window.

## Verification

- No Solidity code paths, constants, or action construction changed — comments and docs only, so the generated calldata is unaffected and `Proposal0020.action.md` is untouched (deliberately not regenerated; it would be byte-identical).
- `prettier@3.2.5 --check` clean on `Proposal0020.md` (the pre-commit hook's formatter).
- Touched Solidity lines verified within the repo's 100-column `line_length`; no `forge fmt`-relevant code changed. Foundry is not installed in this environment, so `forge fmt`/`solhint`/the fork dryrun were not re-run here — the underlying #22040 run covers them and this diff adds no executable change.

## Notes

- Base branch is `claude/proposal-0020-sc-address-1838mf` (#22040's head), which in turn targets `revamp-security-council`. Merge #22040 first, or fold these commits into it.
- The affiliation wording ("Taiko co-founder") is the factual framing; if the proposal author prefers different phrasing for the IPFS-pinned metadata, that text is confined to the executive summary bullet and the **Description** field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrC5PJjdvUNmvbwMNsb2Vp)_