### PR TITLE
docs(protocol): correct and document the bridge's gas-schedule assumptions

### DIFF
--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -46,15 +46,18 @@ contract Bridge is EssentialResolverContract, IBridge {
     /// @dev The amount of gas not to charge fee per cache operation.
     uint256 private constant _GAS_REFUND_PER_CACHE_OPERATION = 20_000;
 
-    /// @dev Gas limit for sending Ether.
+    /// @dev Gas limit for sending Ether, used as the CALL gas operand — a callee-only budget (a
+    /// value-bearing CALL additionally grants the callee the unchanged 2,300 stipend). The
+    /// figures below are historical transaction-level measurements that include the 21k intrinsic
+    /// cost (an EOA callee consumes ~0 gas), so the callee-side margin is far larger than they
+    /// suggest. State-access repricing forks such as EIP-8038 raise mostly caller-side costs
+    /// (value-transfer account write, cold-recipient access) that are paid by this contract
+    /// before forwarding and do not draw on this budget, so no headroom bump is needed for them.
     // - EOA gas used is < 21000
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000
     // - For Gnosis Safe wallet, gas used is about 28000
-    // The cap only bounds recipient griefing; it must stay comfortably above the most expensive
-    // legitimate wallet receive path, including headroom for state-access repricing forks such as
-    // EIP-8038, which add thousands of gas to smart-wallet receive paths.
-    uint256 private constant _SEND_ETHER_GAS_LIMIT = 50_000;
+    uint256 private constant _SEND_ETHER_GAS_LIMIT = 35_000;
 
     /// @dev Place holder value when not using transient storage
     uint256 private constant _PLACEHOLDER = type(uint256).max;

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -51,7 +51,10 @@ contract Bridge is EssentialResolverContract, IBridge {
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000
     // - For Gnosis Safe wallet, gas used is about 28000
-    uint256 private constant _SEND_ETHER_GAS_LIMIT = 35_000;
+    // The cap only bounds recipient griefing; it must stay comfortably above the most expensive
+    // legitimate wallet receive path, including headroom for state-access repricing forks such as
+    // EIP-8038, which add thousands of gas to smart-wallet receive paths.
+    uint256 private constant _SEND_ETHER_GAS_LIMIT = 50_000;
 
     /// @dev Place holder value when not using transient storage
     uint256 private constant _PLACEHOLDER = type(uint256).max;
@@ -654,7 +657,9 @@ contract Bridge is EssentialResolverContract, IBridge {
         // + 32 bytes (offset to last bytes element of Message)
         // + 32 bytes (padded encoding of length of Message.data + dataLength
         //   (padded to 32 // bytes) = 13 * 32 + ((dataLength + 31) / 32 * 32).
-        // Non-zero calldata cost per byte is 16.
+        // Non-zero calldata cost per byte is 16. Calldata-dominated transactions can pay up to
+        // 40 gas per non-zero byte under the EIP-7623 floor, which this estimate ignores because
+        // processMessage transactions are execution-heavy.
         unchecked {
             return uint32(((dataLength + 31) / 32 * 32 + 416) << 4);
         }

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -658,8 +658,11 @@ contract Bridge is EssentialResolverContract, IBridge {
         // + 32 bytes (padded encoding of length of Message.data + dataLength
         //   (padded to 32 // bytes) = 13 * 32 + ((dataLength + 31) / 32 * 32).
         // Non-zero calldata cost per byte is 16. Calldata-dominated transactions can pay up to
-        // 40 gas per non-zero byte under the EIP-7623 floor, which this estimate ignores because
-        // processMessage transactions are execution-heavy.
+        // 40 gas per non-zero byte under the EIP-7623 floor. This estimate deliberately ignores
+        // the floor: processMessage transactions are usually execution-heavy, and an on-chain
+        // floor term would have to be derived from msg.data, which a contract relayer can pad
+        // almost for free to inflate its fee. Recalibrate the additive constants from
+        // MessageProcessed production stats instead.
         unchecked {
             return uint32(((dataLength + 31) / 32 * 32 + 416) << 4);
         }

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -321,11 +321,19 @@ contract Bridge is EssentialResolverContract, IBridge {
                     // - need to have a buffer/small revenue to the realyer since it consumes
                     // maintenance and infra costs to operate
                     uint256 refund = stats.numCacheOps * _GAS_REFUND_PER_CACHE_OPERATION;
-                    // Taking into account the encoded message calldata cost, and can count with 16
-                    // gas per bytes (vs. checking each and every byte if zero or non-zero)
+                    // The first max() operand is the standard-pricing estimate: measured execution
+                    // plus the message calldata at 16 gas per byte (vs. checking each and every
+                    // byte if zero or non-zero). The second is the EIP-7623 calldata floor, which
+                    // charges the whole transaction 21000 + 10 gas per token regardless of
+                    // execution, so a large proof combined with a light invocation undercuts the
+                    // standard estimate. It is mirrored here from this call's full calldata with
+                    // every byte priced as non-zero (4 tokens = 40 gas) — an upper bound that
+                    // needs no byte inspection and is exact for dense proof bytes — assuming the
+                    // relayer calls processMessage directly (msg.data then equals the transaction
+                    // calldata). No extra locals: processMessage sits at the stack-depth limit.
                     stats.gasUsedInFeeCalc = uint32(
-                        GAS_OVERHEAD + gasStart + _messageCalldataCost(_message.data.length)
-                            - gasleft()
+                        (GAS_OVERHEAD + gasStart + _messageCalldataCost(_message.data.length)
+                                - gasleft()).max(21_000 + msg.data.length * 40)
                     );
 
                     uint256 gasCharged = refund.max(stats.gasUsedInFeeCalc) - refund;
@@ -657,9 +665,9 @@ contract Bridge is EssentialResolverContract, IBridge {
         // + 32 bytes (offset to last bytes element of Message)
         // + 32 bytes (padded encoding of length of Message.data + dataLength
         //   (padded to 32 // bytes) = 13 * 32 + ((dataLength + 31) / 32 * 32).
-        // Non-zero calldata cost per byte is 16. Calldata-dominated transactions can pay up to
-        // 40 gas per non-zero byte under the EIP-7623 floor, which this estimate ignores because
-        // processMessage transactions are execution-heavy.
+        // Non-zero calldata cost per byte is 16 under standard EIP-7623 pricing; the calldata
+        // floor (up to 40 gas per non-zero byte) is handled at the fee-calculation site in
+        // processMessage, where the whole transaction's calldata size is known.
         unchecked {
             return uint32(((dataLength + 31) / 32 * 32 + 416) << 4);
         }

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -321,19 +321,11 @@ contract Bridge is EssentialResolverContract, IBridge {
                     // - need to have a buffer/small revenue to the realyer since it consumes
                     // maintenance and infra costs to operate
                     uint256 refund = stats.numCacheOps * _GAS_REFUND_PER_CACHE_OPERATION;
-                    // The first max() operand is the standard-pricing estimate: measured execution
-                    // plus the message calldata at 16 gas per byte (vs. checking each and every
-                    // byte if zero or non-zero). The second is the EIP-7623 calldata floor, which
-                    // charges the whole transaction 21000 + 10 gas per token regardless of
-                    // execution, so a large proof combined with a light invocation undercuts the
-                    // standard estimate. It is mirrored here from this call's full calldata with
-                    // every byte priced as non-zero (4 tokens = 40 gas) — an upper bound that
-                    // needs no byte inspection and is exact for dense proof bytes — assuming the
-                    // relayer calls processMessage directly (msg.data then equals the transaction
-                    // calldata). No extra locals: processMessage sits at the stack-depth limit.
+                    // Taking into account the encoded message calldata cost, and can count with 16
+                    // gas per bytes (vs. checking each and every byte if zero or non-zero)
                     stats.gasUsedInFeeCalc = uint32(
-                        (GAS_OVERHEAD + gasStart + _messageCalldataCost(_message.data.length)
-                                - gasleft()).max(21_000 + msg.data.length * 40)
+                        GAS_OVERHEAD + gasStart + _messageCalldataCost(_message.data.length)
+                            - gasleft()
                     );
 
                     uint256 gasCharged = refund.max(stats.gasUsedInFeeCalc) - refund;
@@ -665,9 +657,9 @@ contract Bridge is EssentialResolverContract, IBridge {
         // + 32 bytes (offset to last bytes element of Message)
         // + 32 bytes (padded encoding of length of Message.data + dataLength
         //   (padded to 32 // bytes) = 13 * 32 + ((dataLength + 31) / 32 * 32).
-        // Non-zero calldata cost per byte is 16 under standard EIP-7623 pricing; the calldata
-        // floor (up to 40 gas per non-zero byte) is handled at the fee-calculation site in
-        // processMessage, where the whole transaction's calldata size is known.
+        // Non-zero calldata cost per byte is 16. Calldata-dominated transactions can pay up to
+        // 40 gas per non-zero byte under the EIP-7623 floor, which this estimate ignores because
+        // processMessage transactions are execution-heavy.
         unchecked {
             return uint32(((dataLength + 31) / 32 * 32 + 416) << 4);
         }


### PR DESCRIPTION
## Summary

An audit of every gas-schedule assumption in `packages/protocol/contracts` against the Glamsterdam repricing candidates ([EIP-8038](https://eips.ethereum.org/EIPS/eip-8038) / [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) state-access repricing) plus the already-live [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) calldata floor (Pectra). Review of the two attempted code changes established that **neither is needed**, and the PR now ships the corrected documentation of the constraints — which is itself the durable value: the comments previously invited exactly the wrong "fixes".

Cross-check against the [ethereum/repricing-impact](https://ethereum.github.io/repricing-impact/affected-contracts.html?schedule=eip-8038) dataset: **no active Taiko L1 contract appears in the EIP-8038 "potentially broken" set** (all 188 addresses ever recorded in `deployments/mainnet-contract-logs-L1.md` verified against the per-address shards).

## What this PR ships

**1. `_SEND_ETHER_GAS_LIMIT` stays 35k; its comment now records the real semantics.** A 35k → 50k bump was attempted on the theory that EIP-8038 erodes the margin over Safe-style receive paths, and reverted after review established the theory conflated two measurement frames: the constant is the **CALL gas operand — a callee-only budget** (plus the unchanged 2,300 stipend on value-bearing calls), while the recorded wallet figures (EOA < 21k, Safe ≈ 28k) are **transaction-level** measurements including the 21k intrinsic cost — an EOA callee consumes ~0. EIP-8038's increases (value-transfer account write, cold-recipient access) are **caller-side** costs paid by the bridge before forwarding and do not draw on this budget; the callee-side delta for a Safe-style receive is roughly +400 (cold singleton access). Widening the cap would only have given an untrusted `destOwner` ~15k more gas to burn after `gasUsedInFeeCalc` is snapshotted. The comment now documents the callee-only semantics so the figures can't be misread again.

**2. The EIP-7623 floor stays out of the fee formula; its comment now records why.** A floor-aware estimate (`max(standard, 21000 + 40 × msg.data.length)`) was attempted and reverted after Codex review: `msg.data` describes the current call, not the outer transaction calldata the floor applies to, and since ABI decoding tolerates trailing bytes, a contract relayer can pad the inner calldata it builds in memory and inflate a `msg.data`-derived floor term almost for free, steering the fee toward the `message.fee` cap at the destination owner's expense. The measured-execution estimate has no such lever. The comment at `_messageCalldataCost` now records this constraint; the floor remains an off-chain recalibration item driven by `MessageProcessed` production stats.

## Assumption inventory (follow-up reference)

| # | Location | Assumption | Exposure | Action |
| --- | --- | --- | --- | --- |
| 1 | `Bridge._SEND_ETHER_GAS_LIMIT = 35_000` | callee-only CALL budget; wallet figures are tx-level | repricing raises mostly caller-side costs; callee-side delta ≈ +400 for Safe-style receive | none — documented; re-measure callee-only if a supported wallet ever approaches the cap |
| 2 | `Bridge._messageCalldataCost()` (16 gas/byte) | pre-EIP-7623 standard pricing | floor (40 gas/non-zero byte) binds when execution < 6 × calldata tokens — real for big-proof, light-invocation claims; relayer then under-compensated (bounded by simulation + `message.fee` cap) | recalibrate from `MessageProcessed` stats; an on-chain floor term is unsafe (see above) |
| 3 | `Bridge.GAS_OVERHEAD = 120_000` | intrinsic + typical proof calldata at today's prices | drifts with intrinsic/calldata/state repricing → relayer over/under-compensation (fee-capped) | recalibrate from `MessageProcessed` stats |
| 4 | `Bridge._GAS_REFUND_PER_CACHE_OPERATION = 20_000` | one fresh SSTORE ≈ 22.1k | fresh-slot cost ≈ unchanged under EIP-8038 (≈ 22k) | keep tied to "cost of one cache write" |
| 5 | `Bridge.GAS_RESERVE = 800_000` | bridge-side overhead around invocation | ≈ +5k per message under EIP-8038 | ample headroom; verify with production stats |
| 6 | `Anchor.ANCHOR_GAS_LIMIT = 1_000_000` (consensus constant) | anchor tx fits in 1M | ~10× headroom remains under EIP-8038-on-L2 | none; mirrored by taiko-client (Go) and taiko-client-rs (Rust) — any change ships in contracts and both clients simultaneously |
| 7 | 63/64 (EIP-150) math in `_checkForwardedGas` | EIP-150 unchanged | untouched by these EIPs | none |
| 8 | economic parameters (`MainnetInbox` config; relayer/SDK gas-limit defaults) | today's L1 cost basis | repricing shifts the cost basis | governance/ops recalibration |

The Shasta L1 `Inbox` contains **no** gas-schedule constants (hash-only ring-buffer storage; clients estimate gas dynamically), and `processMessage` fee accounting is self-measuring (`gasleft()` deltas) — only the additive constants above need retuning, not the mechanism.

## Validation (foundry v1.4.2 per `.tool-versions`)

- `FOUNDRY_PROFILE=shared forge test`: 154/154 pass; layer1 `forge build` clean; `forge fmt --check` clean
- Net diff: comments only — no behavior, storage, or bytecode-semantics change

Split out of #22057 (its sibling #22058 unifies L1/L2 on the transient-storage reentrancy guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xmvsjCrZyCJBVft82LjzJ