### PR TITLE
feat(bridge-ui): offer a private relay when a claim's fee is contestable

### DIFF
--- a/packages/bridge-ui/src/app.config.ts
+++ b/packages/bridge-ui/src/app.config.ts
@@ -19,6 +19,7 @@ export const pendingTransaction = {
 export const storageService = {
   bridgeTxPrefix: 'transactions',
   customTokenPrefix: 'custom-tokens',
+  mevProtectionPrefix: 'mev-protection',
 };
 
 export const bridgeTransactionPoller = {

--- a/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseSteps/ReleasePreCheck.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseSteps/ReleasePreCheck.svelte
@@ -4,6 +4,7 @@
 
   import { ActionButton } from '$components/Button';
   import { Icon } from '$components/Icon';
+  import { MevProtectionNotice } from '$components/MevProtection';
   import type { BridgeTransaction } from '$libs/bridge';
   import { getChainName } from '$libs/chain';
   import { config } from '$libs/wagmi';
@@ -55,6 +56,9 @@
       </div>
     </div>
   </div>
+  {#if correctChain}
+    <MevProtectionNotice chainId={Number(tx.srcChainId)} />
+  {/if}
   {#if !canContinue && !correctChain}
     <div class="h-sep" />
     <div class="f-col space-y-[16px]">

--- a/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseSteps/ReleasePreCheck.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseSteps/ReleasePreCheck.svelte
@@ -4,7 +4,6 @@
 
   import { ActionButton } from '$components/Button';
   import { Icon } from '$components/Icon';
-  import { MevProtectionNotice } from '$components/MevProtection';
   import type { BridgeTransaction } from '$libs/bridge';
   import { getChainName } from '$libs/chain';
   import { config } from '$libs/wagmi';
@@ -56,9 +55,6 @@
       </div>
     </div>
   </div>
-  {#if correctChain}
-    <MevProtectionNotice chainId={Number(tx.srcChainId)} />
-  {/if}
   {#if !canContinue && !correctChain}
     <div class="h-sep" />
     <div class="f-col space-y-[16px]">

--- a/packages/bridge-ui/src/components/Dialogs/Shared/ClaimPreCheck.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/Shared/ClaimPreCheck.svelte
@@ -13,6 +13,7 @@
   import { claimConfig } from '$config';
   import { type BridgeTransaction } from '$libs/bridge';
   import { getChainName } from '$libs/chain';
+  import { isClaimFeeContestable } from '$libs/mev';
   import { shortenAddress } from '$libs/util/shortenAddress';
   import { config } from '$libs/wagmi';
   import { account } from '$stores/account';
@@ -183,7 +184,7 @@
       </div>
     {/if}
   </div>
-  {#if correctChain && !onlyDestOwnerCanClaimWarning}
+  {#if correctChain && tx.message && isClaimFeeContestable(tx.message)}
     <MevProtectionNotice chainId={Number(tx.destChainId)} />
   {/if}
   {#if !canContinue && !correctChain && !onlyDestOwnerCanClaimWarning}

--- a/packages/bridge-ui/src/components/Dialogs/Shared/ClaimPreCheck.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/Shared/ClaimPreCheck.svelte
@@ -7,6 +7,7 @@
   import Alert from '$components/Alert/Alert.svelte';
   import { ActionButton } from '$components/Button';
   import { Icon } from '$components/Icon';
+  import { MevProtectionNotice } from '$components/MevProtection';
   import Spinner from '$components/Spinner/Spinner.svelte';
   import { Tooltip } from '$components/Tooltip';
   import { claimConfig } from '$config';
@@ -182,6 +183,9 @@
       </div>
     {/if}
   </div>
+  {#if correctChain && !onlyDestOwnerCanClaimWarning}
+    <MevProtectionNotice chainId={Number(tx.destChainId)} />
+  {/if}
   {#if !canContinue && !correctChain && !onlyDestOwnerCanClaimWarning}
     <div class="h-sep" />
     <div class="f-col space-y-[16px]">

--- a/packages/bridge-ui/src/components/MevProtection/MevProtectionNotice.svelte
+++ b/packages/bridge-ui/src/components/MevProtection/MevProtectionNotice.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { t } from 'svelte-i18n';
+
+  import { Alert } from '$components/Alert';
+  import { ActionButton } from '$components/Button';
+  import { enablePrivateRpc, getPrivateRpc, hasEnabledPrivateRpc } from '$libs/mev';
+  import { getLogger } from '$libs/util/logger';
+
+  export let chainId: number;
+
+  const log = getLogger('MevProtectionNotice');
+
+  let enabling = false;
+  let accepted = false;
+  let failed = false;
+
+  $: privateRpc = getPrivateRpc(chainId);
+
+  $: alreadyEnabled = hasEnabledPrivateRpc(chainId);
+
+  const enable = async () => {
+    enabling = true;
+    failed = false;
+    try {
+      await enablePrivateRpc(chainId);
+      accepted = true;
+    } catch (err) {
+      // Wallets may refuse to add an endpoint, and the user may simply reject the prompt. Claiming
+      // still works over their own RPC, so this never blocks the flow.
+      log('could not enable the private relay', err);
+      failed = true;
+    } finally {
+      enabling = false;
+    }
+  };
+</script>
+
+{#if privateRpc && !alreadyEnabled && !accepted}
+  <div class="f-col space-y-[12px]">
+    <Alert type="warning" forceColumnFlow>
+      {$t('mev_protection.description', { values: { relay: privateRpc.name } })}
+      <a class="link" href={privateRpc.docsUrl} target="_blank" rel="noreferrer">
+        {$t('mev_protection.learn_more')}
+      </a>
+    </Alert>
+    {#if failed}
+      <Alert type="error">{$t('mev_protection.failed')}</Alert>
+    {/if}
+    <ActionButton onPopup priority="secondary" loading={enabling} disabled={enabling} on:click={enable}>
+      {$t('mev_protection.enable', { values: { relay: privateRpc.name } })}
+    </ActionButton>
+  </div>
+{/if}

--- a/packages/bridge-ui/src/components/MevProtection/index.ts
+++ b/packages/bridge-ui/src/components/MevProtection/index.ts
@@ -1,0 +1,1 @@
+export { default as MevProtectionNotice } from './MevProtectionNotice.svelte';

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -379,6 +379,12 @@
       "switching": "Switching network"
     }
   },
+  "mev_protection": {
+    "description": "Claiming is a public transaction. Anyone watching the mempool can copy it and take the processing fee, leaving you with a failed claim you still paid gas for. {relay} relays it straight to block builders instead, at no extra cost.",
+    "enable": "Protect claims with {relay}",
+    "failed": "Your wallet did not accept the endpoint. You can still claim, but the transaction will be public.",
+    "learn_more": "How this works"
+  },
   "nav": {
     "bridge": "Bridge",
     "explorer": "Explorer",

--- a/packages/bridge-ui/src/libs/error/errors.ts
+++ b/packages/bridge-ui/src/libs/error/errors.ts
@@ -171,3 +171,7 @@ export class ClientError extends Error {
 export class TransactionTimeoutError extends Error {
   name = 'TransactionTimeoutError';
 }
+
+export class UnsupportedPrivateRpcError extends Error {
+  name = 'UnsupportedPrivateRpcError';
+}

--- a/packages/bridge-ui/src/libs/mev/enablePrivateRpc.test.ts
+++ b/packages/bridge-ui/src/libs/mev/enablePrivateRpc.test.ts
@@ -1,0 +1,52 @@
+import { UnsupportedPrivateRpcError } from '$libs/error';
+import { getConnectedWallet } from '$libs/util/getConnectedWallet';
+
+import { enablePrivateRpc } from './enablePrivateRpc';
+import { hasEnabledPrivateRpc } from './privateRpcPreference';
+
+const mainnet = {
+  id: 1,
+  name: 'Ethereum',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: { default: { http: ['https://a-public-node.example'] } },
+};
+
+vi.mock('$libs/chain', () => ({ chains: [], chainIdToChain: () => mainnet }));
+vi.mock('$libs/wagmi', () => ({ config: {} }));
+vi.mock('$libs/util/getConnectedWallet');
+
+const addChain = vi.fn();
+
+describe('enablePrivateRpc', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    addChain.mockReset();
+    vi.mocked(getConnectedWallet).mockResolvedValue({ addChain } as never);
+  });
+
+  it('asks the wallet to point the chain at the private relay instead of a public node', async () => {
+    await enablePrivateRpc(1);
+
+    expect(addChain).toHaveBeenCalledWith({
+      chain: { ...mainnet, rpcUrls: { default: { http: ['https://rpc.flashbots.net?hint=hash'] } } },
+    });
+  });
+
+  it('remembers the choice once the wallet accepted it', async () => {
+    await enablePrivateRpc(1);
+
+    expect(hasEnabledPrivateRpc(1)).toBe(true);
+  });
+
+  it('does not remember the choice when the wallet rejects the prompt', async () => {
+    addChain.mockRejectedValueOnce(new Error('user rejected'));
+
+    await expect(enablePrivateRpc(1)).rejects.toThrow('user rejected');
+    expect(hasEnabledPrivateRpc(1)).toBe(false);
+  });
+
+  it('refuses to touch the wallet for a chain with no private relay', async () => {
+    await expect(enablePrivateRpc(167000)).rejects.toThrow(UnsupportedPrivateRpcError);
+    expect(addChain).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bridge-ui/src/libs/mev/enablePrivateRpc.ts
+++ b/packages/bridge-ui/src/libs/mev/enablePrivateRpc.ts
@@ -1,0 +1,32 @@
+import { chainIdToChain } from '$libs/chain';
+import { UnsupportedPrivateRpcError } from '$libs/error';
+import { getConnectedWallet } from '$libs/util/getConnectedWallet';
+import { getLogger } from '$libs/util/logger';
+
+import { getPrivateRpc } from './privateRpc';
+import { rememberEnabledPrivateRpc } from './privateRpcPreference';
+
+const log = getLogger('mev:enablePrivateRpc');
+
+/**
+ * Asks the connected wallet to point the chain at its private relay, so claims reach block builders
+ * without ever entering the public mempool. The wallet broadcasts the transaction, not this app, so
+ * this can only prompt: the user is free to reject it and claim over their own endpoint instead.
+ *
+ * @param chainId The chain the claim will be sent to
+ */
+export async function enablePrivateRpc(chainId: number): Promise<void> {
+  const privateRpc = getPrivateRpc(chainId);
+
+  if (!privateRpc) {
+    throw new UnsupportedPrivateRpcError(`no private relay is configured for chain ${chainId}`);
+  }
+
+  const chain = chainIdToChain(chainId);
+  const wallet = await getConnectedWallet();
+
+  await wallet.addChain({ chain: { ...chain, rpcUrls: { default: { http: [privateRpc.url] } } } });
+
+  rememberEnabledPrivateRpc(chainId);
+  log(`${privateRpc.name} enabled for chain ${chainId}`);
+}

--- a/packages/bridge-ui/src/libs/mev/index.ts
+++ b/packages/bridge-ui/src/libs/mev/index.ts
@@ -1,4 +1,5 @@
 export * from './enablePrivateRpc';
+export * from './isClaimFeeContestable';
 export * from './privateRpc';
 export * from './privateRpcPreference';
 export * from './types';

--- a/packages/bridge-ui/src/libs/mev/index.ts
+++ b/packages/bridge-ui/src/libs/mev/index.ts
@@ -1,0 +1,4 @@
+export * from './enablePrivateRpc';
+export * from './privateRpc';
+export * from './privateRpcPreference';
+export * from './types';

--- a/packages/bridge-ui/src/libs/mev/isClaimFeeContestable.test.ts
+++ b/packages/bridge-ui/src/libs/mev/isClaimFeeContestable.test.ts
@@ -1,0 +1,20 @@
+import type { Message } from '$libs/bridge';
+
+import { isClaimFeeContestable } from './isClaimFeeContestable';
+
+const message = (gasLimit: number, fee: bigint) => ({ gasLimit, fee }) as Message;
+
+describe('isClaimFeeContestable', () => {
+  it('is contestable when a fee is on offer and anyone may process the message', () => {
+    expect(isClaimFeeContestable(message(1_000_000, 100n))).toBe(true);
+  });
+
+  it('is not contestable with no fee: winning the race only spends gas on someone else behalf', () => {
+    expect(isClaimFeeContestable(message(1_000_000, 0n))).toBe(false);
+  });
+
+  it('is not contestable at gasLimit 0: the bridge lets only the destination owner process it', () => {
+    expect(isClaimFeeContestable(message(0, 0n))).toBe(false);
+    expect(isClaimFeeContestable(message(0, 100n))).toBe(false);
+  });
+});

--- a/packages/bridge-ui/src/libs/mev/isClaimFeeContestable.ts
+++ b/packages/bridge-ui/src/libs/mev/isClaimFeeContestable.ts
@@ -1,0 +1,17 @@
+import type { Message } from '$libs/bridge';
+
+/**
+ * Whether anyone other than the destination owner stands to gain by claiming this message first.
+ *
+ * The bridge only pays the processing fee to a third party when it lets one process the message at
+ * all — `gasLimit == 0` reverts with `B_PERMISSION_DENIED` for any sender but the destination owner
+ * — and when there is a fee to pay out. Outside those two conditions a race has no prize: claiming
+ * someone else's message delivers their funds and costs the sender gas, so nothing is worth hiding
+ * from the mempool.
+ *
+ * @param message The message about to be claimed
+ * @returns Whether the claim's processing fee can be taken by someone else
+ */
+export function isClaimFeeContestable(message: Message): boolean {
+  return message.gasLimit !== 0 && message.fee > 0n;
+}

--- a/packages/bridge-ui/src/libs/mev/privateRpc.test.ts
+++ b/packages/bridge-ui/src/libs/mev/privateRpc.test.ts
@@ -1,0 +1,16 @@
+import { getPrivateRpc } from './privateRpc';
+
+describe('getPrivateRpc', () => {
+  it('uses the maximum privacy hint on mainnet so searchers never see the claim calldata', () => {
+    expect(getPrivateRpc(1)?.url).toBe('https://rpc.flashbots.net?hint=hash');
+  });
+
+  it('covers sepolia so the flow can be exercised on a testnet', () => {
+    expect(getPrivateRpc(11155111)?.name).toBe('Flashbots Protect');
+  });
+
+  it('returns undefined for chains without a private relay', () => {
+    // Taiko Alethia: no private relay market exists for it, claims stay on the wallet's endpoint.
+    expect(getPrivateRpc(167000)).toBeUndefined();
+  });
+});

--- a/packages/bridge-ui/src/libs/mev/privateRpc.ts
+++ b/packages/bridge-ui/src/libs/mev/privateRpc.ts
@@ -1,0 +1,40 @@
+import type { PrivateRpc } from './types';
+
+/**
+ * Claiming is a permissionless call: `processMessage(message, proof)` pays the processing fee to
+ * whoever lands it first. Broadcasting a claim through the public mempool therefore hands anyone
+ * watching the exact calldata needed to take that fee, and the user is left with a reverted
+ * transaction they still paid gas for.
+ *
+ * Flashbots Protect relays transactions directly to block builders instead of gossiping them.
+ * `hint=hash` is its maximum privacy setting: MEV-Share searchers only ever see the transaction
+ * hash, never the message or the merkle proof. It takes no service fee, and it drops transactions
+ * that would revert, so a claim that loses the race costs nothing.
+ *
+ * @see https://docs.flashbots.net/flashbots-protect/settings-guide
+ */
+const privateRpcs: Record<number, PrivateRpc> = {
+  // Ethereum mainnet
+  1: {
+    name: 'Flashbots Protect',
+    url: 'https://rpc.flashbots.net?hint=hash',
+    docsUrl: 'https://docs.flashbots.net/flashbots-protect/overview',
+  },
+  // Sepolia
+  11155111: {
+    name: 'Flashbots Protect',
+    url: 'https://rpc-sepolia.flashbots.net',
+    docsUrl: 'https://docs.flashbots.net/flashbots-protect/overview',
+  },
+};
+
+/**
+ * Returns the private relay covering a chain, or undefined when none does. Only Ethereum has a
+ * private relay market today, so claims on Taiko keep using the wallet's own endpoint.
+ *
+ * @param chainId The chain the claim will be sent to
+ * @returns The relay to offer the user, or undefined when the chain has none
+ */
+export function getPrivateRpc(chainId: number): PrivateRpc | undefined {
+  return privateRpcs[chainId];
+}

--- a/packages/bridge-ui/src/libs/mev/privateRpcPreference.test.ts
+++ b/packages/bridge-ui/src/libs/mev/privateRpcPreference.test.ts
@@ -1,0 +1,18 @@
+import { hasEnabledPrivateRpc, rememberEnabledPrivateRpc } from './privateRpcPreference';
+
+describe('privateRpcPreference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not claim the relay is enabled before the user accepted it', () => {
+    expect(hasEnabledPrivateRpc(1)).toBe(false);
+  });
+
+  it('remembers the choice per chain', () => {
+    rememberEnabledPrivateRpc(1);
+
+    expect(hasEnabledPrivateRpc(1)).toBe(true);
+    expect(hasEnabledPrivateRpc(11155111)).toBe(false);
+  });
+});

--- a/packages/bridge-ui/src/libs/mev/privateRpcPreference.ts
+++ b/packages/bridge-ui/src/libs/mev/privateRpcPreference.ts
@@ -1,0 +1,22 @@
+import { storageService } from '$config';
+
+/**
+ * There is no reliable way to ask a wallet which endpoint it broadcasts through, so we remember
+ * that the user accepted the prompt and stop offering it again for that chain.
+ */
+const storageKey = (chainId: number) => `${storageService.mevProtectionPrefix}-${chainId}`;
+
+/**
+ * @param chainId The chain the claim will be sent to
+ * @returns Whether the user has already added this chain's private relay to their wallet
+ */
+export function hasEnabledPrivateRpc(chainId: number): boolean {
+  return globalThis.localStorage?.getItem(storageKey(chainId)) === 'true';
+}
+
+/**
+ * @param chainId The chain whose private relay the wallet just accepted
+ */
+export function rememberEnabledPrivateRpc(chainId: number): void {
+  globalThis.localStorage?.setItem(storageKey(chainId), 'true');
+}

--- a/packages/bridge-ui/src/libs/mev/types.ts
+++ b/packages/bridge-ui/src/libs/mev/types.ts
@@ -1,0 +1,8 @@
+export type PrivateRpc = {
+  /** Name of the relay, shown to the user before they add it to their wallet. */
+  name: string;
+  /** Endpoint that forwards transactions straight to block builders instead of the public mempool. */
+  url: string;
+  /** Where the user can read what they are opting into. */
+  docsUrl: string;
+};


### PR DESCRIPTION
## Problem

`processMessage(message, proof)` is permissionless and pays the processing fee to whoever lands it first. When a user claims manually, the transaction sitting in the public mempool carries everything a competitor needs — message plus merkle proof — to submit the same call and take the fee. The user's own transaction then reverts on the status check, so they lose the fee refund *and* pay gas for the failure.

This is narrower than it first looks. The bridge only pays a third party when both of these hold:

- **`gasLimit != 0`** — otherwise `processMessage` reverts with `B_PERMISSION_DENIED` for any sender but the destination owner. The UI's "only I can claim" checkbox sets exactly this.
- **`fee > 0`** — otherwise there is no prize. Claiming someone else's message delivers their funds and costs the sender gas.

So the exposed case is a user manually claiming a message that still carries a fee — typically because no relayer picked it up. `isClaimFeeContestable` encodes both conditions and the notice renders only then.

## Change

Offer Flashbots Protect from the claim pre-check, on the chains it covers. It relays transactions straight to block builders instead of gossiping them, takes no service fee, and drops transactions that would revert — so a claim that loses the race costs nothing. The endpoint pins `hint=hash`, its maximum privacy setting, so MEV-Share searchers only ever see the transaction hash and never the message or the proof.

Scope note: the wallet broadcasts the transaction, not this app, so the UI can only prompt — via `wallet_addEthereumChain`. The user is free to reject it and claim over their own endpoint; nothing in the flow is blocked either way. Wallets give no way to read back which endpoint they actually use, so an accepted prompt is remembered per chain to avoid asking again.

Only Ethereum has a private relay market today, so claims landing on Taiko are unaffected and keep using the wallet's own endpoint.

Not applied to the release step: `recallMessage` pays no one — it returns the message value to the source owner — so front-running a release buys nothing.

### Files

- `src/libs/mev/` — the relay table (`privateRpc.ts`), the wallet prompt (`enablePrivateRpc.ts`), the per-chain preference (`privateRpcPreference.ts`), and the contestability predicate (`isClaimFeeContestable.ts`), with unit tests.
- `src/components/MevProtection/MevProtectionNotice.svelte` — the opt-in card; renders nothing on chains with no relay, or once the user has accepted.
- `ClaimPreCheck.svelte` — renders the notice when the wallet is on the destination chain and the fee is contestable.
- `app.config.ts`, `i18n/en.json`, `libs/error/errors.ts` — storage key, copy, and one error type.

## Alternatives considered

MEV Blocker (`/fullprivacy`) is the close runner-up: also free and permissionless, and fastest to inclusion in the [independent RPC benchmark](https://arxiv.org/html/2505.19708v1). Flashbots wins here on covering Sepolia as well as mainnet, so the flow can be exercised on a testnet. `getPrivateRpc` is a plain table, so adding MEV Blocker later — or letting the user pick — is a small change.

Rejected: bloXroute Protect (requires an account and shares transactions with searchers via BackRunMe) and Merkle (74% inclusion success in the same benchmark).

## Out of scope

The off-chain relayer in `packages/relayer` sends the same `processMessage` call and is the party with real, continuous exposure — it competes for fees on every message by definition. It would benefit from the `privateTxMgr` / `TxMgrSelector` pattern that `taiko-client` already uses. This PR is deliberately limited to `packages/bridge-ui`.

## Testing

- `pnpm --filter bridge-ui test:unit` — 12 new tests pass; the 17 pre-existing failures in this environment are unrelated (they need the generated `$chainConfig`, which is built from deployment env vars).
- `pnpm --filter bridge-ui svelte:check` — 0 errors, 0 warnings.
- `pnpm --filter bridge-ui build` — succeeds.
- `prettier --check` and `eslint` clean on all touched files.

Not exercised against a live wallet: the `wallet_addEthereumChain` prompt is covered by unit tests against a mocked wallet client, but the actual prompt UX should be checked in MetaMask before this leaves draft, since wallets vary in how they handle adding an endpoint to a network that already exists.