### PR TITLE
fix(relayer): bound HTTP RPC requests and preserve progress monitoring

### DIFF
--- a/packages/relayer/api/api.go
+++ b/packages/relayer/api/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/http"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/rpcclient"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils"
 	"github.com/urfave/cli/v2"
 )
@@ -49,12 +50,12 @@ func InitFromConfig(ctx context.Context, api *API, cfg *Config) (err error) {
 	ctxDial, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	srcEthClient, err := ethclient.DialContext(ctxDial, cfg.SrcRPCUrl)
+	srcEthClient, err := rpcclient.DialEthClient(ctxDial, cfg.SrcRPCUrl, cfg.ETHClientRequestTimeout)
 	if err != nil {
 		return err
 	}
 
-	destEthClient, err := ethclient.DialContext(ctxDial, cfg.DestRPCUrl)
+	destEthClient, err := rpcclient.DialEthClient(ctxDial, cfg.DestRPCUrl, cfg.ETHClientRequestTimeout)
 	if err != nil {
 		return err
 	}

--- a/packages/relayer/api/config.go
+++ b/packages/relayer/api/config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/cmd/flags"
@@ -25,6 +26,7 @@ type Config struct {
 	// rpc configs
 	SrcRPCUrl               string
 	DestRPCUrl              string
+	ETHClientRequestTimeout time.Duration
 	ProcessingFeeMultiplier float64
 	DestTaikoAddress        common.Address
 	HTTPPort                uint64
@@ -45,6 +47,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		HTTPPort:                c.Uint64(flags.HTTPPort.Name),
 		SrcRPCUrl:               c.String(flags.SrcRPCUrl.Name),
 		DestRPCUrl:              c.String(flags.DestRPCUrl.Name),
+		ETHClientRequestTimeout: c.Duration(flags.ETHClientRequestTimeout.Name),
 		ProcessingFeeMultiplier: c.Float64(flags.ProcessingFeeMultiplier.Name),
 		DestTaikoAddress:        common.HexToAddress(c.String(flags.DestTaikoAddress.Name)),
 		OpenDBFunc: func() (db.DB, error) {

--- a/packages/relayer/api/config_test.go
+++ b/packages/relayer/api/config_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
@@ -47,6 +48,7 @@ func TestNewConfigFromCliContext(t *testing.T) {
 		assert.Equal(t, uint64(1000), c.HTTPPort)
 		assert.Equal(t, "srcRpcUrl", c.SrcRPCUrl)
 		assert.Equal(t, "destRpcUrl", c.DestRPCUrl)
+		assert.Equal(t, 5*time.Minute, c.ETHClientRequestTimeout)
 		assert.Equal(t, destTaikoAddress, c.DestTaikoAddress.Hex())
 
 		c.OpenDBFunc = func() (db.DB, error) {

--- a/packages/relayer/bridge/bridge.go
+++ b/packages/relayer/bridge/bridge.go
@@ -14,11 +14,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
 
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/rpcclient"
 )
 
 type ethClient interface {
@@ -69,12 +69,12 @@ func (b *Bridge) InitFromCli(ctx context.Context, c *cli.Context) error {
 
 // nolint: funlen
 func InitFromConfig(ctx context.Context, b *Bridge, cfg *Config) error {
-	srcEthClient, err := ethclient.Dial(cfg.SrcRPCUrl)
+	srcEthClient, err := rpcclient.DialEthClient(ctx, cfg.SrcRPCUrl, cfg.ETHClientRequestTimeout)
 	if err != nil {
 		return err
 	}
 
-	destEthClient, err := ethclient.Dial(cfg.DestRPCUrl)
+	destEthClient, err := rpcclient.DialEthClient(ctx, cfg.DestRPCUrl, cfg.ETHClientRequestTimeout)
 	if err != nil {
 		return err
 	}

--- a/packages/relayer/bridge/config.go
+++ b/packages/relayer/bridge/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -30,9 +31,10 @@ type Config struct {
 	BackOffMaxRetries    uint64
 
 	// rpc configs
-	SrcRPCUrl        string
-	DestRPCUrl       string
-	ETHClientTimeout uint64
+	SrcRPCUrl               string
+	DestRPCUrl              string
+	ETHClientTimeout        uint64
+	ETHClientRequestTimeout time.Duration
 
 	// BridgeMessage
 	BridgeMessageValue *big.Int
@@ -63,18 +65,19 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	}
 
 	return &Config{
-		BridgePrivateKey:     bridgePrivateKey,
-		DestBridgeAddress:    destBridgeAddress,
-		SrcBridgeAddress:     srcBridgeAddress,
-		SrcRPCUrl:            c.String(flags.SrcRPCUrl.Name),
-		DestRPCUrl:           c.String(flags.DestRPCUrl.Name),
-		Confirmations:        c.Uint64(flags.Confirmations.Name),
-		ConfirmationsTimeout: c.Uint64(flags.ConfirmationTimeout.Name),
-		EnableTaikoL2:        c.Bool(flags.EnableTaikoL2.Name),
-		BackoffRetryInterval: c.Uint64(flags.BackOffRetryInterval.Name),
-		BackOffMaxRetries:    c.Uint64(flags.BackOffMaxRetries.Name),
-		ETHClientTimeout:     c.Uint64(flags.ETHClientTimeout.Name),
-		BridgeMessageValue:   bridgeMessageValue,
+		BridgePrivateKey:        bridgePrivateKey,
+		DestBridgeAddress:       destBridgeAddress,
+		SrcBridgeAddress:        srcBridgeAddress,
+		SrcRPCUrl:               c.String(flags.SrcRPCUrl.Name),
+		DestRPCUrl:              c.String(flags.DestRPCUrl.Name),
+		Confirmations:           c.Uint64(flags.Confirmations.Name),
+		ConfirmationsTimeout:    c.Uint64(flags.ConfirmationTimeout.Name),
+		EnableTaikoL2:           c.Bool(flags.EnableTaikoL2.Name),
+		BackoffRetryInterval:    c.Uint64(flags.BackOffRetryInterval.Name),
+		BackOffMaxRetries:       c.Uint64(flags.BackOffMaxRetries.Name),
+		ETHClientTimeout:        c.Uint64(flags.ETHClientTimeout.Name),
+		ETHClientRequestTimeout: c.Duration(flags.ETHClientRequestTimeout.Name),
+		BridgeMessageValue:      bridgeMessageValue,
 	}, nil
 }
 

--- a/packages/relayer/bridge/config_test.go
+++ b/packages/relayer/bridge/config_test.go
@@ -2,11 +2,43 @@ package bridge
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/cmd/flags"
 	"github.com/urfave/cli/v2"
 )
+
+func TestNewConfigFromCliContextSetsRPCRequestTimeout(t *testing.T) {
+	app := cli.NewApp()
+	app.Flags = flags.BridgeFlags
+	app.Action = func(ctx *cli.Context) error {
+		config, err := NewConfigFromCliContext(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 5*time.Minute, config.ETHClientRequestTimeout)
+		return err
+	}
+
+	err := app.Run([]string{
+		"TestNewConfigFromCliContextSetsRPCRequestTimeout",
+		"--" + flags.BridgePrivateKey.Name, "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f",
+		"--" + flags.BridgeMessageValue.Name, "1",
+		"--" + flags.SrcBridgeAddress.Name, "0x53FaC9201494f0bd17B9892B9fae4d52fe3BD377",
+		"--" + flags.DestBridgeAddress.Name, "0x63FaC9201494f0bd17B9892B9fae4d52fe3BD377",
+		"--" + flags.DatabaseUsername.Name, "dbuser",
+		"--" + flags.DatabasePassword.Name, "dbpass",
+		"--" + flags.DatabaseHost.Name, "dbhost",
+		"--" + flags.DatabaseName.Name, "dbname",
+		"--" + flags.SrcRPCUrl.Name, "srcRpcUrl",
+		"--" + flags.DestRPCUrl.Name, "destRpcUrl",
+		"--" + flags.QueueUsername.Name, "queueuser",
+		"--" + flags.QueuePassword.Name, "queuepass",
+		"--" + flags.QueueHost.Name, "queuehost",
+		"--" + flags.QueuePort.Name, "5555",
+	})
+
+	assert.NoError(t, err)
+}
 
 func TestNewConfigFromCliContextRejectsInvalidBridgeAddress(t *testing.T) {
 	app := cli.NewApp()

--- a/packages/relayer/bridge/config_test.go
+++ b/packages/relayer/bridge/config_test.go
@@ -16,6 +16,7 @@ func TestNewConfigFromCliContextSetsRPCRequestTimeout(t *testing.T) {
 		config, err := NewConfigFromCliContext(ctx)
 		assert.NoError(t, err)
 		assert.Equal(t, 5*time.Minute, config.ETHClientRequestTimeout)
+
 		return err
 	}
 

--- a/packages/relayer/cmd/flags/common.go
+++ b/packages/relayer/cmd/flags/common.go
@@ -1,6 +1,8 @@
 package flags
 
 import (
+	"time"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -93,6 +95,13 @@ var (
 		Value:    10,
 		EnvVars:  []string{"ETH_CLIENT_TIMEOUT"},
 	}
+	ETHClientRequestTimeout = &cli.DurationFlag{
+		Name:     "ethClientRequestTimeout",
+		Usage:    "Maximum duration of an HTTP JSON-RPC request",
+		Category: commonCategory,
+		Value:    5 * time.Minute,
+		EnvVars:  []string{"ETH_CLIENT_REQUEST_TIMEOUT"},
+	}
 	SrcSignalServiceAddress = &cli.StringFlag{
 		Name:     "srcSignalServiceAddress",
 		Usage:    "SignalService address for the source chain",
@@ -130,6 +139,7 @@ var CommonFlags = []cli.Flag{
 	DatabaseMaxOpenConns,
 	MetricsHTTPPort,
 	ETHClientTimeout,
+	ETHClientRequestTimeout,
 	SrcSignalServiceAddress,
 	BackOffMaxRetries,
 	BackOffRetryInterval,

--- a/packages/relayer/cmd/flags/common_test.go
+++ b/packages/relayer/cmd/flags/common_test.go
@@ -1,0 +1,13 @@
+package flags
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestETHClientRequestTimeoutDefaultsToFiveMinutes(t *testing.T) {
+	require.Equal(t, 5*time.Minute, ETHClientRequestTimeout.Value)
+	require.Contains(t, CommonFlags, ETHClientRequestTimeout)
+}

--- a/packages/relayer/indexer/config.go
+++ b/packages/relayer/indexer/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	SrcRPCUrl                        string
 	DestRPCUrl                       string
 	ETHClientTimeout                 uint64
+	ETHClientRequestTimeout          time.Duration
 	BlockBatchSize                   uint64
 	NumGoroutines                    uint64
 	SubscriptionBackoff              uint64
@@ -92,6 +93,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		WatchMode:                        WatchMode(c.String(flags.WatchMode.Name)),
 		SyncMode:                         SyncMode(c.String(flags.SyncMode.Name)),
 		ETHClientTimeout:                 c.Uint64(flags.ETHClientTimeout.Name),
+		ETHClientRequestTimeout:          c.Duration(flags.ETHClientRequestTimeout.Name),
 		NumLatestBlocksEndWhenCrawling:   c.Uint64(flags.NumLatestBlocksEndWhenCrawling.Name),
 		NumLatestBlocksStartWhenCrawling: c.Uint64(flags.NumLatestBlocksStartWhenCrawling.Name),
 		EventName:                        c.String(flags.EventName.Name),

--- a/packages/relayer/indexer/config_test.go
+++ b/packages/relayer/indexer/config_test.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,7 @@ func TestNewConfigFromCliContext(t *testing.T) {
 		assert.Equal(t, common.HexToAddress(srcBridgeAddr), c.SrcBridgeAddress)
 		assert.Equal(t, common.HexToAddress(srcTaikoAddr), c.SrcTaikoAddress)
 		assert.Equal(t, uint64(10), c.ETHClientTimeout)
+		assert.Equal(t, 5*time.Minute, c.ETHClientRequestTimeout)
 		assert.Equal(t, uint64(10), c.DatabaseMaxIdleConns)
 		assert.Equal(t, uint64(10), c.DatabaseMaxOpenConns)
 		assert.Equal(t, uint64(30), c.DatabaseMaxConnLifetime)

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -319,8 +319,20 @@ func (i *Indexer) eventLoop(ctx context.Context) {
 
 // filter is the main function run by Start in the indexer
 func (i *Indexer) filter(ctx context.Context) error {
-	// get the latest header
-	header, err := i.srcEthClient.HeaderByNumber(ctx, nil)
+	// get the latest header.
+	//
+	// Bound only this call: it is a single head query, the same call class that
+	// ethClientTimeout already covers elsewhere in this package, and it is the
+	// first call of every poll — if it hangs, the whole event loop hangs behind
+	// it. Deliberately scoped to its own context rather than shadowing ctx: the
+	// Filter* calls further down keep the caller's context, because a batch scan
+	// (and WaitConfirmations, which runs under its own ConfirmationTimeout) can
+	// legitimately take far longer than ethClientTimeout.
+	headerCtx, cancel := context.WithTimeout(ctx, i.ethClientTimeout)
+
+	defer cancel()
+
+	header, err := i.srcEthClient.HeaderByNumber(headerCtx, nil)
 	if err != nil {
 		return errors.Wrap(err, "i.srcEthClient.HeaderByNumber")
 	}

--- a/packages/relayer/indexer/indexer.go
+++ b/packages/relayer/indexer/indexer.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cyberhorsey/errors"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/errgroup"
 
@@ -24,6 +22,7 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/v4/signalservice"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/rpcclient"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils"
 )
 
@@ -68,7 +67,6 @@ type ethClient interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	BlockNumber(ctx context.Context) (uint64, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
-	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
 	TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error)
 }
 
@@ -148,12 +146,12 @@ func InitFromConfig(ctx context.Context, i *Indexer, cfg *Config) (err error) {
 		return err
 	}
 
-	srcEthClient, err := ethclient.Dial(cfg.SrcRPCUrl)
+	srcEthClient, err := rpcclient.DialEthClient(ctx, cfg.SrcRPCUrl, cfg.ETHClientRequestTimeout)
 	if err != nil {
 		return err
 	}
 
-	destEthClient, err := ethclient.Dial(cfg.DestRPCUrl)
+	destEthClient, err := rpcclient.DialEthClient(ctx, cfg.DestRPCUrl, cfg.ETHClientRequestTimeout)
 	if err != nil {
 		return err
 	}
@@ -287,9 +285,10 @@ func (i *Indexer) Start() error {
 	go i.eventLoop(i.ctx)
 
 	go func() {
+		bo := backoff.WithContext(backoff.NewConstantBackOff(5*time.Second), i.ctx)
 		if err := backoff.Retry(func() error {
 			return utils.ScanBlocks(i.ctx, i.srcEthClient, &i.wg)
-		}, backoff.NewConstantBackOff(5*time.Second)); err != nil {
+		}, bo); err != nil {
 			slog.Error("scan blocks backoff retry", "error", err)
 		}
 	}()

--- a/packages/relayer/pkg/rpcclient/client.go
+++ b/packages/relayer/pkg/rpcclient/client.go
@@ -1,0 +1,56 @@
+package rpcclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// Dial creates an RPC client. HTTP requests are bounded so a stale upstream
+// connection cannot block a relayer worker indefinitely.
+func Dial(ctx context.Context, rawURL string, requestTimeout time.Duration) (*rpc.Client, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse RPC URL: %w", err)
+	}
+
+	var options []rpc.ClientOption
+	switch strings.ToLower(parsedURL.Scheme) {
+	case "http", "https":
+		if requestTimeout <= 0 {
+			return nil, fmt.Errorf("HTTP RPC request timeout must be positive: %s", requestTimeout)
+		}
+		options = append(options, rpc.WithHTTPClient(newHTTPClient(requestTimeout)))
+	}
+
+	client, err := rpc.DialOptions(ctx, rawURL, options...)
+	if err != nil {
+		return nil, fmt.Errorf("dial RPC client: %w", err)
+	}
+
+	return client, nil
+}
+
+func newHTTPClient(requestTimeout time.Duration) *http.Client {
+	return &http.Client{Timeout: requestTimeout}
+}
+
+// DialEthClient creates an Ethereum client backed by Dial.
+func DialEthClient(
+	ctx context.Context,
+	rawURL string,
+	requestTimeout time.Duration,
+) (*ethclient.Client, error) {
+	client, err := Dial(ctx, rawURL, requestTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return ethclient.NewClient(client), nil
+}

--- a/packages/relayer/pkg/rpcclient/client.go
+++ b/packages/relayer/pkg/rpcclient/client.go
@@ -21,11 +21,13 @@ func Dial(ctx context.Context, rawURL string, requestTimeout time.Duration) (*rp
 	}
 
 	var options []rpc.ClientOption
+
 	switch strings.ToLower(parsedURL.Scheme) {
 	case "http", "https":
 		if requestTimeout <= 0 {
 			return nil, fmt.Errorf("HTTP RPC request timeout must be positive: %s", requestTimeout)
 		}
+
 		options = append(options, rpc.WithHTTPClient(newHTTPClient(requestTimeout)))
 	}
 

--- a/packages/relayer/pkg/rpcclient/client_test.go
+++ b/packages/relayer/pkg/rpcclient/client_test.go
@@ -1,0 +1,42 @@
+package rpcclient
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestHTTPClientBoundsRequestDuration(t *testing.T) {
+	requestStarted := make(chan struct{})
+	client := newHTTPClient(25 * time.Millisecond)
+	client.Transport = roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		close(requestStarted)
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	})
+
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://rpc.example", nil)
+	require.NoError(t, err)
+	_, err = client.Do(request)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("JSON-RPC request was not sent")
+	}
+}
+
+func TestDialRejectsUnboundedHTTPClient(t *testing.T) {
+	_, err := Dial(context.Background(), "http://rpc.example", 0)
+	require.ErrorContains(t, err, "must be positive")
+}

--- a/packages/relayer/pkg/rpcclient/client_test.go
+++ b/packages/relayer/pkg/rpcclient/client_test.go
@@ -21,6 +21,7 @@ func TestHTTPClientBoundsRequestDuration(t *testing.T) {
 	client.Transport = roundTripperFunc(func(request *http.Request) (*http.Response, error) {
 		close(requestStarted)
 		<-request.Context().Done()
+
 		return nil, request.Context().Err()
 	})
 

--- a/packages/relayer/pkg/utils/scan_blocks.go
+++ b/packages/relayer/pkg/utils/scan_blocks.go
@@ -2,36 +2,69 @@ package utils
 
 import (
 	"context"
+	"math/big"
 	"sync"
+	"time"
 
-	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 )
 
-type headSubscriber interface {
-	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+const (
+	headPollInterval   = 10 * time.Second
+	headRequestTimeout = 10 * time.Second
+)
+
+type headClient interface {
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 }
 
-func ScanBlocks(ctx context.Context, ethClient headSubscriber, wg *sync.WaitGroup) error {
+func ScanBlocks(ctx context.Context, ethClient headClient, wg *sync.WaitGroup) error {
 	wg.Add(1)
 	defer wg.Done()
 
-	headers := make(chan *types.Header)
+	return scanBlocks(ctx, ethClient, headPollInterval, headRequestTimeout)
+}
 
-	sub, err := ethClient.SubscribeNewHead(ctx, headers)
-	if err != nil {
-		return err
-	}
+func scanBlocks(
+	ctx context.Context,
+	ethClient headClient,
+	pollInterval time.Duration,
+	requestTimeout time.Duration,
+) error {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	var (
+		haveHead bool
+		lastHead common.Hash
+	)
 
 	for {
+		requestCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+		header, err := ethClient.HeaderByNumber(requestCtx, nil)
+		cancel()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+
+		headHash := header.Hash()
+		if !haveHead {
+			haveHead = true
+			lastHead = headHash
+		} else if headHash != lastHead {
+			relayer.BlocksScanned.Inc()
+			lastHead = headHash
+		}
+
 		select {
 		case <-ctx.Done():
 			return nil
-		case err := <-sub.Err():
-			return err
-		case <-headers:
-			relayer.BlocksScanned.Inc()
+		case <-ticker.C:
 		}
 	}
 }

--- a/packages/relayer/pkg/utils/scan_blocks.go
+++ b/packages/relayer/pkg/utils/scan_blocks.go
@@ -44,20 +44,25 @@ func scanBlocks(
 	for {
 		requestCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 		header, err := ethClient.HeaderByNumber(requestCtx, nil)
+
 		cancel()
+
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil
 			}
+
 			return err
 		}
 
 		headHash := header.Hash()
+
 		if !haveHead {
 			haveHead = true
 			lastHead = headHash
 		} else if headHash != lastHead {
 			relayer.BlocksScanned.Inc()
+
 			lastHead = headHash
 		}
 

--- a/packages/relayer/pkg/utils/scan_blocks_test.go
+++ b/packages/relayer/pkg/utils/scan_blocks_test.go
@@ -22,12 +22,14 @@ type pollingHeadClient struct {
 func (c *pollingHeadClient) HeaderByNumber(context.Context, *big.Int) (*types.Header, error) {
 	headNumber := c.headNumber.Load()
 	c.calls.Add(1)
+
 	return &types.Header{Number: big.NewInt(headNumber)}, nil
 }
 
 func TestScanBlocksCountsObservedHeadChanges(t *testing.T) {
 	client := new(pollingHeadClient)
 	client.headNumber.Store(42)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	before := testutil.ToFloat64(relayer.BlocksScanned)
 	errCh := make(chan error, 1)

--- a/packages/relayer/pkg/utils/scan_blocks_test.go
+++ b/packages/relayer/pkg/utils/scan_blocks_test.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"context"
+	"math/big"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/taikoxyz/taiko-mono/packages/relayer"
+)
+
+type pollingHeadClient struct {
+	calls      atomic.Int64
+	headNumber atomic.Int64
+}
+
+func (c *pollingHeadClient) HeaderByNumber(context.Context, *big.Int) (*types.Header, error) {
+	headNumber := c.headNumber.Load()
+	c.calls.Add(1)
+	return &types.Header{Number: big.NewInt(headNumber)}, nil
+}
+
+func TestScanBlocksCountsObservedHeadChanges(t *testing.T) {
+	client := new(pollingHeadClient)
+	client.headNumber.Store(42)
+	ctx, cancel := context.WithCancel(context.Background())
+	before := testutil.ToFloat64(relayer.BlocksScanned)
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- scanBlocks(ctx, client, time.Millisecond, time.Second)
+	}()
+
+	require.Eventually(t, func() bool {
+		return client.calls.Load() >= 1
+	}, time.Second, time.Millisecond)
+	client.headNumber.Store(43)
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(relayer.BlocksScanned)-before == 1
+	}, time.Second, time.Millisecond)
+	cancel()
+
+	require.NoError(t, <-errCh)
+	require.Equal(t, float64(1), testutil.ToFloat64(relayer.BlocksScanned)-before)
+}
+
+func TestScanBlocksPollsHeadWithoutDoubleCountingUnchangedHead(t *testing.T) {
+	client := new(pollingHeadClient)
+	ctx, cancel := context.WithCancel(context.Background())
+	before := testutil.ToFloat64(relayer.BlocksScanned)
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- scanBlocks(ctx, client, time.Millisecond, time.Second)
+	}()
+
+	require.Eventually(t, func() bool {
+		return client.calls.Load() >= 2
+	}, time.Second, time.Millisecond)
+	cancel()
+
+	require.NoError(t, <-errCh)
+	require.Equal(t, float64(0), testutil.ToFloat64(relayer.BlocksScanned)-before)
+}
+
+type blockingHeadClient struct{}
+
+func (*blockingHeadClient) HeaderByNumber(ctx context.Context, _ *big.Int) (*types.Header, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestScanBlocksBoundsEachHeadRequest(t *testing.T) {
+	started := time.Now()
+	err := scanBlocks(context.Background(), new(blockingHeadClient), time.Hour, 20*time.Millisecond)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(started), time.Second)
+}

--- a/packages/relayer/processor/config.go
+++ b/packages/relayer/processor/config.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
@@ -61,11 +62,12 @@ type Config struct {
 	QueuePort     uint64
 	QueuePrefetch uint64
 	// rpc configs
-	SrcRPCUrl        string
-	DestRPCUrl       string
-	ETHClientTimeout uint64
-	OpenQueueFunc    func() (queue.Queue, error)
-	OpenDBFunc       func() (db.DB, error)
+	SrcRPCUrl               string
+	DestRPCUrl              string
+	ETHClientTimeout        uint64
+	ETHClientRequestTimeout time.Duration
+	OpenQueueFunc           func() (queue.Queue, error)
+	OpenDBFunc              func() (db.DB, error)
 
 	UnprofitableMessageQueueExpiration *string
 
@@ -134,6 +136,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		BackoffRetryInterval:               c.Uint64(flags.BackOffRetryInterval.Name),
 		BackOffMaxRetries:                  c.Uint64(flags.BackOffMaxRetries.Name),
 		ETHClientTimeout:                   c.Uint64(flags.ETHClientTimeout.Name),
+		ETHClientRequestTimeout:            c.Duration(flags.ETHClientRequestTimeout.Name),
 		TargetTxHash:                       targetTxHash,
 		UnprofitableMessageQueueExpiration: unprofitableMessageQueueExpiration,
 		TxmgrConfigs: pkgFlags.InitTxmgrConfigsFromCli(

--- a/packages/relayer/processor/config_test.go
+++ b/packages/relayer/processor/config_test.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
@@ -70,6 +71,7 @@ func TestNewConfigFromCliContext(t *testing.T) {
 		assert.Equal(t, uint64(10), c.DatabaseMaxOpenConns)
 		assert.Equal(t, uint64(30), c.DatabaseMaxConnLifetime)
 		assert.Equal(t, uint64(10), c.ETHClientTimeout)
+		assert.Equal(t, 5*time.Minute, c.ETHClientRequestTimeout)
 		assert.Equal(t, true, c.ProfitableOnly)
 		assert.Equal(t, uint64(100), c.QueuePrefetch)
 		assert.Equal(t, true, c.EnableTaikoL2)

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/urfave/cli/v2"
 
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
@@ -37,6 +36,7 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/proof"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/queue"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/repo"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/rpcclient"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils"
 )
 
@@ -53,7 +53,6 @@ type ethClient interface {
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	ChainID(ctx context.Context) (*big.Int, error)
-	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
 	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
@@ -150,17 +149,14 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 		return err
 	}
 
-	srcRpcClient, err := rpc.Dial(cfg.SrcRPCUrl)
+	srcRpcClient, err := rpcclient.Dial(ctx, cfg.SrcRPCUrl, cfg.ETHClientRequestTimeout)
 	if err != nil {
 		return err
 	}
 
-	srcEthClient, err := ethclient.Dial(cfg.SrcRPCUrl)
-	if err != nil {
-		return err
-	}
+	srcEthClient := ethclient.NewClient(srcRpcClient)
 
-	destEthClient, err := ethclient.Dial(cfg.DestRPCUrl)
+	destEthClient, err := rpcclient.DialEthClient(ctx, cfg.DestRPCUrl, cfg.ETHClientRequestTimeout)
 	if err != nil {
 		return err
 	}
@@ -398,9 +394,10 @@ func (p *Processor) Start() error {
 	go p.eventLoop(ctx)
 
 	go func() {
+		bo := backoff.WithContext(backoff.NewConstantBackOff(5*time.Second), ctx)
 		if err := backoff.Retry(func() error {
 			return utils.ScanBlocks(ctx, p.srcEthClient, &p.wg)
-		}, backoff.NewConstantBackOff(5*time.Second)); err != nil {
+		}, bo); err != nil {
 			slog.Error("scan blocks backoff retry", "error", err)
 		}
 	}()

--- a/packages/relayer/prometheus.go
+++ b/packages/relayer/prometheus.go
@@ -8,7 +8,7 @@ import (
 var (
 	BlocksScanned = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "blocks_scanned_ops_total",
-		Help: "The total number of blocks scanned",
+		Help: "The total number of source-chain head changes observed",
 	})
 	QueueMessageAcknowledged = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "queue_message_acknowledged_ops_total",


### PR DESCRIPTION
> Draft — coordinated with [`k8s-configs#1609`](https://github.com/taikoxyz/k8s-configs/pull/1609), which switches the deployed relayer RPC URLs from WebSocket to HTTP. Merge and publish this relayer image before deploying that configuration change.

## What

- Keeps the existing 10-second deadline on the indexer's `HeaderByNumber("latest")` call.
- Adds a shared relayer RPC dialer for API, bridge, indexer, and processor.
- Gives every HTTP JSON-RPC request a configurable overall deadline (`ETH_CLIENT_REQUEST_TIMEOUT`, default `5m`).
- Reuses the processor's bounded source RPC connection for both raw RPC and `ethclient` calls.
- Replaces the metrics-only `SubscribeNewHead` loop with a 10-second `HeaderByNumber` poll, so `blocks_scanned_ops_total` and its existing alerts continue to work over HTTP.
- Makes the block-progress retry loops stop when their component context is canceled.

WebSocket and IPC URLs still use go-ethereum's native transports. The new client-level timeout is applied only to HTTP/HTTPS.

## Why

On 2026-08-30 an internal-devnet relayer stayed `Running` and `Ready` but stopped processing for two hours after the node pods behind its Kubernetes Service were replaced. Its RabbitMQ consumer remained attached, 113k messages accumulated, and the process emitted no new logs. The relayer had no overall timeout on several execution-critical RPC calls, so a stale connection could block a worker indefinitely.

Changing the URLs to HTTP alone is insufficient: Go's HTTP transport normally reuses healthy connections. This PR supplies the missing recovery bound. A stuck request is canceled after at most five minutes; normal RPCs such as fuzz-heavy `FilterLogs` batches that can legitimately exceed ten seconds still have enough time to finish. The dedicated head query keeps its tighter ten-second deadline.

## Metrics compatibility

HTTP does not support `eth_subscribe`, but Hoodi and mainnet alert on:

```promql
increase(blocks_scanned_ops_total[15m]) < 1
```

The new polling loop records actual source-chain head changes rather than counting every poll. The first successful poll establishes a baseline, and later hash changes increment the existing counter. This preserves the alert's progress semantics without requiring a separate WebSocket connection.

## Configuration

| flag | environment variable | default | purpose |
|---|---|---:|---|
| `ethClientTimeout` | `ETH_CLIENT_TIMEOUT` | `10s` | existing short per-call/contract deadline |
| `ethClientRequestTimeout` | `ETH_CLIENT_REQUEST_TIMEOUT` | `5m` | new HTTP client ceiling for every JSON-RPC request |

## Verification

- Affected relayer package tests pass, including new HTTP timeout and polling metric tests.
- `go vet` passes for all changed packages.
- The relayer command builds successfully.
- The repository-wide relayer test command still has two unrelated baseline/environment failures: `pkg/repo` resolves a Moby `Port` API without `Int`, and `pkg/metrics` cannot bind its test port in the restricted sandbox.

## Rollout

1. Merge this PR and wait for the relayer Docker workflow to publish its `sha-<commit>` image.
2. Update `k8s-configs#1609` to that exact image tag.
3. Deploy one internal-devnet relayer first and confirm head-progress metrics, queue acknowledgements, and bridge processing.
4. Roll through Hoodi, then mainnet.
