### PR TITLE
fix(bridge-ui): batch RPC reads so the transactions page stops tripping rate limits

### DIFF
--- a/packages/bridge-ui/config/schemas/configuredChains.schema.json
+++ b/packages/bridge-ui/config/schemas/configuredChains.schema.json
@@ -25,6 +25,7 @@
                   "properties": {
                     "http": {
                       "type": "array",
+                      "minItems": 1,
                       "items": {
                         "type": "string"
                       }

--- a/packages/bridge-ui/src/components/Transactions/Transactions.svelte
+++ b/packages/bridge-ui/src/components/Transactions/Transactions.svelte
@@ -29,6 +29,7 @@
   import type { Account } from '$stores/account';
 
   import { StatusFilterDialog, StatusFilterDropdown } from './Filter';
+  import { getLoadWarning } from './loadWarning';
   import { FungibleTransactionRow, NftTransactionRow } from './Rows/';
   import { StatusInfoDialog } from './Status';
 
@@ -98,15 +99,16 @@
     inFlightAddress = address;
     loadingTxs = true;
     try {
-      const { mergedTransactions, outdatedLocalTransactions, error } = await fetchTransactions(address);
+      const { mergedTransactions, outdatedLocalTransactions, error, failedCount } = await fetchTransactions(address);
       if (generation !== fetchGeneration) return;
       transactions = mergedTransactions;
 
       if (outdatedLocalTransactions.length > 0) {
         await bridgeTxService.removeTransactions(address, outdatedLocalTransactions);
       }
-      if (error) {
-        warningToast({ title: $t('transactions.errors.relayer_offline') });
+      const warning = getLoadWarning({ error, failedCount });
+      if (warning) {
+        warningToast({ title: $t(warning.key, { values: warning.values }) });
       }
     } finally {
       if (generation === fetchGeneration) {

--- a/packages/bridge-ui/src/components/Transactions/loadWarning.test.ts
+++ b/packages/bridge-ui/src/components/Transactions/loadWarning.test.ts
@@ -18,9 +18,18 @@ describe('getLoadWarning', () => {
     });
   });
 
-  it('blames the relayer first when both are set', () => {
-    // A dead relayer explains the missing transactions; two toasts would just be noise.
+  it('reports both when a relayer failed and transactions were also lost', () => {
+    // These coincide routinely: one relayer dies while another answers and loses transactions to
+    // failed on-chain reads. Reporting only the relayer would swallow a count the user cannot
+    // learn any other way.
     expect(getLoadWarning({ error: new Error('relayer down'), failedCount: 3 })).toEqual({
+      key: 'transactions.errors.relayer_offline_and_partial_load',
+      values: { count: 3 },
+    });
+  });
+
+  it('does not use the combined message when only the relayer failed', () => {
+    expect(getLoadWarning({ error: new Error('relayer down'), failedCount: 0 })).toEqual({
       key: 'transactions.errors.relayer_offline',
     });
   });

--- a/packages/bridge-ui/src/components/Transactions/loadWarning.test.ts
+++ b/packages/bridge-ui/src/components/Transactions/loadWarning.test.ts
@@ -28,6 +28,27 @@ describe('getLoadWarning', () => {
     });
   });
 
+  it('does not blame the relayer for a history cut off at the page backstop', () => {
+    // The relayer answered every page it was asked for; the backstop is ours. Reusing
+    // "did not respond" here would be the same misattribution aimed at a different cause.
+    const truncated = new Error('Relayer history truncated at 10 pages');
+    truncated.name = 'RelayerHistoryTruncatedError';
+
+    expect(getLoadWarning({ error: truncated, failedCount: 0 })).toEqual({
+      key: 'transactions.errors.history_truncated',
+    });
+  });
+
+  it('prefers the per-message count over a truncated history when both apply', () => {
+    const truncated = new Error('Relayer history truncated at 10 pages');
+    truncated.name = 'RelayerHistoryTruncatedError';
+
+    expect(getLoadWarning({ error: truncated, failedCount: 2 })).toEqual({
+      key: 'transactions.errors.partial_load',
+      values: { count: 2 },
+    });
+  });
+
   it('does not use the combined message when only the relayer failed', () => {
     expect(getLoadWarning({ error: new Error('relayer down'), failedCount: 0 })).toEqual({
       key: 'transactions.errors.relayer_offline',

--- a/packages/bridge-ui/src/components/Transactions/loadWarning.test.ts
+++ b/packages/bridge-ui/src/components/Transactions/loadWarning.test.ts
@@ -1,0 +1,27 @@
+import { getLoadWarning } from './loadWarning';
+
+describe('getLoadWarning', () => {
+  it('is silent when everything loaded', () => {
+    expect(getLoadWarning({ failedCount: 0 })).toBeNull();
+  });
+
+  it('reports the relayer when the relayer itself failed', () => {
+    expect(getLoadWarning({ error: new Error('relayer down'), failedCount: 0 })).toEqual({
+      key: 'transactions.errors.relayer_offline',
+    });
+  });
+
+  it('reports the count when individual transactions failed to load', () => {
+    expect(getLoadWarning({ failedCount: 3 })).toEqual({
+      key: 'transactions.errors.partial_load',
+      values: { count: 3 },
+    });
+  });
+
+  it('blames the relayer first when both are set', () => {
+    // A dead relayer explains the missing transactions; two toasts would just be noise.
+    expect(getLoadWarning({ error: new Error('relayer down'), failedCount: 3 })).toEqual({
+      key: 'transactions.errors.relayer_offline',
+    });
+  });
+});

--- a/packages/bridge-ui/src/components/Transactions/loadWarning.ts
+++ b/packages/bridge-ui/src/components/Transactions/loadWarning.ts
@@ -4,11 +4,12 @@ export type LoadWarning = {
 };
 
 /**
- * @dev Decides which warning, if any, the transactions page should raise after a fetch.
- *      Extracted from Transactions.svelte so the decision is testable without mounting the
- *      component and its 30 dependencies.
- * @param result The relevant part of a fetchTransactions result
- * @return warning_ The warning to show, or null when the history loaded cleanly
+ * Decides which warning, if any, the transactions page should raise after a fetch. Returns null
+ * when the history loaded cleanly. A dead relayer takes precedence over a per-transaction count:
+ * it already explains the missing rows, so a second toast would only be noise.
+ *
+ * Lives outside Transactions.svelte so the decision is testable without mounting that component
+ * and its 30 dependencies.
  */
 export function getLoadWarning(result: { error?: Error; failedCount: number }): LoadWarning | null {
   if (result.error) return { key: 'transactions.errors.relayer_offline' };

--- a/packages/bridge-ui/src/components/Transactions/loadWarning.ts
+++ b/packages/bridge-ui/src/components/Transactions/loadWarning.ts
@@ -1,0 +1,19 @@
+export type LoadWarning = {
+  key: string;
+  values?: Record<string, number>;
+};
+
+/**
+ * @dev Decides which warning, if any, the transactions page should raise after a fetch.
+ *      Extracted from Transactions.svelte so the decision is testable without mounting the
+ *      component and its 30 dependencies.
+ * @param result The relevant part of a fetchTransactions result
+ * @return warning_ The warning to show, or null when the history loaded cleanly
+ */
+export function getLoadWarning(result: { error?: Error; failedCount: number }): LoadWarning | null {
+  if (result.error) return { key: 'transactions.errors.relayer_offline' };
+  if (result.failedCount > 0) {
+    return { key: 'transactions.errors.partial_load', values: { count: result.failedCount } };
+  }
+  return null;
+}

--- a/packages/bridge-ui/src/components/Transactions/loadWarning.ts
+++ b/packages/bridge-ui/src/components/Transactions/loadWarning.ts
@@ -5,16 +5,25 @@ export type LoadWarning = {
 
 /**
  * Decides which warning, if any, the transactions page should raise after a fetch. Returns null
- * when the history loaded cleanly. A dead relayer takes precedence over a per-transaction count:
- * it already explains the missing rows, so a second toast would only be noise.
+ * when the history loaded cleanly.
+ *
+ * The two failures are independent and routinely coincide: one relayer can die while another
+ * answers and loses transactions to failed on-chain reads. Reporting only the relayer would hide
+ * a count the user has no other way to learn, so that case gets its own combined message rather
+ * than a second toast stacked on the first.
  *
  * Lives outside Transactions.svelte so the decision is testable without mounting that component
  * and its 30 dependencies.
  */
 export function getLoadWarning(result: { error?: Error; failedCount: number }): LoadWarning | null {
-  if (result.error) return { key: 'transactions.errors.relayer_offline' };
-  if (result.failedCount > 0) {
-    return { key: 'transactions.errors.partial_load', values: { count: result.failedCount } };
+  const relayerFailed = Boolean(result.error);
+  const someFailedToLoad = result.failedCount > 0;
+  const values = { count: result.failedCount };
+
+  if (relayerFailed && someFailedToLoad) {
+    return { key: 'transactions.errors.relayer_offline_and_partial_load', values };
   }
+  if (relayerFailed) return { key: 'transactions.errors.relayer_offline' };
+  if (someFailedToLoad) return { key: 'transactions.errors.partial_load', values };
   return null;
 }

--- a/packages/bridge-ui/src/components/Transactions/loadWarning.ts
+++ b/packages/bridge-ui/src/components/Transactions/loadWarning.ts
@@ -7,6 +7,10 @@ export type LoadWarning = {
  * Decides which warning, if any, the transactions page should raise after a fetch. Returns null
  * when the history loaded cleanly.
  *
+ * A truncated history is reported on its own: the relayer is healthy, so it must not borrow the
+ * relayer's wording, and it is the weakest of the three signals - a per-message loss is the more
+ * actionable thing to say when both apply.
+ *
  * The two failures are independent and routinely coincide: one relayer can die while another
  * answers and loses transactions to failed on-chain reads. Reporting only the relayer would hide
  * a count the user has no other way to learn, so that case gets its own combined message rather
@@ -16,7 +20,11 @@ export type LoadWarning = {
  * and its 30 dependencies.
  */
 export function getLoadWarning(result: { error?: Error; failedCount: number }): LoadWarning | null {
-  const relayerFailed = Boolean(result.error);
+  // A history cut off at the page backstop is not a relayer failure - the relayer answered every
+  // page it was asked for. Saying "did not respond" there would be the same misattribution this
+  // whole change exists to remove, aimed at a different cause.
+  const historyTruncated = result.error?.name === 'RelayerHistoryTruncatedError';
+  const relayerFailed = Boolean(result.error) && !historyTruncated;
   const someFailedToLoad = result.failedCount > 0;
   const values = { count: result.failedCount };
 
@@ -25,5 +33,6 @@ export function getLoadWarning(result: { error?: Error; failedCount: number }): 
   }
   if (relayerFailed) return { key: 'transactions.errors.relayer_offline' };
   if (someFailedToLoad) return { key: 'transactions.errors.partial_load', values };
+  if (historyTruncated) return { key: 'transactions.errors.history_truncated' };
   return null;
 }

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -562,7 +562,8 @@
     },
     "errors": {
       "insufficient_balance": "Insufficient balance to claim yourself. Please wait for the relayer to claim for you automatically. Refer to our guide for more information.",
-      "relayer_offline": "Relayer did not respond. Your transactions may only be loaded partially."
+      "relayer_offline": "Relayer did not respond. Your transactions may only be loaded partially.",
+      "partial_load": "{count} transaction(s) could not be loaded. Try refreshing."
     },
     "filter": {
       "all": "All",

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -565,7 +565,8 @@
     "errors": {
       "insufficient_balance": "Insufficient balance to claim yourself. Please wait for the relayer to claim for you automatically. Refer to our guide for more information.",
       "relayer_offline": "Relayer did not respond. Your transactions may only be loaded partially.",
-      "partial_load": "{count} transaction(s) could not be loaded. Try refreshing."
+      "partial_load": "{count} transaction(s) could not be loaded. Try refreshing.",
+      "relayer_offline_and_partial_load": "Relayer did not respond and {count} transaction(s) could not be loaded. Your transactions may only be loaded partially."
     },
     "filter": {
       "all": "All",

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -566,7 +566,8 @@
       "insufficient_balance": "Insufficient balance to claim yourself. Please wait for the relayer to claim for you automatically. Refer to our guide for more information.",
       "relayer_offline": "Relayer did not respond. Your transactions may only be loaded partially.",
       "partial_load": "{count} transaction(s) could not be loaded. Try refreshing.",
-      "relayer_offline_and_partial_load": "Relayer did not respond and {count} transaction(s) could not be loaded. Your transactions may only be loaded partially."
+      "relayer_offline_and_partial_load": "Relayer did not respond and {count} transaction(s) could not be loaded. Your transactions may only be loaded partially.",
+      "history_truncated": "Your transaction history is too long to show in full. The oldest transactions are not listed."
     },
     "filter": {
       "all": "All",

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
@@ -1,4 +1,4 @@
-import type { Address } from 'viem';
+import type { Address, Hash } from 'viem';
 
 import { fetchTransactions } from './fetchTransactions';
 import { type BridgeTransaction, MessageStatus } from './types';
@@ -23,10 +23,10 @@ const getAllByAddressSecond = vi.mocked(relayerApiServices[1].getAllBridgeTransa
 
 const tx = (srcTxHash: string, msgStatus?: MessageStatus) => ({ srcTxHash, msgStatus }) as unknown as BridgeTransaction;
 
-const page = (txs: BridgeTransaction[], max_page: number, failedCount = 0) => ({
+const page = (txs: BridgeTransaction[], max_page: number, failedTxHashes: Hash[] = []) => ({
   txs,
   paginationInfo: { page: 0, size: 500, total: txs.length, total_pages: 1, first: true, last: true, max_page },
-  failedCount,
+  failedTxHashes,
 });
 
 describe('fetchTransactions', () => {
@@ -122,7 +122,9 @@ describe('fetchTransactions', () => {
 
   it('sums transactions that failed to load across every relayer page', async () => {
     // Given: page 0 lost 2 transactions to failed RPC reads, page 1 lost 3
-    getAllByAddress.mockResolvedValueOnce(page([tx('0xa')], 1, 2)).mockResolvedValueOnce(page([tx('0xb')], 1, 3));
+    getAllByAddress
+      .mockResolvedValueOnce(page([tx('0xa')], 1, ['0xf1', '0xf2']))
+      .mockResolvedValueOnce(page([tx('0xb')], 1, ['0xf3', '0xf4', '0xf5']));
 
     // When
     const { failedCount, mergedTransactions } = await fetchTransactions(ADDRESS);
@@ -130,6 +132,36 @@ describe('fetchTransactions', () => {
     // Then
     expect(failedCount).toBe(5);
     expect(mergedTransactions).toHaveLength(2);
+  });
+
+  it('counts a transaction that failed on more than one page only once', async () => {
+    // Given: the relayer returns the same transaction on both pages and it fails both times.
+    // Summing raw per-page tallies would report one lost transaction as two.
+    getAllByAddress
+      .mockResolvedValueOnce(page([tx('0xa')], 1, ['0xf1']))
+      .mockResolvedValueOnce(page([tx('0xb')], 1, ['0xf1']));
+
+    // When
+    const { failedCount } = await fetchTransactions(ADDRESS);
+
+    // Then
+    expect(failedCount).toBe(1);
+  });
+
+  it('does not count a transaction that failed once but loaded from elsewhere', async () => {
+    // Given: page 0 could not enhance 0xdupe, page 1 returned it successfully. It is in the
+    // list, so reporting it as unloadable would be telling the user about a loss they can see
+    // did not happen.
+    getAllByAddress
+      .mockResolvedValueOnce(page([tx('0xa')], 1, ['0xdupe']))
+      .mockResolvedValueOnce(page([tx('0xdupe')], 1));
+
+    // When
+    const { failedCount, mergedTransactions } = await fetchTransactions(ADDRESS);
+
+    // Then
+    expect(mergedTransactions.map((transaction) => transaction.srcTxHash).sort()).toEqual(['0xa', '0xdupe']);
+    expect(failedCount).toBe(0);
   });
 
   it('reports no failures when every page loaded cleanly', async () => {
@@ -157,7 +189,7 @@ describe('fetchTransactions', () => {
     // fetchAllRelayerPages returns early here, so the count it already accumulated has to travel
     // out with the error rather than being discarded with the rest of the history.
     getAllByAddress
-      .mockResolvedValueOnce(page([tx('0xa')], 1, 2))
+      .mockResolvedValueOnce(page([tx('0xa')], 1, ['0xf1', '0xf2']))
       .mockRejectedValueOnce(new Error('page 1 unavailable'));
 
     // When
@@ -167,6 +199,23 @@ describe('fetchTransactions', () => {
     expect(error).toBeInstanceOf(Error);
     expect(failedCount).toBe(2);
     expect(mergedTransactions).toHaveLength(1);
+  });
+
+  it('keeps the count when a completed page produced no surviving rows', async () => {
+    // Given: page 0 answers, but every row on it fails to enhance, so it contributes 0
+    // transactions and a count of 2. Page 1 then throws. Keying the "nothing was fetched"
+    // check on txs.length would rethrow here and discard those 2 - the page did answer.
+    getAllByAddress
+      .mockResolvedValueOnce(page([], 1, ['0xf1', '0xf2']))
+      .mockRejectedValueOnce(new Error('page 1 unavailable'));
+
+    // When
+    const { error, failedCount, mergedTransactions } = await fetchTransactions(ADDRESS);
+
+    // Then
+    expect(error).toBeInstanceOf(Error);
+    expect(failedCount).toBe(2);
+    expect(mergedTransactions).toHaveLength(0);
   });
 
   describe('when one relayer fails', () => {
@@ -206,7 +255,7 @@ describe('fetchTransactions', () => {
       // A rejected relayer has no count to give; the ones that answered still do, and losing
       // their count because a sibling died would under-report what the user cannot see
       getAllByAddress.mockRejectedValue(new Error('relayer down'));
-      getAllByAddressSecond.mockResolvedValueOnce(page([tx('0xa')], 0, 4));
+      getAllByAddressSecond.mockResolvedValueOnce(page([tx('0xa')], 0, ['0xf1', '0xf2', '0xf3', '0xf4']));
 
       const { error, failedCount } = await fetchTransactions(ADDRESS);
 

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
@@ -28,6 +28,7 @@ const tx = (srcTxHash: string, msgStatus?: MessageStatus) => ({ srcTxHash, msgSt
 const page = (txs: BridgeTransaction[], max_page: number) => ({
   txs,
   paginationInfo: { page: 0, size: 500, total: txs.length, total_pages: 1, first: true, last: true, max_page },
+  failedCount: 0,
 });
 
 describe('fetchTransactions', () => {

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
@@ -196,6 +196,22 @@ describe('fetchTransactions', () => {
     expect(failedCount).toBe(0);
   });
 
+  it('lets a local row stand in for one message of its transaction, not every one', async () => {
+    // Given: a batching wallet sent one transaction that emitted two messages, and both failed to
+    // enhance. The local row carries no message hash, so it cannot say which of the two it is -
+    // it stands for one of them. Letting it absorb both would report a complete history while a
+    // claimable message is missing from the list.
+    getLocalTxs.mockResolvedValue([tx('0xtx')]);
+    getAllByAddress.mockResolvedValueOnce(page([], 0, [failedRow('0xtx', '0xmsgA'), failedRow('0xtx', '0xmsgB')]));
+
+    // When
+    const { failedCount, mergedTransactions } = await fetchTransactions(ADDRESS);
+
+    // Then: one row on screen, one message still unaccounted for
+    expect(mergedTransactions).toHaveLength(1);
+    expect(failedCount).toBe(1);
+  });
+
   it('still counts a failed message when a sibling message of the same transaction loaded', async () => {
     // Given: one transaction emitted two messages. 0xmsgB loaded, 0xmsgA did not. They share a
     // transaction hash but are claimed separately, so the one that loaded cannot stand in for

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
@@ -11,15 +11,18 @@ vi.mock('$libs/relayer', () => ({
 vi.mock('$libs/storage', () => ({
   bridgeTxService: {
     getAllTxByAddress: vi.fn().mockResolvedValue([]),
+    removeTransactions: vi.fn(),
   },
 }));
 
 import { relayerApiServices } from '$libs/relayer';
+import { bridgeTxService } from '$libs/storage';
 
 const ADDRESS = '0x1111111111111111111111111111111111111111' as Address;
 
 const getAllByAddress = vi.mocked(relayerApiServices[0].getAllBridgeTransactionByAddress);
 const getAllByAddressSecond = vi.mocked(relayerApiServices[1].getAllBridgeTransactionByAddress);
+const getLocalTxs = vi.mocked(bridgeTxService.getAllTxByAddress);
 
 const tx = (srcTxHash: string, msgStatus?: MessageStatus) => ({ srcTxHash, msgStatus }) as unknown as BridgeTransaction;
 
@@ -34,6 +37,7 @@ describe('fetchTransactions', () => {
     getAllByAddress.mockReset();
     // The second relayer stays quiet unless a test says otherwise
     getAllByAddressSecond.mockReset().mockResolvedValue(page([], 0));
+    getLocalTxs.mockReset().mockResolvedValue([]);
   });
 
   it('does not keep reporting an error after the relayer has recovered', async () => {
@@ -162,6 +166,32 @@ describe('fetchTransactions', () => {
     // Then
     expect(mergedTransactions.map((transaction) => transaction.srcTxHash).sort()).toEqual(['0xa', '0xdupe']);
     expect(failedCount).toBe(0);
+  });
+
+  it('does not count a transaction the local history still shows', async () => {
+    // Given: the relayer could not enhance 0xlocal, but the user bridged it from this browser so
+    // it is in local storage. The merge keeps a local transaction exactly when the relayer set
+    // lacks its hash, so the row is on screen - reporting it as unloadable would contradict what
+    // the user can see.
+    getLocalTxs.mockResolvedValue([tx('0xlocal')]);
+    getAllByAddress.mockResolvedValueOnce(page([tx('0xa')], 0, ['0xlocal']));
+
+    // When
+    const { failedCount, mergedTransactions } = await fetchTransactions(ADDRESS);
+
+    // Then
+    expect(mergedTransactions.map((transaction) => transaction.srcTxHash).sort()).toEqual(['0xa', '0xlocal']);
+    expect(failedCount).toBe(0);
+  });
+
+  it('still counts a failed transaction the local history does not have', async () => {
+    // The companion case: nothing else brings 0xgone back, so it really is missing
+    getLocalTxs.mockResolvedValue([tx('0xunrelated')]);
+    getAllByAddress.mockResolvedValueOnce(page([tx('0xa')], 0, ['0xgone']));
+
+    const { failedCount } = await fetchTransactions(ADDRESS);
+
+    expect(failedCount).toBe(1);
   });
 
   it('reports no failures when every page loaded cleanly', async () => {

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.test.ts
@@ -25,10 +25,10 @@ const getAllByAddress = vi.mocked(relayerApiServices[0].getAllBridgeTransactionB
 
 const tx = (srcTxHash: string, msgStatus?: MessageStatus) => ({ srcTxHash, msgStatus }) as unknown as BridgeTransaction;
 
-const page = (txs: BridgeTransaction[], max_page: number) => ({
+const page = (txs: BridgeTransaction[], max_page: number, failedCount = 0) => ({
   txs,
   paginationInfo: { page: 0, size: 500, total: txs.length, total_pages: 1, first: true, last: true, max_page },
-  failedCount: 0,
+  failedCount,
 });
 
 describe('fetchTransactions', () => {
@@ -116,5 +116,37 @@ describe('fetchTransactions', () => {
       '0xrecalled',
       '0xdone',
     ]);
+  });
+
+  it('sums transactions that failed to load across every relayer page', async () => {
+    // Given: page 0 lost 2 transactions to failed RPC reads, page 1 lost 3
+    getAllByAddress.mockResolvedValueOnce(page([tx('0xa')], 1, 2)).mockResolvedValueOnce(page([tx('0xb')], 1, 3));
+
+    // When
+    const { failedCount, mergedTransactions } = await fetchTransactions(ADDRESS);
+
+    // Then
+    expect(failedCount).toBe(5);
+    expect(mergedTransactions).toHaveLength(2);
+  });
+
+  it('reports no failures when every page loaded cleanly', async () => {
+    getAllByAddress.mockResolvedValueOnce(page([tx('0xa')], 0));
+
+    const { failedCount } = await fetchTransactions(ADDRESS);
+
+    expect(failedCount).toBe(0);
+  });
+
+  it('reports no failure count when the relayer itself failed', async () => {
+    // Given: the first page throws, so nothing was ever enhanced
+    getAllByAddress.mockRejectedValueOnce(new Error('relayer down'));
+
+    // When
+    const { error, failedCount } = await fetchTransactions(ADDRESS);
+
+    // Then: the relayer error is the story, not a per-transaction count
+    expect(error).toBeInstanceOf(Error);
+    expect(failedCount).toBe(0);
   });
 });

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
@@ -11,6 +11,18 @@ import { type BridgeTransaction, MessageStatus } from './types';
 
 const log = getLogger('bridge:fetchTransactions');
 
+/**
+ * The page backstop was reached, so the history shown is real but incomplete. Distinct from a
+ * relayer that failed, because the two need different words: this one is not the relayer's fault
+ * and "did not respond" would be the same misattribution this file exists to remove.
+ */
+export class RelayerHistoryTruncatedError extends Error {
+  constructor(pages: number) {
+    super(`Relayer history truncated at ${pages} pages; older transactions are not shown`);
+    this.name = 'RelayerHistoryTruncatedError';
+  }
+}
+
 const RELAYER_PAGE_SIZE = 500;
 // Backstop against unbounded relayer histories; each page is one API call
 const MAX_RELAYER_PAGES = 10;
@@ -61,7 +73,7 @@ async function fetchAllRelayerPages(
       return {
         txs,
         failedTxs,
-        error: new Error(`Relayer history truncated at ${MAX_RELAYER_PAGES} pages; older transactions are not shown`),
+        error: new RelayerHistoryTruncatedError(MAX_RELAYER_PAGES),
       };
     }
   }
@@ -141,12 +153,18 @@ export async function fetchTransactions(userAddress: Address, chainId?: number) 
   //
   // Compared with isSameBridgeTx rather than by transaction hash, because the two sides are not
   // identified the same way: a failed relayer row knows its message hash while the local row that
-  // rescues it usually does not, and two messages from one transaction share a transaction hash
-  // without being interchangeable. Reusing the shared predicate keeps this from drifting from the
-  // rule the list itself is deduplicated by.
-  const failedCount = [...failedByKey.values()].filter(
-    (failed) => !mergedTransactions.some((tx) => isSameBridgeTx(failed, tx)),
-  ).length;
+  // rescues it usually does not.
+  //
+  // Each row rescues at most one failure. That only matters for the transaction-hash fallback,
+  // which is ambiguous: a local row carries no message hash, so it cannot tell which of several
+  // messages from its transaction it stands for - and it stands for one of them, not all. Exact
+  // message matches are one-to-one anyway, so consuming them changes nothing there.
+  const unrescued = [...failedByKey.values()];
+  for (const tx of mergedTransactions) {
+    const rescued = unrescued.findIndex((failed) => isSameBridgeTx(failed, tx));
+    if (rescued !== -1) unrescued.splice(rescued, 1);
+  }
+  const failedCount = unrescued.length;
 
   if (outdatedLocalTransactions.length > 0) {
     log(

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
@@ -113,17 +113,22 @@ export async function fetchTransactions(userAddress: Address, chainId?: number) 
     return true;
   });
 
-  // A transaction that failed on one page or relayer and loaded on another is not lost, so it
-  // must not be reported as such. seenTxHashes is exactly the set that made it into the list.
-  for (const hash of seenTxHashes) failedTxHashes.delete(hash);
-  const failedCount = failedTxHashes.size;
-
   // Reverse the flattened array to sort transactions in descending order, placing the most recent transactions first
   const relayerTxs: BridgeTransaction[] = dedupedRelayerTxs.reverse();
 
   log(`fetched ${relayerTxs?.length ?? 0} transactions from all relayers`, relayerTxs);
 
   const { mergedTransactions, outdatedLocalTransactions } = mergeAndCaptureOutdatedTransactions(localTxs, relayerTxs);
+
+  // The count answers "how many of your transactions are missing from this list", so it is taken
+  // against the finished list rather than the relayer half of it. A transaction can reach the list
+  // by a route other than the one that failed: another page or relayer returned it, or - because
+  // the merge keeps a local transaction precisely when the relayer set lacks its hash - the row
+  // came from local storage. Counting those would tell the user something is missing while it is
+  // on screen in front of them.
+  for (const tx of mergedTransactions) failedTxHashes.delete(tx.srcTxHash);
+  const failedCount = failedTxHashes.size;
+
   if (outdatedLocalTransactions.length > 0) {
     log(
       `found ${outdatedLocalTransactions.length} outdated transaction(s)`,

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
@@ -1,4 +1,4 @@
-import type { Address } from 'viem';
+import type { Address, Hash } from 'viem';
 
 import { relayerApiServices } from '$libs/relayer';
 import { bridgeTxService } from '$libs/storage';
@@ -17,19 +17,19 @@ async function fetchAllRelayerPages(
   relayerApiService: (typeof relayerApiServices)[number],
   userAddress: Address,
   chainId?: number,
-): Promise<{ txs: BridgeTransaction[]; failedCount: number; error?: Error }> {
+): Promise<{ txs: BridgeTransaction[]; failedTxHashes: Hash[]; error?: Error }> {
   const txs: BridgeTransaction[] = [];
-  let failedCount = 0;
+  const failedTxHashes: Hash[] = [];
 
   for (let page = 0; page < MAX_RELAYER_PAGES; page++) {
     let pageTxs;
     let paginationInfo;
-    let pageFailedCount;
+    let pageFailedTxHashes;
     try {
       ({
         txs: pageTxs,
         paginationInfo,
-        failedCount: pageFailedCount,
+        failedTxHashes: pageFailedTxHashes,
       } = await relayerApiService.getAllBridgeTransactionByAddress(
         userAddress,
         { page, size: RELAYER_PAGE_SIZE },
@@ -37,23 +37,26 @@ async function fetchAllRelayerPages(
       ));
     } catch (error) {
       // Keep the pages already fetched: losing a later page should degrade the history,
-      // not blank it. With nothing fetched yet the caller still needs to hear about it.
-      if (txs.length === 0) throw error;
+      // not blank it. Only a first-page failure means nothing was fetched at all, and the
+      // caller needs to hear about that as a rejection. Keyed on the page index, not on
+      // `txs.length`: a completed page whose rows all failed to enhance leaves `txs` empty
+      // while still carrying failed hashes, and rethrowing there would discard them.
+      if (page === 0) throw error;
       log(`relayer page ${page} failed, returning ${txs.length} transactions already fetched`, error);
       // Degrading is fine; degrading in silence is not. A partial history that looks
       // complete is the one outcome the user cannot tell apart from a correct one.
-      // failedCount carries what the completed pages already lost to failed on-chain reads.
-      return { txs, failedCount, error: error as Error };
+      // failedTxHashes carries what the completed pages already lost to failed on-chain reads.
+      return { txs, failedTxHashes, error: error as Error };
     }
     txs.push(...pageTxs);
-    failedCount += pageFailedCount;
+    failedTxHashes.push(...pageFailedTxHashes);
 
     if (paginationInfo.max_page === undefined || page >= paginationInfo.max_page) break;
     if (page === MAX_RELAYER_PAGES - 1) {
       log(`relayer history truncated at ${MAX_RELAYER_PAGES} pages for ${userAddress}`);
     }
   }
-  return { txs, failedCount };
+  return { txs, failedTxHashes };
 }
 
 export async function fetchTransactions(userAddress: Address, chainId?: number) {
@@ -77,13 +80,15 @@ export async function fetchTransactions(userAddress: Address, chainId?: number) 
   // offline showed the user an empty transaction list
   const relayerResults = await Promise.allSettled(relayerTxPromises);
   const relayerTxsArrays: BridgeTransaction[][] = [];
-  // Only a relayer that answered can report how many of its transactions failed to load; a
-  // relayer that rejected outright has no count to give, and `error` speaks for it instead
-  let failedCount = 0;
+  // Only a relayer that answered can name the transactions it failed to load; a relayer that
+  // rejected outright has nothing to report, and `error` speaks for it instead. Collected as a
+  // set rather than summed: the same transaction can come back from several pages or several
+  // relayers, and adding raw tallies would report one loss more than once
+  const failedTxHashes = new Set<string>();
   for (const result of relayerResults) {
     if (result.status === 'fulfilled') {
       relayerTxsArrays.push(result.value.txs);
-      failedCount += result.value.failedCount;
+      for (const hash of result.value.failedTxHashes) failedTxHashes.add(hash);
       // A relayer that answered some pages and then failed still reports that failure,
       // so a partial history is not presented as a complete one
       if (result.value.error) {
@@ -107,6 +112,11 @@ export async function fetchTransactions(userAddress: Address, chainId?: number) 
     seenTxHashes.add(tx.srcTxHash);
     return true;
   });
+
+  // A transaction that failed on one page or relayer and loaded on another is not lost, so it
+  // must not be reported as such. seenTxHashes is exactly the set that made it into the list.
+  for (const hash of seenTxHashes) failedTxHashes.delete(hash);
+  const failedCount = failedTxHashes.size;
 
   // Reverse the flattened array to sort transactions in descending order, placing the most recent transactions first
   const relayerTxs: BridgeTransaction[] = dedupedRelayerTxs.reverse();

--- a/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
+++ b/packages/bridge-ui/src/libs/bridge/fetchTransactions.ts
@@ -17,14 +17,20 @@ async function fetchAllRelayerPages(
   relayerApiService: (typeof relayerApiServices)[number],
   userAddress: Address,
   chainId?: number,
-): Promise<BridgeTransaction[]> {
+): Promise<{ txs: BridgeTransaction[]; failedCount: number }> {
   const txs: BridgeTransaction[] = [];
+  let failedCount = 0;
 
   for (let page = 0; page < MAX_RELAYER_PAGES; page++) {
     let pageTxs;
     let paginationInfo;
+    let pageFailedCount;
     try {
-      ({ txs: pageTxs, paginationInfo } = await relayerApiService.getAllBridgeTransactionByAddress(
+      ({
+        txs: pageTxs,
+        paginationInfo,
+        failedCount: pageFailedCount,
+      } = await relayerApiService.getAllBridgeTransactionByAddress(
         userAddress,
         { page, size: RELAYER_PAGE_SIZE },
         chainId,
@@ -37,13 +43,14 @@ async function fetchAllRelayerPages(
       break;
     }
     txs.push(...pageTxs);
+    failedCount += pageFailedCount;
 
     if (paginationInfo.max_page === undefined || page >= paginationInfo.max_page) break;
     if (page === MAX_RELAYER_PAGES - 1) {
       log(`relayer history truncated at ${MAX_RELAYER_PAGES} pages for ${userAddress}`);
     }
   }
-  return txs;
+  return { txs, failedCount };
 }
 
 export async function fetchTransactions(userAddress: Address, chainId?: number) {
@@ -55,25 +62,29 @@ export async function fetchTransactions(userAddress: Address, chainId?: number) 
   const localTxs: BridgeTransaction[] = await bridgeTxService.getAllTxByAddress(userAddress);
 
   // Get all transactions from all relayers
-  const relayerTxPromises: Promise<BridgeTransaction[]>[] = relayerApiServices.map(async (relayerApiService) => {
-    const txs = await fetchAllRelayerPages(relayerApiService, userAddress, chainId);
-    log(`fetched ${txs?.length ?? 0} transactions from relayer`, txs);
-    return txs;
-  });
+  const relayerTxPromises: Promise<{ txs: BridgeTransaction[]; failedCount: number }>[] = relayerApiServices.map(
+    async (relayerApiService) => {
+      const result = await fetchAllRelayerPages(relayerApiService, userAddress, chainId);
+      log(`fetched ${result.txs.length} transactions from relayer`, result.txs);
+      return result;
+    },
+  );
 
-  let relayerTxsArrays: BridgeTransaction[][];
+  let relayerResults: { txs: BridgeTransaction[]; failedCount: number }[];
   // Wait for all promises to resolve
   try {
-    relayerTxsArrays = await Promise.all(relayerTxPromises);
+    relayerResults = await Promise.all(relayerTxPromises);
   } catch (e) {
     log('error fetching transactions from relayers', e);
     error = e as Error;
-    relayerTxsArrays = [];
+    relayerResults = [];
   }
+
+  const failedCount = relayerResults.reduce((total, result) => total + result.failedCount, 0);
 
   // Flatten the arrays into a single array, dropping duplicate hashes the relayer
   // may return across pages or relayers
-  const relayerTxsFlattened = relayerTxsArrays.reduce((acc, txs) => acc.concat(txs), []);
+  const relayerTxsFlattened = relayerResults.reduce((acc, result) => acc.concat(result.txs), [] as BridgeTransaction[]);
   const seenTxHashes = new Set<string>();
   const dedupedRelayerTxs = relayerTxsFlattened.filter((tx) => {
     if (seenTxHashes.has(tx.srcTxHash)) return false;
@@ -108,5 +119,5 @@ export async function fetchTransactions(userAddress: Address, chainId?: number) 
     const bStatusIndex = b.msgStatus !== undefined ? statusOrder.indexOf(b.msgStatus) : -1;
     return aStatusIndex - bStatusIndex;
   });
-  return { mergedTransactions, outdatedLocalTransactions, error };
+  return { mergedTransactions, outdatedLocalTransactions, error, failedCount };
 }

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
@@ -808,6 +808,103 @@ describe('RelayerAPIService', () => {
     expect(Number(33_011_093_383_701_312n).toString()).toEqual('33011093383701310');
     expect(parseApiBigInt('33011093383701312')).toEqual(33_011_093_383_701_312n);
   });
+
+  test('getAllBridgeTransactionByAddress counts a transaction whose RPC read threw', async () => {
+    // Given
+    const relayerAPIService = new RelayerAPIService('http://example.com');
+    const paginationParams = { page: 1, size: 10 };
+    const relayerItem = createRelayerItem({
+      id: 1553890,
+      messageId: '6280',
+      msgHash: GOOD_MSG_HASH,
+      blockNumber: '0x7baa30',
+    });
+
+    mockedAxios.get.mockResolvedValue(createApiResponse([relayerItem]));
+    mockedGetTransactionReceipt.mockResolvedValue(createReceiptWithMessageSentLog());
+    // The rate-limited gateway returns an HTML 429 body, which viem surfaces as a thrown error.
+    mockedReadContract.mockRejectedValue(new Error('HTTP request failed.'));
+
+    // When
+    const result = await relayerAPIService.getAllBridgeTransactionByAddress(USER_ADDRESS, paginationParams, 167000);
+
+    // Then: the transaction is dropped, but the caller is told how many were lost
+    expect(result.txs).toHaveLength(0);
+    expect(result.failedCount).toBe(1);
+  });
+
+  test('getAllBridgeTransactionByAddress does not count legitimately filtered rows as failures', async () => {
+    // Given: a row for a route this UI is not configured for. _enhanceTransaction returns undefined
+    // for it via `if (msgStatus === undefined) return;` - a filter, not a load failure.
+    const relayerAPIService = new RelayerAPIService('http://example.com');
+    const paginationParams = { page: 1, size: 10 };
+    const unconfiguredRelayerItem = createRelayerItem({
+      id: 1553891,
+      messageId: '6281',
+      msgHash: BAD_MSG_HASH,
+      blockNumber: '0x7baa31',
+      destChainId: '424242',
+    });
+    const validRelayerItem = createRelayerItem({
+      id: 1553892,
+      messageId: '6282',
+      msgHash: GOOD_MSG_HASH,
+      blockNumber: '0x7baa32',
+      srcTxHash: SECOND_SRC_TX_HASH,
+    });
+
+    mockedAxios.get.mockResolvedValue(createApiResponse([unconfiguredRelayerItem, validRelayerItem]));
+    mockedGetTransactionReceipt.mockResolvedValue(createReceiptWithMessageSentLog());
+    mockedReadContract.mockResolvedValue(MessageStatus.NEW);
+
+    // When
+    const result = await relayerAPIService.getAllBridgeTransactionByAddress(USER_ADDRESS, paginationParams, 167000);
+
+    // Then: one row filtered out, zero reported as failed - warning the user here would be a lie
+    expect(result.txs).toHaveLength(1);
+    expect(result.failedCount).toBe(0);
+  });
+
+  test("getAllBridgeTransactionByAddress does not count another wallet's row as a failure", async () => {
+    // Given: a row owned by USER_ADDRESS, queried on behalf of a different wallet. _enhanceTransaction
+    // drops it via `if (!senderMatch && !receiverMatch) return;` - a filter, not a load failure.
+    // (createRelayerItem hardcodes every owner field to USER_ADDRESS, so vary the query address instead.)
+    const relayerAPIService = new RelayerAPIService('http://example.com');
+    const OTHER_WALLET = '0x1111111111111111111111111111111111111111' as Address;
+    const relayerItem = createRelayerItem({
+      id: 1553893,
+      messageId: '6283',
+      msgHash: GOOD_MSG_HASH,
+      blockNumber: '0x7baa33',
+    });
+
+    mockedAxios.get.mockResolvedValue(createApiResponse([relayerItem]));
+    mockedGetTransactionReceipt.mockResolvedValue(createReceiptWithMessageSentLog());
+    mockedReadContract.mockResolvedValue(MessageStatus.NEW);
+
+    // When
+    const result = await relayerAPIService.getAllBridgeTransactionByAddress(
+      OTHER_WALLET,
+      { page: 1, size: 10 },
+      167000,
+    );
+
+    // Then
+    expect(result.txs).toHaveLength(0);
+    expect(result.failedCount).toBe(0);
+  });
+
+  test('getAllBridgeTransactionByAddress reports zero failures for an empty relayer page', async () => {
+    // Given
+    const relayerAPIService = new RelayerAPIService('http://example.com');
+    mockedAxios.get.mockResolvedValue({ data: { page: 1, size: 10, total: 0, items: [] }, status: 200 });
+
+    // When
+    const result = await relayerAPIService.getAllBridgeTransactionByAddress(USER_ADDRESS, { page: 1, size: 10 });
+
+    // Then
+    expect(result.failedCount).toBe(0);
+  });
 });
 
 function createRelayerItem({

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
@@ -734,6 +734,8 @@ describe('RelayerAPIService', () => {
     // Then
     expect(result.txs).toHaveLength(0);
     expect(mockedReadContract).not.toHaveBeenCalled();
+    // An ambiguous receipt is a deliberate filter, not a failed load - it must not be counted.
+    expect(result.failedCount).toBe(0);
   });
 
   test('getTransactionsFromAPI preserves raw message fee digits before JSON parsing', async () => {

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
@@ -735,7 +735,7 @@ describe('RelayerAPIService', () => {
     expect(result.txs).toHaveLength(0);
     expect(mockedReadContract).not.toHaveBeenCalled();
     // An ambiguous receipt is a deliberate filter, not a failed load - it must not be counted.
-    expect(result.failedCount).toBe(0);
+    expect(result.failedTxHashes).toEqual([]);
   });
 
   test('getTransactionsFromAPI preserves raw message fee digits before JSON parsing', async () => {
@@ -832,7 +832,7 @@ describe('RelayerAPIService', () => {
 
     // Then: the transaction is dropped, but the caller is told how many were lost
     expect(result.txs).toHaveLength(0);
-    expect(result.failedCount).toBe(1);
+    expect(result.failedTxHashes).toHaveLength(1);
   });
 
   test('getAllBridgeTransactionByAddress does not count legitimately filtered rows as failures', async () => {
@@ -864,7 +864,7 @@ describe('RelayerAPIService', () => {
 
     // Then: one row filtered out, zero reported as failed - warning the user here would be a lie
     expect(result.txs).toHaveLength(1);
-    expect(result.failedCount).toBe(0);
+    expect(result.failedTxHashes).toEqual([]);
   });
 
   test("getAllBridgeTransactionByAddress does not count another wallet's row as a failure", async () => {
@@ -893,7 +893,7 @@ describe('RelayerAPIService', () => {
 
     // Then
     expect(result.txs).toHaveLength(0);
-    expect(result.failedCount).toBe(0);
+    expect(result.failedTxHashes).toEqual([]);
   });
 
   test('getAllBridgeTransactionByAddress reports zero failures for an empty relayer page', async () => {
@@ -905,7 +905,7 @@ describe('RelayerAPIService', () => {
     const result = await relayerAPIService.getAllBridgeTransactionByAddress(USER_ADDRESS, { page: 1, size: 10 });
 
     // Then
-    expect(result.failedCount).toBe(0);
+    expect(result.failedTxHashes).toEqual([]);
   });
 
   test('getAllBridgeTransactionByAddress counts a transaction whose receipt read failed', async () => {
@@ -932,7 +932,7 @@ describe('RelayerAPIService', () => {
 
     // Then
     expect(result.txs).toHaveLength(0);
-    expect(result.failedCount).toBe(1);
+    expect(result.failedTxHashes).toHaveLength(1);
   });
 
   test('getAllBridgeTransactionByAddress keeps a transaction that is simply not mined yet', async () => {
@@ -963,7 +963,7 @@ describe('RelayerAPIService', () => {
     // Then
     expect(result.txs).toHaveLength(1);
     expect(result.txs[0].receipt).toBeNull();
-    expect(result.failedCount).toBe(0);
+    expect(result.failedTxHashes).toEqual([]);
   });
 });
 

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
@@ -907,6 +907,64 @@ describe('RelayerAPIService', () => {
     // Then
     expect(result.failedCount).toBe(0);
   });
+
+  test('getAllBridgeTransactionByAddress counts a transaction whose receipt read failed', async () => {
+    // Given: the receipt read fails the way a rate-limited gateway makes it fail. This used to be
+    // swallowed into `receipt = null`, which left the row visible but unclaimable and uncounted.
+    const relayerAPIService = new RelayerAPIService('http://example.com');
+    const relayerItem = createRelayerItem({
+      id: 1553894,
+      messageId: '6284',
+      msgHash: GOOD_MSG_HASH,
+      blockNumber: '0x7baa34',
+    });
+
+    mockedAxios.get.mockResolvedValue(createApiResponse([relayerItem]));
+    mockedGetTransactionReceipt.mockRejectedValue(new Error('HTTP request failed.'));
+    mockedReadContract.mockResolvedValue(MessageStatus.NEW);
+
+    // When
+    const result = await relayerAPIService.getAllBridgeTransactionByAddress(
+      USER_ADDRESS,
+      { page: 1, size: 10 },
+      167000,
+    );
+
+    // Then
+    expect(result.txs).toHaveLength(0);
+    expect(result.failedCount).toBe(1);
+  });
+
+  test('getAllBridgeTransactionByAddress keeps a transaction that is simply not mined yet', async () => {
+    // Given: viem throws TransactionReceiptNotFoundError for a transaction with no receipt yet.
+    // That is an expected state for a fresh bridge, not a load failure - the row must survive and
+    // must not be counted, or every pending bridge would warn the user it had failed to load.
+    const relayerAPIService = new RelayerAPIService('http://example.com');
+    const notMined = new Error('Transaction receipt with hash "0x..." could not be found.');
+    notMined.name = 'TransactionReceiptNotFoundError';
+    const relayerItem = createRelayerItem({
+      id: 1553895,
+      messageId: '6285',
+      msgHash: GOOD_MSG_HASH,
+      blockNumber: '0x7baa35',
+    });
+
+    mockedAxios.get.mockResolvedValue(createApiResponse([relayerItem]));
+    mockedGetTransactionReceipt.mockRejectedValue(notMined);
+    mockedReadContract.mockResolvedValue(MessageStatus.NEW);
+
+    // When
+    const result = await relayerAPIService.getAllBridgeTransactionByAddress(
+      USER_ADDRESS,
+      { page: 1, size: 10 },
+      167000,
+    );
+
+    // Then
+    expect(result.txs).toHaveLength(1);
+    expect(result.txs[0].receipt).toBeNull();
+    expect(result.failedCount).toBe(0);
+  });
 });
 
 function createRelayerItem({

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
@@ -471,7 +471,7 @@ export class RelayerAPIService {
     };
 
     if (!apiTxs.items || apiTxs.items.length === 0) {
-      return { txs: [], paginationInfo, failedCount: 0 };
+      return { txs: [], paginationInfo, failedTxHashes: [] };
     }
 
     const items = RelayerAPIService._filterDuplicateAndWrongBridge(apiTxs.items);
@@ -491,7 +491,9 @@ export class RelayerAPIService {
     // four legitimate filters (not this user's transaction, ambiguous receipt, no msgHash, no
     // configured route); those rows are deliberately not shown, so counting them would report a
     // loss that never happened.
-    let failedCount = 0;
+    // Hashes, not a tally: the caller merges these across pages and relayers, where the same
+    // transaction can appear more than once and can even succeed elsewhere.
+    const failedTxHashes: Hash[] = [];
 
     const txsPromises = txs.map(async (bridgeTx) => {
       if (!bridgeTx) return;
@@ -499,7 +501,7 @@ export class RelayerAPIService {
         return await RelayerAPIService._enhanceTransaction(bridgeTx, address);
       } catch (error) {
         // One failing RPC read must not reject the surrounding Promise.all and wipe the list
-        failedCount++;
+        failedTxHashes.push(bridgeTx.srcTxHash);
         log('Skipping transaction that failed to enhance', { error, srcTxHash: bridgeTx.srcTxHash });
         return;
       }
@@ -512,7 +514,7 @@ export class RelayerAPIService {
     // Spreading to preserve original txs in case of array mutation
     log('Enhanced transactions', [...bridgeTxs]);
 
-    return { txs: bridgeTxs, paginationInfo, failedCount };
+    return { txs: bridgeTxs, paginationInfo, failedTxHashes };
   }
 
   private static _transformTransaction(tx: APIResponseTransaction): BridgeTransaction {

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
@@ -147,8 +147,22 @@ export class RelayerAPIService {
     try {
       return await getTransactionReceipt(config, { chainId, hash });
     } catch (error) {
+      // "Not mined yet" and "the RPC call failed" used to collapse into the same null, which hid
+      // the second one completely: the row rendered with no receipt, isTransactionProcessable
+      // returned false so it could never be claimed, and nothing counted it. Batching made that
+      // worse, since one rate-limited request now carries the receipt reads of up to 50 rows.
+      //
+      // Compared by name rather than instanceof: this monorepo carries three viem copies, and an
+      // error thrown from a different one would silently fail an identity check - turning every
+      // unmined transaction into a counted failure.
+      if ((error as Error)?.name === 'TransactionReceiptNotFoundError') {
+        log(`Transaction ${hash} is not mined yet`);
+        return null;
+      }
+
+      // A real read failure belongs to the caller's counter, not to a silent null.
       log(`Error getting transaction receipt for ${hash}: ${error}`);
-      return null;
+      throw error;
     }
   }
 

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
@@ -451,7 +451,7 @@ export class RelayerAPIService {
     };
 
     if (!apiTxs.items || apiTxs.items.length === 0) {
-      return { txs: [], paginationInfo };
+      return { txs: [], paginationInfo, failedCount: 0 };
     }
 
     const items = RelayerAPIService._filterDuplicateAndWrongBridge(apiTxs.items);
@@ -467,12 +467,18 @@ export class RelayerAPIService {
       })
       .filter((tx): tx is BridgeTransaction => tx !== null);
 
+    // Only a thrown enhancement is a load failure. _enhanceTransaction also returns undefined for
+    // four legitimate filters (not this user's transaction, ambiguous receipt, no msgHash, no
+    // configured route); counting those would warn the user about transactions that were never theirs.
+    let failedCount = 0;
+
     const txsPromises = txs.map(async (bridgeTx) => {
       if (!bridgeTx) return;
       try {
         return await RelayerAPIService._enhanceTransaction(bridgeTx, address);
       } catch (error) {
         // One failing RPC read must not reject the surrounding Promise.all and wipe the list
+        failedCount++;
         log('Skipping transaction that failed to enhance', { error, srcTxHash: bridgeTx.srcTxHash });
         return;
       }
@@ -485,7 +491,7 @@ export class RelayerAPIService {
     // Spreading to preserve original txs in case of array mutation
     log('Enhanced transactions', [...bridgeTxs]);
 
-    return { txs: bridgeTxs, paginationInfo };
+    return { txs: bridgeTxs, paginationInfo, failedCount };
   }
 
   private static _transformTransaction(tx: APIResponseTransaction): BridgeTransaction {

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
@@ -469,7 +469,8 @@ export class RelayerAPIService {
 
     // Only a thrown enhancement is a load failure. _enhanceTransaction also returns undefined for
     // four legitimate filters (not this user's transaction, ambiguous receipt, no msgHash, no
-    // configured route); counting those would warn the user about transactions that were never theirs.
+    // configured route); those rows are deliberately not shown, so counting them would report a
+    // loss that never happened.
     let failedCount = 0;
 
     const txsPromises = txs.map(async (bridgeTx) => {

--- a/packages/bridge-ui/src/libs/relayer/types.ts
+++ b/packages/bridge-ui/src/libs/relayer/types.ts
@@ -5,10 +5,14 @@ import type { BridgeTransaction, RelayerMessage } from '$libs/bridge';
 export type GetAllByAddressResponse = {
   txs: BridgeTransaction[];
   paginationInfo: PaginationInfo;
-  // Transactions the relayer returned but whose on-chain enhancement threw (typically a
-  // rate-limited RPC). Required, not optional: an optional field would let a caller drop it
-  // on the way to the UI without the type checker noticing.
-  failedCount: number;
+  // Source hashes of the transactions the relayer returned but whose on-chain enhancement
+  // threw (typically a rate-limited RPC). Hashes rather than a count, because the caller has
+  // to deduplicate them: the relayer may return the same transaction on more than one page or
+  // from more than one relayer, and summing raw counts would report one loss several times, or
+  // report a loss for a transaction another page loaded successfully.
+  // Required, not optional: an optional field would let a caller drop it on the way to the UI
+  // without the type checker noticing.
+  failedTxHashes: Hash[];
 };
 
 export type PaginationParams = {

--- a/packages/bridge-ui/src/libs/relayer/types.ts
+++ b/packages/bridge-ui/src/libs/relayer/types.ts
@@ -5,6 +5,10 @@ import type { BridgeTransaction, RelayerMessage } from '$libs/bridge';
 export type GetAllByAddressResponse = {
   txs: BridgeTransaction[];
   paginationInfo: PaginationInfo;
+  // Transactions the relayer returned but whose on-chain enhancement threw (typically a
+  // rate-limited RPC). Required, not optional: an optional field lets a caller silently
+  // forget to thread it through, which is how these failures went unreported before.
+  failedCount: number;
 };
 
 export type PaginationParams = {

--- a/packages/bridge-ui/src/libs/relayer/types.ts
+++ b/packages/bridge-ui/src/libs/relayer/types.ts
@@ -6,8 +6,8 @@ export type GetAllByAddressResponse = {
   txs: BridgeTransaction[];
   paginationInfo: PaginationInfo;
   // Transactions the relayer returned but whose on-chain enhancement threw (typically a
-  // rate-limited RPC). Required, not optional: an optional field lets a caller silently
-  // forget to thread it through, which is how these failures went unreported before.
+  // rate-limited RPC). Required, not optional: an optional field would let a caller drop it
+  // on the way to the UI without the type checker noticing.
   failedCount: number;
 };
 

--- a/packages/bridge-ui/src/libs/wagmi/client.test.ts
+++ b/packages/bridge-ui/src/libs/wagmi/client.test.ts
@@ -1,11 +1,20 @@
 import { http } from '@wagmi/core';
 import type { Chain } from 'viem';
 
+// Shared between the $libs/chain mock and the createTransports() calls below, so the "own URL"
+// assertions are checking the exact same chain objects the module under test would receive in
+// production. vi.mock(...) factories are hoisted above imports, so this has to go through
+// vi.hoisted() rather than a plain top-level const.
+const mockChains = vi.hoisted(() => [
+  { id: 1, rpcUrls: { default: { http: ['https://l1.example/'] } } },
+  { id: 167000, rpcUrls: { default: { http: ['https://l2.example/'] } } },
+]);
+
 // The manual mock at __mocks__/@wagmi/core.ts stubs http/createConfig/reconnect, so importing
 // client.ts does not build a real wagmi config or attempt a wallet reconnect.
 vi.mock('@wagmi/core');
 vi.mock('@wagmi/connectors', () => ({ injected: vi.fn(), walletConnect: vi.fn() }));
-vi.mock('$libs/chain', () => ({ chains: [{ id: 1 }, { id: 167000 }] }));
+vi.mock('$libs/chain', () => ({ chains: mockChains }));
 
 import { createTransports, RPC_BATCH_CONFIG } from './client';
 
@@ -15,7 +24,7 @@ describe('createTransports', () => {
     vi.mocked(http).mockClear();
 
     // When
-    const transports = createTransports([{ id: 1 }, { id: 167000 }] as unknown as readonly Chain[]);
+    const transports = createTransports(mockChains as unknown as readonly Chain[]);
 
     // Then: one transport per chain, each carrying the batch config. Without it, a 300-transaction
     // history is 600 separate HTTP requests and the RPC gateway rate-limits the page.
@@ -26,9 +35,25 @@ describe('createTransports', () => {
     }
   });
 
+  it("gives each chain its own resolved URL, never undefined or another chain's URL", () => {
+    // Regression test for the misrouting bug: viem 2.9.31 keys its batch scheduler on the URL
+    // *argument* passed to http() (not the resolved URL) and caches schedulers in a module-level
+    // map. Passing `undefined` for every chain gave them all the same scheduler id ("undefined"),
+    // so concurrent reads on different chains were merged into one batch and flushed through
+    // whichever chain's RPC client triggered it first -- misrouting reads to the wrong chain's
+    // endpoint. Each call's first argument must be that chain's own URL.
+    vi.mocked(http).mockClear();
+
+    createTransports(mockChains as unknown as readonly Chain[]);
+
+    const urls = vi.mocked(http).mock.calls.map((call) => call[0]);
+    expect(urls).toEqual(['https://l1.example/', 'https://l2.example/']);
+  });
+
   it('keeps the batch size bounded so one rate-limited request cannot drop a whole page', () => {
     expect(RPC_BATCH_CONFIG.batchSize).toBe(50);
     // wait must be non-zero: the second read wave resolves on later ticks and would not group.
-    expect(RPC_BATCH_CONFIG.wait).toBeGreaterThan(0);
+    // Pinned to the exact value, not just "> 0", so a silent change from 20 to 200 fails the test.
+    expect(RPC_BATCH_CONFIG.wait).toBe(20);
   });
 });

--- a/packages/bridge-ui/src/libs/wagmi/client.test.ts
+++ b/packages/bridge-ui/src/libs/wagmi/client.test.ts
@@ -1,0 +1,34 @@
+import { http } from '@wagmi/core';
+import type { Chain } from 'viem';
+
+// The manual mock at __mocks__/@wagmi/core.ts stubs http/createConfig/reconnect, so importing
+// client.ts does not build a real wagmi config or attempt a wallet reconnect.
+vi.mock('@wagmi/core');
+vi.mock('@wagmi/connectors', () => ({ injected: vi.fn(), walletConnect: vi.fn() }));
+vi.mock('$libs/chain', () => ({ chains: [{ id: 1 }, { id: 167000 }] }));
+
+import { createTransports, RPC_BATCH_CONFIG } from './client';
+
+describe('createTransports', () => {
+  it('batches RPC reads for every configured chain', () => {
+    // Given: the module-scope config already called http() at import time
+    vi.mocked(http).mockClear();
+
+    // When
+    const transports = createTransports([{ id: 1 }, { id: 167000 }] as unknown as readonly Chain[]);
+
+    // Then: one transport per chain, each carrying the batch config. Without it, a 300-transaction
+    // history is 600 separate HTTP requests and the RPC gateway rate-limits the page.
+    expect(Object.keys(transports).sort()).toEqual(['1', '167000']);
+    expect(http).toHaveBeenCalledTimes(2);
+    for (const call of vi.mocked(http).mock.calls) {
+      expect(call[1]).toEqual({ batch: RPC_BATCH_CONFIG });
+    }
+  });
+
+  it('keeps the batch size bounded so one rate-limited request cannot drop a whole page', () => {
+    expect(RPC_BATCH_CONFIG.batchSize).toBe(50);
+    // wait must be non-zero: the second read wave resolves on later ticks and would not group.
+    expect(RPC_BATCH_CONFIG.wait).toBeGreaterThan(0);
+  });
+});

--- a/packages/bridge-ui/src/libs/wagmi/client.test.ts
+++ b/packages/bridge-ui/src/libs/wagmi/client.test.ts
@@ -50,6 +50,15 @@ describe('createTransports', () => {
     expect(urls).toEqual(['https://l1.example/', 'https://l2.example/']);
   });
 
+  it('refuses to build a transport for a chain with no RPC URL', () => {
+    // An empty `http` array would resolve to undefined and hand the shared-scheduler trap back,
+    // silently - reads would still resolve, against the wrong chain's endpoint. Failing here is
+    // the signal misrouting never gives you.
+    expect(() =>
+      createTransports([{ id: 1, rpcUrls: { default: { http: [] } } }] as unknown as readonly Chain[]),
+    ).toThrow(/no RPC URL/);
+  });
+
   it('keeps the batch size bounded so one rate-limited request cannot drop a whole page', () => {
     expect(RPC_BATCH_CONFIG.batchSize).toBe(50);
     // wait must be non-zero: the second read wave resolves on later ticks and would not group.

--- a/packages/bridge-ui/src/libs/wagmi/client.ts
+++ b/packages/bridge-ui/src/libs/wagmi/client.ts
@@ -11,11 +11,17 @@ export const publicClient = async (chainId: number) => {
   return await getPublicClient(config, { chainId });
 };
 
-function createTransports(chains: readonly Chain[]) {
+// Every transaction row on /transactions costs two RPC reads, and they all fire at once: a
+// 300-transaction history was 600 separate HTTP requests, enough to trip the RPC gateway's rate
+// limiter, which answers 429 with an HTML body that viem cannot parse. Batching collapses them
+// into a handful of requests. This assumes every configured RPC accepts JSON-RPC batch requests.
+export const RPC_BATCH_CONFIG = { batchSize: 50, wait: 20 } as const;
+
+export function createTransports(chains: readonly Chain[]) {
   const transports = chains.reduce(
     (acc, chain) => {
       const { id } = chain;
-      return { ...acc, [id]: http() };
+      return { ...acc, [id]: http(undefined, { batch: RPC_BATCH_CONFIG }) };
     },
     {} as Record<number, ReturnType<typeof http>>,
   );

--- a/packages/bridge-ui/src/libs/wagmi/client.ts
+++ b/packages/bridge-ui/src/libs/wagmi/client.ts
@@ -24,7 +24,16 @@ export function createTransports(chains: readonly Chain[]) {
       // Pass the resolved URL, never undefined: viem 2.9.31 keys its batch scheduler on the URL
       // *argument* and caches schedulers in a module-level map, so http(undefined, ...) would give
       // every chain the same scheduler and send one chain's reads to another chain's endpoint.
-      return { ...acc, [id]: http(chain.rpcUrls.default.http[0], { batch: RPC_BATCH_CONFIG }) };
+      const url = chain.rpcUrls.default.http[0];
+
+      // A chain configured with an empty `http` array would hand `undefined` straight back into
+      // that trap, and silently: reads would still resolve, just against another chain's endpoint.
+      // Refusing to build the config is the loud failure that misrouting never gives you - one of
+      // its symptoms is an uncloseable "bridge is paused" modal for every user, because
+      // checkForPausedContracts reads `paused` per chain and treats an unreadable answer as paused.
+      if (!url) throw new Error(`Chain ${id} has no RPC URL configured; batched transports need one per chain`);
+
+      return { ...acc, [id]: http(url, { batch: RPC_BATCH_CONFIG }) };
     },
     {} as Record<number, ReturnType<typeof http>>,
   );

--- a/packages/bridge-ui/src/libs/wagmi/client.ts
+++ b/packages/bridge-ui/src/libs/wagmi/client.ts
@@ -21,7 +21,10 @@ export function createTransports(chains: readonly Chain[]) {
   const transports = chains.reduce(
     (acc, chain) => {
       const { id } = chain;
-      return { ...acc, [id]: http(undefined, { batch: RPC_BATCH_CONFIG }) };
+      // Pass the resolved URL, never undefined: viem 2.9.31 keys its batch scheduler on the URL
+      // *argument* and caches schedulers in a module-level map, so http(undefined, ...) would give
+      // every chain the same scheduler and send one chain's reads to another chain's endpoint.
+      return { ...acc, [id]: http(chain.rpcUrls.default.http[0], { batch: RPC_BATCH_CONFIG }) };
     },
     {} as Record<number, ReturnType<typeof http>>,
   );


### PR DESCRIPTION
Stacked on #22097 — this cannot merge before it does. (The base branch, `claude/bridge-ui-code-audit-0ljtmq`, has not changed; the PR tracking it has been reopened under a new number twice, #22080 → #22094 → #22097.)

## The bug

`/transactions` intermittently shows `Relayer did not respond. Your transactions may only be loaded partially.` while the relayer is healthy. The message is a misattribution: the relayer returned HTTP 200 in every measurement against production (62 txs → 1.7s, 293 txs → 3.3–4.4s, 282 txs → 6.2s).

`getAllBridgeTransactionByAddress` issues two RPC reads per transaction, all concurrently — `eth_getTransactionReceipt` on the source chain and a `messageStatus` `eth_call` on the destination chain — so a 293-transaction history is **586 concurrent HTTP requests**. `rpc.mainnet.taiko.xyz` / `l1rpc.mainnet.taiko.xyz` sit behind an edge limiter that answers **429 with a `text/html` body**. viem 2.9.31 parses the body *before* checking `response.ok`, so `JSON.parse('<!doctype html>…')` throws first and the resulting `HttpRequestError` carries no `.status` — which means `shouldRetry` misses its 429 branch, falls through to `return true`, and retries, amplifying the burst.

#22097 stopped one such failure from wiping the whole list, which is right. But it did not reduce the fan-out, so under a 429 the failures became *silent* instead: the rows are dropped and the only trace is a `debug` call that emits nothing in production.

## The fix

**1. Batch the reads.** Every wagmi chain transport gets a JSON-RPC batch config. Measured against the same 293-transaction address:

| | HTTP requests | wall time |
|---|---|---|
| before | 586 | 5.8s |
| after (`batchSize: 50, wait: 20`) | **14** | 2.4s |

`batchSize: 50` over plain `batch: true` (which gives 7): it is faster in practice and bounds the blast radius of one failed request to 25 transactions rather than ~150. A non-zero `wait` is required — the second read wave resolves on later ticks and would not otherwise group.

Multicall3 aggregation was measured and rejected: same request count, but it only helps `eth_call` (receipts stay unbatched) and adds a dependency on Multicall3 being deployed on every configured chain. A concurrency limiter was rejected too — it spreads the burst without reducing quota use.

**2. Count what still fails.** `failedCount` is threaded from the places that swallow a genuine load failure up to the page, which now warns the user instead of dropping transactions silently. It counts only real failures — the four legitimate `return;` filters inside `_enhanceTransaction` are not failures, and counting them would report a loss that never happened.

**3. Stop conflating "not mined yet" with "the read failed."** `_getTransactionReceipt` returned `null` for both. The second one then vanished: the row rendered without a receipt, so `isTransactionProcessable` returned false and its claim action could never enable, while `failedCount` stayed 0 and nothing warned. Batching made that worse rather than better — the receipt reads of up to 50 rows now share one request, and receipts go to the source chain while `messageStatus` goes to the destination chain, so one throttled endpoint can null out a whole batch of receipts while the status batch succeeds. Only viem's `TransactionReceiptNotFoundError` still returns `null` and keeps the row; anything else is rethrown and counted.

## One trap worth knowing about

`http(undefined, { batch })` is wrong in viem 2.9.31, and it is the obvious way to write this. That version keys its batch scheduler on the URL **argument** (`createBatchScheduler({ id: \`${url}\` })`) while `schedulerCache` is a module-level `Map`, so every chain would share one queue and cross-chain reads get flushed through whichever chain's client triggered the batch — sending reads to the wrong endpoint. Reproduced: two concurrent `getChainId()` calls, one per chain, produced a single request to the L1 endpoint carrying both.

That would not have been confined to this page. `checkForPausedContracts` fires one `readContract(paused)` per chain concurrently on every page load and its catch returns `true`, so a misrouted read (`0x` → `ContractFunctionZeroDataError`) would have shown an uncloseable "bridge is paused" modal to every user.

`createTransports` therefore passes the resolved URL, and `client.test.ts` asserts each chain receives its own distinct URL. Note that the request-count evidence above is *identical* in the broken and fixed cases — only the routing assertion catches it. viem ≥2.18 keys on the resolved URL and would not need this.

Relatedly, `_getTransactionReceipt` matches viem's error by `name` rather than `instanceof`: this monorepo carries three viem copies, and an error thrown from a different one would fail an identity check silently — turning every pending bridge into a counted failure.

## Interaction with the base branch

The base has moved repeatedly while this was in progress and reworked the same code, so each round was combined rather than one side overwriting the other. Upstream switched the relayer fan-out to `allSettled` and made `fetchAllRelayerPages` report a relayer that dies part-way through its pages — both of which independently closed limitations this branch had flagged. This branch's `failedCount` is threaded through upstream's control flow, and upstream's early return on a later-page failure now carries the count the completed pages had already accumulated, instead of discarding it with the rest of the history.

## Caveat on the evidence

The failure this PR fixes is intermittent rather than deterministic: the same 293-transaction address loaded 293/293 on one run and 0/293 on another. The deterministic evidence is the request count, not any single page load.

## Validation

`pnpm test:unit` (67 files / 450 tests), `pnpm svelte:check` (0 errors), `pnpm lint` and `pnpm build` all pass locally with the CI recipe (`cp .env.example .env` + `pnpm export:config`).

Two behaviours were mutation-checked rather than merely asserted: hardcoding `failedCount: 0` in the page-failure early return fails its test, and making the `TransactionReceiptNotFoundError` name check never match fails the not-mined test while restoring the old swallow fails the counted-failure test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


