### PR TITLE
feat(taiko-client): only publish preconf block requests when the request topic has a peer

### DIFF
--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -902,6 +902,13 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 	return nil
 }
 
+// hasPreconfBlockRequestPeers reports whether any connected peer is subscribed to the
+// preconfirmation block request topic. Publishing to a topic nobody listens on still succeeds,
+// and would consume the `blockRequestsCache` slot for that parent hash, so the caller skips the
+// request instead of burning it on a message no one receives.
+//
+// The topic string mirrors `preconfBlocksRequestTopic` in the op-node fork, which does not
+// export it.
 func (s *PreconfBlockAPIServer) hasPreconfBlockRequestPeers() bool {
 	if s.gossipSubTopicPeers == nil || s.rpc == nil || s.rpc.L2 == nil || s.rpc.L2.ChainID == nil {
 		return false

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -64,6 +64,10 @@ type preconfBlockChainSyncer interface {
 	InsertPreconfBlocksFromEnvelopes(context.Context, []*preconf.Envelope, bool) ([]*types.Header, error)
 }
 
+type gossipSubTopicPeerLister interface {
+	ListPeers(string) []peer.ID
+}
+
 // @title Taiko Preconfirmation Block Server API
 // @version 1.0
 // @termsOfService http://swagger.io/terms/
@@ -82,8 +86,9 @@ type PreconfBlockAPIServer struct {
 	anchorValidator               *validator.AnchorTxValidator
 	highestUnsafeL2PayloadBlockID uint64
 	// P2P network for preconfirmation block propagation
-	p2pNode   *p2p.NodeP2P
-	p2pSigner p2p.Signer
+	p2pNode             *p2p.NodeP2P
+	p2pSigner           p2p.Signer
+	gossipSubTopicPeers gossipSubTopicPeerLister
 	// WebSocket server for preconfirmation block notifications
 	ws *webSocketSever
 	// Lookahead information for the current and next operator
@@ -179,6 +184,7 @@ func New(
 // SetP2PNode sets the P2P node for the preconfirmation block server.
 func (s *PreconfBlockAPIServer) SetP2PNode(p2pNode *p2p.NodeP2P) {
 	s.p2pNode = p2pNode
+	s.gossipSubTopicPeers = p2pNode.GossipSub()
 }
 
 // SetP2PSigner sets the P2P signer for the preconfirmation block server.
@@ -783,6 +789,19 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 			// If the parent payload is not found in the cache and chain is not syncing,
 			// we publish a request to the P2P network.
 			if !s.blockRequestsCache.Contains(currentPayload.Payload.ParentHash) {
+				if !s.hasPreconfBlockRequestPeers() {
+					log.Info(
+						"No peers on preconfirmation block request topic, skip publishing L2Request",
+						"blockID", parentNum,
+						"hash", currentPayload.Payload.ParentHash.Hex(),
+					)
+					return fmt.Errorf(
+						"failed to find parent payload in the cache, number %d, hash %s",
+						currentPayload.Payload.BlockNumber-1,
+						currentPayload.Payload.ParentHash.Hex(),
+					)
+				}
+
 				progress, err := s.rpc.L2ExecutionEngineSyncProgress(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get L2 execution engine sync progress: %w", err)
@@ -881,6 +900,15 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 	metrics.DriverImportedPreconBlocksFromCacheCounter.Add(float64(len(payloadsToImport)))
 
 	return nil
+}
+
+func (s *PreconfBlockAPIServer) hasPreconfBlockRequestPeers() bool {
+	if s.gossipSubTopicPeers == nil || s.rpc == nil || s.rpc.L2 == nil || s.rpc.L2.ChainID == nil {
+		return false
+	}
+
+	topic := fmt.Sprintf("/taiko/%s/0/requestPreconfBlocks", s.rpc.L2.ChainID.String())
+	return len(s.gossipSubTopicPeers.ListPeers(topic)) > 0
 }
 
 // ImportChildBlocksFromCache tries to import the longest cached child envelopes from the cached payload queue.

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -45,12 +45,7 @@ var (
 	wsUpgrader                     = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 )
 
-const (
-	requestSyncMargin                         = uint64(128) // Margin for requesting sync, to avoid requesting very old blocks.
-	preconfBlockRequestPeerPollInterval       = 500 * time.Millisecond
-	preconfBlockRequestPeerReadinessWaitLimit = 12 * time.Second
-)
-
+const requestSyncMargin = uint64(128) // Margin for requesting sync, to avoid requesting very old blocks.
 // monitorLatestProposalOnChainInterval defines how often we reconcile the cached proposal with on-chain state.
 const monitorLatestProposalOnChainInterval = 10 * time.Second
 
@@ -794,12 +789,11 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 			// If the parent payload is not found in the cache and chain is not syncing,
 			// we publish a request to the P2P network.
 			if !s.blockRequestsCache.Contains(currentPayload.Payload.ParentHash) {
-				if !s.waitForPreconfBlockRequestPeers(ctx, preconfBlockRequestPeerReadinessWaitLimit) {
+				if !s.hasPreconfBlockRequestPeers() {
 					log.Info(
-						"Preconfirmation block request topic not ready, skip publishing L2Request",
+						"No peers on preconfirmation block request topic, skip publishing L2Request",
 						"blockID", parentNum,
 						"hash", currentPayload.Payload.ParentHash.Hex(),
-						"waitLimit", preconfBlockRequestPeerReadinessWaitLimit,
 					)
 					return fmt.Errorf(
 						"failed to find parent payload in the cache, number %d, hash %s",
@@ -915,31 +909,6 @@ func (s *PreconfBlockAPIServer) hasPreconfBlockRequestPeers() bool {
 
 	topic := fmt.Sprintf("/taiko/%s/0/requestPreconfBlocks", s.rpc.L2.ChainID.String())
 	return len(s.gossipSubTopicPeers.ListPeers(topic)) > 0
-}
-
-// waitForPreconfBlockRequestPeers waits for the request topic to gain a peer, up to the given limit.
-func (s *PreconfBlockAPIServer) waitForPreconfBlockRequestPeers(ctx context.Context, limit time.Duration) bool {
-	if s.hasPreconfBlockRequestPeers() {
-		return true
-	}
-
-	ticker := time.NewTicker(preconfBlockRequestPeerPollInterval)
-	defer ticker.Stop()
-	timer := time.NewTimer(limit)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return false
-		case <-timer.C:
-			return false
-		case <-ticker.C:
-			if s.hasPreconfBlockRequestPeers() {
-				return true
-			}
-		}
-	}
 }
 
 // ImportChildBlocksFromCache tries to import the longest cached child envelopes from the cached payload queue.

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -789,19 +789,6 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 			// If the parent payload is not found in the cache and chain is not syncing,
 			// we publish a request to the P2P network.
 			if !s.blockRequestsCache.Contains(currentPayload.Payload.ParentHash) {
-				if !s.hasPreconfBlockRequestPeers() {
-					log.Info(
-						"No peers on preconfirmation block request topic, skip publishing L2Request",
-						"blockID", parentNum,
-						"hash", currentPayload.Payload.ParentHash.Hex(),
-					)
-					return fmt.Errorf(
-						"failed to find parent payload in the cache, number %d, hash %s",
-						currentPayload.Payload.BlockNumber-1,
-						currentPayload.Payload.ParentHash.Hex(),
-					)
-				}
-
 				progress, err := s.rpc.L2ExecutionEngineSyncProgress(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get L2 execution engine sync progress: %w", err)
@@ -813,6 +800,17 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 				}
 
 				publishRequest := func() {
+					// Skipping here leaves `blockRequestsCache` untouched on purpose, so a later
+					// inbound payload can drive this walk again once a peer can answer.
+					if !s.hasPreconfBlockRequestPeers() {
+						log.Info(
+							"No peers on preconfirmation block request topic, skip publishing L2Request",
+							"blockID", parentNum,
+							"hash", currentPayload.Payload.ParentHash.Hex(),
+						)
+						return
+					}
+
 					log.Info(
 						"Publishing preconfirmation block request",
 						"blockID", parentNum,

--- a/packages/taiko-client/driver/preconf_blocks/server.go
+++ b/packages/taiko-client/driver/preconf_blocks/server.go
@@ -45,7 +45,12 @@ var (
 	wsUpgrader                     = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 )
 
-const requestSyncMargin = uint64(128) // Margin for requesting sync, to avoid requesting very old blocks.
+const (
+	requestSyncMargin                         = uint64(128) // Margin for requesting sync, to avoid requesting very old blocks.
+	preconfBlockRequestPeerPollInterval       = 500 * time.Millisecond
+	preconfBlockRequestPeerReadinessWaitLimit = 12 * time.Second
+)
+
 // monitorLatestProposalOnChainInterval defines how often we reconcile the cached proposal with on-chain state.
 const monitorLatestProposalOnChainInterval = 10 * time.Second
 
@@ -789,11 +794,12 @@ func (s *PreconfBlockAPIServer) ImportMissingAncientsFromCache(
 			// If the parent payload is not found in the cache and chain is not syncing,
 			// we publish a request to the P2P network.
 			if !s.blockRequestsCache.Contains(currentPayload.Payload.ParentHash) {
-				if !s.hasPreconfBlockRequestPeers() {
+				if !s.waitForPreconfBlockRequestPeers(ctx, preconfBlockRequestPeerReadinessWaitLimit) {
 					log.Info(
-						"No peers on preconfirmation block request topic, skip publishing L2Request",
+						"Preconfirmation block request topic not ready, skip publishing L2Request",
 						"blockID", parentNum,
 						"hash", currentPayload.Payload.ParentHash.Hex(),
+						"waitLimit", preconfBlockRequestPeerReadinessWaitLimit,
 					)
 					return fmt.Errorf(
 						"failed to find parent payload in the cache, number %d, hash %s",
@@ -909,6 +915,31 @@ func (s *PreconfBlockAPIServer) hasPreconfBlockRequestPeers() bool {
 
 	topic := fmt.Sprintf("/taiko/%s/0/requestPreconfBlocks", s.rpc.L2.ChainID.String())
 	return len(s.gossipSubTopicPeers.ListPeers(topic)) > 0
+}
+
+// waitForPreconfBlockRequestPeers waits for the request topic to gain a peer, up to the given limit.
+func (s *PreconfBlockAPIServer) waitForPreconfBlockRequestPeers(ctx context.Context, limit time.Duration) bool {
+	if s.hasPreconfBlockRequestPeers() {
+		return true
+	}
+
+	ticker := time.NewTicker(preconfBlockRequestPeerPollInterval)
+	defer ticker.Stop()
+	timer := time.NewTimer(limit)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-timer.C:
+			return false
+		case <-ticker.C:
+			if s.hasPreconfBlockRequestPeers() {
+				return true
+			}
+		}
+	}
 }
 
 // ImportChildBlocksFromCache tries to import the longest cached child envelopes from the cached payload queue.

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -2,6 +2,8 @@ package preconfblocks
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +14,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/suite"
@@ -248,46 +249,49 @@ func (s *PreconfBlockAPIServerTestSuite) TestTryPutEnvelopeIntoCache() {
 	s.Equal(totalCached+1, s.s.envelopesCache.totalCached)
 }
 
-func TestImportMissingAncientsDoesNotConsumeRequestWithoutTopicPeers(t *testing.T) {
-	requests, err := lru.New[common.Hash, struct{}](maxTrackedPayloads)
-	if err != nil {
-		t.Fatal(err)
-	}
+func (s *PreconfBlockAPIServerTestSuite) TestImportMissingAncientsSkipsRequestWithoutTopicPeers() {
+	topicPeers := new(stubTopicPeerLister) // Nobody is subscribed to the request topic.
+	s.s.gossipSubTopicPeers = topicPeers
+
+	progress, err := s.RPCClient.L2ExecutionEngineSyncProgress(context.Background())
+	s.Nil(err)
+	s.False(progress.IsSyncing())
+
+	// Sit above the sync tip, so the very-old-block skip does not apply and the walk
+	// actually reaches the publish path.
+	tip := progress.HighestOriginBlockID.Uint64()
+	s.Less(tip, math.MaxUint64-requestSyncMargin-1)
+
 	parentHash := common.HexToHash("0x1234")
-	topicPeers := new(stubTopicPeerLister)
-	server := &PreconfBlockAPIServer{
-		rpc:                 &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
-		envelopesCache:      newEnvelopeQueue(),
-		blockRequestsCache:  requests,
-		gossipSubTopicPeers: topicPeers,
-	}
-	payload := &preconf.Envelope{Payload: &eth.ExecutionPayload{
-		BlockNumber: eth.Uint64Quantity(2),
+	envelope := &preconf.Envelope{Payload: &eth.ExecutionPayload{
+		BlockNumber: eth.Uint64Quantity(tip + requestSyncMargin + 1),
 		ParentHash:  parentHash,
 	}}
 
-	if err := server.ImportMissingAncientsFromCache(context.Background(), payload, nil); err == nil {
-		t.Fatal("expected missing parent error")
-	}
-	if requests.Contains(parentHash) {
-		t.Fatal("request without topic peers was added to the de-duplication cache")
-	}
-	if topicPeers.lastTopic != "/taiko/167/0/requestPreconfBlocks" {
-		t.Fatalf("request topic = %q, want %q", topicPeers.lastTopic, "/taiko/167/0/requestPreconfBlocks")
-	}
+	s.NotNil(s.s.ImportMissingAncientsFromCache(context.Background(), envelope, nil))
+
+	// The publish was skipped, so the de-duplication slot must stay free: otherwise the
+	// `Contains` check would short-circuit every later payload asking for the same parent.
+	s.False(s.s.blockRequestsCache.Contains(parentHash))
+	s.Equal(s.requestTopic(), topicPeers.lastTopic)
 }
 
-func TestHasPreconfBlockRequestPeers(t *testing.T) {
-	server := &PreconfBlockAPIServer{
-		rpc: &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
-		gossipSubTopicPeers: &stubTopicPeerLister{
-			peers: []peer.ID{"peer"},
-		},
-	}
+func (s *PreconfBlockAPIServerTestSuite) TestHasPreconfBlockRequestPeers() {
+	s.s.gossipSubTopicPeers = nil
+	s.False(s.s.hasPreconfBlockRequestPeers())
 
-	if !server.hasPreconfBlockRequestPeers() {
-		t.Fatal("expected request topic with a connected peer to be ready")
-	}
+	s.s.gossipSubTopicPeers = new(stubTopicPeerLister)
+	s.False(s.s.hasPreconfBlockRequestPeers())
+
+	topicPeers := &stubTopicPeerLister{peers: []peer.ID{"peer"}}
+	s.s.gossipSubTopicPeers = topicPeers
+	s.True(s.s.hasPreconfBlockRequestPeers())
+	s.Equal(s.requestTopic(), topicPeers.lastTopic)
+}
+
+// requestTopic returns the preconfirmation block request topic for the test chain.
+func (s *PreconfBlockAPIServerTestSuite) requestTopic() string {
+	return fmt.Sprintf("/taiko/%s/0/requestPreconfBlocks", s.RPCClient.L2.ChainID.String())
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestShutdown() {

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -28,12 +28,18 @@ type PreconfBlockAPIServerTestSuite struct {
 }
 
 type stubTopicPeerLister struct {
-	peers     []peer.ID
-	lastTopic string
+	peers      []peer.ID
+	lastTopic  string
+	readyAfter int
+	listCalls  int
 }
 
 func (s *stubTopicPeerLister) ListPeers(topic string) []peer.ID {
 	s.lastTopic = topic
+	s.listCalls++
+	if s.readyAfter > 0 && s.listCalls >= s.readyAfter {
+		return []peer.ID{"peer"}
+	}
 	return s.peers
 }
 
@@ -266,7 +272,9 @@ func TestImportMissingAncientsDoesNotConsumeRequestWithoutTopicPeers(t *testing.
 		ParentHash:  parentHash,
 	}}
 
-	if err := server.ImportMissingAncientsFromCache(context.Background(), payload, nil); err == nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := server.ImportMissingAncientsFromCache(ctx, payload, nil); err == nil {
 		t.Fatal("expected missing parent error")
 	}
 	if requests.Contains(parentHash) {
@@ -274,6 +282,46 @@ func TestImportMissingAncientsDoesNotConsumeRequestWithoutTopicPeers(t *testing.
 	}
 	if topicPeers.lastTopic != "/taiko/167/0/requestPreconfBlocks" {
 		t.Fatalf("request topic = %q, want %q", topicPeers.lastTopic, "/taiko/167/0/requestPreconfBlocks")
+	}
+}
+
+func TestWaitForPreconfBlockRequestPeersRetriesUntilReady(t *testing.T) {
+	topicPeers := &stubTopicPeerLister{readyAfter: 2}
+	server := &PreconfBlockAPIServer{
+		rpc:                 &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
+		gossipSubTopicPeers: topicPeers,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !server.waitForPreconfBlockRequestPeers(ctx, 12*time.Second) {
+		t.Fatal("expected request topic to become ready during the wait")
+	}
+	if topicPeers.listCalls != 2 {
+		t.Fatalf("topic peer checks = %d, want 2", topicPeers.listCalls)
+	}
+}
+
+func TestWaitForPreconfBlockRequestPeersStopsWhenContextIsCanceled(t *testing.T) {
+	server := &PreconfBlockAPIServer{
+		rpc:                 &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
+		gossipSubTopicPeers: new(stubTopicPeerLister),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- server.waitForPreconfBlockRequestPeers(ctx, time.Second)
+	}()
+
+	select {
+	case ready := <-result:
+		if ready {
+			t.Fatal("expected canceled readiness wait to fail")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("readiness wait did not stop after context cancellation")
 	}
 }
 

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -28,18 +28,12 @@ type PreconfBlockAPIServerTestSuite struct {
 }
 
 type stubTopicPeerLister struct {
-	peers      []peer.ID
-	lastTopic  string
-	readyAfter int
-	listCalls  int
+	peers     []peer.ID
+	lastTopic string
 }
 
 func (s *stubTopicPeerLister) ListPeers(topic string) []peer.ID {
 	s.lastTopic = topic
-	s.listCalls++
-	if s.readyAfter > 0 && s.listCalls >= s.readyAfter {
-		return []peer.ID{"peer"}
-	}
 	return s.peers
 }
 
@@ -272,9 +266,7 @@ func TestImportMissingAncientsDoesNotConsumeRequestWithoutTopicPeers(t *testing.
 		ParentHash:  parentHash,
 	}}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-	if err := server.ImportMissingAncientsFromCache(ctx, payload, nil); err == nil {
+	if err := server.ImportMissingAncientsFromCache(context.Background(), payload, nil); err == nil {
 		t.Fatal("expected missing parent error")
 	}
 	if requests.Contains(parentHash) {
@@ -282,46 +274,6 @@ func TestImportMissingAncientsDoesNotConsumeRequestWithoutTopicPeers(t *testing.
 	}
 	if topicPeers.lastTopic != "/taiko/167/0/requestPreconfBlocks" {
 		t.Fatalf("request topic = %q, want %q", topicPeers.lastTopic, "/taiko/167/0/requestPreconfBlocks")
-	}
-}
-
-func TestWaitForPreconfBlockRequestPeersRetriesUntilReady(t *testing.T) {
-	topicPeers := &stubTopicPeerLister{readyAfter: 2}
-	server := &PreconfBlockAPIServer{
-		rpc:                 &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
-		gossipSubTopicPeers: topicPeers,
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if !server.waitForPreconfBlockRequestPeers(ctx, 12*time.Second) {
-		t.Fatal("expected request topic to become ready during the wait")
-	}
-	if topicPeers.listCalls != 2 {
-		t.Fatalf("topic peer checks = %d, want 2", topicPeers.listCalls)
-	}
-}
-
-func TestWaitForPreconfBlockRequestPeersStopsWhenContextIsCanceled(t *testing.T) {
-	server := &PreconfBlockAPIServer{
-		rpc:                 &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
-		gossipSubTopicPeers: new(stubTopicPeerLister),
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	result := make(chan bool, 1)
-	go func() {
-		result <- server.waitForPreconfBlockRequestPeers(ctx, time.Second)
-	}()
-
-	select {
-	case ready := <-result:
-		if ready {
-			t.Fatal("expected canceled readiness wait to fail")
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("readiness wait did not stop after context cancellation")
 	}
 }
 

--- a/packages/taiko-client/driver/preconf_blocks/server_test.go
+++ b/packages/taiko-client/driver/preconf_blocks/server_test.go
@@ -12,17 +12,29 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/internal/testutils"
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/preconf"
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
 type PreconfBlockAPIServerTestSuite struct {
 	testutils.ClientTestSuite
 	s *PreconfBlockAPIServer
+}
+
+type stubTopicPeerLister struct {
+	peers     []peer.ID
+	lastTopic string
+}
+
+func (s *stubTopicPeerLister) ListPeers(topic string) []peer.ID {
+	s.lastTopic = topic
+	return s.peers
 }
 
 func (s *PreconfBlockAPIServerTestSuite) SetupTest() {
@@ -234,6 +246,48 @@ func (s *PreconfBlockAPIServerTestSuite) TestTryPutEnvelopeIntoCache() {
 
 	s.s.tryPutEnvelopeIntoCache(msg, *peerID)
 	s.Equal(totalCached+1, s.s.envelopesCache.totalCached)
+}
+
+func TestImportMissingAncientsDoesNotConsumeRequestWithoutTopicPeers(t *testing.T) {
+	requests, err := lru.New[common.Hash, struct{}](maxTrackedPayloads)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentHash := common.HexToHash("0x1234")
+	topicPeers := new(stubTopicPeerLister)
+	server := &PreconfBlockAPIServer{
+		rpc:                 &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
+		envelopesCache:      newEnvelopeQueue(),
+		blockRequestsCache:  requests,
+		gossipSubTopicPeers: topicPeers,
+	}
+	payload := &preconf.Envelope{Payload: &eth.ExecutionPayload{
+		BlockNumber: eth.Uint64Quantity(2),
+		ParentHash:  parentHash,
+	}}
+
+	if err := server.ImportMissingAncientsFromCache(context.Background(), payload, nil); err == nil {
+		t.Fatal("expected missing parent error")
+	}
+	if requests.Contains(parentHash) {
+		t.Fatal("request without topic peers was added to the de-duplication cache")
+	}
+	if topicPeers.lastTopic != "/taiko/167/0/requestPreconfBlocks" {
+		t.Fatalf("request topic = %q, want %q", topicPeers.lastTopic, "/taiko/167/0/requestPreconfBlocks")
+	}
+}
+
+func TestHasPreconfBlockRequestPeers(t *testing.T) {
+	server := &PreconfBlockAPIServer{
+		rpc: &rpc.Client{L2: &rpc.EthClient{ChainID: big.NewInt(167)}},
+		gossipSubTopicPeers: &stubTopicPeerLister{
+			peers: []peer.ID{"peer"},
+		},
+	}
+
+	if !server.hasPreconfBlockRequestPeers() {
+		t.Fatal("expected request topic with a connected peer to be ready")
+	}
 }
 
 func (s *PreconfBlockAPIServerTestSuite) TestShutdown() {


### PR DESCRIPTION
## Summary

A missing-ancestor backfill request is published with `PublishL2Request`, and its parent hash is
then recorded in `blockRequestsCache` (a 768-entry LRU) so the same parent is not requested twice.
gossipsub's `Publish` is not gated on readiness here, so it returns `nil` even when nothing is
subscribed to the topic. A request sent while no peer is on
`/taiko/<l2ChainID>/0/requestPreconfBlocks` was therefore dropped on the floor *and* still consumed
the de-duplication slot: the node never asked for that parent again until the LRU entry aged out,
and sat behind the chain in the meantime.

- check `ListPeers` on the request topic before publishing, and skip the publish when no connected
  peer is subscribed to it
- leave the skipped request out of `blockRequestsCache`, so the next inbound payload drives the
  ancestor walk again once a peer is actually there to answer it
- cover the zero-peer path, positive readiness, and chain-specific topic construction

### On the reverted commit

7a7f2115d added a 12s readiness wait that blocked in the handler until a peer showed up;
971cd8573 reverts it, leaving only the gate above.

The wait ran inside `OnUnsafeL2Payload`, which holds `s.mutex` for the whole handler — the same
mutex that guards `BuildPreconfBlock` (the sequencer's own `/preconfBlocks` entry point) and
`OnUnsafeL2Request` (serving other nodes' backfill). The ctx the gossip subscriber hands down comes
from `JoinGossip`'s `context.WithCancel(context.Background())` and is only cancelled on p2p
shutdown, so it never expires per message and the wait always burned the full 12s. Because a
timed-out request is deliberately not recorded in `blockRequestsCache`, every queued payload with a
missing parent paid it again, serialized. It converted "cannot backfill" into "cannot produce
blocks" precisely while peers were gone.

The gap it was meant to close — the tail payload of a burst, with no further message left to
re-drive the walk — closes on its own. A request is only useful once a peer appears, and a peer
that appears is gossiping preconf blocks, so the next inbound payload re-drives
`ImportMissingAncientsFromCache` within about one block time.

## Testing

- PASS: `PACKAGE=driver/preconf_blocks make test` — 4 suites, 0 failures, coverage 23.6%
- PASS: `go test -race ./packages/taiko-client/driver/preconf_blocks -run 'TestImportMissingAncients|TestHasPreconfBlockRequestPeers'`
- PASS: `go vet ./packages/taiko-client/driver/preconf_blocks`
- PASS: `gofmt -l packages/taiko-client/driver/preconf_blocks` (no output)
