### PR TITLE
ci(repo): scope secret scans per event and allowlist spec-model hashes

### DIFF
--- a/.github/workflows/repo--secret-scan.yml
+++ b/.github/workflows/repo--secret-scan.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  group: secret-scan-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/repo--secret-scan.yml
+++ b/.github/workflows/repo--secret-scan.yml
@@ -37,10 +37,19 @@ jobs:
           sudo mv gitleaks /usr/local/bin/gitleaks
           gitleaks version
 
+      # Every step pins its own commit range. Omitting --log-opts makes gitleaks
+      # default to `git log --full-history --all`, which — with the full fetch
+      # above — also walks every unmerged remote branch. Only the weekly run
+      # wants that; a PR or a push to main must be gated on its own history.
+
       - name: Scan PR diff
         if: github.event_name == 'pull_request'
         run: gitleaks detect --source . --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" --redact --verbose
 
-      - name: Scan full history
-        if: github.event_name != 'pull_request'
+      - name: Scan main history
+        if: github.event_name == 'push'
+        run: gitleaks detect --source . --log-opts="HEAD" --redact --verbose
+
+      - name: Scan every ref
+        if: github.event_name == 'schedule'
         run: gitleaks detect --source . --redact --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -78,11 +78,19 @@ paths = [
 # trie keys whose *identifiers* end in `key`, e.g.
 #   'registration_commitment_trie_key': '200031adff46d9…660c0ac8'
 # The default generic-api-key rule reads "identifier containing key + 64 hex
-# chars at entropy ~3.8" as a credential. Scoped to that one rule so a real
-# secret committed here is still caught by every other rule.
+# chars at entropy ~3.8" as a credential.
+#
+# Narrowed on both axes: to the generic-api-key rule alone, so private-key,
+# github-pat and the rest still fire here; and, via condition = "AND", to values
+# that are bare 64-hex, so a non-hex credential dropped in this directory is
+# still reported. The irreducible residual is a raw 64-hex private key, which
+# has the same length and entropy as a keccak digest and so cannot be told
+# apart from one.
 [[allowlists]]
 description = "Preconfirmation-v2 spec models: hash constants, not credentials"
 targetRules = ["generic-api-key"]
+condition = "AND"
+regexes = ['''^[a-fA-F0-9]{64}$''']
 paths = [
   '''packages/protocol/docs/preconfirmation-v2/.*''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -92,5 +92,5 @@ targetRules = ["generic-api-key"]
 condition = "AND"
 regexes = ['''^[a-fA-F0-9]{64}$''']
 paths = [
-  '''packages/protocol/docs/preconfirmation-v2/.*''',
+  '''^packages/protocol/docs/preconfirmation-v2/.*''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,7 +10,7 @@ useDefault = true
 # ABI-encoded calldata blobs that merely look like high-entropy hex. Anything
 # not matched here stays flagged rather than risk silencing a real finding.
 
-[allowlist]
+[[allowlists]]
 description = "Public blockchain data and known test keys — not real secrets"
 regexTarget = "line"
 regexes = [
@@ -72,4 +72,17 @@ paths = [
   '''(^|.*/)\.codex/.*''',
   '''(^|.*/)\.claude/.*''',
   '''.*\.claude\.md$''',
+]
+
+# Generated protocol spec models: dicts of keccak digests, storage slots and
+# trie keys whose *identifiers* end in `key`, e.g.
+#   'registration_commitment_trie_key': '200031adff46d9…660c0ac8'
+# The default generic-api-key rule reads "identifier containing key + 64 hex
+# chars at entropy ~3.8" as a credential. Scoped to that one rule so a real
+# secret committed here is still caught by every other rule.
+[[allowlists]]
+description = "Preconfirmation-v2 spec models: hash constants, not credentials"
+targetRules = ["generic-api-key"]
+paths = [
+  '''packages/protocol/docs/preconfirmation-v2/.*''',
 ]


### PR DESCRIPTION
## Why

[Secret Scan run 33349477355](https://github.com/taikoxyz/taiko-mono/actions/runs/33349477355/job/99365685848), on the push of `f9a494975` to `main`, failed with 13 `generic-api-key` findings — all of them in `packages/protocol/docs/preconfirmation-v2/commitment-model.py`.

That file is not on `main`. The commits gitleaks named belong to `claude/chain-liveness-builder-roles-cda13y`, the head branch of #22064, whose own gitleaks check has been red since 2026-08-30 18:03 UTC. Two independent problems produced the red main:

**1. The push scan was gated on unmerged branches.** `Scan full history` ran `gitleaks detect --source .` with no `--log-opts`, and gitleaks then defaults to `git log -p -U0 --full-history --all --diff-filter=tuxdb` ([`sources/git.go`](https://github.com/gitleaks/gitleaks/blob/v8.30.1/sources/git.go#L92-L95)). Since `actions/checkout` runs with `fetch-depth: 0`, every remote branch is already on disk, so `--all` walks all of them. Anyone pushing a high-entropy constant to any branch turns main's CI red.

**2. The findings are false positives.** They are keccak digests, storage slots and trie keys whose *identifiers* end in `key`:

```python
'registration_commitment_trie_key': '200031adff46d90b1cd5c67ff8e31098235d1dddb08ec98b0d20f5f8660c0ac8',
'legacy_genesis_sp1_resume_key_policy_hash': 'b449ce6092b398fd4178d946077f8f19c4f2451cc88d614bb682233134162f12',
```

The existing allowlist does not cover them: its hex exemption is `0x` + exactly 40 chars (contract addresses), while these are bare 64-hex, and `packages/protocol/docs/` is not in `paths`.

## What

**`.github/workflows/repo--secret-scan.yml`** — each event pins its own commit range:

| event | range | rationale |
| --- | --- | --- |
| `pull_request` | `base..head` | unchanged |
| `push` (main) | `--log-opts="HEAD"` | gate main on main's own history |
| `schedule` (weekly) | default `--all` | keep the belt-and-braces sweep of every ref |

**`.gitleaks.toml`** — allowlists the spec-model hash constants for the `generic-api-key` rule *only*, so every other rule stays live in that directory. Converting the singular `[allowlist]` to `[[allowlists]]` is forced: gitleaks errors out on `[allowlist] is deprecated, it cannot be used alongside [[allowlists]]` ([`config/config.go`](https://github.com/gitleaks/gitleaks/blob/v8.30.1/config/config.go#L221-L227)). The two tables are parsed by the same code path, so the conversion is semantically inert — verified below.

## Verification

All runs use the pinned `gitleaks v8.30.1` (official image, same version the workflow installs).

**Reproduced the failure, then confirmed the fix** — the exact commits from the red run:

```
$ gitleaks detect --source . --log-opts="origin/main..origin/claude/chain-liveness-builder-roles-cda13y" --redact --verbose
before: WRN leaks found: 13      (13× generic-api-key, all commitment-model.py)
after:  INF no leaks found
```

**The allowlist conversion changes nothing else.** Old vs. new config over a corpus with one sample per existing entry (eth address, foundry devnet key, GoldenTouch key, `ecdsa.PrivateKey`, `packages/protocol/script/*`, `packages/relayer/processor/*`) plus two controls:

```
old: generic-api-key  misc/control.go            (control, expected)
     generic-api-key  misc/control.go            (control, expected)
     generic-api-key  docs/other/model.py        (control, expected)
     generic-api-key  docs/preconfirmation-v2/model.py
new: (identical, minus the last line)
```

**The new allowlist stays narrow.** Planting a PEM key and a `ghp_…` token inside `packages/protocol/docs/preconfirmation-v2/` still trips `private-key` and `github-pat`; the same hash constant one directory over still trips `generic-api-key`.

**Push-mode scan of main is clean** (`--log-opts="HEAD"`, `no leaks found`), the PR-diff scan of this branch is clean, and the workflow YAML parses with all three steps mutually exclusive by event.

## Review follow-ups

- **Allowlist narrowed to hash-shaped values** (0378a6495) — path-only suppression exempted every `generic-api-key` match in the directory, not just the 64-hex constants: a planted `'vendor_api_key': 'sk-live-…'` was swallowed. `condition = "AND"` with `^[a-fA-F0-9]{64}$` re-arms that case.
- **Path anchored** (f9032d0cc) — the regex was unanchored, so a file at `elsewhere/packages/protocol/docs/preconfirmation-v2/…` matched it too; confirmed by planting one there and watching it get swallowed.
- **Concurrency group split by event** (f9032d0cc) — `schedule` and `push` on `main` share a `github.ref`, so with `cancel-in-progress` a push could cancel the weekly all-ref scan and leave that week covered only by the narrower `HEAD` scan. Harmless before this PR, when both events ran the same scan.

Known residual, stated in the config comment: a raw 64-hex private key has the same length and entropy as a keccak digest, so it stays exempt inside that directory. Pinning the known values, or their gitleaks fingerprints, was considered and rejected — the constants are generated, not fixed. `registration_route_key` is `7ff8e1d5…`, `2b65be65…` and `d50f46ef…` across the three flagged commits, moving from line 5097 to 12901, so any pin would need re-editing on every regeneration of the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
