### PR TITLE
fix(taiko-client): fail closed during preconf catch-up

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -64,6 +64,10 @@ type preconfBlockChainSyncer interface {
 	InsertPreconfBlocksFromEnvelopes(context.Context, []*preconf.Envelope, bool) ([]*types.Header, error)
 }
 
+type gossipSubTopicPeerLister interface {
+	ListPeers(string) []peer.ID
+}
+
 // @title Taiko Preconfirmation Block Server API
 // @version 1.0
 // @termsOfService http://swagger.io/terms/
@@ -82,8 +86,9 @@ type PreconfBlockAPIServer struct {
 	anchorValidator               *validator.AnchorTxValidator
 	highestUnsafeL2PayloadBlockID uint64
 	// P2P network for preconfirmation block propagation
-	p2pNode   *p2p.NodeP2P
-	p2pSigner p2p.Signer
+	p2pNode             *p2p.NodeP2P
+	p2pSigner           p2p.Signer
+	gossipSubTopicPeers gossipSubTopicPeerLister
 	// WebSocket server for preconfirmation block notifications
 	ws *webSocketSever
 	// Lookahead information for the current and next operator
@@ -179,6 +184,7 @@ func New(
 // SetP2PNode sets the P2P node for the preconfirmation block server.
 func (s *PreconfBlockAPIServer) SetP2PNode(p2pNode *p2p.NodeP2P) {
 	s.p2pNode = p2pNode
+	s.gossipSubTopicPeers = p2pNode.GossipSub()
 }
 
 // SetP2PSigner sets the P2P signer for the preconfirmation block server.
@@ -783,6 +789,19 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 			// If the parent payload is not found in the cache and chain is not syncing,
 			// we publish a request to the P2P network.
 			if !s.blockRequestsCache.Contains(currentPayload.Payload.ParentHash) {
+				if !s.hasPreconfBlockRequestPeers() {
+					log.Info(
+						"No peers on preconfirmation block request topic, skip publishing L2Request",
+						"blockID", parentNum,
+						"hash", currentPayload.Payload.ParentHash.Hex(),
+					)
+					return fmt.Errorf(
+						"failed to find parent payload in the cache, number %d, hash %s",
+						currentPayload.Payload.BlockNumber-1,
+						currentPayload.Payload.ParentHash.Hex(),
+					)
+				}
+
 				progress, err := s.rpc.L2ExecutionEngineSyncProgress(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get L2 execution engine sync progress: %w", err)
@@ -881,6 +900,15 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 	metrics.DriverImportedPreconBlocksFromCacheCounter.Add(float64(len(payloadsToImport)))
 
 	return nil
+}
+
+func (s *PreconfBlockAPIServer) hasPreconfBlockRequestPeers() bool {
+	if s.gossipSubTopicPeers == nil || s.rpc == nil || s.rpc.L2 == nil || s.rpc.L2.ChainID == nil {
+		return false
+	}
+
+	topic := fmt.Sprintf("/taiko/%s/0/requestPreconfBlocks", s.rpc.L2.ChainID.String())
+	return len(s.gossipSubTopicPeers.ListPeers(topic)) > 0
 }
 
 // ImportChildBlocksFromCache tries to import the longest cached child envelopes from the cached payload queue.
@@ -1496,6 +1524,9 @@ func (s *PreconfBlockAPIServer) updateHighestUnsafeL2Payload(blockID uint64) {
 func (s *PreconfBlockAPIServer) tryPutEnvelopeIntoCache(msg *eth.ExecutionPayloadEnvelope, from peer.ID) {
 	id := uint64(msg.ExecutionPayload.BlockNumber)
 	h := msg.ExecutionPayload.BlockHash
+	if id > s.highestUnsafeL2PayloadBlockID {
+		s.updateHighestUnsafeL2Payload(id)
+	}
 	if s.envelopesCache.hasExact(id, h) {
 		return
 	}

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -2,6 +2,7 @@ package preconfblocks
 
 import (
 	"context"
+	"encoding/json"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -12,17 +13,29 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/preconf"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
 type PreconfBlockAPIServerTestSuite struct {
 	testutils.ClientTestSuite
 	s *PreconfBlockAPIServer
+}
+
+type stubTopicPeerLister struct {
+	peers     []peer.ID
+	lastTopic string
+}
+
+func (s *stubTopicPeerLister) ListPeers(topic string) []peer.ID {
+	s.lastTopic = topic
+	return s.peers
 }
 
 func (s *PreconfBlockAPIServerTestSuite) SetupTest() {
@@ -234,6 +247,89 @@ func (s *PreconfBlockAPIServerTestSuite) TestTryPutEnvelopeIntoCache() {
 
 	s.s.tryPutEnvelopeIntoCache(msg, *peerID)
 	s.Equal(totalCached+1, s.s.envelopesCache.totalCached)
+}
+
+func TestStatusReportsHighestCachedPayload(t *testing.T) {
+	const (
+		initialBlockID = uint64(100)
+		cachedBlockID  = uint64(101)
+	)
+	server := &PreconfBlockAPIServer{
+		echo:                          echo.New(),
+		rpc:                           new(rpc.Client),
+		envelopesCache:                newEnvelopeQueue(),
+		highestUnsafeL2PayloadBlockID: initialBlockID,
+	}
+	msg := &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(cachedBlockID),
+			BlockHash:   common.BytesToHash(testutils.RandomBytes(32)),
+		},
+	}
+
+	server.tryPutEnvelopeIntoCache(msg, peer.ID("remote"))
+	server.tryPutEnvelopeIntoCache(&eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: eth.Uint64Quantity(initialBlockID - 1),
+			BlockHash:   common.BytesToHash(testutils.RandomBytes(32)),
+		},
+	}, peer.ID("remote"))
+
+	recorder := httptest.NewRecorder()
+	ctx := server.echo.NewContext(httptest.NewRequest(http.MethodGet, "/status", nil), recorder)
+	if err := server.GetStatus(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var status Status
+	if err := json.Unmarshal(recorder.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.HighestUnsafeL2PayloadBlockID != cachedBlockID {
+		t.Fatalf("highest unsafe L2 payload block ID = %d, want %d", status.HighestUnsafeL2PayloadBlockID, cachedBlockID)
+	}
+}
+
+func TestImportMissingAncientsDoesNotConsumeRequestWithoutTopicPeers(t *testing.T) {
+	requests, err := lru.New[common.Hash, struct{}](maxTrackedPayloads)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentHash := common.HexToHash("0x1234")
+	topicPeers := new(stubTopicPeerLister)
+	server := &PreconfBlockAPIServer{
+		rpc:                 &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
+		envelopesCache:      newEnvelopeQueue(),
+		blockRequestsCache:  requests,
+		gossipSubTopicPeers: topicPeers,
+	}
+	payload := &preconf.Envelope{Payload: &eth.ExecutionPayload{
+		BlockNumber: eth.Uint64Quantity(2),
+		ParentHash:  parentHash,
+	}}
+
+	if err := server.ImportMissingAncientsFromCache(context.Background(), payload, nil); err == nil {
+		t.Fatal("expected missing parent error")
+	}
+	if requests.Contains(parentHash) {
+		t.Fatal("request without topic peers was added to the de-duplication cache")
+	}
+	if topicPeers.lastTopic != "/taiko/167/0/requestPreconfBlocks" {
+		t.Fatalf("request topic = %q, want %q", topicPeers.lastTopic, "/taiko/167/0/requestPreconfBlocks")
+	}
+}
+
+func TestHasPreconfBlockRequestPeers(t *testing.T) {
+	server := &PreconfBlockAPIServer{
+		rpc: &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
+		gossipSubTopicPeers: &stubTopicPeerLister{
+			peers: []peer.ID{"peer"},
+		},
+	}
+
+	if !server.hasPreconfBlockRequestPeers() {
+		t.Fatal("expected request topic with a connected peer to be ready")
+	}
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestShutdown() {


### PR DESCRIPTION
## Summary

- advance `highestUnsafeL2PayloadBlockID` when a validated preconfirmation envelope is cached, so `/status` reflects the highest payload known to the driver even before import
- skip missing-ancestor requests while the preconfirmation request topic has no connected peers, without consuming the request de-duplication entry
- keep the existing `/status` schema and Catalyst consumer unchanged

## Why

A restarted follower can receive and cache payloads above its execution-engine head while `highestUnsafeL2PayloadBlockID` remains pinned to that stale head. A consumer comparing those two stale values can incorrectly treat the node as synced and allow sequencing from the wrong parent.

This change makes the existing status check fail closed during that backlog. It also avoids issuing the one suppressed backfill request before the request-topic mesh has any peers.

## Scope

This fixes audit problems #1 and #3. It intentionally does not add timeout/backoff retries for a request published to an existing peer but never answered; that is audit problem #2 and should remain a separate change.

## Tests

- `go test -race ./packages/taiko-client/driver/preconf_blocks -run '^(TestCacheTestSuite|TestStatusReportsHighestCachedPayload|TestImportMissingAncientsDoesNotConsumeRequestWithoutTopicPeers|TestHasPreconfBlockRequestPeers)$' -count=1 -timeout=90s`
- `go vet ./packages/taiko-client/driver/preconf_blocks`
- `git diff --check`
