### PR TITLE
fix(repo): remove dead youtube badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/taikoxyz?style=social)](https://twitter.com/taikoxyz)
 [![Discord](https://img.shields.io/discord/984015101017346058?color=%235865F2&label=Discord&logo=discord&logoColor=%23fff)](https://discord.gg/aGZYtKqMjj)
-[![YouTube](https://img.shields.io/youtube/channel/subscribers/UCxd_ARE9LtAEdnRQA6g1TaQ)](https://www.youtube.com/@taikoxyz)
 
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/taikoxyz/taiko-mono/blob/main/LICENSE)
 


### PR DESCRIPTION
## Summary

Removes the YouTube badge from the root `README.md`.

`https://www.youtube.com/@taikoxyz` returns **404**, which fails the `Check links` workflow on every PR that touches any README. Surfaced by #22044, but not caused by it — that PR does not touch this line.

The badge is dropped rather than repointed. The Twitter and Discord badges directly above it already cover socials, and a subscriber count is not something this README needs to carry.

## What changed

```diff
 [![Twitter Follow](...)](https://twitter.com/taikoxyz)
 [![Discord](...)](https://discord.gg/aGZYtKqMjj)
-[![YouTube](https://img.shields.io/youtube/channel/subscribers/UCxd_ARE9LtAEdnRQA6g1TaQ)](https://www.youtube.com/@taikoxyz)
 
 [![License](...)](.../LICENSE)
```

One line, no other changes.

## Verification

| URL | Status |
| :--- | :--- |
| `https://www.youtube.com/@taikoxyz` | 404 |
| `https://www.youtube.com/@taikoxyz/videos` | 404 |
| `https://www.youtube.com/c/taikoxyz` | 404 |
| `https://www.youtube.com/@Taikoxyz` | 404 |

For the record, the underlying channel is still alive — `https://www.youtube.com/channel/UCxd_ARE9LtAEdnRQA6g1TaQ` returns 200 and the shields badge still renders. Only the handle is gone. If the channel should stay linked from here, the channel-ID URL is the stable form; I could not confirm a current `@handle` because YouTube serves a JavaScript shell to non-browser clients.

`git grep -i youtube` confirms this was the only YouTube social link in the root README.

## When this broke

`Check links` last passed on `main` on **2026-08-07**. The handle died sometime in the ~2.5 weeks since and went unnoticed because the workflow only fires on `paths: **/README.md`, and no README changed in that window.

Lychee reported exactly this one error across 61 unique links; everything else in the repo's READMEs is either passing or an existing redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
