### PR TITLE
fix(bridge-ui): read a relayer value written in exponent form

### DIFF
--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.test.ts
@@ -889,6 +889,40 @@ describe('RelayerAPIService', () => {
     expect(parseApiBigInt('33011093383701312')).toEqual(33_011_093_383_701_312n);
   });
 
+  test('getAllBridgeTransactionByAddress keeps a row whose value arrived in exponent form', async () => {
+    // Given: the relayer serializes Message.Value from a Go float, so 18.5 ETH goes over the wire
+    // as `1.85e19`. The rewrite that keeps large integers out of JSON doubles has to read that
+    // form too: left as a number it was rejected as unsafe, the row never transformed, and the
+    // transactions page told the user a message could not be loaded on every refresh.
+    const relayerAPIService = new RelayerAPIService('http://example.com');
+    const paginationParams = { page: 1, size: 10 };
+    const relayerItem = createRelayerItem({
+      id: 1553895,
+      messageId: '6285',
+      msgHash: GOOD_MSG_HASH,
+      blockNumber: '0x7baa35',
+      amount: '18500000000000000000',
+    });
+    // Serialized, then rewritten to the literal the relayer actually emits - the mocked object
+    // responses the other tests use never reach the string the precision rewrite operates on
+    const rawResponse = JSON.stringify(createApiResponse([relayerItem]).data).replace(
+      '"Value":"185000000000000000"',
+      '"Value":1.85e19',
+    );
+    expect(rawResponse).toContain('"Value":1.85e19');
+
+    mockedAxios.get.mockResolvedValue({ data: rawResponse, status: 200 });
+    mockedGetTransactionReceipt.mockResolvedValue(createReceiptWithMessageSentLog());
+    mockedReadContract.mockResolvedValue(MessageStatus.NEW);
+
+    // When
+    const result = await relayerAPIService.getAllBridgeTransactionByAddress(USER_ADDRESS, paginationParams, 167000);
+
+    // Then
+    expect(result.failedTxs).toEqual([]);
+    expect(result.txs).toHaveLength(1);
+  });
+
   test('getAllBridgeTransactionByAddress counts a transaction whose RPC read threw', async () => {
     // Given
     const relayerAPIService = new RelayerAPIService('http://example.com');

--- a/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
+++ b/packages/bridge-ui/src/libs/relayer/RelayerAPIService.ts
@@ -41,13 +41,19 @@ import {
 const log = getLogger('RelayerAPIService');
 
 const relayerMessageIntegerFields = ['Fee', 'Value', 'Id', 'SrcChainId', 'DestChainId', 'amount', 'fee'];
-// Only a complete integer token is rewritten. The trailing guard matters: `amount` and
-// `fee` can arrive as a decimal or in exponent form, and quoting just the leading digits
-// of `1.5` produces `"1".5` - invalid JSON that takes the whole response down with it.
-const relayerMessageIntegerPattern = new RegExp(
-  `("(${relayerMessageIntegerFields.join('|')})"\\s*:\\s*)(\\d+)(?![\\d.eE])`,
+// The whole numeric token is matched, not just its leading digits. These fields come off Go
+// floats, so a value large enough to need this rewrite is exactly the one likely to arrive in
+// exponent form - 18.5 ETH is written `1.85e19` - and quoting only the digits before the point
+// produces `"1".85e19`, invalid JSON that takes the whole response down with it. Whether a token
+// denotes an integer is `asIntegerDigits`' decision; `amount` and `fee` are not guaranteed whole,
+// and a genuine fraction is left exactly as it was.
+const relayerMessageNumberPattern = new RegExp(
+  `("(${relayerMessageIntegerFields.join('|')})"\\s*:\\s*)(-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)`,
   'g',
 );
+// A uint256 tops out at 78 digits, so a longer expansion is not a bridge value. Bounds the
+// string an absurd exponent could ask this to allocate; the token is left alone instead.
+const MAX_RELAYER_INTEGER_DIGITS = 100;
 type DecodedBridgeMessage = Omit<Message, 'gasLimit'> & { gasLimit: bigint | number };
 type BridgeTransactionAssetDetails = {
   amount: bigint;
@@ -114,8 +120,46 @@ const erc1155InvocationParameters = [
   { type: 'uint256[]' },
 ] as const;
 
+/**
+ * Expands a JSON number token to the integer it denotes, in digits, and returns null when it
+ * denotes anything else - a fraction, or a magnitude no bridge value has.
+ *
+ * Textual throughout: routing the token through a JS number is the precision loss this whole
+ * rewrite exists to avoid.
+ */
+function asIntegerDigits(token: string): string | null {
+  const parts = /^(-?)(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/.exec(token);
+  if (!parts) return null;
+
+  const [, sign, integerPart, fractionPart = '', exponentPart] = parts;
+  const exponent = exponentPart ? Number(exponentPart) : 0;
+  if (!Number.isSafeInteger(exponent)) return null;
+
+  const digits = integerPart + fractionPart;
+  // Where the decimal point lands once the exponent is applied, which is also the digit length
+  // of the result whenever the token has to be padded
+  const pointIndex = integerPart.length + exponent;
+  if (pointIndex <= 0) return null; // `5e-2` and friends are below one, so not an integer
+  if (pointIndex > MAX_RELAYER_INTEGER_DIGITS) return null;
+
+  let whole: string;
+  if (pointIndex >= digits.length) {
+    whole = digits + '0'.repeat(pointIndex - digits.length);
+  } else {
+    if (/[1-9]/.test(digits.slice(pointIndex))) return null; // `1.5` stays a fraction
+    whole = digits.slice(0, pointIndex);
+  }
+
+  // BigInt would accept leading zeros, but the relayer states some of these amounts twice - once
+  // as a number and once as a string - and a normalized form keeps the two comparable
+  return sign + whole.replace(/^0+(?=\d)/, '');
+}
+
 export function preserveMessageIntegerPrecision(rawResponse: string): string {
-  return rawResponse.replace(relayerMessageIntegerPattern, '$1"$3"');
+  return rawResponse.replace(relayerMessageNumberPattern, (match, prefix: string, _field: string, token: string) => {
+    const digits = asIntegerDigits(token);
+    return digits === null ? match : `${prefix}"${digits}"`;
+  });
 }
 
 export function parseRelayerApiResponse(rawResponse: string): APIResponse {

--- a/packages/bridge-ui/src/libs/relayer/relayerJsonPrecision.test.ts
+++ b/packages/bridge-ui/src/libs/relayer/relayerJsonPrecision.test.ts
@@ -5,6 +5,9 @@ import { preserveMessageIntegerPrecision } from './RelayerAPIService';
  * their digits. The rewrite must never produce invalid JSON: `amount` and `fee` are not
  * guaranteed to be whole numbers, and quoting only the leading digits of `1.5` yields
  * `"1".5`, which takes the entire transaction list down.
+ *
+ * The fields come off Go floats, so the rewrite has to read exponent form as well as plain
+ * digits: the values large enough to need it are exactly the ones Go prints as `1.85e19`.
  */
 const roundTrip = (raw: string) => JSON.parse(preserveMessageIntegerPrecision(raw));
 
@@ -26,9 +29,31 @@ describe('preserveMessageIntegerPrecision', () => {
     expect(roundTrip('{"amount":1.5}').amount).toBe(1.5);
   });
 
-  it('leaves an exponent-formed amount as valid JSON', () => {
+  it('keeps an exponent-formed integer as digits', () => {
     expect(() => roundTrip('{"amount":1e5}')).not.toThrow();
-    expect(roundTrip('{"amount":1e5}').amount).toBe(100000);
+    expect(roundTrip('{"amount":1e5}').amount).toBe('100000');
+  });
+
+  it('keeps the digits of an exponent-formed value past 2^53', () => {
+    // 18.5 ETH. Go prints this float as `1.85e19`, which the earlier rewrite left as a JSON
+    // number: `parseApiBigInt` then rejected it as unsafe, `_transformTransaction` threw, and
+    // the transaction was dropped from the user's list on every refresh
+    expect(roundTrip('{"Value":1.85e19}').Value).toBe('18500000000000000000');
+  });
+
+  it('keeps an exponent-formed integer that carries a fraction', () => {
+    expect(roundTrip('{"Value":1.5e1}').Value).toBe('15');
+  });
+
+  it('leaves an exponent-formed fraction as valid JSON', () => {
+    expect(roundTrip('{"amount":1.55e1}').amount).toBe(15.5);
+    expect(roundTrip('{"amount":5e-2}').amount).toBe(0.05);
+  });
+
+  it('leaves a magnitude no bridge value has alone', () => {
+    // Nothing is allocated for an absurd exponent; the token stays a number and fails the
+    // caller's own check instead
+    expect(roundTrip('{"Value":1e1000}').Value).toBe(Infinity);
   });
 
   it('leaves a decimal fee as valid JSON', () => {


### PR DESCRIPTION
Stacked on #22097 — that one should land first.

## The symptom

On #22097's preview deployment, `/transactions` kept showing, for one mainnet wallet:

> 1 transaction(s) could not be loaded. Try refreshing.

Refreshing never cleared it, and nothing showed up in the browser console — the failure is only reported through `getLogger`, i.e. the `debug` package, which is off unless `localStorage.debug` is set.

## Root cause

The relayer serializes `data.Message.Value` from a Go float, and Go prints the shortest round-trip form. So the values large enough to need `preserveMessageIntegerPrecision` are exactly the ones likely to arrive in exponent form. In that wallet's 21 relayer rows, 20 carried `"Value":<digits>` and one carried:

```
"Value":1.85e19
```

18.5 ETH, inbound. The rewrite's pattern was `("(Fee|Value|…)"\s*:\s*)(\d+)(?![\d.eE])`, whose trailing guard deliberately skips decimal and exponent tokens so it can never emit `"1".5`. That leaves `1.85e19` as a JSON number, and from there:

1. `parseApiBigInt` fails `Number.isSafeInteger` and throws `Unsafe integer value from relayer API`;
2. `_transformTransaction` throws, so the row lands in `failedTxs` and is dropped;
3. the row is an inbound transfer — the user is `destOwner`, not the sender — so there is no local-storage row for `fetchTransactions` to rescue it with;
4. `failedCount: 1` → `getLoadWarning` → `transactions.errors.partial_load`.

Deterministic, which is why no amount of refreshing helped.

Worth stating plainly: **#22097 is not at fault here, it is what made this visible.** On `main` the same row is strictly worse — there is no `try`/`catch` around `items.map`, so the throw rejects the whole relayer page and `main`'s `Promise.all` catch sets `relayerTxsArrays = []`, blanking the wallet's entire transaction list. #22097 turned that into "20 of 21 rows plus an honest count"; this PR removes the remaining loss.

## The fix

Match the whole numeric token and decide textually — never by routing it through a JS number — whether it denotes an integer:

| input | before | after |
| --- | --- | --- |
| `"Value":1.85e19` | number, then throws as unsafe | `"18500000000000000000"` |
| `"amount":1e5` | number `100000` | `"100000"` |
| `"amount":1.5` | number `1.5` | number `1.5` |
| `"amount":5e-2` | number `0.05` | number `0.05` |
| `"Value":1e1000` | `Infinity` | `Infinity` |

That last row is a bound rather than an oversight: a uint256 tops out at 78 digits, so a token asking for more than 100 is left alone instead of expanded into a huge string.

**One behaviour change to be aware of:** `{"amount":1e5}` now parses to the string `"100000"` instead of the number `100000`. Both `parseApiBigInt` and `BigInt` accept strings, and the existing expectation in `relayerJsonPrecision.test.ts` was pinning the pre-fix behaviour, so it is updated here.

## Verification

- The new tests are red without the source change and green with it. The end-to-end one fails as `expected [ { …(2) } ] to deeply equal []` — `failedTxs` holding exactly the row the user was warned about.
- The captured mainnet relayer response replayed through the patched module: 21 rows, `failedCount` 1 → **0**. The recovered `Message.Value` string is identical to the relayer's own `amount` string for that row, so nothing is rounded on the way through.
- `pnpm test:unit` — 84 files, 671 tests, all passing
- `pnpm lint` — clean
- `pnpm svelte:check` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
