### PR TITLE
ci(taiko-client-rs): install nightly toolchain after rust-cache so lint restores the shared cache

### DIFF
--- a/.github/workflows/taiko-client-rs--test.yml
+++ b/.github/workflows/taiko-client-rs--test.yml
@@ -77,12 +77,6 @@ jobs:
           toolchain: 1.95.0
           components: clippy
 
-      - name: Install Rust nightly toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2025-09-27
-          components: rustfmt
-
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -94,6 +88,16 @@ jobs:
           save-if: "false"
           workspaces: |
             packages/taiko-client-rs -> target
+
+      # Deliberately after rust-cache: the cache key hashes all installed
+      # toolchains, and the saver of the shared key (Tests job) only has
+      # stable — installing nightly before the cache step changes the key
+      # and makes every restore miss.
+      - name: Install Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-09-27
+          components: rustfmt
 
       - name: Setup just
         uses: extractions/setup-just@v4


### PR DESCRIPTION
## Problem

The Lint job of the taiko-client-rs CI has printed `No cache found.` on **every run** since the shared-cache design landed in #21802, cold-compiling the full reth/alloy dependency tree each time — ~8-9 min on a healthy `arc-runner-set` pod, and two 25-minute job timeouts on a slow pod in [run 32693336860](https://github.com/taikoxyz/taiko-mono/actions/runs/32693336860) (PR #22041, attempts 1 and 3).

## Root cause

`Swatinem/rust-cache` folds **every installed Rust toolchain** into the env-hash segment of its cache key. The Lint job installed `nightly-2025-09-27` (for rustfmt) *before* the cache step, so:

- Lint's restore prefix: `v0-rust-taiko-client-rs-Linux-x64-e7e88179`
- Key saved by the stable-only Tests job on main: `v0-rust-taiko-client-rs-Linux-x64-f8f5d2e0-a477d85e` (2.8 GB)

The prefix never matches, so the `save-if: "false"` / "lint just consumes it" design never actually worked for Lint. Control group from the same run: the stable-only Unit Tests job restored the main cache fine (`Restored from cache key "…-f8f5d2e0-a477d85e"`) and finished in 4m18s.

## Fix

Move the nightly install to *after* `Setup Rust cache` (still before `fmt-check`), with a comment recording the ordering constraint. At restore time Lint's environment is now identical to the saver's.

No behavior change otherwise:

- `rust-toolchain.toml` pins 1.95.0 for the package dir, so cargo/clippy resolve stable regardless of install order
- `just fmt-check` still finds (and would even self-install) the pinned nightly
- Lint never saves (`save-if: "false"`), so there is no save-side effect

## Verification note

This PR only touches the workflow file, and the workflow's path filter is `packages/taiko-client-rs/**`, so the CI in question does not run here. Verification is the first taiko-client-rs PR after merge: its Lint log should show `Restored from cache key "…-f8f5d2e0-…"` instead of `No cache found.`, with clippy dropping to a few minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)