### PR TITLE
fix(bridge-ui): report a claim the prover refuses as "not synced yet" instead of "unknown error"

### DIFF
--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.component.test.ts
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.component.test.ts
@@ -61,7 +61,7 @@ vi.mock('../Shared/dialogTransactionFlow', () => ({
 
 import { errorToast, warningToast } from '$components/NotificationToast/NotificationToast.svelte';
 import { type BridgeTransaction, MessageStatus } from '$libs/bridge';
-import { BlockNotSyncedError, ProofGenerationError } from '$libs/error';
+import { BlockNotSyncedError, ProofGenerationError, WrongBridgeConfigError } from '$libs/error';
 import { TokenType } from '$libs/token';
 import { account } from '$stores/account';
 
@@ -260,6 +260,18 @@ describe('a claim the prover refuses before any transaction', () => {
     expect(warningToast).toHaveBeenCalledWith(notSyncedToast);
     expect(errorToast).not.toHaveBeenCalled();
     expect(claimButton()?.disabled).toBe(false);
+  });
+
+  it('reports a misconfiguration the prover detected as an unknown error, not as a wait', async () => {
+    // The one refusal the prover knows to be permanent: the anchor keeps its checkpoints in a
+    // contract other than the configured SignalService. Telling the user to wait would be a lie
+    await claimRefusedWith(new WrongBridgeConfigError("Anchor's checkpointStore does NOT match SignalService"));
+
+    expect(errorToast).toHaveBeenCalledWith({
+      title: 'bridge.errors.unknown_error.title',
+      message: 'bridge.errors.unknown_error.message',
+    });
+    expect(warningToast).not.toHaveBeenCalled();
   });
 
   it('still reports a failure it cannot classify as an unknown error', async () => {

--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.component.test.ts
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.component.test.ts
@@ -59,7 +59,9 @@ vi.mock('../Shared/dialogTransactionFlow', () => ({
   reportDialogTransaction: (...args: unknown[]) => reportDialogTransaction(...args),
 }));
 
+import { errorToast, warningToast } from '$components/NotificationToast/NotificationToast.svelte';
 import { type BridgeTransaction, MessageStatus } from '$libs/bridge';
+import { BlockNotSyncedError, ProofGenerationError } from '$libs/error';
 import { TokenType } from '$libs/token';
 import { account } from '$stores/account';
 
@@ -217,5 +219,56 @@ describe('closing the claim dialog while a claim is in flight', () => {
     await reopen();
 
     expect(preCheck()).not.toBeNull();
+  });
+});
+
+/**
+ * A claim can be refused before any transaction exists: BridgeProver throws when the destination
+ * chain has not synced the source block yet, or cannot build a proof against the state it has.
+ * That is the same "not yet" a B_SIGNAL_NOT_RECEIVED revert reports, but it used to fall through
+ * to "Unknown error - please try again", which reads as a failure rather than as a wait.
+ */
+describe('a claim the prover refuses before any transaction', () => {
+  const notSyncedToast = {
+    title: 'bridge.errors.claim.not_synced.title',
+    message: 'bridge.errors.claim.not_synced.message',
+  };
+
+  const claimRefusedWith = async (error: unknown) => {
+    await mountAtConfirm();
+    claimControl.next = Promise.resolve({ error });
+    claimButton()!.click();
+    await flush();
+  };
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('reports a source block the destination chain has not synced as not synced yet', async () => {
+    await claimRefusedWith(new BlockNotSyncedError('block is not synced yet'));
+
+    expect(warningToast).toHaveBeenCalledWith(notSyncedToast);
+    expect(errorToast).not.toHaveBeenCalled();
+    // Nothing was sent, so the same button serves the retry once the block has synced
+    expect(claimButton()?.disabled).toBe(false);
+  });
+
+  it('reports a proof that cannot be built against the synced state the same way', async () => {
+    await claimRefusedWith(new ProofGenerationError('proof will not be valid, expected storageProof to not be 0'));
+
+    expect(warningToast).toHaveBeenCalledWith(notSyncedToast);
+    expect(errorToast).not.toHaveBeenCalled();
+    expect(claimButton()?.disabled).toBe(false);
+  });
+
+  it('still reports a failure it cannot classify as an unknown error', async () => {
+    await claimRefusedWith(new Error('boom'));
+
+    expect(errorToast).toHaveBeenCalledWith({
+      title: 'bridge.errors.unknown_error.title',
+      message: 'bridge.errors.unknown_error.message',
+    });
+    expect(warningToast).not.toHaveBeenCalled();
   });
 });

--- a/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.svelte
+++ b/packages/bridge-ui/src/components/Dialogs/ClaimDialog/ClaimDialog.svelte
@@ -11,10 +11,12 @@
   import type { BridgeTransaction } from '$libs/bridge/types';
   import { closeOnEscapeOrOutsideClick } from '$libs/customActions';
   import {
+    BlockNotSyncedError,
     InsufficientBalanceError,
     InvalidProofError,
     NotConnectedError,
     ProcessMessageError,
+    ProofGenerationError,
     RetryError,
   } from '$libs/error';
   import type { NFT } from '$libs/token';
@@ -155,6 +157,19 @@
         break;
       case err instanceof RetryError:
         errorToast({ title: $t('bridge.errors.retry_error') });
+        break;
+      // BridgeProver refuses a claim before any transaction exists when the destination chain
+      // has not synced the source block yet, or cannot build a proof against the state it has.
+      // That is the same "not yet" a B_SIGNAL_NOT_RECEIVED revert reports below, reached
+      // client-side; it used to fall through to "Unknown error - please try again", which
+      // reads as a failure when the next checkpoint resolves it with no action at all
+      case err instanceof BlockNotSyncedError:
+      case err instanceof ProofGenerationError:
+        console.error(err);
+        warningToast({
+          title: $t('bridge.errors.claim.not_synced.title'),
+          message: $t('bridge.errors.claim.not_synced.message'),
+        });
         break;
       case err instanceof ContractFunctionExecutionError:
         console.error(err);

--- a/packages/bridge-ui/src/i18n/en.json
+++ b/packages/bridge-ui/src/i18n/en.json
@@ -90,6 +90,10 @@
           "message": "The message is not proven and cannot be claimed right now.",
           "title": "Not received"
         },
+        "not_synced": {
+          "message": "The destination chain has not synced this message yet, so it cannot be claimed right now. Your funds are safe; wait a few minutes and try again.",
+          "title": "Not synced yet"
+        },
         "quota_reached": {
           "message": "This asset's withdrawal quota is currently used up. Your funds are safe; wait for the quota to replenish, then try claiming again.",
           "title": "Withdrawal quota reached"

--- a/packages/bridge-ui/src/libs/proof/BridgeProver.test.ts
+++ b/packages/bridge-ui/src/libs/proof/BridgeProver.test.ts
@@ -13,7 +13,7 @@ import {
 import { signalServiceAbi } from '$abi';
 import { routingContractsMap } from '$bridgeConfig';
 import type { BridgeTransaction } from '$libs/bridge';
-import { BlockNotSyncedError, ClientError, ProofGenerationError } from '$libs/error';
+import { BlockNotSyncedError, ClientError, ProofGenerationError, WrongBridgeConfigError } from '$libs/error';
 import { BridgeProver } from '$libs/proof/BridgeProver';
 import {
   CacheOption,
@@ -698,6 +698,56 @@ describe('BridgeProver', () => {
       await expect(bridgeProver.getEncodedSignalProof({ bridgeTx: realBridgeTransaction })).rejects.toThrow(
         ProofGenerationError,
       );
+    });
+
+    /** The mocked L1->L2 route is the one with an anchor to ask about its checkpoint store */
+    const l1ToL2Transaction = (): BridgeTransaction => ({
+      ...realBridgeTransaction,
+      srcChainId: BigInt(L1_CHAIN_ID),
+      destChainId: BigInt(L2_CHAIN_ID),
+      message: {
+        ...realBridgeTransaction.message!,
+        srcChainId: BigInt(L1_CHAIN_ID),
+        destChainId: BigInt(L2_CHAIN_ID),
+      },
+    });
+
+    /** The checkpoint lookup fails; the diagnostic read of the anchor answers with `checkpointStore` */
+    const checkpointMissingWithAnchorStore = (checkpointStore: string) =>
+      vi.mocked(readContract).mockImplementation((async (
+        _config: unknown,
+        { functionName }: { functionName: string },
+      ) => {
+        if (functionName === 'checkpointStore') return checkpointStore;
+        throw new Error('SS_CHECKPOINT_NOT_FOUND');
+      }) as unknown as typeof readContract);
+
+    it('throws WrongBridgeConfigError when the anchor keeps its checkpoints outside the SignalService', async () => {
+      // Given
+      const bridgeProver = new BridgeProver();
+      const bridgeTx = l1ToL2Transaction();
+
+      vi.spyOn(bridgeProver, 'getSignalSlot').mockResolvedValue(validSignalSlot);
+      vi.spyOn(bridgeProver, 'getLatestSyncedBlockNumber').mockResolvedValue(BigInt(bridgeTx.blockNumber!));
+      checkpointMissingWithAnchorStore('0x000000000000000000000000000000000000dEaD');
+
+      // When / Then: a deployment mismatch no later checkpoint can cure is not a "not synced yet"
+      await expect(bridgeProver.getEncodedSignalProof({ bridgeTx })).rejects.toThrow(WrongBridgeConfigError);
+    });
+
+    it('keeps a missing checkpoint a ProofGenerationError when the anchor does use the SignalService', async () => {
+      // Given
+      const bridgeProver = new BridgeProver();
+      const bridgeTx = l1ToL2Transaction();
+
+      vi.spyOn(bridgeProver, 'getSignalSlot').mockResolvedValue(validSignalSlot);
+      vi.spyOn(bridgeProver, 'getLatestSyncedBlockNumber').mockResolvedValue(BigInt(bridgeTx.blockNumber!));
+      // The same store, reported in a different letter case as a node may
+      const signalService = routingContractsMap[L2_CHAIN_ID][L1_CHAIN_ID].signalServiceAddress;
+      checkpointMissingWithAnchorStore('0x' + signalService.slice(2).toUpperCase());
+
+      // When / Then
+      await expect(bridgeProver.getEncodedSignalProof({ bridgeTx })).rejects.toThrow(ProofGenerationError);
     });
   });
 

--- a/packages/bridge-ui/src/libs/proof/BridgeProver.ts
+++ b/packages/bridge-ui/src/libs/proof/BridgeProver.ts
@@ -16,7 +16,7 @@ import { signalServiceAbi } from '$abi';
 import { routingContractsMap } from '$bridgeConfig';
 import { type BridgeTransaction, MessageStatus } from '$libs/bridge';
 import { isL2Chain } from '$libs/chain';
-import { BlockNotSyncedError, ClientError, ProofGenerationError } from '$libs/error';
+import { BlockNotSyncedError, ClientError, ProofGenerationError, WrongBridgeConfigError } from '$libs/error';
 import { getLogger } from '$libs/util/logger';
 import { config } from '$libs/wagmi';
 
@@ -166,23 +166,21 @@ export class BridgeProver {
     } catch (error) {
       log('Checkpoint NOT found', { blockNumber, error });
 
-      // Diagnostic: check if Anchor's checkpointStore matches SignalService
+      // Diagnostic: an anchor that keeps its checkpoints in a contract other than the configured
+      // SignalService is a deployment mismatch no later checkpoint can cure. It gets its own class
+      // so the dialogs do not report it as the transient "cannot prove this yet" thrown below
       const anchorAddress = routingContractsMap[destChainId][srcChainId].anchorForkRouter;
       if (anchorAddress) {
-        try {
-          const checkpointStore = await readContract(config, {
-            address: anchorAddress,
-            abi: anchorGetBlockStateAbi,
-            functionName: 'checkpointStore',
-            chainId: destChainId,
-          });
-          if (checkpointStore.toLowerCase() !== destSignalService.toLowerCase()) {
-            throw new ProofGenerationError(
-              `Anchor's checkpointStore (${checkpointStore}) does NOT match SignalService (${destSignalService})`,
-            );
-          }
-        } catch (e) {
-          if (e instanceof ProofGenerationError) throw e;
+        const checkpointStore = await readContract(config, {
+          address: anchorAddress,
+          abi: anchorGetBlockStateAbi,
+          functionName: 'checkpointStore',
+          chainId: destChainId,
+        }).catch(() => undefined);
+        if (checkpointStore && checkpointStore.toLowerCase() !== destSignalService.toLowerCase()) {
+          throw new WrongBridgeConfigError(
+            `Anchor's checkpointStore (${checkpointStore}) does NOT match SignalService (${destSignalService})`,
+          );
         }
       }
 


### PR DESCRIPTION
Stacked on #22097 — base is `claude/bridge-ui-code-audit-0ljtmq`, so the diff here is just this change.

Fixes #22105.

## What was wrong

A zero-fee L1→L2 ETH transfer that was offered **Try claim** answered **Claim now** with

> **Unknown error** — An unexpected error has occurred. Please try again.

before any transaction existed and without a wallet prompt. The console showed `BlockNotSyncedError: block is not synced yet` from `BridgeProver.getEncodedSignalProof`. The claim went through on its own once the destination chain had synced the source block, so only the message shown during that window was wrong: it reads as a failure, and "please try again" cannot succeed until the next checkpoint lands.

## Root cause

`BridgeProver` refuses a claim client-side with `BlockNotSyncedError` when the latest synced source block is below the message's block (or, L2→L1, when the checkpoint search comes back empty), and with `ProofGenerationError` when it cannot build a proof against the state it has. `Claim.svelte` forwards the throw unchanged and `Bridge.processMessage` does not wrap it. `ClaimDialog.handleClaimError` classified `NotConnectedError`, `UserRejectedRequestError`, `InsufficientBalanceError`, `InvalidProofError`, `ProcessMessageError`, `RetryError` and the revert strings inside a `ContractFunctionExecutionError`, then defaulted to the unknown-error toast. Neither prover error had a case.

The release path does **not** have this gap at the reporter's head: `ReleaseDialog` has classified both errors as "not synced yet" since 86eb94d6 (`fix(bridge-ui): address the review of #22097`), an ancestor of `27dd5c2`. This PR brings the claim path in line with it.

## The change

- `ClaimDialog.handleClaimError` gets `BlockNotSyncedError` / `ProofGenerationError` cases ahead of the revert branch, shown as a **warning** toast, the way `ReleaseDialog` treats the same errors. The error is still logged to the console.
- New `bridge.errors.claim.not_synced` strings with claim-side wording: *Not synced yet — The destination chain has not synced this message yet, so it cannot be claimed right now. Your funds are safe; wait a few minutes and try again.* The release strings talk about the source chain, so they are not reused.
- Matching is by class, like every other custom error in that switch. Nothing between the prover and the dialog wraps these errors, so walking `cause` for `error.name` would add a path that cannot currently be taken.

`ProofGenerationError` is mapped the same way because every throw of it left on the claim path is a proof that cannot be built against the state the RPCs currently serve: an empty storage slot, a checkpoint the RPC does not return, or a state root that does not match the source block, which means the source RPC served a block on another fork. The next checkpoint or a canonical RPC resolves each of those.

The one refusal the prover can tell is permanent, an anchor whose `checkpointStore` is not the configured SignalService, now throws the existing `WrongBridgeConfigError` instead (second commit, from the Codex review comment). Both dialogs fall through to the unknown-error toast for it, still logged with both addresses.

## Relationship to #22103

Complementary. #22103 (already merged into this base) stops offering **Try claim** when the sync check *knows* the block is behind, so the reported row would no longer get the button. The `null` (undetermined) path still offers it, and any claim that reaches the prover in that window still ended in "Unknown error". That is what this fixes.

## Tests

`ClaimDialog.component.test.ts` gains four cases that drive the real dialog through the scripted claim stub: `BlockNotSyncedError` and `ProofGenerationError` produce the not-synced warning, no error toast, and leave the Claim button enabled for the retry; `WrongBridgeConfigError` and an unclassified `Error` still produce the unknown-error toast. Both prover cases failed before the dialog change (warning toast never called) and pass after it.

`BridgeProver.test.ts` pins the prover side: a mismatching anchor store throws `WrongBridgeConfigError` (red before the second commit), and a matching store keeps the missing checkpoint a `ProofGenerationError`.

Verified in a worktree at this commit:

- `pnpm vitest run` — 96 files, 815 tests, all passing
- `pnpm svelte:check` — 0 errors, 0 warnings
- `pnpm lint` — clean
- `typos` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
