### PR TITLE
test(protocol): tighten the EIP-8037 send-cap tests and correct its comments

### DIFF
--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -61,29 +61,28 @@ contract Bridge is EssentialResolverContract, IBridge {
     /// suggest. Glamsterdam reprices state on two axes and both reach this budget. EIP-8038
     /// (state access) raises ACCOUNT_WRITE 6,700 -> 9,000 and COLD_ACCOUNT_ACCESS 2,600 -> 3,000,
     /// which this contract pays before forwarding, but it also raises STORAGE_WRITE 2,800 ->
-    /// 10,000 in the frame doing the write. That one is net-metered per transaction — a slot pays
-    /// it once, when it first moves away from its transaction-start value — and adds 7,100 to a
-    /// cold existing-slot write, 7,200 to a warm one. EIP-8037 (state creation) meters a *fresh*
-    /// slot as 64 state bytes * 1,530 gas/byte = 97,920 of state gas; unless the transaction buys
-    /// gas beyond the 16.7M per-transaction execution cap (which no realistic claim transaction
-    /// does, leaving its state-gas reservoir empty), that charge also falls on the callee frame.
-    /// A fresh cold slot therefore goes from 2,100 + 20,000 = 22,100 today to
-    /// 2,100 + 10,000 + 97,920 = 110,020. A smart wallet writing one fresh slot on receive would
-    /// run out of gas under the previous 35,000 cap, and since a failed send reverts processing
-    /// its messages would become unclaimable. Preserving that wallet's budget costs
-    /// 35,000 - 22,100 + 110,020 = 122,920; the cap was sized as 35,000 + 97,920 rounded up,
-    /// before EIP-8038 was accounted for, and still clears that requirement with roughly 12,000
-    /// to spare.
-    /// This is NOT a general "fits before, fits after" guarantee. It holds only for a receive
-    /// path whose SSTOREs are its only repriced operations, creating at most one fresh slot and
-    /// changing at most one further existing slot. EIP-8038 reprices ordinary reads too —
-    /// EXTCODESIZE now bills two warm accesses rather than one — so a path doing one fresh cold
-    /// SSTORE, one cold existing write and ~75 warm EXTCODESIZE reads costs ~34,900 today and
-    /// ~137,420 after the fork: inside the old budget, outside this one, while still meeting the
-    /// storage conditions above. EIP-8037 likewise reprices account creation to 120 state bytes
-    /// = 183,600 gas, so forwarding value to a never-before-used address, or running CREATE,
-    /// fits today and does not after. EIP-8038's parameters are still under review; re-check
-    /// these figures before the fork.
+    /// 10,000 in the frame doing the write: +7,100 on a cold existing-slot write, +7,200 on a
+    /// warm one. EIP-8037 (state creation) meters a *fresh* slot as 64 state bytes * 1,530
+    /// gas/byte = 97,920 of state gas; unless the transaction buys gas beyond the 16.7M
+    /// per-transaction execution cap (which no realistic claim transaction does, leaving its
+    /// state-gas reservoir empty), that charge also falls on the callee frame. A fresh cold slot
+    /// therefore goes from 2,100 + 20,000 = 22,100 today to 2,100 + 10,000 + 97,920 = 110,020.
+    /// A smart wallet writing one fresh slot on receive would run out of gas under the previous
+    /// 35,000 cap, and since a failed send reverts processing its messages would become
+    /// unclaimable. Preserving that wallet's budget costs 35,000 - 22,100 + 110,020 = 122,920;
+    /// the cap was sized as 35,000 + 97,920 rounded up, before EIP-8038 was accounted for, and
+    /// still clears that requirement with roughly 12,000 to spare.
+    /// That margin is what this number buys, and it is NOT a general "fits before, fits after"
+    /// guarantee — do not read it as one. Glamsterdam reprices enough distinct operations that a
+    /// receive path within the old budget can exceed this one while looking modest: EXTCODESIZE
+    /// now bills two warm accesses rather than one; account creation costs 120 state bytes =
+    /// 183,600, so forwarding value to a never-used address or running CREATE fits today and not
+    /// after; and STORAGE_WRITE is charged per departure from a slot's transaction-start value,
+    /// its restore credited only to the transaction refund counter, so a slot rewritten several
+    /// times bills 10,000 each time while the frame's own gas never gets the credit back.
+    /// Recipients doing more than one fresh slot's worth of bookkeeping should be measured
+    /// against the new schedule rather than assumed safe. EIP-8038's parameters are still under
+    /// review; re-check these figures before the fork.
     // - EOA gas used is < 21000
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -61,23 +61,29 @@ contract Bridge is EssentialResolverContract, IBridge {
     /// suggest. Glamsterdam reprices state on two axes and both reach this budget. EIP-8038
     /// (state access) raises ACCOUNT_WRITE 6,700 -> 9,000 and COLD_ACCOUNT_ACCESS 2,600 -> 3,000,
     /// which this contract pays before forwarding, but it also raises STORAGE_WRITE 2,800 ->
-    /// 10,000, charged in the frame doing the write, so every value-changing SSTORE the callee
-    /// makes costs 7,200 more. EIP-8037 (state creation) meters a *fresh* slot as 64 state bytes
-    /// * 1,530 gas/byte = 97,920 of state gas; unless the transaction buys gas beyond the 16.7M
-    /// per-transaction execution cap (which no realistic claim transaction does, leaving its
-    /// state-gas reservoir empty), that charge also falls on the callee frame. A fresh cold slot
-    /// therefore goes from 2,100 + 20,000 = 22,100 today to 2,100 + 10,000 + 97,920 = 110,020.
-    /// A smart wallet writing one fresh slot on receive would run out of gas under the previous
-    /// 35,000 cap, and since a failed send reverts processing its messages would become
-    /// unclaimable. Preserving that wallet's budget costs 35,000 - 22,100 + 110,020 = 122,920;
-    /// the cap was sized as 35,000 + 97,920 rounded up, before EIP-8038 was accounted for, and
-    /// still clears that requirement with roughly 12,000 to spare — room for one more repriced
-    /// existing-slot write, not two. So wallets that fit before the fork still fit after it only
-    /// if their receive path creates at most one fresh slot, changes at most one further existing
-    /// slot, and creates no other new state: EIP-8037 also reprices account creation to 120 state
-    /// bytes = 183,600 gas, so a receive path that forwards value to a never-before-used address,
-    /// or runs CREATE, fits under the legacy budget today yet exceeds this one after the fork.
-    /// EIP-8038's parameters are still under review; re-check these figures before the fork.
+    /// 10,000 in the frame doing the write. That one is net-metered per transaction — a slot pays
+    /// it once, when it first moves away from its transaction-start value — and adds 7,100 to a
+    /// cold existing-slot write, 7,200 to a warm one. EIP-8037 (state creation) meters a *fresh*
+    /// slot as 64 state bytes * 1,530 gas/byte = 97,920 of state gas; unless the transaction buys
+    /// gas beyond the 16.7M per-transaction execution cap (which no realistic claim transaction
+    /// does, leaving its state-gas reservoir empty), that charge also falls on the callee frame.
+    /// A fresh cold slot therefore goes from 2,100 + 20,000 = 22,100 today to
+    /// 2,100 + 10,000 + 97,920 = 110,020. A smart wallet writing one fresh slot on receive would
+    /// run out of gas under the previous 35,000 cap, and since a failed send reverts processing
+    /// its messages would become unclaimable. Preserving that wallet's budget costs
+    /// 35,000 - 22,100 + 110,020 = 122,920; the cap was sized as 35,000 + 97,920 rounded up,
+    /// before EIP-8038 was accounted for, and still clears that requirement with roughly 12,000
+    /// to spare.
+    /// This is NOT a general "fits before, fits after" guarantee. It holds only for a receive
+    /// path whose SSTOREs are its only repriced operations, creating at most one fresh slot and
+    /// changing at most one further existing slot. EIP-8038 reprices ordinary reads too —
+    /// EXTCODESIZE now bills two warm accesses rather than one — so a path doing one fresh cold
+    /// SSTORE, one cold existing write and ~75 warm EXTCODESIZE reads costs ~34,900 today and
+    /// ~137,420 after the fork: inside the old budget, outside this one, while still meeting the
+    /// storage conditions above. EIP-8037 likewise reprices account creation to 120 state bytes
+    /// = 183,600 gas, so forwarding value to a never-before-used address, or running CREATE,
+    /// fits today and does not after. EIP-8038's parameters are still under review; re-check
+    /// these figures before the fork.
     // - EOA gas used is < 21000
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -62,15 +62,19 @@ contract Bridge is EssentialResolverContract, IBridge {
     /// (value-transfer account write, cold-recipient access) that are paid by this contract
     /// before forwarding and do not draw on this budget, so no headroom bump is needed for them.
     /// State-creation repricing (EIP-8037, scheduled for Glamsterdam) does draw on this budget:
-    /// creating a fresh storage slot charges 64 state bytes * 1,530 gas/byte = 97,920 gas, and
-    /// unless the transaction buys gas beyond the 16.7M per-transaction execution cap (which no
-    /// realistic claim transaction does, leaving its state-gas reservoir empty), that charge is
-    /// deducted from the callee frame's own gas. A smart wallet that writes a single fresh slot
-    /// when receiving Ether would then run out of gas under the previous 35,000 cap, and since a
-    /// failed send reverts processing, its messages would become unclaimable. The cap is
-    /// therefore the legacy 35,000 callee budget plus one EIP-8037 slot-creation charge
-    /// (97,920), rounded up — wallets that fit before the fork still fit after it, as long as
-    /// their receive path creates at most one storage slot.
+    /// it reprices a fresh storage slot from 20,000 of execution gas to 64 state bytes * 1,530
+    /// gas/byte = 97,920 of state gas, and unless the transaction buys gas beyond the 16.7M
+    /// per-transaction execution cap (which no realistic claim transaction does, leaving its
+    /// state-gas reservoir empty), that charge is deducted from the callee frame's own gas. A
+    /// smart wallet that writes a single fresh slot when receiving Ether would then run out of
+    /// gas under the previous 35,000 cap, and since a failed send reverts processing, its
+    /// messages would become unclaimable. Preserving the legacy budget for such a wallet costs
+    /// 35,000 - 20,000 + 97,920 = 112,920, so this cap keeps roughly 22,000 of headroom on top.
+    /// Wallets that fit before the fork still fit after it provided their receive path creates
+    /// at most one storage slot AND no other new state: EIP-8037 also reprices account creation
+    /// to 120 state bytes = 183,600 gas, so a receive path that forwards value to a
+    /// never-before-used address, or runs CREATE, fits under the legacy budget today yet exceeds
+    /// this one after the fork.
     // - EOA gas used is < 21000
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -74,15 +74,20 @@ contract Bridge is EssentialResolverContract, IBridge {
     /// still clears that requirement with roughly 12,000 to spare.
     /// That margin is what this number buys, and it is NOT a general "fits before, fits after"
     /// guarantee — do not read it as one. Glamsterdam reprices enough distinct operations that a
-    /// receive path within the old budget can exceed this one while looking modest: EXTCODESIZE
-    /// now bills two warm accesses rather than one; account creation costs 120 state bytes =
-    /// 183,600, so forwarding value to a never-used address or running CREATE fits today and not
-    /// after; and STORAGE_WRITE is charged per departure from a slot's transaction-start value,
-    /// its restore credited only to the transaction refund counter, so a slot rewritten several
-    /// times bills 10,000 each time while the frame's own gas never gets the credit back.
-    /// Recipients doing more than one fresh slot's worth of bookkeeping should be measured
-    /// against the new schedule rather than assumed safe. EIP-8038's parameters are still under
-    /// review; re-check these figures before the fork.
+    /// receive path within the old budget can exceed this one while looking modest. Account
+    /// creation costs 120 state bytes = 183,600, so forwarding value to a never-used address or
+    /// running CREATE fits today and not after. STORAGE_WRITE is charged on every departure from
+    /// a slot's transaction-start value, and the restoring credit goes only to the transaction
+    /// refund counter, so a slot driven away from that value repeatedly (x->y->x->z) bills 10,000
+    /// each departure while the frame's own gas never gets the credit back — note this is per
+    /// departure, not per write: a plain x->y->z pays the write once and WARM_ACCESS thereafter.
+    /// A single extra warm existing-slot write in the receive path costs +7,200, which is already
+    /// 60% of the margin above. Smaller effects add up rather than dominate: EXTCODESIZE now
+    /// bills two warm accesses rather than one, but that is only +100 warm (+500 cold), so it
+    /// takes on the order of 75 of them to matter. Recipients doing more than one fresh slot's
+    /// worth of bookkeeping should be measured against the new schedule rather than assumed safe.
+    /// Both EIP-8037 and EIP-8038 are still in Review; re-check every figure here before the
+    /// fork.
     // - EOA gas used is < 21000
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -58,24 +58,26 @@ contract Bridge is EssentialResolverContract, IBridge {
     /// value-bearing CALL additionally grants the callee the unchanged 2,300 stipend). The
     /// figures below are historical transaction-level measurements that include the 21k intrinsic
     /// cost (an EOA callee consumes ~0 gas), so the callee-side margin is far larger than they
-    /// suggest. State-access repricing forks such as EIP-8038 raise mostly caller-side costs
-    /// (value-transfer account write, cold-recipient access) that are paid by this contract
-    /// before forwarding and do not draw on this budget, so no headroom bump is needed for them.
-    /// State-creation repricing (EIP-8037, scheduled for Glamsterdam) does draw on this budget:
-    /// it reprices a fresh storage slot from 20,000 of execution gas to 64 state bytes * 1,530
-    /// gas/byte = 97,920 of state gas, and unless the transaction buys gas beyond the 16.7M
+    /// suggest. Glamsterdam reprices state on two axes and both reach this budget. EIP-8038
+    /// (state access) raises ACCOUNT_WRITE 6,700 -> 9,000 and COLD_ACCOUNT_ACCESS 2,600 -> 3,000,
+    /// which this contract pays before forwarding, but it also raises STORAGE_WRITE 2,800 ->
+    /// 10,000, charged in the frame doing the write, so every value-changing SSTORE the callee
+    /// makes costs 7,200 more. EIP-8037 (state creation) meters a *fresh* slot as 64 state bytes
+    /// * 1,530 gas/byte = 97,920 of state gas; unless the transaction buys gas beyond the 16.7M
     /// per-transaction execution cap (which no realistic claim transaction does, leaving its
-    /// state-gas reservoir empty), that charge is deducted from the callee frame's own gas. A
-    /// smart wallet that writes a single fresh slot when receiving Ether would then run out of
-    /// gas under the previous 35,000 cap, and since a failed send reverts processing, its
-    /// messages would become unclaimable. Preserving the legacy budget for such a wallet costs
-    /// 35,000 - 20,000 + 97,920 = 112,920, so this cap keeps roughly 22,000 of headroom on top.
-    /// The cap itself was sized additively as 35,000 + 97,920 = 132,920 rounded up to 135,000,
-    /// which is why it sits above the strict 112,920 requirement. Wallets that fit before the
-    /// fork still fit after it provided their receive path creates at most one storage slot AND
-    /// no other new state: EIP-8037 also reprices account creation to 120 state bytes = 183,600
-    /// gas, so a receive path that forwards value to a never-before-used address, or runs
-    /// CREATE, fits under the legacy budget today yet exceeds this one after the fork.
+    /// state-gas reservoir empty), that charge also falls on the callee frame. A fresh cold slot
+    /// therefore goes from 2,100 + 20,000 = 22,100 today to 2,100 + 10,000 + 97,920 = 110,020.
+    /// A smart wallet writing one fresh slot on receive would run out of gas under the previous
+    /// 35,000 cap, and since a failed send reverts processing its messages would become
+    /// unclaimable. Preserving that wallet's budget costs 35,000 - 22,100 + 110,020 = 122,920;
+    /// the cap was sized as 35,000 + 97,920 rounded up, before EIP-8038 was accounted for, and
+    /// still clears that requirement with roughly 12,000 to spare — room for one more repriced
+    /// existing-slot write, not two. So wallets that fit before the fork still fit after it only
+    /// if their receive path creates at most one fresh slot, changes at most one further existing
+    /// slot, and creates no other new state: EIP-8037 also reprices account creation to 120 state
+    /// bytes = 183,600 gas, so a receive path that forwards value to a never-before-used address,
+    /// or runs CREATE, fits under the legacy budget today yet exceeds this one after the fork.
+    /// EIP-8038's parameters are still under review; re-check these figures before the fork.
     // - EOA gas used is < 21000
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000

--- a/packages/protocol/contracts/shared/bridge/Bridge.sol
+++ b/packages/protocol/contracts/shared/bridge/Bridge.sol
@@ -70,11 +70,12 @@ contract Bridge is EssentialResolverContract, IBridge {
     /// gas under the previous 35,000 cap, and since a failed send reverts processing, its
     /// messages would become unclaimable. Preserving the legacy budget for such a wallet costs
     /// 35,000 - 20,000 + 97,920 = 112,920, so this cap keeps roughly 22,000 of headroom on top.
-    /// Wallets that fit before the fork still fit after it provided their receive path creates
-    /// at most one storage slot AND no other new state: EIP-8037 also reprices account creation
-    /// to 120 state bytes = 183,600 gas, so a receive path that forwards value to a
-    /// never-before-used address, or runs CREATE, fits under the legacy budget today yet exceeds
-    /// this one after the fork.
+    /// The cap itself was sized additively as 35,000 + 97,920 = 132,920 rounded up to 135,000,
+    /// which is why it sits above the strict 112,920 requirement. Wallets that fit before the
+    /// fork still fit after it provided their receive path creates at most one storage slot AND
+    /// no other new state: EIP-8037 also reprices account creation to 120 state bytes = 183,600
+    /// gas, so a receive path that forwards value to a never-before-used address, or runs
+    /// CREATE, fits under the legacy budget today yet exceeds this one after the fork.
     // - EOA gas used is < 21000
     // - For Loopring smart wallet, gas used is about 23000
     // - For Argent smart wallet on Ethereum, gas used is about 24000

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -36,6 +36,12 @@ contract Target is IMessageInvocable {
 }
 
 contract TestBridge2_processMessage is TestBridge2Base {
+    /// @dev Mirrors Bridge._SEND_ETHER_GAS_LIMIT (135,000, `private`) plus the 2,300 stipend a
+    /// value-bearing CALL always adds. Retuning the bridge constant must move this one too.
+    /// Written as a literal rather than `135_000 + 2_300` because forge fmt's handling of
+    /// underscores inside a constant expression differs between versions.
+    uint256 private constant _EXPECTED_SEND_BUDGET = 137_300;
+
     function test_bridge2_processMessage_basic() public dealEther(Alice) assertSameTotalBalance {
         vm.startPrank(Alice);
 
@@ -527,8 +533,12 @@ contract TestBridge2_processMessage is TestBridge2Base {
 
         eBridge.processMessage(message, FAKE_PROOF);
 
-        // _SEND_ETHER_GAS_LIMIT (135,000) + the 2,300 stipend, less frame-entry overhead.
-        assertApproxEqAbs(wallet.recordedBudget(), 137_300, 500);
+        // The allowance can never exceed the cap plus the stipend, and frame entry costs a
+        // handful of opcodes below it (57 gas as measured). A tolerance wide enough to absorb
+        // real variation but far tighter than one slot-creation charge is what keeps this test,
+        // rather than the behavioural brackets, the binding constraint on the constant.
+        assertLe(wallet.recordedBudget(), _EXPECTED_SEND_BUDGET);
+        assertGe(wallet.recordedBudget(), _EXPECTED_SEND_BUDGET - 100);
     }
 
     /// @dev Self-claim path with invocation prohibited: msg.sender == destOwner, so the relayer
@@ -563,6 +573,9 @@ contract TestBridge2_processMessage is TestBridge2Base {
     /// @dev The self-claim path's other half: with an invocable `to`, processMessage forwards
     /// raw `gasleft()` to the invocation, a budget large enough for a storage-creating receive.
     /// The refund then goes to a second wallet, so the capped send still carries a first receive.
+    /// `gasLimit` is deliberately set so `_invocationGasLimit` would yield 120,000 — below the
+    /// 131,235 a 5+1 receive needs. Only the `gasleft()` arm of the ternary can satisfy this
+    /// wallet, so collapsing that ternary to the relayer branch turns this test red.
     function test_bridge2_processMessage__self_claim_with_invocation() public {
         MessageReceiver_CreatingFreshStorageSlots invocationWallet =
             new MessageReceiver_CreatingFreshStorageSlots(5);
@@ -574,7 +587,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
         IBridge.Message memory message;
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
-        message.gasLimit = 1_000_000;
+        message.gasLimit = eBridge.getMessageMinGasLimit(0) + 120_000;
         message.fee = 5_000_000;
         message.value = 2 ether;
         message.destOwner = address(refundWallet);
@@ -592,6 +605,41 @@ contract TestBridge2_processMessage is TestBridge2Base {
         assertEq(address(invocationWallet).balance, 2 ether);
         // Self-claim takes no relayer cut, so the entire fee is refunded.
         assertEq(address(refundWallet).balance, 5_000_000);
+        assertEq(address(eBridge).balance, bridgeBalance - 2 ether - 5_000_000);
+    }
+
+    /// @dev The relayer fee payout is a *separate* capped send from the destOwner refund, and a
+    /// relayer may itself be a contract. Every other test here pays the fee to an EOA, where the
+    /// 2,300 stipend alone suffices and the cap is therefore unconstrained: setting that send's
+    /// gas operand to zero leaves the whole suite green. Keeping `destOwner` an EOA makes the
+    /// relayer payout the only leg that needs the budget, so this test pins it specifically.
+    function test_bridge2_processMessage__fee_payout_to_storage_creating_relayer() public {
+        MessageReceiver_CreatingFreshStorageSlots relayerWallet =
+            new MessageReceiver_CreatingFreshStorageSlots(5);
+
+        uint256 aliceBalance = Alice.balance;
+        uint256 bridgeBalance = address(eBridge).balance;
+
+        IBridge.Message memory message;
+        message.destChainId = ethereumChainId;
+        message.srcChainId = taikoChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 5_000_000;
+        message.value = 2 ether;
+        message.destOwner = Alice;
+        message.to = address(eBridge); // invocation prohibited -> the value is refunded to Alice
+
+        vm.prank(address(relayerWallet));
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        bytes32 hash = eBridge.hashMessage(message);
+        assertTrue(eBridge.messageStatus(hash) == IBridge.Status.DONE);
+        // The relayer's cut arrived through the capped send, as a first receive.
+        assertEq(relayerWallet.receiveCount(), 1);
+        uint256 relayerFee = address(relayerWallet).balance;
+        assertTrue(relayerFee > 0);
+        // Alice got the value plus the fee the relayer left behind, and nothing leaked.
+        assertEq(Alice.balance, aliceBalance + 2 ether + 5_000_000 - relayerFee);
         assertEq(address(eBridge).balance, bridgeBalance - 2 ether - 5_000_000);
     }
 

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -573,9 +573,12 @@ contract TestBridge2_processMessage is TestBridge2Base {
     /// @dev The self-claim path's other half: with an invocable `to`, processMessage forwards
     /// raw `gasleft()` to the invocation, a budget large enough for a storage-creating receive.
     /// The refund then goes to a second wallet, so the capped send still carries a first receive.
-    /// `gasLimit` is deliberately set so `_invocationGasLimit` would yield 120,000 — below the
-    /// 131,235 a 5+1 receive needs. Only the `gasleft()` arm of the ternary can satisfy this
-    /// wallet, so collapsing that ternary to the relayer branch turns this test red.
+    /// `gasLimit` is deliberately one above the minimum, so `_invocationGasLimit` would yield 1:
+    /// collapsing the ternary to its relayer branch hands the invocation 1 gas plus the 2,300
+    /// stipend, which cannot complete a 5+1 receive under the current schedule or under
+    /// Glamsterdam pricing. Only the `gasleft()` arm can satisfy this wallet, so that mutation
+    /// turns this test red and keeps doing so across the fork — a margin sized against today's
+    /// prices would not, because the reservoir would absorb the receive's state charges.
     function test_bridge2_processMessage__self_claim_with_invocation() public {
         MessageReceiver_CreatingFreshStorageSlots invocationWallet =
             new MessageReceiver_CreatingFreshStorageSlots(5);

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -5,6 +5,9 @@ import "./TestBridge2Base.sol";
 import {
     MessageReceiver_CreatingFreshStorageSlots
 } from "test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol";
+import {
+    MessageReceiver_RecordingGasBudget
+} from "test/shared/bridge/helpers/MessageReceiver_RecordingGasBudget.sol";
 
 contract Target is IMessageInvocable {
     uint256 public receivedEther;
@@ -485,6 +488,34 @@ contract TestBridge2_processMessage is TestBridge2Base {
         bytes32 hash = eBridge.hashMessage(message);
         assertTrue(eBridge.messageStatus(hash) == IBridge.Status.NEW);
         assertEq(address(wallet).balance, 0);
+    }
+
+    /// @dev Pins the budget the capped Ether send actually forwards. The behavioural tests
+    /// bracket the cap between "a receive path this heavy still fits" and "this one does not",
+    /// which leaves a wide band of wrong values undetected; this measures it. It also needs no
+    /// recalibration at a repricing fork, because the forwarded allowance is independent of
+    /// what storage writes cost.
+    function test_bridge2_processMessage__capped_send_forwards_expected_gas_budget()
+        public
+        transactBy(Carol)
+    {
+        MessageReceiver_RecordingGasBudget wallet = new MessageReceiver_RecordingGasBudget();
+
+        IBridge.Message memory message;
+        message.destChainId = ethereumChainId;
+        message.srcChainId = taikoChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 0;
+        message.value = 2 ether;
+        message.destOwner = address(wallet);
+        // Invocation is prohibited for the bridge itself, so the whole value goes through the
+        // gas-capped send and the recorded budget is that send's allowance.
+        message.to = address(eBridge);
+
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        // _SEND_ETHER_GAS_LIMIT (135,000) + the 2,300 stipend, less frame-entry overhead.
+        assertApproxEqAbs(wallet.recordedBudget(), 137_300, 500);
     }
 
     function test_bridge2_processMessage__context_transient_lifecycle() public transactBy(Carol) {

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -425,15 +425,21 @@ contract TestBridge2_processMessage is TestBridge2Base {
         assertEq(address(eBridge).balance, bridgeBalance - 2 ether);
     }
 
-    /// @dev End-to-end claim of bridged Ether by a storage-creating smart wallet with a relayer
-    /// fee: the invocation pays the value to the wallet, and the unused fee is then refunded to
-    /// the same wallet through the gas-capped Ether send.
+    /// @dev End-to-end claim of bridged Ether by storage-creating smart wallets with a relayer
+    /// fee: the invocation pays the value to `to`, and the unused fee is refunded to destOwner
+    /// through the gas-capped Ether send. destOwner is deliberately a *different* contract from
+    /// `to` so the capped send carries a first receive (5+1 fresh slots, ~133k gas). Pointing
+    /// both at one wallet makes the refund a warm-counter second receive costing only ~91k —
+    /// below the 97,920 one fresh slot costs under EIP-8037, so it would not exercise the
+    /// budget this cap exists to provide.
     function test_bridge2_processMessage__storage_creating_wallet_claims_with_fee()
         public
         transactBy(Carol)
     {
-        MessageReceiver_CreatingFreshStorageSlots wallet =
-            new MessageReceiver_CreatingFreshStorageSlots(4);
+        MessageReceiver_CreatingFreshStorageSlots invocationWallet =
+            new MessageReceiver_CreatingFreshStorageSlots(5);
+        MessageReceiver_CreatingFreshStorageSlots refundWallet =
+            new MessageReceiver_CreatingFreshStorageSlots(5);
 
         uint256 carolBalance = Carol.balance;
         uint256 bridgeBalance = address(eBridge).balance;
@@ -441,26 +447,32 @@ contract TestBridge2_processMessage is TestBridge2Base {
         IBridge.Message memory message;
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
-        message.gasLimit = 1_000_000;
+        // Derived from the bridge's own minimum so the invocation budget stays at 200,000
+        // however GAS_RESERVE is retuned.
+        message.gasLimit = eBridge.getMessageMinGasLimit(0) + 200_000;
         message.fee = 5_000_000;
         message.value = 2 ether;
-        message.destOwner = address(wallet);
+        message.destOwner = address(refundWallet);
         // With empty message.data the invocation is a plain value-bearing call that hits the
         // wallet's receive() — no onMessageInvocation implementation is required.
-        message.to = address(wallet);
+        message.to = address(invocationWallet);
 
         eBridge.processMessage(message, FAKE_PROOF);
 
         bytes32 hash = eBridge.hashMessage(message);
         assertTrue(eBridge.messageStatus(hash) == IBridge.Status.DONE);
-        // The wallet received the value in the invocation and the fee remainder in the refund.
-        assertEq(wallet.receiveCount(), 2);
-        assertTrue(address(wallet).balance > 2 ether);
-        assertTrue(address(wallet).balance < 2 ether + 5_000_000);
-        // The relayer received the rest of the fee.
+        // The invocation delivered the value; the capped refund delivered the fee remainder.
+        assertEq(invocationWallet.receiveCount(), 1);
+        assertEq(refundWallet.receiveCount(), 1);
+        assertEq(address(invocationWallet).balance, 2 ether);
+        assertTrue(address(refundWallet).balance > 0);
+        // The relayer received the rest of the fee, and nothing else moved.
         uint256 relayerFee = Carol.balance - carolBalance;
         assertTrue(relayerFee > 0);
-        assertEq(address(wallet).balance + relayerFee, 2 ether + 5_000_000);
+        assertEq(
+            address(invocationWallet).balance + address(refundWallet).balance + relayerFee,
+            2 ether + 5_000_000
+        );
         assertEq(address(eBridge).balance, bridgeBalance - 2 ether - 5_000_000);
     }
 

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -479,7 +479,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
     /// @dev The cap still bounds how much gas a recipient can consume: a receive path above the
     /// budget (6+1 fresh slots, ~156k gas) keeps failing the refund. 6 rather than 7 slots
     /// brackets the 135k cap as tightly as the schedule allows — 5+1 is the largest that fits.
-    function test_bridge2_processMessage__refund_receiver_exceeding_gas_cap()
+    function test_bridge2_processMessage__RevertWhen_refund_receiver_exceeds_gas_cap()
         public
         transactBy(Carol)
     {

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -587,7 +587,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
         IBridge.Message memory message;
         message.destChainId = ethereumChainId;
         message.srcChainId = taikoChainId;
-        message.gasLimit = eBridge.getMessageMinGasLimit(0) + 120_000;
+        message.gasLimit = eBridge.getMessageMinGasLimit(0) + 1;
         message.fee = 5_000_000;
         message.value = 2 ether;
         message.destOwner = address(refundWallet);

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -393,9 +393,9 @@ contract TestBridge2_processMessage is TestBridge2Base {
     }
 
     /// @dev The refund send to destOwner must budget for a smart wallet that creates fresh
-    /// storage slots in its receive path. Writing 5+1 fresh slots costs ~133k gas under the
-    /// current schedule, which clears the 112,920 a wallet that saturated the legacy 35k budget
-    /// while writing one slot will need under EIP-8037 — 4+1 slots (~111k) does not.
+    /// storage slots in its receive path. Writing 5+1 fresh slots needs a 131,235 gas operand,
+    /// which clears the 122,920 a wallet that saturated the legacy 35k budget while writing one
+    /// slot will need after Glamsterdam — 4+1 slots, needing only 108,992, does not.
     function test_bridge2_processMessage__refund_to_storage_creating_wallet()
         public
         transactBy(Carol)
@@ -430,7 +430,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
     /// through the gas-capped Ether send. destOwner is deliberately a *different* contract from
     /// `to` so the capped send carries a first receive, which needs a 131,235 gas operand.
     /// Pointing both at one wallet would make the refund a warm-counter second receive needing
-    /// only 111,536 — below the 112,920 a legacy one-slot wallet needs after EIP-8037, so it
+    /// only 111,536 — below the 122,920 a legacy one-slot wallet needs after Glamsterdam, so it
     /// would not demonstrate the budget this cap exists to provide.
     function test_bridge2_processMessage__storage_creating_wallet_claims_with_fee()
         public
@@ -479,7 +479,7 @@ contract TestBridge2_processMessage is TestBridge2Base {
     /// @dev The cap still bounds how much gas a recipient can consume: a receive path above the
     /// budget (6+1 fresh slots, ~156k gas) keeps failing the refund. 6 rather than 7 slots
     /// brackets the 135k cap as tightly as the schedule allows — 5+1 is the largest that fits.
-    function test_bridge2_processMessage__RevertWhen_refund_receiver_exceeds_gas_cap()
+    function test_bridge2_processMessage_RevertWhen_refund_receiver_exceeds_gas_cap()
         public
         transactBy(Carol)
     {

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -428,10 +428,10 @@ contract TestBridge2_processMessage is TestBridge2Base {
     /// @dev End-to-end claim of bridged Ether by storage-creating smart wallets with a relayer
     /// fee: the invocation pays the value to `to`, and the unused fee is refunded to destOwner
     /// through the gas-capped Ether send. destOwner is deliberately a *different* contract from
-    /// `to` so the capped send carries a first receive (5+1 fresh slots, ~133k gas). Pointing
-    /// both at one wallet would make the refund a warm-counter second receive costing ~112k —
-    /// just under the 112,920 a legacy one-slot wallet needs after EIP-8037, so it would not
-    /// demonstrate the budget this cap exists to provide.
+    /// `to` so the capped send carries a first receive, which needs a 131,235 gas operand.
+    /// Pointing both at one wallet would make the refund a warm-counter second receive needing
+    /// only 111,536 — below the 112,920 a legacy one-slot wallet needs after EIP-8037, so it
+    /// would not demonstrate the budget this cap exists to provide.
     function test_bridge2_processMessage__storage_creating_wallet_claims_with_fee()
         public
         transactBy(Carol)

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -531,9 +531,9 @@ contract TestBridge2_processMessage is TestBridge2Base {
         assertApproxEqAbs(wallet.recordedBudget(), 137_300, 500);
     }
 
-    /// @dev Self-claim path: msg.sender == destOwner, so processMessage takes the `gasleft()`
-    /// invocation branch and skips the relayer payout, sending value and the whole fee to the
-    /// wallet in one capped send. Every other test of that send runs the relayer path.
+    /// @dev Self-claim path with invocation prohibited: msg.sender == destOwner, so the relayer
+    /// payout is skipped entirely and the value plus the whole fee arrive in a single capped
+    /// send. Every other test of that send runs the relayer path, where a fee cut is deducted.
     function test_bridge2_processMessage__self_claim_by_storage_creating_wallet() public {
         MessageReceiver_CreatingFreshStorageSlots wallet =
             new MessageReceiver_CreatingFreshStorageSlots(5);
@@ -557,6 +557,41 @@ contract TestBridge2_processMessage is TestBridge2Base {
         // No relayer cut on this path: the value and the entire fee arrive in one send.
         assertEq(wallet.receiveCount(), 1);
         assertEq(address(wallet).balance, 2 ether + 5_000_000);
+        assertEq(address(eBridge).balance, bridgeBalance - 2 ether - 5_000_000);
+    }
+
+    /// @dev The self-claim path's other half: with an invocable `to`, processMessage forwards
+    /// raw `gasleft()` to the invocation, a budget large enough for a storage-creating receive.
+    /// The refund then goes to a second wallet, so the capped send still carries a first receive.
+    function test_bridge2_processMessage__self_claim_with_invocation() public {
+        MessageReceiver_CreatingFreshStorageSlots invocationWallet =
+            new MessageReceiver_CreatingFreshStorageSlots(5);
+        MessageReceiver_CreatingFreshStorageSlots refundWallet =
+            new MessageReceiver_CreatingFreshStorageSlots(5);
+
+        uint256 bridgeBalance = address(eBridge).balance;
+
+        IBridge.Message memory message;
+        message.destChainId = ethereumChainId;
+        message.srcChainId = taikoChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 5_000_000;
+        message.value = 2 ether;
+        message.destOwner = address(refundWallet);
+        // Empty data and a plain contract `to`: invocation is permitted, so the gasleft() arm
+        // of the invocation-budget ternary is taken.
+        message.to = address(invocationWallet);
+
+        vm.prank(address(refundWallet));
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        bytes32 hash = eBridge.hashMessage(message);
+        assertTrue(eBridge.messageStatus(hash) == IBridge.Status.DONE);
+        assertEq(invocationWallet.receiveCount(), 1);
+        assertEq(refundWallet.receiveCount(), 1);
+        assertEq(address(invocationWallet).balance, 2 ether);
+        // Self-claim takes no relayer cut, so the entire fee is refunded.
+        assertEq(address(refundWallet).balance, 5_000_000);
         assertEq(address(eBridge).balance, bridgeBalance - 2 ether - 5_000_000);
     }
 

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -531,6 +531,35 @@ contract TestBridge2_processMessage is TestBridge2Base {
         assertApproxEqAbs(wallet.recordedBudget(), 137_300, 500);
     }
 
+    /// @dev Self-claim path: msg.sender == destOwner, so processMessage takes the `gasleft()`
+    /// invocation branch and skips the relayer payout, sending value and the whole fee to the
+    /// wallet in one capped send. Every other test of that send runs the relayer path.
+    function test_bridge2_processMessage__self_claim_by_storage_creating_wallet() public {
+        MessageReceiver_CreatingFreshStorageSlots wallet =
+            new MessageReceiver_CreatingFreshStorageSlots(5);
+
+        uint256 bridgeBalance = address(eBridge).balance;
+
+        IBridge.Message memory message;
+        message.destChainId = ethereumChainId;
+        message.srcChainId = taikoChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 5_000_000;
+        message.value = 2 ether;
+        message.destOwner = address(wallet);
+        message.to = address(eBridge);
+
+        vm.prank(address(wallet));
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        bytes32 hash = eBridge.hashMessage(message);
+        assertTrue(eBridge.messageStatus(hash) == IBridge.Status.DONE);
+        // No relayer cut on this path: the value and the entire fee arrive in one send.
+        assertEq(wallet.receiveCount(), 1);
+        assertEq(address(wallet).balance, 2 ether + 5_000_000);
+        assertEq(address(eBridge).balance, bridgeBalance - 2 ether - 5_000_000);
+    }
+
     function test_bridge2_processMessage__context_transient_lifecycle() public transactBy(Carol) {
         Target target = new Target(eBridge);
 

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -393,15 +393,15 @@ contract TestBridge2_processMessage is TestBridge2Base {
     }
 
     /// @dev The refund send to destOwner must budget for a smart wallet that creates fresh
-    /// storage slots in its receive path. Writing 4+1 fresh slots costs ~112k gas under the
-    /// current schedule — above the previous 35k cap and comparable to what a single fresh slot
-    /// (97,920 gas) plus wallet overhead will cost under EIP-8037.
+    /// storage slots in its receive path. Writing 5+1 fresh slots costs ~133k gas under the
+    /// current schedule, which clears the 112,920 a wallet that saturated the legacy 35k budget
+    /// while writing one slot will need under EIP-8037 — 4+1 slots (~111k) does not.
     function test_bridge2_processMessage__refund_to_storage_creating_wallet()
         public
         transactBy(Carol)
     {
         MessageReceiver_CreatingFreshStorageSlots wallet =
-            new MessageReceiver_CreatingFreshStorageSlots(4);
+            new MessageReceiver_CreatingFreshStorageSlots(5);
 
         uint256 bridgeBalance = address(eBridge).balance;
 
@@ -464,14 +464,15 @@ contract TestBridge2_processMessage is TestBridge2Base {
         assertEq(address(eBridge).balance, bridgeBalance - 2 ether - 5_000_000);
     }
 
-    /// @dev The cap still bounds how much gas a recipient can consume: a receive path far above
-    /// the budget (7+1 fresh slots, ~179k gas) keeps failing the refund.
+    /// @dev The cap still bounds how much gas a recipient can consume: a receive path above the
+    /// budget (6+1 fresh slots, ~156k gas) keeps failing the refund. 6 rather than 7 slots
+    /// brackets the 135k cap as tightly as the schedule allows — 5+1 is the largest that fits.
     function test_bridge2_processMessage__refund_receiver_exceeding_gas_cap()
         public
         transactBy(Carol)
     {
         MessageReceiver_CreatingFreshStorageSlots wallet =
-            new MessageReceiver_CreatingFreshStorageSlots(7);
+            new MessageReceiver_CreatingFreshStorageSlots(6);
 
         IBridge.Message memory message;
         message.destChainId = ethereumChainId;

--- a/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_processMessage.t.sol
@@ -429,9 +429,9 @@ contract TestBridge2_processMessage is TestBridge2Base {
     /// fee: the invocation pays the value to `to`, and the unused fee is refunded to destOwner
     /// through the gas-capped Ether send. destOwner is deliberately a *different* contract from
     /// `to` so the capped send carries a first receive (5+1 fresh slots, ~133k gas). Pointing
-    /// both at one wallet makes the refund a warm-counter second receive costing only ~91k —
-    /// below the 97,920 one fresh slot costs under EIP-8037, so it would not exercise the
-    /// budget this cap exists to provide.
+    /// both at one wallet would make the refund a warm-counter second receive costing ~112k —
+    /// just under the 112,920 a legacy one-slot wallet needs after EIP-8037, so it would not
+    /// demonstrate the budget this cap exists to provide.
     function test_bridge2_processMessage__storage_creating_wallet_claims_with_fee()
         public
         transactBy(Carol)

--- a/packages/protocol/test/shared/bridge/Bridge2_quotaAccounting.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_quotaAccounting.t.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.24;
 
 import "../helpers/CountingQuotaManager.sol";
 import "./TestBridge2Base.sol";
+import {
+    MessageReceiver_CreatingFreshStorageSlots
+} from "test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol";
 
 contract QuotaTarget is IMessageInvocable {
     bool public toFail;
@@ -179,5 +182,35 @@ contract TestBridge2_quotaAccounting is TestBridge2Base {
         eBridge.recallMessage(m, FAKE_PROOF);
         assertTrue(eBridge.messageStatus(eBridge.hashMessage(m)) == IBridge.Status.RECALLED);
         assertEq(qm.calls(), 0);
+    }
+
+    // The capped Ether send to a storage-creating destOwner, with a real QuotaManager wired.
+    // Every other test of that send inherits getQuotaManager() == address(0), which makes
+    // _consumeEtherQuota a no-op and leaves its external call out of the post-invocation tail.
+    function test_quota_processMessage_storage_creating_destOwner_debits_and_refunds()
+        public
+        dealEther(Alice)
+        dealEther(Carol)
+    {
+        MessageReceiver_CreatingFreshStorageSlots wallet =
+            new MessageReceiver_CreatingFreshStorageSlots(5);
+
+        IBridge.Message memory message;
+        message.destChainId = ethereumChainId;
+        message.srcChainId = taikoChainId;
+        message.gasLimit = 1_000_000;
+        message.fee = 0;
+        message.value = 2 ether;
+        message.destOwner = address(wallet);
+        message.to = address(eBridge); // invocation prohibited -> full value refunded
+
+        vm.prank(Carol);
+        eBridge.processMessage(message, FAKE_PROOF);
+
+        bytes32 hash = eBridge.hashMessage(message);
+        assertTrue(eBridge.messageStatus(hash) == IBridge.Status.DONE);
+        assertEq(address(wallet).balance, 2 ether);
+        assertEq(wallet.receiveCount(), 1);
+        assertEq(_ethConsumed(), message.value);
     }
 }

--- a/packages/protocol/test/shared/bridge/Bridge2_quotaAccounting.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_quotaAccounting.t.sol
@@ -189,7 +189,6 @@ contract TestBridge2_quotaAccounting is TestBridge2Base {
     // _consumeEtherQuota a no-op and leaves its external call out of the post-invocation tail.
     function test_quota_processMessage_storage_creating_destOwner_debits_and_refunds()
         public
-        dealEther(Alice)
         dealEther(Carol)
     {
         MessageReceiver_CreatingFreshStorageSlots wallet =

--- a/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
@@ -72,6 +72,8 @@ contract TestBridge2_recallMessage is TestBridge2Base {
         MessageReceiver_CreatingFreshStorageSlots wallet =
             new MessageReceiver_CreatingFreshStorageSlots(5);
 
+        uint256 totalBalance = getBalanceForAccounts() + address(wallet).balance;
+
         IBridge.Message memory message;
         message.srcOwner = address(wallet);
         message.destOwner = Bob;
@@ -88,6 +90,7 @@ contract TestBridge2_recallMessage is TestBridge2Base {
 
         assertEq(address(wallet).balance, 1 ether);
         assertEq(wallet.receiveCount(), 1);
+        assertEq(getBalanceForAccounts() + address(wallet).balance, totalBalance);
     }
 
     function test_bridge2_recallMessage_callable_sender() public dealEther(Carol) {

--- a/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
@@ -63,14 +63,14 @@ contract TestBridge2_recallMessage is TestBridge2Base {
     }
 
     /// @dev A recalled message must be able to return its value to a smart-wallet srcOwner that
-    /// creates fresh storage slots when receiving Ether (~112k gas here, comparable to one fresh
-    /// slot plus overhead under EIP-8037), which exceeded the previous 35k send cap.
+    /// creates fresh storage slots when receiving Ether (5+1 slots, ~133k gas here, clearing the
+    /// 112,920 a one-slot wallet needs under EIP-8037), far above the previous 35k send cap.
     function test_bridge2_recallMessage_storage_creating_wallet_srcOwner()
         public
         transactBy(Carol)
     {
         MessageReceiver_CreatingFreshStorageSlots wallet =
-            new MessageReceiver_CreatingFreshStorageSlots(4);
+            new MessageReceiver_CreatingFreshStorageSlots(5);
 
         IBridge.Message memory message;
         message.srcOwner = address(wallet);

--- a/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
+++ b/packages/protocol/test/shared/bridge/Bridge2_recallMessage.t.sol
@@ -64,7 +64,7 @@ contract TestBridge2_recallMessage is TestBridge2Base {
 
     /// @dev A recalled message must be able to return its value to a smart-wallet srcOwner that
     /// creates fresh storage slots when receiving Ether (5+1 slots, ~133k gas here, clearing the
-    /// 112,920 a one-slot wallet needs under EIP-8037), far above the previous 35k send cap.
+    /// 122,920 a one-slot wallet needs after Glamsterdam), far above the previous 35k send cap.
     function test_bridge2_recallMessage_storage_creating_wallet_srcOwner()
         public
         transactBy(Carol)

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
@@ -3,15 +3,15 @@ pragma solidity ^0.8.24;
 
 /// @dev A recipient that creates `numSlots` fresh storage slots every time it receives Ether,
 /// mimicking a smart wallet whose receive path performs bookkeeping writes. Under the current
-/// gas schedule each fresh slot costs 22,100 gas; under EIP-8037 (Glamsterdam) it costs 97,920
-/// of state gas plus the surviving 2,100 cold-access charge. The `receiveCount` slot itself is
-/// an extra fresh slot on the first receive and a warm rewrite afterwards, so a first receive
-/// creates `numSlots + 1` fresh slots.
+/// gas schedule each fresh slot costs 22,100 gas; after Glamsterdam it costs 110,020 — the
+/// 2,100 cold-access charge, EIP-8038's 10,000 STORAGE_WRITE, and EIP-8037's 97,920 of state
+/// gas. The `receiveCount` slot itself is an extra fresh slot on the first receive and a warm
+/// rewrite afterwards, so a first receive creates `numSlots + 1` fresh slots.
 /// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule. Every
 /// test that exercises Bridge._SEND_ETHER_GAS_LIMIT with this fixture drives a *first* receive,
-/// so if the test EVM ever adopts EIP-8037 pricing the rule is uniform: pass-side counts become
-/// 0 (the counter slot alone is then the one fresh slot) and fail-side counts become 1 (two
-/// fresh slots, 200,040 gas, still above the cap). This is not a proportional rescaling of
+/// so if the test EVM ever adopts Glamsterdam pricing the rule is uniform: pass-side counts
+/// become 0 (the counter slot alone is then the one fresh slot) and fail-side counts become 1
+/// (two fresh slots, 220,140 gas, still above the cap). This is not a proportional rescaling of
 /// today's counts — the counter slot is why the pass-side goes to 0 rather than 1. The
 /// gas-budget pin test in Bridge2_processMessage.t.sol needs no recalibration at all: it
 /// measures the forwarded allowance, not the gas a receive path consumes.

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
@@ -10,10 +10,12 @@ pragma solidity ^0.8.24;
 /// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule, and they
 /// cannot simply be rescaled if the test EVM ever adopts Glamsterdam pricing. Every test that
 /// exercises Bridge._SEND_ETHER_GAS_LIMIT with this fixture drives a *first* receive, so after
-/// the fork the fixture's granularity is one fresh slot = 110,020 gas — coarser than the ~12,000
-/// of headroom between the 122,920 a legacy one-slot wallet needs and the 135,000 cap. No count
-/// brackets that band: 0 slots (the counter slot alone) consumes only 110,020, below the very
-/// requirement the cap exists to guarantee, and 1 slot consumes 220,040, far above the cap. This
+/// the fork the fixture's granularity is one fresh slot = 110,020 gas of slot charges — coarser
+/// than the ~12,000 of headroom between the 122,920 a legacy one-slot wallet needs and the
+/// 135,000 cap. No count brackets that band: 0 slots (the counter slot alone) is charged 110,020,
+/// below the very requirement the cap exists to guarantee, and 1 slot is charged 220,040, far
+/// above the cap. Surrounding opcodes add execution cost on top of those slot charges (~935 gas
+/// for six slots, measured today), nowhere near enough to change that. This
 /// fixture is therefore a pre-fork instrument only. A second trap if anyone tries anyway:
 /// EIP-8037 splits transaction gas above the 16.7M execution cap into a state-gas reservoir, and
 /// state charges draw from that reservoir before they reach the callee frame; foundry.toml sets

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
@@ -3,13 +3,18 @@ pragma solidity ^0.8.24;
 
 /// @dev A recipient that creates `numSlots` fresh storage slots every time it receives Ether,
 /// mimicking a smart wallet whose receive path performs bookkeeping writes. Under the current
-/// gas schedule each fresh slot costs 22,100 gas; under EIP-8037 (Glamsterdam) a single fresh
-/// slot costs 97,920 gas, so 4 fresh slots today approximate the gas a one-slot wallet will
-/// need after the fork. The `receiveCount` slot itself is an extra fresh slot on the first
-/// receive and a warm rewrite afterwards.
-/// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule. If the
-/// test EVM ever adopts EIP-8037 pricing, reduce them accordingly (4 -> 1, 7 -> 2) so the
-/// consumed gas keeps its intended position relative to Bridge._SEND_ETHER_GAS_LIMIT.
+/// gas schedule each fresh slot costs 22,100 gas; under EIP-8037 (Glamsterdam) it costs 97,920
+/// of state gas plus the surviving 2,100 cold-access charge. The `receiveCount` slot itself is
+/// an extra fresh slot on the first receive and a warm rewrite afterwards, so a first receive
+/// creates `numSlots + 1` fresh slots.
+/// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule. Every
+/// test that exercises Bridge._SEND_ETHER_GAS_LIMIT drives a *first* receive, so if the test EVM
+/// ever adopts EIP-8037 pricing the rule is uniform: pass-side counts become 0 (the counter slot
+/// alone is then the one fresh slot) and fail-side counts become 1 (two fresh slots, 195,840
+/// gas, still above the cap). This is not a proportional rescaling of today's counts — the
+/// counter slot is why the pass-side goes to 0 rather than 1. The gas-budget pin test in
+/// Bridge2_processMessage.t.sol needs no recalibration at all: it measures the forwarded
+/// allowance, not the gas a receive path consumes.
 contract MessageReceiver_CreatingFreshStorageSlots {
     uint256 public immutable numSlots;
     uint256 public receiveCount;

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
@@ -8,13 +8,13 @@ pragma solidity ^0.8.24;
 /// an extra fresh slot on the first receive and a warm rewrite afterwards, so a first receive
 /// creates `numSlots + 1` fresh slots.
 /// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule. Every
-/// test that exercises Bridge._SEND_ETHER_GAS_LIMIT drives a *first* receive, so if the test EVM
-/// ever adopts EIP-8037 pricing the rule is uniform: pass-side counts become 0 (the counter slot
-/// alone is then the one fresh slot) and fail-side counts become 1 (two fresh slots, 195,840
-/// gas, still above the cap). This is not a proportional rescaling of today's counts — the
-/// counter slot is why the pass-side goes to 0 rather than 1. The gas-budget pin test in
-/// Bridge2_processMessage.t.sol needs no recalibration at all: it measures the forwarded
-/// allowance, not the gas a receive path consumes.
+/// test that exercises Bridge._SEND_ETHER_GAS_LIMIT with this fixture drives a *first* receive,
+/// so if the test EVM ever adopts EIP-8037 pricing the rule is uniform: pass-side counts become
+/// 0 (the counter slot alone is then the one fresh slot) and fail-side counts become 1 (two
+/// fresh slots, 200,040 gas, still above the cap). This is not a proportional rescaling of
+/// today's counts — the counter slot is why the pass-side goes to 0 rather than 1. The
+/// gas-budget pin test in Bridge2_processMessage.t.sol needs no recalibration at all: it
+/// measures the forwarded allowance, not the gas a receive path consumes.
 contract MessageReceiver_CreatingFreshStorageSlots {
     uint256 public immutable numSlots;
     uint256 public receiveCount;

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
@@ -7,18 +7,21 @@ pragma solidity ^0.8.24;
 /// 2,100 cold-access charge, EIP-8038's 10,000 STORAGE_WRITE, and EIP-8037's 97,920 of state
 /// gas. The `receiveCount` slot itself is an extra fresh slot on the first receive and a warm
 /// rewrite afterwards, so a first receive creates `numSlots + 1` fresh slots.
-/// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule. Every
-/// test that exercises Bridge._SEND_ETHER_GAS_LIMIT with this fixture drives a *first* receive,
-/// so if the test EVM ever adopts Glamsterdam pricing the count rule would be uniform: pass-side
-/// counts become 0 (the counter slot alone is then the one fresh slot) and fail-side counts
-/// become 1 (two fresh slots, 220,140 gas, above the cap). Changing the counts is NOT sufficient
-/// on its own. EIP-8037 splits transaction gas above the 16.7M execution cap into a state-gas
-/// reservoir, and state charges draw from that reservoir before they reach the callee frame;
-/// foundry.toml sets gas_limit to u64::MAX, so the 97,920 would be absorbed there and never
-/// bite the budget under test. Recalibrating therefore also needs a profile whose transaction
-/// gas limit leaves the reservoir empty. The gas-budget pin test in Bridge2_processMessage.t.sol
-/// sidesteps all of this: it measures the forwarded allowance, not the gas a receive path
-/// consumes.
+/// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule, and they
+/// cannot simply be rescaled if the test EVM ever adopts Glamsterdam pricing. Every test that
+/// exercises Bridge._SEND_ETHER_GAS_LIMIT with this fixture drives a *first* receive, so after
+/// the fork the fixture's granularity is one fresh slot = 110,020 gas — coarser than the ~12,000
+/// of headroom between the 122,920 a legacy one-slot wallet needs and the 135,000 cap. No count
+/// brackets that band: 0 slots (the counter slot alone) consumes only 110,020, below the very
+/// requirement the cap exists to guarantee, and 1 slot consumes 220,040, far above the cap. This
+/// fixture is therefore a pre-fork instrument only. A second trap if anyone tries anyway:
+/// EIP-8037 splits transaction gas above the 16.7M execution cap into a state-gas reservoir, and
+/// state charges draw from that reservoir before they reach the callee frame; foundry.toml sets
+/// gas_limit to u64::MAX, so the 97,920 would be absorbed there and never bite the budget under
+/// test without a profile whose transaction gas limit leaves the reservoir empty. The gas-budget
+/// pin test in Bridge2_processMessage.t.sol sidesteps all of this: it measures the forwarded
+/// allowance, not the gas a receive path consumes, and is what will still constrain the constant
+/// after the fork.
 contract MessageReceiver_CreatingFreshStorageSlots {
     uint256 public immutable numSlots;
     uint256 public receiveCount;

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_CreatingFreshStorageSlots.sol
@@ -9,12 +9,16 @@ pragma solidity ^0.8.24;
 /// rewrite afterwards, so a first receive creates `numSlots + 1` fresh slots.
 /// NOTE: the slot counts used by tests are calibrated to the pre-Glamsterdam schedule. Every
 /// test that exercises Bridge._SEND_ETHER_GAS_LIMIT with this fixture drives a *first* receive,
-/// so if the test EVM ever adopts Glamsterdam pricing the rule is uniform: pass-side counts
-/// become 0 (the counter slot alone is then the one fresh slot) and fail-side counts become 1
-/// (two fresh slots, 220,140 gas, still above the cap). This is not a proportional rescaling of
-/// today's counts — the counter slot is why the pass-side goes to 0 rather than 1. The
-/// gas-budget pin test in Bridge2_processMessage.t.sol needs no recalibration at all: it
-/// measures the forwarded allowance, not the gas a receive path consumes.
+/// so if the test EVM ever adopts Glamsterdam pricing the count rule would be uniform: pass-side
+/// counts become 0 (the counter slot alone is then the one fresh slot) and fail-side counts
+/// become 1 (two fresh slots, 220,140 gas, above the cap). Changing the counts is NOT sufficient
+/// on its own. EIP-8037 splits transaction gas above the 16.7M execution cap into a state-gas
+/// reservoir, and state charges draw from that reservoir before they reach the callee frame;
+/// foundry.toml sets gas_limit to u64::MAX, so the 97,920 would be absorbed there and never
+/// bite the budget under test. Recalibrating therefore also needs a profile whose transaction
+/// gas limit leaves the reservoir empty. The gas-budget pin test in Bridge2_processMessage.t.sol
+/// sidesteps all of this: it measures the forwarded allowance, not the gas a receive path
+/// consumes.
 contract MessageReceiver_CreatingFreshStorageSlots {
     uint256 public immutable numSlots;
     uint256 public receiveCount;

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_RecordingGasBudget.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_RecordingGasBudget.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @dev A recipient that records the gas budget its receive path is handed, so a test can pin
+/// Bridge._SEND_ETHER_GAS_LIMIT directly instead of inferring it from how much work a receive
+/// path can afford. `recordedBudget` is the CALL gas operand plus the 2,300 stipend a
+/// value-bearing CALL always adds, less the few opcodes spent entering the frame. Unlike
+/// gas-consumption fixtures this stays valid across gas-schedule changes such as EIP-8037,
+/// because the forwarded allowance does not depend on how storage writes are priced.
+contract MessageReceiver_RecordingGasBudget {
+    uint256 public recordedBudget;
+
+    receive() external payable {
+        recordedBudget = gasleft();
+    }
+}

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_RecordingGasBudget.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_RecordingGasBudget.sol
@@ -7,8 +7,13 @@ pragma solidity ^0.8.24;
 /// value-bearing CALL always adds, less the few opcodes spent entering the frame. Unlike
 /// gas-consumption fixtures this stays valid across gas-schedule changes such as EIP-8037,
 /// because the forwarded allowance does not depend on how storage writes are priced.
+/// `recordedBudget` is pre-initialised so its write is an existing-slot update rather than a
+/// slot creation. That keeps the recorded value identical today while ensuring that after
+/// Glamsterdam the write costs 12,100 rather than 110,020 — otherwise a future cap below
+/// ~112,000 would fail this test with ETH_TRANSFER_FAILED instead of an assertion mismatch,
+/// reporting the wrong cause.
 contract MessageReceiver_RecordingGasBudget {
-    uint256 public recordedBudget;
+    uint256 public recordedBudget = 1;
 
     receive() external payable {
         recordedBudget = gasleft();

--- a/packages/protocol/test/shared/bridge/helpers/MessageReceiver_RecordingGasBudget.sol
+++ b/packages/protocol/test/shared/bridge/helpers/MessageReceiver_RecordingGasBudget.sol
@@ -7,11 +7,13 @@ pragma solidity ^0.8.24;
 /// value-bearing CALL always adds, less the few opcodes spent entering the frame. Unlike
 /// gas-consumption fixtures this stays valid across gas-schedule changes such as EIP-8037,
 /// because the forwarded allowance does not depend on how storage writes are priced.
-/// `recordedBudget` is pre-initialised so its write is an existing-slot update rather than a
-/// slot creation. That keeps the recorded value identical today while ensuring that after
-/// Glamsterdam the write costs 12,100 rather than 110,020 — otherwise a future cap below
-/// ~112,000 would fail this test with ETH_TRANSFER_FAILED instead of an assertion mismatch,
-/// reporting the wrong cause.
+/// `recordedBudget` is pre-initialised so the receive path updates an existing slot rather than
+/// creating one. The constructor runs in the same transaction as the call under test, so by the
+/// time the send arrives the slot is warm with `original = 0, current = 1`; writing it again is
+/// a dirty-slot update billed at WARM_ACCESS (100) under both the current schedule and EIP-8038,
+/// rather than a fresh-slot creation (22,100 today, 110,020 after Glamsterdam) charged inside
+/// the gas-capped frame. Without it a cap too low to cover a slot creation would fail this test
+/// with ETH_TRANSFER_FAILED instead of an assertion mismatch, reporting the wrong cause.
 contract MessageReceiver_RecordingGasBudget {
     uint256 public recordedBudget = 1;
 


### PR DESCRIPTION
## What this is

The zero-semantic-change subset of the review on #22077 ([review comment](https://github.com/taikoxyz/taiko-mono/pull/22077#issuecomment-5476345767)): comment corrections and test tightening. **`Bridge.sol` changes comments only** — verified mechanically, and that is the whole argument for why this needs no protocol review:

```
git diff main...HEAD -- packages/protocol/contracts/shared/bridge/Bridge.sol \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*(///|$)'   # prints nothing
```

Stripping all comments from `Bridge.sol` at base and at tip yields byte-identical files.

## The main deliverable

Before this branch the whole suite passed for **any** `_SEND_ETHER_GAS_LIMIT` in `[108,992, 175,720]` — including values *below* what the constant exists to guarantee. Bisected, at both ends:

| | admissible cap values | width |
|---|---|---|
| `main` (159 tests) | `[108,992, 175,720]` | 66,729 |
| this branch, first pass (163 tests) | `[134,557, 135,557]` | 1,001 |
| this branch, after review (164 tests) | **`[134,957, 135,057]`** | **101** |

A 660× tightening. The old floor sat 13,928 gas *below* the post-fork requirement of 122,920; the new one clears it by 12,037.

(Counts are the whole `test/shared/**` suite — `pnpm test:shared` — not the bridge directory alone, which is 68 → 73. The intervals are identical under either scoping.)

What closes it is a new fixture that records `gasleft()` in its `receive()`, so one test measures the forwarded allowance directly (`135,000 + 2,300` stipend, measured 137,243) instead of inferring it from how much work a recipient can afford. That test also needs **no recalibration at the fork** — it measures the allowance, not gas consumed under a particular SSTORE price.

## Comment corrections

- **The sizing derivation was wrong on both forks.** Amsterdam ships EIP-8038 alongside EIP-8037, and 8038's `STORAGE_WRITE` (2,800 → 10,000) is charged in the frame doing the write — so it draws on this budget, which the previous text excluded as caller-side. A fresh cold slot goes `2,100 + 20,000 = 22,100` today to `2,100 + 10,000 + 97,920 = 110,020`; preserving a legacy one-slot wallet costs `35,000 − 22,100 + 110,020 = **122,920**`, leaving 135,000 with **~12k** of headroom. The cap was sized as `35,000 + 97,920` rounded up, before 8038 was accounted for — it still clears the corrected requirement, but by half the margin previously believed.
- **The compatibility claim is gone, not narrowed.** Three successive counterexamples falsified three successive narrowings, so the comment now states what the cap was sized for plus an explicit non-guarantee. The three: forwarding value to a never-used address costs ~36,600 today but ≥183,600 after (account creation, zero storage slots); one fresh cold SSTORE + one cold existing write + ~75 warm `EXTCODESIZE` reads costs ~34,600 today and ~137,120 after (8038 bills `EXTCODESIZE` as two warm accesses; an earlier draft of this line said 34,900/137,420, which carried 300 gas of unlisted overhead — the delta, and so the conclusion, is unchanged); and one fresh slot plus a single existing slot rewritten as `x→y→x→z→x→w` costs 33,100 today and 142,520 after, because `STORAGE_WRITE` is charged on every departure from a slot's transaction-start value while the restoring credit goes only to the transaction refund counter, never back to the frame's `gas_left`.
- **The fixture's recalibration note was off by one.** A first receive creates `numSlots + 1` fresh slots — the counter slot is fresh too. The old note's "`4 -> 1`" is a two-slot wallet (220,040 gas post-fork). Under a profile whose transaction gas limit leaves EIP-8037's state-gas reservoir empty, following it would have turned the must-pass tests red at exactly the fork it was written for; under the repo's current `gas_limit = u64::MAX` they would instead stay *green for the wrong reason*, because the reservoir absorbs the state charges before the callee frame sees them. The note now records both — the count rule and the fact that counts alone are not sufficient without such a profile.

## Test changes

- Bounds raised `4 -> 5` / `7 -> 6`. `N=4` needed a 108,992 operand — below the 122,920 requirement — so the old lower bound did not demonstrate the guarantee. `N=5` (131,235) clears it; `N=6` (153,478) still fails and brackets the cap more tightly.
- The fee test's capped leg was a *warm-counter second* receive costing 89,392, below what a single fresh slot costs post-fork. Separate wallets for `to` and `destOwner` make it a first receive. Its `gasLimit` is now derived from `getMessageMinGasLimit(0)`, decoupling it from `GAS_RESERVE` — the hardcoded `1_000_000` made it fail at `GAS_RESERVE >= 884,353` with a symptom pointing at the send cap.
- New coverage for the self-claim path with a *cap-sensitive* receiver, on both the prohibited-invocation and `gasleft()` arms. Three pre-existing tests already reached that path (`transactBy(Alice)` with `destOwner = Alice`), but all with EOA `destOwner`s, so none of them put the capped send's budget under any pressure. Also new: the capped send under a live `QuotaManager` — every prior test that drove a storage-creating recipient through that send inherited `getQuotaManager() == address(0)`.
- **The relayer fee payout was entirely unpinned.** `Bridge.sol`'s `msg.sender` send is a separate capped send from the destOwner refund, and every test paid it to an EOA, where the 2,300 stipend alone suffices — setting that send's gas operand to zero left the whole suite green. A new test makes a storage-creating contract the relayer with an EOA `destOwner`, so the payout is the only leg needing the budget.
- The recall test gained the file's value-conservation idiom — a 1-wei leak to a third account previously passed it — and the one negative test was renamed to the `RevertWhen_` form `packages/protocol/CLAUDE.md` specifies.

Each new or changed test was mutation-checked against the full 164-test shared suite. Dropping `stats.processedByRelayer &&` from the payout guard fails exactly the two self-claim tests. Collapsing the invocation-budget ternary to its relayer branch fails the invocation test (alongside three pre-existing tests that already caught it) — the weaker `gasleft() -> 1` mutation cited earlier did not establish this, and the test was strengthened in review to make it do so. Setting the relayer fee payout's gas operand to zero fails exactly the new relayer test. The new quota test is uniquely sensitive to a send-budget regression conditioned on a wired QuotaManager; it is *not* uniquely sensitive to mutations of the quota accounting itself, which pre-existing tests already cover.

## Changes from review

An independent review of this branch confirmed the headline claims (bytecode identity, both bisection endpoints, every gas figure against the EIP text) and produced four fixes, now pushed:

- **`220,140` → `220,040`** in the fixture note, and the recalibration guidance was strengthened. It said counts alone are "not sufficient"; the truth is stronger — post-fork the fixture's granularity is one fresh slot (110,020), coarser than the ~12,000 of headroom, so **no** count brackets the requirement. `N=0` lands *below* 122,920 and `N=1` far above the cap. The fixture is a pre-fork instrument; after the fork only the pin test constrains the constant.
- **The pin test's ±500 tolerance was the sole constraint on the interval**, and ~9× wider than the noise it absorbs (frame entry is 57 gas). It was also centred on 137,300, which the measurement can never reach, so half the band was dead. Now a named `_EXPECTED_SEND_BUDGET` with an upper bound (the allowance can never exceed cap + stipend) and a −100 lower bound: 1,001 admissible values → 101.
- **`self_claim_with_invocation` did not pin the arm its docstring claimed.** Collapsing the ternary left it green, because `gasLimit = 1_000_000` gave the relayer branch 193,344 — well above the 131,235 needed. `gasLimit` is now derived as `getMessageMinGasLimit(0) + 1`, so the alternate arm gets one gas plus the 2,300 stipend. An earlier revision used `+ 120_000`, which works today but not after the fork: the receive's six fresh-slot state charges then come from the transaction's state-gas reservoir, leaving only ~73.5k visible to the frame, which a 120,000 arm would satisfy — the mutation would have stopped being caught at exactly the fork this branch is about. One gas cannot complete the receive under any schedule.
- **`MessageReceiver_RecordingGasBudget` pre-initialises its slot**, keeping a slot creation out of the gas-capped frame so a too-low cap fails on the assertion rather than on `ETH_TRANSFER_FAILED`, which would report the wrong cause. (An earlier revision priced that update at 12,100 — the cold existing-slot figure. The constructor runs in the same transaction as the call under test, so the slot is warm and already dirty when the send arrives and the update is billed at `WARM_ACCESS`.)

Plus the relayer-payout coverage above, and magnitude corrections in the `Bridge.sol` comment: `EXTCODESIZE` is +100 warm (+500 cold), needing ~75 to matter, so it no longer leads the list; the per-departure rule is distinguished from per-write (`x→y→z` pays the write once); and the closing hedge now names EIP-8037 too, since it is also in Review and its 1,530 gas/byte feeds every figure.

## Deliberately excluded

- **`GAS_OVERHEAD` recalibration.** The fee snapshot precedes both capped sends, so the widened burn is unreimbursed. Real recalibration needs production `MessageProcessed` data.
- **A self-claim/self-recall escape hatch for the cap.** A ~3-line semantic change; needs auditor sign-off, so it belongs in its own PR.
- **The pre-existing quota brick** — an Ether claim whose `value + fee` exceeds the QuotaManager ceiling reverts before the status write, wedging the message at NEW. Pre-existing, deserves its own issue.
- **`retryMessage`'s capped send appears to be dead code.** `Status.RETRIABLE` is assigned in exactly one place, inside the branch where `_unableToInvokeMessageCall` is false; that function is pure in the message and the `immutable` `signalService`, so it must return false again on retry. Only an upgrade swapping the `signalService` immutable between the two transactions could reach it. Pre-existing and out of scope here, but worth its own issue.

## Three notes for reviewers

1. **CI could silently invalidate this PR's headline claim.** `.github/workflows/protocol.yml` runs `pnpm fmt:sol` — a *writing* formatter — then auto-commits and force-pushes the result onto the PR branch. `.tool-versions` pins foundry v1.4.2, under which `Bridge.sol` is already clean; but if a runner ever resolves a newer foundry, that step would push a non-comment `Bridge.sol` reformat here. Worth a glance at the diff after any CI auto-commit.
2. The Protocol workflow is gated on `draft == false`, so the 164-test gate will not run in CI while this stays a draft. Every check on this PR currently reports `SKIPPED` except `gitleaks` — the suite this PR is about has never run in CI here.
3. **"No semantic change" is not "no deployment consequence."** The `Bridge` creation and runtime bytecode are byte-identical to `main` with `bytecodeHash=none`, but under the repo default (`ipfs`) they are *not*: NatSpec feeds solc's devdoc, which is hashed into the CBOR metadata trailer. [Proposal0022](https://github.com/taikoxyz/taiko-mono/pull/22083) authenticates deployed implementations with `cast codehash` against a local build, so its deploy and its verification must be done from the same commit relative to this merge.

Also note `lefthook.yml:10` invokes `pnpm -F protocol lint:sol`, which does not exist in `packages/protocol/package.json` (`fmt:sol` does). It is broken on `main` too, so every Solidity commit here used `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





