### PR TITLE
fix(bridge-ui): fix medium and low severity findings from UI audit

### DIFF
--- a/packages/bridge-ui/src/components/Bridge/FungibleBridge.svelte
+++ b/packages/bridge-ui/src/components/Bridge/FungibleBridge.svelte
@@ -2,8 +2,10 @@
   import { t } from 'svelte-i18n';
 
   import { Card } from '$components/Card';
+  import { OnAccount } from '$components/OnAccount';
+  import { OnNetwork } from '$components/OnNetwork';
   import { Step, Stepper } from '$components/Stepper';
-  import { connectedSmartContractWallet } from '$stores/account';
+  import { type Account, connectedSmartContractWallet } from '$stores/account';
 
   import { ImportStep, ReviewStep, StepNavigation } from './FungibleBridgeComponents';
   import { ConfirmationStep, RecipientStep } from './SharedBridgeComponents';
@@ -24,6 +26,20 @@
   let needsManualReviewConfirmation: boolean;
 
   $: needsManualRecipientConfirmation = $connectedSmartContractWallet;
+
+  // A wallet network or account change invalidates what Review/Confirm show,
+  // so the wizard returns to the import step for revalidation
+  function onNetworkChange() {
+    if (activeStep !== BridgeSteps.IMPORT) {
+      activeStep = BridgeSteps.IMPORT;
+    }
+  }
+
+  function onAccountChange(newAccount: Account, oldAccount?: Account) {
+    if (oldAccount && newAccount?.address !== oldAccount?.address && activeStep !== BridgeSteps.IMPORT) {
+      activeStep = BridgeSteps.IMPORT;
+    }
+  }
 
   $: {
     const stepKey = BridgeSteps[activeStep].toLowerCase();
@@ -77,3 +93,6 @@
     </div>
   </Card>
 </div>
+
+<OnNetwork change={onNetworkChange} />
+<OnAccount change={onAccountChange} />

--- a/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/ImportStep/TokenInput/TokenInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/ImportStep/TokenInput/TokenInput.svelte
@@ -79,7 +79,14 @@
     $validatingAmount = true;
     $errorComputingBalance = false;
 
-    $enteredAmount = parseUnits(value, $selectedToken.decimals);
+    try {
+      // Number inputs also emit values parseUnits cannot parse, like '1e5'
+      $enteredAmount = parseUnits(value, $selectedToken.decimals);
+    } catch {
+      $enteredAmount = 0n;
+      $validatingAmount = false;
+      return;
+    }
     debouncedValidateAmount();
   };
 
@@ -101,10 +108,10 @@
           fee: $processingFee,
         });
 
-        // Update state
-        $enteredAmount = maxAmount;
-        value = formatUnits(maxAmount, $selectedToken.decimals);
-        value = truncateDecimal(parseFloat(value), 12).toString();
+        // The displayed value is truncated for readability, so the entered amount is
+        // re-derived from it: what the user sees is exactly what gets bridged
+        value = truncateDecimal(parseFloat(formatUnits(maxAmount, $selectedToken.decimals)), 12).toString();
+        $enteredAmount = parseUnits(value, $selectedToken.decimals);
         validateAmount();
       }
     } catch (err) {

--- a/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/ImportStep/TokenInput/TokenInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/ImportStep/TokenInput/TokenInput.svelte
@@ -29,7 +29,7 @@
   import { refreshUserBalance, renderBalance } from '$libs/util/balance';
   import { debounce } from '$libs/util/debounce';
   import { getLogger } from '$libs/util/logger';
-  import { truncateDecimal } from '$libs/util/truncateDecimal';
+  import { truncateDecimalString } from '$libs/util/truncateDecimal';
   import { type Account, account } from '$stores/account';
   import { ethBalance } from '$stores/balance';
   import { connectedSourceChain } from '$stores/network';
@@ -109,8 +109,10 @@
         });
 
         // The displayed value is truncated for readability, so the entered amount is
-        // re-derived from it: what the user sees is exactly what gets bridged
-        value = truncateDecimal(parseFloat(formatUnits(maxAmount, $selectedToken.decimals)), 12).toString();
+        // re-derived from it: what the user sees is exactly what gets bridged. The
+        // truncation stays on the string, since a float round-trip yields scientific
+        // notation for tiny balances, which parseUnits rejects
+        value = truncateDecimalString(formatUnits(maxAmount, $selectedToken.decimals), 12);
         $enteredAmount = parseUnits(value, $selectedToken.decimals);
         validateAmount();
       }

--- a/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/StepNavigation/StepNavigation.svelte
+++ b/packages/bridge-ui/src/components/Bridge/FungibleBridgeComponents/StepNavigation/StepNavigation.svelte
@@ -20,11 +20,11 @@
   let manuallyConfirmedReviewStep = false;
   let manuallyConfirmedRecipientStep = false;
 
-  const getStepText = () => {
-    if (activeStep === BridgeSteps.REVIEW) {
+  const getStepText = (step: BridgeSteps) => {
+    if (step === BridgeSteps.REVIEW) {
       return $t('common.confirm');
     }
-    if (activeStep === BridgeSteps.CONFIRM) {
+    if (step === BridgeSteps.CONFIRM) {
       return $t('common.ok');
     } else {
       return $t('common.continue');
@@ -66,7 +66,8 @@
 
   $: disabled = !$account || !$account.isConnected || $calculatingProcessingFee;
 
-  $: nextStepButtonText = getStepText();
+  // The step is passed as an argument so the reactive statement tracks it
+  $: nextStepButtonText = getStepText(activeStep);
 
   $: reviewConfirmed = !needsManualReviewConfirmation || manuallyConfirmedReviewStep;
 

--- a/packages/bridge-ui/src/components/Bridge/NFTBridge.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridge.svelte
@@ -79,7 +79,7 @@
     tick().then(() => {
       if ($selectedImportMethod === ImportMethod.MANUAL) {
         // run validations again if we are in manual mode
-        runValidations();
+        runValidations().catch((error) => console.error('Error running validations', error));
       } else {
         resetForm();
       }

--- a/packages/bridge-ui/src/components/Bridge/NFTBridge.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridge.svelte
@@ -9,13 +9,13 @@
   import { OnNetwork } from '$components/OnNetwork';
   import { Step, Stepper } from '$components/Stepper';
   import { hasBridge } from '$libs/bridge/bridges';
-  import { BridgePausedError } from '$libs/error';
   import { ETHToken } from '$libs/token';
   import { isBridgePaused } from '$libs/util/checkForPausedContracts';
   import { type Account, account } from '$stores/account';
 
   import { ImportStep, ReviewStep, StepNavigation } from './NFTBridgeComponents';
   import type IdInput from './NFTBridgeComponents/IDInput/IDInput.svelte';
+  import { selectedImportMethod } from './NFTBridgeComponents/ImportStep/state';
   import { ConfirmationStep, RecipientStep } from './SharedBridgeComponents';
   import type AddressInput from './SharedBridgeComponents/AddressInput/AddressInput.svelte';
   import type { ProcessingFee } from './SharedBridgeComponents/ProcessingFee';
@@ -32,7 +32,6 @@
 
   let recipientStepComponent!: RecipientStep;
   let processingFeeComponent!: ProcessingFee;
-  let importMethod!: ImportMethod;
   let bridgingStatus: BridgingStatus;
 
   let hasEnoughEth: boolean = false;
@@ -49,29 +48,23 @@
     activeStep = BridgeSteps.IMPORT;
     if (newNetwork) {
       const destChainId = $destinationChain?.id;
-      if (!$destinationChain?.id) return;
+      if (!destChainId) return;
       // determine if we simply swapped dest and src networks
       if (newNetwork.id === destChainId) {
         destinationChain.set(oldNetwork);
         return;
       }
-      // check if the new network has a bridge to the current dest network
-      if (hasBridge(newNetwork.id, $destinationChain?.id)) {
-        destinationChain.set(oldNetwork);
-      } else {
-        // if not, set dest network to null
+      // A still-bridgeable destination stays selected; only an unreachable one is cleared
+      if (!hasBridge(newNetwork.id, destChainId)) {
         $destinationChain = null;
       }
     }
   }
 
-  const runValidations = () => {
+  const runValidations = async () => {
     if (addressInputComponent) addressInputComponent.validateAddress();
-    isBridgePaused().then((paused) => {
-      if (paused) {
-        throw new BridgePausedError();
-      }
-    });
+    // Surfaces the paused modal via its store; the bridge classes enforce the actual block
+    await isBridgePaused();
   };
 
   function onAccountChange(account: Account) {
@@ -84,7 +77,7 @@
 
   function updateForm() {
     tick().then(() => {
-      if (importMethod === ImportMethod.MANUAL) {
+      if ($selectedImportMethod === ImportMethod.MANUAL) {
         // run validations again if we are in manual mode
         runValidations();
       } else {
@@ -129,7 +122,11 @@
 
   $: validatingImport = false;
 
-  $: activeStep === BridgeSteps.IMPORT && resetForm();
+  // Only a completed bridge wipes the form when landing back on IMPORT;
+  // plain back-navigation must keep the user's input
+  $: if (activeStep === BridgeSteps.IMPORT && bridgingStatus === BridgingStatus.DONE) {
+    resetForm();
+  }
 
   onDestroy(() => {
     resetForm();

--- a/packages/bridge-ui/src/components/Bridge/NFTBridge.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridge.svelte
@@ -14,10 +14,8 @@
   import { type Account, account } from '$stores/account';
 
   import { ImportStep, ReviewStep, StepNavigation } from './NFTBridgeComponents';
-  import type IdInput from './NFTBridgeComponents/IDInput/IDInput.svelte';
   import { selectedImportMethod } from './NFTBridgeComponents/ImportStep/state';
   import { ConfirmationStep, RecipientStep } from './SharedBridgeComponents';
-  import type AddressInput from './SharedBridgeComponents/AddressInput/AddressInput.svelte';
   import type { ProcessingFee } from './SharedBridgeComponents/ProcessingFee';
   import {
     activeBridge,
@@ -40,8 +38,10 @@
   let nftStepTitle: string;
   let nftStepDescription: string;
 
-  let addressInputComponent!: AddressInput;
-  let nftIdInputComponent!: IdInput;
+  // ImportStep owns the manual-import inputs; they live two levels down, so the reset and
+  // revalidate calls below go through it. The AddressInput/IdInput references that used to
+  // stand here were never bound to anything, which made every call on them a silent no-op.
+  let importStepComponent: ImportStep;
 
   function onNetworkChange(newNetwork: Chain, oldNetwork: Chain) {
     updateForm();
@@ -62,7 +62,7 @@
   }
 
   const runValidations = async () => {
-    if (addressInputComponent) addressInputComponent.validateAddress();
+    importStepComponent?.revalidate();
     // Surfaces the paused modal via its store; the bridge classes enforce the actual block
     await isBridgePaused();
   };
@@ -89,10 +89,7 @@
   const resetForm = () => {
     //we check if these are still mounted, as the user might have left the page
     if (processingFeeComponent) processingFeeComponent.resetProcessingFee();
-    if (addressInputComponent) addressInputComponent.clearAddress();
-
-    // Update balance after bridging
-    if (nftIdInputComponent) nftIdInputComponent.clearIds();
+    importStepComponent?.resetManualImport();
 
     $recipientAddress = $account?.address || null;
     $destOwnerAddress = $account?.address || null;
@@ -147,7 +144,7 @@
     <div class="space-y-[30px]">
       {#if activeStep === BridgeSteps.IMPORT}
         <!-- IMPORT STEP -->
-        <ImportStep bind:validating={validatingImport} />
+        <ImportStep bind:this={importStepComponent} bind:validating={validatingImport} />
       {:else if activeStep === BridgeSteps.REVIEW}
         <!-- REVIEW STEP -->
         <ReviewStep on:editTransactionDetails={handleTransactionDetailsClick} bind:hasEnoughEth />

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/IDInput/IDInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/IDInput/IDInput.svelte
@@ -32,7 +32,9 @@
     if (idInput && idInput instanceof EventTarget) {
       ids = (idInput as HTMLInputElement).value
         .split(',')
-        .map((item) => parseInt(item))
+        .map((item) => item.trim())
+        .filter((item) => item !== '')
+        .map((item) => Number(item))
         .filter((num) => !isNaN(num));
     } else if (Array.isArray(idInput)) {
       ids = idInput;
@@ -42,7 +44,9 @@
       ids = ids.slice(0, limit);
     }
     enteredIds = ids;
-    const isValid = ids.every((num) => Number.isInteger(num));
+    // Token IDs above Number.MAX_SAFE_INTEGER silently lose precision as JS numbers,
+    // which would make the flow act on a different token — reject them instead
+    const isValid = ids.every((num) => Number.isSafeInteger(num) && num >= 0);
     validIdNumbers = isValid ? ids : [];
     state = isValid ? State.VALID : State.INVALID;
     dispatch('inputValidation');

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/IDInput/IDInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/IDInput/IDInput.svelte
@@ -34,8 +34,10 @@
         .split(',')
         .map((item) => item.trim())
         .filter((item) => item !== '')
-        .map((item) => Number(item))
-        .filter((num) => !isNaN(num));
+        // Strictly decimal: Number('0x10') is 16, so a pasted hex id would silently
+        // target a different token
+        .filter((item) => /^\d+$/.test(item))
+        .map((item) => Number(item));
     } else if (Array.isArray(idInput)) {
       ids = idInput;
     }

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/IDInput/IDInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/IDInput/IDInput.svelte
@@ -44,6 +44,14 @@
       ids = ids.slice(0, limit);
     }
     enteredIds = ids;
+
+    // An empty field is neither valid nor an error: nothing has been entered yet
+    if (ids.length === 0) {
+      validIdNumbers = [];
+      state = State.DEFAULT;
+      dispatch('inputValidation');
+      return;
+    }
     // Token IDs above Number.MAX_SAFE_INTEGER silently lose precision as JS numbers,
     // which would make the flow act on a different token — reject them instead
     const isValid = ids.every((num) => Number.isSafeInteger(num) && num >= 0);

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportActions.component.test.ts
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportActions.component.test.ts
@@ -1,0 +1,80 @@
+/**
+ * A scan that failed is not a scan that found nothing.
+ *
+ * `firstScan` gates the initial call-to-action against the "no NFTs found" warning, so
+ * clearing it in a `finally` reported an RPC failure to the user as an empty wallet.
+ */
+import { tick } from 'svelte';
+import { vi } from 'vitest';
+
+vi.mock('svelte-i18n', async () => {
+  const { readable } = await import('svelte/store');
+  return { t: readable((key: string) => key), locale: readable('en'), init: vi.fn(), addMessages: vi.fn() };
+});
+
+const errorToast = vi.fn();
+vi.mock('$components/NotificationToast', () => ({
+  errorToast: (...args: unknown[]) => errorToast(...args),
+  warningToast: vi.fn(),
+  successToast: vi.fn(),
+  infoToast: vi.fn(),
+}));
+
+import ImportActions from './ImportActions.svelte';
+
+let target: HTMLElement;
+let component: { $destroy: () => void } | null = null;
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await tick();
+};
+
+const text = () => target.textContent ?? '';
+
+beforeEach(() => {
+  errorToast.mockReset();
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  component?.$destroy();
+  component = null;
+  target.remove();
+});
+
+describe('initial NFT scan', () => {
+  it('reports an empty wallet only after a scan that completed', async () => {
+    const scanForNFTs = vi.fn().mockResolvedValue(undefined);
+    component = new ImportActions({ target, props: { canImport: true, scanning: false, scanForNFTs } });
+    await tick();
+
+    (target.querySelector('button') as HTMLButtonElement).click();
+    await flush();
+
+    expect(text()).toContain('bridge.nft.step.import.no_nft_found');
+  });
+
+  it('keeps the initial scan action after a failed scan', async () => {
+    const scanForNFTs = vi.fn().mockRejectedValue(new Error('rate limited'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    component = new ImportActions({ target, props: { canImport: true, scanning: false, scanForNFTs } });
+    await tick();
+
+    (target.querySelector('button') as HTMLButtonElement).click();
+    await flush();
+
+    // The failure is surfaced, not silently rendered as an empty wallet
+    expect(errorToast).toHaveBeenCalled();
+    expect(text()).not.toContain('bridge.nft.step.import.no_nft_found');
+    expect(text()).toContain('bridge.actions.nft_scan');
+
+    // And a retry still reaches the scan
+    (target.querySelector('button') as HTMLButtonElement).click();
+    await flush();
+    expect(scanForNFTs).toHaveBeenCalledTimes(2);
+
+    consoleError.mockRestore();
+  });
+});

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportActions.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportActions.svelte
@@ -19,9 +19,13 @@
   function onScanClick() {
     scanning = true;
     scanForNFTs()
+      .then(() => {
+        // Only a scan that actually completed can claim there are no NFTs; leaving the
+        // initial state on failure keeps the retry button instead of a false "none found"
+        firstScan = false;
+      })
       .catch(reportScanFailure)
       .finally(() => {
-        firstScan = false;
         scanning = false;
       });
   }

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportActions.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportActions.svelte
@@ -5,6 +5,7 @@
   import { Alert } from '$components/Alert';
   import { ImportMethod } from '$components/Bridge/types';
   import { ActionButton } from '$components/Button';
+  import { errorToast } from '$components/NotificationToast';
 
   import { selectedImportMethod } from './state';
 
@@ -17,9 +18,21 @@
 
   function onScanClick() {
     scanning = true;
-    scanForNFTs().finally(() => {
-      firstScan = false;
-      scanning = false;
+    scanForNFTs()
+      .catch(reportScanFailure)
+      .finally(() => {
+        firstScan = false;
+        scanning = false;
+      });
+  }
+
+  // A scan that fails now rejects rather than resolving with an empty list, so every
+  // call site has to handle it or it becomes an unhandled rejection
+  function reportScanFailure(error: unknown) {
+    console.error('Error scanning for NFTs', error);
+    errorToast({
+      title: $t('bridge.errors.unknown_error.title'),
+      message: $t('bridge.errors.unknown_error.message'),
     });
   }
 
@@ -45,10 +58,9 @@
       priority="secondary"
       disabled={!canImport}
       loading={scanning}
-      on:click={() =>
-        (async () => {
-          await scanForNFTs();
-        })()}>
+      on:click={() => {
+        scanForNFTs().catch(reportScanFailure);
+      }}>
       {$t('bridge.actions.nft_scan_again')}
     </ActionButton>
 

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportStep.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportStep.svelte
@@ -23,6 +23,14 @@
 
   export let validating = false;
 
+  let manualImportComponent: ManualImport;
+
+  /** Re-runs the manual import's validation; a no-op when it is not mounted */
+  export const revalidate = () => manualImportComponent?.revalidate();
+
+  /** Clears the manual import form; a no-op when it is not mounted */
+  export const resetManualImport = () => manualImportComponent?.reset();
+
   const nextPage = async () => {
     await scanForNFTs(false);
   };
@@ -85,7 +93,7 @@
 <div class="h-sep" />
 
 {#if $selectedImportMethod === ImportMethod.MANUAL}
-  <ManualImport bind:validating />
+  <ManualImport bind:this={manualImportComponent} bind:validating />
 {:else if $selectedImportMethod === ImportMethod.SCAN}
   <ScannedImport refresh={() => scanForNFTs(true)} {nextPage} bind:foundNFTs bind:canProceed />
 {:else}

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportStep.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportStep.svelte
@@ -37,6 +37,12 @@
       if (!accountAddress || !srcChainId || !destChainId) return;
       const nftsFromAPIs = await fetchNFTs({ address: accountAddress, chainId: srcChainId, refresh });
 
+      if (nftsFromAPIs.error) {
+        // Keep the pages already on screen and let the caller decide: overwriting with the
+        // empty result would both lose them and read as "there are no more NFTs"
+        throw nftsFromAPIs.error;
+      }
+
       foundNFTs = nftsFromAPIs.nfts;
 
       if (foundNFTs.length > 0) {

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportStep.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ImportStep.svelte
@@ -29,19 +29,21 @@
 
   const scanForNFTs = async (refresh: boolean) => {
     scanning = true;
-    $selectedNFTs = [];
-    const accountAddress = $account?.address;
-    const srcChainId = $srcChain?.id;
-    const destChainId = $destChain?.id;
-    if (!accountAddress || !srcChainId || !destChainId) return;
-    const nftsFromAPIs = await fetchNFTs({ address: accountAddress, chainId: srcChainId, refresh });
+    try {
+      $selectedNFTs = [];
+      const accountAddress = $account?.address;
+      const srcChainId = $srcChain?.id;
+      const destChainId = $destChain?.id;
+      if (!accountAddress || !srcChainId || !destChainId) return;
+      const nftsFromAPIs = await fetchNFTs({ address: accountAddress, chainId: srcChainId, refresh });
 
-    foundNFTs = nftsFromAPIs.nfts;
+      foundNFTs = nftsFromAPIs.nfts;
 
-    scanning = false;
-
-    if (foundNFTs.length > 0) {
-      $selectedImportMethod = ImportMethod.SCAN;
+      if (foundNFTs.length > 0) {
+        $selectedImportMethod = ImportMethod.SCAN;
+      }
+    } finally {
+      scanning = false;
     }
   };
 

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.component.test.ts
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.component.test.ts
@@ -149,6 +149,76 @@ describe('ManualImport contract address', () => {
     expect(get(importDone)).toBe(false);
   });
 
+  it('validates a replacement address pasted over a validated one', async () => {
+    // The exact A -> B replacement: both valid NFT contracts. The draft watcher must not
+    // read the outgoing address as stale and cancel the lookup that replaced it.
+    detectContractType.mockResolvedValue(TokenType.ERC721);
+
+    await type(addressInput(), ADDRESS_A);
+    await flush();
+    expect(addressIsMarkedValid()).toBe(true);
+
+    // Select-all and paste replaces the whole field in one input event
+    await type(addressInput(), ADDRESS_B);
+    await flush();
+
+    expect(detectContractType).toHaveBeenNthCalledWith(2, ADDRESS_B, SRC_CHAIN);
+    expect(addressIsMarkedValid()).toBe(true);
+  });
+
+  describe('source chain changes', () => {
+    it('revalidates the entered address against the new chain', async () => {
+      detectContractType.mockResolvedValue(TokenType.ERC721);
+      await type(addressInput(), ADDRESS_A);
+      await flush();
+      expect(addressIsMarkedValid()).toBe(true);
+
+      // The same address may host a different contract, or none, on another chain
+      detectContractType.mockClear();
+      detectContractType.mockResolvedValue(TokenType.ERC20);
+      connectedSourceChain.set({ id: 167000 } as never);
+      await flush();
+
+      expect(detectContractType).toHaveBeenCalledWith(ADDRESS_A, 167000);
+      expect(addressIsMarkedValid()).toBe(false);
+      expect(get(importDone)).toBe(false);
+    });
+
+    it('discards an in-flight lookup belonging to the previous chain', async () => {
+      let resolveOnOldChain!: (value: TokenType) => void;
+      detectContractType.mockReturnValueOnce(new Promise<TokenType>((r) => (resolveOnOldChain = r)));
+
+      await type(addressInput(), ADDRESS_A);
+      await tick();
+
+      // The chain changes while the first lookup is still pending
+      detectContractType.mockResolvedValueOnce(TokenType.ERC20);
+      connectedSourceChain.set({ id: 167000 } as never);
+      await flush();
+
+      resolveOnOldChain(TokenType.ERC721);
+      await flush();
+
+      // The old chain's answer must not mark the address valid on the new chain
+      expect(addressIsMarkedValid()).toBe(false);
+      expect(get(importDone)).toBe(false);
+    });
+
+    it('clears a completed selection when the chain changes', async () => {
+      detectContractType.mockResolvedValue(TokenType.ERC721);
+      await type(addressInput(), ADDRESS_A);
+      await flush();
+
+      selectedNFTs.set([{ tokenId: 1 }] as never);
+      connectedSourceChain.set({ id: 167000 } as never);
+      await flush();
+
+      // The selection described a deployment on the chain we just left
+      expect(get(selectedNFTs)).toBeNull();
+      expect(get(importDone)).toBe(false);
+    });
+  });
+
   it('does not report a non-NFT contract as valid', async () => {
     detectContractType.mockResolvedValue(TokenType.ERC20);
 

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.component.test.ts
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.component.test.ts
@@ -1,0 +1,161 @@
+/**
+ * A contract-type lookup describes one address on one chain.
+ *
+ * Without a generation guard, a lookup for an address typed earlier can resolve after a
+ * newer one and re-enable the id field with the wrong type for the address on screen.
+ * AddressInput also dispatches nothing for a cleared field, so the two-way bound draft is
+ * the only signal that a pending lookup has been abandoned.
+ */
+import { tick } from 'svelte';
+import { get } from 'svelte/store';
+import { vi } from 'vitest';
+
+vi.mock('svelte-i18n', async () => {
+  const { readable } = await import('svelte/store');
+  return { t: readable((key: string) => key), locale: readable('en'), init: vi.fn(), addMessages: vi.fn() };
+});
+
+const detectContractType = vi.fn();
+const checkOwnership = vi.fn();
+const getTokenWithInfoFromAddress = vi.fn();
+
+vi.mock('$libs/token', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$libs/token')>()),
+  detectContractType: (...args: unknown[]) => detectContractType(...args),
+  fetchBalance: vi.fn().mockResolvedValue({ value: BigInt(10), decimals: 0, symbol: 'NFT' }),
+}));
+vi.mock('$libs/token/checkOwnership', () => ({ checkOwnership: (...a: unknown[]) => checkOwnership(...a) }));
+vi.mock('$libs/token/getTokenWithInfoFromAddress', () => ({
+  getTokenWithInfoFromAddress: (...a: unknown[]) => getTokenWithInfoFromAddress(...a),
+}));
+
+import { AddressInputState } from '$components/Bridge/SharedBridgeComponents/AddressInput/state';
+import { importDone, selectedNFTs } from '$components/Bridge/state';
+import { TokenType } from '$libs/token';
+import { account } from '$stores/account';
+import { connectedSourceChain } from '$stores/network';
+
+import ManualImport from './ManualImport.svelte';
+
+const ADDRESS_A = '0x1111111111111111111111111111111111111111';
+const ADDRESS_B = '0x2222222222222222222222222222222222222222';
+const SRC_CHAIN = 1;
+
+let target: HTMLElement;
+let component: { $destroy: () => void; $$: { ctx: unknown[] } } | null = null;
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await tick();
+};
+
+const addressInput = () => target.querySelectorAll('input')[0] as HTMLInputElement;
+
+const type = async (input: HTMLInputElement, value: string) => {
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  await tick();
+};
+
+/** The address field's validity styling reflects addressInputState */
+const addressIsMarkedValid = () => addressInput().className.includes('success');
+
+beforeEach(() => {
+  detectContractType.mockReset();
+  checkOwnership.mockReset();
+  getTokenWithInfoFromAddress.mockReset();
+  selectedNFTs.set(null);
+  importDone.set(false);
+  connectedSourceChain.set({ id: SRC_CHAIN } as never);
+  account.set({ address: '0xaaaa', isConnected: true } as never);
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = new ManualImport({ target, props: {} }) as never;
+});
+
+afterEach(() => {
+  component?.$destroy();
+  component = null;
+  target.remove();
+});
+
+describe('ManualImport contract address', () => {
+  it('marks a detected NFT contract valid', async () => {
+    detectContractType.mockResolvedValue(TokenType.ERC721);
+
+    await type(addressInput(), ADDRESS_A);
+    await flush();
+
+    expect(addressIsMarkedValid()).toBe(true);
+  });
+
+  it('does not let an older lookup decide the state of a newer address', async () => {
+    // A is an NFT contract, B is not. If A's late answer wins, a plain ERC20 address is
+    // presented as a valid NFT contract and the id field opens for the wrong type.
+    let resolveA!: (value: TokenType) => void;
+    detectContractType
+      .mockReturnValueOnce(new Promise<TokenType>((resolve) => (resolveA = resolve)))
+      .mockResolvedValueOnce(TokenType.ERC20);
+
+    await type(addressInput(), ADDRESS_A);
+    await tick();
+
+    // A newer address supersedes the pending lookup for A
+    await type(addressInput(), ADDRESS_B);
+    await flush();
+    expect(addressIsMarkedValid()).toBe(false);
+
+    // A resolves late, claiming a type that would make the field valid
+    resolveA(TokenType.ERC721);
+    await flush();
+
+    expect(detectContractType).toHaveBeenNthCalledWith(1, ADDRESS_A, SRC_CHAIN);
+    expect(detectContractType).toHaveBeenNthCalledWith(2, ADDRESS_B, SRC_CHAIN);
+    // B's answer must stand: A describes an address no longer on screen
+    expect(addressIsMarkedValid()).toBe(false);
+    expect(get(importDone)).toBe(false);
+  });
+
+  it('discards a pending lookup when the field is cleared', async () => {
+    let resolveA!: (value: TokenType) => void;
+    detectContractType.mockReturnValue(new Promise<TokenType>((resolve) => (resolveA = resolve)));
+
+    await type(addressInput(), ADDRESS_A);
+    await tick();
+
+    // Clearing dispatches no validation event at all
+    await type(addressInput(), '');
+    await flush();
+
+    resolveA(TokenType.ERC721);
+    await flush();
+
+    // The abandoned lookup must not mark an empty field as a valid NFT contract
+    expect(addressIsMarkedValid()).toBe(false);
+    expect(get(importDone)).toBe(false);
+  });
+
+  it('does not mark a failed lookup valid using the previous address type', async () => {
+    detectContractType.mockResolvedValueOnce(TokenType.ERC721).mockRejectedValueOnce(new Error('rpc down'));
+
+    await type(addressInput(), ADDRESS_A);
+    await flush();
+    expect(addressIsMarkedValid()).toBe(true);
+
+    await type(addressInput(), ADDRESS_B);
+    await flush();
+
+    expect(addressIsMarkedValid()).toBe(false);
+    expect(get(importDone)).toBe(false);
+  });
+
+  it('does not report a non-NFT contract as valid', async () => {
+    detectContractType.mockResolvedValue(TokenType.ERC20);
+
+    await type(addressInput(), ADDRESS_A);
+    await flush();
+
+    expect(addressIsMarkedValid()).toBe(false);
+    expect(AddressInputState.NOT_NFT).toBeDefined();
+  });
+});

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
@@ -47,6 +47,11 @@
     idInputState = IDInputState.DEFAULT;
     isOwnerOfAllToken = false;
     $selectedNFTs = null;
+    // The previous answer is retired here rather than left for the draft watcher: it
+    // describes an address that is no longer the subject, and leaving it would make the
+    // watcher treat the replacement itself as the stale one and cancel its lookup.
+    lastValidatedAddress = null;
+    pendingAddressLookup = null;
   }
 
   // A contract-type lookup describes one address on one chain. Without this, a lookup
@@ -69,37 +74,42 @@
 
     if (isValidEthereumAddress && typeof addr === 'string') {
       contractAddress = addr;
-      pendingAddressLookup = addr;
-
-      let type: TokenType | null;
-      try {
-        type = await detectContractType(addr, srcChainId);
-      } catch {
-        if (generation !== addressValidationGeneration) return;
-        pendingAddressLookup = null;
-        // Without a return the stale type from a previous address would decide the
-        // check below and could mark this failed lookup VALID
-        addressInputState = AddressInputState.INVALID;
-        return;
-      }
-
-      // A newer address, a cleared field, or a source-chain change supersedes this answer
-      if (generation !== addressValidationGeneration) return;
-      if (srcChainId !== $connectedSourceChain?.id) return;
-      pendingAddressLookup = null;
-
-      detectedTokenType = type;
-      if (type !== TokenType.ERC721 && type !== TokenType.ERC1155) {
-        addressInputState = AddressInputState.NOT_NFT;
-        return;
-      }
-
-      lastValidatedAddress = addr;
-      addressInputState = AddressInputState.VALID;
+      await validateContractAddress(addr, srcChainId, generation);
     } else {
       addressInputState = AddressInputState.INVALID;
     }
     return;
+  }
+
+  /** Resolves the contract type for one address on one chain, committing only if current */
+  async function validateContractAddress(addr: Address, srcChainId: number, generation: number) {
+    pendingAddressLookup = addr;
+
+    let type: TokenType | null;
+    try {
+      type = await detectContractType(addr, srcChainId);
+    } catch {
+      if (generation !== addressValidationGeneration) return;
+      pendingAddressLookup = null;
+      // Without a return the stale type from a previous address would decide the
+      // check below and could mark this failed lookup VALID
+      addressInputState = AddressInputState.INVALID;
+      return;
+    }
+
+    // A newer address, a cleared field, or a source-chain change supersedes this answer
+    if (generation !== addressValidationGeneration) return;
+    if (srcChainId !== $connectedSourceChain?.id) return;
+    pendingAddressLookup = null;
+
+    detectedTokenType = type;
+    if (type !== TokenType.ERC721 && type !== TokenType.ERC1155) {
+      addressInputState = AddressInputState.NOT_NFT;
+      return;
+    }
+
+    lastValidatedAddress = addr;
+    addressInputState = AddressInputState.VALID;
   }
 
   /**
@@ -122,6 +132,45 @@
   /** The address a contract-type lookup is currently in flight for, if any */
   let pendingAddressLookup: Maybe<string> = null;
   let lastValidatedAddress: Maybe<string> = null;
+
+  /**
+   * A detected type, an ownership result and a selected NFT all describe a deployment on
+   * one chain. Switching the source chain invalidates every one of them, and an old-chain
+   * lookup still in flight must not land afterwards.
+   */
+  let lastSrcChainId: Maybe<number> = undefined;
+  function onSourceChainChanged(chainId: Maybe<number>) {
+    if (lastSrcChainId === chainId) return;
+    const firstRun = lastSrcChainId === undefined;
+    lastSrcChainId = chainId;
+    if (firstRun) return;
+
+    discardSelectionForNewAddress();
+
+    if (chainId && contractAddress && isAddress(contractAddress)) {
+      // The same address may host a different contract, or none, on the new chain
+      addressInputState = AddressInputState.VALIDATING;
+      validateContractAddress(contractAddress as Address, chainId, addressValidationGeneration);
+    } else {
+      addressInputState = contractAddress ? AddressInputState.INVALID : AddressInputState.DEFAULT;
+    }
+  }
+
+  /** Re-runs address validation, e.g. after the wallet's account changed */
+  export const revalidate = () => {
+    if (addressInputComponent) addressInputComponent.validateAddress();
+  };
+
+  /** Clears the manual import back to an empty form */
+  export const reset = () => {
+    discardSelectionForNewAddress();
+    if (addressInputComponent) addressInputComponent.clearAddress();
+    if (nftIdInputComponent) nftIdInputComponent.clearIds();
+    contractAddress = '';
+    enteredIds = [];
+    nftIdsToImport = [];
+    addressInputState = AddressInputState.DEFAULT;
+  };
 
   // Guards against out-of-order async validations: only the latest entered ID may
   // publish its result into the shared stores
@@ -194,6 +243,7 @@
   }
 
   $: syncContractAddressDraft(contractAddress);
+  $: onSourceChainChanged($connectedSourceChain?.id);
 
   $: displayOwnershipError =
     contractAddress && enteredIds && !isOwnerOfAllToken && nftIdsToImport?.length > 0 && !validating;

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
@@ -40,6 +40,7 @@
    * of it, including any id validation still in flight.
    */
   function discardSelectionForNewAddress() {
+    addressValidationGeneration++;
     idValidationGeneration++;
     validating = false;
     detectedTokenType = null;
@@ -48,11 +49,17 @@
     $selectedNFTs = null;
   }
 
+  // A contract-type lookup describes one address on one chain. Without this, a lookup
+  // for an address typed earlier can resolve after a newer one and re-enable the id
+  // field with the wrong type for the address actually on screen.
+  let addressValidationGeneration = 0;
+
   async function onAddressValidation(event: CustomEvent<{ isValidEthereumAddress: boolean; addr: Address }>) {
     const { isValidEthereumAddress, addr } = event.detail;
     // interfaceSupported = true;
     addressInputState = AddressInputState.VALIDATING;
     discardSelectionForNewAddress();
+    const generation = addressValidationGeneration;
 
     const srcChainId = $connectedSourceChain?.id;
     if (!srcChainId) {
@@ -62,25 +69,59 @@
 
     if (isValidEthereumAddress && typeof addr === 'string') {
       contractAddress = addr;
+      pendingAddressLookup = addr;
+
+      let type: TokenType | null;
       try {
-        detectedTokenType = await detectContractType(addr, srcChainId);
+        type = await detectContractType(addr, srcChainId);
       } catch {
+        if (generation !== addressValidationGeneration) return;
+        pendingAddressLookup = null;
         // Without a return the stale type from a previous address would decide the
         // check below and could mark this failed lookup VALID
         addressInputState = AddressInputState.INVALID;
         return;
       }
-      if (detectedTokenType !== TokenType.ERC721 && detectedTokenType !== TokenType.ERC1155) {
+
+      // A newer address, a cleared field, or a source-chain change supersedes this answer
+      if (generation !== addressValidationGeneration) return;
+      if (srcChainId !== $connectedSourceChain?.id) return;
+      pendingAddressLookup = null;
+
+      detectedTokenType = type;
+      if (type !== TokenType.ERC721 && type !== TokenType.ERC1155) {
         addressInputState = AddressInputState.NOT_NFT;
         return;
       }
 
+      lastValidatedAddress = addr;
       addressInputState = AddressInputState.VALID;
     } else {
       addressInputState = AddressInputState.INVALID;
     }
     return;
   }
+
+  /**
+   * AddressInput dispatches nothing for a cleared field or text without a `0x` prefix, so
+   * the two-way bound draft is the only signal that an in-flight lookup no longer
+   * describes what is on screen.
+   */
+  function syncContractAddressDraft(draft: Maybe<string>) {
+    const current = (draft ?? '').toLowerCase();
+    const stale = (address: Maybe<string>) => !!address && address.toLowerCase() !== current;
+
+    if (stale(pendingAddressLookup) || stale(lastValidatedAddress)) {
+      pendingAddressLookup = null;
+      lastValidatedAddress = null;
+      discardSelectionForNewAddress();
+      addressInputState = draft ? AddressInputState.INVALID : AddressInputState.DEFAULT;
+    }
+  }
+
+  /** The address a contract-type lookup is currently in flight for, if any */
+  let pendingAddressLookup: Maybe<string> = null;
+  let lastValidatedAddress: Maybe<string> = null;
 
   // Guards against out-of-order async validations: only the latest entered ID may
   // publish its result into the shared stores
@@ -151,6 +192,8 @@
       }
     }
   }
+
+  $: syncContractAddressDraft(contractAddress);
 
   $: displayOwnershipError =
     contractAddress && enteredIds && !isOwnerOfAllToken && nftIdsToImport?.length > 0 && !validating;

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
@@ -63,7 +63,12 @@
     return;
   }
 
+  // Guards against out-of-order async validations: only the latest entered ID may
+  // publish its result into the shared stores
+  let idValidationGeneration = 0;
+
   async function onIdInput(): Promise<void> {
+    const generation = ++idValidationGeneration;
     idInputState = IDInputState.VALIDATING;
     validating = true;
 
@@ -83,6 +88,8 @@
           $connectedSourceChain?.id!,
         );
 
+        if (generation !== idValidationGeneration) return;
+
         isOwnerOfAllToken = ownershipResults.every((value) => value.isOwner === true);
 
         if (!isOwnerOfAllToken) {
@@ -98,6 +105,8 @@
           owner: $account?.address,
         });
 
+        if (generation !== idValidationGeneration) return;
+
         if (!token) {
           throw new Error('No token with info');
         }
@@ -110,15 +119,18 @@
         idInputState = IDInputState.INVALID;
       }
     } catch (err) {
+      if (generation !== idValidationGeneration) return;
       console.error(err);
       detectedTokenType = null;
       idInputState = IDInputState.INVALID;
     } finally {
-      if (idInputState !== IDInputState.VALID) {
-        idInputState = IDInputState.DEFAULT;
+      if (generation === idValidationGeneration) {
+        if (idInputState !== IDInputState.VALID) {
+          idInputState = IDInputState.DEFAULT;
+        }
+        validating = false;
       }
     }
-    validating = false;
   }
 
   $: displayOwnershipError =

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ManualImport.svelte
@@ -34,22 +34,42 @@
 
   $: isOwnerOfAllToken = false;
 
+  /**
+   * Everything downstream of the contract address (detected type, validated ids, the
+   * selected NFT) describes the address that was validated. A new address invalidates all
+   * of it, including any id validation still in flight.
+   */
+  function discardSelectionForNewAddress() {
+    idValidationGeneration++;
+    validating = false;
+    detectedTokenType = null;
+    idInputState = IDInputState.DEFAULT;
+    isOwnerOfAllToken = false;
+    $selectedNFTs = null;
+  }
+
   async function onAddressValidation(event: CustomEvent<{ isValidEthereumAddress: boolean; addr: Address }>) {
     const { isValidEthereumAddress, addr } = event.detail;
     // interfaceSupported = true;
     addressInputState = AddressInputState.VALIDATING;
+    discardSelectionForNewAddress();
 
     const srcChainId = $connectedSourceChain?.id;
-    if (!srcChainId) return;
+    if (!srcChainId) {
+      addressInputState = AddressInputState.INVALID;
+      return;
+    }
 
     if (isValidEthereumAddress && typeof addr === 'string') {
       contractAddress = addr;
       try {
         detectedTokenType = await detectContractType(addr, srcChainId);
       } catch {
+        // Without a return the stale type from a previous address would decide the
+        // check below and could mark this failed lookup VALID
         addressInputState = AddressInputState.INVALID;
+        return;
       }
-      if (!$connectedSourceChain?.id) throw new Error('network not found');
       if (detectedTokenType !== TokenType.ERC721 && detectedTokenType !== TokenType.ERC1155) {
         addressInputState = AddressInputState.NOT_NFT;
         return;
@@ -57,7 +77,6 @@
 
       addressInputState = AddressInputState.VALID;
     } else {
-      detectedTokenType = null;
       addressInputState = AddressInputState.INVALID;
     }
     return;
@@ -147,8 +166,15 @@
   $: hasEnteredIds = enteredIds && enteredIds.length > 0;
   $: hasSelectedNFT = $selectedNFTs && $selectedNFTs?.length > 0 && hasEnteredIds;
 
+  // The address itself has to still be valid: editing it after an id was validated would
+  // otherwise leave Continue enabled for the NFT belonging to the previous address
   $: commonChecks =
-    enteredIds && enteredIds.length > 0 && !validating && idInputState === IDInputState.VALID && isOwnerOfAllToken;
+    addressInputState === AddressInputState.VALID &&
+    enteredIds &&
+    enteredIds.length > 0 &&
+    !validating &&
+    idInputState === IDInputState.VALID &&
+    isOwnerOfAllToken;
 
   $: ERC1155Checks = commonChecks && nftHasAmount !== null && hasSelectedNFT !== null && validBalance;
 

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.component.test.ts
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.component.test.ts
@@ -1,0 +1,118 @@
+/**
+ * A failed NFT page must not look like exhaustion.
+ *
+ * The repository used to swallow page failures and return the accumulated list unchanged,
+ * which reaches ScannedImport as "the length did not grow" - indistinguishable from
+ * "there are no more NFTs" - and permanently retired the Load more button even though the
+ * cursor was still valid.
+ */
+import { tick } from 'svelte';
+import { vi } from 'vitest';
+
+vi.mock('svelte-i18n', async () => {
+  const { readable } = await import('svelte/store');
+  return { t: readable((key: string) => key), locale: readable('en'), init: vi.fn(), addMessages: vi.fn() };
+});
+
+const errorToast = vi.fn();
+vi.mock('$components/NotificationToast', () => ({
+  errorToast: (...args: unknown[]) => errorToast(...args),
+  warningToast: vi.fn(),
+  successToast: vi.fn(),
+  infoToast: vi.fn(),
+}));
+
+import type { NFT } from '$libs/token';
+
+import ScannedImport from './ScannedImport.svelte';
+
+const nft = (tokenId: number): NFT => ({ tokenId, addresses: { 1: '0xabc' } }) as unknown as NFT;
+
+/** The paginator button stays mounted and toggles `disabled`, it is never removed */
+const loadMoreButton = (target: HTMLElement) =>
+  Array.from(target.querySelectorAll('button')).find((b) => b.textContent?.includes('paginator.')) as HTMLButtonElement;
+
+/** The refresh control is the icon-only button at the top of the panel */
+const refreshButton = (target: HTMLElement) => target.querySelector('button') as HTMLButtonElement;
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await tick();
+};
+
+let target: HTMLElement;
+let component: { $destroy: () => void } | null = null;
+
+beforeEach(() => {
+  errorToast.mockReset();
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  component?.$destroy();
+  component = null;
+  target.remove();
+});
+
+describe('ScannedImport load more', () => {
+  it('keeps Load more available when a page fetch fails', async () => {
+    const nextPage = vi.fn().mockRejectedValue(new Error('rate limited'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    component = new ScannedImport({
+      target,
+      props: { refresh: vi.fn().mockResolvedValue(undefined), nextPage, foundNFTs: [nft(1)] },
+    });
+
+    expect(loadMoreButton(target).disabled).toBe(false);
+
+    loadMoreButton(target).click();
+    await flush();
+
+    expect(nextPage).toHaveBeenCalledTimes(1);
+    // Still enabled, so the user can retry the page the cursor still points at
+    expect(loadMoreButton(target).disabled).toBe(false);
+    expect(loadMoreButton(target).textContent).toContain('paginator.more');
+
+    // And a retry actually reaches the fetch again
+    loadMoreButton(target).click();
+    await flush();
+    expect(nextPage).toHaveBeenCalledTimes(2);
+
+    consoleError.mockRestore();
+  });
+
+  it('retires Load more only when a successful page adds nothing', async () => {
+    const nextPage = vi.fn().mockResolvedValue(undefined);
+
+    component = new ScannedImport({
+      target,
+      props: { refresh: vi.fn().mockResolvedValue(undefined), nextPage, foundNFTs: [nft(1)] },
+    });
+
+    loadMoreButton(target).click();
+    await flush();
+
+    // The fetch succeeded and the list did not grow: genuinely exhausted
+    expect(loadMoreButton(target).disabled).toBe(true);
+    expect(loadMoreButton(target).textContent).toContain('paginator.everything_loaded');
+  });
+
+  it('surfaces a refresh failure instead of leaving an unhandled rejection', async () => {
+    const refresh = vi.fn().mockRejectedValue(new Error('rate limited'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    component = new ScannedImport({
+      target,
+      props: { refresh, nextPage: vi.fn().mockResolvedValue(undefined), foundNFTs: [nft(1)] },
+    });
+
+    refreshButton(target).click();
+    await flush();
+
+    expect(refresh).toHaveBeenCalled();
+    expect(errorToast).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
@@ -32,6 +32,10 @@
     scanning = true;
     try {
       await nextPage();
+    } catch (error) {
+      // A failed page keeps the button usable for a retry
+      console.error('Error fetching next NFT page', error);
+      return;
     } finally {
       scanning = false;
     }

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
@@ -10,6 +10,7 @@
   import RotatingIcon from '$components/Icon/RotatingIcon.svelte';
   import { NFTDisplay } from '$components/NFTs';
   import { NFTView } from '$components/NFTs/types';
+  import { errorToast } from '$components/NotificationToast';
   import type { NFT } from '$libs/token';
 
   import { selectedImportMethod } from './state';
@@ -48,9 +49,17 @@
   function onRefreshClick() {
     scanning = true;
     hasMoreNFTs = true;
-    refresh().finally(() => {
-      scanning = false;
-    });
+    refresh()
+      .catch((error) => {
+        console.error('Error refreshing NFTs', error);
+        errorToast({
+          title: $t('bridge.errors.unknown_error.title'),
+          message: $t('bridge.errors.unknown_error.message'),
+        });
+      })
+      .finally(() => {
+        scanning = false;
+      });
   }
 
   const changeNFTView = () => {

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/ScannedImport.svelte
@@ -27,16 +27,16 @@
 
   let tokenAmountInput: TokenAmountInput;
 
-  let previousNFTs: NFT[] = [];
-  const handleNextPage = () => {
-    previousNFTs = foundNFTs;
+  const handleNextPage = async () => {
+    const previousCount = foundNFTs.length;
     scanning = true;
-
-    nextPage().finally(() => {
+    try {
+      await nextPage();
+    } finally {
       scanning = false;
-    });
-
-    if (previousNFTs.length === foundNFTs.length) {
+    }
+    // Only after the fetch resolves do we know whether anything new arrived
+    if (foundNFTs.length === previousCount) {
       hasMoreNFTs = false;
     }
   };

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/TokenAmountInput.component.test.ts
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/TokenAmountInput.component.test.ts
@@ -1,0 +1,80 @@
+/**
+ * ERC-1155 amounts: invalid input must not leave the previously entered amount behind.
+ *
+ * Both import flows gate Continue on `$enteredAmount > 0`, so an amount that survives the
+ * input it was replaced by is an amount the user can still bridge without seeing it.
+ */
+import { tick } from 'svelte';
+import { get } from 'svelte/store';
+import { vi } from 'vitest';
+
+vi.mock('svelte-i18n', async () => {
+  const { readable } = await import('svelte/store');
+  return { t: readable((key: string) => key), locale: readable('en'), init: vi.fn(), addMessages: vi.fn() };
+});
+
+vi.mock('$libs/token', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$libs/token')>()),
+  fetchBalance: vi.fn().mockResolvedValue({ value: BigInt(100), decimals: 0, symbol: 'NFT' }),
+}));
+
+import { enteredAmount, selectedToken } from '$components/Bridge/state';
+import { TokenType } from '$libs/token';
+
+import TokenAmountInput from './TokenAmountInput.svelte';
+
+let target: HTMLElement;
+let component: { $destroy: () => void } | null = null;
+
+const type = async (input: HTMLInputElement, value: string) => {
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  await tick();
+};
+
+beforeEach(() => {
+  enteredAmount.set(BigInt(0));
+  selectedToken.set({ type: TokenType.ERC1155, symbol: 'NFT', decimals: 0, addresses: {} } as never);
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = new TokenAmountInput({ target, props: {} });
+});
+
+afterEach(() => {
+  component?.$destroy();
+  component = null;
+  target.remove();
+});
+
+describe('ERC1155 amount input', () => {
+  const input = () => target.querySelector('input') as HTMLInputElement;
+
+  it('accepts a whole number', async () => {
+    await type(input(), '5');
+    expect(get(enteredAmount)).toBe(BigInt(5));
+  });
+
+  it('clears a previously accepted amount when a decimal is entered', async () => {
+    await type(input(), '5');
+    expect(get(enteredAmount)).toBe(BigInt(5));
+
+    await type(input(), '1.5');
+
+    // Leaving 5n here would bridge 5 while the box reads 1.5
+    expect(get(enteredAmount)).toBe(BigInt(0));
+  });
+
+  it('clears a previously accepted amount when exponent notation is entered', async () => {
+    await type(input(), '5');
+    await type(input(), '1e2');
+
+    // Number inputs emit '1e2' natively; BigInt cannot parse it
+    expect(get(enteredAmount)).toBe(BigInt(0));
+  });
+
+  it('clears the amount when the field is emptied', async () => {
+    await type(input(), '5');
+    await type(input(), '');
+    expect(get(enteredAmount)).toBe(BigInt(0));
+  });
+});

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/TokenAmountInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/TokenAmountInput.svelte
@@ -113,27 +113,38 @@
   function inputAmount(event: Event) {
     invalidInput = false;
     $validatingAmount = true; // During validation, we disable all the actions
-    if (!$selectedToken) return;
-    const target = event.target as HTMLInputElement;
-    let value = target.value;
+    try {
+      if (!$selectedToken) return;
+      const target = event.target as HTMLInputElement;
+      const value = target.value;
 
-    if ($selectedToken.type === TokenType.ERC1155) {
+      if ($selectedToken.type !== TokenType.ERC1155) {
+        throw new UnknownTokenTypeError($selectedToken.type);
+      }
+
       // For ERC1155, no decimals are allowed
       if (/[.,]/.test(value)) {
         invalidInput = true;
         return;
       }
-    } else {
+
+      let parsed: bigint;
+      try {
+        // Number inputs also emit values like '1e5', which BigInt cannot parse
+        parsed = BigInt(value);
+      } catch {
+        invalidInput = true;
+        return;
+      }
+
+      sanitizedValue = value;
+      $enteredAmount = parsed;
+
+      debouncedValidateAmount();
+    } finally {
+      // The flag disables every action button and must never survive an early exit
       $validatingAmount = false;
-      throw new UnknownTokenTypeError($selectedToken.type);
     }
-
-    sanitizedValue = value;
-
-    $enteredAmount = BigInt(sanitizedValue);
-    $validatingAmount = false;
-
-    debouncedValidateAmount();
   }
 
   // "MAX" button handler

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/TokenAmountInput.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ImportStep/TokenAmountInput.svelte
@@ -110,6 +110,16 @@
   const debouncedValidateAmount = debounce(validateAmount, 300);
   let sanitizedValue = '';
 
+  /**
+   * Invalid input means no amount was entered. Leaving the previous value in place would
+   * let the import proceed with an amount the user has already replaced on screen: the
+   * parents gate on `$enteredAmount > 0`, so clearing it is what blocks them.
+   */
+  function rejectAmount() {
+    invalidInput = true;
+    $enteredAmount = BigInt(0);
+  }
+
   function inputAmount(event: Event) {
     invalidInput = false;
     $validatingAmount = true; // During validation, we disable all the actions
@@ -124,7 +134,7 @@
 
       // For ERC1155, no decimals are allowed
       if (/[.,]/.test(value)) {
-        invalidInput = true;
+        rejectAmount();
         return;
       }
 
@@ -133,7 +143,7 @@
         // Number inputs also emit values like '1e5', which BigInt cannot parse
         parsed = BigInt(value);
       } catch {
-        invalidInput = true;
+        rejectAmount();
         return;
       }
 

--- a/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ReviewStep/ReviewStep.svelte
+++ b/packages/bridge-ui/src/components/Bridge/NFTBridgeComponents/ReviewStep/ReviewStep.svelte
@@ -46,15 +46,13 @@
     const destChainId = $destChain?.id;
     if (!srcChainId || !destChainId) return;
 
-    await Promise.all(
-      $selectedNFTs.map(async (nft) => {
-        fetchNFTImageUrl(nft).then((nftWithUrl) => {
-          $selectedToken = nftWithUrl;
-          $selectedNFTs = [nftWithUrl];
-        });
-      }),
-    );
-    nftsToDisplay = $selectedNFTs;
+    // Await every lookup and publish the full selection once: assigning inside each
+    // callback collapsed a multi-NFT selection to whichever image resolved last
+    const nftsWithUrl = await Promise.all($selectedNFTs.map((nft) => fetchNFTImageUrl(nft)));
+
+    $selectedNFTs = nftsWithUrl;
+    $selectedToken = nftsWithUrl[0];
+    nftsToDisplay = nftsWithUrl;
   };
 
   const editTransactionDetails = () => {

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/Actions.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/Actions.svelte
@@ -19,7 +19,6 @@
   } from '$components/Bridge/state';
   import ActionButton from '$components/Button/ActionButton.svelte';
   import { Icon } from '$components/Icon';
-  import { BridgePausedError } from '$libs/error';
   import { TokenType } from '$libs/token';
   import { tokenNeedsAllowanceReset } from '$libs/token/approvalReset';
   import { getTokenApprovalStatus } from '$libs/token/getTokenApprovalStatus';
@@ -35,11 +34,9 @@
 
   export let disabled = false;
 
-  let paused = false;
   export let checking = false;
 
   function onApproveClick() {
-    if (paused) throw new BridgePausedError('Bridge is paused');
     approving = true;
     approve().finally(() => {
       approving = false;
@@ -47,8 +44,8 @@
   }
 
   function onBridgeClick() {
-    if (paused) throw new BridgePausedError('Bridge is paused');
-    bridging = true;
+    // The bridge() implementation owns the `bridging` flag: setting it here would leave
+    // it stuck when bridge() returns early on a failed precondition
     bridge();
   }
 
@@ -108,8 +105,7 @@
     $selectedToken &&
     !$validatingAmount &&
     !$insufficientBalance &&
-    $allApproved &&
-    !paused;
+    $allApproved;
 
   $: erc20ConditionsSatisfied =
     commonConditions && !canDoNothing && !$insufficientAllowance && $tokenBalance && $enteredAmount;

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ConfirmationStep/ConfirmationStep.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ConfirmationStep/ConfirmationStep.svelte
@@ -60,50 +60,60 @@
 
     const destinationChain = $destNetwork?.id;
     const userAccount = $account?.address;
-    if (!currentChain || !destinationChain || !userAccount || !$selectedToken) return; //TODO error handling
-
-    const explorer = chainConfig[currentChain]?.blockExplorers?.default.url;
 
     try {
-      await pendingTransactions.add(txHash, currentChain);
+      if (!currentChain || !destinationChain || !userAccount || !$selectedToken) return; //TODO error handling
 
-      successToast({
-        title: $t('bridge.actions.bridge.success.title'),
-        message: $t('bridge.actions.bridge.success.message', {
-          values: {
-            token: $selectedToken.symbol,
-          },
-        }),
-      });
-      icon = successIcon;
-      bridgingStatus = BridgingStatus.DONE;
-      statusTitle = $t('bridge.actions.bridge.success.title');
-      statusDescription = $t('bridge.step.confirm.bridge.success.message', {
-        values: { url: `${explorer}/tx/${txHash}` },
-      });
-    } catch (error) {
-      if (error instanceof TransactionTimeoutError) {
-        handleTimeout(txHash);
-      } else {
-        handleBridgeError(error as Error);
+      const explorer = chainConfig[currentChain]?.blockExplorers?.default.url;
+
+      const bridgeTx = {
+        srcTxHash: txHash,
+        from: userAccount,
+        amount: $enteredAmount,
+        symbol: $selectedToken?.symbol,
+        decimals: isToken($selectedToken) ? $selectedToken.decimals : undefined,
+        srcChainId: BigInt(currentChain),
+        destChainId: BigInt(destinationChain),
+        tokenType: $selectedToken?.type,
+        msgStatus: MessageStatus.NEW,
+        // Needed later to decide whether the manual "try claim" entry applies
+        processingFee: $processingFee,
+        timestamp: Date.now(),
+      } as BridgeTransaction;
+
+      try {
+        await pendingTransactions.add(txHash, currentChain);
+
+        // Confirmed on-chain: record it in the local history
+        bridgeTxService.addTxByAddress(userAccount, bridgeTx);
+
+        successToast({
+          title: $t('bridge.actions.bridge.success.title'),
+          message: $t('bridge.actions.bridge.success.message', {
+            values: {
+              token: $selectedToken.symbol,
+            },
+          }),
+        });
+        icon = successIcon;
+        bridgingStatus = BridgingStatus.DONE;
+        statusTitle = $t('bridge.actions.bridge.success.title');
+        statusDescription = $t('bridge.step.confirm.bridge.success.message', {
+          values: { url: `${explorer}/tx/${txHash}` },
+        });
+      } catch (error) {
+        if (error instanceof TransactionTimeoutError) {
+          // The transaction may still confirm later, so keep it in the local history
+          bridgeTxService.addTxByAddress(userAccount, bridgeTx);
+          handleTimeout(txHash);
+        } else {
+          // Reverted or failed: recording it would leave a phantom pending transaction
+          handleBridgeError(error as Error);
+        }
       }
+    } finally {
+      bridging = false;
     }
-
-    const bridgeTx = {
-      srcTxHash: txHash,
-      from: $account.address,
-      amount: $enteredAmount,
-      symbol: $selectedToken?.symbol,
-      decimals: isToken($selectedToken) ? $selectedToken.decimals : undefined,
-      srcChainId: BigInt(currentChain),
-      destChainId: BigInt(destinationChain),
-      tokenType: $selectedToken?.type,
-      msgStatus: MessageStatus.NEW,
-      timestamp: Date.now(),
-    } as BridgeTransaction;
-    bridging = false;
-
-    bridgeTxService.addTxByAddress(userAccount, bridgeTx);
   };
 
   const handleTimeout = (txHash: Hex) => {
@@ -114,7 +124,8 @@
       title: $t('bridge.actions.bridge.timeout.title'),
       message: $t('bridge.actions.bridge.timeout.message', {
         values: {
-          url: `${explorer}/tx/${approveTxHash}`,
+          // The timed-out transaction itself, not the (possibly absent) approval tx
+          url: `${explorer}/tx/${txHash}`,
         },
       }),
     });
@@ -194,11 +205,8 @@
   }
 
   async function approve() {
-    isBridgePaused().then((paused) => {
-      if (paused) throw new BridgePausedError('Bridge is paused');
-    });
-
     try {
+      if (await isBridgePaused()) throw new BridgePausedError('Bridge is paused');
       if (!$selectedToken || !$connectedSourceChain || !$destNetwork?.id) return;
       const type: TokenType = $selectedToken.type;
       const walletClient = await getConnectedWallet($connectedSourceChain.id);

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.component.test.ts
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.component.test.ts
@@ -1,0 +1,127 @@
+/**
+ * A custom processing fee that never parsed must not be confirmable.
+ *
+ * `inputProcessFee` deliberately keeps the previous fee for incomplete input (so the value
+ * does not jump around mid-keystroke), which means malformed text like `1e5` left
+ * `tempprocessingFee` describing something the user had already replaced on screen.
+ * Confirm only checked the acknowledgement box, so that stale fee could be submitted.
+ */
+import { tick } from 'svelte';
+import { vi } from 'vitest';
+
+vi.mock('svelte-i18n', async () => {
+  const { readable } = await import('svelte/store');
+  return { t: readable((key: string) => key), locale: readable('en'), init: vi.fn(), addMessages: vi.fn() };
+});
+
+import ProcessingFee from './ProcessingFee.svelte';
+
+let target: HTMLElement;
+let component: { $destroy: () => void } | null = null;
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = new ProcessingFee({ target, props: {} });
+});
+
+afterEach(() => {
+  component?.$destroy();
+  component = null;
+  target.remove();
+});
+
+/** Opens the dialog and switches it to the CUSTOM fee method */
+const openCustom = async () => {
+  const edit = Array.from(target.querySelectorAll('button')).find((b) =>
+    b.textContent?.includes('common.edit'),
+  ) as HTMLButtonElement;
+  edit.click();
+  await tick();
+
+  (target.querySelector('#input-custom') as HTMLInputElement).click();
+  await tick();
+};
+
+const feeInput = () => target.querySelector('input[type="number"]') as HTMLInputElement;
+
+const confirmButton = () =>
+  Array.from(target.querySelectorAll('button')).find((b) =>
+    b.textContent?.includes('common.confirm'),
+  ) as HTMLButtonElement;
+
+/**
+ * The acknowledgement checkbox is the last one in the dialog. The earlier one toggles
+ * gasLimitZero, which switches the method to NONE and removes the fee input entirely.
+ */
+const acknowledge = async () => {
+  const checkboxes = Array.from(target.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[];
+  checkboxes[checkboxes.length - 1].click();
+  await tick();
+};
+
+const type = async (value: string) => {
+  const input = feeInput();
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  await tick();
+};
+
+describe('custom processing fee', () => {
+  it('switches to the custom method', async () => {
+    await openCustom();
+    expect(feeInput()).toBeTruthy();
+  });
+
+  it('allows confirming a well-formed custom fee', async () => {
+    await openCustom();
+    await type('0.001');
+    await acknowledge();
+
+    expect(confirmButton().disabled).toBe(false);
+  });
+
+  it('blocks confirming exponent notation that never parsed', async () => {
+    await openCustom();
+    await type('0.001');
+    await acknowledge();
+    expect(confirmButton().disabled).toBe(false);
+
+    // A number input emits this natively; parseCustomFeeInput rejects it, so the fee
+    // still held is 0.001 - an amount no longer on screen
+    await type('1e5');
+
+    expect(confirmButton().disabled).toBe(true);
+  });
+
+  it('re-enables confirm once the input parses again', async () => {
+    await openCustom();
+    await acknowledge();
+    await type('1e5');
+    expect(confirmButton().disabled).toBe(true);
+
+    await type('0.002');
+    expect(confirmButton().disabled).toBe(false);
+  });
+
+  it('treats an empty box as not-yet-filled rather than invalid', async () => {
+    await openCustom();
+    await acknowledge();
+    await type('');
+
+    expect(confirmButton().disabled).toBe(false);
+  });
+
+  it('clears the invalid draft when leaving the custom method', async () => {
+    await openCustom();
+    await acknowledge();
+    await type('1e5');
+    expect(confirmButton().disabled).toBe(true);
+
+    (target.querySelector('#input-recommended') as HTMLInputElement).click();
+    await tick();
+
+    // Back on RECOMMENDED nothing needs confirming, and the invalid draft is retired
+    expect(confirmButton().disabled).toBe(false);
+  });
+});

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.component.test.ts
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.component.test.ts
@@ -112,6 +112,24 @@ describe('custom processing fee', () => {
     expect(confirmButton().disabled).toBe(false);
   });
 
+  it('clears the invalid draft across a CUSTOM -> RECOMMENDED -> CUSTOM round trip', async () => {
+    await openCustom();
+    await acknowledge();
+    await type('1e5');
+    expect(confirmButton().disabled).toBe(true);
+
+    (target.querySelector('#input-recommended') as HTMLInputElement).click();
+    await tick();
+    (target.querySelector('#input-custom') as HTMLInputElement).click();
+    await tick();
+
+    // The round trip recreates an empty input, so the error belonging to the discarded
+    // draft must not still be blocking it
+    // The acknowledgement from before the round trip is still checked
+    expect(feeInput().value).toBe('');
+    expect(confirmButton().disabled).toBe(false);
+  });
+
   it('clears the invalid draft when leaving the custom method', async () => {
     await openCustom();
     await acknowledge();

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
@@ -111,7 +111,6 @@
   }
 
   async function updateProcessingFee(method: ProcessingFeeMethod, recommendedAmount: bigint) {
-    if (method !== ProcessingFeeMethod.CUSTOM) invalidCustomFee = false;
     switch (method) {
       case ProcessingFeeMethod.RECOMMENDED:
         $processingFee = recommendedAmount;
@@ -160,6 +159,12 @@
   $: manuallyConfirmed = false;
 
   $: needsConfirmation = tempProcessingFeeMethod !== ProcessingFeeMethod.RECOMMENDED || $gasLimitZero;
+
+  // Leaving CUSTOM discards the draft along with its error. This has to follow the
+  // dialog's own method: updateProcessingFee runs on the committed $processingFeeMethod,
+  // which the radios do not change, so clearing there left the flag set and a
+  // CUSTOM -> RECOMMENDED -> CUSTOM round trip came back to an empty but blocked input.
+  $: if (tempProcessingFeeMethod !== ProcessingFeeMethod.CUSTOM) invalidCustomFee = false;
 
   // Text that never parsed leaves tempprocessingFee describing an earlier value
   $: customFeeUnusable = tempProcessingFeeMethod === ProcessingFeeMethod.CUSTOM && invalidCustomFee;

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
@@ -12,8 +12,8 @@
   import { Tooltip } from '$components/Tooltip';
   import { closeOnEscapeOrOutsideClick } from '$libs/customActions';
   import { ProcessingFeeMethod } from '$libs/fee';
-  import { parseToWei } from '$libs/util/parseToWei';
 
+  import { parseCustomFeeInput } from './customFee';
   import NoneOption from './NoneOption.svelte';
   import RecommendedFee from './RecommendedFee.svelte';
 
@@ -92,13 +92,12 @@
   function inputProcessFee(event: Event) {
     if (tempProcessingFeeMethod !== ProcessingFeeMethod.CUSTOM) return;
 
-    const { value: initialValue } = event.target as HTMLInputElement;
-    if (parseToWei(initialValue) <= recommendedAmount) {
-      // If the user tries to input 0 or less, we set it to the current recommended amount
-      inputBox?.setValue(formatEther(recommendedAmount));
-    }
-    const { value: finalValue } = event.target as HTMLInputElement;
-    tempprocessingFee = parseToWei(finalValue);
+    const { value } = event.target as HTMLInputElement;
+    // Incomplete or invalid input keeps the previous fee; a custom fee below the
+    // recommended amount is a deliberate choice the warning below covers
+    const parsed = parseCustomFeeInput(value);
+    if (parsed === null) return;
+    tempprocessingFee = parsed;
   }
 
   async function updateProcessingFee(method: ProcessingFeeMethod, recommendedAmount: bigint) {
@@ -214,7 +213,7 @@
       id={dialogId}
       class="modal"
       class:modal-open={modalOpen}
-      use:closeOnEscapeOrOutsideClick={{ enabled: modalOpen, callback: () => (modalOpen = false), uuid: dialogId }}>
+      use:closeOnEscapeOrOutsideClick={{ enabled: modalOpen, callback: cancelModal, uuid: dialogId }}>
       <div class="modal-box relative px-6 py-[35px] md:rounded-[20px] bg-neutral-background">
         <CloseButton onClick={cancelModal} />
 

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/ProcessingFee.svelte
@@ -37,6 +37,10 @@
 
   let tempprocessingFee = $processingFee;
 
+  // Set when the custom fee box holds text that does not parse, so tempprocessingFee
+  // still describes whatever was typed before it
+  let invalidCustomFee = false;
+
   // Public API
   export function resetProcessingFee() {
     inputBox?.clear();
@@ -73,10 +77,12 @@
     modalOpen = true;
     $gasLimitZero = false;
     manuallyConfirmed = false;
+    invalidCustomFee = false;
   }
 
   function cancelModal() {
     inputBox?.clear();
+    invalidCustomFee = false;
     $gasLimitZero = false;
 
     if (tempProcessingFeeMethod === ProcessingFeeMethod.CUSTOM) {
@@ -96,11 +102,16 @@
     // Incomplete or invalid input keeps the previous fee; a custom fee below the
     // recommended amount is a deliberate choice the warning below covers
     const parsed = parseCustomFeeInput(value);
+    // An empty box is not an error, it is simply not filled in yet. Anything else that
+    // fails to parse must block Confirm: silently keeping the previous fee would submit
+    // an amount the user has already replaced on screen.
+    invalidCustomFee = parsed === null && value.trim() !== '';
     if (parsed === null) return;
     tempprocessingFee = parsed;
   }
 
   async function updateProcessingFee(method: ProcessingFeeMethod, recommendedAmount: bigint) {
+    if (method !== ProcessingFeeMethod.CUSTOM) invalidCustomFee = false;
     switch (method) {
       case ProcessingFeeMethod.RECOMMENDED:
         $processingFee = recommendedAmount;
@@ -150,7 +161,10 @@
 
   $: needsConfirmation = tempProcessingFeeMethod !== ProcessingFeeMethod.RECOMMENDED || $gasLimitZero;
 
-  $: confirmDisabled = needsConfirmation && !manuallyConfirmed;
+  // Text that never parsed leaves tempprocessingFee describing an earlier value
+  $: customFeeUnusable = tempProcessingFeeMethod === ProcessingFeeMethod.CUSTOM && invalidCustomFee;
+
+  $: confirmDisabled = (needsConfirmation && !manuallyConfirmed) || customFeeUnusable;
 </script>
 
 {#if small}

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/RecommendedFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/RecommendedFee.svelte
@@ -24,6 +24,7 @@
   // Concurrent computations can resolve out of order (reactive re-runs and the refresh
   // interval overlap); only the latest invocation may publish its result
   let computeGeneration = 0;
+  let inFlight = false;
 
   async function compute(
     token: Maybe<Token | NFT>,
@@ -32,11 +33,18 @@
     to?: Address,
     tokenIds?: number[],
     amounts?: number[],
+    periodicRefresh = false,
   ) {
     // Without token nor destination chain we cannot compute this fee
     if (!token || !destChainId) return;
 
+    // A periodic refresh re-runs identical inputs, so it must not supersede a slower
+    // in-flight computation — doing so would discard every result and never clear the
+    // calculating flag; only input changes may take over
+    if (periodicRefresh && inFlight) return;
+
     const generation = ++computeGeneration;
+    inFlight = true;
     $calculatingProcessingFee = true;
     error = false;
 
@@ -58,6 +66,7 @@
     } finally {
       if (generation === computeGeneration) {
         $calculatingProcessingFee = false;
+        inFlight = false;
       }
     }
   }
@@ -80,6 +89,7 @@
         $recipientAddress || $account?.address,
         $selectedNFTs?.map((nft) => nft.tokenId),
         $selectedToken?.type === TokenType.ERC1155 ? [Number($enteredAmount)] : undefined,
+        true,
       );
     }, processingFeeComponent.intervalComputeRecommendedFee);
   });

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/RecommendedFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/RecommendedFee.svelte
@@ -35,15 +35,22 @@
     amounts?: number[],
     periodicRefresh = false,
   ) {
-    // Without token nor destination chain we cannot compute this fee
-    if (!token || !destChainId) return;
-
     // A periodic refresh re-runs identical inputs, so it must not supersede a slower
     // in-flight computation — doing so would discard every result and never clear the
     // calculating flag; only input changes may take over
     if (periodicRefresh && inFlight) return;
 
     const generation = ++computeGeneration;
+
+    // Without token nor destination chain we cannot compute this fee. The bump above
+    // stops an in-flight result for the old inputs from publishing, so the flags it
+    // can no longer clear are reset here
+    if (!token || !destChainId) {
+      $calculatingProcessingFee = false;
+      inFlight = false;
+      return;
+    }
+
     inFlight = true;
     $calculatingProcessingFee = true;
     error = false;

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/RecommendedFee.svelte
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/RecommendedFee.svelte
@@ -21,6 +21,10 @@
 
   let interval: ReturnType<typeof setInterval>;
 
+  // Concurrent computations can resolve out of order (reactive re-runs and the refresh
+  // interval overlap); only the latest invocation may publish its result
+  let computeGeneration = 0;
+
   async function compute(
     token: Maybe<Token | NFT>,
     srcChainId?: number,
@@ -32,11 +36,12 @@
     // Without token nor destination chain we cannot compute this fee
     if (!token || !destChainId) return;
 
+    const generation = ++computeGeneration;
     $calculatingProcessingFee = true;
     error = false;
 
     try {
-      amount = await recommendProcessingFee({
+      const recommended = await recommendProcessingFee({
         token,
         destChainId,
         srcChainId,
@@ -44,11 +49,16 @@
         tokenIds,
         amounts,
       });
+      if (generation !== computeGeneration) return;
+      amount = recommended;
     } catch (err) {
+      if (generation !== computeGeneration) return;
       console.error(err);
       error = true;
     } finally {
-      $calculatingProcessingFee = false;
+      if (generation === computeGeneration) {
+        $calculatingProcessingFee = false;
+      }
     }
   }
 

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/customFee.test.ts
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/customFee.test.ts
@@ -1,0 +1,28 @@
+import { parseCustomFeeInput } from './customFee';
+
+describe('parseCustomFeeInput', () => {
+  it('parses a valid decimal ETH amount to wei', () => {
+    expect(parseCustomFeeInput('0.01')).toBe(10_000_000_000_000_000n);
+    expect(parseCustomFeeInput('1')).toBe(1_000_000_000_000_000_000n);
+  });
+
+  it('accepts amounts below any recommended fee — a custom fee may undercut it', () => {
+    expect(parseCustomFeeInput('0.000000001')).toBe(1_000_000_000n);
+    expect(parseCustomFeeInput('0')).toBe(0n);
+  });
+
+  it('returns null for empty input so typing is not hijacked', () => {
+    expect(parseCustomFeeInput('')).toBeNull();
+    expect(parseCustomFeeInput('  ')).toBeNull();
+  });
+
+  it('treats a lone decimal point as zero while the user is typing', () => {
+    expect(parseCustomFeeInput('.')).toBe(0n);
+  });
+
+  it('returns null for invalid or negative input', () => {
+    expect(parseCustomFeeInput('abc')).toBeNull();
+    expect(parseCustomFeeInput('1e18')).toBeNull();
+    expect(parseCustomFeeInput('-1')).toBeNull();
+  });
+});

--- a/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/customFee.ts
+++ b/packages/bridge-ui/src/components/Bridge/SharedBridgeComponents/ProcessingFee/customFee.ts
@@ -1,0 +1,22 @@
+import { parseToWei } from '$libs/util/parseToWei';
+
+/**
+ * @dev Parses the custom-fee text input. Returns null while the text is not a complete,
+ *      valid, non-negative ETH amount, so callers can leave prior state untouched while
+ *      the user is still typing.
+ * @param value The raw input value
+ * @return The fee in wei, or null when the input cannot be used
+ */
+export function parseCustomFeeInput(value: string): bigint | null {
+  if (value.trim() === '') return null;
+
+  let parsed: bigint;
+  try {
+    parsed = parseToWei(value);
+  } catch {
+    return null;
+  }
+
+  if (parsed < BigInt(0)) return null;
+  return parsed;
+}

--- a/packages/bridge-ui/src/components/ChainSelectors/ChainSelector.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/ChainSelector.svelte
@@ -29,8 +29,9 @@
       $switchingNetwork = true;
       try {
         await switchChain(config, { chainId: selectedChain.id });
-        if (currentChain && selectedChain.id === currentChain.id) {
-          // swap the chains
+        if (selectedChain.id === $destNetwork?.id) {
+          // The new source was the destination: swap the chains instead of
+          // leaving source and destination identical
           destNetwork.set(currentChain);
         } else {
           setAlternateNetwork();

--- a/packages/bridge-ui/src/components/ChainSelectors/SelectorDialogs/ChainsDialog.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/SelectorDialogs/ChainsDialog.svelte
@@ -26,15 +26,28 @@
 
   let selectedChainId: number | undefined;
 
-  const selectChain = (selectedChain: Chain) => (value = selectedChain);
-  const closeModal = () => (modalOpen = false);
+  // The picked chain stays local until Confirm: writing it to `value` immediately would
+  // show an unconfirmed chain in the pill, even when the dialog is dismissed or the
+  // wallet switch is rejected afterwards
+  let pendingChain: Maybe<Chain> = null;
+
+  const selectChain = (selectedChain: Chain) => (pendingChain = selectedChain);
+
+  const closeModal = () => {
+    modalOpen = false;
+    isOpen = false;
+  };
 
   const onConfirmClick = () => {
-    dispatch('change', { chain: value, switchWallet });
+    if (pendingChain) {
+      dispatch('change', { chain: pendingChain, switchWallet });
+    }
     closeModal();
   };
 
   $: if (isOpen) {
+    pendingChain = null;
+    selectedChainId = value?.id;
     modalOpen = true;
   } else {
     closeModal();

--- a/packages/bridge-ui/src/components/ChainSelectors/SelectorDialogs/ChainsDropdown.svelte
+++ b/packages/bridge-ui/src/components/ChainSelectors/SelectorDialogs/ChainsDropdown.svelte
@@ -24,10 +24,11 @@
     closeDropDown();
   }
 
-  function getChainKeydownHandler(chain: Chain) {
+  function getChainKeydownHandler(chain: Chain, disabled: boolean) {
     return (event: KeyboardEvent) => {
-      if (event.key === 'Enter') {
-        selectChain(chain, isDestination);
+      if (event.key === 'Enter' && !disabled) {
+        // Same flag as the click path: switchWallet is the opposite of isDestination
+        selectChain(chain, !isDestination);
       }
     };
   }
@@ -59,7 +60,7 @@
         on:click={() => {
           if (!disabled) selectChain(chain, !isDestination);
         }}
-        on:keydown={getChainKeydownHandler(chain)}>
+        on:keydown={getChainKeydownHandler(chain, disabled)}>
         <div class="f-row justify-between">
           <div class="f-items-center gap-2">
             <i role="img" aria-label={chain.name}>

--- a/packages/bridge-ui/src/components/Dialogs/Claim.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/Claim.svelte
@@ -66,7 +66,9 @@
 
       // Step 4: Call claim() method on the bridge
       let txHash: Hash;
-      if ($selectedRetryMethod === RETRY_OPTION.RETRY_ONCE) {
+      // The retry-once choice only applies to an actual retry: the store is shared and a
+      // leftover value must never turn a plain claim into a final attempt
+      if (action === ClaimAction.RETRY && $selectedRetryMethod === RETRY_OPTION.RETRY_ONCE) {
         log('Claiming with lastAttempt flag');
         txHash = await bridge.processMessage({ wallet, bridgeTx, lastAttempt: true });
       } else {

--- a/packages/bridge-ui/src/components/Dialogs/Claim.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/Claim.svelte
@@ -44,11 +44,14 @@
   }
 
   export const claim = async (action: ClaimAction, force: boolean = false, skipMessageStatusCheck: boolean = false) => {
-    if (!$account.address) {
-      throw new NotConnectedError('User is not connected');
-    }
-
     try {
+      // Inside the try so it reaches the error dispatch below: every dialog already
+      // handles NotConnectedError there, and a rejection here would instead leave the
+      // caller's claiming/releasing flag stuck
+      if (!$account?.address) {
+        throw new NotConnectedError('User is not connected');
+      }
+
       const { msgHash, message } = bridgeTx;
 
       if (!msgHash || !message) {

--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.svelte
@@ -25,7 +25,6 @@
   } from '$libs/error';
   import type { NFT } from '$libs/token';
   import { getLogger } from '$libs/util/logger';
-  import { connectedSourceChain } from '$stores/network';
   import { pendingTransactions } from '$stores/pendingTransactions';
 
   import { ClaimConfirmStep, ReviewStep } from '../Shared';
@@ -92,31 +91,29 @@
 
     const explorer = chainConfig[Number(bridgeTx.destChainId)]?.blockExplorers?.default.url;
 
-    if (action === ClaimAction.CLAIM) {
-      infoToast({
-        title: $t('transactions.actions.claim.tx.title'),
-        message: $t('transactions.actions.claim.tx.message', {
-          values: {
-            token: bridgeTx.symbol,
-            url: `${explorer}/tx/${txHash}`,
-          },
-        }),
-      });
+    infoToast({
+      title: $t('transactions.actions.claim.tx.title'),
+      message: $t('transactions.actions.claim.tx.message', {
+        values: {
+          token: bridgeTx.symbol,
+          url: `${explorer}/tx/${txHash}`,
+        },
+      }),
+    });
+
+    try {
       await pendingTransactions.add(txHash, Number(bridgeTx.destChainId));
-    } else {
-      // Retry
-      infoToast({
-        title: $t('transactions.actions.claim.tx.title'),
-        message: $t('transactions.actions.claim.tx.message', {
-          values: {
-            token: bridgeTx.symbol,
-            url: `${explorer}/tx/${txHash}`,
-          },
-        }),
+    } catch (error) {
+      // A reverted or timed-out claim must not leave the dialog spinning forever
+      log('claim transaction failed or timed out', { txHash, action, error });
+      claiming = false;
+      errorToast({
+        title: $t('bridge.errors.process_message_error'),
       });
-      await pendingTransactions.add(txHash, Number(bridgeTx.destChainId));
+      return;
     }
 
+    claiming = false;
     claimingDone = true;
 
     dispatch('claimingDone');
@@ -125,7 +122,7 @@
       title: $t('transactions.actions.claim.success.title'),
       message: $t('transactions.actions.claim.success.message', {
         values: {
-          network: $connectedSourceChain.name,
+          url: `${explorer}/tx/${txHash}`,
         },
       }),
     });
@@ -201,6 +198,7 @@
   const reset = () => {
     activeStep = INITIAL_STEP;
     claimingDone = false;
+    claiming = false;
     // canForceTransaction = false;
   };
 

--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/quota.ts
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/quota.ts
@@ -56,5 +56,12 @@ export async function claimWithQuotaGuard({
     return;
   }
 
-  await claim();
+  try {
+    await claim();
+  } catch (error) {
+    // claim() normally reports through its own events; a throw escaping it would
+    // otherwise leave the dialog's claiming flag stuck on
+    setClaiming(false);
+    throw error;
+  }
 }

--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/quotaGuard.test.ts
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/quotaGuard.test.ts
@@ -1,0 +1,40 @@
+import type { BridgeTransaction } from '$libs/bridge/types';
+
+import { claimWithQuotaGuard } from './quota';
+
+vi.mock('$libs/bridge/checkQuota', () => ({
+  isClaimBlockedByQuota: vi.fn().mockResolvedValue(false),
+}));
+
+const bridgeTx = { srcTxHash: '0xabc' } as unknown as BridgeTransaction;
+
+describe('claimWithQuotaGuard', () => {
+  it('clears the claiming flag when claim() throws instead of reporting via its events', async () => {
+    // Claim.svelte can reject (e.g. NotConnectedError) without dispatching an event;
+    // the dialog would otherwise stay stuck in the claiming spinner forever
+    const setClaiming = vi.fn();
+    const claim = vi.fn().mockRejectedValue(new Error('not connected'));
+
+    await expect(
+      claimWithQuotaGuard({
+        bridgeTx,
+        claim,
+        setClaiming,
+        showQuotaReachedToast: vi.fn(),
+      }),
+    ).rejects.toThrow('not connected');
+
+    expect(setClaiming).toHaveBeenNthCalledWith(1, true);
+    expect(setClaiming).toHaveBeenLastCalledWith(false);
+  });
+
+  it('leaves the claiming flag to the event path on success', async () => {
+    const setClaiming = vi.fn();
+    const claim = vi.fn().mockResolvedValue(undefined);
+
+    await claimWithQuotaGuard({ bridgeTx, claim, setClaiming, showQuotaReachedToast: vi.fn() });
+
+    expect(setClaiming).toHaveBeenCalledTimes(1);
+    expect(setClaiming).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseDialog.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseDialog.svelte
@@ -18,7 +18,6 @@
     RetryError,
   } from '$libs/error';
   import { getLogger } from '$libs/util/logger';
-  import { connectedSourceChain } from '$stores/network';
   import { pendingTransactions } from '$stores/pendingTransactions';
 
   import Claim from '../Claim.svelte';
@@ -41,7 +40,7 @@
   let canContinue = false;
   let activeStep: ReleaseSteps = INITIAL_STEP;
   let txHash: Hash;
-  let releasing: boolean;
+  let releasing = false;
   let releasingDone = false;
   let ClaimComponent: Claim;
   let hideContinueButton: boolean;
@@ -58,6 +57,7 @@
 
   const reset = () => {
     releasing = false;
+    releasingDone = false;
     activeStep = INITIAL_STEP;
   };
 
@@ -67,7 +67,10 @@
     log('handle claim tx sent', txHash, action);
     releasing = true;
 
-    const explorer = chainConfig[Number(bridgeTx.destChainId)]?.blockExplorers?.default.url;
+    // recallMessage executes on the source chain, so both the receipt wait and the
+    // explorer link must use the source chain, not the destination
+    const releaseChainId = Number(bridgeTx.srcChainId);
+    const explorer = chainConfig[releaseChainId]?.blockExplorers?.default.url;
 
     infoToast({
       title: $t('transactions.actions.claim.tx.title'),
@@ -78,8 +81,18 @@
         },
       }),
     });
-    await pendingTransactions.add(txHash, Number(bridgeTx.destChainId));
 
+    try {
+      await pendingTransactions.add(txHash, releaseChainId);
+    } catch (error) {
+      // A reverted or timed-out release must not leave the dialog spinning forever
+      log('release transaction failed or timed out', { txHash, error });
+      releasing = false;
+      errorToast({ title: $t('bridge.errors.process_message_error') });
+      return;
+    }
+
+    releasing = false;
     releasingDone = true;
 
     dispatch('claimingDone');
@@ -88,7 +101,7 @@
       title: $t('transactions.actions.claim.success.title'),
       message: $t('transactions.actions.claim.success.message', {
         values: {
-          network: $connectedSourceChain.name,
+          url: `${explorer}/tx/${txHash}`,
         },
       }),
     });
@@ -142,12 +155,12 @@
   };
 
   const handleReleaseClick = async () => {
+    // claim() reports its outcome through the claimingTxSent/error events, which own the
+    // `releasing` flag; clearing it here would re-enable the button while the release
+    // transaction is still pending
     releasing = true;
     await ClaimComponent.claim(ClaimAction.RELEASE);
-    releasing = false;
   };
-
-  $: releasing = false;
 
   $: loading = releasing;
 </script>

--- a/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseDialog.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseDialog.svelte
@@ -157,9 +157,16 @@
   const handleReleaseClick = async () => {
     // claim() reports its outcome through the claimingTxSent/error events, which own the
     // `releasing` flag; clearing it here would re-enable the button while the release
-    // transaction is still pending
+    // transaction is still pending. A throw escaping claim() bypasses those events, so
+    // the flag is cleared here in that case only.
     releasing = true;
-    await ClaimComponent.claim(ClaimAction.RELEASE);
+    try {
+      await ClaimComponent.claim(ClaimAction.RELEASE);
+    } catch (error) {
+      console.error('Release failed before a transaction was sent', error);
+      releasing = false;
+      errorToast({ title: $t('bridge.errors.unknown_error.title') });
+    }
   };
 
   $: loading = releasing;

--- a/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseSteps/ReleasePreCheck.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/ReleaseDialog/ReleaseSteps/ReleasePreCheck.svelte
@@ -26,9 +26,10 @@
     }
   };
 
-  $: txDestChainName = getChainName(Number(tx.destChainId));
+  // Releasing happens on the source chain, which is where the button switches to
+  $: txSrcChainName = getChainName(Number(tx.srcChainId));
 
-  $: correctChain = Number(tx.srcChainId) === $connectedSourceChain.id;
+  $: correctChain = Number(tx.srcChainId) === $connectedSourceChain?.id;
 
   $: if (correctChain && $account) {
     hideContinueButton = false;
@@ -65,7 +66,7 @@
         loading={$switchingNetwork}
         on:click={() => {
           switchChains();
-        }}>{$t('common.switch_to')} {txDestChainName}</ActionButton>
+        }}>{$t('common.switch_to')} {txSrcChainName}</ActionButton>
     </div>
   {/if}
 </div>

--- a/packages/bridge-ui/src/components/Dialogs/RetryDialog/RetryDialog.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/RetryDialog/RetryDialog.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import { t } from 'svelte-i18n';
-  import type { Hash } from 'viem';
+  import { type Hash, UserRejectedRequestError } from 'viem';
 
   import { chainConfig } from '$chainConfig';
   import { CloseButton } from '$components/Button';
   import { DesktopOrLarger } from '$components/DesktopOrLarger';
   import { DialogStep, DialogStepper } from '$components/Dialogs/Stepper';
-  import { errorToast, infoToast, successToast } from '$components/NotificationToast/NotificationToast.svelte';
+  import {
+    errorToast,
+    infoToast,
+    successToast,
+    warningToast,
+  } from '$components/NotificationToast/NotificationToast.svelte';
   import { OnAccount } from '$components/OnAccount';
   import type { BridgeTransaction } from '$libs/bridge';
   import { closeOnEscapeOrOutsideClick } from '$libs/customActions';
@@ -67,6 +72,12 @@
       }))
     ) {
       console.error(err);
+      // Every non-quota failure needs user-visible feedback, not just a console line
+      if (err instanceof UserRejectedRequestError) {
+        warningToast({ title: $t('transactions.actions.claim.rejected.title') });
+      } else {
+        errorToast({ title: $t('bridge.errors.retry_error') });
+      }
     }
     retrying = false;
   };
@@ -79,6 +90,7 @@
     activeStep = INITIAL_STEP;
     $selectedRetryMethod = RETRY_OPTION.CONTINUE;
     retryDone = false;
+    retrying = false;
   };
 
   const closeDialog = () => {
@@ -113,8 +125,18 @@
         },
       }),
     });
-    await pendingTransactions.add(txHash, Number(bridgeTx.destChainId));
 
+    try {
+      await pendingTransactions.add(txHash, Number(bridgeTx.destChainId));
+    } catch (error) {
+      // A reverted or timed-out retry must not leave the dialog spinning forever
+      log('retry transaction failed or timed out', { txHash, error });
+      retrying = false;
+      errorToast({ title: $t('bridge.errors.retry_error') });
+      return;
+    }
+
+    retrying = false;
     retryDone = true;
 
     dispatch('retryDone');

--- a/packages/bridge-ui/src/components/Faucet/Faucet.svelte
+++ b/packages/bridge-ui/src/components/Faucet/Faucet.svelte
@@ -98,8 +98,12 @@
   let mintCheckGeneration = 0;
 
   async function updateMintButtonState(connected: boolean, token?: Token, network?: Chain) {
-    if (!token || !network) return false;
     const generation = ++mintCheckGeneration;
+    // Invalid inputs also invalidate any in-flight check, whose flags are reset here
+    if (!token || !network) {
+      checkingMintable = false;
+      return false;
+    }
     checkingMintable = true;
     mintButtonEnabled = false;
     let reasonNotMintable = '';

--- a/packages/bridge-ui/src/components/Faucet/Faucet.svelte
+++ b/packages/bridge-ui/src/components/Faucet/Faucet.svelte
@@ -93,16 +93,23 @@
   // This function will check whether or not the button to mint should be
   // enabled. If it shouldn't it'll also set the reason why so we can inform
   // the user why they can't mint
+  // Concurrent eligibility checks resolve out of order (token switch, chain switch);
+  // only the latest may publish its result
+  let mintCheckGeneration = 0;
+
   async function updateMintButtonState(connected: boolean, token?: Token, network?: Chain) {
     if (!token || !network) return false;
+    const generation = ++mintCheckGeneration;
     checkingMintable = true;
     mintButtonEnabled = false;
     let reasonNotMintable = '';
     wrongChain = false;
     try {
       await checkMintable(token, network.id);
+      if (generation !== mintCheckGeneration) return;
       mintButtonEnabled = true;
     } catch (err) {
+      if (generation !== mintCheckGeneration) return;
       console.error(err);
       switch (true) {
         case err instanceof InsufficientBalanceError:
@@ -122,9 +129,12 @@
           break;
       }
     } finally {
-      checkingMintable = false;
+      if (generation === mintCheckGeneration) {
+        checkingMintable = false;
+      }
     }
 
+    if (generation !== mintCheckGeneration) return;
     alertMessage = getAlertMessage(connected, reasonNotMintable);
   }
 

--- a/packages/bridge-ui/src/components/OnAccount/OnAccount.svelte
+++ b/packages/bridge-ui/src/components/OnAccount/OnAccount.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
+
   import { noop } from '$libs/util/noop';
   import { type Account, account } from '$stores/account';
 
@@ -6,8 +8,12 @@
 
   let prevAccount: Account;
 
-  account.subscribe((newAccount) => {
+  // Manual subscriptions are not auto-released like $-syntax ones: without the
+  // onDestroy below, every mount leaks a handler that keeps firing forever
+  const unsubscribe = account.subscribe((newAccount) => {
     change(newAccount, prevAccount);
     prevAccount = newAccount;
   });
+
+  onDestroy(unsubscribe);
 </script>

--- a/packages/bridge-ui/src/components/OnNetwork/OnNetwork.svelte
+++ b/packages/bridge-ui/src/components/OnNetwork/OnNetwork.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import type { Chain } from 'viem';
 
   import { noop } from '$libs/util/noop';
@@ -8,10 +9,14 @@
 
   let prevNetwork = $connectedSourceChain;
 
-  connectedSourceChain.subscribe((newNetwork) => {
+  // Manual subscriptions are not auto-released like $-syntax ones: without the
+  // onDestroy below, every mount leaks a handler that keeps firing forever
+  const unsubscribe = connectedSourceChain.subscribe((newNetwork) => {
     // only update if the network has actually changed
     if (newNetwork?.id === prevNetwork?.id) return;
     change(newNetwork, prevNetwork);
     prevNetwork = newNetwork;
   });
+
+  onDestroy(unsubscribe);
 </script>

--- a/packages/bridge-ui/src/components/Paginator/Paginator.svelte
+++ b/packages/bridge-ui/src/components/Paginator/Paginator.svelte
@@ -13,8 +13,9 @@
   const dispatch = createEventDispatcher<{ pageChange: number }>();
 
   function goToPage(page: number) {
+    // Dispatch the clamped value: the raw input can be out of range (typed page numbers)
     currentPage = Math.min(totalPages, Math.max(1, page));
-    dispatch('pageChange', page);
+    dispatch('pageChange', currentPage);
   }
 
   function handleKeydown(event: KeyboardEvent) {

--- a/packages/bridge-ui/src/components/Relayer/Relayer.svelte
+++ b/packages/bridge-ui/src/components/Relayer/Relayer.svelte
@@ -5,6 +5,7 @@
   import { AddressInputState } from '$components/Bridge/SharedBridgeComponents/AddressInput/state';
   import ActionButton from '$components/Button/ActionButton.svelte';
   import Card from '$components/Card/Card.svelte';
+  import { warningToast } from '$components/NotificationToast';
   import OnAccount from '$components/OnAccount/OnAccount.svelte';
   import { FungibleTransactionRow, NftTransactionRow } from '$components/Transactions/Rows';
   import { type BridgeTransaction, fetchTransactions, MessageStatus } from '$libs/bridge';
@@ -45,6 +46,9 @@
         // Also assign empty results: the previous address's transactions must not linger
         transactions = mergedTransactions;
       }
+    } catch (error) {
+      console.error('Error fetching transactions', error);
+      warningToast({ title: $t('transactions.errors.relayer_offline') });
     } finally {
       fetching = false;
     }
@@ -56,6 +60,11 @@
   };
 
   $: inputDisabled = fetching || !$account?.isConnected;
+
+  // No address, no results: rows from a previously searched address must not linger
+  $: if (!addressToSearch) {
+    transactions = [];
+  }
 
   $: addressToSearch = undefined;
   $: searchDisabled = fetching || !addressToSearch || addressState !== AddressInputState.VALID || inputDisabled;

--- a/packages/bridge-ui/src/components/Relayer/Relayer.svelte
+++ b/packages/bridge-ui/src/components/Relayer/Relayer.svelte
@@ -20,9 +20,9 @@
   let addressState = AddressInputState.DEFAULT;
 
   const onAccountChange = async (newAccount: Account, oldAccount?: Account) => {
-    // We want to make sure that we are connected and only
-    // fetch if the account has changed
-    if (newAccount && newAccount.address && newAccount.address !== oldAccount?.address) {
+    // Any change of address resets, including a transition to no address: a search
+    // started while connected must not publish rows into a disconnected view
+    if (newAccount?.address !== oldAccount?.address) {
       reset();
     }
   };

--- a/packages/bridge-ui/src/components/Relayer/Relayer.svelte
+++ b/packages/bridge-ui/src/components/Relayer/Relayer.svelte
@@ -26,8 +26,14 @@
       reset();
     }
   };
+  // Only the most recent search may write results, an error, or clear the loading flag:
+  // switching accounts mid-fetch would otherwise let the previous address's response
+  // repopulate the table and turn off the spinner belonging to the newer search.
+  let searchGeneration = 0;
+
   const reset = () => {
     log('reset');
+    searchGeneration++;
     transactions = [];
     fetching = false;
     addressState = AddressInputState.DEFAULT;
@@ -38,19 +44,22 @@
 
   const fetchTxForAddress = async () => {
     log('fetchTxForAddress');
+    const generation = ++searchGeneration;
     fetching = true;
     try {
       if (addressToSearch) {
         const { mergedTransactions } = await fetchTransactions(addressToSearch);
+        if (generation !== searchGeneration) return;
         log('mergedTransactions', mergedTransactions);
         // Also assign empty results: the previous address's transactions must not linger
         transactions = mergedTransactions;
       }
     } catch (error) {
+      if (generation !== searchGeneration) return;
       console.error('Error fetching transactions', error);
       warningToast({ title: $t('transactions.errors.relayer_offline') });
     } finally {
-      fetching = false;
+      if (generation === searchGeneration) fetching = false;
     }
   };
 

--- a/packages/bridge-ui/src/components/Relayer/Relayer.svelte
+++ b/packages/bridge-ui/src/components/Relayer/Relayer.svelte
@@ -38,14 +38,16 @@
   const fetchTxForAddress = async () => {
     log('fetchTxForAddress');
     fetching = true;
-    if (addressToSearch) {
-      const { mergedTransactions } = await fetchTransactions(addressToSearch);
-      log('mergedTransactions', mergedTransactions);
-      if (mergedTransactions.length > 0) {
+    try {
+      if (addressToSearch) {
+        const { mergedTransactions } = await fetchTransactions(addressToSearch);
+        log('mergedTransactions', mergedTransactions);
+        // Also assign empty results: the previous address's transactions must not linger
         transactions = mergedTransactions;
       }
+    } finally {
+      fetching = false;
     }
-    fetching = false;
   };
 
   const handleTransactionRemoved = (event: CustomEvent<{ transaction: BridgeTransaction }>) => {

--- a/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -112,6 +112,10 @@
 
   const onAddressChange = async (tokenAddress: Address) => {
     const generation = ++lookupGeneration;
+    // Drop the previous token up front: if this lookup fails or the address is not an
+    // ERC20, the form must not keep offering the token from the last address
+    customTokenWithDetails = null;
+    customToken = null;
     if (!tokenAddress) {
       loadingTokenDetails = false;
       return;

--- a/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -80,6 +80,10 @@
   };
 
   const resetForm = () => {
+    // A lookup still in flight belongs to the form being cleared; without this its result
+    // would repopulate the token and the loading flag after the reset
+    lookupGeneration++;
+    loadingTokenDetails = false;
     customToken = null;
     customTokenWithDetails = null;
     isValidEthereumAddress = false;
@@ -177,7 +181,14 @@
       ? formatUnits(customTokenWithDetails.balance, customTokenWithDetails.decimals)
       : 0;
 
-  $: disabled = state !== AddressInputState.VALID || tokenAddress === '' || tokenAddress.length !== 42;
+  // A resolved token is required: the address passing validation says nothing about the
+  // lookup having finished, so Add was clickable while details were still loading or absent
+  $: disabled =
+    state !== AddressInputState.VALID ||
+    tokenAddress === '' ||
+    tokenAddress.length !== 42 ||
+    loadingTokenDetails ||
+    !customToken;
 
   const closeModalIfClickedOutside = (e: MouseEvent) => {
     if (e.target === e.currentTarget) {

--- a/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -100,8 +100,13 @@
     }
   }
 
+  // Lookups for a previously typed address can resolve after a newer one;
+  // only the latest may publish its result
+  let lookupGeneration = 0;
+
   const onAddressChange = async (tokenAddress: Address) => {
     if (!tokenAddress) return;
+    const generation = ++lookupGeneration;
     loadingTokenDetails = true;
     log('Fetching token details for address "%s"…', tokenAddress);
 
@@ -109,11 +114,13 @@
     try {
       type = await detectContractType(tokenAddress, $connectedSourceChain?.id as number);
     } catch (error) {
+      if (generation !== lookupGeneration) return;
       log('Failed to detect contract type: ', error);
       loadingTokenDetails = false;
       state = AddressInputState.NOT_ERC20;
       return;
     }
+    if (generation !== lookupGeneration) return;
 
     if (type !== TokenType.ERC20) {
       loadingTokenDetails = false;
@@ -128,6 +135,7 @@
         contractAddress: tokenAddress as Address,
         srcChainId: srcChain.id,
       });
+      if (generation !== lookupGeneration) return;
       if (!token) return;
       const balance = await readContract(config, {
         address: tokenAddress as Address,
@@ -135,14 +143,18 @@
         functionName: 'balanceOf',
         args: [$account?.address as Address],
       });
+      if (generation !== lookupGeneration) return;
       customTokenWithDetails = { ...token, balance } as Token;
 
       customToken = customTokenWithDetails;
     } catch (error) {
+      if (generation !== lookupGeneration) return;
       state = AddressInputState.INVALID;
       log('Failed to fetch token: ', error);
     }
-    loadingTokenDetails = false;
+    if (generation === lookupGeneration) {
+      loadingTokenDetails = false;
+    }
   };
 
   $: formattedBalance =

--- a/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -97,7 +97,12 @@
     if (isValidEthereumAddress) {
       await onAddressChange(tokenAddress as Address);
     } else {
-      tokenAddress = addr;
+      // Invalid or cleared input also invalidates any in-flight lookup so its stale
+      // token cannot publish into the form
+      lookupGeneration++;
+      loadingTokenDetails = false;
+      customTokenWithDetails = null;
+      customToken = null;
     }
   }
 
@@ -106,55 +111,60 @@
   let lookupGeneration = 0;
 
   const onAddressChange = async (tokenAddress: Address) => {
-    if (!tokenAddress) return;
     const generation = ++lookupGeneration;
+    if (!tokenAddress) {
+      loadingTokenDetails = false;
+      return;
+    }
     loadingTokenDetails = true;
     log('Fetching token details for address "%s"…', tokenAddress);
 
-    let type: TokenType;
     try {
-      type = await detectContractType(tokenAddress, $connectedSourceChain?.id as number);
-    } catch (error) {
+      let type: TokenType;
+      try {
+        type = await detectContractType(tokenAddress, $connectedSourceChain?.id as number);
+      } catch (error) {
+        if (generation !== lookupGeneration) return;
+        log('Failed to detect contract type: ', error);
+        state = AddressInputState.NOT_ERC20;
+        return;
+      }
       if (generation !== lookupGeneration) return;
-      log('Failed to detect contract type: ', error);
-      loadingTokenDetails = false;
-      state = AddressInputState.NOT_ERC20;
-      return;
-    }
-    if (generation !== lookupGeneration) return;
 
-    if (type !== TokenType.ERC20) {
-      loadingTokenDetails = false;
-      state = AddressInputState.NOT_ERC20;
-      return;
-    }
+      if (type !== TokenType.ERC20) {
+        state = AddressInputState.NOT_ERC20;
+        return;
+      }
 
-    const srcChain = $connectedSourceChain;
-    if (!srcChain) return;
-    try {
-      const token = await getTokenWithInfoFromAddress({
-        contractAddress: tokenAddress as Address,
-        srcChainId: srcChain.id,
-      });
-      if (generation !== lookupGeneration) return;
-      if (!token) return;
-      const balance = await readContract(config, {
-        address: tokenAddress as Address,
-        abi: erc20Abi,
-        functionName: 'balanceOf',
-        args: [$account?.address as Address],
-      });
-      if (generation !== lookupGeneration) return;
-      customTokenWithDetails = { ...token, balance } as Token;
+      const srcChain = $connectedSourceChain;
+      if (!srcChain) return;
+      try {
+        const token = await getTokenWithInfoFromAddress({
+          contractAddress: tokenAddress as Address,
+          srcChainId: srcChain.id,
+        });
+        if (generation !== lookupGeneration) return;
+        if (!token) return;
+        const balance = await readContract(config, {
+          address: tokenAddress as Address,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [$account?.address as Address],
+        });
+        if (generation !== lookupGeneration) return;
+        customTokenWithDetails = { ...token, balance } as Token;
 
-      customToken = customTokenWithDetails;
-    } catch (error) {
-      if (generation !== lookupGeneration) return;
-      state = AddressInputState.INVALID;
-      log('Failed to fetch token: ', error);
-    }
-    if (generation === lookupGeneration) {
-      loadingTokenDetails = false;
+        customToken = customTokenWithDetails;
+      } catch (error) {
+        if (generation !== lookupGeneration) return;
+        state = AddressInputState.INVALID;
+        log('Failed to fetch token: ', error);
+      }
+    } finally {
+      // Every exit path clears the flag while this lookup is still the latest
+      if (generation === lookupGeneration) {
+        loadingTokenDetails = false;
+      }
     }
   };
 

--- a/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/AddCustomERC20.svelte
@@ -16,6 +16,7 @@
   import { detectContractType, type GetTokenInfo, type Token, TokenType } from '$libs/token';
   import { getTokenAddresses } from '$libs/token/getTokenAddresses';
   import { getTokenWithInfoFromAddress } from '$libs/token/getTokenWithInfoFromAddress';
+  import { tokenIdentityKey } from '$libs/token/tokenIdentity';
   import { getLogger } from '$libs/util/logger';
   import { config } from '$libs/wagmi';
   import { account } from '$stores/account';
@@ -208,7 +209,7 @@
     {#if customTokens.length > 0}
       <div class="flex h-full w-full flex-col justify-between mt-6">
         <h3 class="title-body-bold mb-7">{$t('token_dropdown.imported_tokens')}</h3>
-        {#each customTokens as ct (ct.symbol)}
+        {#each customTokens as ct (tokenIdentityKey(ct))}
           <div class="flex items-center justify-between">
             <div class="flex items-center m-2 space-x-2">
               <Erc20 />

--- a/packages/bridge-ui/src/components/TokenDropdown/DropdownView.svelte
+++ b/packages/bridge-ui/src/components/TokenDropdown/DropdownView.svelte
@@ -89,7 +89,7 @@
     filteredCustomTokens = customTokens.filter((token) => {
       return (
         token.name.toLowerCase().includes(enteredTokenName.toLowerCase()) ||
-        token.symbol.includes(enteredTokenName.toLowerCase())
+        token.symbol.toLowerCase().includes(enteredTokenName.toLowerCase())
       );
     });
   } else {

--- a/packages/bridge-ui/src/components/Transactions/Dialogs/DesktopDetailsDialog.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Dialogs/DesktopDetailsDialog.svelte
@@ -71,18 +71,21 @@
     }
   };
 
+  // Locally stored transactions only set msgStatus; relayer-derived ones set both
+  $: effectiveStatus = bridgeTx.msgStatus ?? bridgeTx.status;
+
   const checkStatus = async () => {
     const isProcessable = await isTransactionProcessable(bridgeTx);
-    if (bridgeTx.status === MessageStatus.NEW || bridgeTx.status === MessageStatus.RETRIABLE) {
+    if (effectiveStatus === MessageStatus.NEW || effectiveStatus === MessageStatus.RETRIABLE) {
       if (!isProcessable) {
         stillProcessing = true;
       } else {
         stillProcessing = false;
       }
     } else if (
-      bridgeTx.status === MessageStatus.DONE ||
-      bridgeTx.status === MessageStatus.FAILED ||
-      bridgeTx.status === MessageStatus.RECALLED
+      effectiveStatus === MessageStatus.DONE ||
+      effectiveStatus === MessageStatus.FAILED ||
+      effectiveStatus === MessageStatus.RECALLED
     ) {
       stillProcessing = false;
     }
@@ -104,7 +107,7 @@
   $: claimedBy = bridgeTx.claimedBy || null;
   $: isRelayer = false;
 
-  $: if (claimedBy !== to && claimedBy !== destOwner && bridgeTx.status === MessageStatus.DONE) {
+  $: if (claimedBy !== to && claimedBy !== destOwner && effectiveStatus === MessageStatus.DONE) {
     isRelayer = true;
   } else {
     isRelayer = false;
@@ -125,7 +128,7 @@
   id={dialogId}
   class="modal"
   class:modal-open={detailsOpen}
-  use:closeOnEscapeOrOutsideClick={{ enabled: detailsOpen, callback: () => closeDetails, uuid: dialogId }}>
+  use:closeOnEscapeOrOutsideClick={{ enabled: detailsOpen, callback: () => closeDetails(), uuid: dialogId }}>
   <div class="modal-box relative w-full bg-neutral-background !p-0 !pb-[20px]">
     <div class="w-full pt-[35px] px-[24px]">
       <CloseButton onClick={closeDetails} />
@@ -246,7 +249,7 @@
         <!-- From -->
         <div class="flex justify-between">
           <div class="text-secondary-content">{$t('common.status')}</div>
-          <Status bridgeTxStatus={bridgeTx.status} {bridgeTx} textOnly />
+          <Status bridgeTxStatus={effectiveStatus} {bridgeTx} textOnly />
         </div>
 
         <!-- Sender -->

--- a/packages/bridge-ui/src/components/Transactions/Dialogs/MobileDetailsDialog.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Dialogs/MobileDetailsDialog.svelte
@@ -69,18 +69,21 @@
     }
   };
 
+  // Locally stored transactions only set msgStatus; relayer-derived ones set both
+  $: effectiveStatus = bridgeTx.msgStatus ?? bridgeTx.status;
+
   const checkStatus = async () => {
     const isProcessable = await isTransactionProcessable(bridgeTx);
-    if (bridgeTx.status === MessageStatus.NEW || bridgeTx.status === MessageStatus.RETRIABLE) {
+    if (effectiveStatus === MessageStatus.NEW || effectiveStatus === MessageStatus.RETRIABLE) {
       if (!isProcessable) {
         stillProcessing = true;
       } else {
         stillProcessing = false;
       }
     } else if (
-      bridgeTx.status === MessageStatus.DONE ||
-      bridgeTx.status === MessageStatus.FAILED ||
-      bridgeTx.status === MessageStatus.RECALLED
+      effectiveStatus === MessageStatus.DONE ||
+      effectiveStatus === MessageStatus.FAILED ||
+      effectiveStatus === MessageStatus.RECALLED
     ) {
       stillProcessing = false;
     }
@@ -105,7 +108,7 @@
   $: claimedBy = bridgeTx.claimedBy || null;
   $: isRelayer = false;
 
-  $: if (claimedBy !== to && claimedBy !== destOwner && bridgeTx.status === MessageStatus.DONE) {
+  $: if (claimedBy !== to && claimedBy !== destOwner && effectiveStatus === MessageStatus.DONE) {
     isRelayer = true;
   } else {
     isRelayer = false;
@@ -247,7 +250,7 @@
                   </div>
                 </h4>
                 <div class="f-items-center space-x-1">
-                  <Status bridgeTxStatus={bridgeTx.status} {bridgeTx} textOnly />
+                  <Status bridgeTxStatus={effectiveStatus} {bridgeTx} textOnly />
                 </div>
               </li>
 

--- a/packages/bridge-ui/src/components/Transactions/Status/Status.component.test.ts
+++ b/packages/bridge-ui/src/components/Transactions/Status/Status.component.test.ts
@@ -1,0 +1,124 @@
+/**
+ * A transaction row must not leave listeners on the shared per-hash poller.
+ *
+ * onMount awaits an RPC before it starts polling. If the row is unmounted during that
+ * await, onDestroy runs while `polling` is still undefined and therefore cleans up
+ * nothing; the suspended callback then resumes, attaches handlers, and nobody ever
+ * removes them - so the emitter keeps a subscriber and polling never stops.
+ */
+import { tick } from 'svelte';
+import { vi } from 'vitest';
+
+vi.mock('svelte-i18n', async () => {
+  const { readable } = await import('svelte/store');
+  return { t: readable((key: string) => key), locale: readable('en'), init: vi.fn(), addMessages: vi.fn() };
+});
+
+const isTransactionProcessable = vi.fn();
+vi.mock('$libs/bridge/isTransactionProcessable', () => ({
+  isTransactionProcessable: (...args: unknown[]) => isTransactionProcessable(...args),
+}));
+
+const startPolling = vi.fn();
+vi.mock('$libs/polling/messageStatusPoller', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$libs/polling/messageStatusPoller')>()),
+  startPolling: (...args: unknown[]) => startPolling(...args),
+}));
+
+import { account } from '$stores/account';
+
+import Status from './Status.svelte';
+
+const bridgeTx = { msgStatus: 0, srcTxHash: '0x1', msgHash: '0x2' } as never;
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await tick();
+};
+
+/** A stand-in for the shared per-hash poller, tracking what is attached to it */
+const makePoller = () => {
+  const listeners: Record<string, unknown[]> = {};
+  const emitter = {
+    on: (event: string, handler: unknown) => {
+      (listeners[event] ??= []).push(handler);
+    },
+  };
+  return {
+    listeners,
+    handle: {
+      emitter,
+      destroy: (handlers: Record<string, unknown>) => {
+        for (const [event, handler] of Object.entries(handlers)) {
+          listeners[event] = (listeners[event] ?? []).filter((h) => h !== handler);
+        }
+      },
+    },
+    attachedCount: () => Object.values(listeners).reduce((total, l) => total + l.length, 0),
+  };
+};
+
+let target: HTMLElement;
+
+beforeEach(() => {
+  isTransactionProcessable.mockReset();
+  startPolling.mockReset();
+  account.set({ address: '0xaaaa', isConnected: true } as never);
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => target.remove());
+
+describe('Status row polling lifecycle', () => {
+  it('detaches its listeners on a normal unmount', async () => {
+    const poller = makePoller();
+    startPolling.mockReturnValue(poller.handle);
+    isTransactionProcessable.mockResolvedValue(true);
+
+    const component = new Status({ target, props: { bridgeTx, bridgeTxStatus: null } });
+    await flush();
+    expect(poller.attachedCount()).toBe(2);
+
+    component.$destroy();
+    expect(poller.attachedCount()).toBe(0);
+  });
+
+  it('does not attach listeners when unmounted during the initial processability read', async () => {
+    const poller = makePoller();
+    startPolling.mockReturnValue(poller.handle);
+
+    let resolveRead!: (value: boolean) => void;
+    isTransactionProcessable.mockReturnValue(new Promise<boolean>((resolve) => (resolveRead = resolve)));
+
+    const component = new Status({ target, props: { bridgeTx, bridgeTxStatus: null } });
+    await tick();
+
+    // Unmounted while the read is still pending: onDestroy sees no poller yet
+    component.$destroy();
+
+    resolveRead(true);
+    await flush();
+
+    // Nothing may be left subscribed to the shared emitter
+    expect(poller.attachedCount()).toBe(0);
+  });
+
+  it('does not even join the poller after teardown', async () => {
+    const poller = makePoller();
+    startPolling.mockReturnValue(poller.handle);
+
+    let resolveRead!: (value: boolean) => void;
+    isTransactionProcessable.mockReturnValue(new Promise<boolean>((resolve) => (resolveRead = resolve)));
+
+    const component = new Status({ target, props: { bridgeTx, bridgeTxStatus: null } });
+    await tick();
+    component.$destroy();
+
+    resolveRead(true);
+    await flush();
+
+    // Joining would restart the interval for a row nobody is looking at
+    expect(startPolling).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bridge-ui/src/components/Transactions/Status/Status.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Status/Status.svelte
@@ -85,10 +85,17 @@
     if (bridgeTx && $account?.address) {
       bridgeTxStatus = bridgeTx.msgStatus;
 
-      // Can we start claiming/retrying/releasing?
-      isProcessable = await isTransactionProcessable(bridgeTx);
-
       try {
+        // Can we start claiming/retrying/releasing? A single failed read here must not
+        // prevent polling from starting: the poller re-reads this on every tick, so
+        // leaving it false is recoverable while never starting the poller is not.
+        try {
+          isProcessable = await isTransactionProcessable(bridgeTx);
+        } catch (err) {
+          console.warn('Could not determine whether the transaction is processable', err);
+          isProcessable = false;
+        }
+
         polling = startPolling(bridgeTx);
 
         // If there is no emitter, means the bridgeTx is already DONE

--- a/packages/bridge-ui/src/components/Transactions/Status/Status.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Status/Status.svelte
@@ -81,6 +81,20 @@
     }
   }
 
+  // The row can be unmounted while the read below is still pending. onDestroy then finds
+  // no poller to clean up, so anything attached afterwards would never be detached from
+  // the shared per-hash emitter and would keep it polling forever.
+  let destroyed = false;
+
+  /** Detach this row's listeners; polling itself stops once no subscriber is left */
+  const detachPolling = () => {
+    if (!polling) return;
+    polling.destroy({
+      [PollingEvent.PROCESSABLE]: onProcessable,
+      [PollingEvent.STATUS]: onStatusChange,
+    });
+  };
+
   onMount(async () => {
     if (bridgeTx && $account?.address) {
       bridgeTxStatus = bridgeTx.msgStatus;
@@ -95,6 +109,8 @@
           console.warn('Could not determine whether the transaction is processable', err);
           isProcessable = false;
         }
+
+        if (destroyed) return;
 
         polling = startPolling(bridgeTx);
 
@@ -113,13 +129,8 @@
   });
 
   onDestroy(() => {
-    if (polling) {
-      // Only detach this row's listeners; polling itself stops once no subscriber is left
-      polling.destroy({
-        [PollingEvent.PROCESSABLE]: onProcessable,
-        [PollingEvent.STATUS]: onStatusChange,
-      });
-    }
+    destroyed = true;
+    detachPolling();
   });
 </script>
 

--- a/packages/bridge-ui/src/components/Transactions/Status/Status.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Status/Status.svelte
@@ -107,7 +107,11 @@
 
   onDestroy(() => {
     if (polling) {
-      polling.destroy();
+      // Only detach this row's listeners; polling itself stops once no subscriber is left
+      polling.destroy({
+        [PollingEvent.PROCESSABLE]: onProcessable,
+        [PollingEvent.STATUS]: onStatusChange,
+      });
     }
   });
 </script>

--- a/packages/bridge-ui/src/components/Transactions/Transactions.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Transactions.svelte
@@ -86,19 +86,34 @@
     refresh();
   };
 
-  const updateTransactions = async (address: Address) => {
-    if (loadingTxs) return;
-    loadingTxs = true;
-    const { mergedTransactions, outdatedLocalTransactions, error } = await fetchTransactions(address);
-    transactions = mergedTransactions;
+  // Newer fetches (account switch, manual refresh) supersede older in-flight ones,
+  // whose late results must not overwrite the newer data
+  let fetchGeneration = 0;
+  let inFlightAddress: Address | null = null;
 
-    if (outdatedLocalTransactions.length > 0) {
-      await bridgeTxService.removeTransactions(address, outdatedLocalTransactions);
+  const updateTransactions = async (address: Address) => {
+    // A same-address fetch is already running; a different address must go through
+    if (loadingTxs && inFlightAddress === address) return;
+    const generation = ++fetchGeneration;
+    inFlightAddress = address;
+    loadingTxs = true;
+    try {
+      const { mergedTransactions, outdatedLocalTransactions, error } = await fetchTransactions(address);
+      if (generation !== fetchGeneration) return;
+      transactions = mergedTransactions;
+
+      if (outdatedLocalTransactions.length > 0) {
+        await bridgeTxService.removeTransactions(address, outdatedLocalTransactions);
+      }
+      if (error) {
+        warningToast({ title: $t('transactions.errors.relayer_offline') });
+      }
+    } finally {
+      if (generation === fetchGeneration) {
+        loadingTxs = false;
+        inFlightAddress = null;
+      }
     }
-    if (error) {
-      warningToast({ title: $t('transactions.errors.relayer_offline') });
-    }
-    loadingTxs = false;
   };
 
   let previousAccount: Account | null = null;
@@ -130,7 +145,21 @@
 
   $: pageSize = isDesktopOrLarger ? transactionConfig.pageSizeDesktop : transactionConfig.pageSizeMobile;
 
-  $: totalItems = filteredTransactions.length;
+  // The paginator must count exactly what is shown: token AND status filtered
+  $: totalItems = tokenAndStatusFilteredTransactions.length;
+
+  $: totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+
+  let previousStatusFilter: MessageStatus | null = null;
+  $: if (selectedStatus !== previousStatusFilter) {
+    previousStatusFilter = selectedStatus;
+    currentPage = 1;
+  }
+
+  // Keep the current page in range when filters, data, or page size change
+  $: if (currentPage > totalPages) {
+    currentPage = totalPages;
+  }
 
   // Some shortcuts to make the code more readable
   $: isConnected = $account?.isConnected;
@@ -298,7 +327,7 @@
   </Card>
 
   <div class="flex justify-center lg:justify-end pb-5">
-    <Paginator {pageSize} {totalItems} on:pageChange={({ detail }) => handlePageChange(detail)} />
+    <Paginator bind:currentPage {pageSize} {totalItems} on:pageChange={({ detail }) => handlePageChange(detail)} />
   </div>
 
   <StatusFilterDialog bind:selectedStatus bind:menuOpen />

--- a/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC20Bridge.ts
@@ -81,9 +81,7 @@ export class ERC20Bridge extends Bridge {
   }
 
   async estimateGas(args: ERC20BridgeArgs) {
-    isBridgePaused().then((paused) => {
-      if (paused) throw new BridgePausedError('Bridge is paused');
-    });
+    if (await isBridgePaused()) throw new BridgePausedError('Bridge is paused');
 
     const { tokenVaultContract, sendERC20Args } = await ERC20Bridge._prepareTransaction(args as ERC20BridgeArgs);
     const { fee } = sendERC20Args;
@@ -100,9 +98,7 @@ export class ERC20Bridge extends Bridge {
   }
 
   async getAllowance({ amount, tokenAddress, ownerAddress, spenderAddress }: RequireAllowanceArgs) {
-    isBridgePaused().then((paused) => {
-      if (paused) throw new BridgePausedError('Bridge is paused');
-    });
+    if (await isBridgePaused()) throw new BridgePausedError('Bridge is paused');
 
     log('Checking allowance for the amount', amount);
     const allowance = await readContract(config, {

--- a/packages/bridge-ui/src/libs/bridge/ERC721Bridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ERC721Bridge.ts
@@ -1,6 +1,6 @@
 import { getWalletClient, readContract, simulateContract, writeContract } from '@wagmi/core';
 import { get } from 'svelte/store';
-import { getContract, UserRejectedRequestError } from 'viem';
+import { getAddress, getContract, UserRejectedRequestError } from 'viem';
 
 import { erc721Abi, erc721VaultAbi } from '$abi';
 import { destOwnerAddress, gasLimitZero } from '$components/Bridge/state';
@@ -30,12 +30,11 @@ export class ERC721Bridge extends Bridge {
     super(prover);
   }
 
-  async requiresApproval({ tokenAddress, spenderAddress, tokenId }: RequireApprovalArgs) {
-    isBridgePaused().then((paused) => {
-      if (paused) throw new BridgePausedError('Bridge is paused');
-    });
+  async requiresApproval({ tokenAddress, spenderAddress, tokenId, owner }: RequireApprovalArgs) {
+    if (await isBridgePaused()) throw new BridgePausedError('Bridge is paused');
 
-    const chainId = (await getWalletClient(config)).chain.id;
+    const wallet = await getWalletClient(config);
+    const chainId = wallet.chain.id;
 
     log('Checking approval for token ', tokenId);
 
@@ -46,22 +45,40 @@ export class ERC721Bridge extends Bridge {
       args: [tokenId],
       chainId,
     });
-    const requiresApproval = approvedAddress !== spenderAddress;
-    log(`Token with ID ${tokenId} requires approval ${spenderAddress}: ${requiresApproval}`);
-    return requiresApproval;
+
+    // Addresses can differ in casing between config and chain, so compare checksummed
+    if (getAddress(approvedAddress) === getAddress(spenderAddress)) {
+      log(`Token with ID ${tokenId} already approved for ${spenderAddress}`);
+      return false;
+    }
+
+    // An operator-level approval covers the token as well
+    const operator = owner ?? wallet.account.address;
+    const isApprovedForAll = await readContract(config, {
+      abi: erc721Abi,
+      address: tokenAddress,
+      functionName: 'isApprovedForAll',
+      args: [operator, spenderAddress],
+      chainId,
+    });
+    if (isApprovedForAll) {
+      log(`Owner ${operator} has approved ${spenderAddress} for all tokens`);
+      return false;
+    }
+
+    log(`Token with ID ${tokenId} requires approval for ${spenderAddress}`);
+    return true;
   }
 
   async estimateGas(args: ERC721BridgeArgs): Promise<bigint> {
-    isBridgePaused().then((paused) => {
-      if (paused) throw new BridgePausedError('Bridge is paused');
-    });
+    if (await isBridgePaused()) throw new BridgePausedError('Bridge is paused');
 
     const { tokenVaultContract, sendERC721Args } = await ERC721Bridge._prepareTransaction(args);
     const { fee: value } = sendERC721Args;
 
     log('Estimating gas for sendERC721 call with value', value);
 
-    const estimatedGas = tokenVaultContract.estimateGas.sendToken([sendERC721Args], { value });
+    const estimatedGas = await tokenVaultContract.estimateGas.sendToken([sendERC721Args], { value });
 
     log('Gas estimated', estimatedGas);
 

--- a/packages/bridge-ui/src/libs/bridge/ETHBridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/ETHBridge.ts
@@ -96,9 +96,7 @@ export class ETHBridge extends Bridge {
   }
 
   async bridge(args: ETHBridgeArgs) {
-    isBridgePaused().then((paused) => {
-      if (paused) throw new BridgePausedError('Bridge is paused');
-    });
+    if (await isBridgePaused()) throw new BridgePausedError('Bridge is paused');
 
     const { bridgeContract, message } = await ETHBridge._prepareTransaction(args);
     const { value: callValue, fee: processingFee } = message;

--- a/packages/bridge-ui/src/libs/bridge/estimateCostOfBridging.ts
+++ b/packages/bridge-ui/src/libs/bridge/estimateCostOfBridging.ts
@@ -12,8 +12,11 @@ export async function estimateCostOfBridging(
   const publicClient = getPublicClient(config);
   if (!publicClient) throw new Error('No public client found');
 
-  // Calculate the estimated cost of bridging
+  // Calculate the estimated cost of bridging. Reserve using the EIP-1559 max fee the wallet
+  // will actually lock up, not the legacy gas price, which under-reserves and can make a
+  // MAX-amount transaction fail with insufficient funds
   const estimatedGas = await bridge.estimateGas(bridgeArgs);
-  const gasPrice = await publicClient.getGasPrice();
-  return estimatedGas * gasPrice;
+  const { maxFeePerGas } = await publicClient.estimateFeesPerGas();
+  const feePerGas = maxFeePerGas ?? (await publicClient.getGasPrice());
+  return estimatedGas * feePerGas;
 }

--- a/packages/bridge-ui/src/libs/bridge/fetchNFTs.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchNFTs.ts
@@ -37,7 +37,7 @@ export const fetchNFTs = async ({
     return { nfts, error: null };
   } catch (error) {
     console.error('Fetch error:', error);
-    return { nfts: [], error: new Error('') };
+    return { nfts: [], error: error instanceof Error ? error : new Error(String(error)) };
   }
 };
 
@@ -59,16 +59,16 @@ const fetchL1NFTs = async ({
     body: JSON.stringify({ address: userAddress, chainId: srcChainId, refresh }),
   });
 
-  if (moralisResponse.ok) {
-    const responseData = await moralisResponse.json();
-    log('cursor', responseData);
-    const { nfts } = responseData;
-
-    return nfts;
-  } else {
-    console.error('HTTP error:', moralisResponse.statusText);
-    return { nfts: [], error: new Error(moralisResponse.statusText) };
+  if (!moralisResponse.ok) {
+    // Throw instead of returning a foreign shape: the caller maps over the result as NFT[]
+    throw new Error(`Failed to fetch L1 NFTs: ${moralisResponse.status} ${moralisResponse.statusText}`);
   }
+
+  const responseData = await moralisResponse.json();
+  log('cursor', responseData);
+  const { nfts } = responseData;
+
+  return nfts;
 };
 
 const fetchL2NFTs = async ({

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
@@ -1,0 +1,98 @@
+import type { Address } from 'viem';
+
+import { fetchTransactions } from './fetchTransactions';
+import { type BridgeTransaction, MessageStatus } from './types';
+
+vi.mock('$libs/relayer', () => ({
+  relayerApiServices: [
+    {
+      getAllBridgeTransactionByAddress: vi.fn(),
+    },
+  ],
+}));
+
+vi.mock('$libs/storage', () => ({
+  bridgeTxService: {
+    getAllTxByAddress: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import { relayerApiServices } from '$libs/relayer';
+
+const ADDRESS = '0x1111111111111111111111111111111111111111' as Address;
+
+const getAllByAddress = vi.mocked(relayerApiServices[0].getAllBridgeTransactionByAddress);
+
+const tx = (srcTxHash: string, msgStatus?: MessageStatus) => ({ srcTxHash, msgStatus }) as unknown as BridgeTransaction;
+
+const page = (txs: BridgeTransaction[], max_page: number) => ({
+  txs,
+  paginationInfo: { page: 0, size: 500, total: txs.length, total_pages: 1, first: true, last: true, max_page },
+});
+
+describe('fetchTransactions', () => {
+  beforeEach(() => {
+    getAllByAddress.mockReset();
+  });
+
+  it('does not keep reporting an error after the relayer has recovered', async () => {
+    // Given: the first fetch fails
+    getAllByAddress.mockRejectedValueOnce(new Error('relayer down'));
+    const failed = await fetchTransactions(ADDRESS);
+    expect(failed.error).toBeInstanceOf(Error);
+
+    // When: the next fetch succeeds
+    getAllByAddress.mockResolvedValueOnce(page([tx('0xa')], 0));
+    const recovered = await fetchTransactions(ADDRESS);
+
+    // Then: no stale error survives from the earlier failure
+    expect(recovered.error).toBeUndefined();
+    expect(recovered.mergedTransactions).toHaveLength(1);
+  });
+
+  it('fetches all relayer pages and deduplicates transactions across them', async () => {
+    getAllByAddress
+      .mockResolvedValueOnce(page([tx('0xa'), tx('0xb')], 1))
+      .mockResolvedValueOnce(page([tx('0xb'), tx('0xc')], 1));
+
+    const { mergedTransactions } = await fetchTransactions(ADDRESS);
+
+    expect(getAllByAddress).toHaveBeenCalledTimes(2);
+    expect(getAllByAddress).toHaveBeenNthCalledWith(1, ADDRESS, { page: 0, size: 500 }, undefined);
+    expect(getAllByAddress).toHaveBeenNthCalledWith(2, ADDRESS, { page: 1, size: 500 }, undefined);
+    expect(mergedTransactions.map((transaction) => transaction.srcTxHash).sort()).toEqual(['0xa', '0xb', '0xc']);
+  });
+
+  it('stops after the first page when the relayer reports no further pages', async () => {
+    getAllByAddress.mockResolvedValueOnce(page([tx('0xa')], 0));
+
+    await fetchTransactions(ADDRESS);
+
+    expect(getAllByAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it('sorts actionable statuses first and keeps RECALLED between FAILED and DONE', async () => {
+    getAllByAddress.mockResolvedValueOnce(
+      page(
+        [
+          tx('0xdone', MessageStatus.DONE),
+          tx('0xrecalled', MessageStatus.RECALLED),
+          tx('0xnew', MessageStatus.NEW),
+          tx('0xfailed', MessageStatus.FAILED),
+          tx('0xretriable', MessageStatus.RETRIABLE),
+        ],
+        0,
+      ),
+    );
+
+    const { mergedTransactions } = await fetchTransactions(ADDRESS);
+
+    expect(mergedTransactions.map((transaction) => transaction.srcTxHash)).toEqual([
+      '0xnew',
+      '0xretriable',
+      '0xfailed',
+      '0xrecalled',
+      '0xdone',
+    ]);
+  });
+});

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
@@ -71,6 +71,27 @@ describe('fetchTransactions', () => {
     expect(getAllByAddress).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the pages already fetched when a later page fails', async () => {
+    getAllByAddress
+      .mockResolvedValueOnce(page([tx('0xa')], 3))
+      .mockRejectedValueOnce(new Error('relayer page 2 blew up'));
+
+    const { mergedTransactions, error } = await fetchTransactions(ADDRESS);
+
+    // The first page survives and the fetch is not reported as a total failure
+    expect(mergedTransactions.map((transaction) => transaction.srcTxHash)).toEqual(['0xa']);
+    expect(error).toBeUndefined();
+  });
+
+  it('reports the error when the very first page fails', async () => {
+    getAllByAddress.mockRejectedValueOnce(new Error('relayer down'));
+
+    const { mergedTransactions, error } = await fetchTransactions(ADDRESS);
+
+    expect(mergedTransactions).toHaveLength(0);
+    expect(error).toBeInstanceOf(Error);
+  });
+
   it('sorts actionable statuses first and keeps RECALLED between FAILED and DONE', async () => {
     getAllByAddress.mockResolvedValueOnce(
       page(

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
@@ -21,11 +21,21 @@ async function fetchAllRelayerPages(
   const txs: BridgeTransaction[] = [];
 
   for (let page = 0; page < MAX_RELAYER_PAGES; page++) {
-    const { txs: pageTxs, paginationInfo } = await relayerApiService.getAllBridgeTransactionByAddress(
-      userAddress,
-      { page, size: RELAYER_PAGE_SIZE },
-      chainId,
-    );
+    let pageTxs;
+    let paginationInfo;
+    try {
+      ({ txs: pageTxs, paginationInfo } = await relayerApiService.getAllBridgeTransactionByAddress(
+        userAddress,
+        { page, size: RELAYER_PAGE_SIZE },
+        chainId,
+      ));
+    } catch (error) {
+      // Keep the pages already fetched: losing a later page should degrade the history,
+      // not blank it. With nothing fetched yet the caller still needs to hear about it.
+      if (txs.length === 0) throw error;
+      log(`relayer page ${page} failed, returning ${txs.length} transactions already fetched`, error);
+      break;
+    }
     txs.push(...pageTxs);
 
     if (paginationInfo.max_page === undefined || page >= paginationInfo.max_page) break;

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
@@ -8,22 +8,45 @@ import { mergeAndCaptureOutdatedTransactions } from '$libs/util/mergeTransaction
 import { type BridgeTransaction, MessageStatus } from './types';
 
 const log = getLogger('bridge:fetchTransactions');
-let error: Error;
+
+const RELAYER_PAGE_SIZE = 500;
+// Backstop against unbounded relayer histories; each page is one API call
+const MAX_RELAYER_PAGES = 10;
+
+async function fetchAllRelayerPages(
+  relayerApiService: (typeof relayerApiServices)[number],
+  userAddress: Address,
+  chainId?: number,
+): Promise<BridgeTransaction[]> {
+  const txs: BridgeTransaction[] = [];
+
+  for (let page = 0; page < MAX_RELAYER_PAGES; page++) {
+    const { txs: pageTxs, paginationInfo } = await relayerApiService.getAllBridgeTransactionByAddress(
+      userAddress,
+      { page, size: RELAYER_PAGE_SIZE },
+      chainId,
+    );
+    txs.push(...pageTxs);
+
+    if (paginationInfo.max_page === undefined || page >= paginationInfo.max_page) break;
+    if (page === MAX_RELAYER_PAGES - 1) {
+      log(`relayer history truncated at ${MAX_RELAYER_PAGES} pages for ${userAddress}`);
+    }
+  }
+  return txs;
+}
 
 export async function fetchTransactions(userAddress: Address, chainId?: number) {
+  // The error must be scoped per call: a module-level variable would keep reporting
+  // "relayer offline" on every later, successful fetch
+  let error: Error | undefined = undefined;
+
   // Transactions from local storage
   const localTxs: BridgeTransaction[] = await bridgeTxService.getAllTxByAddress(userAddress);
 
   // Get all transactions from all relayers
   const relayerTxPromises: Promise<BridgeTransaction[]>[] = relayerApiServices.map(async (relayerApiService) => {
-    const { txs } = await relayerApiService.getAllBridgeTransactionByAddress(
-      userAddress,
-      {
-        page: 0,
-        size: 500,
-      },
-      chainId,
-    );
+    const txs = await fetchAllRelayerPages(relayerApiService, userAddress, chainId);
     log(`fetched ${txs?.length ?? 0} transactions from relayer`, txs);
     return txs;
   });
@@ -38,11 +61,18 @@ export async function fetchTransactions(userAddress: Address, chainId?: number) 
     relayerTxsArrays = [];
   }
 
-  // Flatten the arrays into a single array
+  // Flatten the arrays into a single array, dropping duplicate hashes the relayer
+  // may return across pages or relayers
   const relayerTxsFlattened = relayerTxsArrays.reduce((acc, txs) => acc.concat(txs), []);
+  const seenTxHashes = new Set<string>();
+  const dedupedRelayerTxs = relayerTxsFlattened.filter((tx) => {
+    if (seenTxHashes.has(tx.srcTxHash)) return false;
+    seenTxHashes.add(tx.srcTxHash);
+    return true;
+  });
 
   // Reverse the flattened array to sort transactions in descending order, placing the most recent transactions first
-  const relayerTxs: BridgeTransaction[] = relayerTxsFlattened.reverse();
+  const relayerTxs: BridgeTransaction[] = dedupedRelayerTxs.reverse();
 
   log(`fetched ${relayerTxs?.length ?? 0} transactions from all relayers`, relayerTxs);
 
@@ -59,6 +89,7 @@ export async function fetchTransactions(userAddress: Address, chainId?: number) 
     MessageStatus.NEW,
     MessageStatus.RETRIABLE,
     MessageStatus.FAILED,
+    MessageStatus.RECALLED,
     MessageStatus.DONE,
   ];
 

--- a/packages/bridge-ui/src/libs/bridge/getMaxAmountToBridge.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/getMaxAmountToBridge.test.ts
@@ -85,6 +85,8 @@ describe('getMaxAmountToBridge()', () => {
       destChainId: MOCK_ARGS.destChainId,
       bridgeAddress: mockDestBridgeAddress,
       fee: MOCK_FEE,
+      // Without the token object the gas-limit estimation throws and MAX silently fails
+      tokenObject: ETHToken,
     });
   });
 });

--- a/packages/bridge-ui/src/libs/bridge/getMaxAmountToBridge.ts
+++ b/packages/bridge-ui/src/libs/bridge/getMaxAmountToBridge.ts
@@ -31,6 +31,9 @@ export async function getMaxAmountToBridge({ to, token, balance, fee, srcChainId
       destChainId,
       bridgeAddress,
       fee,
+      // Required by the message gas-limit estimation; without it the estimate throws
+      // and the MAX button silently does nothing
+      tokenObject: token,
     } as ETHBridgeArgs;
 
     const estimatedCost = await estimateCostOfBridging(bridges.ETH, bridgeArgs);

--- a/packages/bridge-ui/src/libs/nft/infrastructure/api/MoralisNFTRepository.server.test.ts
+++ b/packages/bridge-ui/src/libs/nft/infrastructure/api/MoralisNFTRepository.server.test.ts
@@ -141,15 +141,27 @@ describe('MoralisNFTRepository.server', () => {
     expect(getWalletNFTs).toHaveBeenNthCalledWith(2, expect.objectContaining({ cursor: 'cursor-page2' }));
   });
 
-  it('keeps already-fetched pages when a later page fails', async () => {
+  it('reports a failed page instead of returning the unchanged list', async () => {
     getWalletNFTs.mockResolvedValueOnce(moralisPage([1], 'cursor-page2'));
     await repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: true });
 
     getWalletNFTs.mockRejectedValueOnce(new Error('rate limited'));
-    const afterFailure = await repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: false });
+
+    // Returning the accumulated list here is indistinguishable from "no more NFTs" and
+    // would retire the caller's "load more" button while the cursor is still good
+    await expect(repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: false })).rejects.toThrow(
+      'rate limited',
+    );
+  });
+
+  it('keeps already-fetched pages and the cursor after a failed page', async () => {
+    getWalletNFTs.mockResolvedValueOnce(moralisPage([1], 'cursor-page2'));
+    await repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: true });
+
+    getWalletNFTs.mockRejectedValueOnce(new Error('rate limited'));
+    await expect(repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: false })).rejects.toThrow();
 
     // The first page survives the failed second page and the cursor is retried next call
-    expect(afterFailure).toEqual([{ tokenId: 1, chainId: CHAIN_ID }]);
     getWalletNFTs.mockResolvedValueOnce(moralisPage([2], null));
     const retried = await repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: false });
     expect(retried).toEqual([
@@ -159,12 +171,11 @@ describe('MoralisNFTRepository.server', () => {
     expect(getWalletNFTs).toHaveBeenLastCalledWith(expect.objectContaining({ cursor: 'cursor-page2' }));
   });
 
-  it('returns an empty array when the Moralis request fails, without caching the failure as complete', async () => {
+  it('does not cache a failure as complete', async () => {
     getWalletNFTs.mockRejectedValueOnce(new Error('rate limited'));
-    const failed = await repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: true });
-    expect(failed).toEqual([]);
+    await expect(repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: true })).rejects.toThrow();
 
-    // A retry goes back to the API instead of returning the empty failure result
+    // A retry goes back to the API instead of reporting the wallet as fully fetched
     getWalletNFTs.mockResolvedValueOnce(moralisPage([7], null));
     const retried = await repository.findByAddress({ address: ADDRESS_A, chainId: CHAIN_ID, refresh: false });
     expect(retried).toEqual([{ tokenId: 7, chainId: CHAIN_ID }]);

--- a/packages/bridge-ui/src/libs/nft/infrastructure/api/MoralisNFTRepository.server.ts
+++ b/packages/bridge-ui/src/libs/nft/infrastructure/api/MoralisNFTRepository.server.ts
@@ -52,11 +52,17 @@ class MoralisNFTRepository implements INFTRepository {
     const previous = this.requestQueueByWallet.get(key) ?? Promise.resolve([]);
     const request = previous.catch(() => []).then(() => this.fetchNextPage({ address, chainId, refresh }));
     this.requestQueueByWallet.set(key, request);
-    void request.finally(() => {
+
+    const releaseSlot = () => {
       if (this.requestQueueByWallet.get(key) === request) {
         this.requestQueueByWallet.delete(key);
       }
-    });
+    };
+    // `.finally()` would build a derived promise that rejects with no handler attached
+    // once a failed page propagates; passing the same callback to both arms of `.then()`
+    // settles that promise either way. The caller still sees the rejection via `request`.
+    void request.then(releaseSlot, releaseSlot);
+
     return request;
   }
 
@@ -85,8 +91,11 @@ class MoralisNFTRepository implements INFTRepository {
       return state.nfts;
     } catch (e) {
       console.error('Failed to fetch NFTs from Moralis:', e);
-      // Keep whatever pages were already fetched; the failed page is retried next call
-      return state.nfts;
+      // The accumulated pages and the cursor stay in `state`, so the failed page is
+      // retried on the next call. The failure itself has to reach the caller: returning
+      // the unchanged list looks exactly like "no more NFTs" and would retire the
+      // "load more" button while the cursor is still good.
+      throw e;
     }
   }
 

--- a/packages/bridge-ui/src/libs/polling/messageStatusPoller.ts
+++ b/packages/bridge-ui/src/libs/polling/messageStatusPoller.ts
@@ -125,8 +125,15 @@ export function startPolling(bridgeTx: BridgeTransaction, runImmediately = true)
 
   const pollingFn = async () => {
     log('Polling for transaction', bridgeTx.srcTxHash);
-    const isProcessable = await isTransactionProcessable(bridgeTx);
-    emitter.emit(PollingEvent.PROCESSABLE, isProcessable);
+
+    try {
+      const isProcessable = await isTransactionProcessable(bridgeTx);
+      emitter.emit(PollingEvent.PROCESSABLE, isProcessable);
+    } catch (err) {
+      // Kept separate from the status read below: one failing must not skip the other,
+      // and neither may escape into setInterval where nothing can catch it
+      console.error('Error while checking whether the transaction is processable, will retry', err);
+    }
 
     try {
       const messageStatus: MessageStatus = await destBridgeContract.read.messageStatus([bridgeTx.msgHash]);

--- a/packages/bridge-ui/src/libs/polling/messageStatusPoller.ts
+++ b/packages/bridge-ui/src/libs/polling/messageStatusPoller.ts
@@ -43,10 +43,12 @@ const hashIntervalMap: Record<Hash, Interval> = {};
  *   const { emitter, stopPolling } = startPolling(bridgeTx);
  *
  *   if(emitter) {
- *     emitter.on(PollingEvent.STOP, () => {});
- *     emitter.on(PollingEvent.STATUS, (status: MessageStatus) => {});
- *     emitter.on(PollingEvent.PROCESSABLE, (isProcessable: boolean) => {});
+ *     emitter.on(PollingEvent.STOP, onStop);
+ *     emitter.on(PollingEvent.STATUS, onStatus);
+ *     emitter.on(PollingEvent.PROCESSABLE, onProcessable);
  *   }
+ *   // on teardown, pass back exactly the handlers that were added:
+ *   // destroy({ [PollingEvent.STATUS]: onStatus, [PollingEvent.PROCESSABLE]: onProcessable })
  * } catch (err) {
  *   // something really bad with this bridgeTx
  * }
@@ -109,15 +111,12 @@ export function startPolling(bridgeTx: BridgeTransaction, runImmediately = true)
     }
   };
 
-  const destroy = (handlers?: PollingHandlers) => {
-    if (handlers) {
-      // Remove only this subscriber's listeners: the emitter is shared between all
-      // subscribers of the same transaction hash
-      for (const [event, handler] of Object.entries(handlers)) {
-        if (handler) emitter.removeListener(event, handler);
-      }
-    } else {
-      emitter.removeAllListeners();
+  // `handlers` is required: the emitter is shared by every subscriber of the same
+  // transaction hash, so a subscriber may only ever remove the handlers it added.
+  // A no-arg teardown would silently stop polling for all other rows.
+  const destroy = (handlers: PollingHandlers) => {
+    for (const [event, handler] of Object.entries(handlers)) {
+      if (handler) emitter.removeListener(event, handler);
     }
 
     const hasListeners = Object.values(PollingEvent).some((event) => emitter.listenerCount(event) > 0);

--- a/packages/bridge-ui/src/libs/polling/messageStatusPoller.ts
+++ b/packages/bridge-ui/src/libs/polling/messageStatusPoller.ts
@@ -26,6 +26,9 @@ export enum PollingEvent {
 
 type Interval = Maybe<ReturnType<typeof setInterval>>;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PollingHandlers = Partial<Record<PollingEvent, (...args: any[]) => void>>;
+
 // bridgeTx hash => emitter. If there is already a polling ongoing
 // we return the emitter associated to it
 const hashEmitterMap: Record<Hash, EventEmitter> = {};
@@ -106,9 +109,19 @@ export function startPolling(bridgeTx: BridgeTransaction, runImmediately = true)
     }
   };
 
-  const destroy = () => {
-    stopPolling();
-    emitter.removeAllListeners();
+  const destroy = (handlers?: PollingHandlers) => {
+    if (handlers) {
+      // Remove only this subscriber's listeners: the emitter is shared between all
+      // subscribers of the same transaction hash
+      for (const [event, handler] of Object.entries(handlers)) {
+        if (handler) emitter.removeListener(event, handler);
+      }
+    } else {
+      emitter.removeAllListeners();
+    }
+
+    const hasListeners = Object.values(PollingEvent).some((event) => emitter.listenerCount(event) > 0);
+    if (!hasListeners) stopPolling();
   };
 
   const pollingFn = async () => {
@@ -133,7 +146,11 @@ export function startPolling(bridgeTx: BridgeTransaction, runImmediately = true)
 
       let blockNumber: Hex;
       if (!bridgeTx.blockNumber) {
-        const receipt = await getTransactionReceipt(config, { hash: bridgeTx.srcTxHash });
+        // The bridge tx lives on the source chain; the wallet may be connected elsewhere
+        const receipt = await getTransactionReceipt(config, {
+          hash: bridgeTx.srcTxHash,
+          chainId: Number(srcChainId),
+        });
         blockNumber = toHex(receipt.blockNumber);
         bridgeTx.blockNumber = blockNumber;
       }
@@ -143,9 +160,9 @@ export function startPolling(bridgeTx: BridgeTransaction, runImmediately = true)
         stopPolling();
       }
     } catch (err) {
-      console.error(err);
-      stopPolling();
-      throw new BridgeTxPollingError('something bad happened while polling for status', { cause: err });
+      // A transient RPC failure must not permanently end polling for this transaction;
+      // the next interval tick simply tries again
+      console.error('Error while polling for message status, will retry', err);
     }
   };
 

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
@@ -773,6 +773,20 @@ describe('RelayerAPIService', () => {
     expect(parseApiBigInt(parseRelayerApiResponse(rawResponse).items[0].data.Message.DestChainId)).toEqual(167000n);
   });
 
+  test('parseRelayerApiResponse also preserves the top-level amount and fee digits', () => {
+    // Given: amounts above 2^53 wei (anything over ~0.009 ETH) lose digits as JSON doubles
+    const exactAmount = 1_234_567_890_123_456_789n;
+    const exactTopLevelFee = 9_007_199_254_740_993n;
+    const rawResponse = `{"items":[{"amount":${exactAmount},"fee":${exactTopLevelFee},"data":{"Message":{"Fee":1}}}]}`;
+
+    // When
+    const parsed = parseRelayerApiResponse(rawResponse);
+
+    // Then
+    expect(BigInt(parsed.items[0].amount)).toEqual(exactAmount);
+    expect(BigInt(parsed.items[0].fee!)).toEqual(exactTopLevelFee);
+  });
+
   test('parseRelayerApiResponse ignores escaped Fee-like text inside string values', () => {
     // Given
     const exactFee = 9_007_199_254_740_993n;

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
@@ -500,6 +500,7 @@ export class RelayerAPIService {
 
       const tokenType: TokenType = _eventToTokenType(tx.eventType);
 
+      const relayerFee = tx.fee ? parseApiBigInt(tx.fee) : undefined;
       const messageFee = parseApiBigInt(tx.data.Message.Fee);
       const messageValue = parseApiBigInt(tx.data.Message.Value);
       const messageId = parseApiBigInt(tx.data.Message.Id);
@@ -522,7 +523,7 @@ export class RelayerAPIService {
         canonicalTokenAddress: tx.canonicalTokenAddress,
         processingFee: messageFee,
         claimedBy: tx.claimedBy ? getAddress(tx.claimedBy) : undefined,
-        fee: tx.fee && BigInt(tx.fee) !== BigInt(0) ? BigInt(tx.fee) : undefined,
+        fee: relayerFee && relayerFee !== BigInt(0) ? relayerFee : undefined,
         message: {
           id: messageId,
           to: getAddress(tx.data.Message.To),

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
@@ -38,7 +38,7 @@ import {
 
 const log = getLogger('RelayerAPIService');
 
-const relayerMessageIntegerFields = ['Fee', 'Value', 'Id', 'SrcChainId', 'DestChainId'];
+const relayerMessageIntegerFields = ['Fee', 'Value', 'Id', 'SrcChainId', 'DestChainId', 'amount', 'fee'];
 const relayerMessageIntegerPattern = new RegExp(`("(${relayerMessageIntegerFields.join('|')})"\\s*:\\s*)(\\d+)`, 'g');
 type DecodedBridgeMessage = Omit<Message, 'gasLimit'> & { gasLimit: bigint | number };
 type BridgeTransactionAssetDetails = {
@@ -450,13 +450,46 @@ export class RelayerAPIService {
       max_page,
     };
 
-    if (apiTxs.items?.length === 0) {
+    if (!apiTxs.items || apiTxs.items.length === 0) {
       return { txs: [], paginationInfo };
     }
 
     const items = RelayerAPIService._filterDuplicateAndWrongBridge(apiTxs.items);
 
-    const txs: BridgeTransaction[] = items.map((tx: APIResponseTransaction) => {
+    const txs: BridgeTransaction[] = items
+      .map((tx: APIResponseTransaction) => {
+        try {
+          return RelayerAPIService._transformTransaction(tx);
+        } catch (error) {
+          log('Skipping malformed relayer transaction', { error, tx });
+          return null;
+        }
+      })
+      .filter((tx): tx is BridgeTransaction => tx !== null);
+
+    const txsPromises = txs.map(async (bridgeTx) => {
+      if (!bridgeTx) return;
+      try {
+        return await RelayerAPIService._enhanceTransaction(bridgeTx, address);
+      } catch (error) {
+        // One failing RPC read must not reject the surrounding Promise.all and wipe the list
+        log('Skipping transaction that failed to enhance', { error, srcTxHash: bridgeTx.srcTxHash });
+        return;
+      }
+    });
+
+    const bridgeTxs: BridgeTransaction[] = (await Promise.all(txsPromises)).filter((tx): tx is BridgeTransaction =>
+      Boolean(tx),
+    ); // Removes undefined values
+
+    // Spreading to preserve original txs in case of array mutation
+    log('Enhanced transactions', [...bridgeTxs]);
+
+    return { txs: bridgeTxs, paginationInfo };
+  }
+
+  private static _transformTransaction(tx: APIResponseTransaction): BridgeTransaction {
+    {
       let data: string | Hex = tx.data.Message.Data;
       if (data === '') {
         data = '0x' as Hex;
@@ -489,7 +522,7 @@ export class RelayerAPIService {
         canonicalTokenAddress: tx.canonicalTokenAddress,
         processingFee: messageFee,
         claimedBy: tx.claimedBy ? getAddress(tx.claimedBy) : undefined,
-        fee: tx.fee ? BigInt(tx.fee) : undefined,
+        fee: tx.fee && BigInt(tx.fee) !== BigInt(0) ? BigInt(tx.fee) : undefined,
         message: {
           id: messageId,
           to: getAddress(tx.data.Message.To),
@@ -506,11 +539,14 @@ export class RelayerAPIService {
       } satisfies BridgeTransaction;
 
       return transformedTx;
-    });
+    }
+  }
 
-    const txsPromises = txs.map(async (bridgeTx) => {
-      if (!bridgeTx) return;
-
+  private static async _enhanceTransaction(
+    bridgeTx: BridgeTransaction,
+    address: Address,
+  ): Promise<BridgeTransaction | undefined> {
+    {
       const senderMatch = getAddress(bridgeTx.from) === getAddress(address);
       const receiverMatch = bridgeTx.message && getAddress(bridgeTx.message.destOwner) === getAddress(address);
 
@@ -592,16 +628,7 @@ export class RelayerAPIService {
       bridgeTx.status = msgStatus;
 
       return bridgeTx;
-    });
-
-    const bridgeTxs: BridgeTransaction[] = (await Promise.all(txsPromises)).filter((tx): tx is BridgeTransaction =>
-      Boolean(tx),
-    ); // Removes undefined values
-
-    // Spreading to preserve original txs in case of array mutation
-    log('Enhanced transactions', [...bridgeTxs]);
-
-    return { txs: bridgeTxs, paginationInfo };
+    }
   }
 
   async getBlockInfo(): Promise<Record<number, RelayerBlockInfo>> {

--- a/packages/bridge-ui/src/libs/storage/CustomTokenService.test.ts
+++ b/packages/bridge-ui/src/libs/storage/CustomTokenService.test.ts
@@ -204,6 +204,56 @@ describe('CustomTokenService', () => {
     expect(actual).toStrictEqual([token1Updated, token2]);
   });
 
+  test('does not merge unrelated tokens sharing an address on different chains', () => {
+    // Given: the same hexadecimal address hosts a different contract on each chain
+    const SHARED = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+    const onChain1: Token = {
+      name: 'Mainnet Token',
+      addresses: { '1': SHARED as Address },
+      symbol: 'ONE',
+      decimals: 18,
+      type: TokenType.ERC20,
+      imported: true,
+    };
+    const onChain167000: Token = {
+      name: 'L2 Token',
+      addresses: { '167000': SHARED as Address },
+      symbol: 'TWO',
+      decimals: 18,
+      type: TokenType.ERC20,
+      imported: true,
+    };
+    localStorage.setItem(storageKey, JSON.stringify([onChain1]));
+
+    // When
+    const actual = tokenService.updateToken(onChain167000, address);
+
+    // Then: the stored mainnet token is untouched, since no deployment is shared
+    expect(actual).toStrictEqual([onChain1]);
+  });
+
+  test('matches a stored token whose address differs only in casing', () => {
+    // Given
+    const CHECKSUMMED = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+    const stored: Token = {
+      name: 'Casing Token',
+      addresses: { '1': CHECKSUMMED.toLowerCase() as Address },
+      symbol: 'CASE',
+      decimals: 18,
+      type: TokenType.ERC20,
+      imported: true,
+    };
+    const updated: Token = { ...stored, addresses: { '1': CHECKSUMMED as Address, '167000': '0xabc' as Address } };
+    localStorage.setItem(storageKey, JSON.stringify([stored]));
+
+    // When
+    const actual = tokenService.updateToken(updated, address);
+
+    // Then: the same deployment is recognised and merged rather than duplicated
+    expect(actual).toHaveLength(1);
+    expect(actual[0].addresses['167000']).toBe('0xabc');
+  });
+
   test('does not update a non zeroAddress address to zeroAddress', () => {
     // Given
     const token1Updated: Token = {

--- a/packages/bridge-ui/src/libs/storage/CustomTokenService.test.ts
+++ b/packages/bridge-ui/src/libs/storage/CustomTokenService.test.ts
@@ -120,6 +120,56 @@ describe('CustomTokenService', () => {
     expect(actual).toStrictEqual([token2]);
   });
 
+  test('stores two different tokens that share a symbol', () => {
+    // Given: an unrelated token that happens to use the same symbol as token1
+    const sameSymbolToken: Token = {
+      name: 'Impostor Token',
+      addresses: { address1: '0xabc' },
+      symbol: 'TST',
+      decimals: 18,
+      type: TokenType.ERC20,
+      imported: true,
+    };
+    tokenService.storeToken(token1, address);
+
+    // When
+    const actual = tokenService.storeToken(sameSymbolToken, address);
+
+    // Then: both are kept, keyed by address rather than symbol
+    expect(actual).toStrictEqual([token1, sameSymbolToken]);
+  });
+
+  test('does not store the same token twice even when its symbol was edited', () => {
+    // Given
+    tokenService.storeToken(token1, address);
+    const renamedToken1: Token = { ...token1, symbol: 'TST2' };
+
+    // When
+    const actual = tokenService.storeToken(renamedToken1, address);
+
+    // Then
+    expect(actual).toStrictEqual([token1]);
+  });
+
+  test('removes only the token with matching addresses, not a same-symbol impostor', () => {
+    // Given
+    const sameSymbolToken: Token = {
+      name: 'Impostor Token',
+      addresses: { address1: '0xabc' },
+      symbol: 'TST',
+      decimals: 18,
+      type: TokenType.ERC20,
+      imported: true,
+    };
+    localStorage.setItem(storageKey, JSON.stringify([token1, sameSymbolToken]));
+
+    // When
+    const actual = tokenService.removeToken(token1, address);
+
+    // Then
+    expect(actual).toStrictEqual([sameSymbolToken]);
+  });
+
   test('updates token correctly when an address is zeroAddress', () => {
     // Given
     const token2Updated: Token = {

--- a/packages/bridge-ui/src/libs/storage/CustomTokenService.ts
+++ b/packages/bridge-ui/src/libs/storage/CustomTokenService.ts
@@ -109,11 +109,11 @@ export class CustomTokenService implements TokenService {
       filteredAddresses: Object.keys(filteredAddresses).length,
     });
 
-    // Find the stored token to update
+    // Find the stored token to update. Matching on raw address values would merge two
+    // unrelated tokens that happen to share a hexadecimal address on different chains,
+    // and would miss a match that differs only in casing.
     const storedToken = tokens.find((storedToken) =>
-      Object.values(filteredAddresses).some((addressToUpdate) =>
-        Object.values(storedToken.addresses).includes(addressToUpdate),
-      ),
+      tokensAreSame(storedToken, { ...token, addresses: filteredAddresses } as Token),
     );
 
     // If the stored token was found, update its addresses

--- a/packages/bridge-ui/src/libs/storage/CustomTokenService.ts
+++ b/packages/bridge-ui/src/libs/storage/CustomTokenService.ts
@@ -8,6 +8,22 @@ const STORAGE_PREFIX = 'custom-tokens';
 
 const log = getLogger('storage:CustomTokenService');
 
+// Two custom tokens are the same token if they share any real deployment address; the symbol is
+// only a fallback for entries that carry no addresses, since symbols are not unique
+function tokensAreSame(a: Token, b: Token): boolean {
+  const aAddresses = Object.values(a.addresses ?? {}).filter((addr) => addr && addr !== zeroAddress);
+  const bAddresses = new Set(
+    Object.values(b.addresses ?? {})
+      .filter((addr) => addr && addr !== zeroAddress)
+      .map((addr) => addr.toLowerCase()),
+  );
+
+  if (aAddresses.length > 0 && bAddresses.size > 0) {
+    return aAddresses.some((addr) => bAddresses.has(addr.toLowerCase()));
+  }
+  return a.symbol === b.symbol;
+}
+
 export class CustomTokenService implements TokenService {
   private readonly storage: Storage;
 
@@ -39,7 +55,7 @@ export class CustomTokenService implements TokenService {
 
     let doesTokenAlreadyExist = false;
     if (tokens.length > 0) {
-      doesTokenAlreadyExist = tokens.findIndex((tokenFromStorage) => tokenFromStorage.symbol === token.symbol) >= 0;
+      doesTokenAlreadyExist = tokens.findIndex((tokenFromStorage) => tokensAreSame(tokenFromStorage, token)) >= 0;
     }
 
     if (!doesTokenAlreadyExist) {
@@ -76,7 +92,7 @@ export class CustomTokenService implements TokenService {
 
     const tokens: Token[] = this._getTokensFromStorage(address);
 
-    const updatedTokenList = tokens.filter((tokenFromStorage) => tokenFromStorage.symbol !== token.symbol);
+    const updatedTokenList = tokens.filter((tokenFromStorage) => !tokensAreSame(tokenFromStorage, token));
 
     const storageKey = `${STORAGE_PREFIX}-${address.toLowerCase()}`;
     this.storage.setItem(storageKey, JSON.stringify(updatedTokenList));

--- a/packages/bridge-ui/src/libs/storage/CustomTokenService.ts
+++ b/packages/bridge-ui/src/libs/storage/CustomTokenService.ts
@@ -1,28 +1,13 @@
 import { type Address, zeroAddress } from 'viem';
 
 import type { Token, TokenService } from '$libs/token';
+import { tokensAreSame } from '$libs/token/tokenIdentity';
 import { jsonParseWithDefault } from '$libs/util/jsonParseWithDefault';
 import { getLogger } from '$libs/util/logger';
 
 const STORAGE_PREFIX = 'custom-tokens';
 
 const log = getLogger('storage:CustomTokenService');
-
-// Two custom tokens are the same token if they share any real deployment address; the symbol is
-// only a fallback for entries that carry no addresses, since symbols are not unique
-function tokensAreSame(a: Token, b: Token): boolean {
-  const aAddresses = Object.values(a.addresses ?? {}).filter((addr) => addr && addr !== zeroAddress);
-  const bAddresses = new Set(
-    Object.values(b.addresses ?? {})
-      .filter((addr) => addr && addr !== zeroAddress)
-      .map((addr) => addr.toLowerCase()),
-  );
-
-  if (aAddresses.length > 0 && bAddresses.size > 0) {
-    return aAddresses.some((addr) => bAddresses.has(addr.toLowerCase()));
-  }
-  return a.symbol === b.symbol;
-}
 
 export class CustomTokenService implements TokenService {
   private readonly storage: Storage;

--- a/packages/bridge-ui/src/libs/token/fetchNFTImageUrl.ts
+++ b/packages/bridge-ui/src/libs/token/fetchNFTImageUrl.ts
@@ -5,7 +5,7 @@ import { fetchNFTMetadata } from '$libs/token/fetchNFTMetadata';
 import { decodeBase64ToJson } from '$libs/util/decodeBase64ToJson';
 import { getLogger } from '$libs/util/logger';
 import { resolveIPFSUri } from '$libs/util/resolveIPFSUri';
-import { addMetadataToCache, isMetadataCached } from '$stores/metadata';
+import { addMetadataToCache } from '$stores/metadata';
 import { connectedSourceChain } from '$stores/network';
 
 import { getTokenAddresses } from './getTokenAddresses';
@@ -42,12 +42,8 @@ export const fetchNFTImageUrl = async (token: NFT): Promise<NFT> => {
 
     if (!tokenInfo || !tokenInfo.canonical?.address) return token;
 
-    // check cache for existing metadata
-    if (isMetadataCached({ address: tokenInfo.canonical?.address, id: token.tokenId })) {
-      log('found cached metadata for', tokenInfo.canonical?.address, token.metadata);
-      // Update cache
-      addMetadataToCache({ address: tokenInfo.canonical?.address, id: token.tokenId }, token.metadata);
-    }
+    // Store the resolved metadata so the next lookup hits the cache
+    addMetadataToCache({ address: tokenInfo.canonical.address, id: token.tokenId }, token.metadata);
 
     return token;
   } catch (error) {

--- a/packages/bridge-ui/src/libs/token/fetchNFTMetadata.test.ts
+++ b/packages/bridge-ui/src/libs/token/fetchNFTMetadata.test.ts
@@ -29,6 +29,7 @@ describe('fetchNFTMetadata()', () => {
     vi.mock('$stores/metadata', () => ({
       isMetadataCached: vi.fn(),
       getMetadataFromCache: vi.fn(),
+      addMetadataToCache: vi.fn(),
       metadataCache: {
         update: vi.fn(),
       },
@@ -61,6 +62,7 @@ describe('fetchNFTMetadata()', () => {
       vi.mock('$stores/metadata', () => ({
         isMetadataCached: vi.fn(),
         getMetadataFromCache: vi.fn(),
+        addMetadataToCache: vi.fn(),
         metadataCache: {
           update: vi.fn(),
         },
@@ -103,6 +105,7 @@ describe('fetchNFTMetadata()', () => {
       vi.mock('$stores/metadata', () => ({
         isMetadataCached: vi.fn(),
         getMetadataFromCache: vi.fn(),
+        addMetadataToCache: vi.fn(),
         metadataCache: {
           update: vi.fn(),
         },

--- a/packages/bridge-ui/src/libs/token/fetchNFTMetadata.ts
+++ b/packages/bridge-ui/src/libs/token/fetchNFTMetadata.ts
@@ -7,7 +7,7 @@ import { FetchMetadataError, NoMetadataFoundError, WrongChainError } from '$libs
 import { decodeBase64ToJson } from '$libs/util/decodeBase64ToJson';
 import { getLogger } from '$libs/util/logger';
 import { resolveIPFSUri } from '$libs/util/resolveIPFSUri';
-import { getMetadataFromCache, isMetadataCached, metadataCache } from '$stores/metadata';
+import { addMetadataToCache, getMetadataFromCache, isMetadataCached } from '$stores/metadata';
 import { connectedSourceChain } from '$stores/network';
 
 import { getTokenAddresses } from './getTokenAddresses';
@@ -56,14 +56,9 @@ export async function fetchNFTMetadata(token: NFT): Promise<NFTMetadata | null> 
     };
     if (decodedData.image) {
       // Update cache
-      metadataCache.update((cache) => {
-        const key = tokenInfo.canonical?.address;
-
-        if (key) {
-          cache.set(key, metadata);
-        }
-        return cache;
-      });
+      if (tokenInfo.canonical?.address) {
+        addMetadataToCache({ address: tokenInfo.canonical.address, id: token.tokenId }, metadata);
+      }
       return metadata;
     }
   }
@@ -71,13 +66,9 @@ export async function fetchNFTMetadata(token: NFT): Promise<NFTMetadata | null> 
     const crossChainMetadata = await crossChainFetchNFTMetadata(token);
     if (crossChainMetadata && crossChainMetadata.image) {
       // Update cache
-      metadataCache.update((cache) => {
-        const key = tokenInfo.canonical?.address;
-        if (key) {
-          cache.set(key, crossChainMetadata);
-        }
-        return cache;
-      });
+      if (tokenInfo.canonical?.address) {
+        addMetadataToCache({ address: tokenInfo.canonical.address, id: token.tokenId }, crossChainMetadata);
+      }
       return crossChainMetadata;
     }
   }
@@ -93,13 +84,9 @@ export async function fetchNFTMetadata(token: NFT): Promise<NFTMetadata | null> 
 
     if (metadata.image) {
       // Update cache
-      metadataCache.update((cache) => {
-        const key = tokenInfo.canonical?.address;
-        if (key) {
-          cache.set(key, metadata);
-        }
-        return cache;
-      });
+      if (tokenInfo.canonical?.address) {
+        addMetadataToCache({ address: tokenInfo.canonical.address, id: token.tokenId }, metadata);
+      }
       return metadata;
     }
     throw new NoMetadataFoundError('No image in metadata');

--- a/packages/bridge-ui/src/libs/token/getAddress.test.ts
+++ b/packages/bridge-ui/src/libs/token/getAddress.test.ts
@@ -73,5 +73,37 @@ describe('getAddress', () => {
     it('should return undefined if ERC20 and has no address on the source chain and no destination chain is passed in', async () => {
       expect(await getAddress({ token: HORSEToken, srcChainId: Number(PUBLIC_L2_CHAIN_ID) })).toBeUndefined();
     });
+
+    it('should return the canonical address when the canonical deployment is on the source chain', async () => {
+      // The token object does not know its source-chain address, but the canonical
+      // deployment lives there; the bridged deployment is on the destination chain
+      // and must NOT be returned as a source-chain address
+      const tokenWithoutSrcAddress: Token = {
+        ...HORSEToken,
+        addresses: {
+          [PUBLIC_L1_CHAIN_ID]: zeroAddress,
+          [PUBLIC_L2_CHAIN_ID]: L2_TOKEN_ADDRESS,
+        },
+      };
+
+      vi.mocked(getTokenAddresses).mockResolvedValueOnce({
+        canonical: {
+          address: L1_TOKEN_ADDRESS,
+          chainId: PUBLIC_L1_CHAIN_ID,
+        },
+        bridged: {
+          address: L2_TOKEN_ADDRESS,
+          chainId: PUBLIC_L2_CHAIN_ID,
+        },
+      });
+
+      expect(
+        await getAddress({
+          token: tokenWithoutSrcAddress,
+          srcChainId: Number(PUBLIC_L1_CHAIN_ID),
+          destChainId: Number(PUBLIC_L2_CHAIN_ID),
+        }),
+      ).toEqual(L1_TOKEN_ADDRESS);
+    });
   });
 });

--- a/packages/bridge-ui/src/libs/token/getAddress.ts
+++ b/packages/bridge-ui/src/libs/token/getAddress.ts
@@ -29,12 +29,19 @@ export async function getAddress({ token, srcChainId, destChainId }: GetAddressA
     if (!destChainId) return;
 
     const tokenInfo = await getTokenAddresses({ token, srcChainId, destChainId });
-    if (!tokenInfo || !tokenInfo.bridged) {
+    if (!tokenInfo) {
       log('No token info found for', token, srcChainId, destChainId);
       throw new NoTokenInfoFoundError(`Could not find any token info`);
     }
-    const { address: bridgedAddress } = tokenInfo.bridged;
-    address = bridgedAddress;
+
+    // Pick whichever deployment actually lives on the source chain; the bridged deployment
+    // can just as well be on the destination chain, and returning that address here would
+    // point every later call at the wrong chain
+    if (tokenInfo.canonical?.chainId === srcChainId) {
+      address = tokenInfo.canonical.address;
+    } else if (tokenInfo.bridged?.chainId === srcChainId) {
+      address = tokenInfo.bridged.address;
+    }
 
     if (!address || address === zeroAddress) {
       throw new NoTokenAddressError(`no address found for ${token.symbol} on chain ${srcChainId}`);

--- a/packages/bridge-ui/src/libs/token/getCanonicalInfoForToken.ts
+++ b/packages/bridge-ui/src/libs/token/getCanonicalInfoForToken.ts
@@ -41,6 +41,8 @@ export async function getCanonicalInfoForToken({
     log('addresses for both, fetching canonical one');
     for (const [currentSrcChainId, address] of Object.entries(token.addresses)) {
       if (parseInt(currentSrcChainId) === destChainId) continue;
+      // Placeholder entries carry the zero address and must not be treated as deployments
+      if (!address || address === zeroAddress) continue;
 
       // check store first to save some time
       if (isCanonicalAddress(address)) {

--- a/packages/bridge-ui/src/libs/token/getTokenApprovalStatus.ts
+++ b/packages/bridge-ui/src/libs/token/getTokenApprovalStatus.ts
@@ -101,6 +101,8 @@ export const getTokenApprovalStatus = async (token: Maybe<Token | NFT>): Promise
     const nft = token as NFT;
     const ownerShipChecks = await checkOwnershipOfNFT(token as NFT, ownerAddress, currentChainId);
     if (!ownerShipChecks.every((item) => item.isOwner === true)) {
+      // A stale allApproved=true from a previously selected token must not survive
+      allApproved.set(false);
       return ApprovalStatus.APPROVAL_REQUIRED;
     }
     const wallet = await getConnectedWallet();

--- a/packages/bridge-ui/src/libs/token/tokenIdentity.test.ts
+++ b/packages/bridge-ui/src/libs/token/tokenIdentity.test.ts
@@ -1,0 +1,45 @@
+import type { Address } from 'viem';
+
+import { tokenIdentityKey, tokensAreSame } from './tokenIdentity';
+import { type Token, TokenType } from './types';
+
+const token = (overrides: Partial<Token>): Token =>
+  ({
+    name: 'Token',
+    symbol: 'TKN',
+    decimals: 18,
+    type: TokenType.ERC20,
+    addresses: {},
+    ...overrides,
+  }) as Token;
+
+describe('tokensAreSame', () => {
+  it('matches tokens sharing a deployment on the same chain, case-insensitively', () => {
+    const a = token({ addresses: { 1: '0xAbC0000000000000000000000000000000000001' as Address } });
+    const b = token({ symbol: 'OTHER', addresses: { 1: '0xabc0000000000000000000000000000000000001' as Address } });
+    expect(tokensAreSame(a, b)).toBe(true);
+  });
+
+  it('does not match unrelated tokens at the same address on different chains', () => {
+    const a = token({ addresses: { 1: '0xabc0000000000000000000000000000000000001' as Address } });
+    const b = token({ addresses: { 167000: '0xabc0000000000000000000000000000000000001' as Address } });
+    expect(tokensAreSame(a, b)).toBe(false);
+  });
+
+  it('falls back to the symbol only when no addresses are known', () => {
+    expect(tokensAreSame(token({}), token({}))).toBe(true);
+    expect(tokensAreSame(token({}), token({ symbol: 'OTHER' }))).toBe(false);
+  });
+});
+
+describe('tokenIdentityKey', () => {
+  it('produces distinct keys for same-symbol tokens at different deployments', () => {
+    const a = token({ addresses: { 1: '0xabc0000000000000000000000000000000000001' as Address } });
+    const b = token({ addresses: { 1: '0xdef0000000000000000000000000000000000002' as Address } });
+    expect(tokenIdentityKey(a)).not.toEqual(tokenIdentityKey(b));
+  });
+
+  it('falls back to the symbol for address-less tokens', () => {
+    expect(tokenIdentityKey(token({}))).toBe('TKN');
+  });
+});

--- a/packages/bridge-ui/src/libs/token/tokenIdentity.ts
+++ b/packages/bridge-ui/src/libs/token/tokenIdentity.ts
@@ -1,0 +1,44 @@
+import { zeroAddress } from 'viem';
+
+import type { NFT, Token } from './types';
+
+/**
+ * @dev A token's identity is its set of chain-qualified deployments; symbols are not
+ *      unique, and the same hexadecimal address can host unrelated tokens on
+ *      different chains.
+ * @param token The token
+ * @return One "chainId:address" key per real deployment
+ */
+export function tokenDeploymentKeys(token: Token | NFT): string[] {
+  return Object.entries(token.addresses ?? {})
+    .filter(([, address]) => address && address !== zeroAddress)
+    .map(([chainId, address]) => `${chainId}:${address.toLowerCase()}`);
+}
+
+/**
+ * @dev Two tokens are the same token if they share any chain-qualified deployment;
+ *      the symbol is only a fallback for entries that carry no addresses.
+ * @param a The first token
+ * @param b The second token
+ * @return Whether both describe the same token
+ */
+export function tokensAreSame(a: Token | NFT, b: Token | NFT): boolean {
+  const aKeys = tokenDeploymentKeys(a);
+  const bKeys = new Set(tokenDeploymentKeys(b));
+
+  if (aKeys.length > 0 && bKeys.size > 0) {
+    return aKeys.some((key) => bKeys.has(key));
+  }
+  return a.symbol === b.symbol;
+}
+
+/**
+ * @dev A stable, unique key for rendering token lists that may contain
+ *      distinct tokens sharing a symbol.
+ * @param token The token
+ * @return The identity key
+ */
+export function tokenIdentityKey(token: Token | NFT): string {
+  const keys = tokenDeploymentKeys(token);
+  return keys.length > 0 ? `${token.symbol}|${keys.join('|')}` : token.symbol;
+}

--- a/packages/bridge-ui/src/libs/util/truncateDecimal.test.ts
+++ b/packages/bridge-ui/src/libs/util/truncateDecimal.test.ts
@@ -1,9 +1,27 @@
-import { truncateDecimal } from './truncateDecimal';
+import { truncateDecimal, truncateDecimalString } from './truncateDecimal';
 
 describe('truncateDecimal', () => {
   it('should truncate decimals', () => {
     expect(truncateDecimal(1.23456789, 2)).toEqual(1.23);
     expect(truncateDecimal(12.3456789, 3)).toEqual(12.345);
     expect(truncateDecimal(123.456789, 4)).toEqual(123.4567);
+  });
+});
+
+describe('truncateDecimalString', () => {
+  it('truncates the decimal part of a string', () => {
+    expect(truncateDecimalString('1.23456789', 2)).toEqual('1.23');
+    expect(truncateDecimalString('123.456789', 4)).toEqual('123.4567');
+  });
+
+  it('keeps tiny values out of scientific notation', () => {
+    expect(truncateDecimalString('0.0000001', 12)).toEqual('0.0000001');
+    expect(truncateDecimalString('0.000000123456789012345678', 12)).toEqual('0.000000123456');
+  });
+
+  it('drops trailing zeros and empty decimal parts', () => {
+    expect(truncateDecimalString('1.5000', 12)).toEqual('1.5');
+    expect(truncateDecimalString('2.000', 12)).toEqual('2');
+    expect(truncateDecimalString('42', 12)).toEqual('42');
   });
 });

--- a/packages/bridge-ui/src/libs/util/truncateDecimal.ts
+++ b/packages/bridge-ui/src/libs/util/truncateDecimal.ts
@@ -2,3 +2,17 @@ export function truncateDecimal(num: number, decimalPlaces: number) {
   const factor = 10 ** decimalPlaces;
   return Math.floor(num * factor) / factor;
 }
+
+/**
+ * @dev Truncates the decimal part of a numeric string without routing it through a
+ *      JavaScript number, which would produce scientific notation (1e-7) for very
+ *      small or very large values.
+ * @param value The decimal string, e.g. "0.000000123"
+ * @param decimalPlaces How many decimal places to keep
+ * @return The truncated decimal string
+ */
+export function truncateDecimalString(value: string, decimalPlaces: number): string {
+  const [whole, decimal = ''] = value.split('.');
+  const truncated = decimalPlaces > 0 ? decimal.slice(0, decimalPlaces).replace(/0+$/, '') : '';
+  return truncated ? `${whole}.${truncated}` : whole;
+}

--- a/packages/bridge-ui/src/libs/wagmi/watcher.ts
+++ b/packages/bridge-ui/src/libs/wagmi/watcher.ts
@@ -42,11 +42,16 @@ async function handleAccountChange(data: GetAccountReturnType) {
     switchChainModal.set(true);
     return;
   } else if (chainId) {
+    // The wallet is (back) on a supported chain, so the switch-chain modal must not linger
+    switchChainModal.set(false);
     // When we switch networks, we are actually selecting
     // the source chain.
     const srcChain = chains.find((c) => c.id === Number(chainId));
     if (srcChain) connectedSourceChain.set(srcChain);
     refreshUserBalance();
+  } else {
+    // Disconnected: there is no chain to switch away from anymore
+    switchChainModal.set(false);
   }
 }
 


### PR DESCRIPTION
Stacked on #22080 (critical + high fixes). This PR addresses the remaining medium and low severity findings from the bridge-ui audit, plus the split-verdict and manual-pass observations that were verified against the source. Only `packages/bridge-ui` is touched.

## Data layer
- **fetchTransactions**: the module-level sticky `error` (one relayer blip made every later refresh toast "relayer offline") is now per-call; `RECALLED` added to the status sort order; relayer history paginated beyond the first 500 events (bounded at 10 pages) with cross-page dedup by hash.
- **Bridge-paused guards**: every `isBridgePaused().then(() => { throw })` (ETHBridge, ERC20Bridge, ERC721Bridge, ConfirmationStep, NFTBridge) was a fire-and-forget no-op that only produced unhandled rejections; all are now awaited. The never-assigned `paused` flag in `Actions.svelte` is removed.
- **RelayerAPIService**: a malformed row or a single failed `messageStatus` read no longer rejects the surrounding `Promise.all` and wipes the entire transaction list (per-row transform/enhance with isolation); the top-level `amount`/`fee` fields are now covered by `preserveMessageIntegerPrecision` (they lost digits above 2^53 wei as JSON doubles); missing `items` no longer crashes.
- **messageStatusPoller**: a transient RPC error killed polling permanently and rethrew into `setInterval` (uncatchable) — polling now retries on the next tick; the receipt lookup is pinned to the source chain instead of the wallet's current chain; `destroy()` removes only the caller's own listeners from the shared per-hash emitter.
- **CustomTokenService**: custom tokens are identified by address (symbol only as a fallback for address-less entries), so a second token sharing a symbol is no longer silently dropped and removal cannot delete an unrelated same-symbol token.
- **getMaxAmountToBridge**: the ETH MAX button was completely dead — `bridgeArgs` lacked `tokenObject`, the gas-limit estimation threw, and the caller swallowed it; also reserves gas with EIP-1559 `maxFeePerGas` instead of legacy `eth_gasPrice`, which under-reserved.
- **getAddress**: when the token object has no source-chain address, the function returned the bridged deployment even when it lives on the *destination* chain; it now picks whichever deployment (canonical or bridged) is actually on the source chain.
- **getCanonicalInfoForToken** skips `zeroAddress` placeholder entries; **NFT metadata** cache writes now use the composite `address-id` key the reads expect (the cache never hit before), and `fetchNFTImageUrl`'s inverted only-update-if-already-cached guard is gone; `fetchNFTs`' L1 error path returned `{nfts, error}` where `NFT[]` was expected and erased the error message.
- **ERC721 approval check** compares checksummed addresses (a config casing mismatch produced endless "approval required") and honors `isApprovedForAll`.
- **wagmi watcher** clears the switch-chain modal when the wallet returns to a supported chain or disconnects.

## Bridge flow
- **ProcessingFee**: the custom fee input compared against `recommendedAmount` instead of zero, snapping any lower value to the recommended fee mid-keystroke and making a below-recommended custom fee impossible; input parsing is extracted into `parseCustomFeeInput` (invalid/incomplete input leaves state untouched). Esc/outside-click now cancels (previously it kept a half-applied `gasLimitZero=true`, producing a gasLimit-0 message that still paid the full relayer fee). Recommended-fee computations are generation-guarded so a stale result for the previous chain pair can't become the submitted fee.
- **ConfirmationStep**: a reverted bridge transaction is no longer stored as a phantom pending entry (timeouts still are, since they may confirm); the timeout toast linked `approveTxHash` (undefined for ETH); `bridging` can no longer stick on early return; locally stored transactions now carry `processingFee`, which also makes the zero-fee "Try claim" entry reachable for fresh local transactions.
- **TokenInput**: exponent-notation input (`1e5`) threw in `parseUnits` and left `validatingAmount` stuck true; the MAX button showed a truncated display value while bridging the untruncated amount — display and entered amount now agree.
- **FungibleBridge** returns to the import step when the wallet network or account changes mid-wizard (Review/Confirm previously kept stale chain state); the wizard's next-button label now actually follows the step (the reactive statement had no tracked dependency).

## Dialogs
- **ClaimDialog / RetryDialog / ReleaseDialog**: `pendingTransactions.add` rejections (reverted or timed-out transactions) were unhandled, leaving the dialog spinning forever with Back hidden — even reopening didn't recover because `reset()` never cleared the flags. All three now surface an error toast and reset; dialog resets clear their progress flags.
- **ReleaseDialog**: waited for the `recallMessage` receipt on the destination chain although the transaction executes on the source chain (guaranteed timeout), and linked the wrong explorer; `handleReleaseClick` also cleared `releasing` the moment the tx was sent, re-enabling the button while it was pending.
- **RetryDialog** swallowed every non-quota error silently; the retry-once (`lastAttempt`) flag in `Claim.svelte` now only applies to actual retry actions so a leftover store value can't turn a plain claim into a final attempt; the release pre-check's switch button was labeled with the destination chain while switching to the source chain.
- **Details dialogs** (desktop + mobile) keyed their timeline off `bridgeTx.status`, which locally stored transactions never set — they now use `msgStatus ?? status`; the desktop dialog's Escape callback was `() => closeDetails` (returned the function instead of calling it); the claim success toast passed `{network}` to an i18n message that interpolates `{url}`.

## NFT flow
- **NFTBridge**: navigating Back from Review wiped the entire import state via a reactive `resetForm()` (now only a completed bridge resets); a network change overwrote a still-valid destination with the old source chain; manual-mode revalidation read a never-assigned local `importMethod` (now the real `selectedImportMethod` store).
- **ScannedImport**'s "load more" compared the NFT list against itself synchronously before the fetch resolved, permanently disabling pagination after one click; **ImportStep**'s scan early-return left `scanning=true` forever.
- **ManualImport** ID validation is generation-guarded (a stale response could select a different NFT than the entered ID); **IDInput** rejects token IDs above `Number.MAX_SAFE_INTEGER` instead of silently corrupting them via `parseInt`; the ERC1155 amount input no longer sticks `validatingAmount` on invalid input.
- **NFT ReviewStep** resolved images with un-awaited callbacks that each overwrote `$selectedNFTs` with a single NFT; it now awaits all and publishes the full selection once.

## Selectors / shell
- **ChainsDropdown**: keyboard Enter passed the inverted `switchWallet` flag (selecting a source chain set it as destination) and ignored disabled entries; **ChainSelector**'s swap branch compared against the source instead of the destination, producing source == destination; the mobile **ChainsDialog** published an unconfirmed selection into the pill via two-way binding and couldn't be reopened after its close button.
- **OnAccount / OnNetwork** never unsubscribed — every mount leaked a handler that kept firing after the component was destroyed (16 usage sites, including dialogs and rows that mount repeatedly).
- **DropdownView** compared raw symbols against a lowercased query (uppercase symbols never matched); **AddCustomERC20** and **Faucet** async lookups are generation-guarded; a failed NFT ownership check now clears a stale `allApproved=true`; the manual-claim **Relayer** page kept the previous address's results when a new search returned nothing and could stick its loading flag.

## Intentionally not changed
- `NFTList` multi-select checkboxes still don't feed `$selectedNFTs`: batch transfers are behind the disabled `PUBLIC_NFT_BATCH_TRANSFERS_ENABLED` flag and the downstream bridges only process `tokenIds[0]`, so wiring the checkboxes up would let users "select" a batch that doesn't actually bridge. Left for the batch-transfer feature work.
- `checkBalanceToBridge` remains uncalled (its unit-confusion issue is moot dead code); removing it is a cleanup decision left to the team.

## Tests
New/extended (35 tests added on top of #22080's, 225 total):
- `fetchTransactions.test.ts` (new): error is per-call after relayer recovery, multi-page fetch with cross-page dedup, single-page stop, RECALLED sort position.
- `RelayerAPIService.test.ts`: top-level `amount`/`fee` digits preserved past 2^53.
- `CustomTokenService.test.ts`: same-symbol different-address tokens both stored, renamed token not duplicated, removal doesn't delete a same-symbol impostor.
- `getAddress.test.ts`: canonical-on-source-chain resolution (the fixed bug).
- `customFee.test.ts` (new): valid amounts, below-recommended amounts accepted, incomplete/invalid/negative input leaves state untouched.
- `fetchNFTMetadata.test.ts`: mocks updated for the keyed cache writes.
- Component-internal changes (dialog flag handling, wizard navigation, keyboard paths) have no component-test infrastructure in this package; they are covered by `svelte-check` and traced manually.

## Validation
`pnpm build`, `pnpm svelte:check` (0 errors), `pnpm lint`, and `pnpm test:unit` (225 tests) all pass locally with the CI recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SSZC4UvEbDKAYZXjt3qfA

---
_Generated by [Claude Code](https://claude.ai/code/session_017SSZC4UvEbDKAYZXjt3qfA)_