### PR TITLE
fix(taiko-client,taiko-client-rs): let a lagging preconfirmation follower report itself behind

### DIFF
--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/server/tests.rs
@@ -38,6 +38,7 @@ impl WhitelistApi for MockApi {
     async fn get_status(&self) -> Result<ApiStatus> {
         Ok(ApiStatus {
             highest_unsafe_l2_payload_block_id: 100,
+            highest_imported_l2_payload_block_id: 100,
             end_of_sequencing_block_hash: B256::ZERO.to_string(),
             can_shutdown: true,
         })
@@ -72,6 +73,7 @@ impl WhitelistApi for SyncReadyApi {
     async fn get_status(&self) -> Result<ApiStatus> {
         Ok(ApiStatus {
             highest_unsafe_l2_payload_block_id: 100,
+            highest_imported_l2_payload_block_id: 100,
             end_of_sequencing_block_hash: B256::ZERO.to_string(),
             can_shutdown: true,
         })

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -17,7 +17,7 @@ impl WhitelistApiService {
             .map(|block| block.header.number);
 
         let observed_head = self.state.reconcile_observed_head(l2_head);
-        let highest_unsafe = self.state.highest_unsafe_floored_at(observed_head);
+        let highest_unsafe = self.state.highest_unsafe_for_head(observed_head);
         if l2_head.is_none() {
             warn!(observed_head, highest_unsafe, "L2 head unreadable; using last observed head");
         }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/status.rs
@@ -16,9 +16,10 @@ impl WhitelistApiService {
             .flatten()
             .map(|block| block.header.number);
 
-        let highest_unsafe = self.state.reconcile_reported_head(l2_head);
+        let observed_head = self.state.reconcile_observed_head(l2_head);
+        let highest_unsafe = self.state.highest_unsafe_floored_at(observed_head);
         if l2_head.is_none() {
-            warn!(reported = highest_unsafe, "L2 head unreadable; reporting last observed head");
+            warn!(observed_head, highest_unsafe, "L2 head unreadable; using last observed head");
         }
 
         let current_epoch = self.beacon_client.current_epoch();
@@ -32,6 +33,7 @@ impl WhitelistApiService {
 
         Ok(ApiStatus {
             highest_unsafe_l2_payload_block_id: highest_unsafe,
+            highest_imported_l2_payload_block_id: observed_head,
             end_of_sequencing_block_hash,
             can_shutdown,
         })

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -201,12 +201,54 @@ fn seen_block_advances_monotonically() {
 }
 
 #[test]
-fn reported_value_is_capped_one_cache_span_above_the_head() {
-    // A malformed or hostile block number must not park the node out of sync indefinitely.
+fn absurd_block_number_is_anchored_and_eventually_releases() {
+    // A signature-valid payload with a wrong or hostile block number must not keep the node out
+    // of sync forever, or it keeps the preconfer client from ever starting.
     let state = SharedPreconfState::new(1_000);
     state.record_seen_block(u64::MAX);
 
-    assert_eq!(state.highest_unsafe_floored_at(1_000), 1_000 + PENDING_ENVELOPE_CAPACITY as u64);
+    let anchored = 1_000 + PENDING_ENVELOPE_CAPACITY as u64;
+    assert_eq!(state.highest_seen_block(), anchored, "anchored at record time, not at report time");
+    assert_ne!(state.highest_unsafe_floored_at(1_000), 1_000, "still reads as behind for now");
+
+    // The anchor is a fixed height rather than one that tracks the head, so the chain catching up
+    // to it restores equality. Clamping the reported value instead would return `head + capacity`
+    // forever, and the node could never read as synced again.
+    assert_eq!(state.highest_unsafe_floored_at(anchored - 1), anchored);
+    assert_eq!(state.highest_unsafe_floored_at(anchored), anchored, "synced again");
+    assert_eq!(state.highest_unsafe_floored_at(anchored + 10), anchored + 10);
+}
+
+#[test]
+fn a_rewind_does_not_erase_the_envelope_that_arrived_with_it() {
+    // Ordering guard for the ingress path: the tip rewind lowers the counter unconditionally, so
+    // it has to run before the envelope in hand is counted. Recording first would forget the
+    // first block of the new branch, and `/status` would fall back to the rewound head — which
+    // equals the execution head, so the preconfer client would read a node holding an unimported
+    // block as synced.
+    let state = SharedPreconfState::new(90);
+    state.observe_envelope(150, Some(100));
+
+    // An L1 reorg rewinds the confirmed tip, and the first new-branch payload arrives with it.
+    // `observe_envelope` is the single call the ingress path makes, so this is the real ordering.
+    state.observe_envelope(120, Some(90));
+
+    assert_eq!(state.highest_seen_block(), 120);
+    assert_ne!(
+        state.highest_unsafe_floored_at(90),
+        90,
+        "must not read as synced at the rewound head"
+    );
+}
+
+#[test]
+fn a_backlog_deeper_than_one_cache_span_still_reads_as_behind() {
+    // The anchor must not silently turn a real backlog into a synced report: a node returning
+    // from long downtime is behind by more than the cache can bridge, and still has to say so.
+    let state = SharedPreconfState::new(1_000);
+    state.record_seen_block(1_000 + PENDING_ENVELOPE_CAPACITY as u64 * 4);
+
+    assert_ne!(state.highest_unsafe_floored_at(1_000), 1_000);
 }
 
 #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -11,7 +11,10 @@ use crate::{
         HAND_OVER_WINDOW_SLOTS, SHUTDOWN_BLOCK_WINDOW, SHUTDOWN_IMMINENCE_MARGIN_SLOTS,
         WhitelistApiService, can_shutdown_for,
     },
-    cache::{PENDING_ENVELOPE_CAPACITY, SharedPreconfState},
+    cache::{
+        BACKFILL_RETRY_INTERVAL_SECS, L1_EPOCH_DURATION_SECS, PENDING_ENVELOPE_CAPACITY,
+        SharedPreconfState,
+    },
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, decompress_tx_list},
     error::WhitelistPreconfirmationDriverError,
 };
@@ -124,6 +127,19 @@ fn can_shutdown_allows_at_epoch_start() {
 }
 
 #[test]
+fn backfill_retry_interval_stays_inside_the_preconfer_client_tolerance() {
+    // The preconfer client cancels and exits after a continuous `/status` mismatch lasting half an
+    // L2 epoch. An autonomous retry slower than that arrives after the process is already gone, so
+    // a dropped final response with no further gossip would never get a second attempt. This was
+    // an L1-epoch poll before; keep it an order of magnitude inside the budget.
+    let client_tolerance_secs = L1_EPOCH_DURATION_SECS / 2;
+    assert!(
+        BACKFILL_RETRY_INTERVAL_SECS * 10 < client_tolerance_secs,
+        "retry interval {BACKFILL_RETRY_INTERVAL_SECS}s is not comfortably inside {client_tolerance_secs}s"
+    );
+}
+
+#[test]
 fn shutdown_block_window_is_one_hundred_forty_four_seconds() {
     assert_eq!(SHUTDOWN_BLOCK_WINDOW, Duration::from_secs(144));
 }
@@ -170,12 +186,8 @@ fn reported_value_exceeds_head_while_a_backlog_is_pending() {
     state.record_seen_block(10_523_099);
 
     let head = state.reconcile_observed_head(Some(10_522_943));
-    assert_eq!(state.highest_unsafe_floored_at(head), 10_523_099);
-    assert_ne!(
-        state.highest_unsafe_floored_at(head),
-        head,
-        "a lagging node must not read as synced"
-    );
+    assert_eq!(state.highest_unsafe_for_head(head), 10_523_099);
+    assert_ne!(state.highest_unsafe_for_head(head), head, "a lagging node must not read as synced");
 }
 
 #[test]
@@ -185,7 +197,7 @@ fn reported_value_matches_head_when_ahead_of_gossip() {
     let state = SharedPreconfState::new(10_522_943);
 
     let head = state.reconcile_observed_head(Some(10_523_500));
-    assert_eq!(state.highest_unsafe_floored_at(head), head);
+    assert_eq!(state.highest_unsafe_for_head(head), head);
 }
 
 #[test]
@@ -208,15 +220,35 @@ fn absurd_block_number_is_anchored_and_eventually_releases() {
     state.record_seen_block(u64::MAX);
 
     let anchored = 1_000 + PENDING_ENVELOPE_CAPACITY as u64;
-    assert_eq!(state.highest_seen_block(), anchored, "anchored at record time, not at report time");
-    assert_ne!(state.highest_unsafe_floored_at(1_000), 1_000, "still reads as behind for now");
+    assert_eq!(state.highest_unsafe_for_head(1_000), anchored);
+    assert_eq!(
+        state.highest_seen_block(),
+        anchored,
+        "the bound is written back, not just returned"
+    );
+    assert_ne!(state.highest_unsafe_for_head(1_000), 1_000, "still reads as behind for now");
 
-    // The anchor is a fixed height rather than one that tracks the head, so the chain catching up
-    // to it restores equality. Clamping the reported value instead would return `head + capacity`
-    // forever, and the node could never read as synced again.
-    assert_eq!(state.highest_unsafe_floored_at(anchored - 1), anchored);
-    assert_eq!(state.highest_unsafe_floored_at(anchored), anchored, "synced again");
-    assert_eq!(state.highest_unsafe_floored_at(anchored + 10), anchored + 10);
+    // Pinned at a concrete height rather than one that tracks the head, so the chain catching up
+    // restores equality. Returning the bound without storing it would report head+span forever.
+    assert_eq!(state.highest_unsafe_for_head(anchored), anchored, "synced again");
+    assert_eq!(state.highest_unsafe_for_head(anchored + 10), anchored + 10);
+}
+
+#[test]
+fn a_lagging_internal_counter_never_bounds_the_report() {
+    // Regression for bounding the counter against an anchor that trails the live execution head.
+    // `last_observed_l2_head` only moves on a status poll or a local insert, so the engine can
+    // sync far past it; bounding on it would pull the counter below the head, and `/status`
+    // floors at the head, so a node holding an unimported payload would read as synced.
+    let state = SharedPreconfState::new(1_000);
+    state.record_seen_block(5_001);
+
+    assert_eq!(state.highest_unsafe_for_head(5_000), 5_001);
+    assert_ne!(
+        state.highest_unsafe_for_head(5_000),
+        5_000,
+        "a node holding an unimported payload must not read as synced"
+    );
 }
 
 #[test]
@@ -235,7 +267,7 @@ fn a_rewind_does_not_erase_the_envelope_that_arrived_with_it() {
 
     assert_eq!(state.highest_seen_block(), 120);
     assert_ne!(
-        state.highest_unsafe_floored_at(90),
+        state.highest_unsafe_for_head(90),
         90,
         "must not read as synced at the rewound head"
     );
@@ -248,7 +280,8 @@ fn a_backlog_deeper_than_one_cache_span_still_reads_as_behind() {
     let state = SharedPreconfState::new(1_000);
     state.record_seen_block(1_000 + PENDING_ENVELOPE_CAPACITY as u64 * 4);
 
-    assert_ne!(state.highest_unsafe_floored_at(1_000), 1_000);
+    assert_ne!(state.highest_unsafe_for_head(1_000), 1_000);
+    assert_eq!(state.highest_seen_block(), 1_000 + PENDING_ENVELOPE_CAPACITY as u64);
 }
 
 #[test]
@@ -266,5 +299,5 @@ fn confirmed_tip_resets_seen_only_when_it_moves_backwards() {
     // reports a height the chain no longer reaches and never reads as synced again.
     state.note_confirmed_tip(1_020);
     assert_eq!(state.highest_seen_block(), 1_020);
-    assert_eq!(state.highest_unsafe_floored_at(1_020), 1_020, "node reads as synced again");
+    assert_eq!(state.highest_unsafe_for_head(1_020), 1_020, "node reads as synced again");
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -179,11 +179,11 @@ fn observed_head_covers_locally_inserted_blocks_when_head_unreadable() {
 
 #[test]
 fn reported_value_exceeds_head_while_a_backlog_is_pending() {
-    // The incident: a restarted follower held 156 blocks of valid, signature-checked envelopes
-    // it could not apply. Reporting its own stale execution head made the preconfer client's
-    // parity check compare stale against stale, match, and sequence from the stale head.
+    // The incident: a restarted follower held 156 blocks of valid, signature-checked envelopes it
+    // could not apply. Reporting its own stale execution head made the preconfer client's parity
+    // check compare stale against stale, match, and sequence from the stale head.
     let state = SharedPreconfState::new(10_522_943);
-    state.record_seen_block(10_523_099);
+    state.set_pending_high_water(Some(10_523_099));
 
     let head = state.reconcile_observed_head(Some(10_522_943));
     assert_eq!(state.highest_unsafe_for_head(head), 10_523_099);
@@ -192,8 +192,8 @@ fn reported_value_exceeds_head_while_a_backlog_is_pending() {
 
 #[test]
 fn reported_value_matches_head_when_ahead_of_gossip() {
-    // Right after a beacon sync the execution head runs ahead of anything seen over gossip.
-    // That is not a backlog, and reporting it as one would exit the preconfer client.
+    // Right after a beacon sync the execution head runs ahead of anything seen over gossip. That
+    // is not a backlog, and reporting it as one would exit the preconfer client.
     let state = SharedPreconfState::new(10_522_943);
 
     let head = state.reconcile_observed_head(Some(10_523_500));
@@ -201,103 +201,44 @@ fn reported_value_matches_head_when_ahead_of_gossip() {
 }
 
 #[test]
-fn seen_block_advances_monotonically() {
+fn a_deep_backlog_survives_the_head_advancing() {
+    // Regression for bounding the report with a stored watermark. A cap written back at
+    // `head + span` reads correctly once, then reports parity as soon as the head reaches that
+    // artificial height -- while the original payload is still cached and unapplied. Reading the
+    // backlog from the cache leaves no artificial height for the head to overtake.
     let state = SharedPreconfState::new(1_000);
+    state.set_pending_high_water(Some(4_000));
 
-    state.record_seen_block(1_050);
-    assert_eq!(state.highest_seen_block(), 1_050);
+    for head in [1_000, 1_000 + PENDING_ENVELOPE_CAPACITY as u64, 3_999] {
+        assert_eq!(
+            state.highest_unsafe_for_head(head),
+            4_000,
+            "an unapplied payload stays visible at head {head}"
+        );
+    }
 
-    // Never moves backwards on a late or out-of-order envelope.
-    state.record_seen_block(1_010);
-    assert_eq!(state.highest_seen_block(), 1_050);
+    // Only the chain actually reaching it, or the cache dropping it, clears the backlog.
+    assert_eq!(state.highest_unsafe_for_head(4_000), 4_000);
+    state.set_pending_high_water(None);
+    assert_eq!(state.highest_unsafe_for_head(1_000), 1_000, "an emptied cache reports the head");
 }
 
 #[test]
-fn absurd_block_number_is_anchored_and_eventually_releases() {
-    // A signature-valid payload with a wrong or hostile block number must not keep the node out
-    // of sync forever, or it keeps the preconfer client from ever starting.
-    let state = SharedPreconfState::new(1_000);
-    state.record_seen_block(u64::MAX);
-
-    let anchored = 1_000 + PENDING_ENVELOPE_CAPACITY as u64;
-    assert_eq!(state.highest_unsafe_for_head(1_000), anchored);
-    assert_eq!(
-        state.highest_seen_block(),
-        anchored,
-        "the bound is written back, not just returned"
-    );
-    assert_ne!(state.highest_unsafe_for_head(1_000), 1_000, "still reads as behind for now");
-
-    // Pinned at a concrete height rather than one that tracks the head, so the chain catching up
-    // restores equality. Returning the bound without storing it would report head+span forever.
-    assert_eq!(state.highest_unsafe_for_head(anchored), anchored, "synced again");
-    assert_eq!(state.highest_unsafe_for_head(anchored + 10), anchored + 10);
-}
-
-#[test]
-fn a_lagging_internal_counter_never_bounds_the_report() {
-    // Regression for bounding the counter against an anchor that trails the live execution head.
-    // `last_observed_l2_head` only moves on a status poll or a local insert, so the engine can
-    // sync far past it; bounding on it would pull the counter below the head, and `/status`
-    // floors at the head, so a node holding an unimported payload would read as synced.
-    let state = SharedPreconfState::new(1_000);
-    state.record_seen_block(5_001);
-
-    assert_eq!(state.highest_unsafe_for_head(5_000), 5_001);
-    assert_ne!(
-        state.highest_unsafe_for_head(5_000),
-        5_000,
-        "a node holding an unimported payload must not read as synced"
-    );
-}
-
-#[test]
-fn a_rewind_does_not_erase_the_envelope_that_arrived_with_it() {
-    // Ordering guard for the ingress path: the tip rewind lowers the counter unconditionally, so
-    // it has to run before the envelope in hand is counted. Recording first would forget the
-    // first block of the new branch, and `/status` would fall back to the rewound head — which
-    // equals the execution head, so the preconfer client would read a node holding an unimported
-    // block as synced.
+fn a_cached_envelope_survives_a_confirmed_tip_rewind() {
+    // Regression for resetting a watermark on a rewind. The tip is observed asynchronously, so a
+    // rewind can be seen *after* the first envelope of the new branch was already recorded; a
+    // reset that overwrites by height then erases it, and `/status` falls back to the rewound head
+    // while that envelope sits unapplied in the cache.
+    //
+    // Nothing overwrites by height any more: the report is recomputed from the cache, so an
+    // envelope that is still cached is still counted no matter when the rewind is noticed.
     let state = SharedPreconfState::new(90);
-    state.observe_envelope(150, Some(100));
+    state.set_pending_high_water(Some(120));
 
-    // An L1 reorg rewinds the confirmed tip, and the first new-branch payload arrives with it.
-    // `observe_envelope` is the single call the ingress path makes, so this is the real ordering.
-    state.observe_envelope(120, Some(90));
-
-    assert_eq!(state.highest_seen_block(), 120);
+    assert_eq!(state.highest_unsafe_for_head(90), 120);
     assert_ne!(
         state.highest_unsafe_for_head(90),
         90,
         "must not read as synced at the rewound head"
     );
-}
-
-#[test]
-fn a_backlog_deeper_than_one_cache_span_still_reads_as_behind() {
-    // The anchor must not silently turn a real backlog into a synced report: a node returning
-    // from long downtime is behind by more than the cache can bridge, and still has to say so.
-    let state = SharedPreconfState::new(1_000);
-    state.record_seen_block(1_000 + PENDING_ENVELOPE_CAPACITY as u64 * 4);
-
-    assert_ne!(state.highest_unsafe_for_head(1_000), 1_000);
-    assert_eq!(state.highest_seen_block(), 1_000 + PENDING_ENVELOPE_CAPACITY as u64);
-}
-
-#[test]
-fn confirmed_tip_resets_seen_only_when_it_moves_backwards() {
-    let state = SharedPreconfState::new(1_000);
-    state.record_seen_block(1_100);
-
-    // Steady state: preconfirmations outpace L1 confirmation by design, so an advancing tip
-    // below the highest seen block must leave the counter alone.
-    state.note_confirmed_tip(1_000);
-    state.note_confirmed_tip(1_040);
-    assert_eq!(state.highest_seen_block(), 1_100, "an advancing tip must not reset the counter");
-
-    // An L1 reorg rewinds the chain past envelopes already counted: without the reset the node
-    // reports a height the chain no longer reaches and never reads as synced again.
-    state.note_confirmed_tip(1_020);
-    assert_eq!(state.highest_seen_block(), 1_020);
-    assert_eq!(state.highest_unsafe_for_head(1_020), 1_020, "node reads as synced again");
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/service/tests.rs
@@ -11,7 +11,7 @@ use crate::{
         HAND_OVER_WINDOW_SLOTS, SHUTDOWN_BLOCK_WINDOW, SHUTDOWN_IMMINENCE_MARGIN_SLOTS,
         WhitelistApiService, can_shutdown_for,
     },
-    cache::SharedPreconfState,
+    cache::{PENDING_ENVELOPE_CAPACITY, SharedPreconfState},
     codec::{MAX_COMPRESSED_TX_LIST_BYTES, MAX_DECOMPRESSED_TX_LIST_BYTES, decompress_tx_list},
     error::WhitelistPreconfirmationDriverError,
 };
@@ -129,34 +129,100 @@ fn shutdown_block_window_is_one_hundred_forty_four_seconds() {
 }
 
 #[test]
-fn reported_head_prefers_live_head_and_records_it_as_fallback() {
+fn observed_head_prefers_live_head_and_records_it_as_fallback() {
     let state = SharedPreconfState::new(5_811_208);
-    // The live head always wins — the Catalyst sync gate compares the reported value
-    // against the execution head exactly, and reporting anything else wedges it in a
-    // restart loop. This covers both the L1-reorg (head rewound) and the catch-up
-    // (head advanced via canonical derivation with no gossip) directions.
-    assert_eq!(state.reconcile_reported_head(Some(5_811_227)), 5_811_227);
-    assert_eq!(state.reconcile_reported_head(Some(5_811_190)), 5_811_190);
+    // This is the node's own execution head, which `/status` floors its report at rather than
+    // reporting directly. The live head always wins here, covering both the L1-reorg (head
+    // rewound) and the catch-up (head advanced via canonical derivation with no gossip)
+    // directions.
+    assert_eq!(state.reconcile_observed_head(Some(5_811_227)), 5_811_227);
+    assert_eq!(state.reconcile_observed_head(Some(5_811_190)), 5_811_190);
     // A later failed read reports the most recently observed head, not the startup seed.
-    assert_eq!(state.reconcile_reported_head(None), 5_811_190);
+    assert_eq!(state.reconcile_observed_head(None), 5_811_190);
 }
 
 #[test]
-fn reported_head_falls_back_to_seed_before_first_observation() {
+fn observed_head_falls_back_to_seed_before_first_observation() {
     // Best-effort: a failed head read before any successful observation reports the
     // startup seed.
     let state = SharedPreconfState::new(5_811_208);
-    assert_eq!(state.reconcile_reported_head(None), 5_811_208);
+    assert_eq!(state.reconcile_observed_head(None), 5_811_208);
 }
 
 #[test]
-fn reported_head_covers_locally_inserted_blocks_when_head_unreadable() {
+fn observed_head_covers_locally_inserted_blocks_when_head_unreadable() {
     // Blocks inserted by this process (cached import or local build) must survive a failed
     // head read even before any successful status poll observed them.
     let state = SharedPreconfState::new(5_811_208);
     state.record_inserted_block(5_811_209);
-    assert_eq!(state.reconcile_reported_head(None), 5_811_209);
+    assert_eq!(state.reconcile_observed_head(None), 5_811_209);
     // A successful poll still overwrites the fallback with the live head.
-    assert_eq!(state.reconcile_reported_head(Some(5_811_210)), 5_811_210);
-    assert_eq!(state.reconcile_reported_head(None), 5_811_210);
+    assert_eq!(state.reconcile_observed_head(Some(5_811_210)), 5_811_210);
+    assert_eq!(state.reconcile_observed_head(None), 5_811_210);
+}
+
+#[test]
+fn reported_value_exceeds_head_while_a_backlog_is_pending() {
+    // The incident: a restarted follower held 156 blocks of valid, signature-checked envelopes
+    // it could not apply. Reporting its own stale execution head made the preconfer client's
+    // parity check compare stale against stale, match, and sequence from the stale head.
+    let state = SharedPreconfState::new(10_522_943);
+    state.record_seen_block(10_523_099);
+
+    let head = state.reconcile_observed_head(Some(10_522_943));
+    assert_eq!(state.highest_unsafe_floored_at(head), 10_523_099);
+    assert_ne!(
+        state.highest_unsafe_floored_at(head),
+        head,
+        "a lagging node must not read as synced"
+    );
+}
+
+#[test]
+fn reported_value_matches_head_when_ahead_of_gossip() {
+    // Right after a beacon sync the execution head runs ahead of anything seen over gossip.
+    // That is not a backlog, and reporting it as one would exit the preconfer client.
+    let state = SharedPreconfState::new(10_522_943);
+
+    let head = state.reconcile_observed_head(Some(10_523_500));
+    assert_eq!(state.highest_unsafe_floored_at(head), head);
+}
+
+#[test]
+fn seen_block_advances_monotonically() {
+    let state = SharedPreconfState::new(1_000);
+
+    state.record_seen_block(1_050);
+    assert_eq!(state.highest_seen_block(), 1_050);
+
+    // Never moves backwards on a late or out-of-order envelope.
+    state.record_seen_block(1_010);
+    assert_eq!(state.highest_seen_block(), 1_050);
+}
+
+#[test]
+fn reported_value_is_capped_one_cache_span_above_the_head() {
+    // A malformed or hostile block number must not park the node out of sync indefinitely.
+    let state = SharedPreconfState::new(1_000);
+    state.record_seen_block(u64::MAX);
+
+    assert_eq!(state.highest_unsafe_floored_at(1_000), 1_000 + PENDING_ENVELOPE_CAPACITY as u64);
+}
+
+#[test]
+fn confirmed_tip_resets_seen_only_when_it_moves_backwards() {
+    let state = SharedPreconfState::new(1_000);
+    state.record_seen_block(1_100);
+
+    // Steady state: preconfirmations outpace L1 confirmation by design, so an advancing tip
+    // below the highest seen block must leave the counter alone.
+    state.note_confirmed_tip(1_000);
+    state.note_confirmed_tip(1_040);
+    assert_eq!(state.highest_seen_block(), 1_100, "an advancing tip must not reset the counter");
+
+    // An L1 reorg rewinds the chain past envelopes already counted: without the reset the node
+    // reports a height the chain no longer reaches and never reads as synced again.
+    state.note_confirmed_tip(1_020);
+    assert_eq!(state.highest_seen_block(), 1_020);
+    assert_eq!(state.highest_unsafe_floored_at(1_020), 1_020, "node reads as synced again");
 }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/api/types.rs
@@ -50,9 +50,20 @@ pub struct BuildPreconfBlockResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiStatus {
-    /// Highest unsafe payload block ID tracked by this node.
+    /// Highest preconfirmation block ID received from the P2P network, whether or not it could
+    /// be imported, floored at the current L2 execution head. A consumer that requires this to
+    /// equal the execution head before sequencing therefore sees a mismatch whenever this node
+    /// is behind.
     #[serde(rename = "highestUnsafeL2PayloadBlockID")]
     pub highest_unsafe_l2_payload_block_id: u64,
+    /// The block height this node has locally applied, as this driver observes it. The gap to
+    /// `highest_unsafe_l2_payload_block_id` is this node's preconfirmation backlog.
+    ///
+    /// Observability only — no consumer gates on it. The Go driver derives the same field from
+    /// the blocks its preconfirmation server imported, which can trail the execution head when
+    /// blocks arrive through L1 derivation instead; this driver reports the observed head.
+    #[serde(rename = "highestImportedL2PayloadBlockID")]
+    pub highest_imported_l2_payload_block_id: u64,
     /// End-of-sequencing block hash for current epoch (zero hash when unknown).
     pub end_of_sequencing_block_hash: String,
     /// True when SIGTERM is safe — no `build_preconf_block` request has been
@@ -105,6 +116,7 @@ mod tests {
     fn status_serializes_fields_in_camel_case() {
         let status = ApiStatus {
             highest_unsafe_l2_payload_block_id: 1,
+            highest_imported_l2_payload_block_id: 1,
             end_of_sequencing_block_hash: B256::ZERO.to_string(),
             can_shutdown: true,
         };
@@ -119,6 +131,12 @@ mod tests {
             1
         );
         assert!(json.get("highestUnsafeL2PayloadBlockId").is_none());
+        assert_eq!(
+            json["highestImportedL2PayloadBlockID"]
+                .as_u64()
+                .expect("missing highest imported block ID"),
+            1
+        );
         assert!(
             json["endOfSequencingBlockHash"].as_str().expect("missing EOS hash").starts_with("0x")
         );

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -42,7 +42,13 @@ pub(crate) struct SharedPreconfState {
     recent_envelopes: Arc<Mutex<EnvelopeCache>>,
     /// Most recent L2 head observed by `/status` or advanced by locally inserted blocks,
     /// reported as a fallback when the head is unreadable. Seeded with the head at startup.
-    last_reported_l2_head: Arc<AtomicU64>,
+    last_observed_l2_head: Arc<AtomicU64>,
+    /// Highest block number of any well-formed, signature-valid envelope this node has
+    /// *received*, whether or not it could be imported. Seeded with the head at startup.
+    highest_seen_block: Arc<AtomicU64>,
+    /// Latest L1-confirmed canonical tip observed at envelope admission, used only to detect a
+    /// tip moving backwards. Starts at zero so the first observation reads as an advance.
+    last_confirmed_tip: Arc<AtomicU64>,
 }
 
 impl SharedPreconfState {
@@ -53,7 +59,9 @@ impl SharedPreconfState {
             recent_envelopes: Arc::new(Mutex::new(EnvelopeCache::with_capacity(
                 RECENT_ENVELOPE_CAPACITY,
             ))),
-            last_reported_l2_head: Arc::new(AtomicU64::new(initial_l2_head)),
+            last_observed_l2_head: Arc::new(AtomicU64::new(initial_l2_head)),
+            highest_seen_block: Arc::new(AtomicU64::new(initial_l2_head)),
+            last_confirmed_tip: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -101,18 +109,19 @@ impl SharedPreconfState {
     /// Record a freshly observed L2 head and return it; when the head is `None` (a failed RPC
     /// read) return the most recently recorded value instead.
     ///
-    /// The Catalyst sync gate only opens when the reported value equals the execution head
-    /// exactly, and every canonical block is inserted by this driver, so the live head is
-    /// always the honest answer. The stored value exists purely to keep `/status` answering
-    /// through transient L2 RPC failures; [`Self::record_inserted_block`] keeps it fresh for
-    /// blocks inserted between polls.
-    pub(crate) fn reconcile_reported_head(&self, head: Option<u64>) -> u64 {
+    /// This is the node's own execution head, which `/status` floors its report at rather than
+    /// reporting directly — see [`Self::highest_unsafe_floored_at`]. Reporting it directly made
+    /// the preconfer client's sync gate, which opens when the reported value equals the execution
+    /// head exactly, a tautology: a node that had fallen behind still read as synced. The stored
+    /// value keeps `/status` answering through transient L2 RPC failures, and
+    /// [`Self::record_inserted_block`] keeps it fresh for blocks inserted between polls.
+    pub(crate) fn reconcile_observed_head(&self, head: Option<u64>) -> u64 {
         match head {
             Some(head) => {
-                self.last_reported_l2_head.store(head, Ordering::Relaxed);
+                self.last_observed_l2_head.store(head, Ordering::Relaxed);
                 head
             }
-            None => self.last_reported_l2_head.load(Ordering::Relaxed),
+            None => self.last_observed_l2_head.load(Ordering::Relaxed),
         }
     }
 
@@ -123,7 +132,74 @@ impl SharedPreconfState {
     /// insert sequentially, and any successful status poll overwrites the value with the
     /// live head anyway.
     pub(crate) fn record_inserted_block(&self, block_number: u64) {
-        self.last_reported_l2_head.store(block_number, Ordering::Relaxed);
+        self.last_observed_l2_head.store(block_number, Ordering::Relaxed);
+    }
+
+    /// Advance the highest seen block number, monotonically.
+    ///
+    /// Called for every envelope that passes payload validation, before any decision about
+    /// whether it can be imported. A node holding a backlog it cannot apply therefore reports a
+    /// value above its execution head, which is what lets the preconfer client's parity check
+    /// fail closed instead of comparing two equally stale values.
+    ///
+    /// The value is clamped to [`PENDING_ENVELOPE_CAPACITY`] beyond the last observed head: an
+    /// envelope further ahead than the pending cache can ever bridge needs L1 confirmation to
+    /// recover either way, so letting a malformed or hostile block number park the counter
+    /// arbitrarily high would only keep the node reporting itself out of sync forever.
+    pub(crate) fn record_seen_block(&self, block_number: u64) {
+        let previous = self.highest_seen_block.fetch_max(block_number, Ordering::Relaxed);
+        if block_number > previous {
+            WhitelistPreconfirmationDriverMetrics::set_highest_seen_block(block_number);
+        }
+    }
+
+    /// Record the latest L1-confirmed canonical tip, pulling the highest seen block back down
+    /// when that tip moves *backwards* — an L1 reorg rewinding the chain past envelopes this node
+    /// had already counted.
+    ///
+    /// Without this, an envelope from the discarded branch keeps `/status` reporting a height the
+    /// chain no longer reaches, and the node reports a permanent mismatch until the new branch
+    /// grows past it — the preconfer client exits after roughly half an L2 epoch of that.
+    ///
+    /// Only a backwards move resets. In steady state the highest seen block runs *ahead* of the
+    /// confirmed tip, because preconfirmations outpace L1 confirmation by design; resetting on
+    /// every observation would destroy the counter. The confirmed tip is also the only authority
+    /// safe to reset against — resetting to the local execution head would let a node that is
+    /// genuinely behind declare itself synced, the exact failure this counter exists to prevent.
+    pub(crate) fn note_confirmed_tip(&self, confirmed_tip: u64) {
+        let previous = self.last_confirmed_tip.swap(confirmed_tip, Ordering::Relaxed);
+        if confirmed_tip >= previous {
+            return;
+        }
+
+        let seen = self.highest_seen_block.swap(confirmed_tip, Ordering::Relaxed);
+        WhitelistPreconfirmationDriverMetrics::set_highest_seen_block(confirmed_tip);
+        tracing::info!(
+            previous_confirmed_tip = previous,
+            confirmed_tip,
+            previous_highest_seen = seen,
+            "confirmed tip rewound; reset highest seen preconfirmation block"
+        );
+    }
+
+    /// Highest block number received from the P2P network, imported or not.
+    pub(crate) fn highest_seen_block(&self) -> u64 {
+        self.highest_seen_block.load(Ordering::Relaxed)
+    }
+
+    /// The value `/status` reports as `highestUnsafeL2PayloadBlockID`: the highest envelope seen,
+    /// floored at `head` as returned by [`Self::reconcile_observed_head`].
+    ///
+    /// Above the head, this node is holding envelopes it has not applied and must read as out of
+    /// sync. At or below it, the node is merely ahead of the gossip it has seen — right after a
+    /// beacon sync, for example — and must not report a spurious backlog, because the preconfer
+    /// client exits after roughly half an L2 epoch of continuous mismatch.
+    ///
+    /// The value is also capped one pending-cache span above the head, so a malformed or hostile
+    /// block number cannot park the node out of sync indefinitely: past that span the backlog
+    /// needs L1 confirmation to clear either way.
+    pub(crate) fn highest_unsafe_floored_at(&self, head: u64) -> u64 {
+        self.highest_seen_block().clamp(head, head.saturating_add(PENDING_ENVELOPE_CAPACITY as u64))
     }
 }
 
@@ -368,7 +444,7 @@ mod tests {
         let state = SharedPreconfState::new(7);
         let hash = B256::from([0x77u8; 32]);
 
-        assert_eq!(state.reconcile_reported_head(None), 7, "seed backs the fallback");
+        assert_eq!(state.reconcile_observed_head(None), 7, "seed backs the fallback");
         assert!(state.get_recent(&hash).await.is_none());
 
         state.insert_recent(Arc::new(sample_envelope(hash, 8))).await;

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -27,6 +27,14 @@ const EOS_CACHE_CAPACITY: usize = PENDING_ENVELOPE_CAPACITY;
 const DEFAULT_REQUEST_COOLDOWN_SECS: u64 = 10;
 /// One L1 epoch (32 slots x 12 seconds).
 pub(crate) const L1_EPOCH_DURATION_SECS: u64 = 12 * 32;
+/// How often the driver re-drives cached imports and re-reads the confirmed tip without waiting
+/// for an inbound network event.
+///
+/// This has to stay well inside the preconfer client's tolerance for a continuous `/status`
+/// mismatch, which is half an L2 epoch: it cancels and exits past that. A poll on the order of an
+/// L1 epoch would arrive after the client had already given up, so a dropped final response with
+/// no further gossip would take the process down before the first autonomous retry.
+pub(crate) const BACKFILL_RETRY_INTERVAL_SECS: u64 = 4;
 
 /// Shared mutable state for the whitelist preconfirmation driver.
 ///
@@ -165,22 +173,13 @@ impl SharedPreconfState {
     /// recover either way, so letting a malformed or hostile block number park the counter
     /// arbitrarily high would only keep the node reporting itself out of sync forever.
     pub(crate) fn record_seen_block(&self, block_number: u64) {
-        // Anchor the value one pending-cache span above the last observed head *here*, not where
-        // it is reported. Clamping the reported value instead leaves the raw counter holding the
-        // absurd height, so the report tracks `head + capacity` as the head advances and never
-        // returns to equality — a single signature-valid payload with a wrong or hostile block
-        // number would keep the preconfer client from ever starting. Anchoring at record time
-        // parks the counter at a fixed height that the head eventually passes, at which point the
-        // node reads as synced again.
-        //
-        // A payload beyond this span cannot be bridged from the pending cache anyway; recovering
-        // from a backlog that deep needs L1 confirmation.
-        let ceiling = self
-            .last_observed_l2_head
-            .load(Ordering::Relaxed)
-            .saturating_add(PENDING_ENVELOPE_CAPACITY as u64);
-        let block_number = block_number.min(ceiling);
-
+        // Nothing is bounded here. Every bound available at this point can lag the live execution
+        // head -- `last_observed_l2_head` only moves on a status poll or a local insert, and the
+        // engine syncs forward between them -- and bounding against a lagging anchor would pull
+        // this counter *below* the live head. `/status` floors at the head, so a node holding an
+        // unimported backlog would report parity and read as synced: the fail-open this counter
+        // exists to close. The bound is applied by [`Self::highest_unsafe_for_head`], where the
+        // live head is known.
         let previous = self.highest_seen_block.fetch_max(block_number, Ordering::Relaxed);
         if block_number > previous {
             WhitelistPreconfirmationDriverMetrics::set_highest_seen_block(block_number);
@@ -217,6 +216,10 @@ impl SharedPreconfState {
     }
 
     /// Highest block number received from the P2P network, imported or not.
+    ///
+    /// Test-only: production reads go through [`Self::highest_unsafe_for_head`], which applies the
+    /// bound the raw counter deliberately does not.
+    #[cfg(test)]
     pub(crate) fn highest_seen_block(&self) -> u64 {
         self.highest_seen_block.load(Ordering::Relaxed)
     }
@@ -229,10 +232,38 @@ impl SharedPreconfState {
     /// beacon sync, for example — and must not report a spurious backlog, because the preconfer
     /// client exits after roughly half an L2 epoch of continuous mismatch.
     ///
-    /// No cap is applied here: [`Self::record_seen_block`] already anchors the counter, and a cap
-    /// at this end would track the head upwards and so could never return to equality.
-    pub(crate) fn highest_unsafe_floored_at(&self, head: u64) -> u64 {
-        self.highest_seen_block().max(head)
+    /// The counter is first bounded to one pending-cache span above `head`, with the bound written
+    /// back. Writing it back is the point: a payload beyond that span needs L1 confirmation to
+    /// clear either way, but leaving the raw height in the counter means the reported value tracks
+    /// `head + span` upwards forever and can never return to equality, so one signature-valid
+    /// payload carrying a wrong or hostile block number would keep the preconfer client from ever
+    /// starting. Pinned at a concrete height, the chain can pass it.
+    ///
+    /// The live head is the only safe anchor -- every counter this driver maintains can lag it --
+    /// so the stored bound is always strictly above the head and a real backlog always reports as
+    /// one.
+    pub(crate) fn highest_unsafe_for_head(&self, head: u64) -> u64 {
+        let ceiling = head.saturating_add(PENDING_ENVELOPE_CAPACITY as u64);
+
+        let mut seen = self.highest_seen_block.load(Ordering::Relaxed);
+        if seen > ceiling {
+            tracing::warn!(
+                highest_seen = seen,
+                ceiling,
+                "anchoring highest seen preconfirmation block to the execution head"
+            );
+            // A concurrent ingress may have advanced the counter since the load; leave its value
+            // alone and let the next poll re-anchor.
+            let _ = self.highest_seen_block.compare_exchange(
+                seen,
+                ceiling,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+            seen = ceiling;
+        }
+
+        seen.max(head)
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -135,7 +135,25 @@ impl SharedPreconfState {
         self.last_observed_l2_head.store(block_number, Ordering::Relaxed);
     }
 
+    /// Record one envelope observed at ingress, together with the confirmed tip read alongside
+    /// it.
+    ///
+    /// This exists so the two steps cannot be ordered wrongly at the call site. The rewind check
+    /// lowers the counter unconditionally, so it has to run first: recording first would let a
+    /// rewind erase the very payload that arrived with it, `/status` would fall back to the
+    /// rewound head, and the preconfer client's equality check would read a node holding an
+    /// unimported block as synced.
+    pub(crate) fn observe_envelope(&self, block_number: u64, confirmed_tip: Option<u64>) {
+        if let Some(tip) = confirmed_tip {
+            self.note_confirmed_tip(tip);
+        }
+
+        self.record_seen_block(block_number);
+    }
+
     /// Advance the highest seen block number, monotonically.
+    ///
+    /// Prefer [`Self::observe_envelope`] at ingress; this is the bare primitive.
     ///
     /// Called for every envelope that passes payload validation, before any decision about
     /// whether it can be imported. A node holding a backlog it cannot apply therefore reports a
@@ -147,6 +165,22 @@ impl SharedPreconfState {
     /// recover either way, so letting a malformed or hostile block number park the counter
     /// arbitrarily high would only keep the node reporting itself out of sync forever.
     pub(crate) fn record_seen_block(&self, block_number: u64) {
+        // Anchor the value one pending-cache span above the last observed head *here*, not where
+        // it is reported. Clamping the reported value instead leaves the raw counter holding the
+        // absurd height, so the report tracks `head + capacity` as the head advances and never
+        // returns to equality — a single signature-valid payload with a wrong or hostile block
+        // number would keep the preconfer client from ever starting. Anchoring at record time
+        // parks the counter at a fixed height that the head eventually passes, at which point the
+        // node reads as synced again.
+        //
+        // A payload beyond this span cannot be bridged from the pending cache anyway; recovering
+        // from a backlog that deep needs L1 confirmation.
+        let ceiling = self
+            .last_observed_l2_head
+            .load(Ordering::Relaxed)
+            .saturating_add(PENDING_ENVELOPE_CAPACITY as u64);
+        let block_number = block_number.min(ceiling);
+
         let previous = self.highest_seen_block.fetch_max(block_number, Ordering::Relaxed);
         if block_number > previous {
             WhitelistPreconfirmationDriverMetrics::set_highest_seen_block(block_number);
@@ -195,11 +229,10 @@ impl SharedPreconfState {
     /// beacon sync, for example — and must not report a spurious backlog, because the preconfer
     /// client exits after roughly half an L2 epoch of continuous mismatch.
     ///
-    /// The value is also capped one pending-cache span above the head, so a malformed or hostile
-    /// block number cannot park the node out of sync indefinitely: past that span the backlog
-    /// needs L1 confirmation to clear either way.
+    /// No cap is applied here: [`Self::record_seen_block`] already anchors the counter, and a cap
+    /// at this end would track the head upwards and so could never return to equality.
     pub(crate) fn highest_unsafe_floored_at(&self, head: u64) -> u64 {
-        self.highest_seen_block().clamp(head, head.saturating_add(PENDING_ENVELOPE_CAPACITY as u64))
+        self.highest_seen_block().max(head)
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/cache.rs
@@ -51,12 +51,14 @@ pub(crate) struct SharedPreconfState {
     /// Most recent L2 head observed by `/status` or advanced by locally inserted blocks,
     /// reported as a fallback when the head is unreadable. Seeded with the head at startup.
     last_observed_l2_head: Arc<AtomicU64>,
-    /// Highest block number of any well-formed, signature-valid envelope this node has
-    /// *received*, whether or not it could be imported. Seeded with the head at startup.
-    highest_seen_block: Arc<AtomicU64>,
-    /// Latest L1-confirmed canonical tip observed at envelope admission, used only to detect a
-    /// tip moving backwards. Starts at zero so the first observation reads as an advance.
-    last_confirmed_tip: Arc<AtomicU64>,
+    /// Highest block number held in the importer's pending cache, republished by the importer
+    /// after every mutation of it, or zero when that cache is empty.
+    ///
+    /// This is a projection of the cache, never an independent counter: it is recomputed from the
+    /// cache rather than written to on reorgs or bounded against runaway block numbers. Those
+    /// writes are what let a watermark drift away from the evidence and report parity with a stale
+    /// head. The API service cannot reach the importer's cache directly, hence the projection.
+    pending_high_water: Arc<AtomicU64>,
 }
 
 impl SharedPreconfState {
@@ -68,8 +70,7 @@ impl SharedPreconfState {
                 RECENT_ENVELOPE_CAPACITY,
             ))),
             last_observed_l2_head: Arc::new(AtomicU64::new(initial_l2_head)),
-            highest_seen_block: Arc::new(AtomicU64::new(initial_l2_head)),
-            last_confirmed_tip: Arc::new(AtomicU64::new(0)),
+            pending_high_water: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -143,127 +144,28 @@ impl SharedPreconfState {
         self.last_observed_l2_head.store(block_number, Ordering::Relaxed);
     }
 
-    /// Record one envelope observed at ingress, together with the confirmed tip read alongside
-    /// it.
+    /// Republish the importer's pending-cache high-water mark.
     ///
-    /// This exists so the two steps cannot be ordered wrongly at the call site. The rewind check
-    /// lowers the counter unconditionally, so it has to run first: recording first would let a
-    /// rewind erase the very payload that arrived with it, `/status` would fall back to the
-    /// rewound head, and the preconfer client's equality check would read a node holding an
-    /// unimported block as synced.
-    pub(crate) fn observe_envelope(&self, block_number: u64, confirmed_tip: Option<u64>) {
-        if let Some(tip) = confirmed_tip {
-            self.note_confirmed_tip(tip);
-        }
-
-        self.record_seen_block(block_number);
+    /// Called after every mutation of that cache -- insert, drain, or branch removal -- so the
+    /// reported value always follows the evidence rather than a counter that has to be separately
+    /// corrected.
+    pub(crate) fn set_pending_high_water(&self, highest_block_number: Option<u64>) {
+        let value = highest_block_number.unwrap_or(0);
+        self.pending_high_water.store(value, Ordering::Relaxed);
+        WhitelistPreconfirmationDriverMetrics::set_highest_seen_block(value);
     }
 
-    /// Advance the highest seen block number, monotonically.
+    /// The value `/status` reports as `highestUnsafeL2PayloadBlockID`: the execution head, raised
+    /// to the highest preconfirmation block this node has validated but not applied.
     ///
-    /// Prefer [`Self::observe_envelope`] at ingress; this is the bare primitive.
-    ///
-    /// Called for every envelope that passes payload validation, before any decision about
-    /// whether it can be imported. A node holding a backlog it cannot apply therefore reports a
-    /// value above its execution head, which is what lets the preconfer client's parity check
-    /// fail closed instead of comparing two equally stale values.
-    ///
-    /// The value is clamped to [`PENDING_ENVELOPE_CAPACITY`] beyond the last observed head: an
-    /// envelope further ahead than the pending cache can ever bridge needs L1 confirmation to
-    /// recover either way, so letting a malformed or hostile block number park the counter
-    /// arbitrarily high would only keep the node reporting itself out of sync forever.
-    pub(crate) fn record_seen_block(&self, block_number: u64) {
-        // Nothing is bounded here. Every bound available at this point can lag the live execution
-        // head -- `last_observed_l2_head` only moves on a status poll or a local insert, and the
-        // engine syncs forward between them -- and bounding against a lagging anchor would pull
-        // this counter *below* the live head. `/status` floors at the head, so a node holding an
-        // unimported backlog would report parity and read as synced: the fail-open this counter
-        // exists to close. The bound is applied by [`Self::highest_unsafe_for_head`], where the
-        // live head is known.
-        let previous = self.highest_seen_block.fetch_max(block_number, Ordering::Relaxed);
-        if block_number > previous {
-            WhitelistPreconfirmationDriverMetrics::set_highest_seen_block(block_number);
-        }
-    }
-
-    /// Record the latest L1-confirmed canonical tip, pulling the highest seen block back down
-    /// when that tip moves *backwards* — an L1 reorg rewinding the chain past envelopes this node
-    /// had already counted.
-    ///
-    /// Without this, an envelope from the discarded branch keeps `/status` reporting a height the
-    /// chain no longer reaches, and the node reports a permanent mismatch until the new branch
-    /// grows past it — the preconfer client exits after roughly half an L2 epoch of that.
-    ///
-    /// Only a backwards move resets. In steady state the highest seen block runs *ahead* of the
-    /// confirmed tip, because preconfirmations outpace L1 confirmation by design; resetting on
-    /// every observation would destroy the counter. The confirmed tip is also the only authority
-    /// safe to reset against — resetting to the local execution head would let a node that is
-    /// genuinely behind declare itself synced, the exact failure this counter exists to prevent.
-    pub(crate) fn note_confirmed_tip(&self, confirmed_tip: u64) {
-        let previous = self.last_confirmed_tip.swap(confirmed_tip, Ordering::Relaxed);
-        if confirmed_tip >= previous {
-            return;
-        }
-
-        let seen = self.highest_seen_block.swap(confirmed_tip, Ordering::Relaxed);
-        WhitelistPreconfirmationDriverMetrics::set_highest_seen_block(confirmed_tip);
-        tracing::info!(
-            previous_confirmed_tip = previous,
-            confirmed_tip,
-            previous_highest_seen = seen,
-            "confirmed tip rewound; reset highest seen preconfirmation block"
-        );
-    }
-
-    /// Highest block number received from the P2P network, imported or not.
-    ///
-    /// Test-only: production reads go through [`Self::highest_unsafe_for_head`], which applies the
-    /// bound the raw counter deliberately does not.
-    #[cfg(test)]
-    pub(crate) fn highest_seen_block(&self) -> u64 {
-        self.highest_seen_block.load(Ordering::Relaxed)
-    }
-
-    /// The value `/status` reports as `highestUnsafeL2PayloadBlockID`: the highest envelope seen,
-    /// floored at `head` as returned by [`Self::reconcile_observed_head`].
-    ///
-    /// Above the head, this node is holding envelopes it has not applied and must read as out of
-    /// sync. At or below it, the node is merely ahead of the gossip it has seen — right after a
-    /// beacon sync, for example — and must not report a spurious backlog, because the preconfer
-    /// client exits after roughly half an L2 epoch of continuous mismatch.
-    ///
-    /// The counter is first bounded to one pending-cache span above `head`, with the bound written
-    /// back. Writing it back is the point: a payload beyond that span needs L1 confirmation to
-    /// clear either way, but leaving the raw height in the counter means the reported value tracks
-    /// `head + span` upwards forever and can never return to equality, so one signature-valid
-    /// payload carrying a wrong or hostile block number would keep the preconfer client from ever
-    /// starting. Pinned at a concrete height, the chain can pass it.
-    ///
-    /// The live head is the only safe anchor -- every counter this driver maintains can lag it --
-    /// so the stored bound is always strictly above the head and a real backlog always reports as
-    /// one.
+    /// Raising to the head keeps a node whose execution head runs ahead of the gossip it has seen
+    /// -- right after a beacon sync -- from reporting a backlog it does not have; the preconfer
+    /// client exits after roughly half an L2 epoch of continuous mismatch, so a false "behind" is
+    /// expensive too. Reading the backlog from the cache rather than a counter is what keeps an
+    /// arbitrarily deep one visible: there is no artificial height for the head to overtake, and a
+    /// payload carrying a wrong or hostile block number ages out of the bounded cache on its own.
     pub(crate) fn highest_unsafe_for_head(&self, head: u64) -> u64 {
-        let ceiling = head.saturating_add(PENDING_ENVELOPE_CAPACITY as u64);
-
-        let mut seen = self.highest_seen_block.load(Ordering::Relaxed);
-        if seen > ceiling {
-            tracing::warn!(
-                highest_seen = seen,
-                ceiling,
-                "anchoring highest seen preconfirmation block to the execution head"
-            );
-            // A concurrent ingress may have advanced the counter since the load; leave its value
-            // alone and let the next poll re-anchor.
-            let _ = self.highest_seen_block.compare_exchange(
-                seen,
-                ceiling,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            );
-            seen = ceiling;
-        }
-
-        seen.max(head)
+        self.pending_high_water.load(Ordering::Relaxed).max(head)
     }
 }
 
@@ -317,6 +219,14 @@ impl EnvelopeCache {
     /// Get a cached envelope by block hash.
     pub fn get(&self, hash: &B256) -> Option<&Arc<WhitelistExecutionPayloadEnvelope>> {
         self.entries.get(hash)
+    }
+
+    /// Highest block number held, or `None` when empty.
+    ///
+    /// This is the driver's evidence that the chain reaches beyond its own execution head: an
+    /// envelope cached above the head is one it has validated but not applied.
+    pub fn highest_block_number(&self) -> Option<u64> {
+        self.entries.values().map(|envelope| envelope.execution_payload.block_number).max()
     }
 
     /// Returns true when the cache is empty.
@@ -473,6 +383,25 @@ mod tests {
         assert!(cache.get(&h2).is_none());
         assert!(cache.get(&h3).is_some());
         assert_eq!(cache.sorted_hashes_by_block_number().len(), 2);
+    }
+
+    #[test]
+    fn highest_block_number_tracks_the_cache_contents() {
+        let mut cache = EnvelopeCache::with_capacity(4);
+        assert_eq!(cache.highest_block_number(), None, "an empty cache reports no evidence");
+
+        let low = B256::from([0x11u8; 32]);
+        let high = B256::from([0x22u8; 32]);
+        cache.insert(Arc::new(sample_envelope(low, 40)));
+        cache.insert(Arc::new(sample_envelope(high, 100)));
+        // Gossip arrives out of order, so the answer is the highest block number held, not the
+        // most recently inserted one.
+        cache.insert(Arc::new(sample_envelope(B256::from([0x33u8; 32]), 70)));
+        assert_eq!(cache.highest_block_number(), Some(100));
+
+        // Draining the backlog is what lowers the report; there is no separate value to correct.
+        cache.remove(&high);
+        assert_eq!(cache.highest_block_number(), Some(70));
     }
 
     #[test]

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/cache_import.rs
@@ -128,14 +128,21 @@ impl WhitelistPreconfirmationImporter {
         let block_hash = payload.block_hash;
         let end_of_sequencing = envelope.end_of_sequencing.unwrap_or(false);
 
+        // Below the confirmed boundary this payload must not be inserted (WLP-INV-003), but it is
+        // deferred rather than dropped. The boundary is read from local state, so it can still be
+        // sitting on a branch the network has already abandoned; dropping on that reading destroys
+        // the envelope permanently, and when the boundary later rewinds below it there is nothing
+        // left to show the chain runs ahead of this node -- `/status` reports parity with the
+        // rewound head and a lagging node reads as synced. Keeping it costs one bounded cache slot
+        // and a comparison per pass, and a genuinely confirmed payload is evicted by the ring.
         if block_number <= head_l1_origin_block_id {
             debug!(
                 block_number,
                 block_hash = %block_hash,
                 head_l1_origin_block_id,
-                "dropping outdated cached whitelist preconfirmation payload"
+                "deferring cached whitelist preconfirmation payload at or below the confirmed boundary"
             );
-            return Ok(true);
+            return Ok(false);
         }
 
         if self.block_hash_by_number(block_number).await? == Some(block_hash) {

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -65,6 +65,12 @@ impl WhitelistPreconfirmationImporter {
                 None
             }
         };
+        // A confirmed tip that moved backwards means an L1 reorg rewound the chain past envelopes
+        // this node had already counted as seen.
+        if let Some(tip) = confirmed_tip {
+            self.state.note_confirmed_tip(tip);
+        }
+
         if is_stale_at_confirmed_tip(envelope.execution_payload.block_number, confirmed_tip) {
             debug!(
                 block_number = envelope.execution_payload.block_number,
@@ -147,6 +153,13 @@ impl WhitelistPreconfirmationImporter {
             envelope.execution_payload.timestamp,
             envelope.header_difficulty,
         )?;
+
+        // The envelope is well formed and its signature was checked at gossip acceptance, so it
+        // counts as seen from here on — including when it is dropped as stale or parked in the
+        // pending cache below. This is what lets `/status` report a backlog instead of echoing
+        // this node's own execution head back at the preconfer client.
+        self.state.record_seen_block(envelope.execution_payload.block_number);
+
         self.ingest_validated_envelope(Arc::new(envelope), ingress_source).await;
         Ok(())
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -65,19 +65,27 @@ impl WhitelistPreconfirmationImporter {
                 None
             }
         };
+        // Cache first, judge after. The confirmed tip is read from local state and can be sitting
+        // on a branch the network has already abandoned, so a payload that looks stale against it
+        // may be the first block of the branch that wins. Dropping it here destroys the only
+        // evidence that the chain runs ahead of this node, and once the tip rewinds below it
+        // `/status` reports parity with the rewound head. The drain re-reads the boundary and
+        // still refuses to insert anything at or below it (WLP-INV-003); it just no longer decides
+        // that permanently on one reading.
+        self.cache.insert(envelope.clone());
+        self.update_pending_cache_gauge();
+
         if is_stale_at_confirmed_tip(envelope.execution_payload.block_number, confirmed_tip) {
             debug!(
                 block_number = envelope.execution_payload.block_number,
                 block_hash = %envelope.execution_payload.block_hash,
                 ?confirmed_tip,
                 ingress_source,
-                "ignoring stale whitelist preconfirmation envelope"
+                "whitelist preconfirmation envelope is stale against the confirmed tip; cached for re-evaluation"
             );
             return;
         }
 
-        self.cache.insert(envelope.clone());
-        self.update_pending_cache_gauge();
         self.state.insert_recent(envelope.clone()).await;
         self.record_eos_epoch_if_marked(&envelope, ingress_source).await;
     }

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -65,15 +65,6 @@ impl WhitelistPreconfirmationImporter {
                 None
             }
         };
-        // The envelope is well formed and its signature was checked at gossip acceptance, so it
-        // counts as seen from here on — including when it is dropped as stale just below, or
-        // parked in the pending cache for want of ancestors. This is what lets `/status` report a
-        // backlog instead of echoing this node's own execution head back at the preconfer client.
-        //
-        // The confirmed tip goes in with it so a tip that moved backwards — an L1 reorg — pulls
-        // the counter down before this envelope is counted, never after.
-        self.state.observe_envelope(envelope.execution_payload.block_number, confirmed_tip);
-
         if is_stale_at_confirmed_tip(envelope.execution_payload.block_number, confirmed_tip) {
             debug!(
                 block_number = envelope.execution_payload.block_number,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/ingress.rs
@@ -65,11 +65,14 @@ impl WhitelistPreconfirmationImporter {
                 None
             }
         };
-        // A confirmed tip that moved backwards means an L1 reorg rewound the chain past envelopes
-        // this node had already counted as seen.
-        if let Some(tip) = confirmed_tip {
-            self.state.note_confirmed_tip(tip);
-        }
+        // The envelope is well formed and its signature was checked at gossip acceptance, so it
+        // counts as seen from here on — including when it is dropped as stale just below, or
+        // parked in the pending cache for want of ancestors. This is what lets `/status` report a
+        // backlog instead of echoing this node's own execution head back at the preconfer client.
+        //
+        // The confirmed tip goes in with it so a tip that moved backwards — an L1 reorg — pulls
+        // the counter down before this envelope is counted, never after.
+        self.state.observe_envelope(envelope.execution_payload.block_number, confirmed_tip);
 
         if is_stale_at_confirmed_tip(envelope.execution_payload.block_number, confirmed_tip) {
             debug!(
@@ -153,12 +156,6 @@ impl WhitelistPreconfirmationImporter {
             envelope.execution_payload.timestamp,
             envelope.header_difficulty,
         )?;
-
-        // The envelope is well formed and its signature was checked at gossip acceptance, so it
-        // counts as seen from here on — including when it is dropped as stale or parked in the
-        // pending cache below. This is what lets `/status` report a backlog instead of echoing
-        // this node's own execution head back at the preconfer client.
-        self.state.record_seen_block(envelope.execution_payload.block_number);
 
         self.ingest_validated_envelope(Arc::new(envelope), ingress_source).await;
         Ok(())

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -194,20 +194,6 @@ impl WhitelistPreconfirmationImporter {
         Ok(())
     }
 
-    /// Re-read the L1-confirmed tip and fold it into the shared state.
-    ///
-    /// The tip is otherwise only observed when an envelope arrives, so a rewind that happens while
-    /// gossip is quiet -- an operator hand-over, or this node reporting itself behind and the
-    /// incoming operator declining to sequence -- would leave the seen counter pinned to a height
-    /// on the discarded branch, and `/status` reporting a mismatch that nothing can clear.
-    pub(crate) async fn refresh_confirmed_tip(&mut self) -> Result<()> {
-        if let Some(tip) = self.head_l1_origin_block_id().await? {
-            self.state.note_confirmed_tip(tip);
-        }
-
-        Ok(())
-    }
-
     /// Refresh whether sync is ready.
     ///
     /// Ready when the confirmed head-origin pointer is written, or — at genesis only —
@@ -263,9 +249,16 @@ impl WhitelistPreconfirmationImporter {
             .map_err(WhitelistPreconfirmationDriverError::provider)
     }
 
-    /// Update the pending-cache gauge after pending-cache mutations.
+    /// Republish everything derived from the pending cache, after every mutation of it.
+    ///
+    /// The high-water mark is what `/status` reports a backlog from, and the API service cannot
+    /// reach this cache directly. Recomputing it here, rather than maintaining a counter beside
+    /// it, is what keeps the reported value from drifting away from the evidence: there is no
+    /// separate value to reset on a reorg or bound against a runaway block number, and so no write
+    /// that can erase a real backlog.
     pub(super) fn update_pending_cache_gauge(&self) {
         WhitelistPreconfirmationDriverMetrics::set_cache_pending_count(self.cache.len());
+        self.state.set_pending_high_water(self.cache.highest_block_number());
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/importer/mod.rs
@@ -194,6 +194,20 @@ impl WhitelistPreconfirmationImporter {
         Ok(())
     }
 
+    /// Re-read the L1-confirmed tip and fold it into the shared state.
+    ///
+    /// The tip is otherwise only observed when an envelope arrives, so a rewind that happens while
+    /// gossip is quiet -- an operator hand-over, or this node reporting itself behind and the
+    /// incoming operator declining to sequence -- would leave the seen counter pinned to a height
+    /// on the discarded branch, and `/status` reporting a mismatch that nothing can clear.
+    pub(crate) async fn refresh_confirmed_tip(&mut self) -> Result<()> {
+        if let Some(tip) = self.head_l1_origin_block_id().await? {
+            self.state.note_confirmed_tip(tip);
+        }
+
+        Ok(())
+    }
+
     /// Refresh whether sync is ready.
     ///
     /// Ready when the confirmed head-origin pointer is written, or — at genesis only —

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/metrics.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/metrics.rs
@@ -53,6 +53,8 @@ struct Metrics {
     cache_pending: Gauge,
     /// Recent cache size.
     cache_recent: Gauge,
+    /// Highest preconfirmation block received from the P2P network, imported or not.
+    highest_seen_block: Gauge,
 }
 
 impl Metrics {
@@ -135,6 +137,10 @@ impl Metrics {
                 "Pending cache size",
             ),
             cache_recent: gauge("whitelist_preconf_driver_cache_recent_count", "Recent cache size"),
+            highest_seen_block: gauge(
+                "whitelist_preconf_driver_highest_seen_block",
+                "Highest preconfirmation block received from the P2P network, imported or not",
+            ),
         }
     }
 }
@@ -231,6 +237,12 @@ impl WhitelistPreconfirmationDriverMetrics {
     /// Set the recent cache gauge.
     pub(crate) fn set_cache_recent_count(count: usize) {
         METRICS.cache_recent.set(count as f64);
+    }
+
+    /// Set the highest-seen-block gauge. Its gap to the node's execution head is the
+    /// preconfirmation backlog, which is the signal a lagging follower has no other way to emit.
+    pub(crate) fn set_highest_seen_block(block_number: u64) {
+        METRICS.highest_seen_block.set(block_number as f64);
     }
 }
 

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -206,12 +206,8 @@ impl WhitelistPreconfirmationDriverRunner {
                     }
                 }
                 _ = backfill_retry_interval.tick() => {
-                    // Both of these exist to survive gossip going quiet: nothing else re-drives a
-                    // request whose cooldown has elapsed, and nothing else notices a confirmed-tip
-                    // rewind, once inbound events stop arriving.
-                    if let Err(err) = importer.refresh_confirmed_tip().await {
-                        warn!(error = %err, "failed to refresh confirmed tip on backfill retry");
-                    }
+                    // This exists to survive gossip going quiet: nothing else re-drives a request
+                    // whose cooldown has elapsed once inbound events stop arriving.
                     if let Err(err) = importer.maybe_import_from_cache().await {
                         warn!(
                             error = %err,

--- a/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
+++ b/packages/taiko-client-rs/crates/whitelist-preconfirmation-driver/src/runner.rs
@@ -19,7 +19,7 @@ use crate::{
         WhitelistApiServer, WhitelistApiServerConfig, WhitelistApiService,
         WhitelistApiServiceParams,
     },
-    cache::{L1_EPOCH_DURATION_SECS, SharedPreconfState},
+    cache::{BACKFILL_RETRY_INTERVAL_SECS, SharedPreconfState},
     error::WhitelistPreconfirmationDriverError,
     importer::{WhitelistPreconfirmationImporter, WhitelistPreconfirmationImporterParams},
     network::{NetworkCommand, NetworkConfig, WhitelistNetwork},
@@ -161,12 +161,11 @@ impl WhitelistPreconfirmationDriverRunner {
                 state,
                 beacon_client,
             });
-        let mut sync_ready_interval =
-            tokio::time::interval(tokio::time::Duration::from_secs(L1_EPOCH_DURATION_SECS));
-        // Consume the immediate first tick so the periodic cache poll starts one
-        // full epoch later; event-driven imports still call maybe_import_from_cache
-        // on every inbound network event.
-        sync_ready_interval.tick().await;
+        let mut backfill_retry_interval =
+            tokio::time::interval(tokio::time::Duration::from_secs(BACKFILL_RETRY_INTERVAL_SECS));
+        // Consume the immediate first tick so the first poll lands one interval in; event-driven
+        // imports still call maybe_import_from_cache on every inbound network event.
+        backfill_retry_interval.tick().await;
 
         let WhitelistNetwork { mut event_rx, command_tx, handle: mut node_handle, .. } = network;
         let mut event_syncer_handle = preconf_ingress_sync.handle_mut();
@@ -206,11 +205,17 @@ impl WhitelistPreconfirmationDriverRunner {
                         );
                     }
                 }
-                _ = sync_ready_interval.tick() => {
+                _ = backfill_retry_interval.tick() => {
+                    // Both of these exist to survive gossip going quiet: nothing else re-drives a
+                    // request whose cooldown has elapsed, and nothing else notices a confirmed-tip
+                    // rewind, once inbound events stop arriving.
+                    if let Err(err) = importer.refresh_confirmed_tip().await {
+                        warn!(error = %err, "failed to refresh confirmed tip on backfill retry");
+                    }
                     if let Err(err) = importer.maybe_import_from_cache().await {
                         warn!(
                             error = %err,
-                            "failed to import cached whitelist preconfirmation payloads on sync-ready poll"
+                            "failed to import cached whitelist preconfirmation payloads on backfill retry"
                         );
                     }
                 }

--- a/packages/taiko-client/driver/driver.go
+++ b/packages/taiko-client/driver/driver.go
@@ -202,6 +202,12 @@ func (d *Driver) Start() error {
 			defer d.wg.Done()
 			d.preconfBlockServer.LatestSeenProposalEventLoop(d.ctx)
 		}()
+
+		d.wg.Add(1)
+		go func() {
+			defer d.wg.Done()
+			d.preconfBlockServer.RetryBackfillEventLoop(d.ctx)
+		}()
 	}
 	if d.p2pNode != nil && d.p2pNode.Dv5Udp() != nil {
 		log.Info("Start P2P discovery process")

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -1009,7 +1009,35 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 
 	block = getBlock(l2Head1.Number().Uint64() + 2)
 	s.NotNil(block)
-	insertPayloadFromBlock(block, false)
+	baseFee, overflow = uint256.FromBig(block.BaseFee())
+	s.False(overflow)
+
+	b, err = utils.EncodeAndCompressTxList(block.Transactions())
+	s.Nil(err)
+
+	s.d.preconfBlockServer.PutPayloadsCache(block.Number().Uint64(), &preconf.Envelope{
+		Payload: &eth.ExecutionPayload{
+			BlockHash:     block.Hash(),
+			ParentHash:    block.ParentHash(),
+			FeeRecipient:  block.Coinbase(),
+			PrevRandao:    eth.Bytes32(block.MixDigest()),
+			BlockNumber:   eth.Uint64Quantity(block.Number().Uint64()),
+			GasLimit:      eth.Uint64Quantity(block.GasLimit()),
+			Timestamp:     eth.Uint64Quantity(block.Time()),
+			ExtraData:     block.Extra(),
+			BaseFeePerGas: eth.Uint256Quantity(*baseFee),
+			Transactions:  []eth.Data{b},
+			Withdrawals:   &types.Withdrawals{},
+		},
+		HeaderDifficulty: block.Difficulty(),
+	})
+
+	// No inbound payload from here on. The walk is otherwise driven only by arriving gossip,
+	// which is exactly what an epoch boundary takes away: the outgoing operator stops sequencing
+	// and the incoming one refuses to start while this node reports itself behind, so nothing
+	// would ever re-enter the walk and an expired request cooldown would never be consulted. The
+	// timed re-drive alone has to finish the recovery.
+	s.d.preconfBlockServer.RetryBackfill(context.Background())
 
 	l2Head5, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -1179,6 +1179,52 @@ func TestDriverTestSuite(t *testing.T) {
 	suite.Run(t, new(DriverTestSuite))
 }
 
+func (s *DriverTestSuite) TestOnUnsafeL2PayloadCachesBeforeFallibleRPCs() {
+	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().EventSyncer())
+
+	head, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
+	s.Nil(err)
+
+	baseFee, overflow := uint256.FromBig(head.BaseFee())
+	s.False(overflow)
+
+	b, err := utils.EncodeAndCompressTxList(head.Transactions())
+	s.Nil(err)
+
+	// A well-formed payload well above the current head, so it cannot be applied and its only
+	// trace is the cache.
+	ahead := head.Number().Uint64() + 500
+	payload := &eth.ExecutionPayload{
+		BlockHash:     testutils.RandomHash(),
+		ParentHash:    testutils.RandomHash(),
+		FeeRecipient:  head.Coinbase(),
+		PrevRandao:    eth.Bytes32(head.MixDigest()),
+		BlockNumber:   eth.Uint64Quantity(ahead),
+		GasLimit:      eth.Uint64Quantity(head.GasLimit()),
+		Timestamp:     eth.Uint64Quantity(head.Time()),
+		ExtraData:     head.Extra(),
+		BaseFeePerGas: eth.Uint256Quantity(*baseFee),
+		Transactions:  []eth.Data{b},
+		Withdrawals:   &types.Withdrawals{},
+	}
+
+	// Every RPC after validation fails under a cancelled context, standing in for a flaky L2
+	// endpoint. Gossipsub will not redeliver the message, so if the envelope is only cached after
+	// those calls it is gone for good, and `/status` goes back to reporting parity with a head it
+	// has no reason to believe is current.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	s.NotNil(s.d.preconfBlockServer.OnUnsafeL2Payload(
+		ctx,
+		peer.ID(testutils.RandomBytes(32)),
+		&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload, HeaderDifficulty: head.Difficulty()},
+	), "the failing RPC is still reported")
+
+	s.Equal(ahead, s.preconfStatus().HighestUnsafeL2PayloadBlockID,
+		"a validated payload is recorded even when the import path cannot run")
+}
+
 // preconfStatus fetches /status the same way a preconfer client does.
 func (s *DriverTestSuite) preconfStatus() *preconfblocks.Status {
 	var status preconfblocks.Status

--- a/packages/taiko-client/driver/driver_test.go
+++ b/packages/taiko-client/driver/driver_test.go
@@ -970,6 +970,16 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 	s.Nil(err)
 	s.Equal(l2Head1.Number().Uint64(), l2Head4.Number().Uint64())
 
+	// The node is now sitting on a backlog of valid envelopes it cannot import, with its
+	// execution head pinned. It must report that it is behind: a preconfer client comparing the
+	// reported block ID against the execution head has to see a mismatch, not parity between two
+	// equally stale values.
+	status := s.preconfStatus()
+	s.Greater(status.HighestUnsafeL2PayloadBlockID, l2Head4.Number().Uint64())
+	// The imported counter tracks only what this server applied; blocks that arrived through L1
+	// derivation advance the chain without touching it, so it can trail the execution head.
+	s.LessOrEqual(status.HighestImportedL2PayloadBlockID, l2Head4.Number().Uint64())
+
 	// Insert the only two missing ancient blocks
 	block := getBlock(l2Head1.Number().Uint64() + 1)
 	s.NotNil(block)
@@ -1004,6 +1014,12 @@ func (s *DriverTestSuite) TestOnUnsafeL2PayloadWithMissingAncients() {
 	l2Head5, err := s.d.rpc.L2.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
 	s.Equal(l2Head2.Number.Uint64(), l2Head5.Number().Uint64())
+
+	// Backlog drained: the reported block ID meets the execution head again, so the preconfer
+	// client's parity check passes.
+	status = s.preconfStatus()
+	s.Equal(l2Head5.Number().Uint64(), status.HighestUnsafeL2PayloadBlockID)
+	s.Equal(l2Head5.Number().Uint64(), status.HighestImportedL2PayloadBlockID)
 }
 
 func (s *DriverTestSuite) TestSyncerImportPendingBlocksFromCache() {
@@ -1133,6 +1149,15 @@ func (s *DriverTestSuite) InitProposer() {
 
 func TestDriverTestSuite(t *testing.T) {
 	suite.Run(t, new(DriverTestSuite))
+}
+
+// preconfStatus fetches /status the same way a preconfer client does.
+func (s *DriverTestSuite) preconfStatus() *preconfblocks.Status {
+	var status preconfblocks.Status
+	res, err := resty.New().R().SetResult(&status).Get(s.preconfServerURL.String() + "/status")
+	s.Nil(err)
+	s.True(res.IsSuccess())
+	return &status
 }
 
 // insertPreconfBlock inserts a preconfirmation block with the given parameters.

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -210,9 +210,9 @@ func (s *PreconfBlockAPIServer) BuildPreconfBlock(c echo.Context) error {
 
 	header := headers[0]
 
-	// always update the highest unsafe L2 payload block ID.
+	// always update the highest imported L2 payload block ID.
 	// it's either higher than the existing one, or we reorged.
-	s.updateHighestUnsafeL2Payload(header.Number.Uint64())
+	s.updateHighestImportedL2Payload(header.Number.Uint64())
 
 	// Propagate the preconfirmation block to the P2P network, if the current server
 	// connects to the P2P network.
@@ -331,14 +331,41 @@ type Status struct {
 	// @param totalCached uint64 the total number of cached envelopes after the start of the server.
 	TotalCached uint64 `json:"totalCached"`
 	// @param highestUnsafeL2PayloadBlockID uint64 the highest preconfirmation block ID that the server
-	// @param has received from the P2P network, if its zero, it means the current server has not received
-	// @param any preconfirmation block from the P2P network yet.
+	// @param has received from the P2P network, whether or not it could be imported, floored at the
+	// @param current L2 execution engine head. A consumer that requires this to equal the execution
+	// @param head before sequencing therefore sees a mismatch whenever this node is behind.
 	HighestUnsafeL2PayloadBlockID uint64 `json:"highestUnsafeL2PayloadBlockID"`
+	// @param highestImportedL2PayloadBlockID uint64 the highest preconfirmation block the server has
+	// @param actually inserted into its L2 execution engine. The gap to highestUnsafeL2PayloadBlockID
+	// @param is this node's preconfirmation backlog.
+	HighestImportedL2PayloadBlockID uint64 `json:"highestImportedL2PayloadBlockID"`
 	// @param whether the current epoch has received an end of sequencing block marker
 	EndOfSequencingBlockHash string `json:"endOfSequencingBlockHash"`
 	// CanShutdown is true when the server is safe to receive SIGTERM, i.e.,
 	// not the active or imminent preconfer for the current L1 slot.
 	CanShutdown bool `json:"canShutdown"`
+}
+
+// reportedHighestUnsafeL2Payload is the value `/status` publishes as
+// highestUnsafeL2PayloadBlockID: the highest payload this node has seen, floored at the
+// execution head and capped one envelope-cache span above it.
+//
+// The floor keeps a node whose execution head runs ahead of the gossip it has seen -- right
+// after a beacon sync, before the next proposal event lands -- from reporting a backlog it does
+// not have. That matters because the preconfer client exits the process after roughly half an
+// L2 epoch of continuous mismatch.
+//
+// The cap keeps a malformed or hostile block number from parking the node out of sync
+// indefinitely: a payload further ahead than the envelope cache can bridge needs L1 derivation
+// to clear either way.
+func reportedHighestUnsafeL2Payload(highestSeen, head uint64) uint64 {
+	if highestSeen < head {
+		return head
+	}
+	if ceiling := head + maxTrackedPayloads; highestSeen > ceiling {
+		return ceiling
+	}
+	return highestSeen
 }
 
 // GetStatus returns the current status of the preconfirmation block server.
@@ -349,6 +376,16 @@ type Status struct {
 //	@Success		200	{object} Status
 //	@Router			/status [get]
 func (s *PreconfBlockAPIServer) GetStatus(c echo.Context) error {
+	// Read the execution head before taking any lock. A failed read reports the raw seen
+	// counter, which errs toward reporting a mismatch.
+	highestImported := s.highestImportedL2PayloadBlockID.Load()
+	highestUnsafe := s.highestSeenL2PayloadBlockID.Load()
+	if head, err := s.rpc.L2.BlockNumber(c.Request().Context()); err != nil {
+		log.Warn("Failed to fetch L2 head for preconfirmation status, reporting highest seen", "error", err)
+	} else {
+		highestUnsafe = reportedHighestUnsafeL2Payload(highestUnsafe, head)
+	}
+
 	s.lookaheadMutex.Lock()
 	defer s.lookaheadMutex.Unlock()
 
@@ -375,7 +412,8 @@ func (s *PreconfBlockAPIServer) GetStatus(c echo.Context) error {
 			"currRanges", s.lookahead.CurrRanges,
 			"nextRanges", s.lookahead.NextRanges,
 			"totalCached", s.envelopesCache.getTotalCached(),
-			"highestUnsafeL2PayloadBlockID", s.highestUnsafeL2PayloadBlockID,
+			"highestUnsafeL2PayloadBlockID", highestUnsafe,
+			"highestImportedL2PayloadBlockID", highestImported,
 			"endOfSequencingBlockHash", endOfSequencingBlockHash.Hex(),
 			"currEpoch", s.rpc.L1Beacon.CurrentEpoch(),
 			"canShutdown", canShutdown,
@@ -383,11 +421,12 @@ func (s *PreconfBlockAPIServer) GetStatus(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, Status{
-		Lookahead:                     s.lookahead,
-		TotalCached:                   s.envelopesCache.getTotalCached(),
-		HighestUnsafeL2PayloadBlockID: s.highestUnsafeL2PayloadBlockID,
-		EndOfSequencingBlockHash:      endOfSequencingBlockHash.Hex(),
-		CanShutdown:                   canShutdown,
+		Lookahead:                       s.lookahead,
+		TotalCached:                     s.envelopesCache.getTotalCached(),
+		HighestUnsafeL2PayloadBlockID:   highestUnsafe,
+		HighestImportedL2PayloadBlockID: highestImported,
+		EndOfSequencingBlockHash:        endOfSequencingBlockHash.Hex(),
+		CanShutdown:                     canShutdown,
 	})
 }
 

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -346,6 +346,40 @@ type Status struct {
 	CanShutdown bool `json:"canShutdown"`
 }
 
+// anchorHighestSeenL2Payload bounds the seen counter to one envelope-cache span above the live
+// execution head and writes the bound back, returning the value to report.
+//
+// Writing it back is the point. A payload further ahead than the cache can bridge needs L1
+// derivation to clear either way, but leaving the raw height in the counter means the reported
+// value tracks `head + span` upwards forever and can never return to equality: one
+// signature-valid payload carrying a wrong or hostile block number would keep the preconfer
+// client from ever starting. Pinning the counter at a concrete height lets the chain pass it.
+//
+// The live head is the only safe anchor. Every counter maintained inside this server can lag it
+// -- L1 derivation advances the chain without touching them -- and bounding against a lagging
+// anchor would pull the counter below the head, which reads as synced. Anchored here, the stored
+// value is always `head + span`, strictly above the head, so a real backlog always reports as
+// one.
+func (s *PreconfBlockAPIServer) anchorHighestSeenL2Payload(head uint64) uint64 {
+	seen := s.highestSeenL2PayloadBlockID.Load()
+
+	ceiling := head + maxTrackedPayloads
+	if seen <= ceiling {
+		return seen
+	}
+
+	log.Warn(
+		"Anchoring highest seen L2 payload block ID to the execution head",
+		"highestSeenL2PayloadBlockID", seen,
+		"ceiling", ceiling,
+	)
+	// A concurrent writer holding s.mutex may have advanced the counter since the load; leave its
+	// value alone and let the next poll re-anchor.
+	s.highestSeenL2PayloadBlockID.CompareAndSwap(seen, ceiling)
+
+	return ceiling
+}
+
 // reportedHighestUnsafeL2Payload is the value `/status` publishes as
 // highestUnsafeL2PayloadBlockID: the highest payload this node has seen, floored at the
 // execution head.
@@ -379,7 +413,7 @@ func (s *PreconfBlockAPIServer) GetStatus(c echo.Context) error {
 	if head, err := s.rpc.L2.BlockNumber(c.Request().Context()); err != nil {
 		log.Warn("Failed to fetch L2 head for preconfirmation status, reporting highest seen", "error", err)
 	} else {
-		highestUnsafe = reportedHighestUnsafeL2Payload(highestUnsafe, head)
+		highestUnsafe = reportedHighestUnsafeL2Payload(s.anchorHighestSeenL2Payload(head), head)
 	}
 
 	s.lookaheadMutex.Lock()

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -346,56 +346,26 @@ type Status struct {
 	CanShutdown bool `json:"canShutdown"`
 }
 
-// anchorHighestSeenL2Payload bounds the seen counter to one envelope-cache span above the live
-// execution head and writes the bound back, returning the value to report.
-//
-// Writing it back is the point. A payload further ahead than the cache can bridge needs L1
-// derivation to clear either way, but leaving the raw height in the counter means the reported
-// value tracks `head + span` upwards forever and can never return to equality: one
-// signature-valid payload carrying a wrong or hostile block number would keep the preconfer
-// client from ever starting. Pinning the counter at a concrete height lets the chain pass it.
-//
-// The live head is the only safe anchor. Every counter maintained inside this server can lag it
-// -- L1 derivation advances the chain without touching them -- and bounding against a lagging
-// anchor would pull the counter below the head, which reads as synced. Anchored here, the stored
-// value is always `head + span`, strictly above the head, so a real backlog always reports as
-// one.
-func (s *PreconfBlockAPIServer) anchorHighestSeenL2Payload(head uint64) uint64 {
-	seen := s.highestSeenL2PayloadBlockID.Load()
-
-	ceiling := head + maxTrackedPayloads
-	if seen <= ceiling {
-		return seen
-	}
-
-	log.Warn(
-		"Anchoring highest seen L2 payload block ID to the execution head",
-		"highestSeenL2PayloadBlockID", seen,
-		"ceiling", ceiling,
-	)
-	// A concurrent writer holding s.mutex may have advanced the counter since the load; leave its
-	// value alone and let the next poll re-anchor.
-	s.highestSeenL2PayloadBlockID.CompareAndSwap(seen, ceiling)
-
-	return ceiling
-}
-
 // reportedHighestUnsafeL2Payload is the value `/status` publishes as
-// highestUnsafeL2PayloadBlockID: the highest payload this node has seen, floored at the
-// execution head.
+// highestUnsafeL2PayloadBlockID: the execution head, raised to the highest preconfirmation block
+// this node has validated but not applied.
 //
-// The floor keeps a node whose execution head runs ahead of the gossip it has seen -- right
-// after a beacon sync, before the next proposal event lands -- from reporting a backlog it does
-// not have. That matters because the preconfer client exits the process after roughly half an
-// L2 epoch of continuous mismatch.
+// The backlog is read from the envelope cache rather than tracked in a counter. A cached envelope
+// above the head *is* an unresolved backlog, by definition, so the answer cannot drift from the
+// evidence -- and the cache is a bounded ring, so a payload carrying a wrong or hostile block
+// number ages out on its own instead of needing a cap that would have to be reset, bounded, and
+// written back, each of which can erase a real backlog and report parity with a stale head.
 //
-// No cap is applied here. `updateHighestSeenL2Payload` already anchors the counter, and a cap at
-// this end would track the head upwards and so could never return to equality.
-func reportedHighestUnsafeL2Payload(highestSeen, head uint64) uint64 {
-	if highestSeen < head {
-		return head
+// Raising to the head keeps a node whose execution head runs ahead of the gossip it has seen --
+// right after a beacon sync -- from reporting a backlog it does not have. The preconfer client
+// exits the process after roughly half an L2 epoch of continuous mismatch, so a false "behind" is
+// expensive too.
+func reportedHighestUnsafeL2Payload(head, highestCached uint64, hasCached bool) uint64 {
+	if hasCached && highestCached > head {
+		return highestCached
 	}
-	return highestSeen
+
+	return head
 }
 
 // GetStatus returns the current status of the preconfirmation block server.
@@ -406,15 +376,20 @@ func reportedHighestUnsafeL2Payload(highestSeen, head uint64) uint64 {
 //	@Success		200	{object} Status
 //	@Router			/status [get]
 func (s *PreconfBlockAPIServer) GetStatus(c echo.Context) error {
-	// Read the execution head before taking any lock. A failed read reports the raw seen
-	// counter, which errs toward reporting a mismatch.
+	// Read the execution head before taking any lock. A failed read falls back to the last head
+	// this server saw, which can only under-report the head and so errs toward reporting a
+	// mismatch.
 	highestImported := s.highestImportedL2PayloadBlockID.Load()
-	highestUnsafe := s.highestSeenL2PayloadBlockID.Load()
-	if head, err := s.rpc.L2.BlockNumber(c.Request().Context()); err != nil {
-		log.Warn("Failed to fetch L2 head for preconfirmation status, reporting highest seen", "error", err)
+	head, err := s.rpc.L2.BlockNumber(c.Request().Context())
+	if err != nil {
+		head = s.lastObservedL2Head.Load()
+		log.Warn("Failed to fetch L2 head for preconfirmation status, using last observed", "head", head, "error", err)
 	} else {
-		highestUnsafe = reportedHighestUnsafeL2Payload(s.anchorHighestSeenL2Payload(head), head)
+		s.lastObservedL2Head.Store(head)
 	}
+
+	highestCached, hasCached := s.envelopesCache.highestBlockID()
+	highestUnsafe := reportedHighestUnsafeL2Payload(head, highestCached, hasCached)
 
 	s.lookaheadMutex.Lock()
 	defer s.lookaheadMutex.Unlock()

--- a/packages/taiko-client/driver/preconf_blocks/api.go
+++ b/packages/taiko-client/driver/preconf_blocks/api.go
@@ -348,22 +348,18 @@ type Status struct {
 
 // reportedHighestUnsafeL2Payload is the value `/status` publishes as
 // highestUnsafeL2PayloadBlockID: the highest payload this node has seen, floored at the
-// execution head and capped one envelope-cache span above it.
+// execution head.
 //
 // The floor keeps a node whose execution head runs ahead of the gossip it has seen -- right
 // after a beacon sync, before the next proposal event lands -- from reporting a backlog it does
 // not have. That matters because the preconfer client exits the process after roughly half an
 // L2 epoch of continuous mismatch.
 //
-// The cap keeps a malformed or hostile block number from parking the node out of sync
-// indefinitely: a payload further ahead than the envelope cache can bridge needs L1 derivation
-// to clear either way.
+// No cap is applied here. `updateHighestSeenL2Payload` already anchors the counter, and a cap at
+// this end would track the head upwards and so could never return to equality.
 func reportedHighestUnsafeL2Payload(highestSeen, head uint64) uint64 {
 	if highestSeen < head {
 		return head
-	}
-	if ceiling := head + maxTrackedPayloads; highestSeen > ceiling {
-		return ceiling
 	}
 	return highestSeen
 }

--- a/packages/taiko-client/driver/preconf_blocks/block_requests.go
+++ b/packages/taiko-client/driver/preconf_blocks/block_requests.go
@@ -1,0 +1,68 @@
+package preconfblocks
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// blockRequestCooldown is the minimum time between two backfill requests for the same missing
+// parent hash. It matches the Rust driver's DEFAULT_REQUEST_COOLDOWN_SECS so both
+// implementations retry on the same schedule.
+const blockRequestCooldown = 10 * time.Second
+
+// blockRequestTracker decides when a missing parent hash may be requested from the P2P
+// network again.
+//
+// Suppression is keyed on time, never on a publish having succeeded: PublishL2Request is a
+// bare gossipsub topic publish that returns nil as soon as the message reaches the router,
+// with or without a single mesh peer, so its error carries no delivery information. A request
+// that is never answered is therefore retried once the cooldown elapses, and only an answer
+// clears it for good.
+//
+// It is not safe for concurrent use: every caller reaches it from a P2P handler holding the
+// server's mutex.
+type blockRequestTracker struct {
+	cooldown    time.Duration
+	requestedAt map[common.Hash]time.Time
+}
+
+// newBlockRequestTracker creates a tracker with the given per-hash cooldown.
+func newBlockRequestTracker(cooldown time.Duration) *blockRequestTracker {
+	return &blockRequestTracker{cooldown: cooldown, requestedAt: make(map[common.Hash]time.Time)}
+}
+
+// shouldRequest reports whether the given hash may be requested at `now`, either because it
+// has never been requested or because its cooldown has elapsed. It does not record the
+// request: callers that decide not to publish must leave the window untouched so the next
+// attempt is immediate.
+func (t *blockRequestTracker) shouldRequest(hash common.Hash, now time.Time) bool {
+	// pruneExpired has just dropped every entry past its cooldown, so a surviving entry is one
+	// still inside its window.
+	t.pruneExpired(now)
+
+	_, suppressed := t.requestedAt[hash]
+	return !suppressed
+}
+
+// markPublished records that a request for the given hash has just been published, suppressing
+// further requests for one cooldown window.
+func (t *blockRequestTracker) markPublished(hash common.Hash, now time.Time) {
+	t.requestedAt[hash] = now
+}
+
+// markAnswered clears the hash, so a later request for it is not made to wait out a cooldown
+// window it no longer needs.
+func (t *blockRequestTracker) markAnswered(hash common.Hash) {
+	delete(t.requestedAt, hash)
+}
+
+// pruneExpired drops entries whose cooldown has elapsed, keeping the map bounded by the number
+// of hashes requested within one cooldown window rather than by the lifetime of the process.
+func (t *blockRequestTracker) pruneExpired(now time.Time) {
+	for hash, last := range t.requestedAt {
+		if now.Sub(last) >= t.cooldown {
+			delete(t.requestedAt, hash)
+		}
+	}
+}

--- a/packages/taiko-client/driver/preconf_blocks/block_requests_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/block_requests_test.go
@@ -1,0 +1,91 @@
+package preconfblocks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
+)
+
+type BlockRequestTrackerTestSuite struct {
+	suite.Suite
+}
+
+func TestBlockRequestTrackerTestSuite(t *testing.T) {
+	suite.Run(t, new(BlockRequestTrackerTestSuite))
+}
+
+func (s *BlockRequestTrackerTestSuite) TestCooldownExpires() {
+	var (
+		tracker = newBlockRequestTracker(10 * time.Second)
+		hash    = testutils.RandomHash()
+		now     = time.Now()
+	)
+
+	s.True(tracker.shouldRequest(hash, now), "a hash never requested before is requestable")
+
+	tracker.markPublished(hash, now)
+	s.False(tracker.shouldRequest(hash, now.Add(9*time.Second)), "suppressed inside the window")
+
+	// The whole point of the fix: an unanswered request must not suppress the hash forever.
+	s.True(tracker.shouldRequest(hash, now.Add(10*time.Second)), "requestable once the window elapses")
+}
+
+func (s *BlockRequestTrackerTestSuite) TestSkippedPublishDoesNotConsumeWindow() {
+	var (
+		tracker = newBlockRequestTracker(10 * time.Second)
+		hash    = testutils.RandomHash()
+		now     = time.Now()
+	)
+
+	// A caller that decides not to publish -- no gossip peers yet, block too old -- consults the
+	// tracker but never records, so the next walk retries immediately instead of waiting.
+	s.True(tracker.shouldRequest(hash, now))
+	s.True(tracker.shouldRequest(hash, now))
+}
+
+func (s *BlockRequestTrackerTestSuite) TestAnswerClearsSuppression() {
+	var (
+		tracker = newBlockRequestTracker(10 * time.Second)
+		hash    = testutils.RandomHash()
+		now     = time.Now()
+	)
+
+	tracker.markPublished(hash, now)
+	s.False(tracker.shouldRequest(hash, now))
+
+	tracker.markAnswered(hash)
+	s.True(tracker.shouldRequest(hash, now), "an answer retires the request without waiting out the window")
+}
+
+func (s *BlockRequestTrackerTestSuite) TestPerHashIsolation() {
+	var (
+		tracker = newBlockRequestTracker(10 * time.Second)
+		first   = testutils.RandomHash()
+		second  = testutils.RandomHash()
+		now     = time.Now()
+	)
+
+	tracker.markPublished(first, now)
+	s.False(tracker.shouldRequest(first, now))
+	s.True(tracker.shouldRequest(second, now), "the cooldown is per hash")
+}
+
+func (s *BlockRequestTrackerTestSuite) TestExpiredEntriesArePruned() {
+	var (
+		tracker = newBlockRequestTracker(10 * time.Second)
+		now     = time.Now()
+	)
+
+	for range 32 {
+		tracker.markPublished(testutils.RandomHash(), now)
+	}
+	s.Len(tracker.requestedAt, 32)
+
+	// Any later consultation sweeps the map, so it stays bounded by the number of hashes
+	// requested within one window rather than growing for the lifetime of the process.
+	s.True(tracker.shouldRequest(testutils.RandomHash(), now.Add(10*time.Second)))
+	s.Empty(tracker.requestedAt)
+}

--- a/packages/taiko-client/driver/preconf_blocks/block_requests_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/block_requests_test.go
@@ -89,3 +89,37 @@ func (s *BlockRequestTrackerTestSuite) TestExpiredEntriesArePruned() {
 	s.True(tracker.shouldRequest(testutils.RandomHash(), now.Add(10*time.Second)))
 	s.Empty(tracker.requestedAt)
 }
+
+func (s *BlockRequestTrackerTestSuite) TestDroppedResponseLifecycle() {
+	// The whole point of the cooldown, end to end at the tracker level: a request goes out, the
+	// response is dropped, and the next re-drive -- whether an inbound payload or the retry
+	// ticker -- publishes again once the window has elapsed, rather than being suppressed for the
+	// lifetime of the process.
+	var (
+		tracker = newBlockRequestTracker(blockRequestCooldown)
+		missing = testutils.RandomHash()
+		now     = time.Now()
+		publish = func(at time.Time) bool {
+			if !tracker.shouldRequest(missing, at) {
+				return false
+			}
+			tracker.markPublished(missing, at)
+			return true
+		}
+	)
+
+	s.True(publish(now), "first request goes out")
+
+	// Every re-drive inside the window is suppressed, however many arrive.
+	for _, elapsed := range []time.Duration{0, time.Second, blockRequestCooldown - time.Nanosecond} {
+		s.False(publish(now.Add(elapsed)))
+	}
+
+	// The response never arrives; the ticker fires past the window and the request is retried.
+	retriedAt := now.Add(blockRequestCooldown)
+	s.True(publish(retriedAt), "an unanswered request is retried, not suppressed forever")
+
+	// This time it is answered, which retires the request rather than making the next one wait.
+	tracker.markAnswered(missing)
+	s.True(tracker.shouldRequest(missing, retriedAt))
+}

--- a/packages/taiko-client/driver/preconf_blocks/queue.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue.go
@@ -137,6 +137,34 @@ func (q *envelopeQueue) getLatestEnvelope() *preconf.Envelope {
 	return q.envelopes[0].envelope
 }
 
+// highestBlockID returns the highest block ID held in the queue, and whether the queue holds
+// anything at all.
+//
+// This is the driver's evidence that the chain reaches beyond its own execution head: an envelope
+// cached above the head is one it has validated but not applied. Deriving the reported sync state
+// from it, rather than from a separate high-water counter, is what keeps the two from drifting --
+// a counter has to be reset on reorgs and bounded against runaway block numbers, and every such
+// write is a chance to erase evidence of a real backlog.
+func (q *envelopeQueue) highestBlockID() (uint64, bool) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	var (
+		highest uint64
+		found   bool
+	)
+	for _, item := range q.envelopes {
+		if item == nil {
+			break // no more items
+		}
+		if !found || item.id > highest {
+			highest, found = item.id, true
+		}
+	}
+
+	return highest, found
+}
+
 // getTotalCached retrieves the total number of cached envelopes after the initialization of the queue.
 func (q *envelopeQueue) getTotalCached() uint64 {
 	q.lock.RLock()

--- a/packages/taiko-client/driver/preconf_blocks/queue.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue.go
@@ -165,6 +165,34 @@ func (q *envelopeQueue) highestBlockID() (uint64, bool) {
 	return highest, found
 }
 
+// highestEnvelopeAbove returns the cached envelope with the greatest block ID above the given
+// one, or nil when the queue holds nothing above it.
+//
+// This is the head of the unresolved backlog, which is what a retry has to be driven from. The
+// most *recently inserted* envelope is a different thing entirely: a backfill response for a low
+// missing parent is inserted last while the backlog reaches far higher, and replaying an envelope
+// that is already applied returns at the already-exists check without ever reaching the walk.
+func (q *envelopeQueue) highestEnvelopeAbove(id uint64) *preconf.Envelope {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	var highest *envelopeQueueItem
+	for _, item := range q.envelopes {
+		if item == nil {
+			break // no more items
+		}
+		if item.id > id && (highest == nil || item.id > highest.id) {
+			highest = item
+		}
+	}
+
+	if highest == nil {
+		return nil
+	}
+
+	return highest.envelope
+}
+
 // getTotalCached retrieves the total number of cached envelopes after the initialization of the queue.
 func (q *envelopeQueue) getTotalCached() uint64 {
 	q.lock.RLock()

--- a/packages/taiko-client/driver/preconf_blocks/queue_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue_test.go
@@ -104,3 +104,48 @@ func (s *PreconfBlockAPIServerTestSuite) TestQueueHighestBlockID() {
 	s.True(ok)
 	s.Equal(uint64(100), highest)
 }
+
+func (s *PreconfBlockAPIServerTestSuite) TestQueueHighestEnvelopeAbove() {
+	var (
+		queue   = newEnvelopeQueue()
+		backlog = testutils.RandomHash()
+		lastPut = testutils.RandomHash()
+	)
+
+	put := func(id uint64, hash common.Hash) {
+		queue.put(id, &preconf.Envelope{
+			Payload: &eth.ExecutionPayload{
+				BlockNumber: eth.Uint64Quantity(id),
+				BlockHash:   hash,
+			},
+			HeaderDifficulty: common.Big1,
+		})
+	}
+
+	s.Nil(queue.highestEnvelopeAbove(0), "an empty queue has no backlog head")
+
+	// The unresolved backlog is cached first; a backfill response for a low block lands after it,
+	// which is the ordinary shape while catching up.
+	put(200, backlog)
+	put(100, lastPut)
+
+	// The head has to sit below both for this to mean anything: query from 100 and the newest
+	// entry is not above it either way, so a "first match in newest-first order" implementation
+	// would look correct.
+	pending := queue.highestEnvelopeAbove(50)
+	s.NotNil(pending)
+	s.Equal(
+		uint64(200),
+		uint64(pending.Payload.BlockNumber),
+		"retry drives from the backlog head, not the most recently cached envelope",
+	)
+	s.Equal(backlog, pending.Payload.BlockHash)
+
+	// Once the chain passes the lower entry the backlog head is unchanged.
+	pending = queue.highestEnvelopeAbove(100)
+	s.NotNil(pending)
+	s.Equal(uint64(200), uint64(pending.Payload.BlockNumber))
+
+	s.Nil(queue.highestEnvelopeAbove(200), "nothing above the head means no backlog")
+	s.Nil(queue.highestEnvelopeAbove(1000))
+}

--- a/packages/taiko-client/driver/preconf_blocks/queue_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/queue_test.go
@@ -82,3 +82,25 @@ func (s *PreconfBlockAPIServerTestSuite) TestCacheGetLongestChildren() {
 		s.Equal(longestFork[i].Payload.BlockHash, fork3[i].Payload.BlockHash)
 	}
 }
+
+func (s *PreconfBlockAPIServerTestSuite) TestQueueHighestBlockID() {
+	queue := newEnvelopeQueue()
+
+	_, ok := queue.highestBlockID()
+	s.False(ok, "an empty queue reports no evidence")
+
+	for _, id := range []uint64{40, 100, 70} {
+		queue.put(id, &preconf.Envelope{
+			Payload: &eth.ExecutionPayload{
+				BlockNumber: eth.Uint64Quantity(id),
+				BlockHash:   testutils.RandomHash(),
+			},
+			HeaderDifficulty: common.Big1,
+		})
+	}
+
+	// The highest id, not the most recently inserted one: gossip can arrive out of order.
+	highest, ok := queue.highestBlockID()
+	s.True(ok)
+	s.Equal(uint64(100), highest)
+}

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -50,6 +50,17 @@ const requestSyncMargin = uint64(128) // Margin for requesting sync, to avoid re
 // monitorLatestProposalOnChainInterval defines how often we reconcile the cached proposal with on-chain state.
 const monitorLatestProposalOnChainInterval = 10 * time.Second
 
+// backfillRetryInterval is how often a node holding an unresolved preconfirmation backlog
+// re-drives the missing-ancestor walk on its own.
+//
+// The walk is otherwise driven only by inbound payloads, which is exactly the wrong assumption at
+// an epoch boundary: if the dropped message is the last request before end-of-sequencing, the
+// outgoing operator stops gossiping and the incoming one refuses to sequence because this node is
+// reporting itself behind, so nothing arrives to re-drive anything and the expired cooldown is
+// never consulted. Recovery would then wait for L1 derivation. This ticker is what makes a single
+// dropped gossip message non-terminal on its own.
+const backfillRetryInterval = 4 * time.Second
+
 // shutdownImminenceMarginSlots is the number of upcoming L1 slots CanShutdown
 // treats as already in-window: shutdown is refused not only while the current
 // slot is inside one of this operator's sequencing ranges, but also when a
@@ -822,8 +833,16 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 				publishRequest := func() {
 					// A request published into a mesh that has not formed yet reaches nobody,
 					// and the publish still returns nil. Hold it back instead: the walk is
-					// re-driven by every inbound payload, so the retry costs nothing and does
-					// not consume the cooldown window.
+					// re-driven by inbound payloads and by RetryBackfillEventLoop, so the retry
+					// costs nothing and does not consume the cooldown window.
+					//
+					// This counts peers on the block topics, not on the request topic --
+					// AllBlockTopicsPeers combines the OP block topics, which Taiko does not
+					// use, with preconfBlocksV1. Every node joins all preconf topics together at
+					// startup, so it is a close proxy; an exact request-topic count would need a
+					// new method on the GossipTopicInfo interface in the taikoxyz/optimism fork.
+					// The approximation can still let a publish through to an empty request
+					// topic, which costs one cooldown window rather than the recovery.
 					if len(s.p2pNode.GossipOut().AllBlockTopicsPeers()) == 0 {
 						log.Info(
 							"No gossip peers yet, holding back preconfirmation block request",
@@ -1016,16 +1035,47 @@ func (s *PreconfBlockAPIServer) ValidateExecutionPayload(payload *eth.ExecutionP
 	return nil
 }
 
+// RetryBackfillEventLoop periodically re-drives the missing-ancestor walk while this node holds
+// preconfirmation envelopes it has not been able to apply.
+func (s *PreconfBlockAPIServer) RetryBackfillEventLoop(ctx context.Context) {
+	ticker := time.NewTicker(backfillRetryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.RetryBackfill(ctx)
+		}
+	}
+}
+
+// RetryBackfill re-enters the import walk for the newest cached envelope, which re-publishes a
+// backfill request whose cooldown has elapsed and applies whatever the cache can now bridge.
+//
+// It is a no-op unless this node has seen more than it has applied, so a healthy follower never
+// reaches the walk and never logs.
+func (s *PreconfBlockAPIServer) RetryBackfill(ctx context.Context) {
+	if s.highestSeenL2PayloadBlockID.Load() <= s.highestImportedL2PayloadBlockID.Load() {
+		return
+	}
+
+	if err := s.ImportPendingBlocksFromCache(ctx); err != nil {
+		log.Debug("Preconfirmation backfill retry did not complete", "error", err)
+	}
+}
+
 // ImportPendingBlocksFromCache tries to insert pending blocks from the cache,
 // if there is no payload in the cache, it will skip the operation.
 func (s *PreconfBlockAPIServer) ImportPendingBlocksFromCache(ctx context.Context) error {
 	latestPayload := s.envelopesCache.getLatestEnvelope()
 	if latestPayload == nil {
-		log.Info("No envelopes in cache, skip importing from cache")
+		log.Debug("No envelopes in cache, skip importing from cache")
 		return nil
 	}
 
-	log.Info(
+	log.Debug(
 		"Found pending envelopes in the cache, try importing",
 		"latestPayloadNumber", uint64(latestPayload.Payload.BlockNumber),
 		"latestPayloadBlockHash", latestPayload.Payload.BlockHash.Hex(),
@@ -1489,7 +1539,20 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 	}
 
 	// A header already occupies this block number with a different hash -- the equal-hash case
-	// returned above -- so this payload reorgs the chain and the counter moves back down with it.
+	// returned above -- so this payload reorgs the chain and the imported counter moves back down
+	// with it.
+	//
+	// The seen counter deliberately does not follow it down. A single gossiped payload is not
+	// authoritative about how far the chain reaches: a node already holding a backlog would, on
+	// accepting a competing block below its head, forget every higher block it has seen and go
+	// back to reporting its own head -- the fail-open this counter exists to close. Only
+	// `recordLatestSeenProposal` lowers it, because there the height comes from an L1 proposal
+	// event and is authoritative.
+	//
+	// The cost is that a reorg leaves this node reporting itself behind for roughly (reorg depth
+	// x block time) until the new branch grows past the discarded one. That is bounded and
+	// self-healing, and this branch replaces a block at its own height, so in practice the depth
+	// is small.
 	if header != nil && uint64(msg.ExecutionPayload.BlockNumber) <= header.Number.Uint64() {
 		log.Info(
 			"Preconfirmation block is reorging",
@@ -1547,11 +1610,28 @@ func (s *PreconfBlockAPIServer) updateHighestImportedL2Payload(blockID uint64) {
 // well-formed, signature-valid payload this node receives regardless of whether it could be
 // imported. It only ever moves forward; `recordLatestSeenProposal` moves it back on a reorg.
 //
-// The value is bounded where it is published, by `reportedHighestUnsafeL2Payload`, which has
-// the live execution head to bound it against. This counter is deliberately not bounded here:
-// the highest imported block is not the execution head -- blocks arriving through L1 derivation
-// advance the chain without touching it -- so it cannot supply a trustworthy ceiling.
+// The value is anchored one envelope-cache span above the highest imported block. That has to
+// happen here rather than where the value is published: clamping at the publishing end leaves
+// this counter holding the absurd height, so the reported value tracks `head + span` as the head
+// advances and never returns to equality -- one signature-valid payload carrying a wrong or
+// hostile block number would keep the preconfer client from ever starting. Anchoring here parks
+// the counter at a fixed height the chain eventually passes.
+//
+// The anchor is deliberately loose. The highest imported block is not the execution head -- L1
+// derivation advances the chain without touching it -- so it is only trustworthy as a sanity
+// bound, not as the ceiling for the reported value. A backlog deeper than one cache span still
+// reports as behind; it just reports a floor on how far behind, which is all that matters,
+// because clearing a backlog that deep needs L1 derivation either way.
 func (s *PreconfBlockAPIServer) updateHighestSeenL2Payload(blockID uint64) {
+	if ceiling := s.highestImportedL2PayloadBlockID.Load() + maxTrackedPayloads; blockID > ceiling {
+		log.Warn(
+			"Anchoring highest seen L2 payload block ID",
+			"blockID", blockID,
+			"ceiling", ceiling,
+		)
+		blockID = ceiling
+	}
+
 	// Read-then-write rather than a compare-and-swap loop: every caller holds s.mutex, so no
 	// other writer can interleave here.
 	current := s.highestSeenL2PayloadBlockID.Load()

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -95,15 +95,14 @@ type PreconfBlockAPIServer struct {
 	// highestImportedL2PayloadBlockID is the highest preconfirmation block this node has
 	// actually inserted into its L2 execution engine (or seen land on chain via a proposal).
 	highestImportedL2PayloadBlockID atomic.Uint64
-	// highestSeenL2PayloadBlockID is the highest well-formed, signature-valid preconfirmation
-	// block this node has *received*, whether it could be imported or only cached. A node with
-	// a backlog of cached envelopes has highestSeen > highestImported, which is what lets
-	// `/status` report "I am behind" instead of reporting its own stale head back at the
-	// preconfer client.
+	// lastObservedL2Head is the most recent execution head `/status` managed to read, used only
+	// as a fallback while the L2 RPC is failing.
 	//
-	// Both block IDs are written only under s.mutex; they are atomic so that GetStatus can
-	// read them without taking it.
-	highestSeenL2PayloadBlockID atomic.Uint64
+	// There is deliberately no "highest seen" counter beside it. How far the chain reaches beyond
+	// this node is read from the envelope cache, which is the evidence itself; a counter has to be
+	// reset on reorgs and bounded against runaway block numbers, and every such write is a chance
+	// to erase a real backlog and report parity with a stale head.
+	lastObservedL2Head atomic.Uint64
 	// P2P network for preconfirmation block propagation
 	p2pNode   *p2p.NodeP2P
 	p2pSigner p2p.Signer
@@ -181,10 +180,8 @@ func New(
 		syncReady:                    false,
 	}
 
-	// Both counters start at the current head: before any gossip is received the node is, as
-	// far as it knows, in sync with the network.
 	server.highestImportedL2PayloadBlockID.Store(head.NumberU64())
-	server.highestSeenL2PayloadBlockID.Store(head.NumberU64())
+	server.lastObservedL2Head.Store(head.NumberU64())
 
 	server.echo.HideBanner = true
 	server.configureMiddleware([]string{cors})
@@ -349,12 +346,6 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 		return nil
 	}
 
-	// The payload is well-formed and its gossip signature has already been checked by the
-	// topic validator, so it counts as seen from here on, whatever happens to it below. This
-	// is what makes a node that cannot import report itself as behind rather than reporting
-	// its own stale head.
-	s.updateHighestSeenL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
-
 	// Check if we are ready to insert preconfirmation blocks.
 	if !s.syncReady {
 		log.Info(
@@ -462,10 +453,6 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 		metrics.DriverPreconfInvalidEnvelopeCounter.Inc()
 		return nil
 	}
-
-	// A backfill response is a payload like any other: seeing it means this node knows the
-	// chain reaches at least that height.
-	s.updateHighestSeenL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
 
 	// Check if we are ready to insert preconfirmation blocks.
 	if !s.syncReady {
@@ -1054,10 +1041,22 @@ func (s *PreconfBlockAPIServer) RetryBackfillEventLoop(ctx context.Context) {
 // RetryBackfill re-enters the import walk for the newest cached envelope, which re-publishes a
 // backfill request whose cooldown has elapsed and applies whatever the cache can now bridge.
 //
-// It is a no-op unless this node has seen more than it has applied, so a healthy follower never
-// reaches the walk and never logs.
+// The gate is the cache against the live execution head, not a pair of internal counters: a
+// counter reset can make two counters agree while the cache still holds envelopes that were never
+// applied, which would silence the retry exactly when it is needed.
 func (s *PreconfBlockAPIServer) RetryBackfill(ctx context.Context) {
-	if s.highestSeenL2PayloadBlockID.Load() <= s.highestImportedL2PayloadBlockID.Load() {
+	highestCached, ok := s.envelopesCache.highestBlockID()
+	if !ok {
+		return
+	}
+
+	head, err := s.rpc.L2.BlockNumber(ctx)
+	if err != nil {
+		log.Debug("Failed to fetch L2 head for preconfirmation backfill retry", "error", err)
+		return
+	}
+
+	if highestCached <= head {
 		return
 	}
 
@@ -1344,17 +1343,15 @@ func (s *PreconfBlockAPIServer) recordLatestSeenProposal(proposal *encoding.Last
 		metrics.DriverLastSeenBlockInProposalGauge.Set(float64(proposal.LastBlockID))
 	}
 
-	// If the latest seen proposal is reorged, reset both payload block IDs. The seen counter
-	// must come back down with the imported one: a payload from the discarded branch would
-	// otherwise keep the node reporting itself behind a chain that no longer exists.
+	// If the latest seen proposal is reorged, reset the imported block ID to the canonical tip.
+	// Nothing else needs resetting: how far the chain reaches is read from the envelope cache, and
+	// envelopes on the discarded branch are dropped where the replacement is accepted.
 	if s.latestSeenProposal.PreconfChainReorged {
 		s.highestImportedL2PayloadBlockID.Store(proposal.LastBlockID)
-		s.highestSeenL2PayloadBlockID.Store(proposal.LastBlockID)
 		log.Info(
-			"Latest block ID seen in event is reorged, reset the highest L2 payload block IDs",
+			"Latest block ID seen in event is reorged, reset the highest imported L2 payload block ID",
 			"proposalId", proposal.Shasta().GetEventData().Id,
 			"highestImportedL2PayloadBlockID", proposal.LastBlockID,
-			"highestSeenL2PayloadBlockID", proposal.LastBlockID,
 		)
 
 		metrics.DriverReorgsByProposalCounter.Inc()
@@ -1367,7 +1364,6 @@ func (s *PreconfBlockAPIServer) recordLatestSeenProposal(proposal *encoding.Last
 			"newHighestImportedL2PayloadBlockID", proposal.LastBlockID,
 		)
 		s.highestImportedL2PayloadBlockID.Store(proposal.LastBlockID)
-		s.updateHighestSeenL2Payload(proposal.LastBlockID)
 	}
 }
 
@@ -1542,18 +1538,15 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 	// returned above -- so this payload reorgs the chain and the imported counter moves back down
 	// with it.
 	//
-	// The seen counter deliberately does not follow it down. A single gossiped payload is not
-	// authoritative about how far the chain reaches: a node already holding a backlog would, on
-	// accepting a competing block below its head, forget every higher block it has seen and go
-	// back to reporting its own head -- the fail-open this counter exists to close. Only
-	// `recordLatestSeenProposal` lowers it, because there the height comes from an L1 proposal
-	// event and is authoritative.
+	// Envelopes on the replaced branch stay cached. They are not garbage: gossip delivers
+	// competing branches in arbitrary order, and a branch that loses at this height can win again
+	// once more of it arrives -- TestGossipMessagesRandomReorgs pins exactly that. Dropping them
+	// would leave the driver unable to rebuild the branch it is about to be asked for.
 	//
-	// The cost is that this node reports itself behind until the new branch grows past the
-	// discarded one -- which is not guaranteed to happen, if the replacement branch settles at a
-	// lower height. What does bound it is `anchorHighestSeenL2Payload`: the counter is pulled to
-	// one envelope-cache span above the live head and pinned there, so the report converges once
-	// the chain advances that far. Call it bounded by one cache span, not self-healing.
+	// The cost is that `/status` keeps reporting a backlog while they sit above the head, since
+	// they are validated envelopes this node has not applied -- which is what they are, and the
+	// network may well be on that branch. It clears when the chain reaches them or the bounded
+	// cache evicts them.
 	if header != nil && uint64(msg.ExecutionPayload.BlockNumber) <= header.Number.Uint64() {
 		log.Info(
 			"Preconfirmation block is reorging",
@@ -1602,41 +1595,16 @@ func (s *PreconfBlockAPIServer) updateHighestImportedL2Payload(blockID uint64) {
 	}
 	s.highestImportedL2PayloadBlockID.Store(blockID)
 	metrics.DriverHighestPreconfUnsafePayloadGauge.Set(float64(blockID))
-
-	// An imported block has by definition been seen.
-	s.updateHighestSeenL2Payload(blockID)
-}
-
-// updateHighestSeenL2Payload advances the highest seen L2 payload block ID, which tracks every
-// well-formed, signature-valid payload this node receives regardless of whether it could be
-// imported. It only ever moves forward; `recordLatestSeenProposal` moves it back on a reorg.
-//
-// Nothing is bounded here. Every bound available at this point -- the highest imported block in
-// particular -- can lag the live execution head by more than one envelope-cache span, because L1
-// derivation advances the chain without touching those counters. Bounding against a lagging
-// anchor would pull this counter *below* the live head, and `/status` floors at the head, so a
-// node holding an unimported backlog would report parity and read as synced. That is the
-// fail-open this counter exists to close. The bound is applied by `anchorHighestSeenL2Payload`,
-// where the live head is known.
-func (s *PreconfBlockAPIServer) updateHighestSeenL2Payload(blockID uint64) {
-	// Read-then-write rather than a compare-and-swap loop: every caller holds s.mutex, so no
-	// other writer can interleave here.
-	current := s.highestSeenL2PayloadBlockID.Load()
-	if blockID <= current {
-		return
-	}
-
-	s.highestSeenL2PayloadBlockID.Store(blockID)
-	log.Debug(
-		"Updating highest seen L2 payload block ID",
-		"blockID", blockID,
-		"previousHighestSeenL2PayloadBlockID", current,
-	)
-	metrics.DriverHighestPreconfSeenPayloadGauge.Set(float64(blockID))
 }
 
 // tryPutEnvelopeIntoCache tries to put the given payload into the cache, if it is not already cached.
 func (s *PreconfBlockAPIServer) tryPutEnvelopeIntoCache(msg *eth.ExecutionPayloadEnvelope, from peer.ID) {
+	defer func() {
+		if highest, ok := s.envelopesCache.highestBlockID(); ok {
+			metrics.DriverHighestPreconfSeenPayloadGauge.Set(float64(highest))
+		}
+	}()
+
 	id := uint64(msg.ExecutionPayload.BlockNumber)
 	h := msg.ExecutionPayload.BlockHash
 	if s.envelopesCache.hasExact(id, h) {

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -346,6 +346,14 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 		return nil
 	}
 
+	// Record the envelope before anything that can fail. Everything below this line can return on
+	// a transient RPC error, and gossipsub will not redeliver the message, so caching later would
+	// let a flaky L2 endpoint silently discard the only evidence that the chain runs ahead of this
+	// node -- leaving `/status` reporting parity with a stale head, which is the failure this
+	// whole path exists to prevent. Caching is idempotent, so the import paths below are free to
+	// treat the envelope as theirs.
+	s.tryPutEnvelopeIntoCache(msg, from)
+
 	// Check if we are ready to insert preconfirmation blocks.
 	if !s.syncReady {
 		log.Info(
@@ -355,7 +363,6 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 			"hash", msg.ExecutionPayload.BlockHash.Hex(),
 			"parentHash", msg.ExecutionPayload.ParentHash.Hex(),
 		)
-		s.tryPutEnvelopeIntoCache(msg, from)
 		return nil
 	}
 
@@ -366,7 +373,6 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 	}
 
 	if progress.IsSyncing() {
-		s.tryPutEnvelopeIntoCache(msg, from)
 		return nil
 	}
 
@@ -384,8 +390,6 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 	if quit {
 		return nil
 	}
-
-	s.tryPutEnvelopeIntoCache(msg, from)
 
 	// If the envelope is an end of sequencing message, we need to notify the clients.
 	if msg.EndOfSequencing != nil && *msg.EndOfSequencing && s.rpc.L1Beacon != nil {
@@ -454,6 +458,11 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 		return nil
 	}
 
+	// Record the envelope before anything that can fail, for the same reason as the payload path:
+	// a transient RPC error below would otherwise discard a backfill response that gossipsub will
+	// never resend, and this response is very likely the block closing the gap.
+	s.tryPutEnvelopeIntoCache(msg, from)
+
 	// Check if we are ready to insert preconfirmation blocks.
 	if !s.syncReady {
 		log.Info(
@@ -463,7 +472,6 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 			"hash", msg.ExecutionPayload.BlockHash.Hex(),
 			"parentHash", msg.ExecutionPayload.ParentHash.Hex(),
 		)
-		s.tryPutEnvelopeIntoCache(msg, from)
 		return nil
 	}
 
@@ -479,7 +487,6 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 			"blockID", uint64(msg.ExecutionPayload.BlockNumber),
 			"hash", msg.ExecutionPayload.BlockHash.Hex(),
 		)
-		s.tryPutEnvelopeIntoCache(msg, from)
 		return nil
 	}
 
@@ -501,14 +508,9 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 		return fmt.Errorf("failed to check message block number: %w", err)
 	}
 
-	// Try to import the payload into the L2 EE chain, if can't, cache it.
-	cached, err := s.TryImportingPayload(ctx, headL1Origin, msg, from)
-	if err != nil {
+	// Try to import the payload into the L2 EE chain; it is already cached either way.
+	if _, err := s.TryImportingPayload(ctx, headL1Origin, msg, from); err != nil {
 		return fmt.Errorf("failed to try importing payload: %w", err)
-	}
-
-	if !cached {
-		s.tryPutEnvelopeIntoCache(msg, from)
 	}
 
 	return nil
@@ -1045,22 +1047,33 @@ func (s *PreconfBlockAPIServer) RetryBackfillEventLoop(ctx context.Context) {
 // counter reset can make two counters agree while the cache still holds envelopes that were never
 // applied, which would silence the retry exactly when it is needed.
 func (s *PreconfBlockAPIServer) RetryBackfill(ctx context.Context) {
-	highestCached, ok := s.envelopesCache.highestBlockID()
-	if !ok {
-		return
-	}
-
 	head, err := s.rpc.L2.BlockNumber(ctx)
 	if err != nil {
 		log.Debug("Failed to fetch L2 head for preconfirmation backfill retry", "error", err)
 		return
 	}
 
-	if highestCached <= head {
+	// The same envelope decides both that there is a backlog and what to retry. Deciding from the
+	// highest cached block but retrying the most recently cached one lets the tick replay an
+	// already-applied envelope forever while the backlog above it is never touched.
+	pending := s.envelopesCache.highestEnvelopeAbove(head)
+	if pending == nil {
 		return
 	}
 
-	if err := s.ImportPendingBlocksFromCache(ctx); err != nil {
+	log.Debug(
+		"Retrying preconfirmation backfill",
+		"blockID", uint64(pending.Payload.BlockNumber),
+		"hash", pending.Payload.BlockHash.Hex(),
+		"head", head,
+	)
+
+	if err := s.OnUnsafeL2Payload(ctx, "", &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload:  pending.Payload,
+		Signature:         pending.Signature,
+		IsForcedInclusion: &pending.IsForcedInclusion,
+		HeaderDifficulty:  pending.HeaderDifficulty,
+	}); err != nil {
 		log.Debug("Preconfirmation backfill retry did not complete", "error", err)
 	}
 }

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -1549,10 +1549,11 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 	// `recordLatestSeenProposal` lowers it, because there the height comes from an L1 proposal
 	// event and is authoritative.
 	//
-	// The cost is that a reorg leaves this node reporting itself behind for roughly (reorg depth
-	// x block time) until the new branch grows past the discarded one. That is bounded and
-	// self-healing, and this branch replaces a block at its own height, so in practice the depth
-	// is small.
+	// The cost is that this node reports itself behind until the new branch grows past the
+	// discarded one -- which is not guaranteed to happen, if the replacement branch settles at a
+	// lower height. What does bound it is `anchorHighestSeenL2Payload`: the counter is pulled to
+	// one envelope-cache span above the live head and pinned there, so the report converges once
+	// the chain advances that far. Call it bounded by one cache span, not self-healing.
 	if header != nil && uint64(msg.ExecutionPayload.BlockNumber) <= header.Number.Uint64() {
 		log.Info(
 			"Preconfirmation block is reorging",
@@ -1610,28 +1611,14 @@ func (s *PreconfBlockAPIServer) updateHighestImportedL2Payload(blockID uint64) {
 // well-formed, signature-valid payload this node receives regardless of whether it could be
 // imported. It only ever moves forward; `recordLatestSeenProposal` moves it back on a reorg.
 //
-// The value is anchored one envelope-cache span above the highest imported block. That has to
-// happen here rather than where the value is published: clamping at the publishing end leaves
-// this counter holding the absurd height, so the reported value tracks `head + span` as the head
-// advances and never returns to equality -- one signature-valid payload carrying a wrong or
-// hostile block number would keep the preconfer client from ever starting. Anchoring here parks
-// the counter at a fixed height the chain eventually passes.
-//
-// The anchor is deliberately loose. The highest imported block is not the execution head -- L1
-// derivation advances the chain without touching it -- so it is only trustworthy as a sanity
-// bound, not as the ceiling for the reported value. A backlog deeper than one cache span still
-// reports as behind; it just reports a floor on how far behind, which is all that matters,
-// because clearing a backlog that deep needs L1 derivation either way.
+// Nothing is bounded here. Every bound available at this point -- the highest imported block in
+// particular -- can lag the live execution head by more than one envelope-cache span, because L1
+// derivation advances the chain without touching those counters. Bounding against a lagging
+// anchor would pull this counter *below* the live head, and `/status` floors at the head, so a
+// node holding an unimported backlog would report parity and read as synced. That is the
+// fail-open this counter exists to close. The bound is applied by `anchorHighestSeenL2Payload`,
+// where the live head is known.
 func (s *PreconfBlockAPIServer) updateHighestSeenL2Payload(blockID uint64) {
-	if ceiling := s.highestImportedL2PayloadBlockID.Load() + maxTrackedPayloads; blockID > ceiling {
-		log.Warn(
-			"Anchoring highest seen L2 payload block ID",
-			"blockID", blockID,
-			"ceiling", ceiling,
-		)
-		blockID = ceiling
-	}
-
 	// Read-then-write rather than a compare-and-swap loop: every caller holds s.mutex, so no
 	// other writer can interleave here.
 	current := s.highestSeenL2PayloadBlockID.Load()

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
@@ -76,11 +77,22 @@ type preconfBlockChainSyncer interface {
 // @license.url https://github.com/taikoxyz/taiko-mono/blob/main/LICENSE
 // PreconfBlockAPIServer represents a preconfirmation block server instance.
 type PreconfBlockAPIServer struct {
-	echo                          *echo.Echo
-	rpc                           *rpc.Client
-	chainSyncer                   preconfBlockChainSyncer
-	anchorValidator               *validator.AnchorTxValidator
-	highestUnsafeL2PayloadBlockID uint64
+	echo            *echo.Echo
+	rpc             *rpc.Client
+	chainSyncer     preconfBlockChainSyncer
+	anchorValidator *validator.AnchorTxValidator
+	// highestImportedL2PayloadBlockID is the highest preconfirmation block this node has
+	// actually inserted into its L2 execution engine (or seen land on chain via a proposal).
+	highestImportedL2PayloadBlockID atomic.Uint64
+	// highestSeenL2PayloadBlockID is the highest well-formed, signature-valid preconfirmation
+	// block this node has *received*, whether it could be imported or only cached. A node with
+	// a backlog of cached envelopes has highestSeen > highestImported, which is what lets
+	// `/status` report "I am behind" instead of reporting its own stale head back at the
+	// preconfer client.
+	//
+	// Both block IDs are written only under s.mutex; they are atomic so that GetStatus can
+	// read them without taking it.
+	highestSeenL2PayloadBlockID atomic.Uint64
 	// P2P network for preconfirmation block propagation
 	p2pNode   *p2p.NodeP2P
 	p2pSigner p2p.Signer
@@ -91,7 +103,7 @@ type PreconfBlockAPIServer struct {
 	lookaheadMutex sync.Mutex
 	// Cache
 	envelopesCache               *envelopeQueue
-	blockRequestsCache           *lru.Cache[common.Hash, struct{}]
+	blockRequests                *blockRequestTracker
 	sequencingEndedForEpochCache *lru.Cache[uint64, common.Hash]
 	responseSeenCache            *lru.Cache[common.Hash, time.Time]
 	// ConfigureRoutes
@@ -127,10 +139,6 @@ func New(
 	}
 
 	// Initialize caches.
-	blockRequestsCache, err := lru.New[common.Hash, struct{}](maxTrackedPayloads)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create block requests cache: %w", err)
-	}
 	endOfSequencingCache, err := lru.New[uint64, common.Hash](maxTrackedPayloads)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create end of sequencing cache: %w", err)
@@ -146,22 +154,26 @@ func New(
 	}
 
 	server := &PreconfBlockAPIServer{
-		echo:                          echo.New(),
-		anchorValidator:               anchorValidator,
-		chainSyncer:                   chainSyncer,
-		ws:                            &webSocketSever{rpc: cli, clients: make(map[*websocket.Conn]struct{})},
-		rpc:                           cli,
-		envelopesCache:                newEnvelopeQueue(),
-		preconfOperatorAddress:        preconfOperatorAddress,
-		lookahead:                     &Lookahead{},
-		mutex:                         sync.Mutex{},
-		blockRequestsCache:            blockRequestsCache,
-		sequencingEndedForEpochCache:  endOfSequencingCache,
-		latestSeenProposalCh:          latestSeenProposalCh,
-		responseSeenCache:             responseSeenCache,
-		highestUnsafeL2PayloadBlockID: head.NumberU64(),
-		syncReady:                     false,
+		echo:                         echo.New(),
+		anchorValidator:              anchorValidator,
+		chainSyncer:                  chainSyncer,
+		ws:                           &webSocketSever{rpc: cli, clients: make(map[*websocket.Conn]struct{})},
+		rpc:                          cli,
+		envelopesCache:               newEnvelopeQueue(),
+		preconfOperatorAddress:       preconfOperatorAddress,
+		lookahead:                    &Lookahead{},
+		mutex:                        sync.Mutex{},
+		blockRequests:                newBlockRequestTracker(blockRequestCooldown),
+		sequencingEndedForEpochCache: endOfSequencingCache,
+		latestSeenProposalCh:         latestSeenProposalCh,
+		responseSeenCache:            responseSeenCache,
+		syncReady:                    false,
 	}
+
+	// Both counters start at the current head: before any gossip is received the node is, as
+	// far as it knows, in sync with the network.
+	server.highestImportedL2PayloadBlockID.Store(head.NumberU64())
+	server.highestSeenL2PayloadBlockID.Store(head.NumberU64())
 
 	server.echo.HideBanner = true
 	server.configureMiddleware([]string{cors})
@@ -326,6 +338,12 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Payload(
 		return nil
 	}
 
+	// The payload is well-formed and its gossip signature has already been checked by the
+	// topic validator, so it counts as seen from here on, whatever happens to it below. This
+	// is what makes a node that cannot import report itself as behind rather than reporting
+	// its own stale head.
+	s.updateHighestSeenL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
+
 	// Check if we are ready to insert preconfirmation blocks.
 	if !s.syncReady {
 		log.Info(
@@ -395,6 +413,10 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 	// add responses seen to cache.
 	s.responseSeenCache.Add(msg.ExecutionPayload.BlockHash, time.Now().UTC())
 
+	// An answer has arrived, so any outstanding backfill request for this hash is done. This,
+	// not a successful publish, is what retires a request.
+	s.blockRequests.markAnswered(msg.ExecutionPayload.BlockHash)
+
 	// Ignore the message if it is from the current P2P node, when `from` is empty,
 	// it means the message is for importing the pending blocks from the cache after
 	// a new L2 EE chain has just finished a beacon-sync.
@@ -429,6 +451,10 @@ func (s *PreconfBlockAPIServer) OnUnsafeL2Response(
 		metrics.DriverPreconfInvalidEnvelopeCounter.Inc()
 		return nil
 	}
+
+	// A backfill response is a payload like any other: seeing it means this node knows the
+	// chain reaches at least that height.
+	s.updateHighestSeenL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
 
 	// Check if we are ready to insert preconfirmation blocks.
 	if !s.syncReady {
@@ -782,7 +808,7 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 		if parentPayload == nil {
 			// If the parent payload is not found in the cache and chain is not syncing,
 			// we publish a request to the P2P network.
-			if !s.blockRequestsCache.Contains(currentPayload.Payload.ParentHash) {
+			if s.blockRequests.shouldRequest(currentPayload.Payload.ParentHash, time.Now()) {
 				progress, err := s.rpc.L2ExecutionEngineSyncProgress(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get L2 execution engine sync progress: %w", err)
@@ -794,6 +820,19 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 				}
 
 				publishRequest := func() {
+					// A request published into a mesh that has not formed yet reaches nobody,
+					// and the publish still returns nil. Hold it back instead: the walk is
+					// re-driven by every inbound payload, so the retry costs nothing and does
+					// not consume the cooldown window.
+					if len(s.p2pNode.GossipOut().AllBlockTopicsPeers()) == 0 {
+						log.Info(
+							"No gossip peers yet, holding back preconfirmation block request",
+							"blockID", parentNum,
+							"hash", currentPayload.Payload.ParentHash.Hex(),
+						)
+						return
+					}
+
 					log.Info(
 						"Publishing preconfirmation block request",
 						"blockID", parentNum,
@@ -807,9 +846,12 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 							"hash", currentPayload.Payload.BlockHash.Hex(),
 							"error", err,
 						)
-					} else {
-						s.blockRequestsCache.Add(currentPayload.Payload.ParentHash, struct{}{})
+						return
 					}
+
+					// A nil error only means the message reached the gossipsub router, so this
+					// suppresses the request for one cooldown window rather than for good.
+					s.blockRequests.markPublished(currentPayload.Payload.ParentHash, time.Now())
 				}
 
 				tip := progress.HighestOriginBlockID.Uint64()
@@ -835,7 +877,7 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 		payloadsToImport = append([]*preconf.Envelope{
 			parentPayload,
 		}, payloadsToImport...)
-		s.blockRequestsCache.Remove(parentPayload.Payload.BlockHash)
+		s.blockRequests.markAnswered(parentPayload.Payload.BlockHash)
 
 		// Check if the found parent payload is in the canonical chain,
 		// if it is not, continue to find the parent payload.
@@ -912,7 +954,7 @@ func (s *PreconfBlockAPIServer) ImportChildBlocksFromCache(
 		return fmt.Errorf("failed to insert child preconfirmation blocks from cache: %w", err)
 	}
 
-	s.updateHighestUnsafeL2Payload(endBlockID)
+	s.updateHighestImportedL2Payload(endBlockID)
 
 	metrics.DriverImportedPreconBlocksFromCacheCounter.Add(float64(len(childPayloads)))
 
@@ -1252,25 +1294,30 @@ func (s *PreconfBlockAPIServer) recordLatestSeenProposal(proposal *encoding.Last
 		metrics.DriverLastSeenBlockInProposalGauge.Set(float64(proposal.LastBlockID))
 	}
 
-	// If the latest seen proposal is reorged, reset the highest unsafe L2 payload block ID.
+	// If the latest seen proposal is reorged, reset both payload block IDs. The seen counter
+	// must come back down with the imported one: a payload from the discarded branch would
+	// otherwise keep the node reporting itself behind a chain that no longer exists.
 	if s.latestSeenProposal.PreconfChainReorged {
-		s.highestUnsafeL2PayloadBlockID = proposal.LastBlockID
+		s.highestImportedL2PayloadBlockID.Store(proposal.LastBlockID)
+		s.highestSeenL2PayloadBlockID.Store(proposal.LastBlockID)
 		log.Info(
-			"Latest block ID seen in event is reorged, reset the highest unsafe L2 payload block ID",
+			"Latest block ID seen in event is reorged, reset the highest L2 payload block IDs",
 			"proposalId", proposal.Shasta().GetEventData().Id,
-			"highestUnsafeL2PayloadBlockID", s.highestUnsafeL2PayloadBlockID,
+			"highestImportedL2PayloadBlockID", proposal.LastBlockID,
+			"highestSeenL2PayloadBlockID", proposal.LastBlockID,
 		)
 
 		metrics.DriverReorgsByProposalCounter.Inc()
-	} else if proposal.LastBlockID > s.highestUnsafeL2PayloadBlockID {
-		// Always keep highestUnsafeL2PayloadBlockID in sync with the canonical chain tip.
+	} else if current := s.highestImportedL2PayloadBlockID.Load(); proposal.LastBlockID > current {
+		// Always keep the imported counter in sync with the canonical chain tip.
 		log.Info(
-			"Advancing highest unsafe L2 payload block ID to canonical tip",
+			"Advancing highest imported L2 payload block ID to canonical tip",
 			"proposalId", proposal.Shasta().GetEventData().Id,
-			"previousHighestUnsafeL2PayloadBlockID", s.highestUnsafeL2PayloadBlockID,
-			"newHighestUnsafeL2PayloadBlockID", proposal.LastBlockID,
+			"previousHighestImportedL2PayloadBlockID", current,
+			"newHighestImportedL2PayloadBlockID", proposal.LastBlockID,
 		)
-		s.highestUnsafeL2PayloadBlockID = proposal.LastBlockID
+		s.highestImportedL2PayloadBlockID.Store(proposal.LastBlockID)
+		s.updateHighestSeenL2Payload(proposal.LastBlockID)
 	}
 }
 
@@ -1435,14 +1482,14 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 		return false, fmt.Errorf("failed to insert preconfirmation block from P2P network: %w", err)
 	}
 
-	// If the block number is greater than the highest unsafe L2 payload block ID,
-	// update the highest unsafe L2 payload block ID.
-	if uint64(msg.ExecutionPayload.BlockNumber) > s.highestUnsafeL2PayloadBlockID {
-		s.updateHighestUnsafeL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
+	// If the block number is greater than the highest imported L2 payload block ID,
+	// update the highest imported L2 payload block ID.
+	if uint64(msg.ExecutionPayload.BlockNumber) > s.highestImportedL2PayloadBlockID.Load() {
+		s.updateHighestImportedL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
 	}
 
-	// If the block number is less than or equal to the highest unsafe L2 payload block ID,
-	// we also need to update the highest unsafe L2 payload block ID.
+	// A header already occupies this block number with a different hash -- the equal-hash case
+	// returned above -- so this payload reorgs the chain and the counter moves back down with it.
 	if header != nil && uint64(msg.ExecutionPayload.BlockNumber) <= header.Number.Uint64() {
 		log.Info(
 			"Preconfirmation block is reorging",
@@ -1452,7 +1499,7 @@ func (s *PreconfBlockAPIServer) TryImportingPayload(
 			"headerHash", header.Hash().Hex(),
 			"headerParentHash", header.ParentHash.Hex(),
 		)
-		s.updateHighestUnsafeL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
+		s.updateHighestImportedL2Payload(uint64(msg.ExecutionPayload.BlockNumber))
 	}
 
 	// Try to import the child blocks from the cache, if any.
@@ -1473,23 +1520,52 @@ func envelopeFromMessage(msg *eth.ExecutionPayloadEnvelope) *preconf.Envelope {
 	}
 }
 
-// updateHighestUnsafeL2Payload updates the highest unsafe L2 payload block ID.
-func (s *PreconfBlockAPIServer) updateHighestUnsafeL2Payload(blockID uint64) {
-	if blockID > s.highestUnsafeL2PayloadBlockID {
+// updateHighestImportedL2Payload updates the highest imported L2 payload block ID.
+func (s *PreconfBlockAPIServer) updateHighestImportedL2Payload(blockID uint64) {
+	current := s.highestImportedL2PayloadBlockID.Load()
+	if blockID > current {
 		log.Info(
-			"Updating highest unsafe L2 payload block ID",
+			"Updating highest imported L2 payload block ID",
 			"blockID", blockID,
-			"currentHighestUnsafeL2PayloadBlockID", s.highestUnsafeL2PayloadBlockID,
+			"currentHighestImportedL2PayloadBlockID", current,
 		)
 	} else {
 		log.Info(
-			"Reorging highest unsafe L2 payload blockID",
+			"Reorging highest imported L2 payload blockID",
 			"blockID", blockID,
-			"currentHighestUnsafeL2PayloadBlockID", s.highestUnsafeL2PayloadBlockID,
+			"currentHighestImportedL2PayloadBlockID", current,
 		)
 	}
-	s.highestUnsafeL2PayloadBlockID = blockID
+	s.highestImportedL2PayloadBlockID.Store(blockID)
 	metrics.DriverHighestPreconfUnsafePayloadGauge.Set(float64(blockID))
+
+	// An imported block has by definition been seen.
+	s.updateHighestSeenL2Payload(blockID)
+}
+
+// updateHighestSeenL2Payload advances the highest seen L2 payload block ID, which tracks every
+// well-formed, signature-valid payload this node receives regardless of whether it could be
+// imported. It only ever moves forward; `recordLatestSeenProposal` moves it back on a reorg.
+//
+// The value is bounded where it is published, by `reportedHighestUnsafeL2Payload`, which has
+// the live execution head to bound it against. This counter is deliberately not bounded here:
+// the highest imported block is not the execution head -- blocks arriving through L1 derivation
+// advance the chain without touching it -- so it cannot supply a trustworthy ceiling.
+func (s *PreconfBlockAPIServer) updateHighestSeenL2Payload(blockID uint64) {
+	// Read-then-write rather than a compare-and-swap loop: every caller holds s.mutex, so no
+	// other writer can interleave here.
+	current := s.highestSeenL2PayloadBlockID.Load()
+	if blockID <= current {
+		return
+	}
+
+	s.highestSeenL2PayloadBlockID.Store(blockID)
+	log.Debug(
+		"Updating highest seen L2 payload block ID",
+		"blockID", blockID,
+		"previousHighestSeenL2PayloadBlockID", current,
+	)
+	metrics.DriverHighestPreconfSeenPayloadGauge.Set(float64(blockID))
 }
 
 // tryPutEnvelopeIntoCache tries to put the given payload into the cache, if it is not already cached.

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -308,38 +308,47 @@ func (s *PreconfBlockAPIServerTestSuite) TestReportedHighestUnsafeL2Payload() {
 	}
 }
 
-func (s *PreconfBlockAPIServerTestSuite) TestUpdateHighestSeenL2PayloadAnchorsAndReleases() {
-	s.s.highestImportedL2PayloadBlockID.Store(1000)
-	s.s.highestSeenL2PayloadBlockID.Store(1000)
+func (s *PreconfBlockAPIServerTestSuite) TestAnchorHighestSeenL2PayloadReleasesAsHeadAdvances() {
+	s.s.highestSeenL2PayloadBlockID.Store(1 << 40)
 
 	// A signature-valid payload carrying a wrong or hostile block number must not keep the node
 	// out of sync forever, or it keeps the preconfer client from ever starting.
-	s.s.updateHighestSeenL2Payload(1 << 40)
-
 	anchored := uint64(1000 + maxTrackedPayloads)
-	s.Equal(anchored, s.s.highestSeenL2PayloadBlockID.Load(), "anchored when recorded, not when reported")
+	s.Equal(anchored, s.s.anchorHighestSeenL2Payload(1000))
+	s.Equal(anchored, s.s.highestSeenL2PayloadBlockID.Load(), "the bound is written back, not just returned")
 	s.NotEqual(uint64(1000), reportedHighestUnsafeL2Payload(anchored, 1000), "still reads as behind for now")
 
-	// The anchor is a fixed height rather than one that tracks the head, so the chain catching up
-	// to it restores equality. Capping the reported value instead would return head+span forever.
+	// Pinned at a concrete height rather than one that tracks the head, so the chain catching up
+	// restores equality. Returning the bound without storing it would report head+span forever.
+	s.Equal(anchored, s.s.anchorHighestSeenL2Payload(anchored))
 	s.Equal(anchored, reportedHighestUnsafeL2Payload(anchored, anchored), "synced again")
-	s.Equal(anchored+10, reportedHighestUnsafeL2Payload(anchored, anchored+10))
 }
 
-func (s *PreconfBlockAPIServerTestSuite) TestUpdateHighestSeenL2PayloadKeepsDeepBacklogVisible() {
+func (s *PreconfBlockAPIServerTestSuite) TestAnchorHighestSeenL2PayloadIgnoresLaggingCounters() {
+	// Regression for the anchor being taken from a counter that trails the live execution head.
+	// After a beacon sync the chain advances by L1 derivation without touching highestImported,
+	// so anchoring on it would bound the seen counter far below the head; `/status` floors at the
+	// head, and the node would report parity while holding an unimported payload -- the incident.
 	s.s.highestImportedL2PayloadBlockID.Store(1000)
-	s.s.highestSeenL2PayloadBlockID.Store(1000)
+	s.s.highestSeenL2PayloadBlockID.Store(5001)
 
-	// The anchor must not turn a real backlog into a synced report: a node returning from long
+	const liveHead = uint64(5000)
+	reported := reportedHighestUnsafeL2Payload(s.s.anchorHighestSeenL2Payload(liveHead), liveHead)
+
+	s.Equal(uint64(5001), reported)
+	s.NotEqual(liveHead, reported, "a node holding an unimported payload must not read as synced")
+}
+
+func (s *PreconfBlockAPIServerTestSuite) TestAnchorHighestSeenL2PayloadKeepsDeepBacklogVisible() {
+	// The bound must not turn a real backlog into a synced report: a node returning from long
 	// downtime is behind by more than the cache can bridge, and still has to say so.
-	s.s.updateHighestSeenL2Payload(1000 + maxTrackedPayloads*4)
+	s.s.highestSeenL2PayloadBlockID.Store(1000 + maxTrackedPayloads*4)
 
-	seen := s.s.highestSeenL2PayloadBlockID.Load()
-	s.NotEqual(uint64(1000), reportedHighestUnsafeL2Payload(seen, 1000))
+	reported := reportedHighestUnsafeL2Payload(s.s.anchorHighestSeenL2Payload(1000), 1000)
+	s.NotEqual(uint64(1000), reported)
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestUpdateHighestSeenL2PayloadIsMonotonic() {
-	s.s.highestImportedL2PayloadBlockID.Store(100)
 	s.s.highestSeenL2PayloadBlockID.Store(100)
 
 	s.s.updateHighestSeenL2Payload(150)

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -2,7 +2,6 @@ package preconfblocks
 
 import (
 	"context"
-	"encoding/json"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -237,126 +236,51 @@ func (s *PreconfBlockAPIServerTestSuite) TestTryPutEnvelopeIntoCache() {
 	s.Equal(totalCached+1, s.s.envelopesCache.totalCached)
 }
 
-func (s *PreconfBlockAPIServerTestSuite) TestGetStatusReportsHighestSeen() {
-	head, err := s.s.rpc.L2.BlockNumber(context.Background())
-	s.Nil(err)
-
-	tests := []struct {
-		name             string
-		seen             uint64
-		imported         uint64
-		wantUnsafe       uint64
-		wantSyncedWithEE bool
-	}{
-		{
-			name: "in sync", seen: head, imported: head,
-			wantUnsafe: head, wantSyncedWithEE: true,
-		},
-		{
-			// The incident: a backlog of cached envelopes the node could not import. Reporting
-			// the imported head here is what let a stale node pass a preconfer client's parity
-			// check and sequence from a 156-block-stale head.
-			name: "behind the network", seen: head + 156, imported: head,
-			wantUnsafe: head + 156, wantSyncedWithEE: false,
-		},
-		{
-			// Right after a beacon sync the execution head can run ahead of anything seen over
-			// gossip. That is not a backlog, and must not be reported as one.
-			name: "ahead of gossip", seen: head / 2, imported: head,
-			wantUnsafe: head, wantSyncedWithEE: true,
-		},
-	}
-
-	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
-			s.s.highestSeenL2PayloadBlockID.Store(tt.seen)
-			s.s.highestImportedL2PayloadBlockID.Store(tt.imported)
-
-			rec := httptest.NewRecorder()
-			c := echo.New().NewContext(httptest.NewRequest(http.MethodGet, "/status", nil), rec)
-			s.Nil(s.s.GetStatus(c))
-			s.Equal(http.StatusOK, rec.Code)
-
-			var status Status
-			s.Nil(json.Unmarshal(rec.Body.Bytes(), &status))
-
-			s.Equal(tt.wantUnsafe, status.HighestUnsafeL2PayloadBlockID)
-			s.Equal(tt.imported, status.HighestImportedL2PayloadBlockID)
-			s.Equal(tt.wantSyncedWithEE, status.HighestUnsafeL2PayloadBlockID == head)
-		})
-	}
-}
-
 func (s *PreconfBlockAPIServerTestSuite) TestReportedHighestUnsafeL2Payload() {
 	tests := []struct {
-		name        string
-		highestSeen uint64
-		head        uint64
-		want        uint64
+		name          string
+		head          uint64
+		highestCached uint64
+		hasCached     bool
+		want          uint64
 	}{
-		{name: "in sync", highestSeen: 100, head: 100, want: 100},
-		{name: "behind the network", highestSeen: 256, head: 100, want: 256},
+		{name: "nothing cached", head: 100, hasCached: false, want: 100},
+		{name: "in sync", head: 100, highestCached: 100, hasCached: true, want: 100},
+		{name: "behind the network", head: 100, highestCached: 256, hasCached: true, want: 256},
 		// Right after a beacon sync the execution head runs ahead of anything seen over gossip.
 		// That is not a backlog, and reporting it as one would exit the preconfer client.
-		{name: "ahead of gossip", highestSeen: 40, head: 100, want: 100},
+		{name: "ahead of gossip", head: 100, highestCached: 40, hasCached: true, want: 100},
+		// The evidence is the cache itself, so an arbitrarily deep backlog stays visible however
+		// far the head advances -- there is no watermark for the head to overtake.
+		{name: "backlog far beyond one cache span", head: 1000, highestCached: 1 << 20, hasCached: true, want: 1 << 20},
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			s.Equal(tt.want, reportedHighestUnsafeL2Payload(tt.highestSeen, tt.head))
+			s.Equal(tt.want, reportedHighestUnsafeL2Payload(tt.head, tt.highestCached, tt.hasCached))
 		})
 	}
 }
 
-func (s *PreconfBlockAPIServerTestSuite) TestAnchorHighestSeenL2PayloadReleasesAsHeadAdvances() {
-	s.s.highestSeenL2PayloadBlockID.Store(1 << 40)
+func (s *PreconfBlockAPIServerTestSuite) TestDeepBacklogSurvivesTheHeadAdvancing() {
+	// Regression for bounding the report with a stored watermark. A cap written back at
+	// `head + span` reads correctly once, then reports parity as soon as the head reaches that
+	// artificial height -- while the original payload is still cached and unapplied.
+	const (
+		unimported = uint64(4000)
+		firstHead  = uint64(1000)
+	)
 
-	// A signature-valid payload carrying a wrong or hostile block number must not keep the node
-	// out of sync forever, or it keeps the preconfer client from ever starting.
-	anchored := uint64(1000 + maxTrackedPayloads)
-	s.Equal(anchored, s.s.anchorHighestSeenL2Payload(1000))
-	s.Equal(anchored, s.s.highestSeenL2PayloadBlockID.Load(), "the bound is written back, not just returned")
-	s.NotEqual(uint64(1000), reportedHighestUnsafeL2Payload(anchored, 1000), "still reads as behind for now")
+	for _, head := range []uint64{firstHead, firstHead + maxTrackedPayloads, unimported - 1} {
+		s.Equal(
+			unimported,
+			reportedHighestUnsafeL2Payload(head, unimported, true),
+			"an unapplied payload stays visible at head %d", head,
+		)
+	}
 
-	// Pinned at a concrete height rather than one that tracks the head, so the chain catching up
-	// restores equality. Returning the bound without storing it would report head+span forever.
-	s.Equal(anchored, s.s.anchorHighestSeenL2Payload(anchored))
-	s.Equal(anchored, reportedHighestUnsafeL2Payload(anchored, anchored), "synced again")
-}
-
-func (s *PreconfBlockAPIServerTestSuite) TestAnchorHighestSeenL2PayloadIgnoresLaggingCounters() {
-	// Regression for the anchor being taken from a counter that trails the live execution head.
-	// After a beacon sync the chain advances by L1 derivation without touching highestImported,
-	// so anchoring on it would bound the seen counter far below the head; `/status` floors at the
-	// head, and the node would report parity while holding an unimported payload -- the incident.
-	s.s.highestImportedL2PayloadBlockID.Store(1000)
-	s.s.highestSeenL2PayloadBlockID.Store(5001)
-
-	const liveHead = uint64(5000)
-	reported := reportedHighestUnsafeL2Payload(s.s.anchorHighestSeenL2Payload(liveHead), liveHead)
-
-	s.Equal(uint64(5001), reported)
-	s.NotEqual(liveHead, reported, "a node holding an unimported payload must not read as synced")
-}
-
-func (s *PreconfBlockAPIServerTestSuite) TestAnchorHighestSeenL2PayloadKeepsDeepBacklogVisible() {
-	// The bound must not turn a real backlog into a synced report: a node returning from long
-	// downtime is behind by more than the cache can bridge, and still has to say so.
-	s.s.highestSeenL2PayloadBlockID.Store(1000 + maxTrackedPayloads*4)
-
-	reported := reportedHighestUnsafeL2Payload(s.s.anchorHighestSeenL2Payload(1000), 1000)
-	s.NotEqual(uint64(1000), reported)
-}
-
-func (s *PreconfBlockAPIServerTestSuite) TestUpdateHighestSeenL2PayloadIsMonotonic() {
-	s.s.highestSeenL2PayloadBlockID.Store(100)
-
-	s.s.updateHighestSeenL2Payload(150)
-	s.Equal(uint64(150), s.s.highestSeenL2PayloadBlockID.Load())
-
-	// A late or out-of-order envelope never drags it back; only a proposal reorg does.
-	s.s.updateHighestSeenL2Payload(120)
-	s.Equal(uint64(150), s.s.highestSeenL2PayloadBlockID.Load())
+	// Only the chain actually reaching it clears the backlog.
+	s.Equal(unimported, reportedHighestUnsafeL2Payload(unimported, unimported, true))
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestShutdown() {

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -2,6 +2,7 @@ package preconfblocks
 
 import (
 	"context"
+	"encoding/json"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -234,6 +235,92 @@ func (s *PreconfBlockAPIServerTestSuite) TestTryPutEnvelopeIntoCache() {
 
 	s.s.tryPutEnvelopeIntoCache(msg, *peerID)
 	s.Equal(totalCached+1, s.s.envelopesCache.totalCached)
+}
+
+func (s *PreconfBlockAPIServerTestSuite) TestGetStatusReportsHighestSeen() {
+	head, err := s.s.rpc.L2.BlockNumber(context.Background())
+	s.Nil(err)
+
+	tests := []struct {
+		name             string
+		seen             uint64
+		imported         uint64
+		wantUnsafe       uint64
+		wantSyncedWithEE bool
+	}{
+		{
+			name: "in sync", seen: head, imported: head,
+			wantUnsafe: head, wantSyncedWithEE: true,
+		},
+		{
+			// The incident: a backlog of cached envelopes the node could not import. Reporting
+			// the imported head here is what let a stale node pass a preconfer client's parity
+			// check and sequence from a 156-block-stale head.
+			name: "behind the network", seen: head + 156, imported: head,
+			wantUnsafe: head + 156, wantSyncedWithEE: false,
+		},
+		{
+			// Right after a beacon sync the execution head can run ahead of anything seen over
+			// gossip. That is not a backlog, and must not be reported as one.
+			name: "ahead of gossip", seen: head / 2, imported: head,
+			wantUnsafe: head, wantSyncedWithEE: true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			s.s.highestSeenL2PayloadBlockID.Store(tt.seen)
+			s.s.highestImportedL2PayloadBlockID.Store(tt.imported)
+
+			rec := httptest.NewRecorder()
+			c := echo.New().NewContext(httptest.NewRequest(http.MethodGet, "/status", nil), rec)
+			s.Nil(s.s.GetStatus(c))
+			s.Equal(http.StatusOK, rec.Code)
+
+			var status Status
+			s.Nil(json.Unmarshal(rec.Body.Bytes(), &status))
+
+			s.Equal(tt.wantUnsafe, status.HighestUnsafeL2PayloadBlockID)
+			s.Equal(tt.imported, status.HighestImportedL2PayloadBlockID)
+			s.Equal(tt.wantSyncedWithEE, status.HighestUnsafeL2PayloadBlockID == head)
+		})
+	}
+}
+
+func (s *PreconfBlockAPIServerTestSuite) TestReportedHighestUnsafeL2Payload() {
+	tests := []struct {
+		name        string
+		highestSeen uint64
+		head        uint64
+		want        uint64
+	}{
+		{name: "in sync", highestSeen: 100, head: 100, want: 100},
+		{name: "behind the network", highestSeen: 256, head: 100, want: 256},
+		// Right after a beacon sync the execution head runs ahead of anything seen over gossip.
+		// That is not a backlog, and reporting it as one would exit the preconfer client.
+		{name: "ahead of gossip", highestSeen: 40, head: 100, want: 100},
+		// A payload further ahead than the envelope cache can bridge would otherwise keep the
+		// node reporting itself out of sync forever.
+		{name: "runaway block number", highestSeen: 1 << 40, head: 100, want: 100 + maxTrackedPayloads},
+		{name: "exactly at the cap", highestSeen: 100 + maxTrackedPayloads, head: 100, want: 100 + maxTrackedPayloads},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			s.Equal(tt.want, reportedHighestUnsafeL2Payload(tt.highestSeen, tt.head))
+		})
+	}
+}
+
+func (s *PreconfBlockAPIServerTestSuite) TestUpdateHighestSeenL2PayloadIsMonotonic() {
+	s.s.highestSeenL2PayloadBlockID.Store(100)
+
+	s.s.updateHighestSeenL2Payload(150)
+	s.Equal(uint64(150), s.s.highestSeenL2PayloadBlockID.Load())
+
+	// A late or out-of-order envelope never drags it back; only a proposal reorg does.
+	s.s.updateHighestSeenL2Payload(120)
+	s.Equal(uint64(150), s.s.highestSeenL2PayloadBlockID.Load())
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestShutdown() {

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -299,10 +299,6 @@ func (s *PreconfBlockAPIServerTestSuite) TestReportedHighestUnsafeL2Payload() {
 		// Right after a beacon sync the execution head runs ahead of anything seen over gossip.
 		// That is not a backlog, and reporting it as one would exit the preconfer client.
 		{name: "ahead of gossip", highestSeen: 40, head: 100, want: 100},
-		// A payload further ahead than the envelope cache can bridge would otherwise keep the
-		// node reporting itself out of sync forever.
-		{name: "runaway block number", highestSeen: 1 << 40, head: 100, want: 100 + maxTrackedPayloads},
-		{name: "exactly at the cap", highestSeen: 100 + maxTrackedPayloads, head: 100, want: 100 + maxTrackedPayloads},
 	}
 
 	for _, tt := range tests {
@@ -312,7 +308,38 @@ func (s *PreconfBlockAPIServerTestSuite) TestReportedHighestUnsafeL2Payload() {
 	}
 }
 
+func (s *PreconfBlockAPIServerTestSuite) TestUpdateHighestSeenL2PayloadAnchorsAndReleases() {
+	s.s.highestImportedL2PayloadBlockID.Store(1000)
+	s.s.highestSeenL2PayloadBlockID.Store(1000)
+
+	// A signature-valid payload carrying a wrong or hostile block number must not keep the node
+	// out of sync forever, or it keeps the preconfer client from ever starting.
+	s.s.updateHighestSeenL2Payload(1 << 40)
+
+	anchored := uint64(1000 + maxTrackedPayloads)
+	s.Equal(anchored, s.s.highestSeenL2PayloadBlockID.Load(), "anchored when recorded, not when reported")
+	s.NotEqual(uint64(1000), reportedHighestUnsafeL2Payload(anchored, 1000), "still reads as behind for now")
+
+	// The anchor is a fixed height rather than one that tracks the head, so the chain catching up
+	// to it restores equality. Capping the reported value instead would return head+span forever.
+	s.Equal(anchored, reportedHighestUnsafeL2Payload(anchored, anchored), "synced again")
+	s.Equal(anchored+10, reportedHighestUnsafeL2Payload(anchored, anchored+10))
+}
+
+func (s *PreconfBlockAPIServerTestSuite) TestUpdateHighestSeenL2PayloadKeepsDeepBacklogVisible() {
+	s.s.highestImportedL2PayloadBlockID.Store(1000)
+	s.s.highestSeenL2PayloadBlockID.Store(1000)
+
+	// The anchor must not turn a real backlog into a synced report: a node returning from long
+	// downtime is behind by more than the cache can bridge, and still has to say so.
+	s.s.updateHighestSeenL2Payload(1000 + maxTrackedPayloads*4)
+
+	seen := s.s.highestSeenL2PayloadBlockID.Load()
+	s.NotEqual(uint64(1000), reportedHighestUnsafeL2Payload(seen, 1000))
+}
+
 func (s *PreconfBlockAPIServerTestSuite) TestUpdateHighestSeenL2PayloadIsMonotonic() {
+	s.s.highestImportedL2PayloadBlockID.Store(100)
 	s.s.highestSeenL2PayloadBlockID.Store(100)
 
 	s.s.updateHighestSeenL2Payload(150)

--- a/packages/taiko-client/internal/metrics/metrics.go
+++ b/packages/taiko-client/internal/metrics/metrics.go
@@ -29,9 +29,14 @@ var (
 	DriverL1CurrentHeightGauge             = factory.NewGauge(prometheus.GaugeOpts{Name: "driver_l1Current_height"})
 	DriverL2HeadIDGauge                    = factory.NewGauge(prometheus.GaugeOpts{Name: "driver_l2Head_id"})
 	DriverHighestPreconfUnsafePayloadGauge = factory.NewGauge(prometheus.GaugeOpts{Name: "driver_highest_unsafe_payload"})
-	DriverReorgsByProposalCounter          = factory.NewCounter(prometheus.CounterOpts{Name: "driver_reorgs_by_proposal"})
-	DriverPreconfEnvelopeCounter           = factory.NewCounter(prometheus.CounterOpts{Name: "driver_p2p_envelope"})
-	DriverLastSeenBlockInProposalGauge     = factory.NewGauge(prometheus.GaugeOpts{
+	// DriverHighestPreconfSeenPayloadGauge tracks the highest preconfirmation block received from
+	// the P2P network, imported or not; driver_highest_unsafe_payload above tracks the highest one
+	// actually imported, its name predating the split. The gap between the two is the node's
+	// preconfirmation backlog.
+	DriverHighestPreconfSeenPayloadGauge = factory.NewGauge(prometheus.GaugeOpts{Name: "driver_highest_seen_payload"})
+	DriverReorgsByProposalCounter        = factory.NewCounter(prometheus.CounterOpts{Name: "driver_reorgs_by_proposal"})
+	DriverPreconfEnvelopeCounter         = factory.NewCounter(prometheus.CounterOpts{Name: "driver_p2p_envelope"})
+	DriverLastSeenBlockInProposalGauge   = factory.NewGauge(prometheus.GaugeOpts{
 		Name: "driver_last_seen_block_in_proposal",
 	})
 	DriverL2PreconfBlocksFromRPCGauge = factory.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
## What

On 2026-08-25 Taiko mainnet took a **156-block L2 reorg**. A node was evicted by the
infrastructure, restarted ~45 blocks behind, failed to backfill preconfirmation gossip, and
**kept reporting itself synced for 5 minutes 20 seconds**. Its preconfer client trusted that,
took over the epoch, and re-sequenced from the stale head.

This fixes the two driver-side causes. Either one alone would have prevented the reorg.

## Problem 1 (safety) — a lagging node could not say it was behind

`highestUnsafeL2PayloadBlockID` advanced only on a successful *import*. A node holding a
backlog of signature-valid envelopes it could not apply therefore reported a value equal to
its own stale execution head — and the preconfer client gates sequencing on **equality**
between those two values ([`pacaya/src/node/operator/mod.rs:389`][gate]), so it compared stale
against stale, matched, and proceeded. The one node in the network that knew it was behind had
thrown that knowledge away before anyone could read it.

The field's own doc comment already promised the right thing: *"the highest preconfirmation
block ID that the server **has received** from the P2P network"*. The implementation is what
diverged. So this fixes the implementation rather than the contract:

```
highestUnsafeL2PayloadBlockID   = max(highestSeen, liveL2Head)   # semantics corrected
highestImportedL2PayloadBlockID = <the old value>                # new, observability only
```

Raising to the head keeps a node whose execution head runs ahead of the gossip it has seen —
right after a beacon sync — from reporting a backlog it does not have. The preconfer client exits
the process after roughly half an L2 epoch of continuous mismatch, so a false "behind" is
expensive too.

**No consumer change is required.** The deployed preconfer client's existing equality check
starts failing closed the moment this ships.

The `max(..., liveL2Head)` floor is load-bearing in the other direction: right after a beacon
sync the execution head runs ahead of anything seen over gossip, and that must not read as a
backlog — the preconfer client exits the process after roughly half an L2 epoch of continuous
mismatch. A failed head read degrades to reporting `highestSeen` alone, i.e. toward fail-closed.

There is deliberately **no high-water counter**. The backlog is read from the envelope cache:
an envelope cached above the execution head is, by definition, one this node validated and did
not apply, so

```
highestUnsafeL2PayloadBlockID = max(liveHead, highestCachedBlockNumber)
```

A counter cannot answer this safely, and three attempts each broke a different way — bounding
the reported value made the ceiling track the head so it never returned to equality; bounding at
record time used an anchor that lags the head, pulling the counter *below* it; bounding at report
time with a write-back destroyed the evidence of a real backlog as soon as the head reached the
artificial height. Each is a write to a value that is supposed to *be* the evidence.

Reading the cache instead means nothing to reset on a reorg and nothing to bound against a
runaway block number: an arbitrarily deep backlog stays visible however far the head advances,
and a payload carrying a wrong or hostile block number ages out of the bounded cache on its own.

This only holds if a validated envelope reliably *reaches* the cache, so two paths were
tightened. Go now caches immediately after validation, before the sync-progress, L1-origin and
import RPCs — each of which returns early on a transient error that gossipsub will never
redeliver. The Rust importer no longer discards envelopes at or below the confirmed boundary
permanently: that boundary is read from local state and can be sitting on a branch the network
has abandoned, so admission and drain both defer and re-evaluate against a fresh reading.
`WLP-INV-003` is unchanged in substance — nothing at or below the boundary is ever inserted.

`highestSeen` advances for every well-formed, signature-valid payload the node **receives**,
imported or merely cached, at the single point where validation completes.

**No consumer change is required.** The deployed preconfer client's existing equality check
starts failing closed the moment this ships.

The `max(..., liveL2Head)` floor is load-bearing in the other direction: right after a beacon
sync the execution head runs ahead of anything seen over gossip, and that must not read as a
backlog — the preconfer client exits the process after roughly half an L2 epoch of continuous
mismatch. A failed head read degrades to reporting `highestSeen` alone, i.e. toward fail-closed.

The counter is also **anchored** one envelope-cache span (768) above the head — bounded where the
live head is known, with the bound **written back**. Both halves matter, and getting either wrong
reintroduces a bug:

- Bounding without storing leaves the raw height in the counter, so the report tracks
  `head + span` upwards and can never return to equality. One signature-valid payload carrying a
  wrong or hostile block number would keep the preconfer client from ever starting.
- Bounding against any counter maintained inside the driver is a **fail-open**. All of them can
  lag the live head — L1 derivation advances the chain without touching them, and a beacon sync
  opens a gap wider than one span before the next proposal event closes it. The bound then pulls
  the counter *below* the head, `/status` floors at the head, and a node holding an unimported
  backlog reports parity: the incident, at exactly the moment a node is most likely to be behind.

Anchored on the live head, the stored value is always `head + span`, strictly above the head, and
is a concrete height the chain can pass. Rejecting out-of-range heights outright would also fail
open — a node back from long downtime is legitimately behind by more than one span. Tests pin all
three directions, and the lagging-anchor case is mutation-verified: with the anchor taken from
the imported counter, the regression test reports the live head and fails.

Metrics: `driver_highest_unsafe_payload` keeps reporting the **imported** counter so existing
dashboards keep their meaning; the new `driver_highest_seen_payload` reports the seen counter,
with `whitelist_preconf_driver_highest_seen_block` as its Rust counterpart. **The gap between
seen and applied is a directly alertable measure of follower lag** — the signal that was
entirely absent during the incident.

## Problem 2 (liveness) — one dropped gossip message ended recovery permanently

Backfill de-duplication was an LRU with no TTL and no retry, keyed on `PublishL2Request`
returning `nil`. That publish is a bare gossipsub topic publish with no readiness option: it
returns `nil` as soon as the message reaches the router, with or without a single mesh peer.
`nil` carries no delivery information at all, yet it was used to suppress the request forever.
During the incident exactly one request out of six was never received by any peer, and the
backward walk stayed blocked at that height for 5m20s.

New `blockRequestTracker` (`block_requests.go`) with a **10s per-hash cooldown**, mirroring the
Rust driver's existing `RequestThrottle`, which already had this right. `shouldRequest` and
`markPublished` are deliberately separate so a caller that decides *not* to publish does not
burn the window. Only an answer retires a request for good.

Inbound payloads re-drive the walk every ~2s, which in the incident would have closed the
45-block gap in roughly 10s — about 3.5 minutes before the handover. But gossip is exactly what
an epoch boundary takes away: if the dropped request is the last one before end-of-sequencing,
the outgoing operator stops sequencing and the incoming one refuses to start while this node
reports itself behind, so nothing re-enters the walk and the expired cooldown is never
consulted. `RetryBackfillEventLoop` re-drives it on a 4s timer from `highestEnvelopeAbove(head)`, so the
same envelope both decides there is a backlog and gets retried — driving from the most recently
cached one instead lets the tick replay an already-applied block forever while the backlog above
it is never touched. Without that, a single dropped message
is still terminal until L1 derivation catches up.

The Rust driver's equivalent poll ran on an **L1-epoch** interval, with the first tick consumed —
so its first autonomous retry landed after the preconfer client had already cancelled and exited
(it gives up after half an L2 epoch). It now runs on the same 4s interval, with a test pinning it
an order of magnitude inside that budget.

## Problem 3 (hardening) — folded into the publish path

The failing publish went out on a **10-second-old mesh with fewer than 13 peers**. Requests are
now held back when the gossip topic has no peers, without consuming the cooldown window, so the
next walk retries immediately.

A time-based warm-up was considered and rejected: the failing publish was 10s after host start
and the mesh only reached 13 peers at +30s, so any warm-up short enough to avoid delaying
catch-up would not have helped, and any warm-up long enough to help would delay every restart.
A precise request-topic peer count would need a change to the `taikoxyz/optimism` fork;
`AllBlockTopicsPeers` is already on the `GossipOut` interface and, since Taiko does not use the
OP block topics, is effectively the preconf mesh size.

## Rust driver

`whitelist-preconfirmation-driver` had Problem 1 in a **stronger** form: `/status` reported the
live L2 execution head directly, making the preconfer client's equality gate a tautology. The
comment asserting that this "is always the honest answer" is exactly what the incident
falsified; it is replaced. Its Problem 2 was already correct and is untouched.

It also gains a reset when the **L1-confirmed tip moves backwards**. The tip is refreshed on the
retry tick as well as at ingress, because it was previously read only when an envelope arrived —
so a rewind during quiet gossip (a hand-over, or this node reporting itself behind and the
incoming operator declining to sequence) left the counter pinned to a height on the discarded
branch with nothing able to clear it. The reset is folded together with the seen-counter update
into a single `observe_envelope` call so the two cannot be ordered wrongly:
the reset lowers the counter unconditionally, so recording first would let a rewind erase the
very payload that arrived with it, and a node holding an unimported block would read as synced. This is the analogue of the
Go driver's reset on `PreconfChainReorged`, and without it this change would introduce a new
wedge: after an L2 rewind a stale seen-counter would pin the node out of sync until the new
branch grew past the discarded one, and the preconfer client exits well before that. Only a
backwards move resets — in steady state the seen counter runs *ahead* of the confirmed tip,
because preconfirmations outpace L1 confirmation by design. The reset targets the confirmed tip
rather than the local execution head on purpose: resetting to the head would let a genuinely
lagging node declare itself synced, which is the failure this whole change exists to prevent.

Two `SharedPreconfState` members are renamed (`reconcile_reported_head` → `reconcile_observed_head`,
`last_reported_l2_head` → `last_observed_l2_head`). After this change they no longer return what
`/status` reports, and sat next to a new method that does — two adjacent members using "reported"
in opposite senses.

Both drivers now ship the same `/status` semantics, so the preconfer client sees one contract.

## Testing

- `blockRequestTracker` unit tests: suppression inside the window, release after it, an answer
  clearing it, per-hash isolation, and that a skipped publish does not consume the window.
- `TestOnUnsafeL2PayloadWithMissingAncients` now asserts on `/status` at the exact point the
  node holds an unimportable backlog: reported ID must exceed the pinned execution head, and
  must meet it again once the backlog drains.
- `/status` contract test covering all three cases: in sync, behind, and ahead of gossip.
- Both clients: the anchor releases once the head catches up, and a backlog deeper than one
  cache span still reads as behind.
- The final recovery step of `TestOnUnsafeL2PayloadWithMissingAncients` runs with **zero**
  inbound payloads, driven only by the timed re-drive. The driver's own loop is not started in
  that suite, so the test exercises the mechanism rather than a background goroutine.
- Rust: an *advancing* confirmed tip does not reset the counter while a *rewinding* one does,
  and a rewind arriving with the first new-branch envelope does not erase it. Mutation-checked
  — swapping the two statements inside `observe_envelope`, and reverting the reporting helper to
  its old behaviour, each fail a test.

`PACKAGE=driver/... make test`: all packages `ok`, no failures. `cargo test -p
whitelist-preconfirmation-driver`: 151 passed. `golangci-lint`: 0 issues. `cargo +nightly fmt
--check` and `cargo clippy`: clean.

## Not in this PR

- **Integration test 2b** from the issue (restart a follower, gossip ~150 blocks, drop exactly
  one response, assert it still reaches the network head without an intervening L1 proposal).
  Needs a multi-node harness.
- **Range request primitive** (`[localHead+1, highestSeen]` in one message). Recovery is still
  O(gap) sequential single-block round trips. Needs a new gossip topic in the
  `taikoxyz/optimism` fork.
- The **end-of-sequencing marker** and **`canShutdownLocked`** items, filed separately.

[gate]: https://github.com/taikoxyz/Catalyst/blob/main/pacaya/src/node/operator/mod.rs

## Reviewed and deliberately not changed

- **Envelopes on a branch replaced at the same height stay cached**, so the node keeps reporting a
  backlog while they sit above the head. They are not garbage: gossip delivers competing branches
  in arbitrary order and a branch that loses at one height can win once more of it arrives —
  `TestGossipMessagesRandomReorgs` pins exactly that, and it fails if they are pruned. Reporting a
  backlog is also the honest answer, since the network may well be on that branch. It clears when
  the chain reaches them or the bounded cache evicts them.
- **The empty-mesh gate counts block-topic peers, not request-topic peers.** `AllBlockTopicsPeers`
  combines the OP block topics (which Taiko does not use) with `preconfBlocksV1`; every node joins
  all preconf topics together at startup, so it is a close proxy. An exact count needs a new method
  on `GossipTopicInfo` in the `taikoxyz/optimism` fork. The approximation can let a publish through
  to an empty request topic, which costs one cooldown window rather than the recovery.

## Also noticed, not changed

- `server.go` still has a branch whose condition is a tautology (`blockNumber <=
  header.Number.Uint64()` is always true when the header was fetched *by* that number). The
  misleading comment above it is corrected here; collapsing the branch is pre-existing cleanup.
- `RequestThrottle::should_request` re-tests a cooldown that `prune_expired` has just made
  unreachable. The Go equivalent is written without that dead guard; the Rust one is pre-existing
  and left alone.

## Verification gap

The Rust change to the staleness decision is verified by reading, not by test: `try_import_cached`
has no coverage, and the crate has no importer harness (it needs an `EventSyncer`, an RPC client
and a `BeaconClient`). A green `cargo test` says nothing about that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
