### PR TITLE
feat(protocol): support EIP-2612 permit and Permit2 in ERC20Vault

### DIFF
--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -274,6 +274,11 @@ contract ERC20Vault is BaseVault {
     /// holds a larger standing allowance for this vault will see it replaced by `_op.amount` and
     /// then spent down to zero. That is safe (it only ever reduces standing approval) but it is
     /// destructive, so callers that keep a long-lived allowance should use `sendToken` instead.
+    /// @dev A failed permit is swallowed, so a caller who already holds a sufficient allowance
+    /// bridges against it even when the signature is bad. That is the intended outcome -- the
+    /// caller is the token owner and asked for exactly this transfer -- and it is also what makes
+    /// the front-run case survivable, since a replayed signature leaves the allowance in place.
+    /// A bad signature with no allowance behind it still reverts at the pull.
     /// @param _op Option for sending ERC20 tokens.
     /// @param _deadline The permit signature's expiry timestamp.
     /// @param _v The permit signature's `v` value.
@@ -293,6 +298,13 @@ contract ERC20Vault is BaseVault {
         nonReentrant
         returns (IBridge.Message memory message_)
     {
+        // Validate before calling into `_op.token`. The permit is an external call to a
+        // caller-chosen address, so it must not happen for an operation that cannot proceed
+        // anyway; `_sendToken` re-checks these along with the rest.
+        if (_op.amount == 0) revert VAULT_INVALID_AMOUNT();
+        if (_op.token == address(0)) revert VAULT_INVALID_TOKEN();
+        if (btokenDenylist[_op.token]) revert VAULT_BTOKEN_BLACKLISTED();
+
         // The permit is best-effort: anyone can front-run it by replaying the same signature
         // directly against the token, which consumes the nonce and would make an unguarded call
         // revert. Only the resulting allowance matters, so a failed permit is swallowed here and

--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -6,7 +6,7 @@ import "../libs/LibAddress.sol";
 import "../libs/LibNames.sol";
 import "./BaseVault.sol";
 import "./IBridgedERC20.sol";
-import { IPermit2 } from "./IPermit2.sol";
+import "./IPermit2.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";

--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -392,7 +392,7 @@ contract ERC20Vault is BaseVault {
         checkToAddressOnDestChain(to);
 
         // Transfer the ETH and the tokens to the `to` address
-        address token = _transferTokens(ctoken, to, amount);
+        address token = _transferTokens(ctoken, to, amount, true);
         to.sendEtherAndVerify(msg.value);
 
         emit TokenReceived({
@@ -422,8 +422,10 @@ contract ERC20Vault is BaseVault {
         (CanonicalERC20 memory ctoken,,, uint256 amount) =
             abi.decode(data, (CanonicalERC20, address, address, uint256));
 
-        // Transfer the ETH and tokens back to the owner
-        address token = _transferTokens(ctoken, _message.srcOwner, amount);
+        // Transfer the ETH and tokens back to the owner. The quota is deliberately not debited:
+        // these tokens never left this chain, so returning a failed deposit is not a bridge
+        // inflow and must not be blocked when the quota is exhausted.
+        address token = _transferTokens(ctoken, _message.srcOwner, amount, false);
         _message.srcOwner.sendEtherAndVerify(_message.value);
 
         emit TokenReleased({
@@ -440,10 +442,21 @@ contract ERC20Vault is BaseVault {
         return LibNames.B_ERC20_VAULT;
     }
 
+    /// @dev Releases tokens to `_to`, either by transferring the canonical token this vault
+    /// custodies or by minting the bridged representation.
+    /// @param _ctoken The canonical token.
+    /// @param _to The recipient of the released tokens.
+    /// @param _amount The amount to release.
+    /// @param _consumeQuota Whether to debit the withdrawal quota. True when delivering a message
+    /// from another chain, which is the inflow the quota exists to rate-limit. False when refunding
+    /// a recalled message: those tokens never left this chain, so handing a user back their own
+    /// failed deposit must not be throttled by unrelated bridge traffic.
+    /// @return token_ The address of the token transferred or minted.
     function _transferTokens(
         CanonicalERC20 memory _ctoken,
         address _to,
-        uint256 _amount
+        uint256 _amount,
+        bool _consumeQuota
     )
         private
         returns (address token_)
@@ -457,7 +470,7 @@ contract ERC20Vault is BaseVault {
             // check.
             IBridgedERC20(token_).mint(_to, _amount);
         }
-        _consumeTokenQuota(token_, _amount);
+        if (_consumeQuota) _consumeTokenQuota(token_, _amount);
     }
 
     /// @dev Consumes a given amount of token quota from the quota manager; reverts if quota is
@@ -467,7 +480,8 @@ contract ERC20Vault is BaseVault {
     /// atomically: the token transfer/mint is undone and no partial state remains. Integrators
     /// driving this flow externally (or via a custom vault) must expect the entire release to
     /// revert when quota is exhausted, never a partial release. Skips the external call when nothing
-    /// is released (`_amount == 0`).
+    /// is released (`_amount == 0`). Only cross-chain deliveries reach here; refunds of recalled
+    /// messages are exempt (see `_transferTokens`).
     /// @param _token The token address.
     /// @param _amount The amount of token quota to consume.
     function _consumeTokenQuota(address _token, uint256 _amount) private {

--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -313,7 +313,10 @@ contract ERC20Vault is BaseVault {
     /// @param _nonce The Permit2 unordered nonce.
     /// @param _deadline The Permit2 signature's expiry timestamp.
     /// @param _signature The caller's Permit2 signature, which must authorize exactly `_op.amount`
-    /// of `_op.token`.
+    /// of `_op.token`. Passed to Permit2 verbatim as `bytes`, so a smart-contract wallet may
+    /// authorize the transfer with an EIP-1271 signature: Permit2 routes a signer that has code to
+    /// `isValidSignature` instead of `ecrecover`. Helpers that take a split `(v, r, s)` cannot
+    /// express such a signature, which is why the raw bytes are threaded through here.
     /// @return message_ The constructed message.
     function sendTokenWithPermit2(
         BridgeTransferOp calldata _op,

--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -270,6 +270,10 @@ contract ERC20Vault is BaseVault {
     /// allowance first, so no separate `approve` transaction is needed.
     /// @dev Only usable with tokens that implement EIP-2612; use `sendTokenWithPermit2` otherwise.
     /// The caller must be the permit signer.
+    /// @dev EIP-2612 `permit` *sets* the allowance rather than adding to it, so a caller who already
+    /// holds a larger standing allowance for this vault will see it replaced by `_op.amount` and
+    /// then spent down to zero. That is safe (it only ever reduces standing approval) but it is
+    /// destructive, so callers that keep a long-lived allowance should use `sendToken` instead.
     /// @param _op Option for sending ERC20 tokens.
     /// @param _deadline The permit signature's expiry timestamp.
     /// @param _v The permit signature's `v` value.

--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -6,10 +6,10 @@ import "../libs/LibAddress.sol";
 import "../libs/LibNames.sol";
 import "./BaseVault.sol";
 import "./IBridgedERC20.sol";
-import "./IPermit2.sol";
+import { IPermit2 } from "./IPermit2.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 

--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -46,6 +46,18 @@ contract ERC20Vault is BaseVault {
         string name;
     }
 
+    /// @dev A Permit2 `SignatureTransfer` authorization, threaded from the entrypoint down to the
+    /// pull. Named members rather than a hand-encoded tuple: `nonce` and `deadline` are both
+    /// `uint256`, so transposing them is invisible to both the compiler and the function selector.
+    struct Permit2Data {
+        // The Permit2 unordered nonce.
+        uint256 nonce;
+        // The signature's expiry timestamp.
+        uint256 deadline;
+        // The owner's signature over the permit, passed to Permit2 verbatim.
+        bytes signature;
+    }
+
     /// @dev Represents an operation to send tokens to another chain.
     /// 4 slots
     struct BridgeTransferOp {
@@ -169,8 +181,8 @@ contract ERC20Vault is BaseVault {
     error VAULT_INVALID_AMOUNT();
     error VAULT_INVALID_CTOKEN();
     error VAULT_INVALID_NEW_BTOKEN();
-    error VAULT_INVALID_PERMIT2_SIG();
     error VAULT_LAST_MIGRATION_TOO_CLOSE();
+    error VAULT_PERMIT_NO_ALLOWANCE();
 
     constructor(address _resolver, address _quotaManager) BaseVault(_resolver) {
         quotaManager = IQuotaManager(_quotaManager);
@@ -263,7 +275,8 @@ contract ERC20Vault is BaseVault {
         nonReentrant
         returns (IBridge.Message memory message_)
     {
-        message_ = _sendToken(_op, "");
+        Permit2Data memory noPermit2;
+        message_ = _sendToken(_op, noPermit2, false);
     }
 
     /// @notice Same as `sendToken`, but consumes an EIP-2612 permit signature to set this vault's
@@ -278,7 +291,8 @@ contract ERC20Vault is BaseVault {
     /// bridges against it even when the signature is bad. That is the intended outcome -- the
     /// caller is the token owner and asked for exactly this transfer -- and it is also what makes
     /// the front-run case survivable, since a replayed signature leaves the allowance in place.
-    /// A bad signature with no allowance behind it still reverts at the pull.
+    /// Only the resulting allowance matters, which is what is checked; a signature that leaves no
+    /// allowance behind reverts with `VAULT_PERMIT_NO_ALLOWANCE`.
     /// @param _op Option for sending ERC20 tokens.
     /// @param _deadline The permit signature's expiry timestamp.
     /// @param _v The permit signature's `v` value.
@@ -300,20 +314,28 @@ contract ERC20Vault is BaseVault {
     {
         // Validate before calling into `_op.token`. The permit is an external call to a
         // caller-chosen address, so it must not happen for an operation that cannot proceed
-        // anyway; `_sendToken` re-checks these along with the rest.
-        if (_op.amount == 0) revert VAULT_INVALID_AMOUNT();
-        if (_op.token == address(0)) revert VAULT_INVALID_TOKEN();
-        if (btokenDenylist[_op.token]) revert VAULT_BTOKEN_BLACKLISTED();
+        // anyway. `_sendToken` runs the same `_checkOp` again, so no entrypoint can skip it.
+        _checkOp(_op);
 
         // The permit is best-effort: anyone can front-run it by replaying the same signature
         // directly against the token, which consumes the nonce and would make an unguarded call
-        // revert. Only the resulting allowance matters, so a failed permit is swallowed here and
-        // the pull below reverts on its own if the allowance is genuinely missing.
+        // revert. Only the allowance it leaves behind matters, so a failed permit is swallowed and
+        // the allowance is checked instead.
         try IERC20Permit(_op.token)
             .permit(msg.sender, address(this), _op.amount, _deadline, _v, _r, _s) { }
             catch { }
 
-        message_ = _sendToken(_op, "");
+        // A `permit` call that neither reverts nor grants an allowance is not hypothetical: on a
+        // token whose fallback silently accepts unknown selectors (WETH9 being the obvious one)
+        // the `try` takes its success branch with the allowance still untouched. Checking the
+        // allowance rather than the call's outcome covers that alongside the front-run case, and
+        // fails here with a decodable error instead of deep inside `SafeERC20`.
+        if (IERC20(_op.token).allowance(msg.sender, address(this)) < _op.amount) {
+            revert VAULT_PERMIT_NO_ALLOWANCE();
+        }
+
+        Permit2Data memory noPermit2;
+        message_ = _sendToken(_op, noPermit2, false);
     }
 
     /// @notice Same as `sendToken`, but pulls the tokens with a Permit2 `SignatureTransfer`, so no
@@ -328,7 +350,11 @@ contract ERC20Vault is BaseVault {
     /// of `_op.token`. Passed to Permit2 verbatim as `bytes`, so a smart-contract wallet may
     /// authorize the transfer with an EIP-1271 signature: Permit2 routes a signer that has code to
     /// `isValidSignature` instead of `ecrecover`. Helpers that take a split `(v, r, s)` cannot
-    /// express such a signature, which is why the raw bytes are threaded through here.
+    /// express such a signature, which is why the raw bytes are threaded through here. No length is
+    /// imposed on it for the same reason: Permit2 hands a contract signer whatever bytes it is
+    /// given, and an EIP-1271 wallet that authorizes from stored state (a pre-approved hash, say)
+    /// validates an empty signature. An EOA signature of the wrong length is rejected by Permit2
+    /// itself.
     /// @return message_ The constructed message.
     function sendTokenWithPermit2(
         BridgeTransferOp calldata _op,
@@ -342,31 +368,42 @@ contract ERC20Vault is BaseVault {
         nonReentrant
         returns (IBridge.Message memory message_)
     {
-        if (_signature.length == 0) revert VAULT_INVALID_PERMIT2_SIG();
-        message_ = _sendToken(_op, abi.encode(_nonce, _deadline, _signature));
+        Permit2Data memory permit2 =
+            Permit2Data({ nonce: _nonce, deadline: _deadline, signature: _signature });
+        message_ = _sendToken(_op, permit2, true);
     }
 
-    /// @dev Shared implementation behind `sendToken`, `sendTokenWithPermit` and
-    /// `sendTokenWithPermit2`. The token pull is the only step that differs between them.
+    /// @dev Validates a send operation. Every entrypoint reaches this through `_sendToken`, and
+    /// `sendTokenWithPermit` additionally runs it up front so it never hands execution to a
+    /// caller-chosen token for an operation that cannot proceed. Keeping the checks in one place is
+    /// what stops those two lists from drifting apart.
     /// @param _op Option for sending ERC20 tokens.
-    /// @param _permit2 ABI-encoded `(nonce, deadline, signature)` authorizing a Permit2 transfer,
-    /// or empty to pull via a plain `transferFrom`.
-    /// @return message_ The constructed message.
-    function _sendToken(
-        BridgeTransferOp calldata _op,
-        bytes memory _permit2
-    )
-        private
-        returns (IBridge.Message memory message_)
-    {
+    function _checkOp(BridgeTransferOp calldata _op) private view {
         if (_op.amount == 0) revert VAULT_INVALID_AMOUNT();
         if (_op.token == address(0)) revert VAULT_INVALID_TOKEN();
         if (btokenDenylist[_op.token]) revert VAULT_BTOKEN_BLACKLISTED();
         if (msg.value < _op.fee) revert VAULT_INSUFFICIENT_FEE();
         checkToAddressOnSrcChain(_op.to, _op.destChainId);
+    }
+
+    /// @dev Shared implementation behind `sendToken`, `sendTokenWithPermit` and
+    /// `sendTokenWithPermit2`. The token pull is the only step that differs between them.
+    /// @param _op Option for sending ERC20 tokens.
+    /// @param _permit2 The Permit2 authorization; ignored unless `_usePermit2` is true.
+    /// @param _usePermit2 Whether to pull via Permit2 rather than a plain `transferFrom`.
+    /// @return message_ The constructed message.
+    function _sendToken(
+        BridgeTransferOp calldata _op,
+        Permit2Data memory _permit2,
+        bool _usePermit2
+    )
+        private
+        returns (IBridge.Message memory message_)
+    {
+        _checkOp(_op);
 
         (bytes memory data, CanonicalERC20 memory ctoken, uint256 balanceChange) =
-            _handleMessage(_op, _permit2);
+            _handleMessage(_op, _permit2, _usePermit2);
 
         IBridge.Message memory message = IBridge.Message({
             id: 0, // will receive a new value
@@ -411,7 +448,7 @@ contract ERC20Vault is BaseVault {
         checkToAddressOnDestChain(to);
 
         // Transfer the ETH and the tokens to the `to` address
-        address token = _transferTokens(ctoken, to, amount, true);
+        address token = _transferTokens(ctoken, to, amount);
         to.sendEtherAndVerify(msg.value);
 
         emit TokenReceived({
@@ -426,6 +463,15 @@ contract ERC20Vault is BaseVault {
     }
 
     /// @inheritdoc IRecallableSender
+    /// @dev The refund debits the withdrawal quota just like a cross-chain delivery does. A recall
+    /// is reached through the same destination-chain failure proof that a delivery is, and on the
+    /// bridged branch it mints supply bounded by no vault balance, so the quota is the only numeric
+    /// ceiling on this path and is deliberately kept.
+    /// @dev Consequence worth knowing: `QuotaManager` caps a token's refill at its configured
+    /// quota, so a single recall larger than that cap can never be refunded in one call. An
+    /// out-of-quota refund reverts atomically, leaving the message `NEW` and retryable once the
+    /// quota refills; a recall above the cap stays blocked until the owner raises the token's quota
+    /// via `QuotaManager.updateQuota`.
     function onMessageRecalled(
         IBridge.Message calldata _message,
         bytes32 _msgHash
@@ -441,10 +487,8 @@ contract ERC20Vault is BaseVault {
         (CanonicalERC20 memory ctoken,,, uint256 amount) =
             abi.decode(data, (CanonicalERC20, address, address, uint256));
 
-        // Transfer the ETH and tokens back to the owner. The quota is deliberately not debited:
-        // these tokens never left this chain, so returning a failed deposit is not a bridge
-        // inflow and must not be blocked when the quota is exhausted.
-        address token = _transferTokens(ctoken, _message.srcOwner, amount, false);
+        // Transfer the ETH and tokens back to the owner.
+        address token = _transferTokens(ctoken, _message.srcOwner, amount);
         _message.srcOwner.sendEtherAndVerify(_message.value);
 
         emit TokenReleased({
@@ -463,19 +507,19 @@ contract ERC20Vault is BaseVault {
 
     /// @dev Releases tokens to `_to`, either by transferring the canonical token this vault
     /// custodies or by minting the bridged representation.
+    /// @dev Every release debits the withdrawal quota, whether it settles a delivery from another
+    /// chain or refunds a recalled message. A recall is not itself a cross-chain inflow, but it is
+    /// reached through the same failure-proof primitive as a delivery, and on the bridged branch it
+    /// mints supply that no vault balance bounds -- so the quota is the only numeric ceiling on
+    /// either path and is deliberately applied to both.
     /// @param _ctoken The canonical token.
     /// @param _to The recipient of the released tokens.
     /// @param _amount The amount to release.
-    /// @param _consumeQuota Whether to debit the withdrawal quota. True when delivering a message
-    /// from another chain, which is the inflow the quota exists to rate-limit. False when refunding
-    /// a recalled message: those tokens never left this chain, so handing a user back their own
-    /// failed deposit must not be throttled by unrelated bridge traffic.
     /// @return token_ The address of the token transferred or minted.
     function _transferTokens(
         CanonicalERC20 memory _ctoken,
         address _to,
-        uint256 _amount,
-        bool _consumeQuota
+        uint256 _amount
     )
         private
         returns (address token_)
@@ -489,7 +533,7 @@ contract ERC20Vault is BaseVault {
             // check.
             IBridgedERC20(token_).mint(_to, _amount);
         }
-        if (_consumeQuota) _consumeTokenQuota(token_, _amount);
+        _consumeTokenQuota(token_, _amount);
     }
 
     /// @dev Consumes a given amount of token quota from the quota manager; reverts if quota is
@@ -499,8 +543,7 @@ contract ERC20Vault is BaseVault {
     /// atomically: the token transfer/mint is undone and no partial state remains. Integrators
     /// driving this flow externally (or via a custom vault) must expect the entire release to
     /// revert when quota is exhausted, never a partial release. Skips the external call when nothing
-    /// is released (`_amount == 0`). Only cross-chain deliveries reach here; refunds of recalled
-    /// messages are exempt (see `_transferTokens`).
+    /// is released (`_amount == 0`).
     /// @param _token The token address.
     /// @param _amount The amount of token quota to consume.
     function _consumeTokenQuota(address _token, uint256 _amount) private {
@@ -509,40 +552,44 @@ contract ERC20Vault is BaseVault {
         }
     }
 
-    /// @dev Pulls `_amount` of `_token` from `msg.sender` into this vault. When `_permit2` is
-    /// non-empty the pull is authorized by a Permit2 `SignatureTransfer`, which works for every
-    /// ERC20 regardless of EIP-2612 support; otherwise a plain `transferFrom` against a
-    /// pre-existing allowance is used. The Permit2 owner is always `msg.sender`, so the caller
-    /// remains the token owner and `Message.srcOwner` keeps its meaning as the address a recall
-    /// refunds.
+    /// @dev Pulls `_amount` of `_token` from `msg.sender` into this vault. When `_usePermit2` is
+    /// true the pull is authorized by a Permit2 `SignatureTransfer`, which works for every ERC20
+    /// regardless of EIP-2612 support; otherwise a plain `transferFrom` against a pre-existing
+    /// allowance is used. The Permit2 owner is always `msg.sender`, so the caller remains the token
+    /// owner and `Message.srcOwner` keeps its meaning as the address a recall refunds.
     /// @param _token The token to pull.
     /// @param _amount The amount to pull.
-    /// @param _permit2 ABI-encoded `(nonce, deadline, signature)`, or empty for `transferFrom`.
-    function _pullTokens(address _token, uint256 _amount, bytes memory _permit2) private {
-        if (_permit2.length == 0) {
+    /// @param _permit2 The Permit2 authorization; ignored unless `_usePermit2` is true.
+    /// @param _usePermit2 Whether to pull via Permit2 rather than a plain `transferFrom`.
+    function _pullTokens(
+        address _token,
+        uint256 _amount,
+        Permit2Data memory _permit2,
+        bool _usePermit2
+    )
+        private
+    {
+        if (!_usePermit2) {
             IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
             return;
         }
 
-        (uint256 nonce, uint256 deadline, bytes memory signature) =
-            abi.decode(_permit2, (uint256, uint256, bytes));
-
         IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
             permitted: IPermit2.TokenPermissions({ token: _token, amount: _amount }),
-            nonce: nonce,
-            deadline: deadline
+            nonce: _permit2.nonce,
+            deadline: _permit2.deadline
         });
         IPermit2.SignatureTransferDetails memory details =
             IPermit2.SignatureTransferDetails({ to: address(this), requestedAmount: _amount });
 
-        IPermit2(PERMIT2).permitTransferFrom(permit, details, msg.sender, signature);
+        IPermit2(PERMIT2).permitTransferFrom(permit, details, msg.sender, _permit2.signature);
     }
 
     /// @dev Handles the message on the source chain and returns the encoded
     /// call on the destination call.
     /// @param _op The BridgeTransferOp object.
-    /// @param _permit2 ABI-encoded `(nonce, deadline, signature)` authorizing a Permit2 transfer,
-    /// or empty to pull via a plain `transferFrom`.
+    /// @param _permit2 The Permit2 authorization; ignored unless `_usePermit2` is true.
+    /// @param _usePermit2 Whether to pull via Permit2 rather than a plain `transferFrom`.
     /// @return msgData_ Encoded message data.
     /// @return ctoken_ The canonical token.
     /// @return balanceChange_ User token balance actual change after the token
@@ -550,7 +597,8 @@ contract ERC20Vault is BaseVault {
     /// change is the amount of token transferred away.
     function _handleMessage(
         BridgeTransferOp calldata _op,
-        bytes memory _permit2
+        Permit2Data memory _permit2,
+        bool _usePermit2
     )
         private
         returns (bytes memory msgData_, CanonicalERC20 memory ctoken_, uint256 balanceChange_)
@@ -560,7 +608,7 @@ contract ERC20Vault is BaseVault {
         if (_ctoken.addr != address(0)) {
             ctoken_ = _ctoken;
             // Following the "transfer and burn" pattern, as used by USDC
-            _pullTokens(_op.token, _op.amount, _permit2);
+            _pullTokens(_op.token, _op.amount, _permit2, _usePermit2);
             IBridgedERC20(_op.token).burn(_op.amount);
             balanceChange_ = _op.amount;
         } else {
@@ -579,7 +627,7 @@ contract ERC20Vault is BaseVault {
             // transferred amount.
             IERC20 t = IERC20(_op.token);
             uint256 _balance = t.balanceOf(address(this));
-            _pullTokens(_op.token, _op.amount, _permit2);
+            _pullTokens(_op.token, _op.amount, _permit2, _usePermit2);
             balanceChange_ = t.balanceOf(address(this)) - _balance;
         }
 

--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -6,8 +6,10 @@ import "../libs/LibAddress.sol";
 import "../libs/LibNames.sol";
 import "./BaseVault.sol";
 import "./IBridgedERC20.sol";
+import "./IPermit2.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
@@ -26,6 +28,12 @@ contract ERC20Vault is BaseVault {
     using SafeERC20 for IERC20;
 
     uint256 public constant MIN_MIGRATION_DELAY = 90 days;
+
+    /// @notice The canonical Uniswap Permit2 contract. Permit2 is deployed at this same address on
+    /// every chain via the deterministic deployer, so it needs no per-chain configuration.
+    /// @dev Bridging with a Permit2 signature is opt-in, so on a chain where Permit2 is not
+    /// deployed only `sendTokenWithPermit2` is unavailable; every other entrypoint is unaffected.
+    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
 
     IQuotaManager public immutable quotaManager;
 
@@ -161,6 +169,7 @@ contract ERC20Vault is BaseVault {
     error VAULT_INVALID_AMOUNT();
     error VAULT_INVALID_CTOKEN();
     error VAULT_INVALID_NEW_BTOKEN();
+    error VAULT_INVALID_PERMIT2_SIG();
     error VAULT_LAST_MIGRATION_TOO_CLOSE();
 
     constructor(address _resolver, address _quotaManager) BaseVault(_resolver) {
@@ -254,6 +263,83 @@ contract ERC20Vault is BaseVault {
         nonReentrant
         returns (IBridge.Message memory message_)
     {
+        message_ = _sendToken(_op, "");
+    }
+
+    /// @notice Same as `sendToken`, but consumes an EIP-2612 permit signature to set this vault's
+    /// allowance first, so no separate `approve` transaction is needed.
+    /// @dev Only usable with tokens that implement EIP-2612; use `sendTokenWithPermit2` otherwise.
+    /// The caller must be the permit signer.
+    /// @param _op Option for sending ERC20 tokens.
+    /// @param _deadline The permit signature's expiry timestamp.
+    /// @param _v The permit signature's `v` value.
+    /// @param _r The permit signature's `r` value.
+    /// @param _s The permit signature's `s` value.
+    /// @return message_ The constructed message.
+    function sendTokenWithPermit(
+        BridgeTransferOp calldata _op,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    )
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (IBridge.Message memory message_)
+    {
+        // The permit is best-effort: anyone can front-run it by replaying the same signature
+        // directly against the token, which consumes the nonce and would make an unguarded call
+        // revert. Only the resulting allowance matters, so a failed permit is swallowed here and
+        // the pull below reverts on its own if the allowance is genuinely missing.
+        try IERC20Permit(_op.token)
+            .permit(msg.sender, address(this), _op.amount, _deadline, _v, _r, _s) { }
+            catch { }
+
+        message_ = _sendToken(_op, "");
+    }
+
+    /// @notice Same as `sendToken`, but pulls the tokens with a Permit2 `SignatureTransfer`, so no
+    /// separate `approve` transaction is needed.
+    /// @dev Works for every ERC20 regardless of EIP-2612 support, and requires the caller to have
+    /// approved Permit2 once. The caller must be the permit signer. Reverts if Permit2 is not
+    /// deployed on this chain.
+    /// @param _op Option for sending ERC20 tokens.
+    /// @param _nonce The Permit2 unordered nonce.
+    /// @param _deadline The Permit2 signature's expiry timestamp.
+    /// @param _signature The caller's Permit2 signature, which must authorize exactly `_op.amount`
+    /// of `_op.token`.
+    /// @return message_ The constructed message.
+    function sendTokenWithPermit2(
+        BridgeTransferOp calldata _op,
+        uint256 _nonce,
+        uint256 _deadline,
+        bytes calldata _signature
+    )
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (IBridge.Message memory message_)
+    {
+        if (_signature.length == 0) revert VAULT_INVALID_PERMIT2_SIG();
+        message_ = _sendToken(_op, abi.encode(_nonce, _deadline, _signature));
+    }
+
+    /// @dev Shared implementation behind `sendToken`, `sendTokenWithPermit` and
+    /// `sendTokenWithPermit2`. The token pull is the only step that differs between them.
+    /// @param _op Option for sending ERC20 tokens.
+    /// @param _permit2 ABI-encoded `(nonce, deadline, signature)` authorizing a Permit2 transfer,
+    /// or empty to pull via a plain `transferFrom`.
+    /// @return message_ The constructed message.
+    function _sendToken(
+        BridgeTransferOp calldata _op,
+        bytes memory _permit2
+    )
+        private
+        returns (IBridge.Message memory message_)
+    {
         if (_op.amount == 0) revert VAULT_INVALID_AMOUNT();
         if (_op.token == address(0)) revert VAULT_INVALID_TOKEN();
         if (btokenDenylist[_op.token]) revert VAULT_BTOKEN_BLACKLISTED();
@@ -261,7 +347,7 @@ contract ERC20Vault is BaseVault {
         checkToAddressOnSrcChain(_op.to, _op.destChainId);
 
         (bytes memory data, CanonicalERC20 memory ctoken, uint256 balanceChange) =
-            _handleMessage(_op);
+            _handleMessage(_op, _permit2);
 
         IBridge.Message memory message = IBridge.Message({
             id: 0, // will receive a new value
@@ -390,15 +476,49 @@ contract ERC20Vault is BaseVault {
         }
     }
 
+    /// @dev Pulls `_amount` of `_token` from `msg.sender` into this vault. When `_permit2` is
+    /// non-empty the pull is authorized by a Permit2 `SignatureTransfer`, which works for every
+    /// ERC20 regardless of EIP-2612 support; otherwise a plain `transferFrom` against a
+    /// pre-existing allowance is used. The Permit2 owner is always `msg.sender`, so the caller
+    /// remains the token owner and `Message.srcOwner` keeps its meaning as the address a recall
+    /// refunds.
+    /// @param _token The token to pull.
+    /// @param _amount The amount to pull.
+    /// @param _permit2 ABI-encoded `(nonce, deadline, signature)`, or empty for `transferFrom`.
+    function _pullTokens(address _token, uint256 _amount, bytes memory _permit2) private {
+        if (_permit2.length == 0) {
+            IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
+            return;
+        }
+
+        (uint256 nonce, uint256 deadline, bytes memory signature) =
+            abi.decode(_permit2, (uint256, uint256, bytes));
+
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({ token: _token, amount: _amount }),
+            nonce: nonce,
+            deadline: deadline
+        });
+        IPermit2.SignatureTransferDetails memory details =
+            IPermit2.SignatureTransferDetails({ to: address(this), requestedAmount: _amount });
+
+        IPermit2(PERMIT2).permitTransferFrom(permit, details, msg.sender, signature);
+    }
+
     /// @dev Handles the message on the source chain and returns the encoded
     /// call on the destination call.
     /// @param _op The BridgeTransferOp object.
+    /// @param _permit2 ABI-encoded `(nonce, deadline, signature)` authorizing a Permit2 transfer,
+    /// or empty to pull via a plain `transferFrom`.
     /// @return msgData_ Encoded message data.
     /// @return ctoken_ The canonical token.
     /// @return balanceChange_ User token balance actual change after the token
     /// transfer. This value is calculated so we do not assume token balance
     /// change is the amount of token transferred away.
-    function _handleMessage(BridgeTransferOp calldata _op)
+    function _handleMessage(
+        BridgeTransferOp calldata _op,
+        bytes memory _permit2
+    )
         private
         returns (bytes memory msgData_, CanonicalERC20 memory ctoken_, uint256 balanceChange_)
     {
@@ -407,7 +527,7 @@ contract ERC20Vault is BaseVault {
         if (_ctoken.addr != address(0)) {
             ctoken_ = _ctoken;
             // Following the "transfer and burn" pattern, as used by USDC
-            IERC20(_op.token).safeTransferFrom(msg.sender, address(this), _op.amount);
+            _pullTokens(_op.token, _op.amount, _permit2);
             IBridgedERC20(_op.token).burn(_op.amount);
             balanceChange_ = _op.amount;
         } else {
@@ -426,7 +546,7 @@ contract ERC20Vault is BaseVault {
             // transferred amount.
             IERC20 t = IERC20(_op.token);
             uint256 _balance = t.balanceOf(address(this));
-            t.safeTransferFrom(msg.sender, address(this), _op.amount);
+            _pullTokens(_op.token, _op.amount, _permit2);
             balanceChange_ = t.balanceOf(address(this)) - _balance;
         }
 

--- a/packages/protocol/contracts/shared/vault/ERC20Vault.sol
+++ b/packages/protocol/contracts/shared/vault/ERC20Vault.sol
@@ -9,7 +9,7 @@ import "./IBridgedERC20.sol";
 import "./IPermit2.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 

--- a/packages/protocol/contracts/shared/vault/IPermit2.sol
+++ b/packages/protocol/contracts/shared/vault/IPermit2.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IPermit2
+/// @notice Minimal interface for Uniswap's Permit2 `SignatureTransfer` flow, covering only the
+/// single-token transfer this repository uses.
+/// @dev Permit2 is an immutable contract deployed at the same address on every chain via the
+/// deterministic deployer. Only the members needed here are declared; see
+/// https://github.com/Uniswap/permit2 for the full interface.
+/// @custom:security-contact security@taiko.xyz
+interface IPermit2 {
+    /// @notice The token and amount a signature authorizes.
+    struct TokenPermissions {
+        address token;
+        uint256 amount;
+    }
+
+    /// @notice The signed permit message for a single token transfer.
+    struct PermitTransferFrom {
+        TokenPermissions permitted;
+        uint256 nonce;
+        uint256 deadline;
+    }
+
+    /// @notice The recipient and amount of a transfer authorized by a signature.
+    struct SignatureTransferDetails {
+        address to;
+        uint256 requestedAmount;
+    }
+
+    /// @notice Transfers a token using a signed permit message.
+    /// @dev Reverts if the signature is invalid, replayed, or past its deadline.
+    /// @param permit The permit data signed over by the owner.
+    /// @param transferDetails The recipient and amount of the transfer.
+    /// @param owner The owner of the tokens, and the signer of the permit.
+    /// @param signature The owner's EIP-712 signature over `permit`.
+    function permitTransferFrom(
+        PermitTransferFrom calldata permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    )
+        external;
+}

--- a/packages/protocol/test/shared/helpers/FreeMintERC20TokenWithPermit.sol
+++ b/packages/protocol/test/shared/helpers/FreeMintERC20TokenWithPermit.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
 // An EIP-2612 capable ERC20 token with a mint function anyone can call, for free, to receive
 // 50 tokens. Used to exercise ERC20Vault's `sendTokenWithPermit` entrypoint.

--- a/packages/protocol/test/shared/helpers/FreeMintERC20TokenWithPermit.sol
+++ b/packages/protocol/test/shared/helpers/FreeMintERC20TokenWithPermit.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+
+// An EIP-2612 capable ERC20 token with a mint function anyone can call, for free, to receive
+// 50 tokens. Used to exercise ERC20Vault's `sendTokenWithPermit` entrypoint.
+contract FreeMintERC20TokenWithPermit is ERC20, ERC20Permit {
+    mapping(address minter => bool hasMinted) public minters;
+
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) ERC20Permit(name) { }
+
+    function mint(address to) public {
+        require(!minters[to], "minted already");
+
+        minters[to] = true;
+        _mint(to, 50 * (10 ** decimals()));
+    }
+}

--- a/packages/protocol/test/shared/helpers/Permit2Mock.sol
+++ b/packages/protocol/test/shared/helpers/Permit2Mock.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "src/shared/vault/IPermit2.sol";
+
+/// @notice A faithful stand-in for Uniswap's Permit2 `SignatureTransfer` flow, reproducing its
+/// EIP-712 domain, typehashes and signature checks so tests exercise the real signing scheme.
+/// @dev The domain separator is derived from `address(this)` at call time rather than cached in an
+/// immutable, so this mock keeps working after `vm.etch` places its runtime code at Permit2's
+/// canonical address. Permit2's unordered nonce bitmap is simplified to a used/unused flag, which
+/// is enough to cover replay.
+contract Permit2Mock {
+    using SafeERC20 for IERC20;
+
+    bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    bytes32 private constant _TOKEN_PERMISSIONS_TYPEHASH =
+        keccak256("TokenPermissions(address token,uint256 amount)");
+
+    bytes32 private constant _PERMIT_TRANSFER_FROM_TYPEHASH = keccak256(
+        "PermitTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)"
+    );
+
+    mapping(address owner => mapping(uint256 nonce => bool used)) public nonceUsed;
+
+    error InvalidAmount();
+    error InvalidNonce();
+    error InvalidSignature();
+    error InvalidSignatureLength();
+    error SignatureExpired();
+
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return keccak256(
+            abi.encode(_EIP712_DOMAIN_TYPEHASH, keccak256("Permit2"), block.chainid, address(this))
+        );
+    }
+
+    /// @dev Mirrors Permit2's `permitTransferFrom`. `spender` is bound to `msg.sender`, so a
+    /// signature made for one spender cannot be redeemed by another.
+    function permitTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    )
+        external
+    {
+        if (block.timestamp > permit.deadline) revert SignatureExpired();
+        if (transferDetails.requestedAmount > permit.permitted.amount) revert InvalidAmount();
+        if (nonceUsed[owner][permit.nonce]) revert InvalidNonce();
+        nonceUsed[owner][permit.nonce] = true;
+
+        if (_recover(hashTypedData(permit, msg.sender), signature) != owner) {
+            revert InvalidSignature();
+        }
+
+        IERC20(permit.permitted.token)
+            .safeTransferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+
+    /// @dev Builds the EIP-712 digest a signer must sign for `permit` redeemed by `spender`.
+    function hashTypedData(
+        IPermit2.PermitTransferFrom calldata permit,
+        address spender
+    )
+        public
+        view
+        returns (bytes32)
+    {
+        bytes32 permissions = keccak256(
+            abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted.token, permit.permitted.amount)
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(
+                _PERMIT_TRANSFER_FROM_TYPEHASH, permissions, spender, permit.nonce, permit.deadline
+            )
+        );
+        return keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+    }
+
+    function _recover(
+        bytes32 _digest,
+        bytes calldata _signature
+    )
+        private
+        pure
+        returns (address)
+    {
+        if (_signature.length != 65) revert InvalidSignatureLength();
+
+        bytes32 r = bytes32(_signature[0:32]);
+        bytes32 s = bytes32(_signature[32:64]);
+        uint8 v = uint8(_signature[64]);
+
+        address signer = ecrecover(_digest, v, r, s);
+        if (signer == address(0)) revert InvalidSignature();
+        return signer;
+    }
+}

--- a/packages/protocol/test/shared/helpers/Permit2Mock.sol
+++ b/packages/protocol/test/shared/helpers/Permit2Mock.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IPermit2 } from "src/shared/vault/IPermit2.sol";
@@ -26,11 +27,16 @@ contract Permit2Mock {
 
     mapping(address owner => mapping(uint256 nonce => bool used)) public nonceUsed;
 
-    error InvalidAmount();
+    /// @dev Signatures mirror Uniswap's `SignatureVerification` and `SignatureExpired` errors,
+    /// arguments included: a test that pins a revert reason here pins the one the deployed Permit2
+    /// emits, not a mock-only shape.
+    error InvalidAmount(uint256 maxAmount);
     error InvalidNonce();
+    error InvalidContractSignature();
+    error InvalidSigner();
     error InvalidSignature();
     error InvalidSignatureLength();
-    error SignatureExpired();
+    error SignatureExpired(uint256 signatureDeadline);
 
     function DOMAIN_SEPARATOR() public view returns (bytes32) {
         return keccak256(
@@ -48,14 +54,14 @@ contract Permit2Mock {
     )
         external
     {
-        if (block.timestamp > permit.deadline) revert SignatureExpired();
-        if (transferDetails.requestedAmount > permit.permitted.amount) revert InvalidAmount();
+        if (block.timestamp > permit.deadline) revert SignatureExpired(permit.deadline);
+        if (transferDetails.requestedAmount > permit.permitted.amount) {
+            revert InvalidAmount(permit.permitted.amount);
+        }
         if (nonceUsed[owner][permit.nonce]) revert InvalidNonce();
         nonceUsed[owner][permit.nonce] = true;
 
-        if (_recover(hashTypedData(permit, msg.sender), signature) != owner) {
-            revert InvalidSignature();
-        }
+        _verify(hashTypedData(permit, msg.sender), signature, owner);
 
         IERC20(permit.permitted.token)
             .safeTransferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
@@ -81,14 +87,26 @@ contract Permit2Mock {
         return keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
     }
 
-    function _recover(
+    /// @dev Mirrors Permit2's `SignatureVerification.verify`: a claimed signer that has code is
+    /// routed to EIP-1271 with the signature passed through verbatim -- no length is imposed on it,
+    /// so a wallet that authorizes from stored state validates even an empty one. Only an EOA
+    /// signature is required to be 65 bytes.
+    function _verify(
         bytes32 _digest,
-        bytes calldata _signature
+        bytes calldata _signature,
+        address _claimedSigner
     )
         private
-        pure
-        returns (address)
+        view
     {
+        if (_claimedSigner.code.length != 0) {
+            if (
+                IERC1271(_claimedSigner).isValidSignature(_digest, _signature)
+                    != IERC1271.isValidSignature.selector
+            ) revert InvalidContractSignature();
+            return;
+        }
+
         if (_signature.length != 65) revert InvalidSignatureLength();
 
         bytes32 r = bytes32(_signature[0:32]);
@@ -97,6 +115,6 @@ contract Permit2Mock {
 
         address signer = ecrecover(_digest, v, r, s);
         if (signer == address(0)) revert InvalidSignature();
-        return signer;
+        if (signer != _claimedSigner) revert InvalidSigner();
     }
 }

--- a/packages/protocol/test/shared/helpers/Permit2Mock.sol
+++ b/packages/protocol/test/shared/helpers/Permit2Mock.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "src/shared/vault/IPermit2.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IPermit2 } from "src/shared/vault/IPermit2.sol";
 
 /// @notice A faithful stand-in for Uniswap's Permit2 `SignatureTransfer` flow, reproducing its
 /// EIP-712 domain, typehashes and signature checks so tests exercise the real signing scheme.

--- a/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
@@ -8,6 +8,16 @@ import { IPermit2 } from "src/shared/vault/IPermit2.sol";
 
 /// @notice Covers ERC20Vault's approval-free entrypoints: `sendTokenWithPermit` (EIP-2612) and
 /// `sendTokenWithPermit2` (Uniswap Permit2 `SignatureTransfer`).
+/// @dev Records whether `permit` was reached, so the ordering of validation vs. the external call
+/// can be asserted rather than assumed.
+contract PermitCallRecorder {
+    uint256 public permitCalls;
+
+    function permit(address, address, uint256, uint256, uint8, bytes32, bytes32) external {
+        ++permitCalls;
+    }
+}
+
 contract TestERC20VaultPermit is CommonTest {
     uint256 private constant AlicePK = 0x1;
     uint256 private constant BobPK = 0x2;
@@ -379,6 +389,66 @@ contract TestERC20VaultPermit is CommonTest {
         vm.warp(block.timestamp + 91 days);
         vm.prank(deployer);
         eVault.changeBridgedToken(canonical, btoken_);
+    }
+
+    /// @dev The permit is an external call to a caller-chosen address, so an operation that cannot
+    /// proceed must be rejected before the token is ever touched.
+    function test_20Vault_permit_validates_before_calling_the_token() public {
+        PermitCallRecorder recorder = new PermitCallRecorder();
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // A state counter cannot serve here: the revert under test rolls it back, so it reads zero
+        // either way. The cheatcode engine tracks calls independently of state.
+        vm.expectCall(
+            address(recorder),
+            abi.encodeWithSelector(
+                PermitCallRecorder.permit.selector,
+                Alice,
+                address(eVault),
+                uint256(0),
+                deadline,
+                uint8(0),
+                bytes32(0),
+                bytes32(0)
+            ),
+            0
+        );
+
+        vm.prank(Alice);
+        vm.expectRevert(ERC20Vault.VAULT_INVALID_AMOUNT.selector);
+        eVault.sendTokenWithPermit(_op(address(recorder), 0), deadline, 0, bytes32(0), bytes32(0));
+    }
+
+    /// @dev Likewise for a denylisted bridged token: no call to it at all.
+    function test_20Vault_permit_rejects_a_denylisted_token_before_calling_it() public {
+        (address btokenOld, ERC20Vault.CanonicalERC20 memory canonical) = _registerBridgedToken();
+
+        address btokenNew = address(new BridgedERC20(address(eVault)));
+        vm.warp(block.timestamp + 91 days);
+        vm.prank(deployer);
+        eVault.changeBridgedToken(canonical, btokenNew);
+
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // The denylist check must come before the permit, so the denylisted token is never called.
+        vm.expectCall(
+            btokenOld,
+            abi.encodeWithSelector(
+                PermitCallRecorder.permit.selector,
+                Alice,
+                address(eVault),
+                uint256(1 ether),
+                deadline,
+                uint8(0),
+                bytes32(0),
+                bytes32(0)
+            ),
+            0
+        );
+
+        vm.prank(Alice);
+        vm.expectRevert(ERC20Vault.VAULT_BTOKEN_BLACKLISTED.selector);
+        eVault.sendTokenWithPermit(_op(btokenOld, 1 ether), deadline, 0, bytes32(0), bytes32(0));
     }
 
     /// @dev A bridged token that has been migrated away from is denylisted, and must stay

--- a/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
@@ -264,6 +264,43 @@ contract TestERC20VaultPermit is CommonTest {
         assertEq(uint32(IPermit2.permitTransferFrom.selector), uint32(0x30f28b7a));
     }
 
+    /// @dev The selector pins the *types* tuple, but `nonce` and `deadline` are both `uint256`, so
+    /// transposing them leaves the selector unchanged and a self-consistent mock would agree with
+    /// the mistake. This pins the canonical wire order Permit2 decodes -- permitted.token,
+    /// permitted.amount, nonce, deadline -- by inspecting the calldata our interface produces.
+    /// `Permit2Fork.t.sol` proves the same property end-to-end against the deployed contract.
+    function test_20Vault_permit2_encodes_nonce_before_deadline() public {
+        uint256 nonce = 0x1111;
+        uint256 deadline = 0x2222;
+        uint256 amount = 7;
+        address token = address(0xBEEF);
+
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({ token: token, amount: amount }),
+            nonce: nonce,
+            deadline: deadline
+        });
+        IPermit2.SignatureTransferDetails memory details =
+            IPermit2.SignatureTransferDetails({ to: address(0xCAFE), requestedAmount: amount });
+
+        bytes memory cd = abi.encodeCall(
+            IPermit2.permitTransferFrom, (permit, details, address(0xD00D), hex"00")
+        );
+
+        // PermitTransferFrom is fully static, so it is inlined in the calldata head.
+        assertEq(_word(cd, 0), uint256(uint160(token)));
+        assertEq(_word(cd, 1), amount);
+        assertEq(_word(cd, 2), nonce);
+        assertEq(_word(cd, 3), deadline);
+    }
+
+    /// @dev Reads the `_i`th 32-byte word of `_cd` after its 4-byte selector.
+    function _word(bytes memory _cd, uint256 _i) private pure returns (uint256 w_) {
+        assembly {
+            w_ := mload(add(_cd, add(36, mul(_i, 32))))
+        }
+    }
+
     /// @dev A call to a codeless address cannot be allowed to look like a successful pull. Solidity
     /// emits an extcodesize check for an external call with no return value, so this reverts rather
     /// than silently transferring nothing and bridging a zero balance change.

--- a/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../helpers/FreeMintERC20TokenWithPermit.sol";
+import "../helpers/Permit2Mock.sol";
+import "./ERC20Vault.h.sol";
+
+/// @notice Covers ERC20Vault's approval-free entrypoints: `sendTokenWithPermit` (EIP-2612) and
+/// `sendTokenWithPermit2` (Uniswap Permit2 `SignatureTransfer`).
+contract TestERC20VaultPermit is CommonTest {
+    uint256 private constant AlicePK = 0x1;
+    uint256 private constant BobPK = 0x2;
+
+    SignalService private eSignalService;
+    Bridge private eBridge;
+    ERC20Vault private eVault;
+    FreeMintERC20TokenWithPermit private eToken;
+
+    // Cached because reading `eVault.PERMIT2()` inline would consume a pending `vm.prank`.
+    address private permit2;
+
+    function setUpOnEthereum() internal override {
+        eSignalService = deploySignalServiceWithoutProof(
+            address(this),
+            address(
+                uint160(uint256(keccak256(abi.encodePacked(bytes32("ETH"), "_REMOTE_SIGNAL"))))
+            ),
+            deployer
+        );
+        eBridge = deployBridge(
+            address(new Bridge(address(resolver), address(eSignalService), address(0), address(0)))
+        );
+        eVault = deployERC20Vault();
+
+        eToken = new FreeMintERC20TokenWithPermit("ERC20Permit", "E20P");
+        eToken.mint(Alice);
+
+        register("bridged_erc20", address(new BridgedERC20(address(eVault))));
+
+        // Place the mock's runtime code at Permit2's canonical address, which is what the vault
+        // calls. The mock derives its domain separator from `address(this)`, so it stays valid.
+        permit2 = eVault.PERMIT2();
+        vm.etch(permit2, address(new Permit2Mock()).code);
+
+        vm.deal(Alice, 1 ether);
+    }
+
+    function setUpOnTaiko() internal override {
+        // `sendToken*` needs a destination-chain vault to address the message to, and Bridge
+        // rejects a destination chain that has no registered bridge.
+        deployERC20Vault();
+        register("bridge", address(new PrankDestBridge(eVault)));
+    }
+
+    function _op(uint256 _amount) private view returns (ERC20Vault.BridgeTransferOp memory) {
+        return ERC20Vault.BridgeTransferOp({
+            destChainId: taikoChainId,
+            destOwner: address(0),
+            to: Bob,
+            fee: 0,
+            token: address(eToken),
+            gasLimit: 1_000_000,
+            amount: _amount
+        });
+    }
+
+    function _signPermit2(
+        uint256 _pk,
+        uint256 _amount,
+        uint256 _nonce,
+        uint256 _deadline,
+        address _spender
+    )
+        private
+        view
+        returns (bytes memory)
+    {
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({ token: address(eToken), amount: _amount }),
+            nonce: _nonce,
+            deadline: _deadline
+        });
+        bytes32 digest = Permit2Mock(permit2).hashTypedData(permit, _spender);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _signPermit(
+        uint256 _pk,
+        address _owner,
+        uint256 _amount,
+        uint256 _deadline
+    )
+        private
+        view
+        returns (uint8 v, bytes32 r, bytes32 s)
+    {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                keccak256(
+                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+                ),
+                _owner,
+                address(eVault),
+                _amount,
+                eToken.nonces(_owner),
+                _deadline
+            )
+        );
+        bytes32 digest =
+            keccak256(abi.encodePacked("\x19\x01", eToken.DOMAIN_SEPARATOR(), structHash));
+        return vm.sign(_pk, digest);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Permit2
+    // ---------------------------------------------------------------------------------------
+
+    function test_20Vault_permit2_bridges_without_a_prior_vault_approval() public {
+        uint256 amount = 3 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // Alice approves Permit2 once, and never approves the vault itself.
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+        assertEq(eToken.allowance(Alice, address(eVault)), 0);
+
+        uint256 aliceBefore = eToken.balanceOf(Alice);
+        uint256 vaultBefore = eToken.balanceOf(address(eVault));
+
+        bytes memory sig = _signPermit2(AlicePK, amount, 0, deadline, address(eVault));
+
+        vm.prank(Alice);
+        eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
+
+        assertEq(eToken.balanceOf(Alice), aliceBefore - amount);
+        assertEq(eToken.balanceOf(address(eVault)), vaultBefore + amount);
+        // The vault still holds no standing allowance from Alice.
+        assertEq(eToken.allowance(Alice, address(eVault)), 0);
+    }
+
+    /// @dev The signer must remain the message's `srcOwner`, because `onMessageRecalled` refunds
+    /// tokens to `srcOwner`. If this ever drifts to a non-signer, a failed bridge would refund the
+    /// wrong address.
+    function test_20Vault_permit2_keeps_the_signer_as_the_recall_refund_owner() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+
+        bytes memory sig = _signPermit2(AlicePK, amount, 7, deadline, address(eVault));
+
+        vm.prank(Alice);
+        IBridge.Message memory message = eVault.sendTokenWithPermit2(_op(amount), 7, deadline, sig);
+
+        assertEq(message.srcOwner, Alice);
+        assertEq(message.destOwner, Alice);
+    }
+
+    function test_20Vault_permit2_reverts_on_an_empty_signature() public {
+        vm.prank(Alice);
+        vm.expectRevert(ERC20Vault.VAULT_INVALID_PERMIT2_SIG.selector);
+        eVault.sendTokenWithPermit2(_op(1 ether), 0, block.timestamp + 1 hours, "");
+    }
+
+    function test_20Vault_permit2_reverts_when_the_nonce_is_replayed() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+
+        bytes memory sig = _signPermit2(AlicePK, amount, 42, deadline, address(eVault));
+
+        vm.prank(Alice);
+        eVault.sendTokenWithPermit2(_op(amount), 42, deadline, sig);
+
+        vm.prank(Alice);
+        vm.expectRevert(Permit2Mock.InvalidNonce.selector);
+        eVault.sendTokenWithPermit2(_op(amount), 42, deadline, sig);
+    }
+
+    function test_20Vault_permit2_reverts_when_the_signature_is_not_the_callers() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+
+        // Bob signs, Alice submits: Permit2 recovers Bob but is told the owner is Alice.
+        bytes memory sig = _signPermit2(BobPK, amount, 0, deadline, address(eVault));
+
+        vm.prank(Alice);
+        vm.expectRevert(Permit2Mock.InvalidSignature.selector);
+        eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
+    }
+
+    function test_20Vault_permit2_reverts_when_the_signature_names_another_spender() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+
+        // Signed for Carol as spender; the vault redeems it, so the digest will not match.
+        bytes memory sig = _signPermit2(AlicePK, amount, 0, deadline, Carol);
+
+        vm.prank(Alice);
+        vm.expectRevert(Permit2Mock.InvalidSignature.selector);
+        eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
+    }
+
+    function test_20Vault_permit2_reverts_after_the_deadline() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+
+        bytes memory sig = _signPermit2(AlicePK, amount, 0, deadline, address(eVault));
+
+        vm.warp(deadline + 1);
+
+        vm.prank(Alice);
+        vm.expectRevert(Permit2Mock.SignatureExpired.selector);
+        eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // EIP-2612
+    // ---------------------------------------------------------------------------------------
+
+    function test_20Vault_permit_bridges_without_a_prior_vault_approval() public {
+        uint256 amount = 4 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        assertEq(eToken.allowance(Alice, address(eVault)), 0);
+
+        uint256 aliceBefore = eToken.balanceOf(Alice);
+        uint256 vaultBefore = eToken.balanceOf(address(eVault));
+
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(AlicePK, Alice, amount, deadline);
+
+        vm.prank(Alice);
+        eVault.sendTokenWithPermit(_op(amount), deadline, v, r, s);
+
+        assertEq(eToken.balanceOf(Alice), aliceBefore - amount);
+        assertEq(eToken.balanceOf(address(eVault)), vaultBefore + amount);
+    }
+
+    function test_20Vault_permit_keeps_the_signer_as_the_recall_refund_owner() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(AlicePK, Alice, amount, deadline);
+
+        vm.prank(Alice);
+        IBridge.Message memory message = eVault.sendTokenWithPermit(_op(amount), deadline, v, r, s);
+
+        assertEq(message.srcOwner, Alice);
+        assertEq(message.destOwner, Alice);
+    }
+
+    /// @dev A griefer can replay the permit straight at the token to burn the nonce. The vault must
+    /// still bridge, because the allowance the permit granted is already in place.
+    function test_20Vault_permit_tolerates_a_front_run_permit() public {
+        uint256 amount = 2 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(AlicePK, Alice, amount, deadline);
+
+        // Carol front-runs, consuming Alice's permit nonce and setting the allowance.
+        vm.prank(Carol);
+        eToken.permit(Alice, address(eVault), amount, deadline, v, r, s);
+        assertEq(eToken.allowance(Alice, address(eVault)), amount);
+
+        uint256 aliceBefore = eToken.balanceOf(Alice);
+
+        vm.prank(Alice);
+        eVault.sendTokenWithPermit(_op(amount), deadline, v, r, s);
+
+        assertEq(eToken.balanceOf(Alice), aliceBefore - amount);
+    }
+
+    /// @dev A swallowed permit failure must not mask a genuinely missing allowance.
+    function test_20Vault_permit_reverts_when_the_permit_is_invalid_and_no_allowance_exists()
+        public
+    {
+        uint256 amount = 2 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // Bob's signature is not valid for Alice, and Alice never approved the vault.
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BobPK, Alice, amount, deadline);
+
+        vm.prank(Alice);
+        vm.expectRevert("ERC20: insufficient allowance");
+        eVault.sendTokenWithPermit(_op(amount), deadline, v, r, s);
+    }
+}

--- a/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "../helpers/FreeMintERC20TokenWithPermit.sol";
-import "../helpers/Permit2Mock.sol";
+import { FreeMintERC20TokenWithPermit } from "../helpers/FreeMintERC20TokenWithPermit.sol";
+import { Permit2Mock } from "../helpers/Permit2Mock.sol";
 import "./ERC20Vault.h.sol";
+import { IPermit2 } from "src/shared/vault/IPermit2.sol";
 
 /// @notice Covers ERC20Vault's approval-free entrypoints: `sendTokenWithPermit` (EIP-2612) and
 /// `sendTokenWithPermit2` (Uniswap Permit2 `SignatureTransfer`).

--- a/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.24;
 import { FreeMintERC20TokenWithPermit } from "../helpers/FreeMintERC20TokenWithPermit.sol";
 import { Permit2Mock } from "../helpers/Permit2Mock.sol";
 import "./ERC20Vault.h.sol";
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import { IPermit2 } from "src/shared/vault/IPermit2.sol";
 
 /// @notice Covers ERC20Vault's approval-free entrypoints: `sendTokenWithPermit` (EIP-2612) and
@@ -15,6 +18,87 @@ contract PermitCallRecorder {
 
     function permit(address, address, uint256, uint256, uint8, bytes32, bytes32) external {
         ++permitCalls;
+    }
+}
+
+/// @notice An ERC20 whose fallback silently accepts unknown selectors, which is what WETH9 does.
+/// @dev `permit` therefore neither reverts nor grants anything: the vault's `try` takes its success
+/// branch with the allowance untouched. This is the shape the repo's reverting WETH9 mock cannot
+/// reproduce, and the reason the allowance is checked rather than the call's outcome.
+contract SilentPermitToken is ERC20 {
+    constructor() ERC20("Silent", "SLNT") {
+        _mint(msg.sender, 100 ether);
+    }
+
+    fallback() external payable { }
+    receive() external payable { }
+}
+
+/// @notice A token whose `permit` re-enters `sendTokenWithPermit`, so `nonReentrant` is exercised.
+/// @dev The reentrant call bridges the token's *own* balance against an allowance it grants itself,
+/// so without the guard it would complete a second full bridge. The guard's revert is swallowed by
+/// the outer `catch {}`, which is exactly why the assertion has to be on tokens moved rather than on
+/// the revert reason.
+contract ReenteringPermitToken is ERC20 {
+    ERC20Vault public immutable vault;
+    ERC20Vault.BridgeTransferOp private op;
+
+    constructor(ERC20Vault _vault) ERC20("Reenter", "RNTR") {
+        vault = _vault;
+        _mint(msg.sender, 100 ether);
+    }
+
+    function arm(ERC20Vault.BridgeTransferOp calldata _op) external {
+        op = _op;
+        _mint(address(this), _op.amount);
+        _approve(address(this), address(vault), type(uint256).max);
+    }
+
+    function permit(address, address, uint256, uint256, uint8, bytes32, bytes32) external {
+        ERC20Vault.BridgeTransferOp memory reentrant = op;
+        reentrant.token = address(this);
+        vault.sendTokenWithPermit(reentrant, block.timestamp + 1 hours, 0, bytes32(0), bytes32(0));
+    }
+}
+
+/// @notice A token whose `transferFrom` re-enters `sendTokenWithPermit2`.
+/// @dev Nothing catches on that path, so the guard's revert propagates and can be asserted directly.
+contract ReenteringPermit2Token is ERC20 {
+    ERC20Vault public immutable vault;
+    ERC20Vault.BridgeTransferOp private op;
+
+    constructor(ERC20Vault _vault) ERC20("Reenter2", "RNTR2") {
+        vault = _vault;
+        _mint(msg.sender, 100 ether);
+    }
+
+    function arm(ERC20Vault.BridgeTransferOp calldata _op) external {
+        op = _op;
+    }
+
+    function transferFrom(address, address, uint256) public override returns (bool) {
+        vault.sendTokenWithPermit2(op, 0, block.timestamp + 1 hours, "");
+        return true;
+    }
+}
+
+/// @notice A smart-contract wallet that authorizes a pre-approved digest from stored state.
+/// @dev Signature bytes are irrelevant to it, empty included -- the Safe `signMessage` shape. Real
+/// Permit2 routes a signer with code straight to `isValidSignature`, so the vault must not impose a
+/// length of its own or this wallet cannot bridge.
+contract PreApprovingWallet is IERC1271 {
+    mapping(bytes32 digest => bool approved) public approvedHashes;
+
+    function approveHash(bytes32 _digest) external {
+        approvedHashes[_digest] = true;
+    }
+
+    function approve(address _token, address _spender, uint256 _amount) external {
+        IERC20(_token).approve(_spender, _amount);
+    }
+
+    function isValidSignature(bytes32 _hash, bytes memory) external view returns (bytes4) {
+        return approvedHashes[_hash] ? IERC1271.isValidSignature.selector : bytes4(0xffffffff);
     }
 }
 
@@ -132,6 +216,21 @@ contract TestERC20VaultPermit is CommonTest {
         view
         returns (uint8 v, bytes32 r, bytes32 s)
     {
+        return _signPermitFor(_pk, address(eToken), _owner, _amount, _deadline);
+    }
+
+    /// @dev Same, for any EIP-2612 token -- `BridgedERC20V2` carries its own domain separator.
+    function _signPermitFor(
+        uint256 _pk,
+        address _token,
+        address _owner,
+        uint256 _amount,
+        uint256 _deadline
+    )
+        private
+        view
+        returns (uint8 v, bytes32 r, bytes32 s)
+    {
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
@@ -140,12 +239,13 @@ contract TestERC20VaultPermit is CommonTest {
                 _owner,
                 address(eVault),
                 _amount,
-                eToken.nonces(_owner),
+                IERC20Permit(_token).nonces(_owner),
                 _deadline
             )
         );
-        bytes32 digest =
-            keccak256(abi.encodePacked("\x19\x01", eToken.DOMAIN_SEPARATOR(), structHash));
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", IERC20Permit(_token).DOMAIN_SEPARATOR(), structHash)
+        );
         return vm.sign(_pk, digest);
     }
 
@@ -188,17 +288,70 @@ contract TestERC20VaultPermit is CommonTest {
 
         bytes memory sig = _signPermit2(AlicePK, amount, 7, deadline, address(eVault));
 
+        // A distinct `destOwner` is the whole point: with the default `address(0)` both `srcOwner`
+        // and the `destOwner` fallback resolve to `msg.sender`, so sourcing `srcOwner` from the
+        // wrong field would still pass.
+        ERC20Vault.BridgeTransferOp memory op = _op(amount);
+        op.destOwner = Carol;
+
         vm.prank(Alice);
-        IBridge.Message memory message = eVault.sendTokenWithPermit2(_op(amount), 7, deadline, sig);
+        IBridge.Message memory message = eVault.sendTokenWithPermit2(op, 7, deadline, sig);
 
         assertEq(message.srcOwner, Alice);
-        assertEq(message.destOwner, Alice);
+        assertEq(message.destOwner, Carol);
     }
 
-    function test_20Vault_permit2_reverts_on_an_empty_signature() public {
+    /// @dev The vault imposes no length on the signature; Permit2 decides. For an EOA that means
+    /// Permit2's own `InvalidSignatureLength`, so a vault-side guard would add nothing here -- and
+    /// would break the contract-signer case below, which is why there is none.
+    function test_20Vault_permit2_leaves_an_empty_eoa_signature_to_permit2() public {
         vm.prank(Alice);
-        vm.expectRevert(ERC20Vault.VAULT_INVALID_PERMIT2_SIG.selector);
+        vm.expectRevert(Permit2Mock.InvalidSignatureLength.selector);
         eVault.sendTokenWithPermit2(_op(1 ether), 0, block.timestamp + 1 hours, "");
+    }
+
+    /// @dev Real Permit2 routes a claimed signer that has code straight to
+    /// `IERC1271.isValidSignature` with the signature passed through verbatim, so a wallet that
+    /// authorizes from stored state (a pre-approved hash, as Safe's `signMessage` produces)
+    /// validates an empty signature and transfers. A vault-side length guard would reject this
+    /// documented flow before Permit2 ever saw it.
+    function test_20Vault_permit2_bridges_for_a_contract_wallet_with_an_empty_signature() public {
+        PreApprovingWallet wallet = new PreApprovingWallet();
+
+        uint256 amount = 2 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        eToken.mint(address(wallet));
+        wallet.approve(address(eToken), permit2, type(uint256).max);
+
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({ token: address(eToken), amount: amount }),
+            nonce: 0,
+            deadline: deadline
+        });
+        wallet.approveHash(Permit2Mock(permit2).hashTypedData(permit, address(eVault)));
+
+        uint256 walletBefore = eToken.balanceOf(address(wallet));
+        uint256 vaultBefore = eToken.balanceOf(address(eVault));
+
+        vm.prank(address(wallet));
+        eVault.sendTokenWithPermit2(_op(amount), 0, deadline, "");
+
+        assertEq(eToken.balanceOf(address(wallet)), walletBefore - amount);
+        assertEq(eToken.balanceOf(address(eVault)), vaultBefore + amount);
+    }
+
+    /// @dev The same wallet without the digest approved is rejected -- the empty signature is not a
+    /// bearer instrument, it is only as good as what `isValidSignature` says about it.
+    function test_20Vault_permit2_reverts_for_a_contract_wallet_that_did_not_approve() public {
+        PreApprovingWallet wallet = new PreApprovingWallet();
+
+        eToken.mint(address(wallet));
+        wallet.approve(address(eToken), permit2, type(uint256).max);
+
+        vm.prank(address(wallet));
+        vm.expectRevert(Permit2Mock.InvalidContractSignature.selector);
+        eVault.sendTokenWithPermit2(_op(2 ether), 0, block.timestamp + 1 hours, "");
     }
 
     function test_20Vault_permit2_reverts_when_the_nonce_is_replayed() public {
@@ -229,7 +382,7 @@ contract TestERC20VaultPermit is CommonTest {
         bytes memory sig = _signPermit2(BobPK, amount, 0, deadline, address(eVault));
 
         vm.prank(Alice);
-        vm.expectRevert(Permit2Mock.InvalidSignature.selector);
+        vm.expectRevert(Permit2Mock.InvalidSigner.selector);
         eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
     }
 
@@ -240,11 +393,12 @@ contract TestERC20VaultPermit is CommonTest {
         vm.prank(Alice);
         eToken.approve(permit2, type(uint256).max);
 
-        // Signed for Carol as spender; the vault redeems it, so the digest will not match.
+        // Signed for Carol as spender; the vault redeems it, so the digest will not match and
+        // recovery lands on some other address.
         bytes memory sig = _signPermit2(AlicePK, amount, 0, deadline, Carol);
 
         vm.prank(Alice);
-        vm.expectRevert(Permit2Mock.InvalidSignature.selector);
+        vm.expectRevert(Permit2Mock.InvalidSigner.selector);
         eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
     }
 
@@ -260,8 +414,16 @@ contract TestERC20VaultPermit is CommonTest {
         vm.warp(deadline + 1);
 
         vm.prank(Alice);
-        vm.expectRevert(Permit2Mock.SignatureExpired.selector);
+        vm.expectRevert(abi.encodeWithSelector(Permit2Mock.SignatureExpired.selector, deadline));
         eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
+    }
+
+    /// @dev Every other test in this file etches the mock at whatever `eVault.PERMIT2()` returns,
+    /// so none of them would notice the constant being wrong. This pins the literal: Permit2's
+    /// address is CREATE2-derived from `(factory, salt, initcode hash)`, none of which vary by
+    /// chain, so it is the same on every chain the vault is deployed to.
+    function test_20Vault_permit2_uses_the_canonical_permit2_address() public view {
+        assertEq(eVault.PERMIT2(), 0x000000000022D473030F116dDEE9F6B43aC78BA3);
     }
 
     /// @dev Pins the Permit2 interface to the selector actually present in the canonical deployed
@@ -329,8 +491,11 @@ contract TestERC20VaultPermit is CommonTest {
         // Simulate a chain where Permit2 was never deployed.
         vm.etch(permit2, "");
 
+        // `bytes("")` rather than a bare `expectRevert()`: it matches only the empty revert an
+        // extcodesize check produces, so replacing that mechanism with anything that reverts for a
+        // different reason fails here.
         vm.prank(Alice);
-        vm.expectRevert();
+        vm.expectRevert(bytes(""));
         eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
 
         // Nothing moved: the call did not silently succeed.
@@ -340,8 +505,12 @@ contract TestERC20VaultPermit is CommonTest {
 
     /// @dev `_pullTokens` is reached from both branches of `_handleMessage`. The canonical branch
     /// locks and measures a balance delta; this is the other one -- the bridged "transfer and
-    /// burn" path -- where the pull is followed by `burn`, so a short pull would revert rather
-    /// than silently under-bridge.
+    /// burn" path, where the pull is followed by `burn(_op.amount)` and the full `_op.amount` is
+    /// bridged without measuring what actually arrived. Note that `burn` takes from the vault's own
+    /// balance, so a short pull of a bridged token over-credits the destination rather than
+    /// reverting. That is pre-existing and reachable only for a fee-on-transfer bridged token,
+    /// which is DAO-gated via `changeBridgedToken`; measuring the delta here is not the fix,
+    /// because the canonical branch tolerates short pulls by design.
     function test_20Vault_permit2_bridges_a_bridged_token_via_transfer_and_burn() public {
         (address btoken,) = _registerBridgedToken();
 
@@ -507,11 +676,16 @@ contract TestERC20VaultPermit is CommonTest {
 
         (uint8 v, bytes32 r, bytes32 s) = _signPermit(AlicePK, Alice, amount, deadline);
 
+        // See the Permit2 counterpart: `destOwner` must differ from the caller for this to have
+        // any teeth.
+        ERC20Vault.BridgeTransferOp memory op = _op(amount);
+        op.destOwner = Carol;
+
         vm.prank(Alice);
-        IBridge.Message memory message = eVault.sendTokenWithPermit(_op(amount), deadline, v, r, s);
+        IBridge.Message memory message = eVault.sendTokenWithPermit(op, deadline, v, r, s);
 
         assertEq(message.srcOwner, Alice);
-        assertEq(message.destOwner, Alice);
+        assertEq(message.destOwner, Carol);
     }
 
     /// @dev A griefer can replay the permit straight at the token to burn the nonce. The vault must
@@ -546,7 +720,239 @@ contract TestERC20VaultPermit is CommonTest {
         (uint8 v, bytes32 r, bytes32 s) = _signPermit(BobPK, Alice, amount, deadline);
 
         vm.prank(Alice);
-        vm.expectRevert("ERC20: insufficient allowance");
+        vm.expectRevert(ERC20Vault.VAULT_PERMIT_NO_ALLOWANCE.selector);
         eVault.sendTokenWithPermit(_op(amount), deadline, v, r, s);
+    }
+
+    /// @dev The case the `try/catch` alone cannot see: a token whose fallback silently accepts
+    /// unknown selectors takes the *success* branch with the allowance still zero. WETH9 is exactly
+    /// this shape and is one of the quota-capped vault tokens, so the failure must be decodable
+    /// rather than a generic `SafeERC20` string from deep inside the pull.
+    function test_20Vault_permit_reverts_when_permit_silently_grants_nothing() public {
+        SilentPermitToken silent = new SilentPermitToken();
+        assertTrue(silent.transfer(Alice, 10 ether));
+
+        uint256 amount = 2 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // The call succeeds and grants nothing, so only the allowance distinguishes the outcome.
+        assertEq(silent.allowance(Alice, address(eVault)), 0);
+
+        vm.prank(Alice);
+        vm.expectRevert(ERC20Vault.VAULT_PERMIT_NO_ALLOWANCE.selector);
+        eVault.sendTokenWithPermit(
+            _op(address(silent), amount), deadline, 0, bytes32(0), bytes32(0)
+        );
+    }
+
+    /// @dev The allowance check must not undo the front-run tolerance: a standing allowance is a
+    /// legitimate basis to bridge on, whoever set it. Same token, same failed permit, allowance
+    /// present -- and it goes through.
+    function test_20Vault_permit_bridges_on_a_standing_allowance_when_permit_grants_nothing()
+        public
+    {
+        SilentPermitToken silent = new SilentPermitToken();
+        assertTrue(silent.transfer(Alice, 10 ether));
+
+        uint256 amount = 2 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        silent.approve(address(eVault), amount);
+
+        uint256 aliceBefore = silent.balanceOf(Alice);
+        uint256 vaultBefore = silent.balanceOf(address(eVault));
+
+        vm.prank(Alice);
+        eVault.sendTokenWithPermit(
+            _op(address(silent), amount), deadline, 0, bytes32(0), bytes32(0)
+        );
+
+        assertEq(silent.balanceOf(Alice), aliceBefore - amount);
+        assertEq(silent.balanceOf(address(eVault)), vaultBefore + amount);
+    }
+
+    /// @dev EIP-2612 through the bridged "transfer and burn" branch. `BridgedERC20` has no `permit`,
+    /// so this needs a `BridgedERC20V2`; without it the burn branch is covered for Permit2 only.
+    function test_20Vault_permit_bridges_a_bridged_token_via_transfer_and_burn() public {
+        (BridgedERC20V2 btoken,) = _registerBridgedTokenV2();
+
+        vm.prank(address(eVault));
+        btoken.mint(Alice, 10 ether);
+
+        uint256 amount = 3 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        assertEq(btoken.allowance(Alice, address(eVault)), 0);
+
+        (uint8 v, bytes32 r, bytes32 s) =
+            _signPermitFor(AlicePK, address(btoken), Alice, amount, deadline);
+
+        uint256 supplyBefore = btoken.totalSupply();
+
+        vm.prank(Alice);
+        IBridge.Message memory message =
+            eVault.sendTokenWithPermit(_op(address(btoken), amount), deadline, v, r, s);
+
+        assertEq(btoken.balanceOf(Alice), 10 ether - amount);
+        assertEq(btoken.totalSupply(), supplyBefore - amount);
+        assertEq(btoken.balanceOf(address(eVault)), 0);
+        assertEq(message.srcOwner, Alice);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Modifiers, fee and value
+    // ---------------------------------------------------------------------------------------
+
+    function test_20Vault_permit_reverts_when_paused() public {
+        vm.prank(deployer);
+        eVault.pause();
+
+        vm.prank(Alice);
+        vm.expectRevert(EssentialContract.INVALID_PAUSE_STATUS.selector);
+        eVault.sendTokenWithPermit(
+            _op(1 ether), block.timestamp + 1 hours, 0, bytes32(0), bytes32(0)
+        );
+    }
+
+    function test_20Vault_permit2_reverts_when_paused() public {
+        vm.prank(deployer);
+        eVault.pause();
+
+        vm.prank(Alice);
+        vm.expectRevert(EssentialContract.INVALID_PAUSE_STATUS.selector);
+        eVault.sendTokenWithPermit2(_op(1 ether), 0, block.timestamp + 1 hours, "");
+    }
+
+    /// @dev `nonReentrant` is load-bearing on `sendTokenWithPermit`: `permit` hands execution to a
+    /// caller-chosen address before the pull. The guard's revert is swallowed by the surrounding
+    /// `catch {}`, so the observable consequence is what is asserted -- the reentrant bridge moves
+    /// no tokens. Drop the modifier and the vault receives `2 * amount` instead.
+    function test_20Vault_permit_blocks_a_reentrant_bridge() public {
+        ReenteringPermitToken token = new ReenteringPermitToken(eVault);
+        assertTrue(token.transfer(Alice, 10 ether));
+
+        uint256 amount = 1 ether;
+        token.arm(_op(address(token), amount));
+
+        vm.prank(Alice);
+        token.approve(address(eVault), amount);
+
+        uint256 aliceBefore = token.balanceOf(Alice);
+        uint256 tokenBefore = token.balanceOf(address(token));
+
+        // The reentrant call is attempted -- the guard is what stops it, not a missing call.
+        vm.expectCall(
+            address(eVault), abi.encodeWithSelector(ERC20Vault.sendTokenWithPermit.selector), 2
+        );
+
+        vm.prank(Alice);
+        eVault.sendTokenWithPermit(
+            _op(address(token), amount), block.timestamp + 1 hours, 0, bytes32(0), bytes32(0)
+        );
+
+        // Only Alice's bridge went through; the token's own armed balance is untouched.
+        assertEq(token.balanceOf(Alice), aliceBefore - amount);
+        assertEq(token.balanceOf(address(token)), tokenBefore);
+        assertEq(token.balanceOf(address(eVault)), amount);
+    }
+
+    /// @dev Nothing catches on the Permit2 path, so there the guard's revert is directly observable.
+    function test_20Vault_permit2_reverts_on_reentrancy() public {
+        ReenteringPermit2Token token = new ReenteringPermit2Token(eVault);
+        assertTrue(token.transfer(Alice, 10 ether));
+
+        uint256 amount = 1 ether;
+        token.arm(_op(address(token), amount));
+
+        vm.prank(Alice);
+        token.approve(permit2, type(uint256).max);
+
+        bytes memory sig = _signPermit2(
+            AlicePK, address(token), amount, 0, block.timestamp + 1 hours, address(eVault)
+        );
+
+        vm.prank(Alice);
+        vm.expectRevert(EssentialContract.REENTRANT_CALL.selector);
+        eVault.sendTokenWithPermit2(_op(address(token), amount), 0, block.timestamp + 1 hours, sig);
+    }
+
+    function test_20Vault_permit_reverts_when_value_is_below_the_fee() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        ERC20Vault.BridgeTransferOp memory op = _op(amount);
+        op.fee = 1000;
+
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(AlicePK, Alice, amount, deadline);
+
+        vm.prank(Alice);
+        vm.expectRevert(BaseVault.VAULT_INSUFFICIENT_FEE.selector);
+        eVault.sendTokenWithPermit{ value: 999 }(op, deadline, v, r, s);
+    }
+
+    function test_20Vault_permit2_reverts_when_value_is_below_the_fee() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+
+        ERC20Vault.BridgeTransferOp memory op = _op(amount);
+        op.fee = 1000;
+
+        bytes memory sig = _signPermit2(AlicePK, amount, 0, deadline, address(eVault));
+
+        vm.prank(Alice);
+        vm.expectRevert(BaseVault.VAULT_INSUFFICIENT_FEE.selector);
+        eVault.sendTokenWithPermit2{ value: 999 }(op, 0, deadline, sig);
+    }
+
+    /// @dev The value path end to end: `msg.value - fee` becomes the message value and the fee is
+    /// carried on the message, exactly as `sendToken` does it.
+    function test_20Vault_permit2_carries_value_and_fee_onto_the_message() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+
+        ERC20Vault.BridgeTransferOp memory op = _op(amount);
+        op.fee = 1000;
+
+        bytes memory sig = _signPermit2(AlicePK, amount, 0, deadline, address(eVault));
+
+        vm.prank(Alice);
+        IBridge.Message memory message =
+            eVault.sendTokenWithPermit2{ value: 5000 }(op, 0, deadline, sig);
+
+        assertEq(message.fee, 1000);
+        assertEq(message.value, 4000);
+    }
+
+    /// @dev Registers a `BridgedERC20V2`, which unlike `BridgedERC20` implements EIP-2612.
+    function _registerBridgedTokenV2()
+        private
+        returns (BridgedERC20V2 btoken_, ERC20Vault.CanonicalERC20 memory canonical_)
+    {
+        FreeMintERC20TokenWithPermit origin = new FreeMintERC20TokenWithPermit("ORIGV2", "ORIGV2");
+
+        canonical_ = ERC20Vault.CanonicalERC20({
+            chainId: 999, addr: address(origin), decimals: 18, symbol: "ORIGV2", name: "ORIGV2"
+        });
+
+        btoken_ = BridgedERC20V2(
+            deploy({
+                name: "",
+                impl: address(new BridgedERC20V2(address(eVault))),
+                data: abi.encodeCall(
+                    BridgedERC20V2.init, (deployer, address(origin), 999, 18, "ORIGV2", "ORIGV2")
+                )
+            })
+        );
+
+        vm.warp(block.timestamp + 91 days);
+        vm.prank(deployer);
+        eVault.changeBridgedToken(canonical_, address(btoken_));
     }
 }

--- a/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_permit.t.sol
@@ -54,12 +54,23 @@ contract TestERC20VaultPermit is CommonTest {
     }
 
     function _op(uint256 _amount) private view returns (ERC20Vault.BridgeTransferOp memory) {
+        return _op(address(eToken), _amount);
+    }
+
+    function _op(
+        address _token,
+        uint256 _amount
+    )
+        private
+        view
+        returns (ERC20Vault.BridgeTransferOp memory)
+    {
         return ERC20Vault.BridgeTransferOp({
             destChainId: taikoChainId,
             destOwner: address(0),
             to: Bob,
             fee: 0,
-            token: address(eToken),
+            token: _token,
             gasLimit: 1_000_000,
             amount: _amount
         });
@@ -76,8 +87,23 @@ contract TestERC20VaultPermit is CommonTest {
         view
         returns (bytes memory)
     {
+        return _signPermit2(_pk, address(eToken), _amount, _nonce, _deadline, _spender);
+    }
+
+    function _signPermit2(
+        uint256 _pk,
+        address _token,
+        uint256 _amount,
+        uint256 _nonce,
+        uint256 _deadline,
+        address _spender
+    )
+        private
+        view
+        returns (bytes memory)
+    {
         IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
-            permitted: IPermit2.TokenPermissions({ token: address(eToken), amount: _amount }),
+            permitted: IPermit2.TokenPermissions({ token: _token, amount: _amount }),
             nonce: _nonce,
             deadline: _deadline
         });
@@ -226,6 +252,124 @@ contract TestERC20VaultPermit is CommonTest {
         vm.prank(Alice);
         vm.expectRevert(Permit2Mock.SignatureExpired.selector);
         eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
+    }
+
+    /// @dev Pins the Permit2 interface to the selector actually present in the canonical deployed
+    /// Permit2. Uniswap's `PermitTransferFrom` has no `spender` member -- the spender is bound
+    /// into the EIP-712 typehash as `msg.sender` -- so adding one would silently change this
+    /// selector and make the vault call a function that does not exist on the real contract.
+    /// 0x30f28b7a is the selector found in Permit2's dispatcher at
+    /// 0x000000000022D473030F116dDEE9F6B43aC78BA3 on Ethereum mainnet and Taiko Alethia.
+    function test_20Vault_permit2_interface_matches_canonical_permit2_selector() public {
+        assertEq(uint32(IPermit2.permitTransferFrom.selector), uint32(0x30f28b7a));
+    }
+
+    /// @dev A call to a codeless address cannot be allowed to look like a successful pull. Solidity
+    /// emits an extcodesize check for an external call with no return value, so this reverts rather
+    /// than silently transferring nothing and bridging a zero balance change.
+    function test_20Vault_permit2_reverts_when_permit2_has_no_code() public {
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        eToken.approve(permit2, type(uint256).max);
+
+        bytes memory sig = _signPermit2(AlicePK, amount, 0, deadline, address(eVault));
+
+        uint256 aliceBefore = eToken.balanceOf(Alice);
+        uint256 vaultBefore = eToken.balanceOf(address(eVault));
+
+        // Simulate a chain where Permit2 was never deployed.
+        vm.etch(permit2, "");
+
+        vm.prank(Alice);
+        vm.expectRevert();
+        eVault.sendTokenWithPermit2(_op(amount), 0, deadline, sig);
+
+        // Nothing moved: the call did not silently succeed.
+        assertEq(eToken.balanceOf(Alice), aliceBefore);
+        assertEq(eToken.balanceOf(address(eVault)), vaultBefore);
+    }
+
+    /// @dev `_pullTokens` is reached from both branches of `_handleMessage`. The canonical branch
+    /// locks and measures a balance delta; this is the other one -- the bridged "transfer and
+    /// burn" path -- where the pull is followed by `burn`, so a short pull would revert rather
+    /// than silently under-bridge.
+    function test_20Vault_permit2_bridges_a_bridged_token_via_transfer_and_burn() public {
+        (address btoken,) = _registerBridgedToken();
+
+        vm.prank(address(eVault));
+        BridgedERC20(btoken).mint(Alice, 10 ether);
+
+        uint256 amount = 3 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        BridgedERC20(btoken).approve(permit2, type(uint256).max);
+        assertEq(BridgedERC20(btoken).allowance(Alice, address(eVault)), 0);
+
+        bytes memory sig = _signPermit2(AlicePK, btoken, amount, 0, deadline, address(eVault));
+
+        uint256 supplyBefore = BridgedERC20(btoken).totalSupply();
+
+        vm.prank(Alice);
+        IBridge.Message memory message =
+            eVault.sendTokenWithPermit2(_op(btoken, amount), 0, deadline, sig);
+
+        // Transfer and burn: Alice is debited, supply shrinks, and the vault keeps nothing.
+        assertEq(BridgedERC20(btoken).balanceOf(Alice), 10 ether - amount);
+        assertEq(BridgedERC20(btoken).totalSupply(), supplyBefore - amount);
+        assertEq(BridgedERC20(btoken).balanceOf(address(eVault)), 0);
+        assertEq(message.srcOwner, Alice);
+    }
+
+    /// @dev Registers a bridged token whose canonical lives on another chain, so `_handleMessage`
+    /// takes its bridged branch. Mirrors the setup used by the existing ERC20Vault suite.
+    function _registerBridgedToken()
+        private
+        returns (address btoken_, ERC20Vault.CanonicalERC20 memory canonical_)
+    {
+        FreeMintERC20TokenWithPermit origin = new FreeMintERC20TokenWithPermit("ORIG", "ORIG");
+
+        ERC20Vault.CanonicalERC20 memory canonical = ERC20Vault.CanonicalERC20({
+            chainId: 999, addr: address(origin), decimals: 18, symbol: "ORIG", name: "ORIG"
+        });
+
+        btoken_ = address(new BridgedERC20(address(eVault)));
+        canonical_ = canonical;
+
+        // changeBridgedToken enforces MIN_MIGRATION_DELAY against a zero baseline.
+        vm.warp(block.timestamp + 91 days);
+        vm.prank(deployer);
+        eVault.changeBridgedToken(canonical, btoken_);
+    }
+
+    /// @dev A bridged token that has been migrated away from is denylisted, and must stay
+    /// unbridgeable through the permit entrypoints too -- not just through `sendToken`.
+    function test_20Vault_permit2_rejects_a_denylisted_bridged_token() public {
+        (address btokenOld, ERC20Vault.CanonicalERC20 memory canonical) = _registerBridgedToken();
+
+        vm.prank(address(eVault));
+        BridgedERC20(btokenOld).mint(Alice, 10 ether);
+
+        // Migrate the canonical onto a new bridged token; the old one is denylisted.
+        address btokenNew = address(new BridgedERC20(address(eVault)));
+        vm.warp(block.timestamp + 91 days);
+        vm.prank(deployer);
+        eVault.changeBridgedToken(canonical, btokenNew);
+        assertTrue(eVault.btokenDenylist(btokenOld));
+
+        uint256 amount = 1 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        vm.prank(Alice);
+        BridgedERC20(btokenOld).approve(permit2, type(uint256).max);
+
+        bytes memory sig = _signPermit2(AlicePK, btokenOld, amount, 0, deadline, address(eVault));
+
+        vm.prank(Alice);
+        vm.expectRevert(ERC20Vault.VAULT_BTOKEN_BLACKLISTED.selector);
+        eVault.sendTokenWithPermit2(_op(btokenOld, amount), 0, deadline, sig);
     }
 
     // ---------------------------------------------------------------------------------------

--- a/packages/protocol/test/shared/vault/ERC20Vault_quota.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_quota.t.sol
@@ -7,8 +7,12 @@ import "./ERC20Vault.h.sol";
 
 /// @dev Verifies that the ERC20Vault debits the token quota exactly for the tokens actually
 /// released to a recipient ("debit only on actual release"). Because the vault consumes quota in
-/// the same atomic call that transfers/mints the tokens, a reverted (e.g. out-of-quota) delivery
-/// releases nothing and debits nothing, and each successful delivery is debited exactly once.
+/// the same atomic call that transfers/mints the tokens, a reverted (e.g. out-of-quota) release
+/// releases nothing and debits nothing, and each successful release is debited exactly once.
+/// @dev Both release paths are covered: delivering a message from another chain, and refunding a
+/// message that was recalled. Both debit the same bucket -- a recall is reached through the same
+/// destination-chain failure proof a delivery is, and on the bridged branch it mints supply that no
+/// vault balance bounds, so exempting it would leave that path with no numeric ceiling at all.
 contract TestERC20Vault_quota is CommonTest {
     SignalService private eSignalService;
     ERC20Vault private eVault;
@@ -160,14 +164,12 @@ contract TestERC20Vault_quota is CommonTest {
         });
     }
 
-    // Refunding a recalled message is exempt from the quota: those tokens never left this chain,
-    // so returning a user's own failed deposit must not be throttled by unrelated bridge traffic.
-    function test_quota_recall_refund_is_exempt_from_quota() public {
+    // A refund debits the quota exactly like a delivery does. A recall is reached through the same
+    // destination-chain failure proof a delivery is, so the quota is the backstop for a forged one.
+    function test_quota_recall_refund_debits_amount() public {
         vm.chainId(taikoChainId);
 
         uint64 amount = 10;
-        qm.setLimit(1); // any debit of `amount` would revert
-
         uint256 aliceBefore = eERC20Token1.balanceOf(Alice);
 
         // Pre-build the message: it reads token metadata, which would consume the prank.
@@ -176,53 +178,57 @@ contract TestERC20Vault_quota is CommonTest {
         eVault.onMessageRecalled(message, bytes32(0));
 
         assertEq(eERC20Token1.balanceOf(Alice) - aliceBefore, amount);
-        // The quota manager is not consulted at all on the refund path.
-        assertEq(qm.calls(), 0);
-        assertEq(qm.totalConsumed(), 0);
+        assertEq(qm.consumed(address(eERC20Token1)), amount);
+        assertEq(qm.totalConsumed(), amount);
     }
 
-    // The exemption is specific to refunds: under the very same exhausted quota, a cross-chain
-    // delivery is still rejected.
-    function test_quota_blocks_delivery_but_not_refund_under_the_same_limit() public {
+    // An exhausted quota blocks a refund just as it blocks a delivery, and the refund releases
+    // nothing: the debit is the last step of `_transferTokens`, so the revert unwinds the transfer.
+    function test_quota_recall_refund_insufficient_reverts_and_releases_nothing() public {
         vm.chainId(taikoChainId);
 
         uint64 amount = 10;
-        qm.setLimit(1);
+        qm.setLimit(amount - 1);
 
-        // A delivery from another chain is throttled ...
-        ERC20Vault.CanonicalERC20 memory canonical = _canonical();
-        vm.expectRevert(QuotaManager.QM_OUT_OF_QUOTA.selector);
-        tBridge.sendReceiveERC20ToERC20Vault(
-            canonical,
-            Alice,
-            Bob,
-            amount,
-            0,
-            bytes32(0),
-            bytes32(0),
-            address(eVault),
-            ethereumChainId,
-            0
-        );
-
-        // ... while a refund of a failed message goes through.
         uint256 aliceBefore = eERC20Token1.balanceOf(Alice);
+        uint256 vaultBefore = eERC20Token1.balanceOf(address(eVault));
+
         IBridge.Message memory message = _recallMessage(amount);
         vm.prank(address(tBridge));
+        vm.expectRevert(QuotaManager.QM_OUT_OF_QUOTA.selector);
         eVault.onMessageRecalled(message, bytes32(0));
 
-        assertEq(eERC20Token1.balanceOf(Alice) - aliceBefore, amount);
+        assertEq(eERC20Token1.balanceOf(Alice), aliceBefore);
+        assertEq(eERC20Token1.balanceOf(address(eVault)), vaultBefore);
         assertEq(qm.totalConsumed(), 0);
     }
 
-    // The exemption also covers the other branch of `_transferTokens`: a refund whose canonical
-    // lives on a third chain is settled by minting the bridged representation, which must likewise
-    // not be throttled.
-    function test_quota_recall_refund_of_a_bridged_token_is_exempt_from_quota() public {
+    // Deliveries and refunds draw on the same bucket: a delivery that spends the quota leaves a
+    // refund of the same size unaffordable. This is the mainnet-L1 property the exemption removed.
+    function test_quota_delivery_and_refund_share_the_same_limit() public {
         vm.chainId(taikoChainId);
 
         uint64 amount = 10;
-        qm.setLimit(1); // any debit of `amount` would revert
+        qm.setLimit(amount);
+
+        // The delivery spends the whole bucket ...
+        _receive(amount);
+        assertEq(qm.totalConsumed(), amount);
+
+        // ... so a refund of the same size no longer fits.
+        IBridge.Message memory message = _recallMessage(amount);
+        vm.prank(address(tBridge));
+        vm.expectRevert(QuotaManager.QM_OUT_OF_QUOTA.selector);
+        eVault.onMessageRecalled(message, bytes32(0));
+    }
+
+    // The debit covers the other branch of `_transferTokens` too: a refund whose canonical lives on
+    // a third chain is settled by *minting* the bridged representation. That branch is bounded by no
+    // vault balance, so the quota is the only numeric ceiling on it.
+    function test_quota_recall_refund_of_a_bridged_token_debits_amount() public {
+        vm.chainId(taikoChainId);
+
+        uint64 amount = 10;
 
         // chainId 999 != block.chainid, so the refund takes the mint branch.
         ERC20Vault.CanonicalERC20 memory foreign = ERC20Vault.CanonicalERC20({
@@ -240,7 +246,31 @@ contract TestERC20Vault_quota is CommonTest {
         address btoken = eVault.canonicalToBridged(999, address(eERC20Token1));
         assertTrue(btoken != address(0), "bridged token not deployed");
         assertEq(BridgedERC20(btoken).balanceOf(Alice), amount);
-        assertEq(qm.calls(), 0);
+        // Debited against the bridged token, which is what was released.
+        assertEq(qm.consumed(btoken), amount);
+        assertEq(qm.totalConsumed(), amount);
+    }
+
+    // And the mint branch is throttled, not just metered: an exhausted quota mints nothing.
+    function test_quota_recall_refund_of_a_bridged_token_is_throttled() public {
+        vm.chainId(taikoChainId);
+
+        uint64 amount = 10;
+        qm.setLimit(amount - 1);
+
+        ERC20Vault.CanonicalERC20 memory foreign = ERC20Vault.CanonicalERC20({
+            chainId: 999,
+            addr: address(eERC20Token1),
+            decimals: eERC20Token1.decimals(),
+            symbol: eERC20Token1.symbol(),
+            name: eERC20Token1.name()
+        });
+
+        IBridge.Message memory message = _recallMessage(foreign, amount);
+        vm.prank(address(tBridge));
+        vm.expectRevert(QuotaManager.QM_OUT_OF_QUOTA.selector);
+        eVault.onMessageRecalled(message, bytes32(0));
+
         assertEq(qm.totalConsumed(), 0);
     }
 

--- a/packages/protocol/test/shared/vault/ERC20Vault_quota.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_quota.t.sol
@@ -128,6 +128,80 @@ contract TestERC20Vault_quota is CommonTest {
         assertEq(qm.totalConsumed(), 2 * uint256(amount));
     }
 
+    /// @dev Builds a message shaped like one this vault would have sent, so it can be handed back
+    /// through `onMessageRecalled`.
+    function _recallMessage(uint64 _amount) internal view returns (IBridge.Message memory) {
+        bytes memory inner = abi.encode(_canonical(), Alice, Bob, uint256(_amount));
+        return IBridge.Message({
+            id: 0,
+            fee: 0,
+            gasLimit: 0,
+            from: address(eVault),
+            srcChainId: taikoChainId,
+            srcOwner: Alice,
+            destChainId: ethereumChainId,
+            destOwner: Alice,
+            to: address(0),
+            value: 0,
+            data: abi.encodeCall(ERC20Vault.onMessageInvocation, (inner))
+        });
+    }
+
+    // Refunding a recalled message is exempt from the quota: those tokens never left this chain,
+    // so returning a user's own failed deposit must not be throttled by unrelated bridge traffic.
+    function test_quota_recall_refund_is_exempt_from_quota() public {
+        vm.chainId(taikoChainId);
+
+        uint64 amount = 10;
+        qm.setLimit(1); // any debit of `amount` would revert
+
+        uint256 aliceBefore = eERC20Token1.balanceOf(Alice);
+
+        // Pre-build the message: it reads token metadata, which would consume the prank.
+        IBridge.Message memory message = _recallMessage(amount);
+        vm.prank(address(tBridge));
+        eVault.onMessageRecalled(message, bytes32(0));
+
+        assertEq(eERC20Token1.balanceOf(Alice) - aliceBefore, amount);
+        // The quota manager is not consulted at all on the refund path.
+        assertEq(qm.calls(), 0);
+        assertEq(qm.totalConsumed(), 0);
+    }
+
+    // The exemption is specific to refunds: under the very same exhausted quota, a cross-chain
+    // delivery is still rejected.
+    function test_quota_blocks_delivery_but_not_refund_under_the_same_limit() public {
+        vm.chainId(taikoChainId);
+
+        uint64 amount = 10;
+        qm.setLimit(1);
+
+        // A delivery from another chain is throttled ...
+        ERC20Vault.CanonicalERC20 memory canonical = _canonical();
+        vm.expectRevert(QuotaManager.QM_OUT_OF_QUOTA.selector);
+        tBridge.sendReceiveERC20ToERC20Vault(
+            canonical,
+            Alice,
+            Bob,
+            amount,
+            0,
+            bytes32(0),
+            bytes32(0),
+            address(eVault),
+            ethereumChainId,
+            0
+        );
+
+        // ... while a refund of a failed message goes through.
+        uint256 aliceBefore = eERC20Token1.balanceOf(Alice);
+        IBridge.Message memory message = _recallMessage(amount);
+        vm.prank(address(tBridge));
+        eVault.onMessageRecalled(message, bytes32(0));
+
+        assertEq(eERC20Token1.balanceOf(Alice) - aliceBefore, amount);
+        assertEq(qm.totalConsumed(), 0);
+    }
+
     // Releasing zero tokens skips the quota manager call entirely.
     function test_quota_zero_amount_skips_external_call() public {
         vm.chainId(taikoChainId);

--- a/packages/protocol/test/shared/vault/ERC20Vault_quota.t.sol
+++ b/packages/protocol/test/shared/vault/ERC20Vault_quota.t.sol
@@ -44,6 +44,8 @@ contract TestERC20Vault_quota is CommonTest {
         );
         tBridge = new PrankDestBridge(eVault);
         register("bridge", address(tBridge));
+        // The bridged refund branch deploys a BridgedERC20, so the impl must resolve on this chain.
+        register("bridged_erc20", address(new BridgedERC20(address(eVault))));
     }
 
     function _canonical() internal view returns (ERC20Vault.CanonicalERC20 memory) {
@@ -131,7 +133,18 @@ contract TestERC20Vault_quota is CommonTest {
     /// @dev Builds a message shaped like one this vault would have sent, so it can be handed back
     /// through `onMessageRecalled`.
     function _recallMessage(uint64 _amount) internal view returns (IBridge.Message memory) {
-        bytes memory inner = abi.encode(_canonical(), Alice, Bob, uint256(_amount));
+        return _recallMessage(_canonical(), _amount);
+    }
+
+    function _recallMessage(
+        ERC20Vault.CanonicalERC20 memory _ctoken,
+        uint64 _amount
+    )
+        internal
+        view
+        returns (IBridge.Message memory)
+    {
+        bytes memory inner = abi.encode(_ctoken, Alice, Bob, uint256(_amount));
         return IBridge.Message({
             id: 0,
             fee: 0,
@@ -199,6 +212,35 @@ contract TestERC20Vault_quota is CommonTest {
         eVault.onMessageRecalled(message, bytes32(0));
 
         assertEq(eERC20Token1.balanceOf(Alice) - aliceBefore, amount);
+        assertEq(qm.totalConsumed(), 0);
+    }
+
+    // The exemption also covers the other branch of `_transferTokens`: a refund whose canonical
+    // lives on a third chain is settled by minting the bridged representation, which must likewise
+    // not be throttled.
+    function test_quota_recall_refund_of_a_bridged_token_is_exempt_from_quota() public {
+        vm.chainId(taikoChainId);
+
+        uint64 amount = 10;
+        qm.setLimit(1); // any debit of `amount` would revert
+
+        // chainId 999 != block.chainid, so the refund takes the mint branch.
+        ERC20Vault.CanonicalERC20 memory foreign = ERC20Vault.CanonicalERC20({
+            chainId: 999,
+            addr: address(eERC20Token1),
+            decimals: eERC20Token1.decimals(),
+            symbol: eERC20Token1.symbol(),
+            name: eERC20Token1.name()
+        });
+
+        IBridge.Message memory message = _recallMessage(foreign, amount);
+        vm.prank(address(tBridge));
+        eVault.onMessageRecalled(message, bytes32(0));
+
+        address btoken = eVault.canonicalToBridged(999, address(eERC20Token1));
+        assertTrue(btoken != address(0), "bridged token not deployed");
+        assertEq(BridgedERC20(btoken).balanceOf(Alice), amount);
+        assertEq(qm.calls(), 0);
         assertEq(qm.totalConsumed(), 0);
     }
 

--- a/packages/protocol/test/shared/vault/Permit2Fork.t.sol
+++ b/packages/protocol/test/shared/vault/Permit2Fork.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "forge-std/src/Test.sol";
+import { IPermit2 } from "src/shared/vault/IPermit2.sol";
+
+contract Permit2ForkToken is ERC20 {
+    constructor() ERC20("Fork", "FORK") { }
+
+    function mint(address _to, uint256 _amount) external {
+        _mint(_to, _amount);
+    }
+}
+
+/// @notice Mirrors the Permit2 branch of `ERC20Vault._pullTokens` exactly, so the fork test
+/// exercises the same interface and the same call shape the vault uses.
+contract Permit2Puller {
+    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
+    function pull(address _token, uint256 _amount, bytes memory _permit2) external {
+        (uint256 nonce, uint256 deadline, bytes memory signature) =
+            abi.decode(_permit2, (uint256, uint256, bytes));
+
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({ token: _token, amount: _amount }),
+            nonce: nonce,
+            deadline: deadline
+        });
+        IPermit2.SignatureTransferDetails memory details =
+            IPermit2.SignatureTransferDetails({ to: address(this), requestedAmount: _amount });
+
+        IPermit2(PERMIT2).permitTransferFrom(permit, details, msg.sender, signature);
+    }
+}
+
+/// @notice Validates `IPermit2` against the real deployed Permit2 rather than a mock.
+/// @dev The unit tests pin the function selector, but `nonce` and `deadline` are both `uint256`,
+/// so transposing them would leave the selector unchanged and a self-consistent mock would agree
+/// with the mistake. Only the real contract, which derives the EIP-712 digest itself from the
+/// struct we hand it, can reject a wrong field order. Skipped when no RPC is configured.
+contract TestPermit2Fork is Test {
+    address private constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+    uint256 private constant AlicePK = 0xA11CE;
+
+    bytes32 private constant TOKEN_PERMISSIONS_TYPEHASH =
+        keccak256("TokenPermissions(address token,uint256 amount)");
+
+    bytes32 private constant PERMIT_TRANSFER_FROM_TYPEHASH = keccak256(
+        "PermitTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)"
+    );
+
+    function _fork() private returns (bool) {
+        string memory rpc = vm.envOr("PERMIT2_FORK_RPC_URL", string(""));
+        if (bytes(rpc).length == 0) return false;
+        vm.createSelectFork(rpc);
+        return PERMIT2.code.length != 0;
+    }
+
+    /// @dev Signs the canonical Permit2 digest, reading the domain separator from the deployed
+    /// contract so the test cannot drift from the real signing domain.
+    function _sign(
+        address _token,
+        uint256 _amount,
+        uint256 _nonce,
+        uint256 _deadline,
+        address _spender
+    )
+        private
+        view
+        returns (bytes memory)
+    {
+        bytes32 domainSeparator = IPermit2Domain(PERMIT2).DOMAIN_SEPARATOR();
+        bytes32 permissions = keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, _token, _amount));
+        bytes32 structHash = keccak256(
+            abi.encode(PERMIT_TRANSFER_FROM_TYPEHASH, permissions, _spender, _nonce, _deadline)
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(AlicePK, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function test_real_permit2_accepts_our_struct_layout() public {
+        if (!_fork()) {
+            emit log("skipped: set PERMIT2_FORK_RPC_URL to run against real Permit2");
+            return;
+        }
+
+        address alice = vm.addr(AlicePK);
+        Permit2ForkToken token = new Permit2ForkToken();
+        token.mint(alice, 100 ether);
+
+        vm.prank(alice);
+        token.approve(PERMIT2, type(uint256).max);
+
+        Permit2Puller puller = new Permit2Puller();
+
+        uint256 amount = 5 ether;
+        // Deliberately far apart: if `nonce` and `deadline` were transposed, the real Permit2
+        // would read a deadline of 12345 (long past) or a nonce of a timestamp, and reject.
+        uint256 nonce = 12_345;
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes memory sig = _sign(address(token), amount, nonce, deadline, address(puller));
+
+        vm.prank(alice);
+        puller.pull(address(token), amount, abi.encode(nonce, deadline, sig));
+
+        assertEq(token.balanceOf(address(puller)), amount);
+        assertEq(token.balanceOf(alice), 100 ether - amount);
+    }
+
+    /// @dev The same signature must not be redeemable twice against the real contract.
+    function test_real_permit2_rejects_a_replayed_nonce() public {
+        if (!_fork()) return;
+
+        address alice = vm.addr(AlicePK);
+        Permit2ForkToken token = new Permit2ForkToken();
+        token.mint(alice, 100 ether);
+
+        vm.prank(alice);
+        token.approve(PERMIT2, type(uint256).max);
+
+        Permit2Puller puller = new Permit2Puller();
+
+        uint256 amount = 1 ether;
+        uint256 nonce = 999;
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(address(token), amount, nonce, deadline, address(puller));
+        bytes memory blob = abi.encode(nonce, deadline, sig);
+
+        vm.prank(alice);
+        puller.pull(address(token), amount, blob);
+
+        vm.prank(alice);
+        vm.expectRevert();
+        puller.pull(address(token), amount, blob);
+    }
+}
+
+interface IPermit2Domain {
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}

--- a/packages/protocol/test/shared/vault/Permit2Fork.t.sol
+++ b/packages/protocol/test/shared/vault/Permit2Fork.t.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "forge-std/src/Test.sol";
-import { IPermit2 } from "src/shared/vault/IPermit2.sol";
+import { IBridge } from "src/shared/bridge/IBridge.sol";
+import { IResolver } from "src/shared/common/IResolver.sol";
+import { LibNames } from "src/shared/libs/LibNames.sol";
+import { ERC20Vault } from "src/shared/vault/ERC20Vault.sol";
 
 contract Permit2ForkToken is ERC20 {
     constructor() ERC20("Fork", "FORK") { }
@@ -13,35 +17,62 @@ contract Permit2ForkToken is ERC20 {
     }
 }
 
-/// @notice Mirrors the Permit2 branch of `ERC20Vault._pullTokens` exactly, so the fork test
-/// exercises the same interface and the same call shape the vault uses.
-contract Permit2Puller {
-    address public constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+/// @notice The smallest scaffolding an `ERC20Vault` needs to reach its token pull: a bridge to
+/// address the outbound message to, and a vault registered on the destination chain.
+contract ForkResolver is IResolver {
+    address public immutable bridge;
+    address public immutable destVault;
+    uint64 public immutable destChainId;
 
-    function pull(address _token, uint256 _amount, bytes memory _permit2) external {
-        (uint256 nonce, uint256 deadline, bytes memory signature) =
-            abi.decode(_permit2, (uint256, uint256, bytes));
+    constructor(address _bridge, address _destVault, uint64 _destChainId) {
+        bridge = _bridge;
+        destVault = _destVault;
+        destChainId = _destChainId;
+    }
 
-        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
-            permitted: IPermit2.TokenPermissions({ token: _token, amount: _amount }),
-            nonce: nonce,
-            deadline: deadline
-        });
-        IPermit2.SignatureTransferDetails memory details =
-            IPermit2.SignatureTransferDetails({ to: address(this), requestedAmount: _amount });
+    function resolve(
+        uint256 _chainId,
+        bytes32 _name,
+        bool _allowZeroAddress
+    )
+        external
+        view
+        returns (address addr_)
+    {
+        if (_name == LibNames.B_BRIDGE) addr_ = bridge;
+        else if (_name == LibNames.B_ERC20_VAULT && _chainId == destChainId) addr_ = destVault;
 
-        IPermit2(PERMIT2).permitTransferFrom(permit, details, msg.sender, signature);
+        require(addr_ != address(0) || _allowZeroAddress, RESOLVED_TO_ZERO_ADDRESS());
     }
 }
 
-/// @notice Validates `IPermit2` against the real deployed Permit2 rather than a mock.
-/// @dev The unit tests pin the function selector, but `nonce` and `deadline` are both `uint256`,
-/// so transposing them would leave the selector unchanged and a self-consistent mock would agree
-/// with the mistake. Only the real contract, which derives the EIP-712 digest itself from the
-/// struct we hand it, can reject a wrong field order. Skipped when no RPC is configured.
+/// @notice Accepts the vault's outbound message so the send completes; the pull is what is under
+/// test here, not the messaging.
+contract ForkBridgeStub {
+    function sendMessage(IBridge.Message calldata _message)
+        external
+        payable
+        returns (bytes32 msgHash_, IBridge.Message memory message_)
+    {
+        message_ = _message;
+        msgHash_ = keccak256(abi.encode(_message));
+    }
+}
+
+/// @notice Validates `ERC20Vault`'s Permit2 pull against the real deployed Permit2 rather than a
+/// mock, by driving the vault's own `sendTokenWithPermit2`.
+/// @dev The unit tests pin the function selector, but `nonce` and `deadline` are both `uint256`, so
+/// transposing them would leave the selector unchanged and a self-consistent mock would agree with
+/// the mistake. Only the real contract, which derives the EIP-712 digest itself from the struct it
+/// is handed, can reject a wrong field order.
+/// @dev Requires `PERMIT2_FORK_RPC_URL`; without it every test here reports as *skipped* rather
+/// than passed, so an unconfigured run cannot be mistaken for a green one. With it set, a chain
+/// that has no Permit2 fails loudly instead of skipping quietly -- that is a misconfigured RPC, not
+/// an absent one.
 contract TestPermit2Fork is Test {
     address private constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
     uint256 private constant AlicePK = 0xA11CE;
+    uint64 private constant DEST_CHAIN_ID = 167_000;
 
     bytes32 private constant TOKEN_PERMISSIONS_TYPEHASH =
         keccak256("TokenPermissions(address token,uint256 amount)");
@@ -50,11 +81,52 @@ contract TestPermit2Fork is Test {
         "PermitTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)"
     );
 
-    function _fork() private returns (bool) {
+    /// @dev Selects the fork, or skips the calling test when no RPC is configured. Returns the
+    /// deployed vault so each test drives the real contract rather than a copy of its pull.
+    function _forkAndDeployVault() private returns (ERC20Vault vault_) {
         string memory rpc = vm.envOr("PERMIT2_FORK_RPC_URL", string(""));
-        if (bytes(rpc).length == 0) return false;
+        if (bytes(rpc).length == 0) {
+            emit log("skipped: set PERMIT2_FORK_RPC_URL to run against real Permit2");
+            vm.skip(true);
+            return ERC20Vault(address(0));
+        }
+
         vm.createSelectFork(rpc);
-        return PERMIT2.code.length != 0;
+        require(
+            PERMIT2.code.length != 0,
+            "PERMIT2_FORK_RPC_URL points at a chain with no Permit2 deployed"
+        );
+
+        address resolver = address(
+            new ForkResolver(address(new ForkBridgeStub()), address(0xDE57), DEST_CHAIN_ID)
+        );
+        vault_ = ERC20Vault(
+            address(
+                new ERC1967Proxy(
+                    address(new ERC20Vault(resolver, address(0))),
+                    abi.encodeCall(ERC20Vault.init, (address(this)))
+                )
+            )
+        );
+    }
+
+    function _op(
+        address _token,
+        uint256 _amount
+    )
+        private
+        pure
+        returns (ERC20Vault.BridgeTransferOp memory)
+    {
+        return ERC20Vault.BridgeTransferOp({
+            destChainId: DEST_CHAIN_ID,
+            destOwner: address(0),
+            to: address(0xB0B),
+            fee: 0,
+            token: _token,
+            gasLimit: 1_000_000,
+            amount: _amount
+        });
     }
 
     /// @dev Signs the canonical Permit2 digest, reading the domain separator from the deployed
@@ -80,11 +152,8 @@ contract TestPermit2Fork is Test {
         return abi.encodePacked(r, s, v);
     }
 
-    function test_real_permit2_accepts_our_struct_layout() public {
-        if (!_fork()) {
-            emit log("skipped: set PERMIT2_FORK_RPC_URL to run against real Permit2");
-            return;
-        }
+    function test_real_permit2_accepts_the_vaults_call() public {
+        ERC20Vault vault = _forkAndDeployVault();
 
         address alice = vm.addr(AlicePK);
         Permit2ForkToken token = new Permit2ForkToken();
@@ -92,8 +161,6 @@ contract TestPermit2Fork is Test {
 
         vm.prank(alice);
         token.approve(PERMIT2, type(uint256).max);
-
-        Permit2Puller puller = new Permit2Puller();
 
         uint256 amount = 5 ether;
         // Deliberately far apart: if `nonce` and `deadline` were transposed, the real Permit2
@@ -101,18 +168,18 @@ contract TestPermit2Fork is Test {
         uint256 nonce = 12_345;
         uint256 deadline = block.timestamp + 1 hours;
 
-        bytes memory sig = _sign(address(token), amount, nonce, deadline, address(puller));
+        bytes memory sig = _sign(address(token), amount, nonce, deadline, address(vault));
 
         vm.prank(alice);
-        puller.pull(address(token), amount, abi.encode(nonce, deadline, sig));
+        vault.sendTokenWithPermit2(_op(address(token), amount), nonce, deadline, sig);
 
-        assertEq(token.balanceOf(address(puller)), amount);
+        assertEq(token.balanceOf(address(vault)), amount);
         assertEq(token.balanceOf(alice), 100 ether - amount);
     }
 
     /// @dev The same signature must not be redeemable twice against the real contract.
     function test_real_permit2_rejects_a_replayed_nonce() public {
-        if (!_fork()) return;
+        ERC20Vault vault = _forkAndDeployVault();
 
         address alice = vm.addr(AlicePK);
         Permit2ForkToken token = new Permit2ForkToken();
@@ -121,20 +188,46 @@ contract TestPermit2Fork is Test {
         vm.prank(alice);
         token.approve(PERMIT2, type(uint256).max);
 
-        Permit2Puller puller = new Permit2Puller();
+        uint256 amount = 1 ether;
+        uint256 nonce = 999;
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory sig = _sign(address(token), amount, nonce, deadline, address(vault));
+
+        vm.prank(alice);
+        vault.sendTokenWithPermit2(_op(address(token), amount), nonce, deadline, sig);
+
+        vm.prank(alice);
+        vm.expectRevert();
+        vault.sendTokenWithPermit2(_op(address(token), amount), nonce, deadline, sig);
+
+        // Exactly one pull went through.
+        assertEq(token.balanceOf(address(vault)), amount);
+    }
+
+    /// @dev Transposing `nonce` and `deadline` leaves the selector untouched, so only the real
+    /// contract can catch it: it reads the nonce as a deadline and rejects the signature as
+    /// expired. A mock built on the same struct would agree with the mistake instead.
+    function test_real_permit2_rejects_a_transposed_nonce_and_deadline() public {
+        ERC20Vault vault = _forkAndDeployVault();
+
+        address alice = vm.addr(AlicePK);
+        Permit2ForkToken token = new Permit2ForkToken();
+        token.mint(alice, 100 ether);
+
+        vm.prank(alice);
+        token.approve(PERMIT2, type(uint256).max);
 
         uint256 amount = 1 ether;
         uint256 nonce = 999;
         uint256 deadline = block.timestamp + 1 hours;
-        bytes memory sig = _sign(address(token), amount, nonce, deadline, address(puller));
-        bytes memory blob = abi.encode(nonce, deadline, sig);
+        bytes memory sig = _sign(address(token), amount, nonce, deadline, address(vault));
 
+        // Arguments swapped at the entrypoint: `999` now lands where the deadline belongs.
         vm.prank(alice);
-        puller.pull(address(token), amount, blob);
+        vm.expectRevert(abi.encodeWithSignature("SignatureExpired(uint256)", nonce));
+        vault.sendTokenWithPermit2(_op(address(token), amount), deadline, nonce, sig);
 
-        vm.prank(alice);
-        vm.expectRevert();
-        puller.pull(address(token), amount, blob);
+        assertEq(token.balanceOf(address(vault)), 0);
     }
 }
 


### PR DESCRIPTION
## Summary

Adds approval-free ERC20 bridging to `ERC20Vault`: `sendToken` requires a prior `approve`, so bridging always costs two transactions. `sendTokenWithPermit` (EIP-2612) and `sendTokenWithPermit2` (Uniswap Permit2 `SignatureTransfer`) fold the approval into the bridge call.

`Bridge.sol` is untouched: it holds no ERC20 logic, so `ERC20Vault._handleMessage` is the only place a token pull happens.

**Scope note:** an earlier revision of this PR also exempted refunds of recalled messages from the withdrawal quota. That has been reverted — see [Quota: no behavioural change](#quota-no-behavioural-change) below. The PR is now confined to the permit entrypoints.

## Permit and Permit2 entrypoints

Permit2 is the one that matters. Deposits lock *canonical third-party* tokens, and USDT, WBTC and others have no `permit`. `BridgedERC20V2` already gives EIP-2612 to Taiko-minted tokens, so Permit2 fills exactly the gap it cannot cover — approval-free bridging for **every** ERC20. A user who has already approved Permit2 elsewhere bridges with no approval step at all.

**Design notes**

- **Permit2 as a `constant`, not a constructor argument.** Its address is CREATE2-derived from `(factory, salt, initcode hash)` — none of which vary by chain — so it is identical everywhere by construction. As a `constant` it uses no storage, needs no per-chain configuration, keeps all five `new ERC20Vault(...)` call sites unchanged, and cannot be repointed by any admin action or deployment mistake. A resolver entry would instead make the pull authority admin-repointable. Deployed on Ethereum L1 and Taiko Alethia today; the Taiko Hoodi deployment is a single permissionless CREATE2 transaction and is landing imminently. Nothing in this PR changes either way — the address is already correct, and until Hoodi has it only `sendTokenWithPermit2` is unavailable there, failing loudly rather than silently.
- **The Permit2 owner stays `msg.sender`.** In this vault `msg.sender` serves four roles at once: payer, `Message.srcOwner`, the `destOwner` fallback, and the message's `from`. They coincide today only because the caller must have approved beforehand. Keeping the Permit2 owner as `msg.sender` preserves that — `onMessageRecalled` refunds `srcOwner`, so decoupling them carelessly would refund the wrong address when a bridge fails. Relayer-submitted deposits would need the signer threaded through all four roles and are deliberately out of scope.
- **The signature is passed to Permit2 as raw `bytes`, with no length imposed on it.** Smart-contract wallets can authorize with EIP-1271: Permit2 routes a claimed signer that has code to `isValidSignature` rather than `ecrecover`, handing it the bytes verbatim and checking no length. A wallet that authorizes from stored state — Safe's `signMessage` pre-approved-hash shape — therefore validates an *empty* signature, so a vault-side length guard would reject a documented flow before Permit2 ever saw it. For EOAs a guard adds nothing, since Permit2 already rejects a bad length itself. Helpers that take a split `(v, r, s)` cannot express an EIP-1271 signature at all, which is why the bytes are threaded through rather than reusing an existing library helper.
- **The EIP-2612 permit is best-effort, and the *allowance* is what is checked.** A griefer can replay the signature at the token to burn its nonce, so the failure is swallowed. But a swallowed failure is not the only way to end up with no allowance: on a token whose fallback silently accepts unknown selectors — WETH9, one of the quota-capped vault tokens — the `permit` selector hits the fallback and the `try` takes its **success** branch with the allowance still zero. Checking `allowance(msg.sender, address(this)) >= _op.amount` after the call covers both, and fails with `VAULT_PERMIT_NO_ALLOWANCE` instead of a generic `SafeERC20` string from deep inside the pull. It keeps the front-run tolerance intact, because a replayed permit leaves the allowance in place. Note this means a caller with a standing allowance bridges against it even when the signature is bad — intended, since the caller owns the tokens and asked for exactly that transfer.
- **Validation precedes the external call, from a single list.** `_checkOp` holds all five checks and runs both up front in `sendTokenWithPermit` (so an operation that cannot proceed never hands execution to a caller-chosen address) and inside `_sendToken` (so no entrypoint can skip it). One list rather than two means they cannot drift — the earlier pre-permit copy was missing `msg.value < fee` and `checkToAddressOnSrcChain`.
- **The Permit2 authorization travels as a typed `Permit2Data` struct**, not a hand-encoded `(nonce, deadline, signature)` blob. `nonce` and `deadline` are both `uint256`, so transposing them is invisible to the compiler *and* to the function selector; named struct members make the layout compiler-checked instead of repeated at the encode and decode sites. Three separate typed parameters hit `Stack too deep` under the non-IR `shared` profile, so bundling is necessary either way.
- **Fee-on-transfer accounting preserved** — the balance-delta measurement still wraps the pull.

## Quota: no behavioural change

An earlier revision of this PR made `onMessageRecalled` skip `_consumeTokenQuota`, on the reasoning that a recalled deposit never left this chain. **That is reverted; refunds debit the quota exactly as before this PR.** Recorded here because the reasoning was wrong in a way worth writing down:

- A recall is reached through the *same* primitive a delivery is. `Bridge.recallMessage` gates only on `Status.NEW`, `isSignalSent`, and a proof that the destination chain signalled `signalForFailedMessage`. The source chain never learns that a message was processed on the destination, so every historical deposit is still `NEW` and stays recallable if that proof class can be forged.
- ERC20 messages carry `value = msg.value - fee`, which is 0 in practice, and `Bridge._consumeEtherQuota` is a no-op for 0. An exempt ERC20 recall would therefore have consumed **no quota of any kind**, turning the recall exit of the mainnet L1 vault unmetered.
- "These tokens never left this chain" does not hold on the bridged branch at all: a send **burns** the user's tokens and a recall **mints** new supply, bounded by no vault balance. The quota is the only numeric ceiling there.
- The debit is also not a leftover — it was deliberately restored after the 2026-06-22 exploit, in #21821 for the Bridge and #21828 for the vault, which is what the live L1 implementation runs.

The narrow real problem behind the original change is documented on `onMessageRecalled` rather than fixed by removing the limiter: `QuotaManager.availableQuota` caps a token's refill at its configured quota, so a single recall larger than that cap can never be refunded in one call. An out-of-quota refund reverts atomically, leaving the message `NEW` and retryable once the quota refills; a recall above the cap stays blocked until the owner raises the token's quota via `updateQuota`. Giving recalls their own bucket in `QuotaManager` would change a live L1 contract and deserves its own PR with its own security review.

## Changes

| File | |
|---|---|
| `contracts/shared/vault/ERC20Vault.sol` | Two entrypoints, `Permit2Data`, shared `_checkOp`/`_sendToken`/`_pullTokens` |
| `contracts/shared/vault/IPermit2.sol` | Minimal `SignatureTransfer` interface (new) |
| `test/shared/vault/ERC20Vault_permit.t.sol` | 31 tests (new) |
| `test/shared/vault/Permit2Fork.t.sol` | 3 fork tests against the deployed Permit2 (new) |
| `test/shared/vault/ERC20Vault_quota.t.sol` | 5 tests pinning that refunds are metered (new file, no behaviour change) |
| `test/shared/helpers/Permit2Mock.sol` | Permit2 mock (new) |
| `test/shared/helpers/FreeMintERC20TokenWithPermit.sol` | EIP-2612 test token (new) |

**No ABI or storage-layout change.** Method identifiers diffed against `main`: 27 → 30 selectors, none removed or altered — `sendToken` remains `0xb84d9ffe`, which is what the relayer's Go binding hardcodes. `gen-layouts.sh` regenerates with no diff. Deployed size 18,330 → 19,630 bytes, 4,946 under the EIP-170 limit (worth stating because `foundry.toml` suppresses error 5574; the anvil deploy step in protocol CI does enforce EIP-170, so an overflow fails there).

Existing `sendToken` callers pay **+877 gas whole-tx (+0.43%)** from the shared internal call, or **+726 (+0.80%)** measured at the call itself (median over the 8 `sendToken` calls in `ERC20Vault.t.sol`). Removing that entirely would mean duplicating message construction across two paths in an asset-custody contract, which was judged the worse trade.

## Testing

Coverage includes both entrypoints end-to-end on **both** branches of `_handleMessage` — canonical lock, and bridged transfer-and-burn (the EIP-2612 × burn case needs a `BridgedERC20V2`, since plain `BridgedERC20` has no `permit`). Also: replayed nonce, wrong signer, signature naming another spender, expired deadline, front-run permit, denylisted bridged token, Permit2 absent, `whenNotPaused` and `nonReentrant` on both entrypoints, the fee/value path, and that a recall still refunds the signer.

Several tests pin properties a self-consistent mock would otherwise hide:

- `..._interface_matches_canonical_permit2_selector` asserts the selector is `0x30f28b7a`, the one present in the dispatcher of the deployed Permit2. Uniswap's `PermitTransferFrom` has no `spender` member (it is bound into the EIP-712 typehash as `msg.sender`); adding one would change the selector to `0x105b689e`, which does not exist on the real contract.
- `..._uses_the_canonical_permit2_address` pins the constant itself. Every other unit test etches the mock at whatever `PERMIT2()` returns, so none of them would notice it being wrong.
- `..._encodes_nonce_before_deadline` plus `Permit2Fork.t.sol` cover what the selector cannot: `nonce` and `deadline` are both `uint256`, so transposing them leaves the selector unchanged. Against mainnet the real contract rejects a transposition with `SignatureExpired(999)` — the nonce read as a deadline.
- `..._reverts_when_permit2_has_no_code` asserts a codeless Permit2 reverts and moves no tokens. `vm.expectRevert(bytes(""))` matches only the empty extcodesize revert, so replacing that mechanism with anything else that reverts still fails the test.
- `nonReentrant` is asserted differently per path, because the EIP-2612 path's `catch {}` swallows the guard's revert: there the assertion is that a reentrant bridge moves no tokens (drop the modifier and the vault receives `2 × amount`); on the Permit2 path nothing catches, so `REENTRANT_CALL` is observed directly.

`Permit2Mock` carries Uniswap's real error signatures — `SignatureExpired(uint256)`, `InvalidAmount(uint256)`, `InvalidSigner` distinct from `InvalidSignature` — plus an EIP-1271 branch, so a revert reason a test pins is the one mainnet emits rather than a mock-only shape.

`Permit2Fork.t.sol` drives the vault's own `sendTokenWithPermit2` against a minimal resolver and bridge stub, rather than a copy of `_pullTokens`. It requires `PERMIT2_FORK_RPC_URL`; without it the tests report as **skipped** (`vm.skip`) rather than silently passing while asserting nothing, and with an RPC set that has no Permit2 it fails loudly instead of skipping quietly.

Results: **200 shared** (3 fork tests skipped), **374 L1**, **12 L2** passing. `forge fmt --check` and solhint clean on the files this PR touches.

## Follow-ups (not in this PR)

- `bridge-ui` still does the two-step `approve` → `sendToken` flow and needs updating to surface the benefit to users.
- A dedicated recall bucket in `QuotaManager`, if the refill cap above turns out to bite in practice.
- `ERC20Vault.sol:21` carries a stale self-referential comment, and `bridge-ui`'s `ERC20Bridge.ts` sends a `solverFee` field the struct no longer has — both leftovers from a removed solver variant, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXoMaSNwmtDYZfB13HX1WJ