### PR TITLE
fix(protocol): budget the bridge's Ether sends for EIP-8037 state-creation repricing

### DIFF
--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -61,11 +61,21 @@ contract Bridge is EssentialResolverContract, IBridge {
     /// suggest. State-access repricing forks such as EIP-8038 raise mostly caller-side costs
     /// (value-transfer account write, cold-recipient access) that are paid by this contract
     /// before forwarding and do not draw on this budget, so no headroom bump is needed for them.
+    /// State-creation repricing (EIP-8037, scheduled for Glamsterdam) does draw on this budget:
+    /// creating a fresh storage slot charges 64 state bytes * 1,530 gas/byte = 97,920 gas, and
+    /// unless the transaction buys gas beyond the 16.7M per-transaction execution cap (which no
+    /// realistic claim transaction does, leaving its state-gas reservoir empty), that charge is
+    /// deducted from the callee frame's own gas. A smart wallet that writes a single fresh slot
+    /// when receiving Ether would then run out of gas under the previous 35,000 cap, and since a
+    /// failed send reverts processing, its messages would become unclaimable. The cap is
+    /// therefore the legacy 35,000 callee budget plus one EIP-8037 slot-creation charge
+    /// (97,920), rounded up — wallets that fit before the fork still fit after it, as long as
+    /// their receive path creates at most one storage slot.
     // - EOA gas used is < 21000
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000
     // - For Gnosis Safe wallet, gas used is about 28000
-    uint256 private constant _SEND_ETHER_GAS_LIMIT = 35_000;
+    uint256 private constant _SEND_ETHER_GAS_LIMIT = 135_000;
 
     /// @dev Place holder value stored in the context slots between message invocations.
     uint256 private constant _PLACEHOLDER = type(uint256).max;

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -442,6 +442,8 @@ contract TestBridge2_processMessage is TestBridge2Base {
         message.fee = 5_000_000;
         message.value = 2 ether;
         message.destOwner = address(wallet);
+        // With empty message.data the invocation is a plain value-bearing call that hits the
+        // wallet's receive() — no onMessageInvocation implementation is required.
         message.to = address(wallet);
 
         eBridge.processMessage(message, FAKE_PROOF);

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.24;
 
 import "./TestBridge2Base.sol";
-import "test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol";
+import {
+    MessageReceiver_CreatingFreshStorageSlots
+} from "test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol";
 
 contract Target is IMessageInvocable {
     uint256 public receivedEther;

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "./TestBridge2Base.sol";
+import "test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol";
 
 contract Target is IMessageInvocable {
     uint256 public receivedEther;
@@ -384,6 +385,102 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         uint256 totalBalance2 = getBalanceForAccounts() + address(target).balance;
         assertEq(totalBalance2, totalBalance);
+    }
+
+    /// @dev The refund send to destOwner must budget for a smart wallet that creates fresh
+    /// storage slots in its receive path. Writing 4+1 fresh slots costs ~112k gas under the
+    /// current schedule — above the previous 35k cap and comparable to what a single fresh slot
+    /// (97,920 gas) plus wallet overhead will cost under EIP-8037.
+    function test_bridge2_processMessage__refund_to_storage_creating_wallet()
+        public
+        transactBy(Carol)
+    {
+        MessageReceiver_CreatingFreshStorageSlots wallet =
+            new MessageReceiver_CreatingFreshStorageSlots(4);
+
+        uint256 bridgeBalance = address(eBridge).balance;
+
+        IBridge.Message memory message;
+        message.destChainId = ethereumChainId;
+        message.srcChainId = taikoChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 0;
+        message.value = 2 ether;
+        message.destOwner = address(wallet);
+        // Invocation is prohibited for the bridge itself, so the full value is refunded to
+        // destOwner through the gas-capped Ether send.
+        message.to = address(eBridge);
+
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        bytes32 hash = eBridge.hashMessage(message);
+        assertTrue(eBridge.messageStatus(hash) == IBridge.Status.DONE);
+        assertEq(address(wallet).balance, 2 ether);
+        assertEq(wallet.receiveCount(), 1);
+        assertEq(address(eBridge).balance, bridgeBalance - 2 ether);
+    }
+
+    /// @dev End-to-end claim of bridged Ether by a storage-creating smart wallet with a relayer
+    /// fee: the invocation pays the value to the wallet, and the unused fee is then refunded to
+    /// the same wallet through the gas-capped Ether send.
+    function test_bridge2_processMessage__storage_creating_wallet_claims_with_fee()
+        public
+        transactBy(Carol)
+    {
+        MessageReceiver_CreatingFreshStorageSlots wallet =
+            new MessageReceiver_CreatingFreshStorageSlots(4);
+
+        uint256 carolBalance = Carol.balance;
+        uint256 bridgeBalance = address(eBridge).balance;
+
+        IBridge.Message memory message;
+        message.destChainId = ethereumChainId;
+        message.srcChainId = taikoChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 5_000_000;
+        message.value = 2 ether;
+        message.destOwner = address(wallet);
+        message.to = address(wallet);
+
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        bytes32 hash = eBridge.hashMessage(message);
+        assertTrue(eBridge.messageStatus(hash) == IBridge.Status.DONE);
+        // The wallet received the value in the invocation and the fee remainder in the refund.
+        assertEq(wallet.receiveCount(), 2);
+        assertTrue(address(wallet).balance > 2 ether);
+        assertTrue(address(wallet).balance < 2 ether + 5_000_000);
+        // The relayer received the rest of the fee.
+        uint256 relayerFee = Carol.balance - carolBalance;
+        assertTrue(relayerFee > 0);
+        assertEq(address(wallet).balance + relayerFee, 2 ether + 5_000_000);
+        assertEq(address(eBridge).balance, bridgeBalance - 2 ether - 5_000_000);
+    }
+
+    /// @dev The cap still bounds how much gas a recipient can consume: a receive path far above
+    /// the budget (7+1 fresh slots, ~179k gas) keeps failing the refund.
+    function test_bridge2_processMessage__refund_receiver_exceeding_gas_cap()
+        public
+        transactBy(Carol)
+    {
+        MessageReceiver_CreatingFreshStorageSlots wallet =
+            new MessageReceiver_CreatingFreshStorageSlots(7);
+
+        IBridge.Message memory message;
+        message.destChainId = ethereumChainId;
+        message.srcChainId = taikoChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 0;
+        message.value = 2 ether;
+        message.destOwner = address(wallet);
+        message.to = address(eBridge);
+
+        vm.expectRevert(LibAddress.ETH_TRANSFER_FAILED.selector);
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        bytes32 hash = eBridge.hashMessage(message);
+        assertTrue(eBridge.messageStatus(hash) == IBridge.Status.NEW);
+        assertEq(address(wallet).balance, 0);
     }
 
     function test_bridge2_processMessage__context_transient_lifecycle() public transactBy(Carol) {

--- a/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.24;
 
 import "./TestBridge2Base.sol";
-import "test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol";
+import {
+    MessageReceiver_CreatingFreshStorageSlots
+} from "test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol";
 
 contract TestRecallableSender is IRecallableSender, IERC165 {
     IBridge private bridge;

--- a/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "./TestBridge2Base.sol";
+import "test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol";
 
 contract TestRecallableSender is IRecallableSender, IERC165 {
     IBridge private bridge;
@@ -57,6 +58,34 @@ contract TestBridge2_recallMessage is TestBridge2Base {
         // recall the same message again
         vm.expectRevert(Bridge.B_INVALID_STATUS.selector);
         eBridge.recallMessage(m, FAKE_PROOF);
+    }
+
+    /// @dev A recalled message must be able to return its value to a smart-wallet srcOwner that
+    /// creates fresh storage slots when receiving Ether (~112k gas here, comparable to one fresh
+    /// slot plus overhead under EIP-8037), which exceeded the previous 35k send cap.
+    function test_bridge2_recallMessage_storage_creating_wallet_srcOwner()
+        public
+        transactBy(Carol)
+    {
+        MessageReceiver_CreatingFreshStorageSlots wallet =
+            new MessageReceiver_CreatingFreshStorageSlots(4);
+
+        IBridge.Message memory message;
+        message.srcOwner = address(wallet);
+        message.destOwner = Bob;
+        message.srcChainId = ethereumChainId;
+        message.destChainId = taikoChainId;
+        message.value = 1 ether;
+        message.to = Zachary;
+
+        (, IBridge.Message memory m) = eBridge.sendMessage{ value: 1 ether }(message);
+
+        eBridge.recallMessage(m, FAKE_PROOF);
+        bytes32 hash = eBridge.hashMessage(m);
+        assertTrue(eBridge.messageStatus(hash) == IBridge.Status.RECALLED);
+
+        assertEq(address(wallet).balance, 1 ether);
+        assertEq(wallet.receiveCount(), 1);
     }
 
     function test_bridge2_recallMessage_callable_sender() public dealEther(Carol) {

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @dev A recipient that creates `numSlots` fresh storage slots every time it receives Ether,
+/// mimicking a smart wallet whose receive path performs bookkeeping writes. Under the current
+/// gas schedule each fresh slot costs 22,100 gas; under EIP-8037 (Glamsterdam) a single fresh
+/// slot costs 97,920 gas, so 4-5 fresh slots today approximate the gas a one-slot wallet will
+/// need after the fork. The `receiveCount` slot itself is an extra fresh slot on the first
+/// receive and a warm rewrite afterwards.
+contract MessageReceiver_CreatingFreshStorageSlots {
+    uint256 public immutable numSlots;
+    uint256 public receiveCount;
+    mapping(uint256 slot => uint256 value) public ledger;
+
+    constructor(uint256 _numSlots) {
+        numSlots = _numSlots;
+    }
+
+    receive() external payable {
+        unchecked {
+            uint256 base = receiveCount * numSlots;
+            for (uint256 i; i < numSlots; ++i) {
+                ledger[base + i] = msg.value + i + 1;
+            }
+            receiveCount += 1;
+        }
+    }
+}

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
@@ -4,9 +4,12 @@ pragma solidity ^0.8.24;
 /// @dev A recipient that creates `numSlots` fresh storage slots every time it receives Ether,
 /// mimicking a smart wallet whose receive path performs bookkeeping writes. Under the current
 /// gas schedule each fresh slot costs 22,100 gas; under EIP-8037 (Glamsterdam) a single fresh
-/// slot costs 97,920 gas, so 4-5 fresh slots today approximate the gas a one-slot wallet will
+/// slot costs 97,920 gas, so 4 fresh slots today approximate the gas a one-slot wallet will
 /// need after the fork. The `receiveCount` slot itself is an extra fresh slot on the first
 /// receive and a warm rewrite afterwards.
+/// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule. If the
+/// test EVM ever adopts EIP-8037 pricing, reduce them accordingly (4 -> 1, 7 -> 2) so the
+/// consumed gas keeps its intended position relative to Bridge._SEND_ETHER_GAS_LIMIT.
 contract MessageReceiver_CreatingFreshStorageSlots {
     uint256 public immutable numSlots;
     uint256 public receiveCount;


### PR DESCRIPTION
## Problem

EIP-8037 (state-creation repricing, scheduled for Glamsterdam) makes creating a fresh storage slot cost **64 state bytes × 1,530 gas/byte = 97,920 gas** (vs 22,100 today). State gas is charged to a transaction-level reservoir first, but the reservoir is funded only by transaction gas *above* the 16.7M per-transaction execution cap — so for every realistic claim transaction the reservoir is empty and the charge falls through to **the current call frame's own gas**.

The bridge sends all capped Ether transfers with `_SEND_ETHER_GAS_LIMIT = 35_000`:

- `processMessage` → fee-remainder refund to `destOwner` (reverts the whole claim on failure, on **both** the relayer path and the self-claim path, for any nonzero-fee message);
- `processMessage` → relayer fee payout to `msg.sender` (reverts on failure);
- `recallMessage` → value back to `srcOwner` (reverts on failure);
- `retryMessage` → value to `destOwner` on the invocation-prohibited branch (non-reverting).

Post-Glamsterdam, a smart-wallet `destOwner` that writes a single fresh storage slot when receiving Ether would run out of gas inside the 35k cap. Because the failed send reverts `processMessage` before the status update, the message stays `NEW` forever: the relayer can't process it, and the owner can't self-claim either (the full fee still routes to `destOwner` through the same capped send). The bridged Ether would be unclaimable. The existing comment on the constant only reasoned about EIP-8038 (state-*access* repricing, caller-side costs) and predates 8037's finalization.

## Fix

Raise `_SEND_ETHER_GAS_LIMIT` from 35,000 to **135,000** = the legacy 35,000 callee budget + one EIP-8037 slot-creation charge (97,920), rounded up. This preserves the same guarantee across the fork: every wallet that fit in the old cap still fits, provided its receive path creates at most one fresh storage slot (the old cap likewise only ever covered one 22.1k slot plus overhead). On chains before the fork the extra headroom is inert for honest recipients, and the cap continues to bound how much relayer gas a malicious recipient can burn.

### Alternatives considered

- **Non-reverting refunds with a claimable-credit mapping (pull pattern)** — removes gas assumptions entirely and survives any future repricing, but adds storage to an upgradeable contract, a new external claim function, and new audit surface. Worth considering as a follow-up if we want zero coupling to gas schedules.
- **Forwarding all remaining gas on refunds** — rejected: unbounded relayer gas-griefing by a malicious `destOwner`.
- **Relying on claimers to buy reservoir gas (tx gas above the 16.7M execution cap)** — rejected: forces every relayer and self-claimer to front ~16.7M gas × basefee per claim and breaks standard estimation flows.

### Follow-ups (out of scope here)

`GAS_RESERVE` (800k), `GAS_OVERHEAD` (120k) and `_GAS_REFUND_PER_CACHE_OPERATION` (20k) are relayer-fee calibration constants explicitly meant to be retuned with production data; Glamsterdam inflates the bridge's own fresh-slot writes (message status, signal cache) too, so they should be recalibrated from Platåberget/testnet measurements before the fork. Those affect relayer economics, not claimability. Bridge UI / relayer default `gasLimit` suggestions for messages invoking contract recipients will also need raising, since invocation gas is user-chosen per message.

## Tests

New helper `MessageReceiver_CreatingFreshStorageSlots` writes N fresh slots per Ether receive. With N=4 (~112k gas today, representative of a one-fresh-slot wallet post-8037: 97,920 + overhead — and well above the old 35k cap, so these tests fail on `main`'s constant):

- `test_bridge2_processMessage__refund_to_storage_creating_wallet` — pure capped-refund path (invocation-prohibited target) delivers full value to the wallet;
- `test_bridge2_processMessage__storage_creating_wallet_claims_with_fee` — end-to-end relayer claim: invocation pays value, capped send refunds the fee remainder, relayer keeps its cut, balances conserve;
- `test_bridge2_recallMessage_storage_creating_wallet_srcOwner` — recall returns value to a storage-writing `srcOwner`;
- `test_bridge2_processMessage__refund_receiver_exceeding_gas_cap` — N=7 (~179k) still fails with `ETH_TRANSFER_FAILED` and leaves the message `NEW`, pinning the cap from above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbPMYpG2UWajo5ehLdmAvi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbPMYpG2UWajo5ehLdmAvi)_