### PR TITLE
fix(relayer): land a claim every relay refuses, and see what the mocks drop

### DIFF
--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -108,8 +108,14 @@ claims still in it.
 To fix an existing queue, either is enough:
 
 - Set `dead-letter-routing-key` to `<queue>-process` with a broker policy on that queue. Policies
-  are not part of the declare-equivalence check, so this needs no redeclare and can be applied while
-  the queue is running. This is the one to prefer.
+  are not part of the declare-equivalence check, so this needs no redeclare, can be applied while the
+  queue is running, and takes effect for messages already enqueued — nothing has to be drained. This
+  is the one to prefer.
+
+  ```sh
+  rabbitmqctl set_policy dlrk "^<queue>$" \
+    '{"dead-letter-routing-key":"<queue>-process"}' --apply-to queues --priority 1
+  ```
 - Drain the queue and delete it, so the next start declares it afresh. This loses anything still
   queued, so drain first.
 
@@ -121,8 +127,8 @@ transaction not yet confirmed — does not cost the claim. The message is republ
 `TRANSIENT_ERROR_QUEUE_EXPIRATION` on it, and the original delivery is acknowledged. That value is
 **milliseconds**, as every AMQP expiration is, and defaults to `30000`. It is checked at startup: a
 duration string such as `30s` is accepted by the publish and then closes the channel, which the
-relayer would otherwise survive only as a reconnect loop. When the expiration elapses the broker dead-letters it back onto the processing queue
-and it is tried again.
+relayer would otherwise survive only as a reconnect loop. When the expiration elapses the broker
+dead-letters it back onto the processing queue and it is tried again.
 
 The wait is what makes this safe to repeat. `QUEUE_PREFETCH_COUNT` defaults to 1 and a delivery is
 acknowledged only after processing, so exactly one message is in flight per replica: negatively
@@ -192,7 +198,15 @@ connection and then never answers cannot spend the budget the endpoints behind i
 is `RPC_TIMEOUT` (12 seconds by default), not `TX_SEND_TIMEOUT`: the transaction manager calls the
 backend once per publish under its network timeout, and the share is that divided by the endpoints
 still to try. Lowering `RPC_TIMEOUT` or configuring many endpoints therefore shrinks each attempt,
-and an endpoint that runs out of its share is charged with a failure.
+and an endpoint that spends its whole share without answering is charged with a failure.
+
+The share has a floor of a second. Below that an attempt is too short for a relay to answer in, so
+the endpoint would fail on the budget rather than on its health — and a timeout is charged with no
+deduplication, which is how endpoints flap in and out of rotation for no reason of their own. When
+the share would fall below the floor the attempt takes the whole remaining budget instead, and the
+endpoints behind it are skipped **without being charged**, since they never got a usable context. At
+the 12 second default this only bites past a dozen endpoints, or when `RPC_TIMEOUT` has been
+lowered.
 
 Because it is the same signed
 transaction every time, offering it to the next endpoint after one refuses is idempotent — at most
@@ -203,10 +217,27 @@ because a competitor already processed the message, say — is charged once for 
 every resubmission, so one such claim does not cost a healthy relay its turn. That is judged by
 nonce, not by transaction hash: once any endpoint accepts a send the transaction manager bumps the
 fee before resending, so every resubmission of one claim carries a new hash while remaining one
-claim. A timeout or a
+claim.
+
+Two answers are not charged at all. A relay that already holds the nonce replies `replacement
+transaction underpriced` or `already known`, which reads as a refusal but says the opposite — it is
+carrying the claim, which is what steering the resend to it was for. Those are counted by
+`private_rpc_held_nonce_ops_total` and, so that an endpoint answering this way to everything cannot
+keep its place indefinitely, they still count towards the consecutive ceiling. An endpoint given a
+share of the budget too small to answer in is not charged either; see below. A timeout or a
 transport failure always counts, even for the same transaction, since that is what an endpoint
 being down looks like. Only once no endpoint is left in
 rotation does a transaction go out through `DEST_RPC_URL`.
+
+One claim can be refused by every endpoint without any of them being unhealthy — each is charged
+once for it, so none trips, and the claim would otherwise loop until `TX_SEND_TIMEOUT` while the
+relays go on serving everything else. After three consecutive sends of one nonce that every endpoint
+in rotation *answered* with a refusal, that claim is broadcast publicly and
+`private_rpc_all_refused_ops_total` counts it. A timeout or transport failure does not count towards
+this: an endpoint being down is what tripping handles, and counting it here would push claims into
+the open during an outage before the rotation had a chance to empty. Broadcasting publicly gives a
+competitor the message and proof, so it is deliberately the last resort — but a claim that never
+lands is worth less than one landed in the open.
 
 Three metrics are worth alerting on, all labelled or counted so they can be read without access to
 the logs. `private_rpc_failures_ops_total` is labelled by the refusing endpoint's position in the

--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -222,8 +222,10 @@ claim.
 Two answers are not charged at all. A relay that already holds the nonce replies `replacement
 transaction underpriced` or `already known`, which reads as a refusal but says the opposite — it is
 carrying the claim, which is what steering the resend to it was for. Those are counted by
-`private_rpc_held_nonce_ops_total` and, so that an endpoint answering this way to everything cannot
-keep its place indefinitely, they still count towards the consecutive ceiling. An endpoint given a
+`private_rpc_held_nonce_ops_total`. An answer for a nonce the endpoint has demonstrably taken is
+free, however many claims it is carrying at once, as is one repeat of the last nonce it answered
+for; anything beyond that counts towards the consecutive ceiling, so an endpoint answering this way
+for a succession of claims it never took cannot keep its place indefinitely. An endpoint given a
 share of the budget too small to answer in is not charged either; see below. A timeout or a
 transport failure always counts, even for the same transaction, since that is what an endpoint
 being down looks like. Only once no endpoint is left in
@@ -231,10 +233,22 @@ rotation does a transaction go out through `DEST_RPC_URL`.
 
 One claim can be refused by every endpoint without any of them being unhealthy — each is charged
 once for it, so none trips, and the claim would otherwise loop until `TX_SEND_TIMEOUT` while the
-relays go on serving everything else. After three consecutive sends of one nonce that every endpoint
-in rotation *answered* with a refusal, that claim is broadcast publicly and
-`private_rpc_all_refused_ops_total` counts it. A landed claim clears its count, so a persistently
-refused one is exposed on one send in three rather than on every send.
+relays go on serving everything else. After three consecutive sends that every endpoint in rotation
+*answered* with a refusal, that claim is broadcast publicly and
+`private_rpc_all_refused_ops_total` counts it.
+
+That probation is served once per claim, not once per exposure. Once a claim has been broadcast it
+stays in the public pool on every subsequent send, until a private endpoint takes it back and clears
+the run. Restarting the count there would withhold the next two fee-bumped resubmissions from a pool
+that already holds the stale low-fee variant of the same claim: there is no privacy left to save by
+then, and the replacement would be kept from the only place that can mine it.
+
+The run belongs to the claim rather than to the nonce it was sent under, because nonces are reused.
+A claim abandoned at `TX_SEND_TIMEOUT` leaves its count behind — only an accepted send clears one —
+and the next message signed with that nonce would otherwise inherit a probation it had served none
+of, and be broadcast on its first refusal instead of its third. The claim is identified by its
+calldata, which is the message and its proof: unchanged by the fee bumps that change everything else
+about the transaction, and different for every other claim.
 
 Two answers do not count towards this. A timeout or transport failure means the endpoint is down,
 which tripping handles, and counting it here would push claims into the open during an outage before

--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -233,19 +233,31 @@ One claim can be refused by every endpoint without any of them being unhealthy �
 once for it, so none trips, and the claim would otherwise loop until `TX_SEND_TIMEOUT` while the
 relays go on serving everything else. After three consecutive sends of one nonce that every endpoint
 in rotation *answered* with a refusal, that claim is broadcast publicly and
-`private_rpc_all_refused_ops_total` counts it. A timeout or transport failure does not count towards
-this: an endpoint being down is what tripping handles, and counting it here would push claims into
-the open during an outage before the rotation had a chance to empty. Broadcasting publicly gives a
+`private_rpc_all_refused_ops_total` counts it. A landed claim clears its count, so a persistently
+refused one is exposed on one send in three rather than on every send.
+
+Two answers do not count towards this. A timeout or transport failure means the endpoint is down,
+which tripping handles, and counting it here would push claims into the open during an outage before
+the rotation had a chance to empty. An endpoint answering that it already holds the nonce does not
+count either — the claim is already where it needs to be, so broadcasting it would leak one every
+relay is carrying. Broadcasting publicly gives a
 competitor the message and proof, so it is deliberately the last resort — but a claim that never
 lands is worth less than one landed in the open.
 
-Three metrics are worth alerting on, all labelled or counted so they can be read without access to
+Five metrics are worth alerting on, all labelled or counted so they can be read without access to
 the logs. `private_rpc_failures_ops_total` is labelled by the refusing endpoint's position in the
 failover order, so it says which relay is unhealthy. `private_rpc_trips_ops_total`, labelled the
 same way, counts an endpoint actually leaving the rotation rather than each refusal on the way
 there — one fewer place to send privately. `private_rpc_unavailable_ops_total` counts transactions
 that went out through `DEST_RPC_URL` while private endpoints were configured — that is the relayer
-running exposed, and matters more than any individual refusal. Alongside them,
+running exposed, and matters more than any individual refusal.
+
+Two more count the other way a claim reaches the public mempool: not because the rotation was empty,
+but because every endpoint in it refused this one claim. `private_rpc_all_refused_attempts_ops_total`
+counts each time such a claim was offered to `DEST_RPC_URL`, and `private_rpc_all_refused_ops_total`
+counts the times that endpoint took it. Both count sends rather than distinct claims, so a claim
+refused for long enough is counted once per broadcast. Read together: attempts climbing while
+broadcasts do not means the public endpoint is failing as well and the claim is reaching nobody. Alongside them,
 `private_rpc_sends_ops_total`, labelled the same way, counts the transactions each endpoint
 accepted. It is not an alert on its own; it is what turns the refusals into a rate, which is what
 separates a busy relay turning down a few claims from one that has started turning down most of

--- a/packages/relayer/indexer/handle_events_coverage_test.go
+++ b/packages/relayer/indexer/handle_events_coverage_test.go
@@ -65,6 +65,8 @@ func TestHandleCheckpointSavedEventSavesTheCheckpoint(t *testing.T) {
 	assert.Equal(t, event.Raw.BlockNumber, saved.EmittedBlockID)
 	assert.Equal(t, event.Raw.BlockNumber, saved.SyncedInBlockID)
 	assert.Equal(t, common.Hash(event.StateRoot).Hex(), saved.SyncData)
+	assert.Equal(t, i.destChainId.Uint64(), saved.SyncedChainID,
+		"both reader queries filter on this, so a zero here is a row that is never found")
 	assert.Equal(t, relayer.EventNameCheckpointSaved, saved.Name)
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(relayer.CheckpointSavedEventsIndexed)-before)

--- a/packages/relayer/indexer/handle_events_coverage_test.go
+++ b/packages/relayer/indexer/handle_events_coverage_test.go
@@ -52,8 +52,21 @@ func TestHandleCheckpointSavedEventSavesTheCheckpoint(t *testing.T) {
 	require.NoError(t, i.handleCheckpointSavedEvent(context.Background(), checkpointSavedEvent(), false))
 
 	// The processor waits on these rows before it can prove a message, so the checkpoint has to
-	// be persisted with the synced block it represents.
+	// be persisted with the synced block it represents. A row count cannot see that: rewriting the
+	// handler to persist zeroes for all of it left this test, and the whole package, green.
 	require.Equal(t, 1, repo.SavedCount())
+
+	saved := repo.SavedEvents()[0]
+
+	event := checkpointSavedEvent()
+
+	assert.Equal(t, event.BlockNumber.Uint64(), saved.BlockID,
+		"the synced block is what wait_header_synced gates every claim on")
+	assert.Equal(t, event.Raw.BlockNumber, saved.EmittedBlockID)
+	assert.Equal(t, event.Raw.BlockNumber, saved.SyncedInBlockID)
+	assert.Equal(t, common.Hash(event.StateRoot).Hex(), saved.SyncData)
+	assert.Equal(t, relayer.EventNameCheckpointSaved, saved.Name)
+
 	assert.Equal(t, float64(1), testutil.ToFloat64(relayer.CheckpointSavedEventsIndexed)-before)
 }
 

--- a/packages/relayer/pkg/mock/event_repository.go
+++ b/packages/relayer/pkg/mock/event_repository.go
@@ -44,6 +44,13 @@ func (r *EventRepository) SavedCount() int {
 	return len(r.events)
 }
 
+// SavedEvents returns the events persisted via Save, in order. For tests that need to assert what
+// was written rather than only how much: a row count cannot tell a correct block number from a
+// zero, and the fields it would miss are the ones every claim is gated on.
+func (r *EventRepository) SavedEvents() []*relayer.Event {
+	return slices.Clone(r.events)
+}
+
 func (r *EventRepository) Save(ctx context.Context, opts *relayer.SaveEventOpts) (*relayer.Event, error) {
 	event := &relayer.Event{
 		ID:           rand.Int(), // nolint: gosec
@@ -56,6 +63,23 @@ func (r *EventRepository) Save(ctx context.Context, opts *relayer.SaveEventOpts)
 		MessageOwner: opts.MessageOwner,
 		MsgHash:      opts.MsgHash,
 		EventType:    opts.EventType,
+
+		// The checkpoint fields have to be carried, not dropped. wait_header_synced gates every
+		// claim on the block numbers these hold, so a handler that wrote the wrong one would leave
+		// a test asserting only a row count perfectly green while every claim waited on a header
+		// that never syncs, or was released against one that had not.
+		SyncedChainID:   opts.SyncedChainID,
+		BlockID:         opts.BlockID,
+		EmittedBlockID:  opts.EmittedBlockID,
+		SyncedInBlockID: opts.SyncedInBlockID,
+		SyncData:        opts.SyncData,
+		Kind:            opts.Kind,
+
+		CanonicalTokenAddress:  opts.CanonicalTokenAddress,
+		CanonicalTokenSymbol:   opts.CanonicalTokenSymbol,
+		CanonicalTokenName:     opts.CanonicalTokenName,
+		CanonicalTokenDecimals: opts.CanonicalTokenDecimals,
+		Amount:                 opts.Amount,
 	}
 
 	r.events = append(r.events, event)

--- a/packages/relayer/pkg/mock/mock_tx_sender.go
+++ b/packages/relayer/pkg/mock/mock_tx_sender.go
@@ -63,11 +63,6 @@ type TxSender struct {
 	sent []*types.Transaction
 }
 
-// NewFailingTxSender returns a sender that refuses every transaction with err.
-func NewFailingTxSender(err error) *TxSender {
-	return &TxSender{err: err}
-}
-
 func (s *TxSender) SendTransaction(_ context.Context, tx *types.Transaction) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/packages/relayer/pkg/mock/mock_tx_sender.go
+++ b/packages/relayer/pkg/mock/mock_tx_sender.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 	"math/big"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
@@ -52,4 +53,38 @@ func (t *TxManager) SuggestGasPriceCaps(ctx context.Context) (
 
 func (t *TxManager) API() rpc.API {
 	panic("unimplemented")
+}
+
+// TxSender is a private endpoint that accepts everything it is offered, recording what it took.
+// It satisfies utils.TxSender.
+type TxSender struct {
+	mu   sync.Mutex
+	err  error
+	sent []*types.Transaction
+}
+
+// NewFailingTxSender returns a sender that refuses every transaction with err.
+func NewFailingTxSender(err error) *TxSender {
+	return &TxSender{err: err}
+}
+
+func (s *TxSender) SendTransaction(_ context.Context, tx *types.Transaction) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.err != nil {
+		return s.err
+	}
+
+	s.sent = append(s.sent, tx)
+
+	return nil
+}
+
+// SentCount returns how many transactions this endpoint accepted. For tests.
+func (s *TxSender) SentCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return len(s.sent)
 }

--- a/packages/relayer/pkg/queue/rabbitmq/queue.go
+++ b/packages/relayer/pkg/queue/rabbitmq/queue.go
@@ -517,6 +517,17 @@ func (r *RabbitMQ) Notify(ctx context.Context, wg *sync.WaitGroup) error {
 }
 
 // Subscribe should be called by consumers.
+// logNotifyClose records a close notification, which carries no error when the close was graceful.
+func logNotifyClose(message string, err *amqp.Error) {
+	if err != nil {
+		slog.Error(message, "err", err.Error())
+
+		return
+	}
+
+	slog.Error(message)
+}
+
 func (r *RabbitMQ) Subscribe(ctx context.Context, msgChan chan<- queue.Message, wg *sync.WaitGroup) error {
 	wg.Add(1)
 
@@ -577,11 +588,14 @@ func (r *RabbitMQ) Subscribe(ctx context.Context, msgChan chan<- queue.Message, 
 
 			return nil
 		case err := <-r.connErrCh:
-			slog.Error("rabbitmq notify close connection", "err", err.Error())
+			// A graceful close closes the notify channel without sending, so a receive yields a
+			// nil *amqp.Error — and Error() has a value receiver, so calling it through that nil
+			// pointer panics the consume loop. Notify already guards both arms; this one did not.
+			logNotifyClose("rabbitmq notify close connection", err)
 
 			return queue.ErrClosed
 		case err := <-r.chErrCh:
-			slog.Error("rabbitmq notify close channel", "err", err.Error())
+			logNotifyClose("rabbitmq notify close channel", err)
 
 			return queue.ErrClosed
 		case d, ok := <-msgs:

--- a/packages/relayer/pkg/queue/rabbitmq/queue.go
+++ b/packages/relayer/pkg/queue/rabbitmq/queue.go
@@ -472,11 +472,7 @@ func (r *RabbitMQ) Notify(ctx context.Context, wg *sync.WaitGroup) error {
 
 			return nil
 		case err := <-r.connErrCh:
-			if err != nil {
-				slog.Error("rabbitmq notify close connection", "err", err.Error())
-			} else {
-				slog.Error("rabbitmq notify close connection")
-			}
+			logNotifyClose("rabbitmq notify close connection", err)
 
 			relayer.QueueConnectionNotifyClosed.Inc()
 
@@ -489,11 +485,7 @@ func (r *RabbitMQ) Notify(ctx context.Context, wg *sync.WaitGroup) error {
 
 			return queue.ErrClosed
 		case err := <-r.chErrCh:
-			if err != nil {
-				slog.Error("rabbitmq notify close channel", "err", err.Error())
-			} else {
-				slog.Error("rabbitmq notify close channel")
-			}
+			logNotifyClose("rabbitmq notify close channel", err)
 
 			relayer.QueueChannelNotifyClosed.Inc()
 
@@ -516,7 +508,6 @@ func (r *RabbitMQ) Notify(ctx context.Context, wg *sync.WaitGroup) error {
 	}
 }
 
-// Subscribe should be called by consumers.
 // logNotifyClose records a close notification, which carries no error when the close was graceful.
 func logNotifyClose(message string, err *amqp.Error) {
 	if err != nil {
@@ -528,6 +519,7 @@ func logNotifyClose(message string, err *amqp.Error) {
 	slog.Error(message)
 }
 
+// Subscribe should be called by consumers.
 func (r *RabbitMQ) Subscribe(ctx context.Context, msgChan chan<- queue.Message, wg *sync.WaitGroup) error {
 	wg.Add(1)
 

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -81,6 +81,13 @@ const MinPrivateRPCAttemptShare = time.Second
 // trying privately first.
 const DefaultPrivateRPCAllRefusedLimit = 3
 
+// maxTrackedRefusedNonces bounds the per-nonce refusal counts.
+//
+// A claim that is abandoned — its send timed out, the processor gave up — never comes back to clear
+// its own entry, so without a bound the map would grow for as long as the relayer runs. Far more
+// than the processor has in flight at once, so a live claim is never evicted in practice.
+const maxTrackedRefusedNonces = 256
+
 // DefaultPrivateRPCAttemptTimeout caps a single attempt when the caller supplied no deadline.
 //
 // The transaction manager always calls SendTransaction under its NetworkTimeout, so this does not
@@ -143,13 +150,13 @@ type SendingBackend struct {
 
 	private          []TxSender
 	hosts            []string
-	allRefusedNonce  uint64
-	allRefusedCount  int
-	hasAllRefused    bool
+	allRefused       map[uint64]int
 	allRefusedLimit  int
 	failures         []int
 	failedAt         []time.Time
 	lastCharged      []uint64
+	lastHeld         []uint64
+	hasHeld          []bool
 	hasCharged       []bool
 	consecutive      []int
 	generation       []uint64
@@ -192,6 +199,8 @@ func NewSendingBackend(
 		failures:         make([]int, len(private)),
 		failedAt:         make([]time.Time, len(private)),
 		lastCharged:      make([]uint64, len(private)),
+		lastHeld:         make([]uint64, len(private)),
+		hasHeld:          make([]bool, len(private)),
 		hasCharged:       make([]bool, len(private)),
 		consecutive:      make([]int, len(private)),
 		generation:       make([]uint64, len(private)),
@@ -199,6 +208,7 @@ func NewSendingBackend(
 		hasAccepted:      make([]bool, len(private)),
 		failureThreshold: DefaultPrivateRPCFailureThreshold,
 		failureCeiling:   DefaultPrivateRPCConsecutiveFailureCeiling,
+		allRefused:       make(map[uint64]int),
 		allRefusedLimit:  DefaultPrivateRPCAllRefusedLimit,
 		retryInterval:    interval,
 		now:              time.Now,
@@ -320,7 +330,7 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			// recordFailure entirely meant it could never reach the ceiling that exists to end
 			// exactly that: it would hold its place indefinitely while nothing was ever sent
 			// through it.
-			if tripped := b.recordHeldNonce(endpoint); tripped {
+			if tripped := b.recordHeldNonce(endpoint, tx.Nonce()); tripped {
 				relayer.PrivateRPCTrips.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
 				slog.Warn("Private endpoint taken out of rotation",
@@ -380,6 +390,8 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			"afterSends", b.allRefusedLimit,
 		)
 
+		relayer.PrivateRPCAllRefusedAttempts.Inc()
+
 		publicErr := b.ETHBackend.SendTransaction(ctx, tx)
 		if publicErr == nil {
 			b.clearAllRefused(tx.Nonce())
@@ -402,20 +414,17 @@ func (b *SendingBackend) clearAllRefused(nonce uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.hasAllRefused && b.allRefusedNonce == nonce {
-		b.allRefusedCount = 0
-	}
+	delete(b.allRefused, nonce)
 }
 
 // countAllRefused records that every endpoint in rotation refused this nonce, and reports whether
-// that has now happened often enough in a row to justify broadcasting it publicly.
+// that has now happened often enough for this claim to justify broadcasting it publicly.
 //
-// One slot rather than a map: the transaction manager resends an unconfirmed nonce every
-// RESUBMISSION_TIMEOUT, so consecutive refusals of one claim land here in a row, and a different
-// nonce means a different claim and starts the count again. Claims are handled concurrently, so
-// two claims both being refused can reset each other's count — the same trade the failure
-// deduplication makes, and with the same consequence: the fallback is delayed, never skipped, and
-// only for as long as both claims keep failing.
+// Counted per nonce. A single slot could not do this: the processor handles claims concurrently, so
+// two claims both being refused overwrote each other's slot on every send and neither count ever
+// passed one — the fallback never fired at all in the very case it exists for, which is more than
+// one claim nobody will take. The count is per claim because the decision is: this claim has been
+// offered privately enough times.
 //
 // The count is cleared by a send some endpoint accepted, and by nothing else — in particular not by
 // firing. Clearing it there cost the claim the threshold it had just earned: if the public send then
@@ -428,15 +437,23 @@ func (b *SendingBackend) countAllRefused(nonce uint64) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if !b.hasAllRefused || b.allRefusedNonce != nonce {
-		b.allRefusedNonce = nonce
-		b.allRefusedCount = 0
-		b.hasAllRefused = true
+	b.allRefused[nonce]++
+
+	// Bounded, because a nonce whose claim is abandoned never comes back to clear its own entry.
+	// Nonces only ascend, so the smallest is the stalest.
+	for len(b.allRefused) > maxTrackedRefusedNonces {
+		stalest := nonce
+
+		for tracked := range b.allRefused {
+			if tracked < stalest {
+				stalest = tracked
+			}
+		}
+
+		delete(b.allRefused, stalest)
 	}
 
-	b.allRefusedCount++
-
-	return b.allRefusedCount >= b.allRefusedLimit
+	return b.allRefused[nonce] >= b.allRefusedLimit
 }
 
 // attemptContext gives one endpoint its share of the time left on ctx, so an endpoint that hangs
@@ -659,6 +676,8 @@ func (b *SendingBackend) inRotation() []admission {
 			b.failures[i] = 0
 			b.lastCharged[i] = 0
 			b.hasCharged[i] = false
+			b.lastHeld[i] = 0
+			b.hasHeld[i] = false
 			b.consecutive[i] = 0
 
 			// highestAccepted and hasAccepted are deliberately kept. They record which nonces this
@@ -785,8 +804,9 @@ func (b *SendingBackend) recordFailure(endpoint admission, nonce uint64, rejecti
 // it could never reach the bound that exists for precisely that — it skipped the accounting
 // altogether and kept its place forever while nothing went through it.
 //
-// A send it accepts clears the count, as it clears every other.
-func (b *SendingBackend) recordHeldNonce(endpoint admission) (tripped bool) {
+// A send it accepts clears the count, as it clears every other, and clears the remembered nonce
+// with it.
+func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (tripped bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -795,6 +815,19 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission) (tripped bool) {
 	if b.generation[index] != endpoint.generation {
 		return false
 	}
+
+	// Only a nonce this endpoint has not already answered for counts. The transaction manager
+	// resubmits an unconfirmed nonce every RESUBMISSION_TIMEOUT, and the endpoint holding it says
+	// so every time — that is one claim being carried correctly, not an endpoint taking nothing.
+	// Counted per answer, ten resends of a single claim reached the ceiling in about eight minutes
+	// and took out the very endpoint holding it; with one endpoint configured the claim then went
+	// public through the unavailable path, which is the exposure the exemption exists to prevent.
+	if b.hasHeld[index] && b.lastHeld[index] == nonce {
+		return false
+	}
+
+	b.lastHeld[index] = nonce
+	b.hasHeld[index] = true
 
 	b.consecutive[index]++
 
@@ -833,6 +866,8 @@ func (b *SendingBackend) recordSuccess(index int, nonce uint64) {
 	b.failedAt[index] = time.Time{}
 	b.lastCharged[index] = 0
 	b.hasCharged[index] = false
+	b.lastHeld[index] = 0
+	b.hasHeld[index] = false
 	b.consecutive[index] = 0
 
 	relayer.PrivateRPCInRotation.WithLabelValues(strconv.Itoa(index)).Set(1)

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -316,7 +316,9 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 		}
 
 		// An endpoint that answers because it is already holding this nonce is not refusing the
-		// claim, and steering the resend to it is the whole point of doing so. Nothing is charged.
+		// claim, and steering the resend to it is the whole point of doing so. It is not charged as
+		// a failure; a nonce this endpoint has not answered for before does count towards the
+		// consecutive ceiling, so answering this to everything still ends. See recordHeldNonce.
 		if holdsTheNonce(err) {
 			// Not a refusal, so it cannot count towards the public fallback either. Every endpoint
 			// answering that it holds this nonce means the claim is already everywhere it needs to
@@ -385,11 +387,6 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 	// only once for it, so nobody leaves the rotation over one unwanted claim and the fallback
 	// below would never be reached — the claim would simply loop until TX_SEND_TIMEOUT.
 	if allAnsweredRejection && b.countAllRefused(tx.Nonce()) {
-		slog.Warn("Every private endpoint refused this claim, broadcasting publicly",
-			"txHash", tx.Hash().Hex(),
-			"afterSends", b.allRefusedLimit,
-		)
-
 		relayer.PrivateRPCAllRefusedAttempts.Inc()
 
 		publicErr := b.ETHBackend.SendTransaction(ctx, tx)
@@ -397,8 +394,22 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			b.clearAllRefused(tx.Nonce())
 			relayer.PrivateRPCAllRefused.Inc()
 
+			// Logged after the fact rather than before it. Announcing the broadcast up front left
+			// a log asserting an exposure that had not happened whenever the public endpoint then
+			// failed, which is the reading an operator would trust least once they noticed.
+			slog.Warn("Every private endpoint refused this claim, broadcast publicly",
+				"txHash", tx.Hash().Hex(),
+				"afterSends", b.allRefusedLimit,
+			)
+
 			return nil
 		}
+
+		slog.Error("Every private endpoint refused this claim and the public endpoint would not "+
+			"take it either",
+			"txHash", tx.Hash().Hex(),
+			"error", redactEndpoints(publicErr, b.hosts),
+		)
 
 		// The public attempt is the last and most complete thing tried, so it is what the caller
 		// should classify on: a refusal from a relay may not be transient, but a public endpoint
@@ -901,10 +912,12 @@ func (b *SendingBackend) recordSuccess(index int, nonce uint64) {
 // one". A first send arriving out of order behind a higher nonce is treated as a resend by that
 // test; that only reorders private endpoints against each other and costs nothing.
 //
-// Nothing is charged for the reordering itself, and nothing is charged for what the holder answers
-// either: a relay that already has the nonce replies "replacement transaction underpriced" or
-// "already known", which reads as a refusal but is evidence it is holding the claim. See
-// holdsTheNonce. Non-inclusion is usually a fee that was too low or a race already lost, not an
+// Nothing is charged for the reordering itself, and what the holder answers is not charged as a
+// failure: a relay that already has the nonce replies "replacement transaction underpriced" or
+// "already known", which reads as a refusal but is evidence it is holding the claim. It is not free
+// either — a nonce the endpoint has not answered for before counts towards the consecutive ceiling,
+// so an endpoint answering this to every claim still steps aside. See holdsTheNonce and
+// recordHeldNonce. Non-inclusion is usually a fee that was too low or a race already lost, not an
 // unhealthy relay, and tripping an endpoint for it would push claims into the public mempool for
 // reasons that have nothing to do with the endpoint — the exposure this exists to remove. Bounding
 // how long a send waits for inclusion is TX_SEND_TIMEOUT's job.
@@ -939,7 +952,9 @@ func (b *SendingBackend) prioritiseNonceHolder(admitted []admission, nonce uint6
 // suppresses them. Three of those took the preferred relay out of rotation for five minutes, for
 // doing exactly what steering the resend to it was meant to achieve.
 //
-// Both answers are evidence the endpoint is holding the claim, so neither is charged.
+// Both answers are evidence the endpoint is holding the claim, so neither is charged as a failure.
+// Both still count towards the consecutive ceiling when the nonce is one this endpoint has not
+// answered for already; see recordHeldNonce.
 //
 // This matches on geth's wording, which reaches us only from a relay that proxies its node's
 // txpool errors verbatim. Neither shipped default does: Flashbots' rpc-endpoint answers a duplicate

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -15,9 +15,11 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
@@ -98,6 +100,32 @@ const DefaultPrivateRPCAttemptTimeout = 30 * time.Second
 // urlInErrorText matches a URL inside an error message, so it can be kept out of the logs.
 var urlInErrorText = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s"]*`)
 
+// refusalRun is a run of consecutive sends of one nonce that every endpoint in rotation refused.
+//
+// The claim is stamped on the run so it cannot outlive the claim that earned it. Nonces recycle: a
+// claim abandoned at TX_SEND_TIMEOUT leaves its count behind — only an accepted send clears one, and
+// an abandoned claim never comes back to be accepted — and resetNonce then hands the same nonce to
+// an unrelated message. Keyed on the nonce alone that message inherited the run and went out
+// publicly on its first all-refused send rather than its third, skipping the private probation the
+// fallback exists to serve. The trigger needs only a public blip, a send timeout and nonce reuse,
+// all of which are ordinary.
+type refusalRun struct {
+	claim common.Hash
+	count int
+}
+
+// claimIdentity identifies the message a transaction carries, across the re-signing that changes
+// everything else about it.
+//
+// The calldata is the encoded message and its proof: identical for every resend of one claim, and
+// different for every other claim. Nothing else here is both — the nonce recycles, and the hash and
+// the fee change on every bump, which is why recordFailure's deduplication keys on the nonce in the
+// first place. Hashing a few kilobytes of proof costs microseconds against the network round trip
+// that follows it.
+func claimIdentity(tx *types.Transaction) common.Hash {
+	return crypto.Keccak256Hash(tx.Data())
+}
+
 // admission is one endpoint's place in a send's rotation snapshot: which endpoint, and which of
 // that endpoint's admissions the send was let in under.
 //
@@ -150,7 +178,7 @@ type SendingBackend struct {
 
 	private          []TxSender
 	hosts            []string
-	allRefused       map[uint64]int
+	allRefused       map[uint64]refusalRun
 	allRefusedLimit  int
 	failures         []int
 	failedAt         []time.Time
@@ -208,7 +236,7 @@ func NewSendingBackend(
 		hasAccepted:      make([]bool, len(private)),
 		failureThreshold: DefaultPrivateRPCFailureThreshold,
 		failureCeiling:   DefaultPrivateRPCConsecutiveFailureCeiling,
-		allRefused:       make(map[uint64]int),
+		allRefused:       make(map[uint64]refusalRun),
 		allRefusedLimit:  DefaultPrivateRPCAllRefusedLimit,
 		retryInterval:    interval,
 		now:              time.Now,
@@ -386,12 +414,13 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 	// Every endpoint in rotation refused this claim. Tripping is per endpoint and each was charged
 	// only once for it, so nobody leaves the rotation over one unwanted claim and the fallback
 	// below would never be reached — the claim would simply loop until TX_SEND_TIMEOUT.
-	if allAnsweredRejection && b.countAllRefused(tx.Nonce()) {
+	if allAnsweredRejection && b.countAllRefused(tx.Nonce(), claimIdentity(tx)) {
 		relayer.PrivateRPCAllRefusedAttempts.Inc()
 
 		publicErr := b.ETHBackend.SendTransaction(ctx, tx)
 		if publicErr == nil {
-			b.clearAllRefused(tx.Nonce())
+			// The run is deliberately kept. This claim is in the open now, so every resend of it
+			// belongs in the public pool too until a relay takes it back — see countAllRefused.
 			relayer.PrivateRPCAllRefused.Inc()
 
 			// Logged after the fact rather than before it. Announcing the broadcast up front left
@@ -420,7 +449,8 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 	return b.redacted(err)
 }
 
-// clearAllRefused forgets the refusal run for this nonce, because an endpoint has just taken it.
+// clearAllRefused forgets the refusal run for this nonce, because a private endpoint has just taken
+// it. Only a private accept clears one: see countAllRefused for why a public one does not.
 func (b *SendingBackend) clearAllRefused(nonce uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -437,18 +467,34 @@ func (b *SendingBackend) clearAllRefused(nonce uint64) {
 // one claim nobody will take. The count is per claim because the decision is: this claim has been
 // offered privately enough times.
 //
-// The count is cleared by a send some endpoint accepted, and by nothing else — in particular not by
-// firing. Clearing it there cost the claim the threshold it had just earned: if the public send then
-// failed, three more all-refused sends were needed before the fallback could be tried again, which
-// at the 48s resubmission default is past the two-minute TxNotInMempoolTimeout. The claim would end
-// that send never having reached the mempool at all, which is the one thing this exists to prevent.
-// Once the limit is reached the fallback is therefore offered on every subsequent send of that
-// nonce, until one of them lands.
-func (b *SendingBackend) countAllRefused(nonce uint64) bool {
+// The count is cleared by a send a private endpoint accepted, and by nothing else — in particular
+// not by firing, and not by the public send that fires succeeding. Clearing it on firing cost the
+// claim the threshold it had just earned: if the public send then failed, three more all-refused
+// sends were needed before the fallback could be tried again, which at the 48s resubmission default
+// is past the two-minute TxNotInMempoolTimeout, and the claim would end that send never having
+// reached the mempool at all. Clearing it on a successful public send is wrong for the opposite
+// reason: the claim is in the open by then, so there is no privacy left to spend, and withholding
+// the next two fee-bumped resubmissions from the public pool only leaves the stale low-fee variant
+// there to be mined instead — or leaves a relay holding the bumped one while the public pool holds
+// the original, which is the two-variants-racing case prioritiseNonceHolder exists to avoid. Once
+// the limit is reached the fallback is therefore offered on every subsequent send of that nonce,
+// until a private endpoint takes it back.
+//
+// The run belongs to a claim, not to a nonce; see refusalRun.
+func (b *SendingBackend) countAllRefused(nonce uint64, claim common.Hash) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.allRefused[nonce]++
+	run := b.allRefused[nonce]
+
+	// A nonce carrying a different claim than the run recorded for it is a recycled nonce, not a
+	// resend: the run started against a claim that is gone, and this one has served none of it.
+	if run.claim != claim {
+		run = refusalRun{claim: claim}
+	}
+
+	run.count++
+	b.allRefused[nonce] = run
 
 	// Bounded, because a nonce whose claim is abandoned never comes back to clear its own entry.
 	// Nonces only ascend, so the smallest is the stalest.
@@ -464,7 +510,10 @@ func (b *SendingBackend) countAllRefused(nonce uint64) bool {
 		delete(b.allRefused, stalest)
 	}
 
-	return b.allRefused[nonce] >= b.allRefusedLimit
+	// Read back rather than returned from the local run, so that a live entry the bound has just
+	// evicted reports no fallback rather than one: losing the count should cost the claim its
+	// probation over again, never hand it straight to the public mempool.
+	return b.allRefused[nonce].count >= b.allRefusedLimit
 }
 
 // attemptContext gives one endpoint its share of the time left on ctx, so an endpoint that hangs
@@ -817,6 +866,10 @@ func (b *SendingBackend) recordFailure(endpoint admission, nonce uint64, rejecti
 //
 // A send it accepts clears the count, as it clears every other, and clears the remembered nonce
 // with it.
+//
+// Two answers are free: one for a nonce the endpoint has demonstrably taken, and one repeat of the
+// last nonce it answered for. What is left to charge is an endpoint answering this way for a
+// succession of distinct claims it never took, which is the state the ceiling exists to end.
 func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (tripped bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -827,12 +880,22 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (trip
 		return false
 	}
 
-	// Only a nonce this endpoint has not already answered for counts. The transaction manager
-	// resubmits an unconfirmed nonce every RESUBMISSION_TIMEOUT, and the endpoint holding it says
-	// so every time — that is one claim being carried correctly, not an endpoint taking nothing.
-	// Counted per answer, ten resends of a single claim reached the ceiling in about eight minutes
-	// and took out the very endpoint holding it; with one endpoint configured the claim then went
-	// public through the unavailable path, which is the exposure the exemption exists to prevent.
+	// An endpoint answering for a nonce it has demonstrably taken is the holder by construction,
+	// however many claims it is carrying at once, so the answer costs it nothing. The single
+	// remembered nonce below cannot see that: two concurrently held claims alternate past it, every
+	// answer counts, and ten answers — about four minutes at the resubmission default — took the
+	// endpoint holding both of them out of rotation.
+	if b.hasAccepted[index] && nonce <= b.highestAccepted[index] {
+		return false
+	}
+
+	// Kept as well, for a nonce this endpoint never accepted: it may be answering for a claim it
+	// learned from another relay's gossip rather than from us, and one such claim resent is not
+	// evidence of an endpoint taking nothing. The transaction manager resubmits an unconfirmed
+	// nonce every RESUBMISSION_TIMEOUT and the holder says so every time. Counted per answer, ten
+	// resends of a single claim reached the ceiling in about eight minutes and took out the very
+	// endpoint holding it; with one endpoint configured the claim then went public through the
+	// unavailable path, which is the exposure the exemption exists to prevent.
 	if b.hasHeld[index] && b.lastHeld[index] == nonce {
 		return false
 	}

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -380,11 +380,18 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			"afterSends", b.allRefusedLimit,
 		)
 
-		if publicErr := b.ETHBackend.SendTransaction(ctx, tx); publicErr == nil {
+		publicErr := b.ETHBackend.SendTransaction(ctx, tx)
+		if publicErr == nil {
+			b.clearAllRefused(tx.Nonce())
 			relayer.PrivateRPCAllRefused.Inc()
 
 			return nil
 		}
+
+		// The public attempt is the last and most complete thing tried, so it is what the caller
+		// should classify on: a refusal from a relay may not be transient, but a public endpoint
+		// that could not be reached is.
+		return b.redacted(publicErr)
 	}
 
 	return b.redacted(err)
@@ -410,8 +417,13 @@ func (b *SendingBackend) clearAllRefused(nonce uint64) {
 // deduplication makes, and with the same consequence: the fallback is delayed, never skipped, and
 // only for as long as both claims keep failing.
 //
-// The count is cleared once it fires, so a claim that stays unwanted is offered publicly on the
-// first refusal of each subsequent run rather than once and never again.
+// The count is cleared by a send some endpoint accepted, and by nothing else — in particular not by
+// firing. Clearing it there cost the claim the threshold it had just earned: if the public send then
+// failed, three more all-refused sends were needed before the fallback could be tried again, which
+// at the 48s resubmission default is past the two-minute TxNotInMempoolTimeout. The claim would end
+// that send never having reached the mempool at all, which is the one thing this exists to prevent.
+// Once the limit is reached the fallback is therefore offered on every subsequent send of that
+// nonce, until one of them lands.
 func (b *SendingBackend) countAllRefused(nonce uint64) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -424,13 +436,7 @@ func (b *SendingBackend) countAllRefused(nonce uint64) bool {
 
 	b.allRefusedCount++
 
-	if b.allRefusedCount < b.allRefusedLimit {
-		return false
-	}
-
-	b.allRefusedCount = 0
-
-	return true
+	return b.allRefusedCount >= b.allRefusedLimit
 }
 
 // attemptContext gives one endpoint its share of the time left on ctx, so an endpoint that hangs

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -67,6 +67,20 @@ const DefaultPrivateRPCConsecutiveFailureCeiling = 10
 // rest were never asked.
 const MinPrivateRPCAttemptShare = time.Second
 
+// DefaultPrivateRPCAllRefusedLimit is how many sends of one nonce may be refused by every endpoint
+// in rotation before that claim is offered publicly.
+//
+// Tripping is per endpoint, so a claim that every relay declines individually trips nobody: each is
+// charged once for it, other claims keep clearing their tallies, and the rotation never empties. The
+// claim then loops until TX_SEND_TIMEOUT with nothing to show for it and no metric moving, because
+// the relays are healthy and only this claim is unwanted.
+//
+// Going public gives a competitor the message and proof, which is what this package exists to
+// prevent, so it is the last resort rather than the first — but a claim that never lands is worth
+// less than one landed in the open. At the 48s resubmission default this is a couple of minutes of
+// trying privately first.
+const DefaultPrivateRPCAllRefusedLimit = 3
+
 // DefaultPrivateRPCAttemptTimeout caps a single attempt when the caller supplied no deadline.
 //
 // The transaction manager always calls SendTransaction under its NetworkTimeout, so this does not
@@ -129,6 +143,10 @@ type SendingBackend struct {
 
 	private          []TxSender
 	hosts            []string
+	allRefusedNonce  uint64
+	allRefusedCount  int
+	hasAllRefused    bool
+	allRefusedLimit  int
 	failures         []int
 	failedAt         []time.Time
 	lastCharged      []uint64
@@ -181,6 +199,7 @@ func NewSendingBackend(
 		hasAccepted:      make([]bool, len(private)),
 		failureThreshold: DefaultPrivateRPCFailureThreshold,
 		failureCeiling:   DefaultPrivateRPCConsecutiveFailureCeiling,
+		allRefusedLimit:  DefaultPrivateRPCAllRefusedLimit,
 		retryInterval:    interval,
 		now:              time.Now,
 	}
@@ -195,6 +214,7 @@ func NewSendingBackend(
 		relayer.PrivateRPCFailures.WithLabelValues(endpoint).Add(0)
 		relayer.PrivateRPCSends.WithLabelValues(endpoint).Add(0)
 		relayer.PrivateRPCTrips.WithLabelValues(endpoint).Add(0)
+		relayer.PrivateRPCHeldNonce.WithLabelValues(endpoint).Add(0)
 		relayer.PrivateRPCInRotation.WithLabelValues(endpoint).Set(1)
 	}
 
@@ -238,6 +258,11 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 
 	var err error
 
+	// Only a send every endpoint answered counts toward the public fallback below. A timeout or a
+	// transport failure is an outage, which tripping already handles by emptying the rotation; the
+	// fallback exists for the opposite case, healthy relays that all decline one claim.
+	allAnsweredRejection := true
+
 	for attempt, endpoint := range inRotation {
 		attemptCtx, cancel := attemptContext(ctx, len(inRotation)-attempt)
 
@@ -265,6 +290,7 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 		cancel()
 
 		if err == nil {
+			b.clearAllRefused(tx.Nonce())
 			b.recordSuccess(endpoint.index, tx.Nonce())
 			relayer.PrivateRPCSends.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
@@ -282,6 +308,28 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 		// An endpoint that answers because it is already holding this nonce is not refusing the
 		// claim, and steering the resend to it is the whole point of doing so. Nothing is charged.
 		if holdsTheNonce(err) {
+			// Not a refusal, so it cannot count towards the public fallback either. Every endpoint
+			// answering that it holds this nonce means the claim is already everywhere it needs to
+			// be — broadcasting it publicly then would leak a claim the relays are all carrying.
+			allAnsweredRejection = false
+
+			relayer.PrivateRPCHeldNonce.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
+
+			// Charged against the consecutive count but not the failure tally. An endpoint that
+			// answers this way for every send is not healthy however good its reason, and skipping
+			// recordFailure entirely meant it could never reach the ceiling that exists to end
+			// exactly that: it would hold its place indefinitely while nothing was ever sent
+			// through it.
+			if tripped := b.recordHeldNonce(endpoint); tripped {
+				relayer.PrivateRPCTrips.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
+
+				slog.Warn("Private endpoint taken out of rotation",
+					"endpoint", endpoint.index,
+					"reason", "answered that it holds every nonce offered",
+					"retryIn", b.retryInterval,
+				)
+			}
+
 			slog.Info("Private endpoint already holds this nonce",
 				"endpoint", endpoint.index,
 				"nonce", tx.Nonce(),
@@ -296,7 +344,12 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 		// to be able to trip. Checking the deadline before the send rather than after is what
 		// keeps that true for the last endpoint in rotation, whose share is the rest of the
 		// budget and which therefore always finds ctx expired once it has hung.
-		tripped := b.recordFailure(endpoint, tx.Nonce(), answeredWithRejection(err))
+		rejection := answeredWithRejection(err)
+		if !rejection {
+			allAnsweredRejection = false
+		}
+
+		tripped := b.recordFailure(endpoint, tx.Nonce(), rejection)
 		relayer.PrivateRPCFailures.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
 		slog.Warn("Private endpoint refused a transaction",
@@ -318,7 +371,66 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 		}
 	}
 
+	// Every endpoint in rotation refused this claim. Tripping is per endpoint and each was charged
+	// only once for it, so nobody leaves the rotation over one unwanted claim and the fallback
+	// below would never be reached — the claim would simply loop until TX_SEND_TIMEOUT.
+	if allAnsweredRejection && b.countAllRefused(tx.Nonce()) {
+		slog.Warn("Every private endpoint refused this claim, broadcasting publicly",
+			"txHash", tx.Hash().Hex(),
+			"afterSends", b.allRefusedLimit,
+		)
+
+		if publicErr := b.ETHBackend.SendTransaction(ctx, tx); publicErr == nil {
+			relayer.PrivateRPCAllRefused.Inc()
+
+			return nil
+		}
+	}
+
 	return b.redacted(err)
+}
+
+// clearAllRefused forgets the refusal run for this nonce, because an endpoint has just taken it.
+func (b *SendingBackend) clearAllRefused(nonce uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.hasAllRefused && b.allRefusedNonce == nonce {
+		b.allRefusedCount = 0
+	}
+}
+
+// countAllRefused records that every endpoint in rotation refused this nonce, and reports whether
+// that has now happened often enough in a row to justify broadcasting it publicly.
+//
+// One slot rather than a map: the transaction manager resends an unconfirmed nonce every
+// RESUBMISSION_TIMEOUT, so consecutive refusals of one claim land here in a row, and a different
+// nonce means a different claim and starts the count again. Claims are handled concurrently, so
+// two claims both being refused can reset each other's count — the same trade the failure
+// deduplication makes, and with the same consequence: the fallback is delayed, never skipped, and
+// only for as long as both claims keep failing.
+//
+// The count is cleared once it fires, so a claim that stays unwanted is offered publicly on the
+// first refusal of each subsequent run rather than once and never again.
+func (b *SendingBackend) countAllRefused(nonce uint64) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if !b.hasAllRefused || b.allRefusedNonce != nonce {
+		b.allRefusedNonce = nonce
+		b.allRefusedCount = 0
+		b.hasAllRefused = true
+	}
+
+	b.allRefusedCount++
+
+	if b.allRefusedCount < b.allRefusedLimit {
+		return false
+	}
+
+	b.allRefusedCount = 0
+
+	return true
 }
 
 // attemptContext gives one endpoint its share of the time left on ctx, so an endpoint that hangs
@@ -359,8 +471,12 @@ func attemptContext(ctx context.Context, remaining int) (context.Context, contex
 //
 // The URL pattern alone is not enough. A name that fails to resolve, or a certificate that does not
 // match, puts the host in the error outside any URL — `lookup relay.example.com on 10.0.0.1:53: no
-// such host` — so the configured hosts are replaced by name as well. That also covers the internal
-// addresses the loopback and private-range exception exists to allow.
+// such host` — so the configured hosts are replaced by name as well.
+//
+// What survives, in that same example, is `10.0.0.1:53`: addresses the resolver produced rather than
+// names we were configured with. The IP a dial reports goes the same way. Matching bare `ip:port`
+// shapes in error text is the kind of pattern that quietly stops matching, so this does not try —
+// a relay's provider can still be inferred from a failing deployment's logs.
 func redactEndpoints(err error, hosts []string) string {
 	text := urlInErrorText.ReplaceAllString(err.Error(), "[redacted]")
 
@@ -655,6 +771,36 @@ func (b *SendingBackend) recordFailure(endpoint admission, nonce uint64, rejecti
 	return false
 }
 
+// recordHeldNonce counts an endpoint answering that it already holds the nonce.
+//
+// It is not a refusal, so it does not touch the failure tally that the threshold reads and does not
+// mark the endpoint unhealthy. But it does count towards the consecutive ceiling: an endpoint that
+// answers this way to everything is taking no transactions, whatever its reason, and without this
+// it could never reach the bound that exists for precisely that — it skipped the accounting
+// altogether and kept its place forever while nothing went through it.
+//
+// A send it accepts clears the count, as it clears every other.
+func (b *SendingBackend) recordHeldNonce(endpoint admission) (tripped bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	index := endpoint.index
+
+	if b.generation[index] != endpoint.generation {
+		return false
+	}
+
+	b.consecutive[index]++
+
+	if b.consecutive[index] >= b.failureCeiling {
+		b.leaveRotation(index)
+
+		return true
+	}
+
+	return false
+}
+
 // leaveRotation takes the endpoint at index out of rotation for the retry interval, ending the
 // admission its in-flight sends were let in under so their results cannot be charged to the next
 // one. The caller holds the lock.
@@ -753,6 +899,13 @@ func (b *SendingBackend) prioritiseNonceHolder(admitted []admission, nonce uint6
 // doing exactly what steering the resend to it was meant to achieve.
 //
 // Both answers are evidence the endpoint is holding the claim, so neither is charged.
+//
+// This matches on geth's wording, which reaches us only from a relay that proxies its node's
+// txpool errors verbatim. Neither shipped default does: Flashbots' rpc-endpoint answers a duplicate
+// resubmission with success and collapses its own rejections to -32603, and MEV Blocker publishes
+// no such wording. So in the recommended configuration this is inert — and so is the over-charging
+// it exists to prevent. It is here for relays that do proxy geth, and it is worth knowing that a
+// change of wording on either side moves both.
 func holdsTheNonce(err error) bool {
 	if err == nil {
 		return false

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -290,6 +290,9 @@ func TestSendingBackend_RefusingTheSameTransactionAgainDoesNotTrip(t *testing.T)
 func TestSendingBackend_AFeeBumpedResendIsStillTheSameClaim(t *testing.T) {
 	first := &fakeSender{err: rpcRejection{"failed to get tx into the mempool"}}
 	b := NewSendingBackend(&fakeBackend{}, []TxSender{first}, nil, nil)
+	// The all-refused fallback is not what is under test here; leave it out of the way so the
+	// charge count is the only thing this asserts.
+	b.allRefusedLimit = 1 << 30
 
 	// One endpoint, so the ordering cannot mask what is being tested: every resend reaches this
 	// endpoint, and only the deduplication decides whether it is charged again.
@@ -983,6 +986,9 @@ func TestSendingBackend_AnEndpointRefusingEverythingStepsAside(t *testing.T) {
 	broken := &fakeSender{err: rpcRejection{"internal error"}}
 
 	b := NewSendingBackend(public, []TxSender{broken}, nil, nil)
+	// This is about the ceiling emptying the rotation; the all-refused fallback would otherwise
+	// short-circuit the run by going public before the ceiling is reached.
+	b.allRefusedLimit = 1 << 30
 
 	unavailableBefore := testutil.ToFloat64(relayer.PrivateRPCUnavailable)
 
@@ -1370,6 +1376,74 @@ func TestSendingBackend_KeepsTheAcceptedMarkAcrossATrip(t *testing.T) {
 	assert.Len(t, first.sent, 3)
 }
 
+func TestSendingBackend_OffersAClaimEveryEndpointRefusesToThePublicMempool(t *testing.T) {
+	public := &fakeBackend{}
+	first := &fakeSender{err: rpcRejection{"claim not accepted"}}
+	second := &fakeSender{err: rpcRejection{"claim not accepted"}}
+
+	b := NewSendingBackend(public, []TxSender{first, second}, nil, nil)
+
+	before := testutil.ToFloat64(relayer.PrivateRPCAllRefused)
+
+	tx := txWithNonce(21)
+
+	// Tripping is per endpoint and each is charged once for this claim, so no endpoint leaves the
+	// rotation over it: without the fallback the claim would loop until TX_SEND_TIMEOUT with the
+	// relays healthy, nothing tripped and no metric moving.
+	for i := 0; i < DefaultPrivateRPCAllRefusedLimit-1; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), tx))
+	}
+
+	assert.Empty(t, public.sent, "the public mempool is the last resort, not the second")
+
+	require.NoError(t, b.SendTransaction(context.Background(), tx))
+
+	assert.Len(t, public.sent, 1, "a claim that never lands is worth less than one landed in the open")
+	assert.Equal(t, []int{0, 1}, rotation(b), "the relays are healthy; only this claim is unwanted")
+	assert.Equal(t, float64(1), testutil.ToFloat64(relayer.PrivateRPCAllRefused)-before)
+}
+
+func TestSendingBackend_ADifferentClaimStartsTheRefusalRunAgain(t *testing.T) {
+	public := &fakeBackend{}
+	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	// Keep the endpoint in rotation: distinct refused claims would otherwise trip it, and the
+	// claim would go public over an empty rotation rather than over the run this is about.
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	// Refusals of different claims are not a run: each is one claim the relay would not take, and
+	// going public on the strength of that would leak claims that were never persistently refused.
+	for nonce := uint64(1); nonce <= uint64(2*DefaultPrivateRPCAllRefusedLimit); nonce++ {
+		require.Error(t, b.SendTransaction(context.Background(), txWithNonce(nonce)))
+	}
+
+	assert.Empty(t, public.sent)
+}
+
+func TestSendingBackend_AnOutageDoesNotCountTowardsThePublicFallback(t *testing.T) {
+	public := &fakeBackend{}
+	only := &fakeSender{err: errors.New("connection refused")}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	// Keep the endpoint in rotation, so this isolates the fallback from the trip that would
+	// otherwise send the claim public for an entirely different reason.
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	tx := txWithNonce(9)
+
+	// A transport failure says the endpoint is down, which tripping handles by emptying the
+	// rotation. Counting it here as well would push claims public during an outage before the
+	// rotation had a chance to empty.
+	for i := 0; i < 2*DefaultPrivateRPCAllRefusedLimit; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), tx))
+	}
+
+	assert.Empty(t, public.sent)
+}
+
 func TestSendingBackend_DoesNotChargeAHolderForHavingTheNonce(t *testing.T) {
 	public := &fakeBackend{}
 	// What a relay answers when it already has this nonce. It is a JSON-RPC error, so it reads as
@@ -1449,4 +1523,64 @@ func TestSendingBackend_CreatesEverySeriesUpFront(t *testing.T) {
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(relayer.PrivateRPCInRotation.WithLabelValues("0")),
 		"an endpoint starts in rotation")
+}
+
+func TestSendingBackend_AHeldNonceDoesNotReachThePublicMempool(t *testing.T) {
+	public := &fakeBackend{}
+	// Every endpoint answers that it is already holding this nonce. The claim is therefore
+	// everywhere it needs to be, and broadcasting it publicly would leak one the relays all carry.
+	first := &fakeSender{err: rpcRejection{txpool.ErrReplaceUnderpriced.Error()}}
+	second := &fakeSender{err: rpcRejection{txpool.ErrAlreadyKnown.Error()}}
+
+	b := NewSendingBackend(public, []TxSender{first, second}, nil, nil)
+
+	tx := txWithNonce(31)
+
+	for i := 0; i < 2*DefaultPrivateRPCAllRefusedLimit; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), tx))
+	}
+
+	assert.Empty(t, public.sent, "holding a claim is not refusing it")
+	assert.Equal(t, []int{0, 1}, rotation(b))
+}
+
+func TestSendingBackend_AnEndpointHoldingEveryNonceStillStepsAside(t *testing.T) {
+	public := &fakeBackend{}
+	// A relay answering this to everything is taking no transactions, whatever its reason. Skipping
+	// the accounting entirely meant it could never reach the ceiling that exists for exactly that,
+	// so it kept its place forever while nothing went through it.
+	only := &fakeSender{err: rpcRejection{txpool.ErrAlreadyKnown.Error()}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+
+	before := testutil.ToFloat64(relayer.PrivateRPCHeldNonce.WithLabelValues("0"))
+
+	for i := 0; i < DefaultPrivateRPCConsecutiveFailureCeiling; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), txWithNonce(uint64(i))))
+	}
+
+	assert.Empty(t, rotation(b), "answering this to everything has to end somewhere")
+	assert.Equal(t, 0, b.failures[0], "but it is still not a refusal")
+	assert.Equal(t, float64(DefaultPrivateRPCConsecutiveFailureCeiling),
+		testutil.ToFloat64(relayer.PrivateRPCHeldNonce.WithLabelValues("0"))-before,
+		"the path has to be visible; nothing else counts it")
+}
+
+func TestSendingBackend_AnAcceptedSendClearsTheHeldNonceRun(t *testing.T) {
+	only := &fakeSender{err: rpcRejection{txpool.ErrAlreadyKnown.Error()}}
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{only}, nil, nil)
+
+	for i := 0; i < DefaultPrivateRPCConsecutiveFailureCeiling-1; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), txWithNonce(uint64(i))))
+	}
+
+	// One taken transaction says the endpoint is working, which is what the run was counting
+	// against.
+	only.err = nil
+	require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(99)))
+
+	only.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+	require.Error(t, b.SendTransaction(context.Background(), txWithNonce(100)))
+
+	assert.Equal(t, []int{0}, rotation(b), "the run restarts from the send it accepted")
 }

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -1675,3 +1675,58 @@ func TestSendingBackend_AnAcceptedSendClearsTheRefusalRun(t *testing.T) {
 
 	assert.Equal(t, 1, len(public.sent), "a fresh claim is not immediately exposed")
 }
+
+func TestSendingBackend_ConcurrentClaimsDoNotStarveTheFallback(t *testing.T) {
+	public := &fakeBackend{}
+	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	// The processor handles claims concurrently, so sends for different nonces interleave. A single
+	// slot was overwritten on every send, so neither count ever passed one and the fallback never
+	// fired — in the very case it exists for, more than one claim nobody will take.
+	for round := 0; round < DefaultPrivateRPCAllRefusedLimit; round++ {
+		for _, nonce := range []uint64{51, 52} {
+			_ = b.SendTransaction(context.Background(), txWithNonce(nonce))
+		}
+	}
+
+	assert.Len(t, public.sent, 2, "each claim earns the fallback on its own count")
+}
+
+func TestSendingBackend_ARepeatedHoldOfOneNonceDoesNotTripTheHolder(t *testing.T) {
+	public := &fakeBackend{}
+	// The transaction manager resends an unconfirmed nonce every RESUBMISSION_TIMEOUT, and the
+	// endpoint holding it says so every time. That is one claim being carried correctly. Counted
+	// per answer, ten resends took out the endpoint holding the claim — and with one endpoint
+	// configured the claim then went public, which is the exposure the exemption prevents.
+	only := &fakeSender{err: rpcRejection{txpool.ErrAlreadyKnown.Error()}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+
+	tx := txWithNonce(61)
+
+	for i := 0; i < 3*DefaultPrivateRPCConsecutiveFailureCeiling; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), tx))
+	}
+
+	assert.Equal(t, []int{0}, rotation(b), "one claim held is not an endpoint taking nothing")
+	assert.Empty(t, public.sent, "and the claim it is holding must not be leaked")
+}
+
+func TestSendingBackend_BoundsTheRefusedNonceTracking(t *testing.T) {
+	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	// An abandoned claim never comes back to clear its own entry, so the map has to be bounded or
+	// it grows for as long as the relayer runs.
+	for nonce := uint64(0); nonce < uint64(maxTrackedRefusedNonces)*2; nonce++ {
+		_ = b.SendTransaction(context.Background(), txWithNonce(nonce))
+	}
+
+	assert.LessOrEqual(t, len(b.allRefused), maxTrackedRefusedNonces)
+}

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -30,6 +30,8 @@ type fakeBackend struct {
 	mu                sync.Mutex
 	pendingNonce      uint64
 	pendingNonceCalls int
+	err               error
+	sendCalls         int
 	sent              []*types.Transaction
 	closed            bool
 	closeCalls        int
@@ -48,9 +50,24 @@ func (f *fakeBackend) SendTransaction(_ context.Context, tx *types.Transaction) 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	f.sendCalls++
+
+	if f.err != nil {
+		return f.err
+	}
+
 	f.sent = append(f.sent, tx)
 
 	return nil
+}
+
+// attempts counts every send offered to this backend, including the ones it refused. For tests
+// that care whether the fallback was reached rather than whether it landed.
+func (f *fakeBackend) attempts() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.sendCalls
 }
 
 func (f *fakeBackend) Close() {
@@ -1585,4 +1602,76 @@ func TestSendingBackend_AnAcceptedSendClearsTheHeldNonceRun(t *testing.T) {
 	require.Error(t, b.SendTransaction(context.Background(), txWithNonce(100)))
 
 	assert.Equal(t, []int{0}, rotation(b), "the run restarts from the send it accepted")
+}
+
+func TestSendingBackend_RetriesThePublicFallbackAfterItFails(t *testing.T) {
+	public := &fakeBackend{err: errors.New("public endpoint unreachable")}
+	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	tx := txWithNonce(41)
+
+	for i := 0; i < DefaultPrivateRPCAllRefusedLimit; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), tx))
+	}
+
+	require.Equal(t, 1, public.attempts(), "the threshold is reached and the fallback is tried")
+
+	// Clearing the count here cost the claim the threshold it had just earned: three more
+	// all-refused sends at the 48s resubmission default is past the two-minute
+	// TxNotInMempoolTimeout, so the claim would end that send never having reached the mempool.
+	require.Error(t, b.SendTransaction(context.Background(), tx))
+
+	assert.Equal(t, 2, public.attempts(), "past the limit, every send retries the fallback")
+}
+
+func TestSendingBackend_ReportsThePublicFailureRatherThanTheRefusal(t *testing.T) {
+	public := &fakeBackend{err: errors.New("public endpoint unreachable")}
+	only := &fakeSender{err: rpcRejection{"execution reverted"}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	tx := txWithNonce(42)
+
+	var err error
+	for i := 0; i < DefaultPrivateRPCAllRefusedLimit; i++ {
+		err = b.SendTransaction(context.Background(), tx)
+	}
+
+	// The public attempt is the last and most complete thing tried, and what the caller classifies
+	// on: a relay's refusal may not be transient, an unreachable endpoint is.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "public endpoint unreachable")
+	assert.NotContains(t, err.Error(), "execution reverted")
+}
+
+func TestSendingBackend_AnAcceptedSendClearsTheRefusalRun(t *testing.T) {
+	public := &fakeBackend{}
+	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	tx := txWithNonce(43)
+
+	// Only the send that reaches the limit gets the fallback; the ones before it carry the
+	// endpoint's refusal back to the caller.
+	for i := 0; i < DefaultPrivateRPCAllRefusedLimit-1; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), tx))
+	}
+
+	require.NoError(t, b.SendTransaction(context.Background(), tx))
+	require.Len(t, public.sent, 1, "the fallback landed it")
+
+	// A landed claim ends the run, so the next refusal starts counting again rather than going
+	// straight back to the public mempool.
+	require.Error(t, b.SendTransaction(context.Background(), txWithNonce(44)))
+
+	assert.Equal(t, 1, len(public.sent), "a fresh claim is not immediately exposed")
 }

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -1577,9 +1577,11 @@ func TestSendingBackend_AnAcceptedSendClearsTheHeldNonceRun(t *testing.T) {
 	// One taken transaction says the endpoint is working, which is what the run was counting
 	// against.
 	only.err = nil
+
 	require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(99)))
 
 	only.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+
 	require.Error(t, b.SendTransaction(context.Background(), txWithNonce(100)))
 
 	assert.Equal(t, []int{0}, rotation(b), "the run restarts from the send it accepted")

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -1730,3 +1730,61 @@ func TestSendingBackend_BoundsTheRefusedNonceTracking(t *testing.T) {
 
 	assert.LessOrEqual(t, len(b.allRefused), maxTrackedRefusedNonces)
 }
+
+func TestSendingBackend_ExposesARefusedClaimOnlyOneSendInThree(t *testing.T) {
+	public := &fakeBackend{}
+	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	tx := txWithNonce(71)
+
+	// The rate is the privacy property the whole trade rests on. Without the clear on a landed
+	// public send, every send past the third goes public and a persistently refused claim is
+	// broadcast on every resubmission instead of one in three.
+	for i := 0; i < 3*DefaultPrivateRPCAllRefusedLimit; i++ {
+		_ = b.SendTransaction(context.Background(), tx)
+	}
+
+	assert.Len(t, public.sent, 3, "one exposure per completed run, not one per send")
+}
+
+func TestSendingBackend_DropsAHeldAnswerFromAnEndpointThatHasSinceLeft(t *testing.T) {
+	b, _, _, _, _ := newTestBackend(t, nil)
+
+	stale := admit(b, 0)
+
+	trip(b, 0)
+
+	before := b.consecutive[0]
+
+	// A held answer that outlived the trip belongs to the admission that is over, not to the fresh
+	// budget the endpoint comes back with, so it must not move the count at all.
+	require.False(t, b.recordHeldNonce(stale, 5))
+	assert.Equal(t, before, b.consecutive[0], "a stale admission spends nothing")
+}
+
+func TestSendingBackend_AnOutageIsNotAnAnsweredRefusal(t *testing.T) {
+	public := &fakeBackend{}
+	// A real transport failure, rather than a bare errors.New that is neither a net.Error nor an
+	// rpc.Error and so proves less than it looks.
+	only := &fakeSender{err: &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: errors.New("connection refused"),
+	}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	tx := txWithNonce(81)
+
+	for i := 0; i < 3*DefaultPrivateRPCAllRefusedLimit; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), tx))
+	}
+
+	assert.Empty(t, public.sent, "an endpoint being down is what tripping handles")
+}

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -135,6 +135,13 @@ func txWithNonce(nonce uint64) *types.Transaction {
 	return types.NewTx(&types.DynamicFeeTx{Nonce: nonce, Gas: 21_000})
 }
 
+// txWithNonceAndCall builds a transaction carrying distinct calldata, so two claims that share a
+// nonce are as distinguishable here as a recycled nonce makes them in production: the calldata is
+// the encoded message and its proof.
+func txWithNonceAndCall(nonce uint64, call string) *types.Transaction {
+	return types.NewTx(&types.DynamicFeeTx{Nonce: nonce, Gas: 21_000, Data: []byte(call)})
+}
+
 // newTestBackend builds a backend over one public endpoint and two private ones, with a clock the
 // test controls so retry intervals can be exercised without sleeping.
 func newTestBackend(t *testing.T, retryInterval *time.Duration) (
@@ -1420,7 +1427,7 @@ func TestSendingBackend_OffersAClaimEveryEndpointRefusesToThePublicMempool(t *te
 	assert.Equal(t, float64(1), testutil.ToFloat64(relayer.PrivateRPCAllRefused)-before)
 }
 
-func TestSendingBackend_ADifferentClaimStartsTheRefusalRunAgain(t *testing.T) {
+func TestSendingBackend_RefusalsOfDistinctClaimsAreNotARun(t *testing.T) {
 	public := &fakeBackend{}
 	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
 
@@ -1638,6 +1645,9 @@ func TestSendingBackend_ReportsThePublicFailureRatherThanTheRefusal(t *testing.T
 
 	tx := txWithNonce(42)
 
+	attemptsBefore := testutil.ToFloat64(relayer.PrivateRPCAllRefusedAttempts)
+	broadcastsBefore := testutil.ToFloat64(relayer.PrivateRPCAllRefused)
+
 	var err error
 	for i := 0; i < DefaultPrivateRPCAllRefusedLimit; i++ {
 		err = b.SendTransaction(context.Background(), tx)
@@ -1648,6 +1658,15 @@ func TestSendingBackend_ReportsThePublicFailureRatherThanTheRefusal(t *testing.T
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "public endpoint unreachable")
 	assert.NotContains(t, err.Error(), "execution reverted")
+
+	// Attempts climbing while broadcasts do not is the whole reason the attempts counter exists:
+	// without it a public endpoint that is also failing reads as silence, and the claim reaching
+	// nobody looks exactly like the claim never having needed the fallback.
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(relayer.PrivateRPCAllRefusedAttempts)-attemptsBefore,
+		"the offer to the public endpoint is counted whether or not it was taken")
+	assert.Equal(t, broadcastsBefore, testutil.ToFloat64(relayer.PrivateRPCAllRefused),
+		"nothing was broadcast, so nothing may be counted as broadcast")
 }
 
 func TestSendingBackend_AnAcceptedSendClearsTheRefusalRun(t *testing.T) {
@@ -1669,11 +1688,18 @@ func TestSendingBackend_AnAcceptedSendClearsTheRefusalRun(t *testing.T) {
 	require.NoError(t, b.SendTransaction(context.Background(), tx))
 	require.Len(t, public.sent, 1, "the fallback landed it")
 
-	// A landed claim ends the run, so the next refusal starts counting again rather than going
-	// straight back to the public mempool.
-	require.Error(t, b.SendTransaction(context.Background(), txWithNonce(44)))
+	// The clear under test is a private accept of this same nonce. Asserting it against a fresh
+	// nonce proved nothing: a nonce with no run of its own has nothing to clear, so the assertion
+	// held whether or not an accept cleared anything.
+	only.err = nil
 
-	assert.Equal(t, 1, len(public.sent), "a fresh claim is not immediately exposed")
+	require.NoError(t, b.SendTransaction(context.Background(), tx))
+
+	only.err = rpcRejection{"claim not accepted"}
+	_ = b.SendTransaction(context.Background(), tx)
+
+	assert.Len(t, public.sent, 1,
+		"a relay took the claim back, so it serves its private probation again")
 }
 
 func TestSendingBackend_ConcurrentClaimsDoNotStarveTheFallback(t *testing.T) {
@@ -1716,6 +1742,50 @@ func TestSendingBackend_ARepeatedHoldOfOneNonceDoesNotTripTheHolder(t *testing.T
 	assert.Empty(t, public.sent, "and the claim it is holding must not be leaked")
 }
 
+func TestSendingBackend_TwoHeldClaimsDoNotTripTheHolder(t *testing.T) {
+	public := &fakeBackend{}
+	only := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+
+	held := []uint64{91, 92}
+
+	// The endpoint takes both claims, which is what makes it their holder.
+	for _, nonce := range held {
+		require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(nonce)))
+	}
+
+	only.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+
+	// Now it answers for both as the manager resubmits them. A single remembered nonce could not
+	// tell this from an endpoint taking nothing: the two alternate past it, every answer counts,
+	// and ten of them took the endpoint holding both claims out of rotation in about four minutes.
+	for i := 0; i < 3*DefaultPrivateRPCConsecutiveFailureCeiling; i++ {
+		for _, nonce := range held {
+			_ = b.SendTransaction(context.Background(), txWithNonce(nonce))
+		}
+	}
+
+	assert.Equal(t, []int{0}, rotation(b), "two claims carried is not an endpoint taking nothing")
+	assert.Empty(t, public.sent, "and neither of the claims it carries may be leaked")
+}
+
+func TestSendingBackend_AnEndpointHoldingWhatItNeverTookStillStepsAside(t *testing.T) {
+	public := &fakeBackend{}
+	only := &fakeSender{err: rpcRejection{txpool.ErrAlreadyKnown.Error()}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+
+	// Nothing was ever accepted here, so no nonce is below the accepted mark and the holder guard
+	// does not apply. An endpoint answering this way for a succession of claims it never took is
+	// the state the ceiling exists to end, and the guard must not have reopened it.
+	for nonce := uint64(0); nonce < uint64(DefaultPrivateRPCConsecutiveFailureCeiling); nonce++ {
+		_ = b.SendTransaction(context.Background(), txWithNonce(nonce))
+	}
+
+	assert.Empty(t, rotation(b), "holding everything while taking nothing still ends")
+}
+
 func TestSendingBackend_BoundsTheRefusedNonceTracking(t *testing.T) {
 	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
 	b := NewSendingBackend(&fakeBackend{}, []TxSender{only}, nil, nil)
@@ -1729,9 +1799,19 @@ func TestSendingBackend_BoundsTheRefusedNonceTracking(t *testing.T) {
 	}
 
 	assert.LessOrEqual(t, len(b.allRefused), maxTrackedRefusedNonces)
+
+	// The policy matters as much as the bound, and only the bound was pinned: evicting the highest
+	// instead passed the whole suite while dropping the newest entry on every send — which is the
+	// self-eviction of a live claim, promoted from an edge nobody can construct to every send.
+	// Nonces only ascend, so the lowest is the stalest.
+	_, keptLowest := b.allRefused[0]
+	_, keptHighest := b.allRefused[uint64(maxTrackedRefusedNonces)*2-1]
+
+	assert.False(t, keptLowest, "the stalest entry is the one to drop")
+	assert.True(t, keptHighest, "the newest entry is the one most likely to be a live claim")
 }
 
-func TestSendingBackend_ExposesARefusedClaimOnlyOneSendInThree(t *testing.T) {
+func TestSendingBackend_ServesTheProbationOnceAndThenKeepsTheClaimPublic(t *testing.T) {
 	public := &fakeBackend{}
 	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
 
@@ -1741,14 +1821,53 @@ func TestSendingBackend_ExposesARefusedClaimOnlyOneSendInThree(t *testing.T) {
 
 	tx := txWithNonce(71)
 
-	// The rate is the privacy property the whole trade rests on. Without the clear on a landed
-	// public send, every send past the third goes public and a persistently refused claim is
-	// broadcast on every resubmission instead of one in three.
-	for i := 0; i < 3*DefaultPrivateRPCAllRefusedLimit; i++ {
+	// The probation before the first exposure is the privacy property: a claim is not broadcast
+	// until it has been offered privately the full limit of times.
+	for i := 0; i < DefaultPrivateRPCAllRefusedLimit-1; i++ {
 		_ = b.SendTransaction(context.Background(), tx)
 	}
 
-	assert.Len(t, public.sent, 3, "one exposure per completed run, not one per send")
+	require.Empty(t, public.sent, "the probation has to be served in full before any exposure")
+
+	// After it, every resend belongs in the public pool too. Restarting the count here would
+	// withhold the next two fee-bumped resubmissions from a pool that already holds the stale
+	// low-fee variant of this very claim — no privacy left to save, and the replacement kept from
+	// the only place that can mine it.
+	sends := 2 * DefaultPrivateRPCAllRefusedLimit
+	for i := 0; i < sends; i++ {
+		_ = b.SendTransaction(context.Background(), tx)
+	}
+
+	assert.Len(t, public.sent, sends, "an exposed claim stays exposed until a relay takes it back")
+}
+
+func TestSendingBackend_ARecycledNonceDoesNotInheritTheRefusalRun(t *testing.T) {
+	// The public endpoint fails, so the run is never cleared: this is the state an abandoned claim
+	// leaves behind at TX_SEND_TIMEOUT, with resetNonce free to hand the nonce to another message.
+	public := &fakeBackend{err: errors.New("public endpoint unreachable")}
+	only := &fakeSender{err: rpcRejection{"claim not accepted"}}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	abandoned := txWithNonceAndCall(81, "the claim that earned the run")
+	for i := 0; i < DefaultPrivateRPCAllRefusedLimit; i++ {
+		require.Error(t, b.SendTransaction(context.Background(), abandoned))
+	}
+
+	require.Equal(t, DefaultPrivateRPCAllRefusedLimit, b.allRefused[81].count,
+		"the run has to survive the failed broadcast, or this proves nothing")
+
+	// A different message, the same nonce. Keyed on the nonce alone it inherited a run it had
+	// served none of and went out publicly on its first all-refused send.
+	public.err = nil
+
+	err := b.SendTransaction(context.Background(),
+		txWithNonceAndCall(81, "an unrelated message that reused the nonce"))
+
+	assert.Empty(t, public.sent, "a fresh claim serves its own probation, whatever the nonce did")
+	assert.Error(t, err, "and the refusal it did get is what the caller classifies on")
 }
 
 func TestSendingBackend_DropsAHeldAnswerFromAnEndpointThatHasSinceLeft(t *testing.T) {

--- a/packages/relayer/processor/config.go
+++ b/packages/relayer/processor/config.go
@@ -389,9 +389,11 @@ func isLocalHost(host string) bool {
 // underpriced has had several chances to catch up, and a match with the PRIVATE_RPC_RETRY_INTERVAL
 // default, so a stalled claim and a tripped endpoint come back on the same timescale.
 //
-// It is a ceiling rather than the usual exit. A send no endpoint will take ends earlier, at the
-// transaction manager's TxNotInMempoolTimeout — two minutes by default — because no publish ever
-// succeeded.
+// It is a ceiling rather than the usual exit, though less often than it used to be. A send nothing
+// will take ends earlier, at the transaction manager's TxNotInMempoolTimeout — two minutes by
+// default — because no publish ever succeeded. The public fallback changes that for a claim every
+// private endpoint refuses: its third send goes out through DEST_RPC_URL, and one successful
+// publish disarms that exit, so such a send now runs to this full five minutes.
 const DefaultPrivateRPCSendTimeout = 5 * time.Minute
 
 // privateRPCSendTimeout returns the send timeout to run with, supplying a default rather than

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -391,27 +391,6 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 //
 // For http and https the client is built without contacting the endpoint, so a relay that is down
 // does not fail this; config parsing rejects every other scheme for that reason.
-// installPrivateSending puts a SendingBackend between the transaction manager and the chain, so
-// that broadcasts go to the private endpoints while every read still goes to the endpoint the
-// transaction manager was configured with. It returns the backend so the caller can close it.
-//
-// This is a named function rather than two lines inline because the assignment is the whole
-// feature: without it every claim is signed and broadcast exactly as before, through the public
-// mempool, and nothing else observes the difference. Kept inline it had no test that failed when
-// it was removed.
-func installPrivateSending(
-	txmgrConfig *txmgr.Config,
-	senders []utils.TxSender,
-	hosts []string,
-	retryInterval *time.Duration,
-) *utils.SendingBackend {
-	backend := utils.NewSendingBackend(txmgrConfig.Backend, senders, hosts, retryInterval)
-
-	txmgrConfig.Backend = backend
-
-	return backend
-}
-
 // privateRPCHosts returns the host names of the configured endpoints, for keeping them out of the
 // text of any error this processor logs. Entries that will not parse contribute nothing: they are
 // rejected before this point, and a blank host would match everywhere.
@@ -454,6 +433,27 @@ func dialPrivateSenders(ctx context.Context, urls []string) ([]utils.TxSender, e
 	}
 
 	return senders, nil
+}
+
+// installPrivateSending puts a SendingBackend between the transaction manager and the chain, so
+// that broadcasts go to the private endpoints while every read still goes to the endpoint the
+// transaction manager was configured with. It returns the backend so the caller can close it.
+//
+// This is a named function rather than two lines inline because the assignment is the whole
+// feature: without it every claim is signed and broadcast exactly as before, through the public
+// mempool, and nothing else observes the difference. Kept inline it had no test that failed when
+// it was removed.
+func installPrivateSending(
+	txmgrConfig *txmgr.Config,
+	senders []utils.TxSender,
+	hosts []string,
+	retryInterval *time.Duration,
+) *utils.SendingBackend {
+	backend := utils.NewSendingBackend(txmgrConfig.Backend, senders, hosts, retryInterval)
+
+	txmgrConfig.Backend = backend
+
+	return backend
 }
 
 func (p *Processor) Name() string {

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -305,13 +305,12 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 		return err
 	}
 
-	sendingBackend := utils.NewSendingBackend(
-		txmgrConfig.Backend,
+	sendingBackend := installPrivateSending(
+		txmgrConfig,
 		privateSenders,
 		privateRPCHosts(cfg.DestPrivateRPCUrls),
 		&cfg.PrivateRPCRetryInterval,
 	)
-	txmgrConfig.Backend = sendingBackend
 
 	if p.txmgr, err = txmgr.NewSimpleTxManagerFromConfig(
 		"processor",
@@ -392,6 +391,27 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 //
 // For http and https the client is built without contacting the endpoint, so a relay that is down
 // does not fail this; config parsing rejects every other scheme for that reason.
+// installPrivateSending puts a SendingBackend between the transaction manager and the chain, so
+// that broadcasts go to the private endpoints while every read still goes to the endpoint the
+// transaction manager was configured with. It returns the backend so the caller can close it.
+//
+// This is a named function rather than two lines inline because the assignment is the whole
+// feature: without it every claim is signed and broadcast exactly as before, through the public
+// mempool, and nothing else observes the difference. Kept inline it had no test that failed when
+// it was removed.
+func installPrivateSending(
+	txmgrConfig *txmgr.Config,
+	senders []utils.TxSender,
+	hosts []string,
+	retryInterval *time.Duration,
+) *utils.SendingBackend {
+	backend := utils.NewSendingBackend(txmgrConfig.Backend, senders, hosts, retryInterval)
+
+	txmgrConfig.Backend = backend
+
+	return backend
+}
+
 // privateRPCHosts returns the host names of the configured endpoints, for keeping them out of the
 // text of any error this processor logs. Entries that will not parse contribute nothing: they are
 // rejected before this point, and a blank host would match everywhere.

--- a/packages/relayer/processor/processor_test.go
+++ b/packages/relayer/processor/processor_test.go
@@ -9,11 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils"
 
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
@@ -616,3 +619,33 @@ func TestDialPrivateSenders(t *testing.T) {
 		assert.Nil(t, senders, "a partial list would leave the relayer believing it is private")
 	})
 }
+
+func TestInstallPrivateSendingReplacesTheTransactionManagersBackend(t *testing.T) {
+	txmgrConfig := &txmgr.Config{Backend: &stubETHBackend{}}
+
+	sender := &mock.TxSender{}
+
+	backend := installPrivateSending(txmgrConfig, []utils.TxSender{sender}, []string{"relay.example"}, nil)
+
+	// The assignment is the entire feature. Without it every claim is signed and broadcast exactly
+	// as before — through the public mempool — and no other assertion in this suite notices.
+	require.NotNil(t, backend)
+	assert.Same(t, backend, txmgrConfig.Backend,
+		"the transaction manager has to be given the wrapping backend, not the bare client")
+	assert.Equal(t, 1, backend.NumPrivateEndpoints())
+
+	// And the wrapper still answers reads out of the endpoint it replaced.
+	require.NoError(t, backend.SendTransaction(context.Background(), types.NewTx(&types.DynamicFeeTx{
+		Nonce: 1,
+		Gas:   21_000,
+	})))
+	assert.Equal(t, 1, sender.SentCount(), "the broadcast goes to the private endpoint")
+}
+
+// stubETHBackend stands in for the endpoint the transaction manager was configured with. Only the
+// type matters here: the point of the test is which backend the manager is left holding.
+type stubETHBackend struct {
+	txmgr.ETHBackend
+}
+
+func (s *stubETHBackend) Close() {}

--- a/packages/relayer/prometheus.go
+++ b/packages/relayer/prometheus.go
@@ -50,6 +50,13 @@ var (
 			"is the relays being up and declining one particular claim, and it is a deliberate " +
 			"trade of that claim's privacy against never landing it",
 	})
+	PrivateRPCAllRefusedAttempts = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "private_rpc_all_refused_attempts_ops_total",
+		Help: "The total number of times a claim every private endpoint refused was offered to " +
+			"the public endpoint, whether or not that endpoint took it. Read against " +
+			"private_rpc_all_refused_ops_total: attempts climbing while broadcasts do not means " +
+			"the public endpoint is failing too, and the claim is reaching nobody",
+	})
 	PrivateRPCUnavailable = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "private_rpc_unavailable_ops_total",
 		Help: "The total number of sends that went out through the public endpoint while private " +

--- a/packages/relayer/prometheus.go
+++ b/packages/relayer/prometheus.go
@@ -32,8 +32,10 @@ var (
 		Name: "private_rpc_held_nonce_ops_total",
 		Help: "The total number of sends a private RPC endpoint answered by saying it already " +
 			"holds that nonce, labelled by that endpoint's position in the configured order. " +
-			"Not a failure — the endpoint is carrying the claim — but without it an endpoint " +
-			"answering this way is invisible, since nothing else counts the path",
+			"Not counted as a failure — the endpoint is carrying the claim — but a nonce it has " +
+			"not answered for before does count towards the consecutive ceiling, so an endpoint " +
+			"answering this to everything still steps aside. Without this counter the path is " +
+			"invisible, since nothing else records it",
 	}, []string{"endpoint"})
 	PrivateRPCTrips = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "private_rpc_trips_ops_total",
@@ -44,11 +46,12 @@ var (
 	}, []string{"endpoint"})
 	PrivateRPCAllRefused = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "private_rpc_all_refused_ops_total",
-		Help: "The total number of claims broadcast publicly because every private endpoint in " +
-			"rotation refused them repeatedly. Distinct from private_rpc_unavailable_ops_total, " +
-			"which counts claims sent publicly because no endpoint was in rotation at all: this " +
-			"is the relays being up and declining one particular claim, and it is a deliberate " +
-			"trade of that claim's privacy against never landing it",
+		Help: "The total number of sends broadcast publicly because every private endpoint in " +
+			"rotation refused that claim repeatedly. Counts sends rather than distinct claims, so " +
+			"a claim refused for long enough is counted once per broadcast. Distinct from " +
+			"private_rpc_unavailable_ops_total, which counts sends made publicly because no " +
+			"endpoint was in rotation at all: this is the relays being up and declining one " +
+			"particular claim, a deliberate trade of that claim's privacy against never landing it",
 	})
 	PrivateRPCAllRefusedAttempts = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "private_rpc_all_refused_attempts_ops_total",

--- a/packages/relayer/prometheus.go
+++ b/packages/relayer/prometheus.go
@@ -28,6 +28,13 @@ var (
 			"labelled by that endpoint's position in the configured order. Trips are monotonic, " +
 			"so they cannot answer what the rotation looks like right now; this can",
 	}, []string{"endpoint"})
+	PrivateRPCHeldNonce = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "private_rpc_held_nonce_ops_total",
+		Help: "The total number of sends a private RPC endpoint answered by saying it already " +
+			"holds that nonce, labelled by that endpoint's position in the configured order. " +
+			"Not a failure — the endpoint is carrying the claim — but without it an endpoint " +
+			"answering this way is invisible, since nothing else counts the path",
+	}, []string{"endpoint"})
 	PrivateRPCTrips = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "private_rpc_trips_ops_total",
 		Help: "The total number of times a private RPC endpoint was taken out of the failover " +
@@ -35,6 +42,14 @@ var (
 			"transition worth alerting on: an endpoint out of rotation is one fewer place to " +
 			"send privately, and the last one leaving means claims go to the public mempool",
 	}, []string{"endpoint"})
+	PrivateRPCAllRefused = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "private_rpc_all_refused_ops_total",
+		Help: "The total number of claims broadcast publicly because every private endpoint in " +
+			"rotation refused them repeatedly. Distinct from private_rpc_unavailable_ops_total, " +
+			"which counts claims sent publicly because no endpoint was in rotation at all: this " +
+			"is the relays being up and declining one particular claim, and it is a deliberate " +
+			"trade of that claim's privacy against never landing it",
+	})
 	PrivateRPCUnavailable = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "private_rpc_unavailable_ops_total",
 		Help: "The total number of sends that went out through the public endpoint while private " +


### PR DESCRIPTION
Follow-up to #22070, which merged as a squash — this branch was rebuilt on `main`, so the diff is only what it adds.

Findings 6, 13 and 15 from [davidtaikocha's first review](https://github.com/taikoxyz/taiko-mono/pull/22070#issuecomment-5472883757), plus the ledger from [round 4](https://github.com/taikoxyz/taiko-mono/pull/22070#issuecomment-5473983221). Four review rounds on this PR are folded in below rather than listed separately: a [Codex P1](https://github.com/taikoxyz/taiko-mono/pull/22074#discussion_r3892008705), a [DeepSeek round](https://github.com/taikoxyz/taiko-mono/pull/22074#issuecomment-5474373074), and davidtaikocha's [polish list](https://github.com/taikoxyz/taiko-mono/pull/22074#issuecomment-5474413210) and [round 2](https://github.com/taikoxyz/taiko-mono/pull/22074#issuecomment-5474659291).

## A claim every relay refuses never reached the public mempool

Tripping is per endpoint, and the deduplication charges each once for a given claim. So a claim every relay declines individually trips nobody: the rotation stays full, other claims keep clearing the tallies, and this one loops until `TX_SEND_TIMEOUT` with no metric moving — the relays are healthy, only this claim is unwanted.

After three consecutive sends that every endpoint in rotation *answered* with a refusal, the claim goes out through `DEST_RPC_URL`, counted by `private_rpc_all_refused_ops_total`. Distinct from `private_rpc_unavailable_ops_total`, which means no endpoint was in rotation at all; this means they were all up and all said no.

**The run belongs to the claim, not to the nonce.** A per-claim count is what the decision needs — a single slot was starved outright by ordinary concurrency, since two interleaving claims reset each other and neither ever reached the limit — but keying on the nonce alone was not enough either, because nonces recycle. A claim that reached the limit while the public endpoint was failing keeps its count, is abandoned at `TX_SEND_TIMEOUT`, and `resetNonce` hands that nonce to an unrelated message, which would inherit a probation it had served none of and be broadcast on its first refusal instead of its third. The claim is identified by its calldata — the encoded message and its proof — which is unchanged by the fee bumps that change the hash, and different for every other claim. The map is bounded at 256 entries, evicting the lowest nonce as the stalest; a live entry evicted by that bound reports *no* fallback, so losing a count costs a claim its probation again rather than exposing it.

**The probation is served once per claim, not once per exposure.** It is cleared by a send a *private* endpoint accepted, and by nothing else. Not by the fallback firing: that cost the claim the threshold it had just earned, and three more all-refused sends at the 48s `RESUBMISSION_TIMEOUT` default is ~144s, past the two-minute `TxNotInMempoolTimeout` — the claim would end the send never having reached any mempool. And not by the public send succeeding either: the claim is in the open by then, so restarting the count buys no privacy and withholds the next two fee-bumped resubmissions from a pool that already holds the stale low-fee variant, or leaves a relay holding the bumped one while the public pool holds the original — the two-variants-racing case `prioritiseNonceHolder` exists to avoid. The public error is propagated, since it is the last and most complete thing attempted and classifies better than the refusal before it.

Two things deliberately do **not** count towards the limit:

- **A timeout or transport failure.** That means the endpoint is down, which tripping already handles by emptying the rotation. Counting an outage here would push claims into the open *before* the rotation had a chance to empty.
- **A relay answering that it holds the nonce.** The claim is already where it needs to be, so going public would leak one every relay is carrying. This one was a bug the merge of the two branches created — each half was correct alone.

Broadcasting publicly hands a competitor the message and proof, which is what #22070 exists to prevent, so it is the last resort — but a claim that never lands is worth less than one landed in the open.

## An endpoint holding every nonce never stepped aside

From round 4, measured at 500 straight answers with the rotation intact. The holder exemption added in #22070 skipped the failure accounting entirely, so an endpoint answering this way to everything could never reach the consecutive ceiling that exists for an endpoint taking nothing — it kept its place indefinitely with nothing sent through it, and no counter moved.

Holding is still not a refusal, so the tally the threshold reads is untouched, but it counts towards the ceiling, and `private_rpc_held_nonce_ops_total` makes the path visible.

Which answers are free is the part that took three attempts to get right, each wrong version taking out the endpoint *carrying* a claim. The manager resends an unconfirmed nonce every `RESUBMISSION_TIMEOUT` and the holder says so each time: counting every answer reached the ceiling in ten resends, about eight minutes, and with one endpoint configured the claim then went public through the unavailable path. Remembering only the last nonce fixed that but not its two-claim variant — two concurrently held claims alternate past a single slot, and ten answers took the holder out in about four minutes. So an answer for a nonce the endpoint has **demonstrably accepted** is free, however many claims it is carrying, with the single-slot check kept underneath it for a nonce it never took (it may be answering for a claim it learned from another relay's gossip). What is left to charge is a succession of *distinct* claims it never took, which is the state the ceiling exists to end — pinned by its own test.

Also flagged in round 4 and now recorded in the code: `holdsTheNonce` matches geth's wording, which reaches us only from a relay proxying its node's txpool errors verbatim. **Neither shipped default does** — Flashbots' `rpc-endpoint` answers a duplicate resubmission with success and collapses rejections to `-32603`; MEV Blocker publishes no such wording. So in the recommended configuration both the exemption and the over-charging it prevents are inert. The comment says so rather than stating the premise as general truth.

## The line that installs the feature had no test

Every block of the wiring had a coverage count of zero. Deleting the assignment of the `SendingBackend` onto the transaction manager's config left the entire suite green while every claim went out through the public mempool — precisely the exposure #22070 closes. It now lives in `installPrivateSending`, whose internals are pinned by a test that fails when the assignment is removed.

**Scoped deliberately:** that pins the helper, not the call site. Replacing the call in `InitFromConfig` with an unwired `NewSendingBackend` still leaves the suite green, and `InitFromConfig` has no tests at all. The seam finding 13 asked for needs `InitFromConfig` to be constructible without live dials, which is a refactor of its own; it is in the still-open list rather than claimed as closed here.

## The mock dropped the fields the handler exists to write

`mock.EventRepository.Save` built an `Event` without `BlockID`, `EmittedBlockID`, `SyncData` or the synced chain, and the checkpoint test asserted a row count — so a handler rewritten to persist zeroes passed. `wait_header_synced` gates every claim on those rows: a wrong block number would hold up every claim, or release claims against a header that had not synced, with CI green throughout.

`SyncedChainID` is asserted too. It is the field both reader queries filter on (`pkg/repo/event.go:228` and `:253`), so zeroing it passes a row-count assertion while every claim waits forever on a row that is never found.

## A nil close notification panicked the consume loop

`Subscribe`'s error arms called `err.Error()` on a `*amqp.Error` that is nil after a graceful close, and `Error()` has a value receiver. `Notify` guarded both arms; `Subscribe` guarded neither. Pre-existing, identical on `main` before this.

## Verification

Every fix is mutation-checked by running the revert rather than assuming it. The current set: dropping the claim stamp, dropping the holder guard, evicting the highest nonce instead of the lowest, restoring the clear on a public accept, `clearAllRefused` as a no-op, the holder guard made unconditional, deleting the wiring assignment, and zeroing the checkpoint fields. Each fails its own test.

Two of these were caught only because a revert was actually run: the leak-rate test passed a first revert because there are two `clearAllRefused` call sites and it hit the wrong one, and evicting the highest nonce — the pathological direction, since it drops the newest entry on every send — passed the entire suite while only the size bound was pinned.

`golangci-lint` 2.13.2 (the release CI uses) reports 0 issues; `go build`, `go vet`, `gofmt` and `typos` clean; full relayer suite green under `-race` apart from `pkg/repo`'s testcontainers tests, which need Docker in this environment — davidtaikocha ran those and they pass.

**Not exercised against a live broker or endpoint.** The hoodi soak davidtaikocha asked for before mainnet covers #22070 and this equally.

## Still open

Filed rather than fixed. None is reachable in the recommended configuration:

- **A holder in rotation permanently vetoes the fallback for its claim.** `recordSuccess` clears `consecutive` on every accepted send, so a stuck holder never reaches the ceiling under ordinary traffic — the *refusing* endpoint trips instead, degenerating the rotation to the holder alone, which also disables the empty-rotation escape. `recordHeldNonce`'s doc implies the ceiling reliably ends this state; it does not. Fix shape: a held streak only that endpoint's own accepts clear.
- An `InitFromConfig`-level test seam, per the scoping note above.
- A testcontainers-backed test for the 406 redeclare fallback path.
- `NotifyReturn` / publisher confirms.
- The `waitForConfirmations` receipt-never-seen split.
- The failover threshold rebalance — three claims a competitor took can trip a healthy relay.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBxwfV96VV6CMcFf3tZyKD