### PR TITLE
fix(relayer): end a claim's send at its nonce's holder, and ack duplicate deliveries

### DIFF
--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -190,7 +190,15 @@ fixed entry cap: `QUEUE_PREFETCH_COUNT` is configurable, so an arbitrary cap cou
 claim while it is still waiting for inclusion. Its size instead follows the unresolved accepted
 nonce window. A receipt observed through `DEST_RPC_URL` for nonce N releases exact records through
 N, because transactions from one account execute in nonce order; the high-water mark remains for
-ordering only.
+ordering only. Every transaction the backend sends is indexed by hash so that any receipt can be
+resolved to its nonce — including a claim that no relay would take and that landed through the
+public fallback, whose hash no private endpoint ever saw.
+
+That release and a resend can cross: the receipt arrives while a fee-bumped resend is already on
+its way to the endpoint holding that nonce, and the answer comes back after the record is gone. A
+nonce known to have mined therefore ends a send on its own. Nothing at that nonce can land again,
+so the endpoints behind the holder have nothing to offer but a refusal they would then be charged
+for.
 
 Plain `http://` is rejected unless the host is the name `localhost` or an IP literal in a loopback,
 private or link-local range: a signed claim on the wire in cleartext can be read and front-run,

--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -203,9 +203,17 @@ for it. The retained record goes when the next nonce mines, so at most one settl
 Receipts are read before the transaction manager has confirmation depth, so one can be observed for
 a transaction a reorg then removes. The nonce is live again and may be recycled to a different
 claim: an acceptance carrying a claim other than the retained one replaces it, while a repeat of
-the claim already recorded is treated as the stale fee variant it is. The hash index is bounded as
-well — a mined nonce collects the variants it replaced, since a nonce executes once, and a cap
-covers a nonce that never lands at all, where no later receipt can ever collect anything.
+the claim already recorded is treated as the stale fee variant it is. Sends answer in any order, so
+each acceptance also records which send learned it, and an older send's success cannot displace a
+newer one — a resend of the claim the reorg removed can otherwise report success after its
+replacement was recorded and put the departed claim back in front.
+
+The hash index is bounded: a mined nonce collects the variants it replaced, since a nonce executes
+once, and a cap covers a nonce that never lands at all, where no later receipt can ever collect
+anything. The cap drops the oldest send first, the one a relay is least likely still to hold.
+Because a cap can in principle drop the hash that does land, a receipt this index cannot resolve is
+settled against the account's nonce on `DEST_RPC_URL` instead, so releasing never depends on the
+cache hitting.
 
 Plain `http://` is rejected unless the host is the name `localhost` or an IP literal in a loopback,
 private or link-local range: a signed claim on the wire in cleartext can be read and front-run,

--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -116,6 +116,7 @@ To fix an existing queue, either is enough:
   rabbitmqctl set_policy dlrk "^<queue>$" \
     '{"dead-letter-routing-key":"<queue>-process"}' --apply-to queues --priority 1
   ```
+
 - Drain the queue and delete it, so the next start declares it afresh. This loses anything still
   queued, so drain first.
 
@@ -176,10 +177,20 @@ offered **first** any transaction whose nonce is at or below the highest it has 
 relay replaces a transaction the way a mempool does — same nonce, higher fee — so the endpoint
 already holding a nonce is the one place a resend achieves something, retiring the stale low-fee
 variant. Offering it elsewhere leaves both variants live in different builders' pools with nothing
-to enforce one transaction per nonce. Claims are handled concurrently, so this is a high-water mark
-rather than a record of each nonce; the cost is that a first send arriving out of order behind a
-higher nonce is treated as a resend, which only reorders private endpoints against each other.
-Nothing is charged for that reordering.
+to enforce one transaction per nonce. Claims are handled concurrently, so a high-water mark does
+this ordering; the cost is that a first send arriving out of order behind a higher nonce is treated
+as a resend, which only reorders private endpoints against each other. Nothing is charged for that
+reordering.
+
+Ending a send needs stronger evidence than that high-water mark. For each private acceptance the
+backend also records the endpoint, nonce and claim calldata hash. If that endpoint later answers
+`already known` or `replacement transaction underpriced` for the same nonce and claim, the resend
+ends there instead of offering another copy to the endpoints behind it. The exact record has no
+fixed entry cap: `QUEUE_PREFETCH_COUNT` is configurable, so an arbitrary cap could evict an older
+claim while it is still waiting for inclusion. Its size instead follows the unresolved accepted
+nonce window. A receipt observed through `DEST_RPC_URL` for nonce N releases exact records through
+N, because transactions from one account execute in nonce order; the high-water mark remains for
+ordering only.
 
 Plain `http://` is rejected unless the host is the name `localhost` or an IP literal in a loopback,
 private or link-local range: a signed claim on the wire in cleartext can be read and front-run,
@@ -231,10 +242,17 @@ transport failure always counts, even for the same transaction, since that is wh
 being down looks like. Only once no endpoint is left in
 rotation does a transaction go out through `DEST_RPC_URL`.
 
+The exact record also distinguishes a recycled nonce. If the endpoint accepted the same claim,
+the held answer ends the send immediately. If it accepted a different claim under that nonce, the
+answer is a refusal of the current claim and routing continues, including the all-refused public
+fallback. If there is no exact record, routing continues to the remaining private endpoints, but
+the unattributed hold still shields the claim from the public fallback because it may have reached
+that relay through private gossip.
+
 One claim can be refused by every endpoint without any of them being unhealthy — each is charged
 once for it, so none trips, and the claim would otherwise loop until `TX_SEND_TIMEOUT` while the
 relays go on serving everything else. After three consecutive sends that every endpoint in rotation
-*answered* with a refusal, that claim is broadcast publicly and
+_answered_ with a refusal, that claim is broadcast publicly and
 `private_rpc_all_refused_ops_total` counts it.
 
 That probation is served once per claim, not once per exposure. Once a claim has been broadcast it
@@ -250,11 +268,13 @@ of, and be broadcast on its first refusal instead of its third. The claim is ide
 calldata, which is the message and its proof: unchanged by the fee bumps that change everything else
 about the transaction, and different for every other claim.
 
-Two answers do not count towards this. A timeout or transport failure means the endpoint is down,
-which tripping handles, and counting it here would push claims into the open during an outage before
-the rotation had a chance to empty. An endpoint answering that it already holds the nonce does not
-count either — the claim is already where it needs to be, so broadcasting it would leak one every
-relay is carrying. Broadcasting publicly gives a
+Two situations do not count towards this. A timeout or transport failure means the endpoint is
+down, which tripping handles, and counting it here would push claims into the open during an outage
+before the rotation had a chance to empty. A held answer for this exact claim does not count either,
+nor does one with no exact local attribution: the relay may already be carrying the claim, so a
+public broadcast could leak it. A held answer attributed to a different claim under a recycled
+nonce does count as a refusal, because it proves the endpoint is not carrying the current claim.
+Broadcasting publicly gives a
 competitor the message and proof, so it is deliberately the last resort — but a claim that never
 lands is worth less than one landed in the open.
 

--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -194,11 +194,11 @@ ordering only. Every transaction the backend sends is indexed by hash so that an
 resolved to its nonce — including a claim that no relay would take and that landed through the
 public fallback, whose hash no private endpoint ever saw.
 
-That release and a resend can cross: the receipt arrives while a fee-bumped resend is already on
-its way to the endpoint holding that nonce, and the answer comes back after the record is gone. A
-nonce known to have mined therefore ends a send on its own. Nothing at that nonce can land again,
-so the endpoints behind the holder have nothing to offer but a refusal they would then be charged
-for.
+The release stops strictly below the mined nonce, keeping that nonce's own record. A receipt and a
+resend can cross — the receipt arrives while a fee-bumped resend is already on its way to the
+endpoint holding that nonce — and the answer that comes back afterwards needs the record to still
+be there, or the send continues to a backup that refuses a claim which is now done and is charged
+for it. The retained record goes when the next nonce mines, so at most one settled nonce is held.
 
 Plain `http://` is rejected unless the host is the name `localhost` or an IP literal in a loopback,
 private or link-local range: a signed claim on the wire in cleartext can be read and front-run,

--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -200,6 +200,13 @@ endpoint holding that nonce — and the answer that comes back afterwards needs 
 be there, or the send continues to a backup that refuses a claim which is now done and is charged
 for it. The retained record goes when the next nonce mines, so at most one settled nonce is held.
 
+Receipts are read before the transaction manager has confirmation depth, so one can be observed for
+a transaction a reorg then removes. The nonce is live again and may be recycled to a different
+claim: an acceptance carrying a claim other than the retained one replaces it, while a repeat of
+the claim already recorded is treated as the stale fee variant it is. The hash index is bounded as
+well — a mined nonce collects the variants it replaced, since a nonce executes once, and a cap
+covers a nonce that never lands at all, where no later receipt can ever collect anything.
+
 Plain `http://` is rejected unless the host is the name `localhost` or an IP literal in a loopback,
 private or link-local range: a signed claim on the wire in cleartext can be read and front-run,
 which is the exposure these endpoints exist to remove, reached by another route. Names are not

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -360,7 +360,8 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			// recordFailure entirely meant it could never reach the ceiling that exists to end
 			// exactly that: it would hold its place indefinitely while nothing was ever sent
 			// through it.
-			if tripped := b.recordHeldNonce(endpoint, tx.Nonce()); tripped {
+			tripped, demonstrated := b.recordHeldNonce(endpoint, tx.Nonce())
+			if tripped {
 				relayer.PrivateRPCTrips.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
 				slog.Warn("Private endpoint taken out of rotation",
@@ -373,8 +374,25 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			slog.Info("Private endpoint already holds this nonce",
 				"endpoint", endpoint.index,
 				"nonce", tx.Nonce(),
+				"endsSend", demonstrated,
 			)
 
+			// A nonce this endpoint has demonstrably taken makes it the holder, so the claim is
+			// already where it needs to be and this send is complete. Offering the same signed
+			// transaction to the endpoints behind it leaves the stale variant live in a second
+			// builder's pool — the thing steering a resend to its holder exists to avoid — and
+			// earns a refusal from a relay that did nothing wrong: the receipt lands while a
+			// resubmission is still in flight, and the next endpoint simulates a claim that is
+			// now done. Nothing resets that count while the holder keeps taking every claim
+			// first, so three claims took a healthy backup out of rotation. Returning nil is also
+			// the honest answer for the transaction manager, which is what arms the fee bump and
+			// what TxNotInMempoolTimeout reads: the transaction is at a relay.
+			if demonstrated {
+				return nil
+			}
+
+			// For a nonce it never took, the answer may be about a claim it learned from another
+			// relay's gossip. The endpoints behind it genuinely have not been asked.
 			continue
 		}
 
@@ -870,14 +888,20 @@ func (b *SendingBackend) recordFailure(endpoint admission, nonce uint64, rejecti
 // Two answers are free: one for a nonce the endpoint has demonstrably taken, and one repeat of the
 // last nonce it answered for. What is left to charge is an endpoint answering this way for a
 // succession of distinct claims it never took, which is the state the ceiling exists to end.
-func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (tripped bool) {
+//
+// It also reports whether this endpoint is the demonstrated holder of the nonce — the first of
+// those two free answers. The caller ends the send there rather than offering the same signed
+// transaction to the endpoints behind it; see SendTransaction. The predicate lives here because
+// this is the one place that owns hasAccepted and highestAccepted, and a second copy of it would
+// drift.
+func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (tripped, demonstrated bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	index := endpoint.index
 
 	if b.generation[index] != endpoint.generation {
-		return false
+		return false, false
 	}
 
 	// An endpoint answering for a nonce it has demonstrably taken is the holder by construction,
@@ -886,7 +910,7 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (trip
 	// answer counts, and ten answers — about four minutes at the resubmission default — took the
 	// endpoint holding both of them out of rotation.
 	if b.hasAccepted[index] && nonce <= b.highestAccepted[index] {
-		return false
+		return false, true
 	}
 
 	// Kept as well, for a nonce this endpoint never accepted: it may be answering for a claim it
@@ -897,7 +921,7 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (trip
 	// endpoint holding it; with one endpoint configured the claim then went public through the
 	// unavailable path, which is the exposure the exemption exists to prevent.
 	if b.hasHeld[index] && b.lastHeld[index] == nonce {
-		return false
+		return false, false
 	}
 
 	b.lastHeld[index] = nonce
@@ -908,10 +932,10 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (trip
 	if b.consecutive[index] >= b.failureCeiling {
 		b.leaveRotation(index)
 
-		return true
+		return true, false
 	}
 
-	return false
+	return false, false
 }
 
 // leaveRotation takes the endpoint at index out of rotation for the retry interval, ending the

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -571,8 +571,10 @@ func (b *SendingBackend) rememberSentNonce(tx *types.Transaction) {
 // already replaced.
 func (b *SendingBackend) boundSentNonces(justAdded uint64) {
 	for len(b.sentTxNonces) > maxTrackedSentNonces {
-		stalest := justAdded
-		var evict common.Hash
+		var (
+			stalest = justAdded
+			evict   common.Hash
+		)
 
 		for hash, nonce := range b.sentTxNonces {
 			if evict == (common.Hash{}) || nonce < stalest {

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -90,14 +90,6 @@ const DefaultPrivateRPCAllRefusedLimit = 3
 // than the processor has in flight at once, so a live claim is never evicted in practice.
 const maxTrackedRefusedNonces = 256
 
-// maxTrackedAcceptedNonces bounds the per-endpoint record of which nonces it took.
-//
-// Same shape and same reason as maxTrackedRefusedNonces, and deliberately the same size: both are
-// far more than the processor has in flight at once, so a live claim is never evicted in practice.
-// Evicting one is not a correctness problem either — the send simply stops treating that endpoint
-// as the nonce's holder and offers the claim onward, which is where it started.
-const maxTrackedAcceptedNonces = 256
-
 // DefaultPrivateRPCAttemptTimeout caps a single attempt when the caller supplied no deadline.
 //
 // The transaction manager always calls SendTransaction under its NetworkTimeout, so this does not
@@ -224,6 +216,9 @@ type SendingBackend struct {
 	highestAccepted  []uint64
 	hasAccepted      []bool
 	accepted         []map[uint64]common.Hash
+	acceptedTxNonces map[common.Hash]uint64
+	minedThrough     uint64
+	hasMined         bool
 	failureThreshold int
 	failureCeiling   int
 	retryInterval    time.Duration
@@ -269,6 +264,7 @@ func NewSendingBackend(
 		highestAccepted:  make([]uint64, len(private)),
 		hasAccepted:      make([]bool, len(private)),
 		accepted:         newAcceptedNonceSets(len(private)),
+		acceptedTxNonces: make(map[common.Hash]uint64),
 		failureThreshold: DefaultPrivateRPCFailureThreshold,
 		failureCeiling:   DefaultPrivateRPCConsecutiveFailureCeiling,
 		allRefused:       make(map[uint64]refusalRun),
@@ -364,7 +360,7 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 
 		if err == nil {
 			b.clearAllRefused(tx.Nonce())
-			b.recordSuccess(endpoint.index, tx.Nonce(), claimIdentity(tx))
+			b.recordSuccess(endpoint.index, tx)
 			relayer.PrivateRPCSends.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
 			return nil
@@ -508,6 +504,57 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 	}
 
 	return b.redacted(err)
+}
+
+// TransactionReceipt forwards receipt reads to the public endpoint and releases exact acceptance
+// records once one of the transactions behind them has landed on the observed chain. A sender
+// account's nonces execute in order, so a receipt for nonce N makes the pending-holder records at or
+// below N obsolete. The high-water marks are deliberately retained: they only prioritise an
+// endpoint and never end a send, while the exact records below are the stronger fact used to do
+// that.
+func (b *SendingBackend) TransactionReceipt(
+	ctx context.Context,
+	txHash common.Hash,
+) (*types.Receipt, error) {
+	receipt, err := b.ETHBackend.TransactionReceipt(ctx, txHash)
+	if err == nil && receipt != nil {
+		b.clearAcceptedThrough(txHash)
+	}
+
+	return receipt, err
+}
+
+// clearAcceptedThrough removes exact acceptance state made obsolete by a mined transaction. The
+// tx hash identifies its nonce because recordSuccess records every signed variant accepted by a
+// private endpoint; a receipt for an unrelated or publicly broadcast transaction has no private
+// state to release here.
+func (b *SendingBackend) clearAcceptedThrough(txHash common.Hash) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	nonce, ok := b.acceptedTxNonces[txHash]
+	if !ok {
+		return
+	}
+
+	if !b.hasMined || nonce > b.minedThrough {
+		b.minedThrough = nonce
+		b.hasMined = true
+	}
+
+	for index := range b.accepted {
+		for acceptedNonce := range b.accepted[index] {
+			if acceptedNonce <= nonce {
+				delete(b.accepted[index], acceptedNonce)
+			}
+		}
+	}
+
+	for acceptedHash, acceptedNonce := range b.acceptedTxNonces {
+		if acceptedNonce <= nonce {
+			delete(b.acceptedTxNonces, acceptedHash)
+		}
+	}
 }
 
 // clearAllRefused forgets the refusal run for this nonce, because a private endpoint has just taken
@@ -1039,9 +1086,11 @@ func (b *SendingBackend) leaveRotation(index int) {
 // demonstrably just accepted a transaction, so it belongs back in rotation whatever the tally from
 // the outage says. The generation is left alone, which keeps the failures still in flight from that
 // outage from being charged against the budget this clears.
-func (b *SendingBackend) recordSuccess(index int, nonce uint64, claim common.Hash) {
+func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	nonce := tx.Nonce()
 
 	b.failures[index] = 0
 	b.failedAt[index] = time.Time{}
@@ -1059,6 +1108,14 @@ func (b *SendingBackend) recordSuccess(index int, nonce uint64, claim common.Has
 
 	b.hasAccepted[index] = true
 
+	// A receipt query and the next private send can be in flight together. If the receipt wins the
+	// lock, a success that comes back afterwards belongs to a transaction whose nonce is already
+	// mined and must not restore the exact state just released. The health reset and high-water
+	// update above still describe the endpoint accurately.
+	if b.hasMined && nonce <= b.minedThrough {
+		return
+	}
+
 	// The mark above answers "is this endpoint plausibly carrying claims around this nonce", which
 	// is all the accounting exemption and the holder-first ordering need. It cannot answer "did
 	// this endpoint take this exact transaction", because claims are signed in nonce order and
@@ -1067,27 +1124,13 @@ func (b *SendingBackend) recordSuccess(index int, nonce uint64, claim common.Has
 	// what was accepted is kept as well.
 	//
 	// Stamped with the claim for the same reason the refusal runs are: nonces recycle. A claim
-	// abandoned at TX_SEND_TIMEOUT leaves this entry behind — only an accepted send writes one,
-	// and an abandoned claim never comes back to be accepted — and resetNonce then hands the nonce
-	// to an unrelated message. Keyed on the nonce alone, that message inherits the acceptance, and
-	// the endpoint answering "replacement transaction underpriced" about the claim it is still
-	// holding would end the new claim's send with nobody carrying it.
-	b.accepted[index][nonce] = claim
-
-	// Bounded the way the refusal counts are, and for the same reason: a claim abandoned at
-	// TX_SEND_TIMEOUT never comes back to clear its entry. Nonces only ascend, so the smallest is
-	// the stalest, and a stale entry only ever costs a send that ends one endpoint too early.
-	for len(b.accepted[index]) > maxTrackedAcceptedNonces {
-		stalest := nonce
-
-		for tracked := range b.accepted[index] {
-			if tracked < stalest {
-				stalest = tracked
-			}
-		}
-
-		delete(b.accepted[index], stalest)
-	}
+	// abandoned at TX_SEND_TIMEOUT can leave this entry behind until a transaction at this nonce or
+	// a later one lands, and resetNonce can meanwhile hand the nonce to an unrelated message. Keyed
+	// on the nonce alone, that message inherits the acceptance, and the endpoint answering
+	// "replacement transaction underpriced" about the claim it is still holding would end the new
+	// claim's send with nobody carrying it.
+	b.accepted[index][nonce] = claimIdentity(tx)
+	b.acceptedTxNonces[tx.Hash()] = nonce
 }
 
 // newAcceptedNonceSets builds one accepted-nonce record per endpoint, mapping each nonce to the

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -198,7 +198,7 @@ type SendingBackend struct {
 	generation       []uint64
 	highestAccepted  []uint64
 	hasAccepted      []bool
-	accepted         []map[uint64]struct{}
+	accepted         []map[uint64]common.Hash
 	failureThreshold int
 	failureCeiling   int
 	retryInterval    time.Duration
@@ -339,7 +339,7 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 
 		if err == nil {
 			b.clearAllRefused(tx.Nonce())
-			b.recordSuccess(endpoint.index, tx.Nonce())
+			b.recordSuccess(endpoint.index, tx.Nonce(), claimIdentity(tx))
 			relayer.PrivateRPCSends.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
 			return nil
@@ -370,7 +370,7 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			// recordFailure entirely meant it could never reach the ceiling that exists to end
 			// exactly that: it would hold its place indefinitely while nothing was ever sent
 			// through it.
-			tripped, demonstrated := b.recordHeldNonce(endpoint, tx.Nonce())
+			tripped, demonstrated := b.recordHeldNonce(endpoint, tx.Nonce(), claimIdentity(tx))
 			if tripped {
 				relayer.PrivateRPCTrips.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
@@ -910,7 +910,11 @@ func (b *SendingBackend) recordFailure(endpoint admission, nonce uint64, rejecti
 //
 // The answer is about the endpoint's mempool rather than its health, so it is read before the
 // generation guard and survives it.
-func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (tripped, demonstrated bool) {
+func (b *SendingBackend) recordHeldNonce(
+	endpoint admission,
+	nonce uint64,
+	claim common.Hash,
+) (tripped, demonstrated bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -922,7 +926,12 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (trip
 	// endpoint is unhealthy, it does not unsay what it is carrying. Suppressing the accounting is
 	// what the guard is for — dropping the acceptance too would send the claim onward and leave
 	// the same signed transaction live in a second builder's pool.
-	_, demonstrated = b.accepted[index][nonce]
+	// Both halves have to match. A nonce this endpoint took, now carrying a different claim, is a
+	// recycled nonce: the endpoint is answering about the transaction it still holds, which is not
+	// the one being offered, and the endpoints behind it have not been asked about this claim at
+	// all.
+	accepted, known := b.accepted[index][nonce]
+	demonstrated = known && accepted == claim
 
 	if b.generation[index] != endpoint.generation {
 		return false, demonstrated
@@ -989,7 +998,7 @@ func (b *SendingBackend) leaveRotation(index int) {
 // demonstrably just accepted a transaction, so it belongs back in rotation whatever the tally from
 // the outage says. The generation is left alone, which keeps the failures still in flight from that
 // outage from being charged against the budget this clears.
-func (b *SendingBackend) recordSuccess(index int, nonce uint64) {
+func (b *SendingBackend) recordSuccess(index int, nonce uint64, claim common.Hash) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -1013,9 +1022,16 @@ func (b *SendingBackend) recordSuccess(index int, nonce uint64) {
 	// is all the accounting exemption and the holder-first ordering need. It cannot answer "did
 	// this endpoint take this exact transaction", because claims are signed in nonce order and
 	// sent concurrently: a later nonce can be accepted while an earlier one never was, and the
-	// mark then covers a nonce nobody here has seen. Ending a send needs the stronger fact, so the
-	// nonces actually accepted are kept as well.
-	b.accepted[index][nonce] = struct{}{}
+	// mark then covers a nonce nobody here has seen. Ending a send needs the stronger fact, so
+	// what was accepted is kept as well.
+	//
+	// Stamped with the claim for the same reason the refusal runs are: nonces recycle. A claim
+	// abandoned at TX_SEND_TIMEOUT leaves this entry behind — only an accepted send writes one,
+	// and an abandoned claim never comes back to be accepted — and resetNonce then hands the nonce
+	// to an unrelated message. Keyed on the nonce alone, that message inherits the acceptance, and
+	// the endpoint answering "replacement transaction underpriced" about the claim it is still
+	// holding would end the new claim's send with nobody carrying it.
+	b.accepted[index][nonce] = claim
 
 	// Bounded the way the refusal counts are, and for the same reason: a claim abandoned at
 	// TX_SEND_TIMEOUT never comes back to clear its entry. Nonces only ascend, so the smallest is
@@ -1033,12 +1049,13 @@ func (b *SendingBackend) recordSuccess(index int, nonce uint64) {
 	}
 }
 
-// newAcceptedNonceSets builds one accepted-nonce set per endpoint.
-func newAcceptedNonceSets(endpoints int) []map[uint64]struct{} {
-	sets := make([]map[uint64]struct{}, endpoints)
+// newAcceptedNonceSets builds one accepted-nonce record per endpoint, mapping each nonce to the
+// claim that was accepted under it.
+func newAcceptedNonceSets(endpoints int) []map[uint64]common.Hash {
+	sets := make([]map[uint64]common.Hash, endpoints)
 
 	for i := range sets {
-		sets[i] = make(map[uint64]struct{})
+		sets[i] = make(map[uint64]common.Hash)
 	}
 
 	return sets

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -563,17 +563,31 @@ func (b *SendingBackend) clearAcceptedThrough(txHash common.Hash) {
 		b.hasMined = true
 	}
 
+	// Strictly below the mined nonce, never including it. A resend can already be on its way to the
+	// endpoint holding that nonce when its receipt arrives: the receipt wins the lock, and the
+	// answer that comes back afterwards would find no record and look like an endpoint holding a
+	// nonce it never took — so the send would continue to a backup, which refuses a claim that is
+	// now done and is charged for it. That is the failure this whole path exists to stop, and on
+	// the mainnet claim it was built for the receipt was on chain twelve seconds before the holder
+	// answered, so it is the ordinary ordering rather than a narrow race.
+	//
+	// Keeping this one record rather than concluding from the mined nonce alone also keeps the
+	// answer claim-aware. A watermark would say "mined, so end the send" for a nonce that a reorg
+	// had made live again and that had since been recycled to a different claim, stranding that
+	// claim with nobody carrying it. The record says which claim the endpoint actually took.
+	//
+	// It is released in turn by the next nonce to mine, so at most one settled nonce is retained.
 	for index := range b.accepted {
 		for acceptedNonce := range b.accepted[index] {
-			if acceptedNonce <= nonce {
+			if acceptedNonce < nonce {
 				delete(b.accepted[index], acceptedNonce)
 			}
 		}
 	}
 
-	for acceptedHash, acceptedNonce := range b.sentTxNonces {
-		if acceptedNonce <= nonce {
-			delete(b.sentTxNonces, acceptedHash)
+	for sentHash, sentNonce := range b.sentTxNonces {
+		if sentNonce < nonce {
+			delete(b.sentTxNonces, sentHash)
 		}
 	}
 }
@@ -1038,21 +1052,6 @@ func (b *SendingBackend) recordHeldNonce(
 		answer = heldThisClaim
 	case known:
 		answer = heldOtherClaim
-
-	// The exact record is released as soon as a receipt says the nonce is mined, and a resend can
-	// already be on its way to its holder when that happens: the receipt wins the lock, the record
-	// goes, and the answer that comes back afterwards would look like an endpoint holding a nonce
-	// it never took. On the mainnet claim this failover was built for, the receipt was on chain
-	// twelve seconds before the holder answered, so this is the ordinary ordering rather than a
-	// narrow race.
-	//
-	// A mined nonce settles the question on its own. The account's nonces execute in order, so once
-	// N is on chain nothing at N can ever land again, and passing the transaction to the endpoints
-	// behind this one can only earn a refusal from a relay that did nothing wrong — the exact
-	// failure this whole path exists to stop. It is also the claim that mined: resetNonce only ever
-	// recycles a nonce the account has not spent.
-	case b.hasMined && nonce <= b.minedThrough:
-		answer = heldThisClaim
 
 	default:
 		answer = heldUnattributed

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -90,6 +90,14 @@ const DefaultPrivateRPCAllRefusedLimit = 3
 // than the processor has in flight at once, so a live claim is never evicted in practice.
 const maxTrackedRefusedNonces = 256
 
+// maxTrackedAcceptedNonces bounds the per-endpoint record of which nonces it took.
+//
+// Same shape and same reason as maxTrackedRefusedNonces, and deliberately the same size: both are
+// far more than the processor has in flight at once, so a live claim is never evicted in practice.
+// Evicting one is not a correctness problem either — the send simply stops treating that endpoint
+// as the nonce's holder and offers the claim onward, which is where it started.
+const maxTrackedAcceptedNonces = 256
+
 // DefaultPrivateRPCAttemptTimeout caps a single attempt when the caller supplied no deadline.
 //
 // The transaction manager always calls SendTransaction under its NetworkTimeout, so this does not
@@ -190,6 +198,7 @@ type SendingBackend struct {
 	generation       []uint64
 	highestAccepted  []uint64
 	hasAccepted      []bool
+	accepted         []map[uint64]struct{}
 	failureThreshold int
 	failureCeiling   int
 	retryInterval    time.Duration
@@ -234,6 +243,7 @@ func NewSendingBackend(
 		generation:       make([]uint64, len(private)),
 		highestAccepted:  make([]uint64, len(private)),
 		hasAccepted:      make([]bool, len(private)),
+		accepted:         newAcceptedNonceSets(len(private)),
 		failureThreshold: DefaultPrivateRPCFailureThreshold,
 		failureCeiling:   DefaultPrivateRPCConsecutiveFailureCeiling,
 		allRefused:       make(map[uint64]refusalRun),
@@ -889,19 +899,33 @@ func (b *SendingBackend) recordFailure(endpoint admission, nonce uint64, rejecti
 // last nonce it answered for. What is left to charge is an endpoint answering this way for a
 // succession of distinct claims it never took, which is the state the ceiling exists to end.
 //
-// It also reports whether this endpoint is the demonstrated holder of the nonce — the first of
-// those two free answers. The caller ends the send there rather than offering the same signed
-// transaction to the endpoints behind it; see SendTransaction. The predicate lives here because
-// this is the one place that owns hasAccepted and highestAccepted, and a second copy of it would
-// drift.
+// It also reports whether this endpoint actually took this nonce, which the caller uses to end the
+// send there rather than offer the same signed transaction to the endpoints behind it; see
+// SendTransaction. That is a stricter question than the first free answer above, and deliberately
+// so: not charging an endpoint that is plausibly carrying claims around this nonce costs nothing
+// when the guess is generous, while ending a send on the same guess leaves the claim with nobody
+// holding it. The two are read from different state for that reason — the exemption from the
+// high-water mark, the answer from the nonces actually accepted. Both live here because this is
+// the one place that owns them, and a second copy would drift.
+//
+// The answer is about the endpoint's mempool rather than its health, so it is read before the
+// generation guard and survives it.
 func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (tripped, demonstrated bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	index := endpoint.index
 
+	// Which transactions this endpoint took is a fact about the endpoint's mempool, not a
+	// judgement about its health, so it is read before the generation guard and survives it. A
+	// concurrent send can trip this endpoint while our answer is still on the wire; that says the
+	// endpoint is unhealthy, it does not unsay what it is carrying. Suppressing the accounting is
+	// what the guard is for — dropping the acceptance too would send the claim onward and leave
+	// the same signed transaction live in a second builder's pool.
+	_, demonstrated = b.accepted[index][nonce]
+
 	if b.generation[index] != endpoint.generation {
-		return false, false
+		return false, demonstrated
 	}
 
 	// An endpoint answering for a nonce it has demonstrably taken is the holder by construction,
@@ -909,8 +933,14 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (trip
 	// remembered nonce below cannot see that: two concurrently held claims alternate past it, every
 	// answer counts, and ten answers — about four minutes at the resubmission default — took the
 	// endpoint holding both of them out of rotation.
+	//
+	// The high-water mark is the right instrument for that exemption and the wrong one for ending
+	// a send. Not charging an endpoint that is plausibly carrying claims around this nonce costs
+	// nothing if the guess is generous; ending a send on the same guess strands the claim with
+	// nobody holding it until TX_SEND_TIMEOUT. So the exemption keeps the mark and the caller gets
+	// the exact answer.
 	if b.hasAccepted[index] && nonce <= b.highestAccepted[index] {
-		return false, true
+		return false, demonstrated
 	}
 
 	// Kept as well, for a nonce this endpoint never accepted: it may be answering for a claim it
@@ -920,8 +950,11 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (trip
 	// resends of a single claim reached the ceiling in about eight minutes and took out the very
 	// endpoint holding it; with one endpoint configured the claim then went public through the
 	// unavailable path, which is the exposure the exemption exists to prevent.
+	// Everything from here reports the acceptance it read rather than a literal false. A nonce this
+	// endpoint took satisfies the mark above and never reaches these lines, so today the two are
+	// the same value; carrying it keeps them the same if that stops being true.
 	if b.hasHeld[index] && b.lastHeld[index] == nonce {
-		return false, false
+		return false, demonstrated
 	}
 
 	b.lastHeld[index] = nonce
@@ -932,10 +965,10 @@ func (b *SendingBackend) recordHeldNonce(endpoint admission, nonce uint64) (trip
 	if b.consecutive[index] >= b.failureCeiling {
 		b.leaveRotation(index)
 
-		return true, false
+		return true, demonstrated
 	}
 
-	return false, false
+	return false, demonstrated
 }
 
 // leaveRotation takes the endpoint at index out of rotation for the retry interval, ending the
@@ -975,6 +1008,40 @@ func (b *SendingBackend) recordSuccess(index int, nonce uint64) {
 	}
 
 	b.hasAccepted[index] = true
+
+	// The mark above answers "is this endpoint plausibly carrying claims around this nonce", which
+	// is all the accounting exemption and the holder-first ordering need. It cannot answer "did
+	// this endpoint take this exact transaction", because claims are signed in nonce order and
+	// sent concurrently: a later nonce can be accepted while an earlier one never was, and the
+	// mark then covers a nonce nobody here has seen. Ending a send needs the stronger fact, so the
+	// nonces actually accepted are kept as well.
+	b.accepted[index][nonce] = struct{}{}
+
+	// Bounded the way the refusal counts are, and for the same reason: a claim abandoned at
+	// TX_SEND_TIMEOUT never comes back to clear its entry. Nonces only ascend, so the smallest is
+	// the stalest, and a stale entry only ever costs a send that ends one endpoint too early.
+	for len(b.accepted[index]) > maxTrackedAcceptedNonces {
+		stalest := nonce
+
+		for tracked := range b.accepted[index] {
+			if tracked < stalest {
+				stalest = tracked
+			}
+		}
+
+		delete(b.accepted[index], stalest)
+	}
+}
+
+// newAcceptedNonceSets builds one accepted-nonce set per endpoint.
+func newAcceptedNonceSets(endpoints int) []map[uint64]struct{} {
+	sets := make([]map[uint64]struct{}, endpoints)
+
+	for i := range sets {
+		sets[i] = make(map[uint64]struct{})
+	}
+
+	return sets
 }
 
 // prioritiseNonceHolder moves the endpoints that have already accepted this nonce to the front of

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -216,7 +216,7 @@ type SendingBackend struct {
 	highestAccepted  []uint64
 	hasAccepted      []bool
 	accepted         []map[uint64]common.Hash
-	acceptedTxNonces map[common.Hash]uint64
+	sentTxNonces     map[common.Hash]uint64
 	minedThrough     uint64
 	hasMined         bool
 	failureThreshold int
@@ -264,7 +264,7 @@ func NewSendingBackend(
 		highestAccepted:  make([]uint64, len(private)),
 		hasAccepted:      make([]bool, len(private)),
 		accepted:         newAcceptedNonceSets(len(private)),
-		acceptedTxNonces: make(map[common.Hash]uint64),
+		sentTxNonces:     make(map[common.Hash]uint64),
 		failureThreshold: DefaultPrivateRPCFailureThreshold,
 		failureCeiling:   DefaultPrivateRPCConsecutiveFailureCeiling,
 		allRefused:       make(map[uint64]refusalRun),
@@ -312,6 +312,10 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 
 		// DEST_RPC_URL can carry an API key too, so the public path is redacted the same way.
 		err := b.ETHBackend.SendTransaction(ctx, tx)
+
+		if err == nil {
+			b.rememberSentNonce(tx)
+		}
 
 		// Counted only once the broadcast actually went out. A send that failed against our own
 		// node never reached the mempool, so counting it would overstate the exposure this metric
@@ -476,6 +480,8 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 
 		publicErr := b.ETHBackend.SendTransaction(ctx, tx)
 		if publicErr == nil {
+			b.rememberSentNonce(tx)
+
 			// The run is deliberately kept. This claim is in the open now, so every resend of it
 			// belongs in the public pool too until a relay takes it back — see countAllRefused.
 			relayer.PrivateRPCAllRefused.Inc()
@@ -524,15 +530,30 @@ func (b *SendingBackend) TransactionReceipt(
 	return receipt, err
 }
 
+// rememberSentNonce indexes a transaction this backend put on the wire, so that a receipt for it
+// can later be resolved to the nonce it occupied.
+//
+// Every transaction, not only the ones a private endpoint accepted. A claim that no relay would
+// take goes out through the public endpoint and lands there under a hash no private endpoint ever
+// saw; without it in the index, clearAcceptedThrough cannot recover the nonce and releases nothing,
+// so the private records for that nonce stay for the life of the process. These records have no
+// cap — that was removed so a burst larger than the old bound could not evict a live acceptance —
+// which makes every landing path having to be recognisable here a requirement rather than a tidy-up.
+func (b *SendingBackend) rememberSentNonce(tx *types.Transaction) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.sentTxNonces[tx.Hash()] = tx.Nonce()
+}
+
 // clearAcceptedThrough removes exact acceptance state made obsolete by a mined transaction. The
-// tx hash identifies its nonce because recordSuccess records every signed variant accepted by a
-// private endpoint; a receipt for an unrelated or publicly broadcast transaction has no private
-// state to release here.
+// tx hash identifies its nonce because every transaction this backend sends is indexed by
+// rememberSentNonce; a receipt for a transaction this backend never sent has no state to release.
 func (b *SendingBackend) clearAcceptedThrough(txHash common.Hash) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	nonce, ok := b.acceptedTxNonces[txHash]
+	nonce, ok := b.sentTxNonces[txHash]
 	if !ok {
 		return
 	}
@@ -550,9 +571,9 @@ func (b *SendingBackend) clearAcceptedThrough(txHash common.Hash) {
 		}
 	}
 
-	for acceptedHash, acceptedNonce := range b.acceptedTxNonces {
+	for acceptedHash, acceptedNonce := range b.sentTxNonces {
 		if acceptedNonce <= nonce {
-			delete(b.acceptedTxNonces, acceptedHash)
+			delete(b.sentTxNonces, acceptedHash)
 		}
 	}
 }
@@ -1017,6 +1038,22 @@ func (b *SendingBackend) recordHeldNonce(
 		answer = heldThisClaim
 	case known:
 		answer = heldOtherClaim
+
+	// The exact record is released as soon as a receipt says the nonce is mined, and a resend can
+	// already be on its way to its holder when that happens: the receipt wins the lock, the record
+	// goes, and the answer that comes back afterwards would look like an endpoint holding a nonce
+	// it never took. On the mainnet claim this failover was built for, the receipt was on chain
+	// twelve seconds before the holder answered, so this is the ordinary ordering rather than a
+	// narrow race.
+	//
+	// A mined nonce settles the question on its own. The account's nonces execute in order, so once
+	// N is on chain nothing at N can ever land again, and passing the transaction to the endpoints
+	// behind this one can only earn a refusal from a relay that did nothing wrong — the exact
+	// failure this whole path exists to stop. It is also the claim that mined: resetNonce only ever
+	// recycles a nonce the account has not spent.
+	case b.hasMined && nonce <= b.minedThrough:
+		answer = heldThisClaim
+
 	default:
 		answer = heldUnattributed
 	}
@@ -1130,7 +1167,7 @@ func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction) {
 	// "replacement transaction underpriced" about the claim it is still holding would end the new
 	// claim's send with nobody carrying it.
 	b.accepted[index][nonce] = claimIdentity(tx)
-	b.acceptedTxNonces[tx.Hash()] = nonce
+	b.sentTxNonces[tx.Hash()] = nonce
 }
 
 // newAcceptedNonceSets builds one accepted-nonce record per endpoint, mapping each nonce to the

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -90,6 +90,15 @@ const DefaultPrivateRPCAllRefusedLimit = 3
 // than the processor has in flight at once, so a live claim is never evicted in practice.
 const maxTrackedRefusedNonces = 256
 
+// maxTrackedSentNonces bounds the index of transactions this backend has sent.
+//
+// Deliberately far above the exact acceptance records it serves, which are one per endpoint per
+// unresolved nonce: this holds every fee variant of every one of them, and a send produces a
+// variant per RESUBMISSION_TIMEOUT for as long as TX_SEND_TIMEOUT allows. At the defaults that is
+// six or seven per attempt, so this is hundreds of attempts deep on a nonce that never lands. See
+// boundSentNonces for why an evicted entry costs a lookup rather than correctness.
+const maxTrackedSentNonces = 1024
+
 // DefaultPrivateRPCAttemptTimeout caps a single attempt when the caller supplied no deadline.
 //
 // The transaction manager always calls SendTransaction under its NetworkTimeout, so this does not
@@ -544,6 +553,35 @@ func (b *SendingBackend) rememberSentNonce(tx *types.Transaction) {
 	defer b.mu.Unlock()
 
 	b.sentTxNonces[tx.Hash()] = tx.Nonce()
+	b.boundSentNonces(tx.Nonce())
+}
+
+// boundSentNonces caps the index. The caller holds the lock.
+//
+// A mined nonce collects its own variants and everything below it, which is what keeps this index
+// the size of the unresolved window in ordinary running. A nonce that never lands has no later
+// receipt to do that: nonces execute in order, so nothing above it can mine either, while
+// TX_SEND_TIMEOUT keeps handing the nonce back out and every fee variant of every attempt adds a
+// hash. Without a bound that grows for the life of the process.
+//
+// Dropping an entry costs a lookup, not correctness: a receipt that cannot be resolved to a nonce
+// simply releases nothing that time, and the next receipt that can resolve releases everything
+// below it anyway. Nonces ascend, so the lowest is the stalest — and when one nonce is stuck it is
+// the only one here, which leaves the oldest variants of it, the low-fee ones its own resends have
+// already replaced.
+func (b *SendingBackend) boundSentNonces(justAdded uint64) {
+	for len(b.sentTxNonces) > maxTrackedSentNonces {
+		stalest := justAdded
+		var evict common.Hash
+
+		for hash, nonce := range b.sentTxNonces {
+			if evict == (common.Hash{}) || nonce < stalest {
+				stalest, evict = nonce, hash
+			}
+		}
+
+		delete(b.sentTxNonces, evict)
+	}
 }
 
 // clearAcceptedThrough removes exact acceptance state made obsolete by a mined transaction. The
@@ -585,8 +623,12 @@ func (b *SendingBackend) clearAcceptedThrough(txHash common.Hash) {
 		}
 	}
 
+	// The index goes the same way, and the variants of the nonce that just mined go with it. A
+	// nonce executes once, so every other transaction recorded at it — the lower-fee variants the
+	// resends replaced — can never produce a receipt again. The one that landed is kept, because
+	// the transaction manager reads its receipt more than once.
 	for sentHash, sentNonce := range b.sentTxNonces {
-		if sentNonce < nonce {
+		if sentNonce < nonce || (sentNonce == nonce && sentHash != txHash) {
 			delete(b.sentTxNonces, sentHash)
 		}
 	}
@@ -1144,11 +1186,21 @@ func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction) {
 
 	b.hasAccepted[index] = true
 
+	claim := claimIdentity(tx)
+
 	// A receipt query and the next private send can be in flight together. If the receipt wins the
-	// lock, a success that comes back afterwards belongs to a transaction whose nonce is already
-	// mined and must not restore the exact state just released. The health reset and high-water
-	// update above still describe the endpoint accurately.
-	if b.hasMined && nonce <= b.minedThrough {
+	// lock, a success that comes back afterwards is a fee-bumped variant of the transaction that
+	// just mined, and re-recording it would only add a hash nothing can ever produce a receipt for.
+	// The health reset and high-water update above still describe the endpoint accurately.
+	//
+	// Judged by the claim rather than by the mined nonce alone. A receipt is read before the
+	// transaction manager has confirmation depth, so one can be observed for a transaction a reorg
+	// then removes; the nonce is live again and can be recycled to a different claim, which this
+	// endpoint may then accept. Skipping on the nonce meant the retained record still named the
+	// claim that went away, so the new claim's own holder answered for it and was read as holding
+	// someone else's — and the send carried on to a backup that had no reason to be asked. A
+	// different claim under a mined nonce is the chain having moved, not a stale variant.
+	if b.hasMined && nonce <= b.minedThrough && b.accepted[index][nonce] == claim {
 		return
 	}
 
@@ -1165,8 +1217,10 @@ func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction) {
 	// on the nonce alone, that message inherits the acceptance, and the endpoint answering
 	// "replacement transaction underpriced" about the claim it is still holding would end the new
 	// claim's send with nobody carrying it.
-	b.accepted[index][nonce] = claimIdentity(tx)
+	b.accepted[index][nonce] = claim
 	b.sentTxNonces[tx.Hash()] = nonce
+
+	b.boundSentNonces(nonce)
 }
 
 // newAcceptedNonceSets builds one accepted-nonce record per endpoint, mapping each nonce to the

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -123,6 +123,25 @@ type refusalRun struct {
 	count int
 }
 
+// acceptance is what one endpoint took under one nonce: which claim, and which send learned it.
+//
+// The send is what orders two answers about the same nonce. Sends run concurrently and their
+// results come back in any order, so an endpoint's success can describe a state two steps out of
+// date: a resend of a claim that has since been reorged out and replaced can report success after
+// the replacement was already recorded, and by claim alone that reads as the chain having moved
+// again. The claim says what; this says when.
+type acceptance struct {
+	claim common.Hash
+	send  uint64
+}
+
+// sentTx is a transaction this backend put on the wire: the nonce it occupies, so a receipt can be
+// resolved to one, and the send that put it there, so the index can be trimmed oldest-first.
+type sentTx struct {
+	nonce uint64
+	send  uint64
+}
+
 // claimIdentity identifies the message a transaction carries, across the re-signing that changes
 // everything else about it.
 //
@@ -224,8 +243,11 @@ type SendingBackend struct {
 	generation       []uint64
 	highestAccepted  []uint64
 	hasAccepted      []bool
-	accepted         []map[uint64]common.Hash
-	sentTxNonces     map[common.Hash]uint64
+	accepted         []map[uint64]acceptance
+	sentTxNonces     map[common.Hash]sentTx
+	sends            uint64
+	account          common.Address
+	hasAccount       bool
 	minedThrough     uint64
 	hasMined         bool
 	failureThreshold int
@@ -273,7 +295,7 @@ func NewSendingBackend(
 		highestAccepted:  make([]uint64, len(private)),
 		hasAccepted:      make([]bool, len(private)),
 		accepted:         newAcceptedNonceSets(len(private)),
-		sentTxNonces:     make(map[common.Hash]uint64),
+		sentTxNonces:     make(map[common.Hash]sentTx),
 		failureThreshold: DefaultPrivateRPCFailureThreshold,
 		failureCeiling:   DefaultPrivateRPCConsecutiveFailureCeiling,
 		allRefused:       make(map[uint64]refusalRun),
@@ -309,6 +331,10 @@ func NewSendingBackend(
 // context, fail instantly, and be counted as failing, which is how the failover for the outage
 // mode it matters most for would take the healthy relays down with it.
 func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	// Taken before anything is offered anywhere, so that two sends of one nonce are ordered by when
+	// they started rather than by when their answers happen to come back.
+	send := b.nextSend()
+
 	inRotation := b.inRotation()
 
 	if len(inRotation) == 0 {
@@ -323,7 +349,7 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 		err := b.ETHBackend.SendTransaction(ctx, tx)
 
 		if err == nil {
-			b.rememberSentNonce(tx)
+			b.rememberSentNonce(tx, send)
 		}
 
 		// Counted only once the broadcast actually went out. A send that failed against our own
@@ -373,7 +399,7 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 
 		if err == nil {
 			b.clearAllRefused(tx.Nonce())
-			b.recordSuccess(endpoint.index, tx)
+			b.recordSuccess(endpoint.index, tx, send)
 			relayer.PrivateRPCSends.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
 			return nil
@@ -489,7 +515,7 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 
 		publicErr := b.ETHBackend.SendTransaction(ctx, tx)
 		if publicErr == nil {
-			b.rememberSentNonce(tx)
+			b.rememberSentNonce(tx, send)
 
 			// The run is deliberately kept. This claim is in the open now, so every resend of it
 			// belongs in the public pool too until a relay takes it back — see countAllRefused.
@@ -532,8 +558,8 @@ func (b *SendingBackend) TransactionReceipt(
 	txHash common.Hash,
 ) (*types.Receipt, error) {
 	receipt, err := b.ETHBackend.TransactionReceipt(ctx, txHash)
-	if err == nil && receipt != nil {
-		b.clearAcceptedThrough(txHash)
+	if err == nil && receipt != nil && !b.clearAcceptedThrough(txHash) {
+		b.clearAcceptedBelowChain(ctx)
 	}
 
 	return receipt, err
@@ -548,12 +574,12 @@ func (b *SendingBackend) TransactionReceipt(
 // so the private records for that nonce stay for the life of the process. These records have no
 // cap — that was removed so a burst larger than the old bound could not evict a live acceptance —
 // which makes every landing path having to be recognisable here a requirement rather than a tidy-up.
-func (b *SendingBackend) rememberSentNonce(tx *types.Transaction) {
+func (b *SendingBackend) rememberSentNonce(tx *types.Transaction, send uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.sentTxNonces[tx.Hash()] = tx.Nonce()
-	b.boundSentNonces(tx.Nonce())
+	b.sentTxNonces[tx.Hash()] = sentTx{nonce: tx.Nonce(), send: send}
+	b.boundSentNonces()
 }
 
 // boundSentNonces caps the index. The caller holds the lock.
@@ -564,21 +590,23 @@ func (b *SendingBackend) rememberSentNonce(tx *types.Transaction) {
 // TX_SEND_TIMEOUT keeps handing the nonce back out and every fee variant of every attempt adds a
 // hash. Without a bound that grows for the life of the process.
 //
-// Dropping an entry costs a lookup, not correctness: a receipt that cannot be resolved to a nonce
-// simply releases nothing that time, and the next receipt that can resolve releases everything
-// below it anyway. Nonces ascend, so the lowest is the stalest — and when one nonce is stuck it is
-// the only one here, which leaves the oldest variants of it, the low-fee ones its own resends have
-// already replaced.
-func (b *SendingBackend) boundSentNonces(justAdded uint64) {
+// The oldest send goes first. Every entry under a stuck nonce shares that nonce, so the nonce
+// cannot order them and map iteration carries no age; the send number can, and it is the only thing
+// here that says which resend a relay is least likely to still be holding — its own later variants
+// have replaced it. A receipt whose entry has gone is not a correctness problem either: the caller
+// settles it against the chain instead, so releasing never depends on this cache hitting. See
+// clearAcceptedBelowChain.
+func (b *SendingBackend) boundSentNonces() {
 	for len(b.sentTxNonces) > maxTrackedSentNonces {
 		var (
-			stalest = justAdded
-			evict   common.Hash
+			oldest uint64
+			evict  common.Hash
+			found  bool
 		)
 
-		for hash, nonce := range b.sentTxNonces {
-			if evict == (common.Hash{}) || nonce < stalest {
-				stalest, evict = nonce, hash
+		for hash, sent := range b.sentTxNonces {
+			if !found || sent.send < oldest {
+				oldest, evict, found = sent.send, hash, true
 			}
 		}
 
@@ -589,14 +617,89 @@ func (b *SendingBackend) boundSentNonces(justAdded uint64) {
 // clearAcceptedThrough removes exact acceptance state made obsolete by a mined transaction. The
 // tx hash identifies its nonce because every transaction this backend sends is indexed by
 // rememberSentNonce; a receipt for a transaction this backend never sent has no state to release.
-func (b *SendingBackend) clearAcceptedThrough(txHash common.Hash) {
+// nextSend hands out the ticket that orders one send against every other.
+func (b *SendingBackend) nextSend() uint64 {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	nonce, ok := b.sentTxNonces[txHash]
-	if !ok {
+	b.sends++
+
+	return b.sends
+}
+
+// PendingNonceAt forwards to the public endpoint and remembers the account it was asked about.
+//
+// The nonce itself has to come from our own node — resolving it against a private endpoint is what
+// would let two concurrent claims be signed with the same nonce. The account is kept because it is
+// the only place this backend learns which address it is sending for, and settling a receipt it
+// cannot resolve from its own index needs it; see clearAcceptedBelowChain.
+func (b *SendingBackend) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	b.mu.Lock()
+	b.account, b.hasAccount = account, true
+	b.mu.Unlock()
+
+	return b.ETHBackend.PendingNonceAt(ctx, account)
+}
+
+// clearAcceptedBelowChain releases exact state against the account's settled nonce rather than
+// against this backend's own index.
+//
+// The index is a cache and is capped, so a receipt can arrive for a transaction whose hash has been
+// evicted. Left there, nothing would release the exact records, and those are deliberately uncapped
+// — a burst larger than any fixed bound must not evict a live acceptance. Asking the chain what the
+// account has settled makes the release independent of whether the lookup hit.
+//
+// The transaction at the settled nonce minus one is the most recent to execute, and its record is
+// the one an already-in-flight resend still needs, so the release stops below it exactly as the
+// index-driven path does.
+func (b *SendingBackend) clearAcceptedBelowChain(ctx context.Context) {
+	b.mu.Lock()
+	account, known := b.account, b.hasAccount
+	b.mu.Unlock()
+
+	if !known {
 		return
 	}
+
+	settled, err := b.NonceAt(ctx, account, nil)
+	if err != nil || settled == 0 {
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	mined := settled - 1
+
+	if !b.hasMined || mined > b.minedThrough {
+		b.minedThrough, b.hasMined = mined, true
+	}
+
+	for index := range b.accepted {
+		for acceptedNonce := range b.accepted[index] {
+			if acceptedNonce < mined {
+				delete(b.accepted[index], acceptedNonce)
+			}
+		}
+	}
+
+	for sentHash, sent := range b.sentTxNonces {
+		if sent.nonce < mined {
+			delete(b.sentTxNonces, sentHash)
+		}
+	}
+}
+
+func (b *SendingBackend) clearAcceptedThrough(txHash common.Hash) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	landed, ok := b.sentTxNonces[txHash]
+	if !ok {
+		return false
+	}
+
+	nonce := landed.nonce
 
 	if !b.hasMined || nonce > b.minedThrough {
 		b.minedThrough = nonce
@@ -629,11 +732,13 @@ func (b *SendingBackend) clearAcceptedThrough(txHash common.Hash) {
 	// nonce executes once, so every other transaction recorded at it — the lower-fee variants the
 	// resends replaced — can never produce a receipt again. The one that landed is kept, because
 	// the transaction manager reads its receipt more than once.
-	for sentHash, sentNonce := range b.sentTxNonces {
-		if sentNonce < nonce || (sentNonce == nonce && sentHash != txHash) {
+	for sentHash, sent := range b.sentTxNonces {
+		if sent.nonce < nonce || (sent.nonce == nonce && sentHash != txHash) {
 			delete(b.sentTxNonces, sentHash)
 		}
 	}
+
+	return true
 }
 
 // clearAllRefused forgets the refusal run for this nonce, because a private endpoint has just taken
@@ -1092,7 +1197,7 @@ func (b *SendingBackend) recordHeldNonce(
 	accepted, known := b.accepted[index][nonce]
 
 	switch {
-	case known && accepted == claim:
+	case known && accepted.claim == claim:
 		answer = heldThisClaim
 	case known:
 		answer = heldOtherClaim
@@ -1166,7 +1271,7 @@ func (b *SendingBackend) leaveRotation(index int) {
 // demonstrably just accepted a transaction, so it belongs back in rotation whatever the tally from
 // the outage says. The generation is left alone, which keeps the failures still in flight from that
 // outage from being charged against the budget this clears.
-func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction) {
+func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction, send uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -1189,6 +1294,16 @@ func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction) {
 	b.hasAccepted[index] = true
 
 	claim := claimIdentity(tx)
+	recorded, known := b.accepted[index][nonce]
+
+	// Sends run concurrently and answer in any order, so this success can be older than the record
+	// it would replace: a resend of a claim that has since been reorged out and recycled can report
+	// success after the replacement was already recorded, and by claim alone that reads as the
+	// chain having moved again — putting the claim that is gone back in front of the one this
+	// endpoint is actually carrying. The send number says which answer is newer.
+	if known && recorded.send > send {
+		return
+	}
 
 	// A receipt query and the next private send can be in flight together. If the receipt wins the
 	// lock, a success that comes back afterwards is a fee-bumped variant of the transaction that
@@ -1202,7 +1317,7 @@ func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction) {
 	// claim that went away, so the new claim's own holder answered for it and was read as holding
 	// someone else's — and the send carried on to a backup that had no reason to be asked. A
 	// different claim under a mined nonce is the chain having moved, not a stale variant.
-	if b.hasMined && nonce <= b.minedThrough && b.accepted[index][nonce] == claim {
+	if b.hasMined && nonce <= b.minedThrough && known && recorded.claim == claim {
 		return
 	}
 
@@ -1219,19 +1334,19 @@ func (b *SendingBackend) recordSuccess(index int, tx *types.Transaction) {
 	// on the nonce alone, that message inherits the acceptance, and the endpoint answering
 	// "replacement transaction underpriced" about the claim it is still holding would end the new
 	// claim's send with nobody carrying it.
-	b.accepted[index][nonce] = claim
-	b.sentTxNonces[tx.Hash()] = nonce
+	b.accepted[index][nonce] = acceptance{claim: claim, send: send}
+	b.sentTxNonces[tx.Hash()] = sentTx{nonce: nonce, send: send}
 
-	b.boundSentNonces(nonce)
+	b.boundSentNonces()
 }
 
 // newAcceptedNonceSets builds one accepted-nonce record per endpoint, mapping each nonce to the
 // claim that was accepted under it.
-func newAcceptedNonceSets(endpoints int) []map[uint64]common.Hash {
-	sets := make([]map[uint64]common.Hash, endpoints)
+func newAcceptedNonceSets(endpoints int) []map[uint64]acceptance {
+	sets := make([]map[uint64]acceptance, endpoints)
 
 	for i := range sets {
-		sets[i] = make(map[uint64]common.Hash)
+		sets[i] = make(map[uint64]acceptance)
 	}
 
 	return sets

--- a/packages/relayer/pkg/utils/sending_backend.go
+++ b/packages/relayer/pkg/utils/sending_backend.go
@@ -134,6 +134,31 @@ func claimIdentity(tx *types.Transaction) common.Hash {
 	return crypto.Keccak256Hash(tx.Data())
 }
 
+// heldAnswer says what an endpoint answering that it already holds a nonce means for the claim
+// being offered. The three cases do not agree on either question the caller has to settle: whether
+// the send is finished, and whether the answer shields this claim from the public fallback.
+type heldAnswer int
+
+const (
+	// heldUnattributed is a hold for a nonce this endpoint never took from us. It may be carrying
+	// our claim, learned from another relay's gossip, or it may be answering about something we
+	// cannot see. Nothing distinguishes them here, so the claim keeps the benefit of the doubt: the
+	// send goes on to the endpoints behind it, and the answer still keeps the claim out of the
+	// public mempool.
+	heldUnattributed heldAnswer = iota
+
+	// heldThisClaim is a hold for the exact claim being offered. The endpoint is carrying it, so
+	// the send is complete and there is nothing to gain by asking anyone else.
+	heldThisClaim
+
+	// heldOtherClaim is a hold for a nonce this endpoint took under a different claim — a recycled
+	// nonce whose earlier claim it is still carrying. That is a refusal of this claim in everything
+	// but wording: the endpoint has something else under this nonce, we cannot replace it, and it
+	// is demonstrably not holding what we are offering. Shielding this claim from the public
+	// fallback on the strength of that answer would leave nobody carrying it at all.
+	heldOtherClaim
+)
+
 // admission is one endpoint's place in a send's rotation snapshot: which endpoint, and which of
 // that endpoint's admissions the send was let in under.
 //
@@ -358,11 +383,6 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 		// a failure; a nonce this endpoint has not answered for before does count towards the
 		// consecutive ceiling, so answering this to everything still ends. See recordHeldNonce.
 		if holdsTheNonce(err) {
-			// Not a refusal, so it cannot count towards the public fallback either. Every endpoint
-			// answering that it holds this nonce means the claim is already everywhere it needs to
-			// be — broadcasting it publicly then would leak a claim the relays are all carrying.
-			allAnsweredRejection = false
-
 			relayer.PrivateRPCHeldNonce.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
 			// Charged against the consecutive count but not the failure tally. An endpoint that
@@ -370,7 +390,18 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			// recordFailure entirely meant it could never reach the ceiling that exists to end
 			// exactly that: it would hold its place indefinitely while nothing was ever sent
 			// through it.
-			tripped, demonstrated := b.recordHeldNonce(endpoint, tx.Nonce(), claimIdentity(tx))
+			tripped, answer := b.recordHeldNonce(endpoint, tx.Nonce(), claimIdentity(tx))
+
+			// An endpoint that might be carrying this claim is not refusing it, so it cannot count
+			// towards the public fallback: every endpoint answering that way means the claim is
+			// already where it needs to be, and broadcasting it then would leak one the relays are
+			// all holding. An endpoint holding a different claim under a recycled nonce is the
+			// opposite — it is proof this claim is not there — and treating it as protection left
+			// a claim nobody carried looping until TX_SEND_TIMEOUT with the fallback suppressed.
+			if answer != heldOtherClaim {
+				allAnsweredRejection = false
+			}
+
 			if tripped {
 				relayer.PrivateRPCTrips.WithLabelValues(strconv.Itoa(endpoint.index)).Inc()
 
@@ -384,7 +415,8 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			slog.Info("Private endpoint already holds this nonce",
 				"endpoint", endpoint.index,
 				"nonce", tx.Nonce(),
-				"endsSend", demonstrated,
+				"endsSend", answer == heldThisClaim,
+				"holdsAnotherClaim", answer == heldOtherClaim,
 			)
 
 			// A nonce this endpoint has demonstrably taken makes it the holder, so the claim is
@@ -397,12 +429,13 @@ func (b *SendingBackend) SendTransaction(ctx context.Context, tx *types.Transact
 			// first, so three claims took a healthy backup out of rotation. Returning nil is also
 			// the honest answer for the transaction manager, which is what arms the fee bump and
 			// what TxNotInMempoolTimeout reads: the transaction is at a relay.
-			if demonstrated {
+			if answer == heldThisClaim {
 				return nil
 			}
 
-			// For a nonce it never took, the answer may be about a claim it learned from another
-			// relay's gossip. The endpoints behind it genuinely have not been asked.
+			// For anything else the endpoints behind this one genuinely have not been asked: the
+			// answer was either about a claim we cannot attribute, or about a different claim
+			// under a recycled nonce.
 			continue
 		}
 
@@ -914,27 +947,35 @@ func (b *SendingBackend) recordHeldNonce(
 	endpoint admission,
 	nonce uint64,
 	claim common.Hash,
-) (tripped, demonstrated bool) {
+) (tripped bool, answer heldAnswer) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	index := endpoint.index
 
-	// Which transactions this endpoint took is a fact about the endpoint's mempool, not a
-	// judgement about its health, so it is read before the generation guard and survives it. A
-	// concurrent send can trip this endpoint while our answer is still on the wire; that says the
-	// endpoint is unhealthy, it does not unsay what it is carrying. Suppressing the accounting is
-	// what the guard is for — dropping the acceptance too would send the claim onward and leave
-	// the same signed transaction live in a second builder's pool.
-	// Both halves have to match. A nonce this endpoint took, now carrying a different claim, is a
-	// recycled nonce: the endpoint is answering about the transaction it still holds, which is not
-	// the one being offered, and the endpoints behind it have not been asked about this claim at
-	// all.
+	// What this endpoint took is a fact about its mempool, not a judgement about its health, so it
+	// is read before the generation guard and survives it. A concurrent send can trip this
+	// endpoint while our answer is still on the wire; that says the endpoint is unhealthy, it does
+	// not unsay what it is carrying. Suppressing the accounting is what the guard is for —
+	// dropping the acceptance too would send the claim onward and leave the same signed
+	// transaction live in a second builder's pool.
+	//
+	// Both halves have to match for this to be our claim. A nonce this endpoint took, now carrying
+	// a different claim, is a recycled nonce: the endpoint is answering about the transaction it
+	// still holds, which is not the one being offered.
 	accepted, known := b.accepted[index][nonce]
-	demonstrated = known && accepted == claim
+
+	switch {
+	case known && accepted == claim:
+		answer = heldThisClaim
+	case known:
+		answer = heldOtherClaim
+	default:
+		answer = heldUnattributed
+	}
 
 	if b.generation[index] != endpoint.generation {
-		return false, demonstrated
+		return false, answer
 	}
 
 	// An endpoint answering for a nonce it has demonstrably taken is the holder by construction,
@@ -949,7 +990,7 @@ func (b *SendingBackend) recordHeldNonce(
 	// nobody holding it until TX_SEND_TIMEOUT. So the exemption keeps the mark and the caller gets
 	// the exact answer.
 	if b.hasAccepted[index] && nonce <= b.highestAccepted[index] {
-		return false, demonstrated
+		return false, answer
 	}
 
 	// Kept as well, for a nonce this endpoint never accepted: it may be answering for a claim it
@@ -963,7 +1004,7 @@ func (b *SendingBackend) recordHeldNonce(
 	// endpoint took satisfies the mark above and never reaches these lines, so today the two are
 	// the same value; carrying it keeps them the same if that stops being true.
 	if b.hasHeld[index] && b.lastHeld[index] == nonce {
-		return false, demonstrated
+		return false, answer
 	}
 
 	b.lastHeld[index] = nonce
@@ -974,10 +1015,10 @@ func (b *SendingBackend) recordHeldNonce(
 	if b.consecutive[index] >= b.failureCeiling {
 		b.leaveRotation(index)
 
-		return true, demonstrated
+		return true, answer
 	}
 
-	return false, demonstrated
+	return false, answer
 }
 
 // leaveRotation takes the endpoint at index out of rotation for the retry interval, ending the

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -36,6 +36,17 @@ type fakeBackend struct {
 	closed            bool
 	closeCalls        int
 	receipt           *types.Receipt
+	settledNonce      uint64
+	settledNonceCalls int
+}
+
+func (f *fakeBackend) NonceAt(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.settledNonceCalls++
+
+	return f.settledNonce, nil
 }
 
 func (f *fakeBackend) PendingNonceAt(_ context.Context, _ common.Address) (uint64, error) {
@@ -113,6 +124,39 @@ func (f *fakeSender) SendTransaction(_ context.Context, tx *types.Transaction) e
 }
 
 func (f *fakeSender) Close() { f.closed = true }
+
+// stallingSender holds one send inside the endpoint until the test lets it finish, so its result
+// can be made to arrive after later sends of the same nonce have already been recorded. Unlike
+// gatedSender below it gates a single send rather than a set of nonces, and it still records what
+// it takes.
+type stallingSender struct {
+	fakeSender
+	stallMu sync.Mutex
+	armed   bool
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *stallingSender) arm() {
+	s.stallMu.Lock()
+	defer s.stallMu.Unlock()
+
+	s.armed = true
+}
+
+func (s *stallingSender) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	s.stallMu.Lock()
+	hold := s.armed
+	s.armed = false
+	s.stallMu.Unlock()
+
+	if hold {
+		close(s.entered)
+		<-s.release
+	}
+
+	return s.fakeSender.SendTransaction(ctx, tx)
+}
 
 // rpcRejection models a JSON-RPC error response: the relay was reachable and answered that it will
 // not take this transaction. go-ethereum surfaces these as rpc.Error, which is how the backend
@@ -437,7 +481,7 @@ func TestSendingBackend_ASuccessfulSendReadmitsATrippedEndpoint(t *testing.T) {
 	require.Equal(t, []int{1}, rotation(b))
 
 	// An endpoint that just took a transaction is not down, whatever its recent record.
-	b.recordSuccess(0, txWithNonce(1))
+	b.recordSuccess(0, txWithNonce(1), b.nextSend())
 
 	assert.Equal(t, []int{0, 1}, rotation(b))
 }
@@ -2174,7 +2218,7 @@ func TestSendingBackend_DoesNotRestoreAcceptanceAfterReceiptWinsRace(t *testing.
 		GasTipCap: big.NewInt(2),
 		Data:      mined.Data(),
 	})
-	b.recordSuccess(0, late)
+	b.recordSuccess(0, late, b.nextSend())
 
 	// The mined nonce keeps the record it already had — an in-flight resend still needs it — but
 	// the stale variant adds nothing of its own, so it cannot reopen the window a later receipt
@@ -2278,6 +2322,59 @@ func TestSendingBackend_APostReorgAcceptanceReplacesTheStaleHolderRecord(t *test
 	assert.Empty(t, backup.sent, "the endpoint that accepted this claim is still its holder")
 }
 
+func TestSendingBackend_ALateSuccessDoesNotUnseatANewerAcceptance(t *testing.T) {
+	public := &fakeBackend{receipt: &types.Receipt{}}
+	holder := &stallingSender{entered: make(chan struct{}), release: make(chan struct{})}
+	backup := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{holder, backup}, nil, nil)
+
+	first := txWithNonceAndCall(40, "the claim that mined")
+
+	require.NoError(t, b.SendTransaction(context.Background(), first))
+
+	_, err := b.TransactionReceipt(context.Background(), first.Hash())
+	require.NoError(t, err)
+
+	// A fee-bumped resend of the first claim goes out and stalls inside the endpoint.
+	stalled := types.NewTx(&types.DynamicFeeTx{
+		Nonce:     first.Nonce(),
+		Gas:       21_000,
+		GasTipCap: big.NewInt(9),
+		Data:      first.Data(),
+	})
+
+	holder.arm()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		_ = b.SendTransaction(context.Background(), stalled)
+	}()
+
+	<-holder.entered
+
+	// While it is stalled the reorg puts the nonce back, and it is recycled to a different claim
+	// which this endpoint accepts.
+	second := txWithNonceAndCall(40, "the claim that inherited the nonce")
+
+	require.NoError(t, b.SendTransaction(context.Background(), second))
+
+	// Only now does the stalled send report success. It describes a state two steps out of date,
+	// and reading it as the chain having moved again puts the claim that is gone back in front of
+	// the one this endpoint is actually carrying.
+	close(holder.release)
+	<-done
+
+	holder.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+
+	require.NoError(t, b.SendTransaction(context.Background(), second))
+
+	assert.Empty(t, backup.sent, "an older result cannot unseat the acceptance that replaced it")
+}
+
 func TestSendingBackend_CollectsTheDeadVariantsOfAMinedNonce(t *testing.T) {
 	public := &fakeBackend{receipt: &types.Receipt{}}
 	only := &fakeSender{}
@@ -2307,6 +2404,36 @@ func TestSendingBackend_CollectsTheDeadVariantsOfAMinedNonce(t *testing.T) {
 	assert.Contains(t, b.sentTxNonces, landed.Hash(), "the one that landed is still read more than once")
 }
 
+func TestSendingBackend_AnEvictedLookupStillReleasesOlderRecords(t *testing.T) {
+	public := &fakeBackend{receipt: &types.Receipt{}, settledNonce: 42}
+	only := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+
+	settled := txWithNonceAndCall(40, "the settled claim")
+	landed := txWithNonceAndCall(41, "the claim that lands")
+
+	require.NoError(t, b.SendTransaction(context.Background(), settled))
+	require.NoError(t, b.SendTransaction(context.Background(), landed))
+
+	// The backend learns which account it sends for the way it does in production.
+	_, err := b.PendingNonceAt(context.Background(), common.Address{})
+	require.NoError(t, err)
+
+	// The index is a capped cache, so the hash of the transaction that lands can have been evicted
+	// before its receipt is read. The exact records are deliberately uncapped, so nothing else
+	// would ever release them.
+	delete(b.sentTxNonces, landed.Hash())
+
+	_, err = b.TransactionReceipt(context.Background(), landed.Hash())
+	require.NoError(t, err)
+
+	assert.NotContains(t, b.accepted[0], settled.Nonce(),
+		"releasing has to survive a lookup the cache cannot answer")
+	assert.Contains(t, b.accepted[0], landed.Nonce(),
+		"and still stop below the nonce that just settled")
+}
+
 func TestSendingBackend_BoundsTheSentTransactionIndex(t *testing.T) {
 	only := &fakeSender{}
 
@@ -2315,9 +2442,26 @@ func TestSendingBackend_BoundsTheSentTransactionIndex(t *testing.T) {
 	// A nonce that never lands has no later receipt to collect its variants — nothing above it can
 	// mine either — while TX_SEND_TIMEOUT keeps handing the nonce back out and every fee variant of
 	// every attempt adds a hash.
+	var first, last *types.Transaction
+
 	for tip := int64(1); tip <= int64(maxTrackedSentNonces)*2; tip++ {
-		require.NoError(t, b.SendTransaction(context.Background(), txWithNonceAndTip(40, tip)))
+		variant := txWithNonceAndTip(40, tip)
+
+		require.NoError(t, b.SendTransaction(context.Background(), variant))
+
+		if first == nil {
+			first = variant
+		}
+
+		last = variant
 	}
 
 	assert.LessOrEqual(t, len(b.sentTxNonces), maxTrackedSentNonces)
+
+	// The bound alone says nothing about which entries survive it, and every variant here shares a
+	// nonce, so nothing about the nonce can order them either. Dropping the newest would satisfy
+	// the bound while discarding the resend most likely still to be live in a relay's pool, so the
+	// send number is what decides.
+	assert.NotContains(t, b.sentTxNonces, first.Hash(), "the oldest send is the one to drop")
+	assert.Contains(t, b.sentTxNonces, last.Hash(), "the newest send is the one to keep")
 }

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -1881,7 +1881,10 @@ func TestSendingBackend_DropsAHeldAnswerFromAnEndpointThatHasSinceLeft(t *testin
 
 	// A held answer that outlived the trip belongs to the admission that is over, not to the fresh
 	// budget the endpoint comes back with, so it must not move the count at all.
-	require.False(t, b.recordHeldNonce(stale, 5))
+	tripped, demonstrated := b.recordHeldNonce(stale, 5)
+
+	require.False(t, tripped)
+	require.False(t, demonstrated, "a stale admission is not a holder this send may stop at")
 	assert.Equal(t, before, b.consecutive[0], "a stale admission spends nothing")
 }
 
@@ -1906,4 +1909,73 @@ func TestSendingBackend_AnOutageIsNotAnAnsweredRefusal(t *testing.T) {
 	}
 
 	assert.Empty(t, public.sent, "an endpoint being down is what tripping handles")
+}
+
+func TestSendingBackend_AHolderAnsweringForItsOwnNonceEndsTheSend(t *testing.T) {
+	public := &fakeBackend{}
+	holder := &fakeSender{}
+	// Healthy, because fakeSender records a transaction only when it takes one: a backup that
+	// refuses leaves `sent` empty whether or not it was asked, which would assert nothing.
+	backup := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{holder, backup}, nil, nil)
+
+	tx := txWithNonce(7210)
+
+	// Taking the claim is what makes this nonce demonstrably the holder's.
+	require.NoError(t, b.SendTransaction(context.Background(), tx))
+	require.Empty(t, backup.sent, "the first endpoint took it, so the second was never asked")
+
+	holder.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+
+	// The manager resubmits while the receipt is still in flight, and the holder says it is still
+	// holding the nonce. The claim is already where it needs to be: offering the same signed
+	// transaction to the endpoint behind it leaves the stale variant live in a second builder's
+	// pool, which is the thing steering resends to the holder exists to avoid.
+	require.NoError(t, b.SendTransaction(context.Background(), tx))
+
+	assert.Empty(t, backup.sent, "a claim its holder is carrying goes nowhere else")
+	assert.Empty(t, public.sent, "and it is certainly not broadcast publicly")
+}
+
+func TestSendingBackend_AHoldersResendDoesNotTripTheBackup(t *testing.T) {
+	holder := &fakeSender{}
+	// What MEV Blocker actually answered on mainnet once the claim had been mined: it simulates
+	// against the pending block and the message is already done.
+	backup := &fakeSender{err: rpcRejection{"Failed in pending block with: Reverted"}}
+
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{holder, backup}, nil, nil)
+
+	var resend error
+
+	// Every claim ends this way in production: the receipt lands, and the resubmission already in
+	// flight finds the holder still holding the nonce. The backup is reached only on that last
+	// resend and refuses for a reason that is about the claim, not about the backup. Nothing ever
+	// resets its count, because the holder takes every claim first — so three claims took a
+	// perfectly healthy relay out of rotation.
+	for nonce := uint64(1); nonce <= uint64(DefaultPrivateRPCFailureThreshold); nonce++ {
+		holder.err = nil
+		require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(nonce)))
+
+		holder.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+		resend = b.SendTransaction(context.Background(), txWithNonce(nonce))
+	}
+
+	assert.Equal(t, []int{0, 1}, rotation(b), "a backup that was never asked stays in rotation")
+	assert.Equal(t, 0, b.failures[1], "it was never asked, so it refused nothing")
+	assert.NoError(t, resend, "a claim the holder is carrying is not a failed publish")
+}
+
+func TestSendingBackend_AHeldAnswerForANonceItNeverTookStillTriesTheNext(t *testing.T) {
+	first := &fakeSender{err: rpcRejection{txpool.ErrAlreadyKnown.Error()}}
+	second := &fakeSender{}
+
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{first, second}, nil, nil)
+
+	// This endpoint never took this nonce, so its answer may be about a claim it learned from
+	// another relay's gossip rather than from us. The endpoints behind it genuinely have not been
+	// asked, and stopping here would leave the claim with nobody carrying it.
+	require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(55)))
+
+	assert.Len(t, second.sent, 1, "an endpoint that never took this nonce does not end the send")
 }

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -1979,3 +1979,71 @@ func TestSendingBackend_AHeldAnswerForANonceItNeverTookStillTriesTheNext(t *test
 
 	assert.Len(t, second.sent, 1, "an endpoint that never took this nonce does not end the send")
 }
+
+func TestSendingBackend_AHighWaterMarkIsNotProofOfHoldingThisNonce(t *testing.T) {
+	holder := &fakeSender{}
+	backup := &fakeSender{}
+
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{holder, backup}, nil, nil)
+
+	// Claims are signed in nonce order but sent concurrently, so a later nonce can be accepted
+	// while an earlier one still has not been. The high-water mark cannot tell those apart, and it
+	// is exempting the accounting rather than deciding where a claim lives, so it does not have to.
+	require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(9)))
+
+	holder.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+
+	// Nonce 4 was never taken here. The answer may be about a claim this relay learned from
+	// another's gossip, so the backup is the only endpoint that might actually end up carrying it:
+	// ending the send on the strength of the mark alone would strand the claim until
+	// TX_SEND_TIMEOUT with nobody holding it.
+	require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(4)))
+
+	assert.Len(t, backup.sent, 1, "a nonce below the high-water mark is not one this endpoint took")
+}
+
+func TestSendingBackend_AStaleAdmissionStillKnowsWhatItAccepted(t *testing.T) {
+	b, _, _, _, _ := newTestBackend(t, nil)
+
+	require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(5)))
+
+	stale := admit(b, 0)
+
+	trip(b, 0)
+
+	before := b.consecutive[0]
+
+	// A concurrent send can trip this endpoint while our held answer is still on the wire. Leaving
+	// the rotation says the endpoint is unhealthy; it does not unsay which transaction it took.
+	// The generation guard exists to stop a stale result from spending the fresh budget, so it
+	// suppresses the accounting — but the claim really is at this relay, and offering it onward
+	// would put the same signed transaction in a second builder's pool.
+	tripped, demonstrated := b.recordHeldNonce(stale, 5)
+
+	assert.False(t, tripped)
+	assert.True(t, demonstrated, "acceptance is a fact, not a judgement about health")
+	assert.Equal(t, before, b.consecutive[0], "a stale admission still spends nothing")
+}
+
+func TestSendingBackend_BoundsTheAcceptedNonceTracking(t *testing.T) {
+	only := &fakeSender{}
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{only}, nil, nil)
+
+	// Every accepted nonce is remembered so a resend can be recognised as one this endpoint took,
+	// and a claim abandoned at TX_SEND_TIMEOUT never comes back to clear its entry — so the record
+	// has to be bounded or it grows for as long as the relayer runs.
+	for nonce := uint64(0); nonce < uint64(maxTrackedAcceptedNonces)*2; nonce++ {
+		require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(nonce)))
+	}
+
+	assert.LessOrEqual(t, len(b.accepted[0]), maxTrackedAcceptedNonces)
+
+	// Nonces only ascend, so the lowest is the stalest, and the newest is the one whose resend
+	// still has to be recognised. Evicting that one instead would quietly undo the fix on every
+	// send while leaving the bound satisfied.
+	_, keptLowest := b.accepted[0][0]
+	_, keptHighest := b.accepted[0][uint64(maxTrackedAcceptedNonces)*2-1]
+
+	assert.False(t, keptLowest, "the stalest entry is the one to drop")
+	assert.True(t, keptHighest, "the newest entry is the one most likely to be a live claim")
+}

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -2132,9 +2132,11 @@ func TestSendingBackend_ReleasesExactAcceptancesThroughAMinedNonce(t *testing.T)
 	holder := &fakeSender{}
 	b := NewSendingBackend(public, []TxSender{holder}, nil, nil)
 
+	settled := txWithNonceAndCall(39, "settled")
 	mined := txWithNonceAndCall(40, "mined")
 	stillPending := txWithNonceAndCall(41, "pending")
 
+	require.NoError(t, b.SendTransaction(context.Background(), settled))
 	require.NoError(t, b.SendTransaction(context.Background(), mined))
 	require.NoError(t, b.SendTransaction(context.Background(), stillPending))
 
@@ -2142,8 +2144,16 @@ func TestSendingBackend_ReleasesExactAcceptancesThroughAMinedNonce(t *testing.T)
 
 	require.NoError(t, err)
 	require.Same(t, public.receipt, receipt)
-	assert.NotContains(t, b.accepted[0], mined.Nonce(), "a mined nonce no longer needs exact holder state")
+	assert.NotContains(t, b.accepted[0], settled.Nonce(), "an earlier nonce cannot still be pending")
+	assert.Contains(t, b.accepted[0], mined.Nonce(),
+		"the mined nonce's own record is what an already-in-flight resend still needs")
 	assert.Contains(t, b.accepted[0], stillPending.Nonce(), "a later live acceptance is retained")
+
+	// It goes in turn, so at most one settled nonce is ever retained.
+	_, err = b.TransactionReceipt(context.Background(), stillPending.Hash())
+
+	require.NoError(t, err)
+	assert.NotContains(t, b.accepted[0], mined.Nonce(), "the next nonce to mine releases it")
 }
 
 func TestSendingBackend_DoesNotRestoreAcceptanceAfterReceiptWinsRace(t *testing.T) {
@@ -2166,7 +2176,10 @@ func TestSendingBackend_DoesNotRestoreAcceptanceAfterReceiptWinsRace(t *testing.
 	})
 	b.recordSuccess(0, late)
 
-	assert.NotContains(t, b.accepted[0], mined.Nonce())
+	// The mined nonce keeps the record it already had — an in-flight resend still needs it — but
+	// the stale variant adds nothing of its own, so it cannot reopen the window a later receipt
+	// closes.
+	assert.Contains(t, b.accepted[0], mined.Nonce())
 	assert.NotContains(t, b.sentTxNonces, late.Hash())
 }
 
@@ -2206,30 +2219,30 @@ func TestSendingBackend_APublicLandingReleasesThePrivateAcceptance(t *testing.T)
 	b.failureThreshold = 1 << 30
 	b.failureCeiling = 1 << 30
 
-	accepted := txWithNonceAndCall(81, "the accepted claim")
+	accepted := txWithNonceAndCall(80, "the accepted claim")
 
 	require.NoError(t, b.SendTransaction(context.Background(), accepted))
 	require.Contains(t, b.accepted[0], accepted.Nonce())
 
-	// The nonce is recycled, every private endpoint refuses the claim that inherited it, and it
-	// goes out publicly instead.
+	// The next claim is one every private endpoint refuses, so it goes out publicly instead — under
+	// a hash no private endpoint ever saw.
 	only.err = rpcRejection{"claim not accepted"}
 
-	inherited := txWithNonceAndCall(81, "the message that inherited the nonce")
+	public81 := txWithNonceAndCall(81, "the claim no relay would take")
 
 	for i := 0; i < DefaultPrivateRPCAllRefusedLimit; i++ {
-		_ = b.SendTransaction(context.Background(), inherited)
+		_ = b.SendTransaction(context.Background(), public81)
 	}
 
 	require.Equal(t, 1, public.attempts(), "the claim reached the public endpoint")
 
-	// That transaction lands. The account's nonces execute in order, so nothing at or below it is
-	// still pending anywhere — including the private acceptance the earlier claim left behind.
-	_, err := b.TransactionReceipt(context.Background(), inherited.Hash())
+	// It lands there. The account's nonces execute in order, so nothing below it can still be
+	// pending — including the private acceptance at 80. A landing this backend cannot resolve to a
+	// nonce releases nothing, and these records have no cap, so it would stay for the life of the
+	// process.
+	_, err := b.TransactionReceipt(context.Background(), public81.Hash())
 	require.NoError(t, err)
 
 	assert.NotContains(t, b.accepted[0], accepted.Nonce(),
-		"a nonce that mined publicly leaves nothing private still pending at it")
-	assert.Empty(t, b.sentTxNonces,
-		"the records have no cap, so a landing they cannot recognise accumulates for good")
+		"a public landing has to release the private state it settles")
 }

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -2167,5 +2167,69 @@ func TestSendingBackend_DoesNotRestoreAcceptanceAfterReceiptWinsRace(t *testing.
 	b.recordSuccess(0, late)
 
 	assert.NotContains(t, b.accepted[0], mined.Nonce())
-	assert.NotContains(t, b.acceptedTxNonces, late.Hash())
+	assert.NotContains(t, b.sentTxNonces, late.Hash())
+}
+
+func TestSendingBackend_AReceiptDoesNotStrandAResendAlreadyAtItsHolder(t *testing.T) {
+	public := &fakeBackend{receipt: &types.Receipt{}}
+	holder := &fakeSender{}
+	backup := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{holder, backup}, nil, nil)
+
+	tx := txWithNonce(7210)
+
+	require.NoError(t, b.SendTransaction(context.Background(), tx))
+	require.Empty(t, backup.sent)
+
+	// The manager polls for the receipt while a fee-bumped resend is already on its way to the
+	// holder. The receipt wins the lock and releases the exact acceptance.
+	_, err := b.TransactionReceipt(context.Background(), tx.Hash())
+	require.NoError(t, err)
+
+	// Only then does the holder answer the resend that was already in flight. It is still the
+	// endpoint carrying this claim, and the whole point of the exact record is that the send ends
+	// there rather than handing the same signed transaction to a backup that will refuse a claim
+	// which is now done — and be charged for it.
+	holder.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+
+	require.NoError(t, b.SendTransaction(context.Background(), tx))
+
+	assert.Empty(t, backup.sent, "a resend already in flight still ends at the endpoint holding it")
+}
+
+func TestSendingBackend_APublicLandingReleasesThePrivateAcceptance(t *testing.T) {
+	public := &fakeBackend{receipt: &types.Receipt{}}
+	only := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+	b.failureThreshold = 1 << 30
+	b.failureCeiling = 1 << 30
+
+	accepted := txWithNonceAndCall(81, "the accepted claim")
+
+	require.NoError(t, b.SendTransaction(context.Background(), accepted))
+	require.Contains(t, b.accepted[0], accepted.Nonce())
+
+	// The nonce is recycled, every private endpoint refuses the claim that inherited it, and it
+	// goes out publicly instead.
+	only.err = rpcRejection{"claim not accepted"}
+
+	inherited := txWithNonceAndCall(81, "the message that inherited the nonce")
+
+	for i := 0; i < DefaultPrivateRPCAllRefusedLimit; i++ {
+		_ = b.SendTransaction(context.Background(), inherited)
+	}
+
+	require.Equal(t, 1, public.attempts(), "the claim reached the public endpoint")
+
+	// That transaction lands. The account's nonces execute in order, so nothing at or below it is
+	// still pending anywhere — including the private acceptance the earlier claim left behind.
+	_, err := b.TransactionReceipt(context.Background(), inherited.Hash())
+	require.NoError(t, err)
+
+	assert.NotContains(t, b.accepted[0], accepted.Nonce(),
+		"a nonce that mined publicly leaves nothing private still pending at it")
+	assert.Empty(t, b.sentTxNonces,
+		"the records have no cap, so a landing they cannot recognise accumulates for good")
 }

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -429,7 +429,7 @@ func TestSendingBackend_ASuccessfulSendReadmitsATrippedEndpoint(t *testing.T) {
 	require.Equal(t, []int{1}, rotation(b))
 
 	// An endpoint that just took a transaction is not down, whatever its recent record.
-	b.recordSuccess(0, 1)
+	b.recordSuccess(0, 1, claimIdentity(txWithNonce(1)))
 
 	assert.Equal(t, []int{0, 1}, rotation(b))
 }
@@ -1881,10 +1881,10 @@ func TestSendingBackend_DropsAHeldAnswerFromAnEndpointThatHasSinceLeft(t *testin
 
 	// A held answer that outlived the trip belongs to the admission that is over, not to the fresh
 	// budget the endpoint comes back with, so it must not move the count at all.
-	tripped, demonstrated := b.recordHeldNonce(stale, 5)
+	tripped, demonstrated := b.recordHeldNonce(stale, 5, claimIdentity(txWithNonce(5)))
 
 	require.False(t, tripped)
-	require.False(t, demonstrated, "a stale admission is not a holder this send may stop at")
+	require.False(t, demonstrated, "this endpoint never accepted that nonce")
 	assert.Equal(t, before, b.consecutive[0], "a stale admission spends nothing")
 }
 
@@ -2018,11 +2018,32 @@ func TestSendingBackend_AStaleAdmissionStillKnowsWhatItAccepted(t *testing.T) {
 	// The generation guard exists to stop a stale result from spending the fresh budget, so it
 	// suppresses the accounting — but the claim really is at this relay, and offering it onward
 	// would put the same signed transaction in a second builder's pool.
-	tripped, demonstrated := b.recordHeldNonce(stale, 5)
+	tripped, demonstrated := b.recordHeldNonce(stale, 5, claimIdentity(txWithNonce(5)))
 
 	assert.False(t, tripped)
 	assert.True(t, demonstrated, "acceptance is a fact, not a judgement about health")
 	assert.Equal(t, before, b.consecutive[0], "a stale admission still spends nothing")
+}
+
+func TestSendingBackend_ARecycledNonceIsNotTheClaimThatWasAccepted(t *testing.T) {
+	holder := &fakeSender{}
+	backup := &fakeSender{}
+
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{holder, backup}, nil, nil)
+
+	// One claim is accepted at this nonce and then abandoned at TX_SEND_TIMEOUT — only an accepted
+	// send clears the record, and an abandoned claim never comes back to be accepted. resetNonce
+	// then hands the same nonce to an unrelated message, whose encoded message and proof make it a
+	// different claim.
+	require.NoError(t, b.SendTransaction(context.Background(), txWithNonceAndCall(81, "the accepted claim")))
+
+	// The endpoint is still holding the first claim, so it answers that the replacement is
+	// underpriced. That is an answer about the transaction it has, not about the one being offered.
+	holder.err = rpcRejection{txpool.ErrReplaceUnderpriced.Error()}
+
+	require.NoError(t, b.SendTransaction(context.Background(), txWithNonceAndCall(81, "the message that inherited the nonce")))
+
+	assert.Len(t, backup.sent, 1, "a recycled nonce is not evidence about the claim now carrying it")
 }
 
 func TestSendingBackend_BoundsTheAcceptedNonceTracking(t *testing.T) {

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -1881,10 +1881,10 @@ func TestSendingBackend_DropsAHeldAnswerFromAnEndpointThatHasSinceLeft(t *testin
 
 	// A held answer that outlived the trip belongs to the admission that is over, not to the fresh
 	// budget the endpoint comes back with, so it must not move the count at all.
-	tripped, demonstrated := b.recordHeldNonce(stale, 5, claimIdentity(txWithNonce(5)))
+	tripped, answer := b.recordHeldNonce(stale, 5, claimIdentity(txWithNonce(5)))
 
 	require.False(t, tripped)
-	require.False(t, demonstrated, "this endpoint never accepted that nonce")
+	require.Equal(t, heldUnattributed, answer, "this endpoint never accepted that nonce")
 	assert.Equal(t, before, b.consecutive[0], "a stale admission spends nothing")
 }
 
@@ -2018,10 +2018,10 @@ func TestSendingBackend_AStaleAdmissionStillKnowsWhatItAccepted(t *testing.T) {
 	// The generation guard exists to stop a stale result from spending the fresh budget, so it
 	// suppresses the accounting — but the claim really is at this relay, and offering it onward
 	// would put the same signed transaction in a second builder's pool.
-	tripped, demonstrated := b.recordHeldNonce(stale, 5, claimIdentity(txWithNonce(5)))
+	tripped, answer := b.recordHeldNonce(stale, 5, claimIdentity(txWithNonce(5)))
 
 	assert.False(t, tripped)
-	assert.True(t, demonstrated, "acceptance is a fact, not a judgement about health")
+	assert.Equal(t, heldThisClaim, answer, "acceptance is a fact, not a judgement about health")
 	assert.Equal(t, before, b.consecutive[0], "a stale admission still spends nothing")
 }
 
@@ -2044,6 +2044,51 @@ func TestSendingBackend_ARecycledNonceIsNotTheClaimThatWasAccepted(t *testing.T)
 	require.NoError(t, b.SendTransaction(context.Background(), txWithNonceAndCall(81, "the message that inherited the nonce")))
 
 	assert.Len(t, backup.sent, 1, "a recycled nonce is not evidence about the claim now carrying it")
+}
+
+func TestSendingBackend_AHolderOfSomeoneElsesClaimDoesNotBlockTheFallback(t *testing.T) {
+	public := &fakeBackend{}
+	holder := &fakeSender{}
+	backup := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{holder, backup}, nil, nil)
+
+	require.NoError(t, b.SendTransaction(context.Background(), txWithNonceAndCall(81, "the accepted claim")))
+
+	// The holder is answering about the claim it still has, and the backup will not take the one
+	// that inherited the nonce. Nobody is carrying the new claim, so the privacy argument for
+	// suppressing the public fallback — that every relay already has it — does not hold here, and
+	// suppressing it anyway leaves the claim looping until TX_SEND_TIMEOUT.
+	holder.err = rpcRejection{txpool.ErrReplaceUnderpriced.Error()}
+	backup.err = rpcRejection{"claim not accepted"}
+
+	inherited := txWithNonceAndCall(81, "the message that inherited the nonce")
+
+	for i := 0; i < DefaultPrivateRPCAllRefusedLimit; i++ {
+		_ = b.SendTransaction(context.Background(), inherited)
+	}
+
+	assert.Equal(t, 1, public.attempts(),
+		"a relay holding someone else's claim is not carrying this one")
+}
+
+func TestSendingBackend_AGossipedHoldStillProtectsTheClaim(t *testing.T) {
+	public := &fakeBackend{}
+	first := &fakeSender{err: rpcRejection{txpool.ErrAlreadyKnown.Error()}}
+	second := &fakeSender{err: rpcRejection{"claim not accepted"}}
+
+	b := NewSendingBackend(public, []TxSender{first, second}, nil, nil)
+
+	tx := txWithNonce(31)
+
+	// This endpoint never took this nonce, so its answer may be about our claim, learned from
+	// another relay's gossip. Unlike the case above there is no evidence it is carrying something
+	// else, and broadcasting on a maybe would leak a claim the relays are already holding.
+	for i := 0; i < 2*DefaultPrivateRPCAllRefusedLimit; i++ {
+		_ = b.SendTransaction(context.Background(), tx)
+	}
+
+	assert.Empty(t, public.sent, "an unattributed hold is still not a refusal")
 }
 
 func TestSendingBackend_BoundsTheAcceptedNonceTracking(t *testing.T) {

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -2246,3 +2246,78 @@ func TestSendingBackend_APublicLandingReleasesThePrivateAcceptance(t *testing.T)
 	assert.NotContains(t, b.accepted[0], accepted.Nonce(),
 		"a public landing has to release the private state it settles")
 }
+
+func TestSendingBackend_APostReorgAcceptanceReplacesTheStaleHolderRecord(t *testing.T) {
+	public := &fakeBackend{receipt: &types.Receipt{}}
+	holder := &fakeSender{}
+	backup := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{holder, backup}, nil, nil)
+
+	first := txWithNonceAndCall(40, "the claim that mined")
+
+	require.NoError(t, b.SendTransaction(context.Background(), first))
+
+	// The transaction manager reads the receipt before it has confirmation depth, so this can be
+	// observed for a transaction that a reorg then removes.
+	_, err := b.TransactionReceipt(context.Background(), first.Hash())
+	require.NoError(t, err)
+
+	// The nonce is live again and gets recycled to a different claim, which this endpoint accepts.
+	second := txWithNonceAndCall(40, "the claim that inherited the nonce")
+
+	require.NoError(t, b.SendTransaction(context.Background(), second))
+	require.Empty(t, backup.sent, "the first endpoint took it")
+
+	// Its resend has to end here. This endpoint demonstrably holds the claim being offered, and a
+	// record left over from the transaction the reorg removed does not say otherwise.
+	holder.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
+
+	require.NoError(t, b.SendTransaction(context.Background(), second))
+
+	assert.Empty(t, backup.sent, "the endpoint that accepted this claim is still its holder")
+}
+
+func TestSendingBackend_CollectsTheDeadVariantsOfAMinedNonce(t *testing.T) {
+	public := &fakeBackend{receipt: &types.Receipt{}}
+	only := &fakeSender{}
+
+	b := NewSendingBackend(public, []TxSender{only}, nil, nil)
+
+	// One claim resent at rising fees: the same nonce under a new hash each time, and only one of
+	// them can ever execute.
+	var variants []*types.Transaction
+
+	for tip := int64(1); tip <= 6; tip++ {
+		variant := txWithNonceAndTip(40, tip)
+
+		require.NoError(t, b.SendTransaction(context.Background(), variant))
+
+		variants = append(variants, variant)
+	}
+
+	require.Len(t, b.sentTxNonces, len(variants))
+
+	landed := variants[len(variants)-1]
+
+	_, err := b.TransactionReceipt(context.Background(), landed.Hash())
+	require.NoError(t, err)
+
+	assert.Len(t, b.sentTxNonces, 1, "the variants a mined nonce replaced can never produce a receipt")
+	assert.Contains(t, b.sentTxNonces, landed.Hash(), "the one that landed is still read more than once")
+}
+
+func TestSendingBackend_BoundsTheSentTransactionIndex(t *testing.T) {
+	only := &fakeSender{}
+
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{only}, nil, nil)
+
+	// A nonce that never lands has no later receipt to collect its variants — nothing above it can
+	// mine either — while TX_SEND_TIMEOUT keeps handing the nonce back out and every fee variant of
+	// every attempt adds a hash.
+	for tip := int64(1); tip <= int64(maxTrackedSentNonces)*2; tip++ {
+		require.NoError(t, b.SendTransaction(context.Background(), txWithNonceAndTip(40, tip)))
+	}
+
+	assert.LessOrEqual(t, len(b.sentTxNonces), maxTrackedSentNonces)
+}

--- a/packages/relayer/pkg/utils/sending_backend_test.go
+++ b/packages/relayer/pkg/utils/sending_backend_test.go
@@ -35,6 +35,7 @@ type fakeBackend struct {
 	sent              []*types.Transaction
 	closed            bool
 	closeCalls        int
+	receipt           *types.Receipt
 }
 
 func (f *fakeBackend) PendingNonceAt(_ context.Context, _ common.Address) (uint64, error) {
@@ -59,6 +60,13 @@ func (f *fakeBackend) SendTransaction(_ context.Context, tx *types.Transaction) 
 	f.sent = append(f.sent, tx)
 
 	return nil
+}
+
+func (f *fakeBackend) TransactionReceipt(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.receipt, nil
 }
 
 // attempts counts every send offered to this backend, including the ones it refused. For tests
@@ -429,7 +437,7 @@ func TestSendingBackend_ASuccessfulSendReadmitsATrippedEndpoint(t *testing.T) {
 	require.Equal(t, []int{1}, rotation(b))
 
 	// An endpoint that just took a transaction is not down, whatever its recent record.
-	b.recordSuccess(0, 1, claimIdentity(txWithNonce(1)))
+	b.recordSuccess(0, txWithNonce(1))
 
 	assert.Equal(t, []int{0, 1}, rotation(b))
 }
@@ -1955,6 +1963,7 @@ func TestSendingBackend_AHoldersResendDoesNotTripTheBackup(t *testing.T) {
 	// perfectly healthy relay out of rotation.
 	for nonce := uint64(1); nonce <= uint64(DefaultPrivateRPCFailureThreshold); nonce++ {
 		holder.err = nil
+
 		require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(nonce)))
 
 		holder.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
@@ -2041,7 +2050,10 @@ func TestSendingBackend_ARecycledNonceIsNotTheClaimThatWasAccepted(t *testing.T)
 	// underpriced. That is an answer about the transaction it has, not about the one being offered.
 	holder.err = rpcRejection{txpool.ErrReplaceUnderpriced.Error()}
 
-	require.NoError(t, b.SendTransaction(context.Background(), txWithNonceAndCall(81, "the message that inherited the nonce")))
+	require.NoError(t, b.SendTransaction(
+		context.Background(),
+		txWithNonceAndCall(81, "the message that inherited the nonce"),
+	))
 
 	assert.Len(t, backup.sent, 1, "a recycled nonce is not evidence about the claim now carrying it")
 }
@@ -2091,25 +2103,69 @@ func TestSendingBackend_AGossipedHoldStillProtectsTheClaim(t *testing.T) {
 	assert.Empty(t, public.sent, "an unattributed hold is still not a refusal")
 }
 
-func TestSendingBackend_BoundsTheAcceptedNonceTracking(t *testing.T) {
-	only := &fakeSender{}
-	b := NewSendingBackend(&fakeBackend{}, []TxSender{only}, nil, nil)
+func TestSendingBackend_PreservesEveryAcceptanceUntilItsNonceMines(t *testing.T) {
+	holder := &fakeSender{}
+	backup := &fakeSender{}
+	b := NewSendingBackend(&fakeBackend{}, []TxSender{holder, backup}, nil, nil)
 
-	// Every accepted nonce is remembered so a resend can be recognised as one this endpoint took,
-	// and a claim abandoned at TX_SEND_TIMEOUT never comes back to clear its entry — so the record
-	// has to be bounded or it grows for as long as the relayer runs.
-	for nonce := uint64(0); nonce < uint64(maxTrackedAcceptedNonces)*2; nonce++ {
-		require.NoError(t, b.SendTransaction(context.Background(), txWithNonce(nonce)))
+	const acceptedClaims = 300
+
+	first := txWithNonceAndCall(0, "claim-0")
+	require.NoError(t, b.SendTransaction(context.Background(), first))
+
+	for nonce := uint64(1); nonce < acceptedClaims; nonce++ {
+		tx := txWithNonceAndCall(nonce, fmt.Sprintf("claim-%d", nonce))
+		require.NoError(t, b.SendTransaction(context.Background(), tx))
 	}
 
-	assert.LessOrEqual(t, len(b.accepted[0]), maxTrackedAcceptedNonces)
+	// A large prefetch can leave more than 256 accepted claims awaiting receipts at once. The
+	// oldest is still live, so the holder's response must end its resend instead of offering it to
+	// a second relay.
+	holder.err = rpcRejection{txpool.ErrAlreadyKnown.Error()}
 
-	// Nonces only ascend, so the lowest is the stalest, and the newest is the one whose resend
-	// still has to be recognised. Evicting that one instead would quietly undo the fix on every
-	// send while leaving the bound satisfied.
-	_, keptLowest := b.accepted[0][0]
-	_, keptHighest := b.accepted[0][uint64(maxTrackedAcceptedNonces)*2-1]
+	require.NoError(t, b.SendTransaction(context.Background(), first))
+	assert.Empty(t, backup.sent, "a live acceptance is not evicted by an arbitrary tracking cap")
+}
 
-	assert.False(t, keptLowest, "the stalest entry is the one to drop")
-	assert.True(t, keptHighest, "the newest entry is the one most likely to be a live claim")
+func TestSendingBackend_ReleasesExactAcceptancesThroughAMinedNonce(t *testing.T) {
+	public := &fakeBackend{receipt: &types.Receipt{}}
+	holder := &fakeSender{}
+	b := NewSendingBackend(public, []TxSender{holder}, nil, nil)
+
+	mined := txWithNonceAndCall(40, "mined")
+	stillPending := txWithNonceAndCall(41, "pending")
+
+	require.NoError(t, b.SendTransaction(context.Background(), mined))
+	require.NoError(t, b.SendTransaction(context.Background(), stillPending))
+
+	receipt, err := b.TransactionReceipt(context.Background(), mined.Hash())
+
+	require.NoError(t, err)
+	require.Same(t, public.receipt, receipt)
+	assert.NotContains(t, b.accepted[0], mined.Nonce(), "a mined nonce no longer needs exact holder state")
+	assert.Contains(t, b.accepted[0], stillPending.Nonce(), "a later live acceptance is retained")
+}
+
+func TestSendingBackend_DoesNotRestoreAcceptanceAfterReceiptWinsRace(t *testing.T) {
+	public := &fakeBackend{receipt: &types.Receipt{}}
+	b := NewSendingBackend(public, []TxSender{&fakeSender{}}, nil, nil)
+
+	mined := txWithNonceAndCall(40, "the claim")
+	require.NoError(t, b.SendTransaction(context.Background(), mined))
+
+	_, err := b.TransactionReceipt(context.Background(), mined.Hash())
+	require.NoError(t, err)
+
+	// A fee-bumped send can already be in flight when a receipt watcher finds the mined variant.
+	// Its later success is stale and must not make the confirmed nonce look live again.
+	late := types.NewTx(&types.DynamicFeeTx{
+		Nonce:     mined.Nonce(),
+		Gas:       21_000,
+		GasTipCap: big.NewInt(2),
+		Data:      mined.Data(),
+	})
+	b.recordSuccess(0, late)
+
+	assert.NotContains(t, b.accepted[0], mined.Nonce())
+	assert.NotContains(t, b.acceptedTxNonces, late.Hash())
 }

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -85,7 +85,7 @@ func (p *Processor) processMessage(
 		defer p.processingTxHashMu.Unlock()
 
 		if _, ok := p.processingTxHashes[hash]; ok {
-			slog.Warn("already processing txHash", "txhash", hash.Hex())
+			slog.Debug("already processing txHash", "txhash", hash.Hex())
 			return errAlreadyProcessing
 		}
 

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -46,6 +46,33 @@ func inFlightKey(event *bridge.BridgeMessageSent) common.Hash {
 	return common.Hash(event.MsgHash)
 }
 
+// claimDelivery takes the in-flight claim for the message a delivery carries and returns the
+// release for it, which the caller must run once the delivery is completely finished with.
+//
+// The claim has to outlive processMessage. Acking, nacking or republishing a delivery happens after
+// processMessage returns, and a duplicate that arrived in between would otherwise take the claim
+// and start work while the first delivery's disposition was still in flight — which is exactly what
+// the claim exists to prevent, and QUEUE_PREFETCH_COUNT above one makes ordinary.
+//
+// A body that will not decode never held a claim, so its release is a no-op and the caller can
+// defer it unconditionally.
+func (p *Processor) claimDelivery(m queue.Message) (release func(), err error) {
+	msgBody := &queue.QueueMessageSentBody{}
+	if err := json.Unmarshal(m.Body, msgBody); err != nil {
+		return func() {}, nil
+	}
+
+	if msgBody.Event == nil {
+		return func() {}, nil
+	}
+
+	if err := p.beginProcessing(msgBody.Event); err != nil {
+		return func() {}, err
+	}
+
+	return func() { p.endProcessing(msgBody.Event) }, nil
+}
+
 // beginProcessing claims a message for this replica, reporting errAlreadyProcessing when another
 // delivery of the same message is already being worked on. The caller must pair a successful claim
 // with endProcessing.
@@ -120,14 +147,6 @@ func (p *Processor) processMessage(
 	}
 
 	slog.Info("message received", "srcTxHash", msgBody.Event.Raw.TxHash.Hex())
-
-	// if another delivery of this message is already being worked on, we don't need to continue
-	if err := p.beginProcessing(msgBody.Event); err != nil {
-		return false, 0, err
-	}
-
-	// otherwise, make sure when we exit, this message stops being claimed
-	defer p.endProcessing(msgBody.Event)
 
 	if msgBody.TimesRetried >= p.maxMessageRetries {
 		slog.Warn("max retries reached", "timesRetried", msgBody.TimesRetried)

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	errUnprocessable     = errors.New("message is unprocessable")
-	errAlreadyProcessing = errors.New("already processing txHash")
+	errAlreadyProcessing = errors.New("already processing msgHash")
 )
 
 const gasRefundPerCacheOperation uint64 = 20_000

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -34,6 +34,48 @@ var (
 
 const gasRefundPerCacheOperation uint64 = 20_000
 
+// inFlightKey identifies the message a delivery carries, so that two deliveries of it can be told
+// from two deliveries that merely arrived together.
+//
+// The message, not the transaction that emitted it. One transaction can emit several MessageSent
+// events — a contract bridging more than one token does exactly that — and the indexer publishes one
+// queue message per event, so siblings arrive as separate deliveries sharing a source transaction
+// hash. Keyed on that hash, the second sibling looked like a duplicate of the first and was
+// discarded although nothing had processed it.
+func inFlightKey(event *bridge.BridgeMessageSent) common.Hash {
+	return common.Hash(event.MsgHash)
+}
+
+// beginProcessing claims a message for this replica, reporting errAlreadyProcessing when another
+// delivery of the same message is already being worked on. The caller must pair a successful claim
+// with endProcessing.
+func (p *Processor) beginProcessing(event *bridge.BridgeMessageSent) error {
+	key := inFlightKey(event)
+
+	p.processingMsgHashMu.Lock()
+	defer p.processingMsgHashMu.Unlock()
+
+	if _, ok := p.processingMsgHashes[key]; ok {
+		slog.Debug("already processing msgHash", "msgHash", key.Hex())
+
+		return errAlreadyProcessing
+	}
+
+	p.processingMsgHashes[key] = true
+
+	return nil
+}
+
+// endProcessing releases the claim beginProcessing took.
+func (p *Processor) endProcessing(event *bridge.BridgeMessageSent) {
+	key := inFlightKey(event)
+
+	p.processingMsgHashMu.Lock()
+	defer p.processingMsgHashMu.Unlock()
+
+	delete(p.processingMsgHashes, key)
+}
+
 // eventStatusFromMsgHash will check the event's msgHash/signal, and
 // get its on-chain current status.
 func (p *Processor) eventStatusFromMsgHash(
@@ -79,32 +121,13 @@ func (p *Processor) processMessage(
 
 	slog.Info("message received", "srcTxHash", msgBody.Event.Raw.TxHash.Hex())
 
-	// check if we already processing this hash
-	checkHash := func(hash common.Hash) error {
-		p.processingTxHashMu.Lock()
-		defer p.processingTxHashMu.Unlock()
-
-		if _, ok := p.processingTxHashes[hash]; ok {
-			slog.Debug("already processing txHash", "txhash", hash.Hex())
-			return errAlreadyProcessing
-		}
-
-		p.processingTxHashes[hash] = true
-
-		return nil
-	}
-
-	// if we are, we don't need to continue
-	if err := checkHash(msgBody.Event.Raw.TxHash); err != nil {
+	// if another delivery of this message is already being worked on, we don't need to continue
+	if err := p.beginProcessing(msgBody.Event); err != nil {
 		return false, 0, err
 	}
 
-	// otherwise, make sure when we exit, we remove this hash from being checked
-	defer func(hash common.Hash) {
-		p.processingTxHashMu.Lock()
-		defer p.processingTxHashMu.Unlock()
-		delete(p.processingTxHashes, hash)
-	}(msgBody.Event.Raw.TxHash)
+	// otherwise, make sure when we exit, this message stops being claimed
+	defer p.endProcessing(msgBody.Event)
 
 	if msgBody.TimesRetried >= p.maxMessageRetries {
 		slog.Warn("max retries reached", "timesRetried", msgBody.TimesRetried)

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -392,6 +392,69 @@ func Test_ProcessMessage_messageUnprocessable(t *testing.T) {
 	assert.Equal(t, false, shouldRequeue)
 }
 
+// messageSentFromOneTransaction builds a delivery for one MessageSent event, letting a test give
+// two events the same source transaction and different messages — which is what a contract bridging
+// more than one token emits.
+func messageSentFromOneTransaction(
+	txHash, msgHash common.Hash,
+) (*bridge.BridgeMessageSent, queue.Message) {
+	event := &bridge.BridgeMessageSent{
+		MsgHash: msgHash,
+		Message: bridge.IBridgeMessage{
+			GasLimit:   1,
+			SrcChainId: mock.MockChainID.Uint64(),
+			Id:         1,
+		},
+		Raw: types.Log{
+			Address: relayer.ZeroAddress,
+			Topics:  []common.Hash{relayer.ZeroHash},
+			Data:    []byte{0xff},
+			TxHash:  txHash,
+		},
+	}
+
+	marshalled, _ := json.Marshal(&queue.QueueMessageSentBody{Event: event, ID: 0})
+
+	return event, queue.Message{Body: marshalled}
+}
+
+func Test_ProcessMessage_ASiblingOfTheSameTransactionIsNotADuplicate(t *testing.T) {
+	p := newTestProcessor(true)
+
+	txHash := common.HexToHash("0x01a64b21f1c8df54600a462c5ba521bff7c09f83d67ebe314a666e079d1b68dd")
+
+	first, _ := messageSentFromOneTransaction(txHash, common.HexToHash("0xaa"))
+	_, second := messageSentFromOneTransaction(txHash, common.HexToHash("0xbb"))
+
+	// Claimed through the same path production uses, so the claim is whatever the key says it is
+	// rather than whatever this test assumed.
+	require.NoError(t, p.beginProcessing(first))
+	defer p.endProcessing(first)
+
+	_, _, err := p.processMessage(context.Background(), second)
+
+	assert.NotErrorIs(t, err, errAlreadyProcessing,
+		"one transaction can emit several messages; a sibling is not a duplicate")
+}
+
+func Test_ProcessMessage_TheSameMessageInFlightIsADuplicate(t *testing.T) {
+	p := newTestProcessor(true)
+
+	txHash := common.HexToHash("0xdead")
+	msgHash := common.HexToHash("0xaa")
+
+	inFlight, _ := messageSentFromOneTransaction(txHash, msgHash)
+	_, redelivered := messageSentFromOneTransaction(txHash, msgHash)
+
+	require.NoError(t, p.beginProcessing(inFlight))
+	defer p.endProcessing(inFlight)
+
+	_, _, err := p.processMessage(context.Background(), redelivered)
+
+	assert.ErrorIs(t, err, errAlreadyProcessing,
+		"the delivery already being processed is the authoritative one")
+}
+
 func Test_ProcessMessage_unprofitable(t *testing.T) {
 	p := newTestProcessor(true)
 

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -470,6 +470,25 @@ func (q *blockingQueue) Ack(ctx context.Context, msg queue.Message) error {
 	return q.recordingQueue.Ack(ctx, msg)
 }
 
+// panickingQueue panics where a delivery's disposition would start, then blocks inside the nack the
+// recovery makes, so the window between the two can be inspected.
+type panickingQueue struct {
+	recordingQueue
+	nackStarted chan struct{}
+	nackGate    chan struct{}
+}
+
+func (q *panickingQueue) Ack(_ context.Context, _ queue.Message) error {
+	panic("settling this delivery blew up")
+}
+
+func (q *panickingQueue) Nack(ctx context.Context, msg queue.Message, requeue bool) error {
+	close(q.nackStarted)
+	<-q.nackGate
+
+	return q.recordingQueue.Nack(ctx, msg, requeue)
+}
+
 func Test_ProcessDelivery_HoldsTheClaimUntilTheDispositionCompletes(t *testing.T) {
 	release := make(chan struct{})
 	q := &blockingQueue{ackStarted: make(chan struct{}), ackGate: release}
@@ -501,6 +520,47 @@ func Test_ProcessDelivery_HoldsTheClaimUntilTheDispositionCompletes(t *testing.T
 
 	assert.ErrorIs(t, err, errAlreadyProcessing,
 		"the claim has to outlive the Ack, or a duplicate starts while it is still going out")
+}
+
+func Test_ProcessDelivery_HoldsTheClaimThroughAPanicsNack(t *testing.T) {
+	release := make(chan struct{})
+	q := &panickingQueue{nackStarted: make(chan struct{}), nackGate: release}
+
+	p := newTestProcessor(true)
+	p.queue = q
+
+	_, delivery := messageSentFromOneTransaction(
+		common.HexToHash("0xdead"),
+		common.HexToHash("0xaa"),
+	)
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		// The caller's own net, standing in for the recovery that used to live out here. With the
+		// recovery inside the claim nothing reaches it; with the recovery out here it is what
+		// settles the delivery — after the claim has already been released on the way out.
+		defer func() {
+			if r := recover(); r != nil {
+				_ = p.queue.Nack(context.Background(), delivery, false)
+			}
+		}()
+
+		p.processDelivery(context.Background(), delivery)
+	}()
+
+	// Wait until the recovery's nack is going out.
+	<-q.nackStarted
+
+	_, err := p.claimDelivery(delivery)
+
+	close(release)
+	<-done
+
+	assert.ErrorIs(t, err, errAlreadyProcessing,
+		"a panic still settles the delivery, and that settlement is inside the claim")
 }
 
 func Test_ProcessMessage_unprofitable(t *testing.T) {

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -431,7 +431,7 @@ func Test_ProcessMessage_ASiblingOfTheSameTransactionIsNotADuplicate(t *testing.
 	require.NoError(t, p.beginProcessing(first))
 	defer p.endProcessing(first)
 
-	_, _, err := p.processMessage(context.Background(), second)
+	_, err := p.claimDelivery(second)
 
 	assert.NotErrorIs(t, err, errAlreadyProcessing,
 		"one transaction can emit several messages; a sibling is not a duplicate")
@@ -449,10 +449,58 @@ func Test_ProcessMessage_TheSameMessageInFlightIsADuplicate(t *testing.T) {
 	require.NoError(t, p.beginProcessing(inFlight))
 	defer p.endProcessing(inFlight)
 
-	_, _, err := p.processMessage(context.Background(), redelivered)
+	_, err := p.claimDelivery(redelivered)
 
 	assert.ErrorIs(t, err, errAlreadyProcessing,
 		"the delivery already being processed is the authoritative one")
+}
+
+// blockingQueue holds a delivery inside its Ack until the test lets go, so the window between
+// processMessage returning and the disposition finishing can be inspected.
+type blockingQueue struct {
+	recordingQueue
+	ackStarted chan struct{}
+	ackGate    chan struct{}
+}
+
+func (q *blockingQueue) Ack(ctx context.Context, msg queue.Message) error {
+	close(q.ackStarted)
+	<-q.ackGate
+
+	return q.recordingQueue.Ack(ctx, msg)
+}
+
+func Test_ProcessDelivery_HoldsTheClaimUntilTheDispositionCompletes(t *testing.T) {
+	release := make(chan struct{})
+	q := &blockingQueue{ackStarted: make(chan struct{}), ackGate: release}
+
+	p := newTestProcessor(true)
+	p.queue = q
+
+	_, delivery := messageSentFromOneTransaction(
+		common.HexToHash("0xdead"),
+		common.HexToHash("0xaa"),
+	)
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		p.processDelivery(context.Background(), delivery)
+	}()
+
+	// Wait until the delivery is inside its disposition: processMessage has returned, so the old
+	// defer would already have released the claim here.
+	<-q.ackStarted
+
+	_, err := p.claimDelivery(delivery)
+
+	close(release)
+	<-done
+
+	assert.ErrorIs(t, err, errAlreadyProcessing,
+		"the claim has to outlive the Ack, or a duplicate starts while it is still going out")
 }
 
 func Test_ProcessMessage_unprofitable(t *testing.T) {

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -591,6 +591,18 @@ func (p *Processor) handleProcessMessageResult(
 			slog.Error("process message failed", "err", err.Error())
 
 			p.handleTransientProcessMessageError(ctx, m)
+		case errors.Is(err, errAlreadyProcessing):
+			// A duplicate of a delivery this replica is still working on. The in-flight one is
+			// authoritative — processMessage registers the delete of its hash as a defer the
+			// moment it takes it, so every exit path releases it — which makes the copy carry
+			// nothing. Acking discards the copy without touching the claim. Falling through to
+			// default nacked it with requeue=false instead, dead-lettering a message that was
+			// never a failure, about six times a minute for every claim waiting on a checkpoint.
+			relayer.MessageSentEventsDuplicateDelivery.Inc()
+
+			if err := p.queue.Ack(ctx, m); err != nil {
+				slog.Error("Err acking message", "err", err.Error())
+			}
 		default:
 			slog.Error("process message failed", "err", err.Error())
 

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -116,8 +116,8 @@ type Processor struct {
 
 	maxMessageRetries uint64
 
-	processingTxHashes map[common.Hash]bool
-	processingTxHashMu sync.Mutex
+	processingMsgHashes map[common.Hash]bool
+	processingMsgHashMu sync.Mutex
 
 	minFeeToProcess uint64
 
@@ -376,7 +376,7 @@ func InitFromConfig(ctx context.Context, p *Processor, cfg *Config) error {
 
 	p.maxMessageRetries = cfg.MaxMessageRetries
 
-	p.processingTxHashes = make(map[common.Hash]bool, 0)
+	p.processingMsgHashes = make(map[common.Hash]bool, 0)
 
 	p.minFeeToProcess = p.cfg.MinFeeToProcess
 

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -565,11 +565,29 @@ func (p *Processor) eventLoop(ctx context.Context) {
 					}
 				}()
 
-				shouldRequeue, timesRetried, err := p.processMessage(ctx, m)
-				p.handleProcessMessageResult(ctx, m, shouldRequeue, timesRetried, err)
+				p.processDelivery(ctx, m)
 			}(msg)
 		}
 	}
+}
+
+// processDelivery runs one delivery and settles it on the queue, holding the message's in-flight
+// claim across both so a duplicate cannot start while this delivery's Ack, Nack or transient
+// republish is still going out.
+func (p *Processor) processDelivery(ctx context.Context, m queue.Message) {
+	release, err := p.claimDelivery(m)
+
+	defer release()
+
+	if err != nil {
+		p.handleProcessMessageResult(ctx, m, false, 0, err)
+
+		return
+	}
+
+	shouldRequeue, timesRetried, err := p.processMessage(ctx, m)
+
+	p.handleProcessMessageResult(ctx, m, shouldRequeue, timesRetried, err)
 }
 
 func (p *Processor) handleProcessMessageResult(

--- a/packages/relayer/processor/processor.go
+++ b/packages/relayer/processor/processor.go
@@ -554,19 +554,7 @@ func (p *Processor) eventLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case msg := <-p.msgCh:
-			go func(m queue.Message) {
-				defer func() {
-					if r := recover(); r != nil {
-						slog.Error("panic processing message", "panic", r)
-
-						if err := p.queue.Nack(ctx, m, false); err != nil {
-							slog.Error("Err nacking panicked message", "err", err.Error())
-						}
-					}
-				}()
-
-				p.processDelivery(ctx, m)
-			}(msg)
+			go p.processDelivery(ctx, msg)
 		}
 	}
 }
@@ -574,10 +562,25 @@ func (p *Processor) eventLoop(ctx context.Context) {
 // processDelivery runs one delivery and settles it on the queue, holding the message's in-flight
 // claim across both so a duplicate cannot start while this delivery's Ack, Nack or transient
 // republish is still going out.
+//
+// A panic settles the delivery too, and inside the same claim. Recovering outside it — in the
+// goroutine that calls this — meant the release ran while the stack unwound and the nack went out
+// afterwards, so a duplicate could take the message back while that nack was still in flight or
+// failing, which is the window the claim exists to close.
 func (p *Processor) processDelivery(ctx context.Context, m queue.Message) {
 	release, err := p.claimDelivery(m)
 
 	defer release()
+
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("panic processing message", "panic", r)
+
+			if err := p.queue.Nack(ctx, m, false); err != nil {
+				slog.Error("Err nacking panicked message", "err", err.Error())
+			}
+		}
+	}()
 
 	if err != nil {
 		p.handleProcessMessageResult(ctx, m, false, 0, err)

--- a/packages/relayer/processor/processor_test.go
+++ b/packages/relayer/processor/processor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/utils"
@@ -331,6 +332,32 @@ func TestHandleProcessMessageResultAcksUnprocessableMessages(t *testing.T) {
 
 	assert.Equal(t, 1, q.acked)
 	assert.Equal(t, 0, q.nacked)
+}
+
+func TestHandleProcessMessageResultAcksDuplicateDeliveries(t *testing.T) {
+	q := &recordingQueue{}
+	p := newTestProcessor(false)
+	p.queue = q
+
+	before := testutil.ToFloat64(relayer.MessageSentEventsDuplicateDelivery)
+
+	// The crawler republishes every message still in NEW status on each pass, so a claim waiting
+	// on a checkpoint is redelivered for as long as it waits. The delivery already being processed
+	// is the authoritative one and releases the hash on every exit path, so the copy carries
+	// nothing. Nacking it dead-lettered a message that was never a failure.
+	p.handleProcessMessageResult(
+		context.Background(),
+		queue.Message{Body: []byte(`{}`)},
+		true,
+		0,
+		errAlreadyProcessing,
+	)
+
+	assert.Equal(t, 1, q.acked)
+	assert.Equal(t, 0, q.nacked)
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(relayer.MessageSentEventsDuplicateDelivery)-before,
+		"the path has to be visible once it stops being logged as an error")
 }
 
 func TestHandleProcessMessageResultRespectsShouldRequeueOnUnknownErrors(t *testing.T) {

--- a/packages/relayer/processor/processor_test.go
+++ b/packages/relayer/processor/processor_test.go
@@ -58,9 +58,9 @@ func newTestProcessor(profitableOnly bool) *Processor {
 		cfg: &Config{
 			DestBridgeAddress: common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
 		},
-		maxMessageRetries:  5,
-		destQuotaManager:   &mock.QuotaManager{},
-		processingTxHashes: make(map[common.Hash]bool, 0),
+		maxMessageRetries:   5,
+		destQuotaManager:    &mock.QuotaManager{},
+		processingMsgHashes: make(map[common.Hash]bool, 0),
 	}
 }
 

--- a/packages/relayer/prometheus.go
+++ b/packages/relayer/prometheus.go
@@ -32,10 +32,11 @@ var (
 		Name: "private_rpc_held_nonce_ops_total",
 		Help: "The total number of sends a private RPC endpoint answered by saying it already " +
 			"holds that nonce, labelled by that endpoint's position in the configured order. " +
-			"Not counted as a failure — the endpoint is carrying the claim — but a nonce it has " +
-			"not answered for before does count towards the consecutive ceiling, so an endpoint " +
-			"answering this to everything still steps aside. Without this counter the path is " +
-			"invisible, since nothing else records it",
+			"The answer reports that the nonce is occupied, not necessarily that the endpoint " +
+			"carries the claim being offered: a recycled nonce may belong to an earlier claim. " +
+			"Not counted as a failure, but a nonce it has not answered for before does count " +
+			"towards the consecutive ceiling, so an endpoint answering this to everything still " +
+			"steps aside. Without this counter the path is invisible, since nothing else records it",
 	}, []string{"endpoint"})
 	PrivateRPCTrips = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "private_rpc_trips_ops_total",
@@ -76,7 +77,7 @@ var (
 	MessageSentEventsDuplicateDelivery = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "message_sent_events_duplicate_delivery_ops_total",
 		Help: "The total number of deliveries discarded because this replica was already " +
-			"processing that source transaction. The crawler republishes every message still in " +
+			"processing that message hash. The crawler republishes every message still in " +
 			"NEW status on each pass, so a claim waiting on a checkpoint is redelivered for as " +
 			"long as it waits. Nothing else records this once the duplicates stop being logged " +
 			"as errors, and a counter climbing on its own is a claim that is not moving",

--- a/packages/relayer/prometheus.go
+++ b/packages/relayer/prometheus.go
@@ -73,6 +73,14 @@ var (
 			"failure that may resolve on its own. A message climbing this counter on its own is " +
 			"one the relayer cannot land and keeps re-reading",
 	})
+	MessageSentEventsDuplicateDelivery = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "message_sent_events_duplicate_delivery_ops_total",
+		Help: "The total number of deliveries discarded because this replica was already " +
+			"processing that source transaction. The crawler republishes every message still in " +
+			"NEW status on each pass, so a claim waiting on a checkpoint is redelivered for as " +
+			"long as it waits. Nothing else records this once the duplicates stop being logged " +
+			"as errors, and a counter climbing on its own is a claim that is not moving",
+	})
 	QueueMessageAcknowledged = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "queue_message_acknowledged_ops_total",
 		Help: "The total number of acknowledged queue events",


### PR DESCRIPTION
Two defects that #22070 could only expose once it was carrying real claims. `DEST_PRIVATE_RPC_URLS` was enabled on the mainnet L2→L1 processor on 2026-09-01 at 01:57:05Z — a config-only change on an image that already had the code — and the first claim through it found both.

The claim itself succeeded, and cleanly: message `0xb1395af059080682051ce303d3f63804d6d73d26fd31bf6f6c3290e1c0b2a5e6` was accepted by Flashbots, mined in L1 block 25879543 as `0x7b4218cee205c5089cba4a39f26ed4a800a9d8cb4ec786203a23a023c4693bb1`, and `messageStatus` is `2`. Final counters were `sends=3/0 fail=0/1 held=1/0 trips=0/0 unavailable=0 all_refused=0 processed=1 reverted=0` — the claim never reached the public mempool, which is the guarantee the feature exists for. The `fail=0/1` is the first defect below.

## A benign tail race walks a healthy backup endpoint out of rotation

```
02:48:23  tx 0x7b4218ce… mined in L1 block 25879543
02:48:35  Private endpoint already holds this nonce  endpoint=0 nonce=7210
02:48:36  Private endpoint refused a transaction     endpoint=1 txHash=0x7b4218ce…
          error="Failed in pending block with: Reverted"
02:48:36  Mined tx  txHash=7b4218ce…
```

The transaction manager's next resubmission was already in flight when the receipt landed. It went to endpoint 0 first, correctly, because endpoint 0 holds nonce 7210, and Flashbots answered that it still holds it. The send then **continued to endpoint 1**, which simulated the transaction against the pending block, saw the now-DONE message revert, and refused. MEV Blocker did nothing wrong and was charged a failure anyway.

That charge sticks. In `recordFailure`, `consecutive[index]++` runs before the same-nonce deduplication, and the deduplication would not apply regardless because every claim carries a distinct nonce. Both counters are cleared only by `recordSuccess`, which fires only when *that* endpoint accepts something — and in steady state endpoint 0 always accepts first, so endpoint 1 never gets a reset. At `DefaultPrivateRPCFailureThreshold = 3`, **three claims take MEV Blocker out of rotation for five minutes**. It returns, and three more take it out again. At the observed L2→L1 volume of roughly seven claims a day, about twice a day.

Four consequences, in rough order of how much they matter:

1. The backup spends much of its life out of rotation, so when the primary genuinely fails there may be no private endpoint left and claims go out through `DEST_RPC_URL` — the exposure this whole feature removes.
2. `private_rpc_trips`, documented as "the transition worth alerting on", fires on non-outages.
3. The same signed transaction is left live in two builders' pools, which #22070's own description argues against: "sending it elsewhere leaves both live in different builders' pools."
4. `SendTransaction` returns endpoint 1's rejection, so the transaction manager is told the publish failed while endpoint 0 is demonstrably carrying the claim. A non-nil return does not arm `bumpFees` and does not count toward `successFullPublishCount`, which gates `TxNotInMempoolTimeout`.

### The fix

`recordHeldNonce` now reports, as a second return value, whether the answering endpoint actually took this nonce. The send ends there rather than offering the claim to the endpoints behind it. The predicate stays inside `recordHeldNonce` rather than becoming a second query function: it is the one place that owns this state, and a copy would drift.

That question is answered from what the endpoint actually accepted, not from the `highestAccepted` high-water mark. The mark is right for the two jobs it already had — exempting the accounting, and ordering the holder first — and wrong for this one. Claims are signed in nonce order but sent concurrently, so a later nonce can be accepted while an earlier one never was; the mark then covers a nonce nobody here has seen. Being generous costs nothing when the consequence is "don't charge this endpoint", and strands the claim with nobody holding it until `TX_SEND_TIMEOUT` when the consequence is "stop the send". So the exemption and the ordering keep the mark, and the terminal decision reads an exact record — bounded at 256 and evicting the stalest, mirroring the refusal counts, because a claim abandoned at `TX_SEND_TIMEOUT` never comes back to clear its entry.

That record stores `claimIdentity` alongside each nonce, and both have to match, for the same reason `refusalRun` carries a claim hash. Nonces recycle: the abandoned claim leaves its entry behind and `resetNonce` hands the nonce to an unrelated message, which would otherwise inherit the acceptance — the endpoint answering `replacement transaction underpriced` about the claim it is still holding would end the new claim's send with nobody carrying it. The identity is the calldata, stable across the fee bumps within one send and different for every other claim, so the holder path itself is unaffected.

The acceptance is read *before* the generation guard, so it survives one. A concurrent send can trip an endpoint while our held answer is still on the wire; that says the endpoint is unhealthy, not that it stopped carrying what it took. The guard exists to stop a stale result from spending the fresh budget — it suppresses the accounting and leaves the fact alone.

For a nonce the endpoint never accepted — the gossip case, where it may have learned the claim from another relay — the existing `continue` is preserved, because the endpoints behind it genuinely have not been asked.

Deliberately unchanged: `recordSuccess` is not called (it clears `consecutive` and `failures`, defeating the ceiling `recordHeldNonce` exists to enforce); `private_rpc_sends` is not incremented (no new transaction was accepted, and `private_rpc_held_nonce` already records this path); `clearAllRefused` is not touched (a held answer already sets `allAnsweredRejection = false`, so this path never contributes to a run).

One behaviour genuinely narrows: if a holder accepts a nonce and then goes silent, that claim no longer falls through to a sibling. This is the case `TX_SEND_TIMEOUT` was introduced for — "a relay can accept a transaction that never gets included, and acceptance is the only signal this layer gets" — so the send ends at the five-minute bound and the message is requeued as transient. Held answers for nonces the endpoint never accepted remain bounded by the consecutive ceiling.

## `errAlreadyProcessing` was dead-lettered

The crawler runs with `WATCH_MODE=crawl-past-blocks` and rescans ~50k blocks every ~10 seconds, republishing every message still in `NEW` status. A claim parked in `waitHeaderSynced` — 25m34s for the claim above — is therefore redelivered every ten seconds, each time with a fresh `msgId`:

```
02:37:11 rabbitmq message found msgId=829c946b…
02:37:11 already processing txHash txhash=0x01a64b21…
02:37:11 ERROR process message failed err="already processing txHash"
02:37:11 negatively acknowledged rabbitmq message msgId=829c946b… requeue=false
```

`errAlreadyProcessing` is neither `errUnprocessable` nor transient, so it fell to `default:` and was nacked with `requeue=false`.

It means one thing: this replica is already working on this message. The duplicate carries nothing and the in-flight delivery is authoritative, so it is acked. That is safe because the claim is released on every exit path by a `defer` registered the moment it is taken, and the map is rebuilt at startup — a message cannot become stuck and silently swallow every future delivery.

Acking rather than dead-lettering also makes the guard's key matter, so it moves from the source transaction hash to the message hash. One transaction can emit several `MessageSent` events — a contract bridging more than one token does exactly that — and the indexer publishes one queue message per event, so siblings arrive as separate deliveries sharing a transaction hash. Keyed on that hash the second sibling looked like a duplicate; that was survivable while such a delivery went to a dead-letter queue the broker was dropping anyway, and it stops being survivable once a duplicate is acked. The guard moves out of `processMessage` into `beginProcessing`/`endProcessing` so the key is derived in one place and a test can claim a message the same way production does.

The log drops to debug, because an expected event happening six times a minute is not a warning, and a new `message_sent_events_duplicate_delivery_ops_total` counter takes over the job of making a republish storm visible.

### The same window proved the dead-letter route is dropping messages

Eleven `Nack(requeue=false)` calls between 02:37:00 and 02:39:03 left `dlx-167000-1-MessageSent-queue` pinned at exactly 418 messages. This confirms #22070's account of the routing-key bug on live infrastructure; the 418 are historical residue. The fix shipped there is still inactive on mainnet because the pre-existing queue kept its own arguments — the startup 406 says so and names the remedy.

## Ordering constraint

**This must land before an operator applies the `dead-letter-routing-key` policy.** Today the duplicate rejections above are silently discarded. Once the policy makes dead-lettering work, they would instead accumulate in `dlx-167000-1-MessageSent-queue` at roughly six per minute for every claim parked in `waitHeaderSynced` — about 150 per 25-minute checkpoint wait.

## Out of scope

The crawler's rescan-and-republish cadence is unchanged. Duplicate deliveries still happen; they are now discarded cleanly and counted.

## Testing

Nine new tests in `sending_backend_test.go` and three across `processor_test.go` / `process_message_test.go`, all under `-race`, following each file's existing style.

- A holder answering held-nonce for a nonce it took ends the send: `SendTransaction` returns nil and the backup is never asked. The backup is deliberately healthy, because `fakeSender` records a transaction only when it takes one — a refusing backup leaves `sent` empty whether or not it was asked, which would assert nothing.
- Three claims each ending in a holder's held-nonce answer leave the backup in rotation with `failures` at zero, and the last resend returns nil.
- A held answer for a nonce the endpoint never took still continues to the next endpoint.
- A nonce below the high-water mark that this endpoint never accepted — the out-of-order case — still reaches the backup.
- An endpoint tripped while its held answer was in flight still reports the nonce it accepted, without the stale admission spending anything.
- A nonce recycled to a different claim — same number, different calldata — still reaches the backup when the endpoint answers about the claim it is still holding.
- A hold for someone else's claim under a recycled nonce no longer shields this claim from the public fallback, while a hold for a nonce the endpoint never took still does.
- The accepted-nonce record stays bounded and evicts the stalest rather than the newest.
- A duplicate delivery acks, never nacks, and moves the counter by one.
- A sibling message from the same transaction is not treated as a duplicate, while a redelivery of the same message is.

Each behavioural fix is mutation-checked, and every mutation fails only the test that pins it: reverting the termination to an unconditional `continue` fails the two claim-level tests; making every held answer end the send fails the gossip test along with five existing ones; swapping the exact record back for the high-water mark fails only the out-of-order test; moving the acceptance read back behind the generation guard fails only the tripped-holder test; matching on the nonce without the claim identity fails only the recycled-nonce test; clearing `allAnsweredRejection` unconditionally fails only the fallback test, and clearing it only for this claim fails the three that pin the gossip protection; keying the in-flight claim on the transaction hash fails only the sibling test.

`gofmt`, `go build`, `go vet` clean; `pkg/utils`, `processor`, `indexer`, `pkg/queue/rabbitmq` and the root package all pass under `-race`. `pkg/repo` is excluded — its testcontainers tests need Docker and do not build here, which predates this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
