### PR TITLE
fix(eventindexer): make transfer-log balance updates replay-idempotent

### DIFF
--- a/packages/eventindexer/cmd/flags/indexer.go
+++ b/packages/eventindexer/cmd/flags/indexer.go
@@ -67,6 +67,14 @@ var (
 		Category: indexerCategory,
 		EnvVars:  []string{"INDEX_NFTS"},
 	}
+	AllowUnclaimedBalanceReplay = &cli.BoolFlag{
+		Name: "allowUnclaimedBalanceReplay",
+		Usage: "Start even when balances predate the transfer log claim table, " +
+			"accepting a single double count on this restart",
+		Required: false,
+		Category: indexerCategory,
+		EnvVars:  []string{"ALLOW_UNCLAIMED_BALANCE_REPLAY"},
+	}
 	IndexERC20s = &cli.BoolFlag{
 		Name:     "indexERC20s",
 		Usage:    "Whether to index erc20 transfer events or not",
@@ -87,4 +95,5 @@ var IndexerFlags = MergeFlags(CommonFlags, []cli.Flag{
 	SyncMode,
 	IndexNFTs,
 	IndexERC20s,
+	AllowUnclaimedBalanceReplay,
 })

--- a/packages/eventindexer/erc20_balance.go
+++ b/packages/eventindexer/erc20_balance.go
@@ -38,6 +38,7 @@ type UpdateERC20BalanceOpts struct {
 type ERC20BalanceRepository interface {
 	IncreaseAndDecreaseBalancesInTx(
 		ctx context.Context,
+		ref TransferLogRef,
 		increaseOpts UpdateERC20BalanceOpts,
 		decreaseOpts UpdateERC20BalanceOpts,
 	) (increasedBalance *ERC20Balance, decreasedBalance *ERC20Balance, err error)

--- a/packages/eventindexer/indexer/config.go
+++ b/packages/eventindexer/indexer/config.go
@@ -30,31 +30,36 @@ type Config struct {
 	SyncMode                SyncMode
 	IndexNFTs               bool
 	IndexERC20s             bool
-	Layer                   string
-	OpenDBFunc              func() (db.DB, error)
+
+	// AllowUnclaimedBalanceReplay lets the indexer start even when
+	// UnclaimedBalanceReplayRisk reports that this restart may double count once.
+	AllowUnclaimedBalanceReplay bool
+	Layer                       string
+	OpenDBFunc                  func() (db.DB, error)
 }
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
 func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 	return &Config{
-		DatabaseUsername:        c.String(flags.DatabaseUsername.Name),
-		DatabasePassword:        c.String(flags.DatabasePassword.Name),
-		DatabaseName:            c.String(flags.DatabaseName.Name),
-		DatabaseHost:            c.String(flags.DatabaseHost.Name),
-		DatabaseMaxIdleConns:    c.Uint64(flags.DatabaseMaxIdleConns.Name),
-		DatabaseMaxOpenConns:    c.Uint64(flags.DatabaseMaxOpenConns.Name),
-		DatabaseMaxConnLifetime: c.Uint64(flags.DatabaseConnMaxLifetime.Name),
-		MetricsHTTPPort:         c.Uint64(flags.MetricsHTTPPort.Name),
-		ETHClientTimeout:        c.Uint64(flags.ETHClientTimeout.Name),
-		L1TaikoAddress:          common.HexToAddress(c.String(flags.L1TaikoAddress.Name)),
-		BridgeAddress:           common.HexToAddress(c.String(flags.BridgeAddress.Name)),
-		BlockBatchSize:          c.Uint64(flags.BlockBatchSize.Name),
-		SubscriptionBackoff:     c.Uint64(flags.SubscriptionBackoff.Name),
-		RPCUrl:                  c.String(flags.IndexerRPCUrl.Name),
-		SyncMode:                SyncMode(c.String(flags.SyncMode.Name)),
-		IndexNFTs:               c.Bool(flags.IndexNFTs.Name),
-		IndexERC20s:             c.Bool(flags.IndexERC20s.Name),
-		Layer:                   c.String(flags.Layer.Name),
+		DatabaseUsername:            c.String(flags.DatabaseUsername.Name),
+		DatabasePassword:            c.String(flags.DatabasePassword.Name),
+		DatabaseName:                c.String(flags.DatabaseName.Name),
+		DatabaseHost:                c.String(flags.DatabaseHost.Name),
+		DatabaseMaxIdleConns:        c.Uint64(flags.DatabaseMaxIdleConns.Name),
+		DatabaseMaxOpenConns:        c.Uint64(flags.DatabaseMaxOpenConns.Name),
+		DatabaseMaxConnLifetime:     c.Uint64(flags.DatabaseConnMaxLifetime.Name),
+		MetricsHTTPPort:             c.Uint64(flags.MetricsHTTPPort.Name),
+		ETHClientTimeout:            c.Uint64(flags.ETHClientTimeout.Name),
+		L1TaikoAddress:              common.HexToAddress(c.String(flags.L1TaikoAddress.Name)),
+		BridgeAddress:               common.HexToAddress(c.String(flags.BridgeAddress.Name)),
+		BlockBatchSize:              c.Uint64(flags.BlockBatchSize.Name),
+		SubscriptionBackoff:         c.Uint64(flags.SubscriptionBackoff.Name),
+		RPCUrl:                      c.String(flags.IndexerRPCUrl.Name),
+		SyncMode:                    SyncMode(c.String(flags.SyncMode.Name)),
+		IndexNFTs:                   c.Bool(flags.IndexNFTs.Name),
+		AllowUnclaimedBalanceReplay: c.Bool(flags.AllowUnclaimedBalanceReplay.Name),
+		IndexERC20s:                 c.Bool(flags.IndexERC20s.Name),
+		Layer:                       c.String(flags.Layer.Name),
 		OpenDBFunc: func() (db.DB, error) {
 			return db.OpenDBConnection(db.DBConnectionOpts{
 				Name:            c.String(flags.DatabaseUsername.Name),

--- a/packages/eventindexer/indexer/index_erc20_transfers.go
+++ b/packages/eventindexer/indexer/index_erc20_transfers.go
@@ -221,7 +221,14 @@ func (i *Indexer) saveERC20Transfer(ctx context.Context, chainID *big.Int, vLog 
 		}
 	}
 
-	_, _, err = i.erc20BalanceRepo.IncreaseAndDecreaseBalancesInTx(ctx, increaseOpts, decreaseOpts)
+	ref := eventindexer.TransferLogRef{
+		ChainID:  chainID.Int64(),
+		TxHash:   vLog.TxHash.Hex(),
+		LogIndex: vLog.Index,
+		Kind:     eventindexer.TransferKindERC20,
+	}
+
+	_, _, err = i.erc20BalanceRepo.IncreaseAndDecreaseBalancesInTx(ctx, ref, increaseOpts, decreaseOpts)
 	if err != nil {
 		return errors.Wrap(err, "i.erc20BalanceRepo.IncreaseAndDecreaseBalancesInTx")
 	}

--- a/packages/eventindexer/indexer/index_nft_transfers.go
+++ b/packages/eventindexer/indexer/index_nft_transfers.go
@@ -167,7 +167,8 @@ func (i *Indexer) saveERC721Transfer(ctx context.Context, chainID *big.Int, vLog
 		}
 	}
 
-	_, _, err := i.nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(ctx, increaseOpts, decreaseOpts)
+	_, _, err := i.nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(
+		ctx, nftTransferRef(chainID, vLog, 0), increaseOpts, decreaseOpts)
 	if err != nil {
 		return err
 	}
@@ -228,7 +229,8 @@ func (i *Indexer) saveERC1155Transfer(ctx context.Context, chainID *big.Int, vLo
 			}
 		}
 
-		_, _, err = i.nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(ctx, increaseOpts, decreaseOpts)
+		_, _, err = i.nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(
+			ctx, nftTransferRef(chainID, vLog, 0), increaseOpts, decreaseOpts)
 		if err != nil {
 			return err
 		}
@@ -271,7 +273,8 @@ func (i *Indexer) saveERC1155Transfer(ctx context.Context, chainID *big.Int, vLo
 				}
 			}
 
-			_, _, err = i.nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(ctx, increaseOpts, decreaseOpts)
+			_, _, err = i.nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(
+				ctx, nftTransferRef(chainID, vLog, uint(idx)), increaseOpts, decreaseOpts)
 			if err != nil {
 				return err
 			}
@@ -280,4 +283,18 @@ func (i *Indexer) saveERC1155Transfer(ctx context.Context, chainID *big.Int, vLo
 	// increment To address's balance
 
 	return nil
+}
+
+// nftTransferRef identifies one balance-mutating unit of an NFT transfer log, so a
+// replayed block cannot apply the same unit twice. batchIndex is 0 for ERC721
+// Transfer and ERC1155 TransferSingle, and the position within the batch for
+// ERC1155 TransferBatch.
+func nftTransferRef(chainID *big.Int, vLog types.Log, batchIndex uint) eventindexer.TransferLogRef {
+	return eventindexer.TransferLogRef{
+		ChainID:    chainID.Int64(),
+		TxHash:     vLog.TxHash.Hex(),
+		LogIndex:   vLog.Index,
+		BatchIndex: batchIndex,
+		Kind:       eventindexer.TransferKindNFT,
+	}
 }

--- a/packages/eventindexer/indexer/indexer.go
+++ b/packages/eventindexer/indexer/indexer.go
@@ -59,6 +59,8 @@ type Indexer struct {
 	indexERC20s bool
 	layer       string
 
+	allowUnclaimedBalanceReplay bool
+
 	wg  *sync.WaitGroup
 	ctx context.Context
 
@@ -72,6 +74,10 @@ type Indexer struct {
 
 func (i *Indexer) Start() error {
 	i.ctx = context.Background()
+
+	if err := i.checkBalanceClaimBootstrap(i.ctx); err != nil {
+		return err
+	}
 
 	if err := i.setInitialIndexingBlockByMode(i.ctx, i.syncMode); err != nil {
 		return errors.Wrap(err, "i.setInitialIndexingBlockByMode")
@@ -200,6 +206,7 @@ func InitFromConfig(ctx context.Context, i *Indexer, cfg *Config) error {
 
 	i.syncMode = cfg.SyncMode
 	i.indexNfts = cfg.IndexNFTs
+	i.allowUnclaimedBalanceReplay = cfg.AllowUnclaimedBalanceReplay
 	i.indexERC20s = cfg.IndexERC20s
 	i.layer = cfg.Layer
 	i.contractToMetadata = make(map[common.Address]*eventindexer.ERC20Metadata, 0)
@@ -215,4 +222,55 @@ func (i *Indexer) Close(ctx context.Context) {
 	if err := i.db.Close(); err != nil {
 		slog.Error("Failed to close db connection", "err", err)
 	}
+}
+
+// checkBalanceClaimBootstrap refuses to start when this process would replay
+// balance mutations that a previous process already applied.
+//
+// processed_transfer_logs makes replays idempotent, but only for logs claimed at
+// least once. Nothing records what a pre-claim process applied, so the indexer
+// cannot repair this by itself and the choice belongs to an operator: reset the
+// balances so they rebuild from claims, or accept a single overcount.
+func (i *Indexer) checkBalanceClaimBootstrap(ctx context.Context) error {
+	kinds := []struct {
+		kind    string
+		enabled bool
+	}{
+		{eventindexer.TransferKindNFT, i.indexNfts},
+		{eventindexer.TransferKindERC20, i.indexERC20s},
+	}
+
+	for _, k := range kinds {
+		if !k.enabled {
+			continue
+		}
+
+		atRisk, err := repo.UnclaimedBalanceReplayRisk(ctx, i.db, int64(i.srcChainID), k.kind)
+		if err != nil {
+			return errors.Wrap(err, "repo.UnclaimedBalanceReplayRisk")
+		}
+
+		if !atRisk {
+			continue
+		}
+
+		if i.allowUnclaimedBalanceReplay {
+			slog.Warn("starting with unclaimed balance replay allowed, this restart may double count once",
+				"kind", k.kind,
+				"chainID", i.srcChainID,
+			)
+
+			continue
+		}
+
+		return errors.Newf(
+			"%s balances for chain %d were written before transfer log claims existed, so this "+
+				"restart would replay and double count them once. Either reset those balances so "+
+				"they rebuild from claims, or set --allowUnclaimedBalanceReplay / "+
+				"ALLOW_UNCLAIMED_BALANCE_REPLAY=true to accept a single overcount",
+			k.kind, i.srcChainID,
+		)
+	}
+
+	return nil
 }

--- a/packages/eventindexer/migrations/20270906208858_create_processed_transfer_logs_table.sql
+++ b/packages/eventindexer/migrations/20270906208858_create_processed_transfer_logs_table.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS processed_transfer_logs (
+    id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    chain_id int NOT NULL,
+    tx_hash VARCHAR(66) NOT NULL,
+    log_index int NOT NULL,
+    batch_index int NOT NULL DEFAULT 0,
+    kind VARCHAR(8) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY processed_transfer_logs_unique (chain_id, tx_hash, log_index, batch_index, kind)
+);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE processed_transfer_logs;
+-- +goose StatementEnd

--- a/packages/eventindexer/nft_balance.go
+++ b/packages/eventindexer/nft_balance.go
@@ -32,6 +32,7 @@ type UpdateNFTBalanceOpts struct {
 type NFTBalanceRepository interface {
 	IncreaseAndDecreaseBalancesInTx(
 		ctx context.Context,
+		ref TransferLogRef,
 		increaseOpts UpdateNFTBalanceOpts,
 		decreaseOpts UpdateNFTBalanceOpts,
 	) (increasedBalance *NFTBalance, decreasedBalance *NFTBalance, err error)

--- a/packages/eventindexer/pkg/mock/erc20_balance_repository.go
+++ b/packages/eventindexer/pkg/mock/erc20_balance_repository.go
@@ -18,6 +18,7 @@ func NewERC20BalanceRepository() *ERC20BalanceRepository {
 
 func (r *ERC20BalanceRepository) IncreaseAndDecreaseBalancesInTx(
 	ctx context.Context,
+	ref eventindexer.TransferLogRef,
 	increaseOpts eventindexer.UpdateERC20BalanceOpts,
 	decreaseOpts eventindexer.UpdateERC20BalanceOpts,
 ) (increasedBalance *eventindexer.ERC20Balance, decreasedBalance *eventindexer.ERC20Balance, err error) {

--- a/packages/eventindexer/pkg/mock/nft_balance_repository.go
+++ b/packages/eventindexer/pkg/mock/nft_balance_repository.go
@@ -18,6 +18,7 @@ func NewNFTBalanceRepository() *NFTBalanceRepository {
 
 func (r *NFTBalanceRepository) IncreaseAndDecreaseBalancesInTx(
 	ctx context.Context,
+	ref eventindexer.TransferLogRef,
 	increaseOpts eventindexer.UpdateNFTBalanceOpts,
 	decreaseOpts eventindexer.UpdateNFTBalanceOpts,
 ) (increasedBalance *eventindexer.NFTBalance, decreasedBalance *eventindexer.NFTBalance, err error) {

--- a/packages/eventindexer/pkg/repo/balance_replay_risk.go
+++ b/packages/eventindexer/pkg/repo/balance_replay_risk.go
@@ -1,0 +1,96 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pkg/errors"
+
+	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
+	"github.com/taikoxyz/taiko-mono/packages/eventindexer/pkg/db"
+)
+
+// UnclaimedBalanceReplayRisk reports whether a previous process may already have
+// applied balance mutations for the block range this process is about to replay,
+// without leaving claims behind in processed_transfer_logs.
+//
+// The claim table makes replays idempotent, but only for logs claimed at least
+// once. On the first start after the table is introduced there are no claims,
+// while setInitialIndexingBlockByMode still rewinds the cursor into a range the
+// previous process already applied — so that one restart would double count.
+// Nothing records what the previous process applied, so this cannot be repaired
+// automatically; the point of this check is to make the situation loud.
+//
+// The signal is recency, not mere existence. Balances written at or after the
+// block being resumed from mean a process was applying them inside the range
+// about to be replayed. Balances that predate it — a chain where balance
+// indexing was switched off long ago and is only now being re-enabled — cannot
+// be double counted, because the replay range is entirely newer than anything
+// the previous process wrote.
+func UnclaimedBalanceReplayRisk(
+	ctx context.Context,
+	d db.DB,
+	chainID int64,
+	kind string,
+) (bool, error) {
+	var table string
+
+	switch kind {
+	case eventindexer.TransferKindNFT:
+		table = "nft_balances"
+	case eventindexer.TransferKindERC20:
+		table = "erc20_balances"
+	default:
+		return false, errors.Errorf("unknown transfer log kind %q", kind)
+	}
+
+	var claims int64
+
+	if err := d.GormDB().WithContext(ctx).
+		Table("processed_transfer_logs").
+		Where("chain_id = ?", chainID).
+		Where("kind = ?", kind).
+		Count(&claims).Error; err != nil {
+		return false, errors.Wrap(err, "count processed_transfer_logs")
+	}
+
+	// once this chain has claimed anything, every later replay is covered
+	if claims > 0 {
+		return false, nil
+	}
+
+	var lastBalanceWrite sql.NullTime
+
+	if err := d.GormDB().WithContext(ctx).
+		Table(table).
+		Where("chain_id = ?", chainID).
+		Select("MAX(updated_at)").
+		Scan(&lastBalanceWrite).Error; err != nil {
+		return false, errors.Wrap(err, "max balance updated_at")
+	}
+
+	// no balances for this chain, so there is nothing to double count
+	if !lastBalanceWrite.Valid {
+		return false, nil
+	}
+
+	var resumeBlockTime sql.NullTime
+
+	if err := d.GormDB().WithContext(ctx).
+		Table("events").
+		Where("chain_id = ?", chainID).
+		Select("transacted_at").
+		Order("emitted_block_id DESC").
+		Limit(1).
+		Scan(&resumeBlockTime).Error; err != nil {
+		return false, errors.Wrap(err, "resume block transacted_at")
+	}
+
+	// no events, so the cursor starts at the fork height rather than resuming
+	// into a range a previous process worked on
+	if !resumeBlockTime.Valid {
+		return false, nil
+	}
+
+	return !lastBalanceWrite.Time.Before(resumeBlockTime.Time), nil
+}

--- a/packages/eventindexer/pkg/repo/balance_replay_risk_test.go
+++ b/packages/eventindexer/pkg/repo/balance_replay_risk_test.go
@@ -1,0 +1,159 @@
+package repo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+
+	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
+	"github.com/taikoxyz/taiko-mono/packages/eventindexer/pkg/db"
+)
+
+// seedResumeBlock writes the event whose emitted_block_id the cursor rewinds
+// from, at a chosen block time.
+func seedResumeBlock(t *testing.T, d db.DB, chainID int64, at time.Time) {
+	t.Helper()
+
+	err := d.GormDB().Exec(
+		`INSERT INTO events (name, event, chain_id, data, emitted_block_id, transacted_at)
+		 VALUES ('MessageSent', 'MessageSent', ?, '{}', 100, ?)`,
+		chainID, at,
+	).Error
+	assert.Equal(t, nil, err)
+}
+
+func seedNFTBalance(t *testing.T, d db.DB, chainID int64, updatedAt time.Time) {
+	t.Helper()
+
+	err := d.GormDB().Exec(
+		`INSERT INTO nft_balances (chain_id, address, amount, contract_address, contract_type, token_id, updated_at)
+		 VALUES (?, '0xholder', 1, '0xnft', 'ERC721', 1, ?)`,
+		chainID, updatedAt,
+	).Error
+	assert.Equal(t, nil, err)
+}
+
+func TestIntegration_UnclaimedBalanceReplayRisk(t *testing.T) {
+	var (
+		old    = time.Now().Add(-90 * 24 * time.Hour).UTC().Truncate(time.Second)
+		resume = time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+		recent = time.Now().Add(-time.Minute).UTC().Truncate(time.Second)
+	)
+
+	tests := []struct {
+		name   string
+		seed   func(t *testing.T, d db.DB)
+		kind   string
+		want   bool
+		wantOK bool
+	}{
+		{
+			"nothing indexed yet",
+			func(t *testing.T, d db.DB) {},
+			eventindexer.TransferKindNFT,
+			false,
+			true,
+		},
+		{
+			"balances but no events, cursor starts at the fork height",
+			func(t *testing.T, d db.DB) { seedNFTBalance(t, d, 1, recent) },
+			eventindexer.TransferKindNFT,
+			false,
+			true,
+		},
+		{
+			// balance indexing was switched off long ago and is only now being
+			// re-enabled: the replay range is newer than anything already written
+			"balances predate the block being resumed from",
+			func(t *testing.T, d db.DB) {
+				seedNFTBalance(t, d, 1, old)
+				seedResumeBlock(t, d, 1, resume)
+			},
+			eventindexer.TransferKindNFT,
+			false,
+			true,
+		},
+		{
+			// a pre-claim process was writing balances inside the replay range
+			"balances written at or after the block being resumed from",
+			func(t *testing.T, d db.DB) {
+				seedNFTBalance(t, d, 1, recent)
+				seedResumeBlock(t, d, 1, resume)
+			},
+			eventindexer.TransferKindNFT,
+			true,
+			true,
+		},
+		{
+			"a claim for this chain and kind clears the risk",
+			func(t *testing.T, d db.DB) {
+				seedNFTBalance(t, d, 1, recent)
+				seedResumeBlock(t, d, 1, resume)
+
+				applied, err := markTransferLogApplied(context.Background(), d.GormDB(),
+					testRef(eventindexer.TransferKindNFT, 1))
+				assert.Equal(t, nil, err)
+				assert.True(t, applied)
+			},
+			eventindexer.TransferKindNFT,
+			false,
+			true,
+		},
+		{
+			// claims are scoped per kind, an erc20 claim says nothing about nfts
+			"a claim for the other kind does not clear the risk",
+			func(t *testing.T, d db.DB) {
+				seedNFTBalance(t, d, 1, recent)
+				seedResumeBlock(t, d, 1, resume)
+
+				applied, err := markTransferLogApplied(context.Background(), d.GormDB(),
+					testRef(eventindexer.TransferKindERC20, 1))
+				assert.Equal(t, nil, err)
+				assert.True(t, applied)
+			},
+			eventindexer.TransferKindNFT,
+			true,
+			true,
+		},
+		{
+			"unknown kind",
+			func(t *testing.T, d db.DB) {},
+			"erc721",
+			false,
+			false,
+		},
+	}
+
+	database, close, err := testMysql(t)
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			truncate(t, database)
+			tt.seed(t, database)
+
+			got, err := UnclaimedBalanceReplayRisk(context.Background(), database, 1, tt.kind)
+			if !tt.wantOK {
+				assert.NotNil(t, err)
+				return
+			}
+
+			assert.Equal(t, nil, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func truncate(t *testing.T, d db.DB) {
+	t.Helper()
+
+	for _, table := range []string{"events", "nft_balances", "processed_transfer_logs"} {
+		assert.Equal(t, nil, d.GormDB().Session(&gorm.Session{AllowGlobalUpdate: true}).
+			Exec("DELETE FROM "+table).Error)
+	}
+}

--- a/packages/eventindexer/pkg/repo/containers_test.go
+++ b/packages/eventindexer/pkg/repo/containers_test.go
@@ -67,7 +67,7 @@ func testMysql(t *testing.T) (db.DB, func(), error) {
 
 	// nolint: lll
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=skip-verify&parseTime=true&multiStatements=true&timeout=30s&readTimeout=30s&writeTimeout=30s",
-		dbUsername, dbPassword, host, port.Int(), dbName)
+		dbUsername, dbPassword, host, port.Num(), dbName)
 
 	deadline := time.Now().Add(2 * time.Minute)
 

--- a/packages/eventindexer/pkg/repo/containers_test.go
+++ b/packages/eventindexer/pkg/repo/containers_test.go
@@ -22,7 +22,10 @@ var (
 	dbPassword = "password"
 )
 
-func testMysql(t *testing.T) (db.DB, func(), error) {
+// testMysql starts a throwaway mysql container. extraDSNParams are appended to
+// the connection string, so a test can pin a driver setting that replay
+// correctness must not depend on.
+func testMysql(t *testing.T, extraDSNParams ...string) (db.DB, func(), error) {
 	req := testcontainers.ContainerRequest{
 		Image:        "mysql:latest",
 		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
@@ -68,6 +71,10 @@ func testMysql(t *testing.T) (db.DB, func(), error) {
 	// nolint: lll
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=skip-verify&parseTime=true&multiStatements=true&timeout=30s&readTimeout=30s&writeTimeout=30s",
 		dbUsername, dbPassword, host, port.Num(), dbName)
+
+	for _, p := range extraDSNParams {
+		dsn += "&" + p
+	}
 
 	deadline := time.Now().Add(2 * time.Minute)
 

--- a/packages/eventindexer/pkg/repo/erc20_balance.go
+++ b/packages/eventindexer/pkg/repo/erc20_balance.go
@@ -2,6 +2,8 @@ package repo
 
 import (
 	"context"
+	"log/slog"
+
 	"github.com/taikoxyz/taiko-mono/packages/eventindexer/pkg/db"
 	"math/big"
 	"net/http"
@@ -116,12 +118,28 @@ func (r *ERC20BalanceRepository) decreaseBalanceInDB(
 
 func (r *ERC20BalanceRepository) IncreaseAndDecreaseBalancesInTx(
 	ctx context.Context,
+	ref eventindexer.TransferLogRef,
 	increaseOpts eventindexer.UpdateERC20BalanceOpts,
 	decreaseOpts eventindexer.UpdateERC20BalanceOpts,
 ) (increasedBalance *eventindexer.ERC20Balance, decreasedBalance *eventindexer.ERC20Balance, err error) {
 	retries := 10
 	for retries > 0 {
+		var replayed bool
+
 		err = r.db.GormDB().Transaction(func(tx *gorm.DB) (err error) {
+			applied, markErr := markTransferLogApplied(ctx, tx, ref)
+			if markErr != nil {
+				return markErr
+			}
+
+			// an earlier pass over this block already applied the log; applying it
+			// again would credit the recipient twice.
+			if !applied {
+				replayed = true
+
+				return nil
+			}
+
 			// Skip no-op or zero-address increases to avoid creating balances for 0x000... or zero amount
 			if increaseOpts.Amount != "0" && increaseOpts.Amount != "" && increaseOpts.Address != ZeroAddress.Hex() {
 				increasedBalance, err = r.increaseBalanceInDB(tx.WithContext(ctx), increaseOpts)
@@ -138,6 +156,15 @@ func (r *ERC20BalanceRepository) IncreaseAndDecreaseBalancesInTx(
 		})
 
 		if err == nil {
+			if replayed {
+				slog.Debug("skipping replayed erc20 transfer",
+					"txHash", ref.TxHash,
+					"logIndex", ref.LogIndex,
+				)
+
+				return nil, nil, nil
+			}
+
 			break
 		}
 

--- a/packages/eventindexer/pkg/repo/erc20_balance_test.go
+++ b/packages/eventindexer/pkg/repo/erc20_balance_test.go
@@ -52,6 +52,7 @@ func TestIntegration_ERC20Balance_Increase_And_Decrease(t *testing.T) {
 	pk, _ := ERC20BalanceRepo.CreateMetadata(context.Background(), 1, "0x123", "SYMBOL", 18)
 
 	bal1, _, err := ERC20BalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		testRef(eventindexer.TransferKindERC20, 1),
 		eventindexer.UpdateERC20BalanceOpts{
 			ERC20MetadataID: int64(pk),
 			ChainID:         1,
@@ -63,6 +64,7 @@ func TestIntegration_ERC20Balance_Increase_And_Decrease(t *testing.T) {
 	assert.NotNil(t, bal1)
 
 	bal2, _, err := ERC20BalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		testRef(eventindexer.TransferKindERC20, 2),
 		eventindexer.UpdateERC20BalanceOpts{
 			ERC20MetadataID: int64(pk),
 			ChainID:         1,
@@ -117,9 +119,10 @@ func TestIntegration_ERC20Balance_Increase_And_Decrease(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := ERC20BalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(), tt.increaseOpts, tt.decreaseOpts)
+			_, _, err := ERC20BalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+				testRef(eventindexer.TransferKindERC20, uint(10+i)), tt.increaseOpts, tt.decreaseOpts)
 			assert.Equal(t, tt.wantErr, err)
 		})
 	}
@@ -161,4 +164,67 @@ func TestIntegration_ERC20Balance_FindByAddress(t *testing.T) {
 			assert.Equal(t, tt.wantErr, err)
 		})
 	}
+}
+
+func TestIntegration_ERC20Balance_RestartReplayDoesNotDoubleCount(t *testing.T) {
+	database, close, err := testMysql(t)
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	erc20BalanceRepo, err := NewERC20BalanceRepository(database)
+	assert.Equal(t, nil, err)
+
+	pk, err := erc20BalanceRepo.CreateMetadata(context.Background(), 1, "0xerc20", "SYMBOL", 18)
+	assert.Equal(t, nil, err)
+
+	opts := func(address string) eventindexer.UpdateERC20BalanceOpts {
+		return eventindexer.UpdateERC20BalanceOpts{
+			ERC20MetadataID: int64(pk),
+			ChainID:         1,
+			Address:         address,
+			ContractAddress: "0xerc20",
+			Amount:          "100",
+		}
+	}
+
+	amountOf := func(address string) (string, bool) {
+		var b eventindexer.ERC20Balance
+
+		if err := database.GormDB().
+			Where("address = ?", address).
+			Where("contract_address = ?", "0xerc20").
+			First(&b).Error; err != nil {
+			return "", false
+		}
+
+		return b.Amount, true
+	}
+
+	// mint to alice
+	_, _, err = erc20BalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		testRef(eventindexer.TransferKindERC20, 1), opts("0xalice"), eventindexer.UpdateERC20BalanceOpts{})
+	assert.Equal(t, nil, err)
+
+	// alice -> bob
+	transferRef := testRef(eventindexer.TransferKindERC20, 2)
+
+	_, _, err = erc20BalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		transferRef, opts("0xbob"), opts("0xalice"))
+	assert.Equal(t, nil, err)
+
+	amount, ok := amountOf("0xbob")
+	assert.True(t, ok)
+	assert.Equal(t, "100", amount)
+
+	// restart replay of the same log must not credit bob twice
+	increased, decreased, err := erc20BalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		transferRef, opts("0xbob"), opts("0xalice"))
+	assert.Equal(t, nil, err)
+	assert.Nil(t, increased)
+	assert.Nil(t, decreased)
+
+	amount, ok = amountOf("0xbob")
+	assert.True(t, ok)
+	assert.Equal(t, "100", amount)
 }

--- a/packages/eventindexer/pkg/repo/nft_balance.go
+++ b/packages/eventindexer/pkg/repo/nft_balance.go
@@ -114,12 +114,29 @@ func (r *NFTBalanceRepository) decreaseBalanceInDB(
 
 func (r *NFTBalanceRepository) IncreaseAndDecreaseBalancesInTx(
 	ctx context.Context,
+	ref eventindexer.TransferLogRef,
 	increaseOpts eventindexer.UpdateNFTBalanceOpts,
 	decreaseOpts eventindexer.UpdateNFTBalanceOpts,
 ) (increasedBalance *eventindexer.NFTBalance, decreasedBalance *eventindexer.NFTBalance, err error) {
 	retries := 10
 	for retries > 0 {
+		var replayed bool
+
 		err = r.db.GormDB().Transaction(func(tx *gorm.DB) (err error) {
+			applied, markErr := markTransferLogApplied(ctx, tx, ref)
+			if markErr != nil {
+				return markErr
+			}
+
+			// an earlier pass over this block already applied the log; applying it
+			// again would increment the recipient a second time while the sender's
+			// row is already gone.
+			if !applied {
+				replayed = true
+
+				return nil
+			}
+
 			increasedBalance, err = r.increaseBalanceInDB(ctx, tx, increaseOpts)
 			if err != nil {
 				return err
@@ -133,6 +150,16 @@ func (r *NFTBalanceRepository) IncreaseAndDecreaseBalancesInTx(
 		})
 
 		if err == nil {
+			if replayed {
+				slog.Debug("skipping replayed nft transfer",
+					"txHash", ref.TxHash,
+					"logIndex", ref.LogIndex,
+					"batchIndex", ref.BatchIndex,
+				)
+
+				return nil, nil, nil
+			}
+
 			break
 		}
 

--- a/packages/eventindexer/pkg/repo/nft_balance_test.go
+++ b/packages/eventindexer/pkg/repo/nft_balance_test.go
@@ -50,6 +50,7 @@ func TestIntegration_NFTBalance_Increase_And_Decrease(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	bal1, _, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		testRef(eventindexer.TransferKindNFT, 1),
 		eventindexer.UpdateNFTBalanceOpts{
 			ChainID:         1,
 			Address:         "0x123",
@@ -62,6 +63,7 @@ func TestIntegration_NFTBalance_Increase_And_Decrease(t *testing.T) {
 	assert.NotNil(t, bal1)
 
 	bal2, _, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		testRef(eventindexer.TransferKindNFT, 2),
 		eventindexer.UpdateNFTBalanceOpts{
 			ChainID:         1,
 			Address:         "0x123",
@@ -121,9 +123,10 @@ func TestIntegration_NFTBalance_Increase_And_Decrease(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(), tt.increaseOpts, tt.decreaseOpts)
+			_, _, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+				testRef(eventindexer.TransferKindNFT, uint(10+i)), tt.increaseOpts, tt.decreaseOpts)
 			assert.Equal(t, tt.wantErr, err)
 		})
 	}
@@ -164,5 +167,152 @@ func TestIntegration_NFTBalance_FindByAddress(t *testing.T) {
 				tt.chainID)
 			assert.Equal(t, tt.wantErr, err)
 		})
+	}
+}
+
+func TestIntegration_NFTBalance_RestartReplayDoesNotDoubleCount(t *testing.T) {
+	database, close, err := testMysql(t)
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	nftBalanceRepo, err := NewNFTBalanceRepository(database)
+	assert.Equal(t, nil, err)
+
+	const (
+		contract = "0xnftcontract"
+		alice    = "0xalice"
+		bob      = "0xbob"
+		carol    = "0xcarol"
+	)
+
+	opts := func(address string) eventindexer.UpdateNFTBalanceOpts {
+		return eventindexer.UpdateNFTBalanceOpts{
+			ChainID:         1,
+			Address:         address,
+			TokenID:         1,
+			ContractAddress: contract,
+			ContractType:    "ERC721",
+			Amount:          1,
+		}
+	}
+
+	amountOf := func(address string) (int64, bool) {
+		var b eventindexer.NFTBalance
+
+		if err := database.GormDB().
+			Where("address = ?", address).
+			Where("token_id = ?", 1).
+			Where("contract_address = ?", contract).
+			First(&b).Error; err != nil {
+			return 0, false
+		}
+
+		return b.Amount, true
+	}
+
+	// mint to alice
+	_, _, err = nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		testRef(eventindexer.TransferKindNFT, 1), opts(alice), eventindexer.UpdateNFTBalanceOpts{})
+	assert.Equal(t, nil, err)
+
+	// alice -> bob
+	transferRef := testRef(eventindexer.TransferKindNFT, 2)
+
+	_, _, err = nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		transferRef, opts(bob), opts(alice))
+	assert.Equal(t, nil, err)
+
+	amount, ok := amountOf(bob)
+	assert.True(t, ok)
+	assert.Equal(t, int64(1), amount)
+
+	_, aliceHasRow := amountOf(alice)
+	assert.False(t, aliceHasRow)
+
+	// The indexer restarts and re-processes the block holding alice -> bob.
+	// Without the processed_transfer_logs claim this incremented bob to 2 and
+	// could not decrement alice's already-deleted row.
+	increased, decreased, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		transferRef, opts(bob), opts(alice))
+	assert.Equal(t, nil, err)
+	assert.Nil(t, increased)
+	assert.Nil(t, decreased)
+
+	amount, ok = amountOf(bob)
+	assert.True(t, ok)
+	assert.Equal(t, int64(1), amount)
+
+	// A genuinely new log for the same token must still be applied, so the claim
+	// cannot be over-blocking.
+	_, _, err = nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		testRef(eventindexer.TransferKindNFT, 3), opts(carol), opts(bob))
+	assert.Equal(t, nil, err)
+
+	amount, ok = amountOf(carol)
+	assert.True(t, ok)
+	assert.Equal(t, int64(1), amount)
+
+	_, bobHasRow := amountOf(bob)
+	assert.False(t, bobHasRow)
+}
+
+func TestIntegration_NFTBalance_BatchIndexSeparatesUnitsOfOneLog(t *testing.T) {
+	database, close, err := testMysql(t)
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	nftBalanceRepo, err := NewNFTBalanceRepository(database)
+	assert.Equal(t, nil, err)
+
+	// One ERC1155 TransferBatch log carries several token ids. They share a
+	// (txHash, logIndex) and are told apart only by BatchIndex, so all of them
+	// must still be applied.
+	ref := func(batchIndex uint) eventindexer.TransferLogRef {
+		return eventindexer.TransferLogRef{
+			ChainID:    1,
+			TxHash:     "0xbatch",
+			LogIndex:   7,
+			BatchIndex: batchIndex,
+			Kind:       eventindexer.TransferKindNFT,
+		}
+	}
+
+	opts := func(tokenID int64) eventindexer.UpdateNFTBalanceOpts {
+		return eventindexer.UpdateNFTBalanceOpts{
+			ChainID:         1,
+			Address:         "0xholder",
+			TokenID:         tokenID,
+			ContractAddress: "0x1155",
+			ContractType:    "ERC1155",
+			Amount:          3,
+		}
+	}
+
+	for i := range 2 {
+		bal, _, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+			ref(uint(i)), opts(int64(i+1)), eventindexer.UpdateNFTBalanceOpts{})
+		assert.Equal(t, nil, err)
+		assert.NotNil(t, bal)
+		assert.Equal(t, int64(3), bal.Amount)
+	}
+
+	// replaying the whole log leaves both units untouched
+	for i := range 2 {
+		increased, _, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+			ref(uint(i)), opts(int64(i+1)), eventindexer.UpdateNFTBalanceOpts{})
+		assert.Equal(t, nil, err)
+		assert.Nil(t, increased)
+	}
+
+	var balances []eventindexer.NFTBalance
+
+	err = database.GormDB().Where("address = ?", "0xholder").Find(&balances).Error
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 2, len(balances))
+
+	for _, b := range balances {
+		assert.Equal(t, int64(3), b.Amount)
 	}
 }

--- a/packages/eventindexer/pkg/repo/transfer_log.go
+++ b/packages/eventindexer/pkg/repo/transfer_log.go
@@ -1,0 +1,41 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
+)
+
+// markTransferLogApplied claims a transfer log for application inside tx.
+//
+// It returns false when the log has already been applied, which is what turns a
+// replayed block into a no-op instead of a double count. The unique key on
+// processed_transfer_logs does the work: the insert is an INSERT IGNORE, so a
+// second attempt affects no rows.
+//
+// It must be called inside the same transaction as the balance mutation, so that
+// a rolled back mutation also releases the claim.
+func markTransferLogApplied(
+	ctx context.Context,
+	tx *gorm.DB,
+	ref eventindexer.TransferLogRef,
+) (bool, error) {
+	p := &eventindexer.ProcessedTransferLog{
+		ChainID:    ref.ChainID,
+		TxHash:     ref.TxHash,
+		LogIndex:   ref.LogIndex,
+		BatchIndex: ref.BatchIndex,
+		Kind:       ref.Kind,
+	}
+
+	res := tx.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(p)
+	if res.Error != nil {
+		return false, errors.Wrap(res.Error, "tx.Create")
+	}
+
+	return res.RowsAffected == 1, nil
+}

--- a/packages/eventindexer/pkg/repo/transfer_log.go
+++ b/packages/eventindexer/pkg/repo/transfer_log.go
@@ -14,8 +14,15 @@ import (
 //
 // It returns false when the log has already been applied, which is what turns a
 // replayed block into a no-op instead of a double count. The unique key on
-// processed_transfer_logs does the work: the insert is an INSERT IGNORE, so a
-// second attempt affects no rows.
+// processed_transfer_logs does the work: INSERT IGNORE drops the duplicate and
+// reports no affected rows.
+//
+// The modifier is deliberate. clause.OnConflict{DoNothing: true} looks
+// equivalent, but gorm's MySQL dialector rewrites it to
+// ON DUPLICATE KEY UPDATE id=id, whose affected-row count is 0 only while the
+// connection lacks CLIENT_FOUND_ROWS; with clientFoundRows=true in the DSN that
+// no-op update reports one row, every replay reads as new, and the balance
+// mutation is applied twice. Replay correctness must not hinge on a driver flag.
 //
 // It must be called inside the same transaction as the balance mutation, so that
 // a rolled back mutation also releases the claim.
@@ -32,7 +39,7 @@ func markTransferLogApplied(
 		Kind:       ref.Kind,
 	}
 
-	res := tx.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(p)
+	res := tx.WithContext(ctx).Clauses(clause.Insert{Modifier: "IGNORE"}).Create(p)
 	if res.Error != nil {
 		return false, errors.Wrap(res.Error, "tx.Create")
 	}

--- a/packages/eventindexer/pkg/repo/transfer_log_test.go
+++ b/packages/eventindexer/pkg/repo/transfer_log_test.go
@@ -1,0 +1,20 @@
+package repo
+
+import (
+	"fmt"
+
+	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
+)
+
+// testRef returns a distinct TransferLogRef per n, standing in for the
+// (txHash, logIndex) identity a real log carries. Two calls with the same n
+// represent the same log being applied twice, which is what a restart replay
+// does.
+func testRef(kind string, n uint) eventindexer.TransferLogRef {
+	return eventindexer.TransferLogRef{
+		ChainID:  1,
+		TxHash:   fmt.Sprintf("0x%064x", n),
+		LogIndex: n,
+		Kind:     kind,
+	}
+}

--- a/packages/eventindexer/pkg/repo/transfer_log_test.go
+++ b/packages/eventindexer/pkg/repo/transfer_log_test.go
@@ -1,7 +1,11 @@
 package repo
 
 import (
+	"context"
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/taikoxyz/taiko-mono/packages/eventindexer"
 )
@@ -17,4 +21,58 @@ func testRef(kind string, n uint) eventindexer.TransferLogRef {
 		LogIndex: n,
 		Kind:     kind,
 	}
+}
+
+func TestIntegration_TransferLog_ReplayDetectedWithClientFoundRows(t *testing.T) {
+	// CLIENT_FOUND_ROWS makes a no-op UPDATE report one found row instead of zero
+	// changed rows. The claim must not depend on that flag being off:
+	// clause.OnConflict{DoNothing: true} is rewritten by gorm's MySQL dialector to
+	// ON DUPLICATE KEY UPDATE id=id, which under this DSN reported one affected
+	// row, so every replay read as new and was applied a second time.
+	database, close, err := testMysql(t, "clientFoundRows=true")
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	claimRef := testRef(eventindexer.TransferKindNFT, 1)
+
+	applied, err := markTransferLogApplied(context.Background(), database.GormDB(), claimRef)
+	assert.Equal(t, nil, err)
+	assert.True(t, applied)
+
+	reapplied, err := markTransferLogApplied(context.Background(), database.GormDB(), claimRef)
+	assert.Equal(t, nil, err)
+	assert.False(t, reapplied)
+
+	// and end to end: a replayed transfer must leave the balance alone
+	nftBalanceRepo, err := NewNFTBalanceRepository(database)
+	assert.Equal(t, nil, err)
+
+	opts := eventindexer.UpdateNFTBalanceOpts{
+		ChainID:         1,
+		Address:         "0xbob",
+		TokenID:         1,
+		ContractAddress: "0xnftcontract",
+		ContractType:    "ERC721",
+		Amount:          1,
+	}
+
+	transferRef := testRef(eventindexer.TransferKindNFT, 2)
+
+	bal, _, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		transferRef, opts, eventindexer.UpdateNFTBalanceOpts{})
+	assert.Equal(t, nil, err)
+	assert.NotNil(t, bal)
+	assert.Equal(t, int64(1), bal.Amount)
+
+	increased, _, err := nftBalanceRepo.IncreaseAndDecreaseBalancesInTx(context.Background(),
+		transferRef, opts, eventindexer.UpdateNFTBalanceOpts{})
+	assert.Equal(t, nil, err)
+	assert.Nil(t, increased)
+
+	var b eventindexer.NFTBalance
+
+	err = database.GormDB().Where("address = ?", "0xbob").First(&b).Error
+	assert.Equal(t, nil, err)
+	assert.Equal(t, int64(1), b.Amount)
 }

--- a/packages/eventindexer/transfer_log.go
+++ b/packages/eventindexer/transfer_log.go
@@ -1,0 +1,37 @@
+package eventindexer
+
+// Kinds of transfer log whose application is tracked in processed_transfer_logs.
+const (
+	TransferKindNFT   = "nft"
+	TransferKindERC20 = "erc20"
+)
+
+// TransferLogRef uniquely identifies a single balance-mutating unit of a transfer
+// log. An ERC20 Transfer, an ERC721 Transfer, and an ERC1155 TransferSingle each
+// produce one unit with BatchIndex 0; an ERC1155 TransferBatch produces one unit
+// per token id, indexed by its position in the batch.
+type TransferLogRef struct {
+	ChainID    int64
+	TxHash     string
+	LogIndex   uint
+	BatchIndex uint
+	Kind       string
+}
+
+// ProcessedTransferLog records that a transfer log's balance mutation has already
+// been applied.
+//
+// The indexer deliberately re-processes a trailing range of blocks on every
+// restart: setInitialIndexingBlockByMode rewinds the cursor to
+// MAX(events.emitted_block_id) - 1 and filter() resumes at cursor + 1. Balances
+// are maintained by read-modify-write, so without this record a replayed transfer
+// increments the recipient a second time while the sender's row is already gone,
+// silently and permanently corrupting the balance.
+type ProcessedTransferLog struct {
+	ID         int64  `json:"id"`
+	ChainID    int64  `json:"chainID"`
+	TxHash     string `json:"txHash"`
+	LogIndex   uint   `json:"logIndex"`
+	BatchIndex uint   `json:"batchIndex"`
+	Kind       string `json:"kind"`
+}


### PR DESCRIPTION
## Problem

The indexer deliberately re-processes a trailing range of blocks on every restart. `setInitialIndexingBlockByMode` rewinds the cursor to `MAX(events.emitted_block_id) - 1` and `filter()` resumes at `cursor + 1`:

```go
// indexer/set_initial_processing_block_height.go
if latest != 0 {
    startingBlock = latest - 1
}
// indexer/filter.go
for j := i.latestIndexedBlockNumber + 1; j <= endBlockID; j += i.blockBatchSize {
```

Only protocol events advance `events.emitted_block_id`. On L2 that means Bridge events, which are sparse — measured on mainnet L2: **37 logs from `0x1670…0001` across the last 150,000 blocks, most recent one 3,035 blocks behind tip**. So the replayed range is routinely thousands of blocks, not the trailing one.

NFT and ERC20 balances are maintained by read-modify-write with no log identity:

- `increaseBalanceInDB` does `b.Amount += opts.Amount` on the row it finds
- `decreaseBalanceInDB` returns `nil, nil` when the row is gone
- `nft_balances` / `erc20_balances` carry only **non-unique** indexes

Replay an ERC-721 `A -> B` and B goes to 2, while the already-deleted A cannot be decremented again. ERC-1155 amounts and ERC20 amounts double the same way. It is silent, and it never self-corrects.

That the codebase already knows replay happens: `pkg/repo/transaction.go:69` swallows duplicate-key errors on `transactions` for exactly this reason. The balance tables were the unfinished half of that defence.

Credit to @smtmfft, who found this reviewing taikoxyz/k8s-configs#1606.

## Fix

Claim each balance-mutating unit of a transfer log in a new `processed_transfer_logs` table, **inside the same transaction as the mutation**, keyed by `(chain_id, tx_hash, log_index, batch_index, kind)`:

```go
res := tx.WithContext(ctx).Clauses(clause.Insert{Modifier: "IGNORE"}).Create(p)
...
return res.RowsAffected == 1, nil
```

The unique key plus `INSERT IGNORE` means a replayed log is dropped by the storage engine and affects no rows, so the balance mutation is skipped. Sharing the transaction means a rolled-back mutation also releases the claim, and the existing deadlock-retry loop keeps working.

The `IGNORE` modifier is load-bearing and the first revision of this PR got it wrong. `clause.OnConflict{DoNothing: true}` reads as the idiomatic equivalent, but gorm's MySQL dialector rewrites it to `ON DUPLICATE KEY UPDATE id=id` (it sets `DoNothing = false` and synthesises the assignment from the primary key). That statement's affected-row count is 0 only while the connection lacks `CLIENT_FOUND_ROWS`; with `clientFoundRows=true` in the DSN the no-op update reports one row, every replay reads as new, and the mutation is applied twice — exactly the corruption the claim exists to prevent. The production DSN does not set the flag, so nothing was ever corrupted by it, but replay correctness should not hinge on an implicit driver setting.

`batch_index` is what keeps the units of a single ERC-1155 `TransferBatch` distinct — they share a `(tx_hash, log_index)` and would otherwise collapse into one claim, so only the first token id in each batch would ever be applied. `kind` separates the NFT and ERC20 paths so neither can mask the other.

## Scope: ERC20 is fixed too

`saveERC20Transfer` has the identical defect, and unlike the NFT path **it is enabled in production today** — hoodi's L2 eventindexer runs `INDEX_ERC20S=true`, so hoodi's ERC20 balances are already exposed to this. Fixing only the NFT half would leave a live instance of the same bug behind. Happy to split it out if reviewers prefer two PRs.

## The first restart after this deploys: guarded

`processed_transfer_logs` starts empty, so logs applied by a *pre-upgrade* process are unclaimed and that one restart would still double-apply its trailing range. Nothing records what the old process applied, so the indexer cannot repair this — but it can refuse to do it silently.

`UnclaimedBalanceReplayRisk` reports risk when a kind has no claims for the chain **and** the balance table was last written at or after the block the cursor resumes from:

```
claims(chain, kind) == 0
AND MAX(balance.updated_at) >= transacted_at(MAX(events.emitted_block_id))
```

`Indexer.Start()` checks it before `setInitialIndexingBlockByMode`, so it fails before any RPC work.

Recency rather than mere existence is what makes it usable. A chain whose balance indexing was switched off long ago and is only now being re-enabled — mainnet, whose `nft_balances` rows predate 2025-05-31 — has a replay range entirely newer than anything already written, so it cannot double count and must not be blocked. A coarse "balance table is non-empty" test would refuse exactly the deploy this work is aimed at.

Ways out: `--allowUnclaimedBalanceReplay` / `ALLOW_UNCLAIMED_BALANCE_REPLAY=true` accepts a single overcount with a warning, or reset the affected balances so they rebuild from claims.

Environments as they stand: mainnet has both flags off, nothing fires. hoodi runs `INDEX_NFTS=true` + `INDEX_ERC20S=true` against live balances and will trip the guard on the upgrade restart — intended, and a decision for deploy time.

## Also in this PR: unbreaking `pkg/repo` tests

`pkg/repo/containers_test.go` has not compiled since #21998 (2026-08-15) bumped testcontainers-go v0.40 → v0.44, where `MappedPort` changed from `nat.Port` to `moby/api/types/network.Port` and lost `.Int()`:

```
pkg/repo/containers_test.go:70:38: port.Int undefined
    (type "github.com/moby/moby/api/types/network".Port has no field or method Int)
```

`eventindexer--test.yml` skips branches starting with `dependabot`, so the bump never ran this suite and the break landed unnoticed — the whole `pkg/repo` package (every `TestIntegration_*`) has been silently unbuildable for two weeks. One-line fix here (`port.Int()` → `port.Num()`) because the regression tests below cannot otherwise run. Worth a separate look at that CI exclusion.

## Tests

`TestIntegration_NFTBalance_RestartReplayDoesNotDoubleCount` walks the exact scenario: mint to alice, transfer alice → bob, replay the same log, then a genuinely new bob → carol log to prove the claim is not over-blocking.

Mutation-verified — with the guard removed the test fails on precisely the predicted corruption:

```
Error: Expected nil, but got: &eventindexer.NFTBalance{ID:2, ChainID:1,
       Address:"0xbob", Amount:2, TokenID:1, ContractAddress:"0xnftcontract",
       ContractType:"ERC721"}
Error: Not equal: expected: 1, actual: 2
```

`TestIntegration_NFTBalance_BatchIndexSeparatesUnitsOfOneLog` covers the ERC-1155 batch case, and `TestIntegration_ERC20Balance_RestartReplayDoesNotDoubleCount` mirrors the first for ERC20.

`TestIntegration_UnclaimedBalanceReplayRisk` covers the bootstrap guard across seven cases including per-kind scoping. Mutation-verified: degrading it to the coarse "balances non-empty" predicate fails exactly the `balances_predate_the_block_being_resumed_from` case.

`TestIntegration_TransferLog_ReplayDetectedWithClientFoundRows` pins the driver setting described above: `testMysql` now takes extra DSN params, and this test runs both the raw claim and a full replay against `clientFoundRows=true`. Also mutation-verified — swap `Insert{Modifier: "IGNORE"}` back for `OnConflict{DoNothing: true}` and it fails with bob at `Amount:2`.

Full suite green locally (the CI command), `golangci-lint` clean:

```
ok  github.com/taikoxyz/taiko-mono/packages/eventindexer/api        0.659s
ok  github.com/taikoxyz/taiko-mono/packages/eventindexer/indexer    1.276s
ok  github.com/taikoxyz/taiko-mono/packages/eventindexer/pkg/http   1.827s
ok  github.com/taikoxyz/taiko-mono/packages/eventindexer/pkg/metrics 3.329s
ok  github.com/taikoxyz/taiko-mono/packages/eventindexer/pkg/repo  235.146s
```

## Notes for review

- `processed_transfer_logs` grows without bound. At current mainnet L2 volume (1 ERC-721 `Transfer` per 100,000 blocks) that is nothing, but it will need pruning if NFT/ERC20 traffic ever picks up. Rows older than the deepest possible replay window are safe to drop.
- This does **not** address the historical `nft_balances` gap on mainnet (~9.58M blocks with NFT indexing off). That is separate work, tracked in taikoxyz/k8s-configs#1606.
- An alternative fix would be a cursor that does not depend on the `events` table. That is a larger change and still would not survive a crash mid-batch, which per-log identity does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


