### PR TITLE
fix(relayer): report the claimer of a message the relayer claimed itself

### DIFF
--- a/packages/relayer/event.go
+++ b/packages/relayer/event.go
@@ -146,6 +146,11 @@ type EventRepository interface {
 		event string,
 		msgHash string,
 	) (*Event, error)
+	FindAllByEventAndMsgHash(
+		ctx context.Context,
+		event string,
+		msgHash string,
+	) ([]*Event, error)
 	Delete(ctx context.Context, id int) error
 	CheckpointSyncedEventByBlockNumberOrGreater(
 		ctx context.Context,

--- a/packages/relayer/pkg/http/get_events_by_address.go
+++ b/packages/relayer/pkg/http/get_events_by_address.go
@@ -1,8 +1,10 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"html"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"strconv"
@@ -113,46 +115,30 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 	for i := range *page.Items.(*[]relayer.Event) {
 		v := &(*page.Items.(*[]relayer.Event))[i]
 
-		msgProcessedEvent, err := srv.eventRepo.FirstByEventAndMsgHash(
-			c.Request().Context(),
-			relayer.EventNameMessageStatusChanged,
-			v.MsgHash,
-		)
-		if err != nil {
+		claim, err := srv.claimLog(c.Request().Context(), v.MsgHash)
+		if err != nil || claim == nil {
 			continue
 		}
 
-		if msgProcessedEvent == nil {
+		v.ProcessedTxHash = claim.TransactionHash
+
+		// The sender is recovered through the block the transaction was mined in, so a row
+		// that carries only the hash can name the transaction but not the claimer
+		if claim.TransactionIndex == "" || claim.BlockHash == "" {
 			continue
 		}
 
-		r := &JSONData{}
-
-		if err := json.Unmarshal(msgProcessedEvent.Data, r); err != nil {
-			continue
-		}
-
-		if r.Raw.TransactionIndex == "" || r.Raw.TransactionHash == "" {
-			continue
-		}
-
-		var ethClient ethClient
-
-		if new(big.Int).SetInt64(msgProcessedEvent.ChainID).Cmp(srv.srcChainID) == 0 {
-			ethClient = srv.srcEthClient
-		} else {
-			ethClient = srv.destEthClient
-		}
+		ethClient := srv.clientForChain(srv.claimChainID(c.Request().Context(), v))
 
 		tx, _, err := ethClient.TransactionByHash(
 			c.Request().Context(),
-			common.HexToHash(r.Raw.TransactionHash),
+			common.HexToHash(claim.TransactionHash),
 		)
 		if err != nil {
 			continue
 		}
 
-		txIndex, err := strconv.ParseInt(r.Raw.TransactionIndex[2:], 16, 64)
+		txIndex, err := strconv.ParseInt(claim.TransactionIndex[2:], 16, 64)
 		if err != nil {
 			continue
 		}
@@ -160,15 +146,91 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 		sender, err := ethClient.TransactionSender(
 			c.Request().Context(),
 			tx,
-			common.HexToHash(r.Raw.BlockHash),
+			common.HexToHash(claim.BlockHash),
 			uint(txIndex),
 		)
 		if err == nil {
 			v.ClaimedBy = sender.Hex()
 		}
-
-		v.ProcessedTxHash = r.Raw.TransactionHash
 	}
 
 	return c.JSON(http.StatusOK, page)
+}
+
+// claimLog returns the MessageStatusChanged log to read a message's claim from: newest
+// first, the first fully indexed DONE row, or failing that the first DONE row that at least
+// names the transaction.
+//
+// A message has more than one such row when the relayer claims it: the processor records
+// its own claim before the destination chain's indexer stores the log, and until now that
+// record carried nothing but the transaction hash. Taking the first row by id took that
+// stub, and a stub cannot name the claimer, so every message the relayer claimed came back
+// with neither claimer nor claim hash while every self-claim came back with both.
+//
+// Only DONE counts. A retried message also has a complete row for the attempt that left it
+// RETRIABLE, and a recalled one has a RECALLED row mined on the source chain; neither is a
+// claim, and reporting one would name the wrong transaction, chain and sender.
+func (srv *Server) claimLog(ctx context.Context, msgHash string) (*Raw, error) {
+	rows, err := srv.eventRepo.FindAllByEventAndMsgHash(ctx, relayer.EventNameMessageStatusChanged, msgHash)
+	if err != nil {
+		slog.Warn("could not read the status rows of a message", "msgHash", msgHash, "error", err)
+
+		return nil, err
+	}
+
+	var named *Raw
+
+	for i := len(rows) - 1; i >= 0; i-- {
+		row := rows[i]
+		if row.Status != relayer.EventStatusDone {
+			continue
+		}
+
+		r := &JSONData{}
+		if err := json.Unmarshal(row.Data, r); err != nil {
+			continue
+		}
+
+		if r.Raw.TransactionHash == "" {
+			continue
+		}
+
+		if r.Raw.TransactionIndex != "" && r.Raw.BlockHash != "" {
+			return &r.Raw, nil
+		}
+
+		if named == nil {
+			named = &r.Raw
+		}
+	}
+
+	return named, nil
+}
+
+// claimChainID is the chain a message's claim was mined on: the message's destination.
+// The status rows do not agree on where they are filed - the indexer files a log under the
+// chain it watches, the processor files its own claim under the message's source chain, and
+// the indexer's resume and reorg checks key on that column - so the message is asked, not
+// the row.
+func (srv *Server) claimChainID(ctx context.Context, v *relayer.Event) int64 {
+	if v.Event == relayer.EventNameMessageSent {
+		return v.DestChainID
+	}
+
+	sent, err := srv.eventRepo.FirstByEventAndMsgHash(ctx, relayer.EventNameMessageSent, v.MsgHash)
+	if err == nil && sent != nil {
+		return sent.DestChainID
+	}
+
+	return v.ChainID
+}
+
+// clientForChain is the RPC client for one of the two chains this server is configured
+// with; anything that is not the source chain is taken to be the destination.
+func (srv *Server) clientForChain(chainID int64) ethClient {
+	if big.NewInt(chainID).Cmp(srv.srcChainID) == 0 {
+		return srv.srcEthClient
+	}
+
+	return srv.destEthClient
 }

--- a/packages/relayer/pkg/http/get_events_by_address.go
+++ b/packages/relayer/pkg/http/get_events_by_address.go
@@ -157,19 +157,24 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 	return c.JSON(http.StatusOK, page)
 }
 
-// claimLog returns the MessageStatusChanged log to read a message's claim from: newest
-// first, the first fully indexed DONE row, or failing that the first DONE row that at least
-// names the transaction.
+// claimLog returns the MessageStatusChanged log to read a message's claim from, or nil when
+// the message is not currently claimed.
 //
-// A message has more than one such row when the relayer claims it: the processor records
-// its own claim before the destination chain's indexer stores the log, and until now that
-// record carried nothing but the transaction hash. Taking the first row by id took that
-// stub, and a stub cannot name the claimer, so every message the relayer claimed came back
-// with neither claimer nor claim hash while every self-claim came back with both.
+// The newest row decides. A message has more than one such row when the relayer claims it:
+// the processor records its own claim before the destination chain's indexer stores the log,
+// and until now that record carried nothing but the transaction hash. Taking the first row
+// by id took that stub, and a stub cannot name the claimer, so every message the relayer
+// claimed came back with neither claimer nor claim hash while every self-claim came back
+// with both.
 //
-// Only DONE counts. A retried message also has a complete row for the attempt that left it
-// RETRIABLE, and a recalled one has a RECALLED row mined on the source chain; neither is a
-// claim, and reporting one would name the wrong transaction, chain and sender.
+// Only a newest row that is DONE is a claim. The chain cannot move a message on from DONE,
+// so a newer non-DONE row means the DONE was orphaned by a reorg of its block and the
+// message was then retried or recalled; reorg cleanup never removes status rows (it keys on
+// block_id, which they do not set), so the orphaned row stays and only the order can tell.
+// A retried message's RETRIABLE row and a recalled message's RECALLED row are not claims
+// either. The order is insertion order, which can briefly put an indexer row for an older
+// transition after the processor's row for a newer one; the answer is then "not claimed"
+// until the indexer catches up, which is what it was before the processor row could be read.
 func (srv *Server) claimLog(ctx context.Context, msgHash string) (*Raw, error) {
 	rows, err := srv.eventRepo.FindAllByEventAndMsgHash(ctx, relayer.EventNameMessageStatusChanged, msgHash)
 	if err != nil {
@@ -178,40 +183,31 @@ func (srv *Server) claimLog(ctx context.Context, msgHash string) (*Raw, error) {
 		return nil, err
 	}
 
-	var named *Raw
-
-	for i := len(rows) - 1; i >= 0; i-- {
-		row := rows[i]
-		if row.Status != relayer.EventStatusDone {
-			continue
-		}
-
-		r := &JSONData{}
-		if err := json.Unmarshal(row.Data, r); err != nil {
-			continue
-		}
-
-		if r.Raw.TransactionHash == "" {
-			continue
-		}
-
-		if r.Raw.TransactionIndex != "" && r.Raw.BlockHash != "" {
-			return &r.Raw, nil
-		}
-
-		if named == nil {
-			named = &r.Raw
-		}
+	if len(rows) == 0 {
+		return nil, nil
 	}
 
-	return named, nil
+	latest := rows[len(rows)-1]
+	if latest.Status != relayer.EventStatusDone {
+		return nil, nil
+	}
+
+	r := &JSONData{}
+	if err := json.Unmarshal(latest.Data, r); err != nil {
+		return nil, nil
+	}
+
+	if r.Raw.TransactionHash == "" {
+		return nil, nil
+	}
+
+	return &r.Raw, nil
 }
 
 // claimChainID is the chain a message's claim was mined on: the message's destination.
-// The status rows do not agree on where they are filed - the indexer files a log under the
-// chain it watches, the processor files its own claim under the message's source chain, and
-// the indexer's resume and reorg checks key on that column - so the message is asked, not
-// the row.
+// Status rows are filed under the chain they were emitted on, but a row can predate that
+// convention (the processor's own claim used to be filed under the message's source chain),
+// so the message is asked, not the row.
 func (srv *Server) claimChainID(ctx context.Context, v *relayer.Event) int64 {
 	if v.Event == relayer.EventNameMessageSent {
 		return v.DestChainID

--- a/packages/relayer/pkg/http/get_events_by_address.go
+++ b/packages/relayer/pkg/http/get_events_by_address.go
@@ -121,30 +121,30 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 	for i := range *page.Items.(*[]relayer.Event) {
 		v := &(*page.Items.(*[]relayer.Event))[i]
 
-		claim, err := srv.claimLog(c.Request().Context(), v, headers)
+		claim, err := srv.claimLog(c.Request().Context(), v.MsgHash, headers)
 		if err != nil || claim == nil {
 			continue
 		}
 
-		v.ProcessedTxHash = claim.TransactionHash
+		v.ProcessedTxHash = claim.raw.TransactionHash
 
 		// The sender is recovered through the block the transaction was mined in, so a row
 		// that carries only the hash can name the transaction but not the claimer
-		if claim.TransactionIndex == "" || claim.BlockHash == "" {
+		if claim.raw.TransactionIndex == "" || claim.raw.BlockHash == "" {
 			continue
 		}
 
-		ethClient := srv.clientForChain(srv.claimChainID(c.Request().Context(), v))
+		ethClient := srv.clientForChain(claim.chainID)
 
 		tx, _, err := ethClient.TransactionByHash(
 			c.Request().Context(),
-			common.HexToHash(claim.TransactionHash),
+			common.HexToHash(claim.raw.TransactionHash),
 		)
 		if err != nil {
 			continue
 		}
 
-		txIndex, err := strconv.ParseInt(claim.TransactionIndex[2:], 16, 64)
+		txIndex, err := strconv.ParseInt(claim.raw.TransactionIndex[2:], 16, 64)
 		if err != nil {
 			continue
 		}
@@ -152,7 +152,7 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 		sender, err := ethClient.TransactionSender(
 			c.Request().Context(),
 			tx,
-			common.HexToHash(claim.BlockHash),
+			common.HexToHash(claim.raw.BlockHash),
 			uint(txIndex),
 		)
 		if err == nil {
@@ -163,23 +163,30 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 	return c.JSON(http.StatusOK, page)
 }
 
-// statusRow is a MessageStatusChanged row placed where its log sits on the chain.
+// statusRow is a MessageStatusChanged row placed where its log sits on the chain it is
+// filed under.
 type statusRow struct {
 	status   relayer.EventStatus
 	raw      Raw
+	chainID  int64
 	block    uint64
 	logIndex uint64
 	id       int
+}
+
+// claim is the log a message's claim is read from, and the chain it was mined on.
+type claim struct {
+	raw     Raw
+	chainID int64
 }
 
 // headerHashes caches, for one request, the hash of the canonical header at a height on a
 // chain, so a block that several rows or messages sit in is fetched once.
 type headerHashes map[string]common.Hash
 
-// canonicalHash is the hash of the block the chain has at a height.
+// canonicalHash is the hash of the block a chain has at a height.
 func (srv *Server) canonicalHash(
 	ctx context.Context,
-	client ethClient,
 	chainID int64,
 	block uint64,
 	cache headerHashes,
@@ -189,7 +196,7 @@ func (srv *Server) canonicalHash(
 		return hash, nil
 	}
 
-	header, err := client.HeaderByNumber(ctx, new(big.Int).SetUint64(block))
+	header, err := srv.clientForChain(chainID).HeaderByNumber(ctx, new(big.Int).SetUint64(block))
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -200,17 +207,32 @@ func (srv *Server) canonicalHash(
 	return hash, nil
 }
 
-// claimLog returns the MessageStatusChanged log to read a message's claim from, or nil when
-// the message is not currently claimed.
+// canonical reports whether the chain a row is filed under still has the block the row
+// names. Both writers file a row under the chain its log was emitted on - the indexer under
+// the chain it watches, the processor under the message's destination - so that column is
+// the chain to ask.
+func (srv *Server) canonical(ctx context.Context, row statusRow, cache headerHashes) (bool, error) {
+	hash, err := srv.canonicalHash(ctx, row.chainID, row.block, cache)
+	if err != nil {
+		slog.Debug("could not check a status row against its chain", "chainID", row.chainID, "error", err)
+
+		return false, err
+	}
+
+	return hash == common.HexToHash(row.raw.BlockHash), nil
+}
+
+// claimLog returns the log to read a message's claim from, or nil when the message is not
+// currently claimed.
 //
 // The latest canonical transition decides. Rows are walked from the latest coordinates
 // down - block number, then log index, which both writers record verbatim from the log -
-// and each is checked against the chain: the block the chain has at that height must be
-// the block the row names. Coordinates alone cannot tell a fork from a retry, and reorg
-// cleanup never removes status rows (it keys on block_id, which they do not set), so a
-// DONE mined on a fork the chain abandoned stays next to what the canonical fork recorded
-// instead, at a lower height or at the same height under another block hash. Row ids do
-// not order transitions either: the indexer stores the logs of one filter range from
+// and each is checked against the chain it is filed under: the block that chain has at the
+// row's height must be the block the row names. Coordinates alone cannot tell a fork from a
+// retry, and reorg cleanup never removes status rows (it keys on block_id, which they do not
+// set), so a DONE mined on a fork the chain abandoned stays next to what the canonical fork
+// recorded instead, at a lower height or at the same height under another block hash. Row
+// ids do not order transitions either: the indexer stores the logs of one filter range from
 // independent goroutines.
 //
 // A message has more than one such row when the relayer claims it: the processor records
@@ -221,35 +243,42 @@ func (srv *Server) canonicalHash(
 // has no position on the chain and nothing to check it against, so it is consulted only
 // while the message has no positioned row at all, whichever of the two was committed first.
 //
-// Only a canonical latest transition that is DONE is a claim. A row the chain cannot vouch
-// for, because the header lookup failed, is not reported either: an open question is not a
-// claim. A RECALLED row anywhere means the message is not claimed: a recall on the source
-// chain proves the destination recorded FAILED, which is terminal there.
-func (srv *Server) claimLog(ctx context.Context, v *relayer.Event, cache headerHashes) (*Raw, error) {
-	rows, err := srv.eventRepo.FindAllByEventAndMsgHash(ctx, relayer.EventNameMessageStatusChanged, v.MsgHash)
+// A RECALLED row is emitted on the source chain and vetoes a claim while that chain still
+// has the block it names: a canonical recall proves the destination recorded FAILED, which
+// is terminal there, and a recall whose block the source chain replaced does not outlive
+// its fork. A row the chain cannot vouch for, because the header lookup failed, settles
+// nothing: it is neither a claim nor, for a recall, a veto that can be dismissed, so the
+// answer is that the message is not known to be claimed.
+func (srv *Server) claimLog(ctx context.Context, msgHash string, cache headerHashes) (*claim, error) {
+	rows, err := srv.eventRepo.FindAllByEventAndMsgHash(ctx, relayer.EventNameMessageStatusChanged, msgHash)
 	if err != nil {
-		slog.Warn("could not read the status rows of a message", "msgHash", v.MsgHash, "error", err)
+		slog.Warn("could not read the status rows of a message", "msgHash", msgHash, "error", err)
 
 		return nil, err
 	}
 
-	var positioned, unpositioned []statusRow
+	var transitions, stubs, recalls []statusRow
 
 	for _, row := range rows {
-		if row.Status == relayer.EventStatusRecalled {
-			return nil, nil
-		}
-
 		r := &JSONData{}
 		if err := json.Unmarshal(row.Data, r); err != nil || r.Raw.TransactionHash == "" {
+			// A recall that cannot be read cannot be checked either
+			if row.Status == relayer.EventStatusRecalled {
+				return nil, nil
+			}
+
 			continue
 		}
 
-		s := statusRow{status: row.Status, raw: r.Raw, id: row.ID}
+		s := statusRow{status: row.Status, raw: r.Raw, chainID: row.ChainID, id: row.ID}
 
 		block, err := hexQuantity(r.Raw.BlockNumber)
 		if err != nil {
-			unpositioned = append(unpositioned, s)
+			if row.Status == relayer.EventStatusRecalled {
+				return nil, nil
+			}
+
+			stubs = append(stubs, s)
 
 			continue
 		}
@@ -257,26 +286,38 @@ func (srv *Server) claimLog(ctx context.Context, v *relayer.Event, cache headerH
 		s.block = block
 		// Every real log carries its index; a row without one still has its block
 		s.logIndex, _ = hexQuantity(r.Raw.LogIndex)
-		positioned = append(positioned, s)
+
+		if row.Status == relayer.EventStatusRecalled {
+			recalls = append(recalls, s)
+		} else {
+			transitions = append(transitions, s)
+		}
 	}
 
-	if len(positioned) == 0 {
-		if len(unpositioned) == 0 {
+	for _, recall := range recalls {
+		vetoes, err := srv.canonical(ctx, recall, cache)
+		if err != nil || vetoes {
+			return nil, nil
+		}
+	}
+
+	if len(transitions) == 0 {
+		if len(stubs) == 0 {
 			return nil, nil
 		}
 
-		sort.SliceStable(unpositioned, func(a, b int) bool { return unpositioned[a].id < unpositioned[b].id })
+		sort.SliceStable(stubs, func(a, b int) bool { return stubs[a].id < stubs[b].id })
 
-		latest := unpositioned[len(unpositioned)-1]
+		latest := stubs[len(stubs)-1]
 		if latest.status != relayer.EventStatusDone {
 			return nil, nil
 		}
 
-		return &latest.raw, nil
+		return &claim{raw: latest.raw, chainID: latest.chainID}, nil
 	}
 
-	sort.SliceStable(positioned, func(a, b int) bool {
-		x, y := positioned[a], positioned[b]
+	sort.SliceStable(transitions, func(a, b int) bool {
+		x, y := transitions[a], transitions[b]
 		if x.block != y.block {
 			return x.block < y.block
 		}
@@ -288,21 +329,16 @@ func (srv *Server) claimLog(ctx context.Context, v *relayer.Event, cache headerH
 		return x.id < y.id
 	})
 
-	chainID := srv.claimChainID(ctx, v)
-	client := srv.clientForChain(chainID)
+	for i := len(transitions) - 1; i >= 0; i-- {
+		row := transitions[i]
 
-	for i := len(positioned) - 1; i >= 0; i-- {
-		row := positioned[i]
-
-		canonical, err := srv.canonicalHash(ctx, client, chainID, row.block, cache)
+		ok, err := srv.canonical(ctx, row, cache)
 		if err != nil {
-			slog.Debug("could not check a status row against the chain", "msgHash", v.MsgHash, "error", err)
-
 			return nil, nil
 		}
 
 		// The chain has another block at this height: this row is a fork's
-		if canonical != common.HexToHash(row.raw.BlockHash) {
+		if !ok {
 			continue
 		}
 
@@ -310,7 +346,7 @@ func (srv *Server) claimLog(ctx context.Context, v *relayer.Event, cache headerH
 			return nil, nil
 		}
 
-		return &row.raw, nil
+		return &claim{raw: row.raw, chainID: row.chainID}, nil
 	}
 
 	return nil, nil
@@ -323,23 +359,6 @@ func hexQuantity(s string) (uint64, error) {
 	}
 
 	return strconv.ParseUint(s[2:], 16, 64)
-}
-
-// claimChainID is the chain a message's claim was mined on: the message's destination.
-// Status rows are filed under the chain they were emitted on, but a row can predate that
-// convention (the processor's own claim used to be filed under the message's source chain),
-// so the message is asked, not the row.
-func (srv *Server) claimChainID(ctx context.Context, v *relayer.Event) int64 {
-	if v.Event == relayer.EventNameMessageSent {
-		return v.DestChainID
-	}
-
-	sent, err := srv.eventRepo.FirstByEventAndMsgHash(ctx, relayer.EventNameMessageSent, v.MsgHash)
-	if err == nil && sent != nil {
-		return sent.DestChainID
-	}
-
-	return v.ChainID
 }
 
 // clientForChain is the RPC client for one of the two chains this server is configured

--- a/packages/relayer/pkg/http/get_events_by_address.go
+++ b/packages/relayer/pkg/http/get_events_by_address.go
@@ -3,10 +3,12 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"html"
 	"log/slog"
 	"math/big"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"github.com/cyberhorsey/webutils"
@@ -14,6 +16,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
 )
+
+var errNotHexQuantity = errors.New("not a 0x-prefixed hex quantity")
 
 type JSONData struct {
 	Raw Raw `json:"Raw"`
@@ -157,24 +161,37 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 	return c.JSON(http.StatusOK, page)
 }
 
+// statusRow is a MessageStatusChanged row placed where its log sits on the chain.
+type statusRow struct {
+	status   relayer.EventStatus
+	raw      Raw
+	block    uint64
+	logIndex uint64
+	id       int
+}
+
 // claimLog returns the MessageStatusChanged log to read a message's claim from, or nil when
 // the message is not currently claimed.
 //
-// The newest row decides. A message has more than one such row when the relayer claims it:
-// the processor records its own claim before the destination chain's indexer stores the log,
-// and until now that record carried nothing but the transaction hash. Taking the first row
-// by id took that stub, and a stub cannot name the claimer, so every message the relayer
-// claimed came back with neither claimer nor claim hash while every self-claim came back
-// with both.
+// The latest transition decides, in the chain's own order: block number, then log index,
+// which both writers record verbatim from the log. Row ids do not order transitions - the
+// indexer stores the logs of one filter range from independent goroutines, so the DONE at
+// block N+1 can be committed before the RETRIABLE at block N.
 //
-// Only a newest row that is DONE is a claim. The chain cannot move a message on from DONE,
-// so a newer non-DONE row means the DONE was orphaned by a reorg of its block and the
-// message was then retried or recalled; reorg cleanup never removes status rows (it keys on
-// block_id, which they do not set), so the orphaned row stays and only the order can tell.
-// A retried message's RETRIABLE row and a recalled message's RECALLED row are not claims
-// either. The order is insertion order, which can briefly put an indexer row for an older
-// transition after the processor's row for a newer one; the answer is then "not claimed"
-// until the indexer catches up, which is what it was before the processor row could be read.
+// A message has more than one such row when the relayer claims it: the processor records
+// its own claim before the destination chain's indexer stores the log, and until now that
+// record carried nothing but the transaction hash. Taking the first row by id took that
+// stub, and a stub cannot name the claimer, so every message the relayer claimed came back
+// with neither claimer nor claim hash while every self-claim came back with both. A stub
+// has no position on the chain, so it is consulted only while the message has no
+// positioned row at all, whichever of the two was committed first.
+//
+// Only a latest transition that is DONE is a claim. The chain cannot move a message on
+// from DONE, so a later non-DONE row means the DONE was orphaned by a reorg of its block;
+// reorg cleanup never removes status rows (it keys on block_id, which they do not set), so
+// the orphaned row stays and only the order can tell. A RECALLED row anywhere means the
+// message is not claimed: a recall on the source chain proves the destination recorded
+// FAILED, which is terminal there, so the two chains' rows need no common order.
 func (srv *Server) claimLog(ctx context.Context, msgHash string) (*Raw, error) {
 	rows, err := srv.eventRepo.FindAllByEventAndMsgHash(ctx, relayer.EventNameMessageStatusChanged, msgHash)
 	if err != nil {
@@ -183,25 +200,70 @@ func (srv *Server) claimLog(ctx context.Context, msgHash string) (*Raw, error) {
 		return nil, err
 	}
 
-	if len(rows) == 0 {
+	var positioned, unpositioned []statusRow
+
+	for _, row := range rows {
+		if row.Status == relayer.EventStatusRecalled {
+			return nil, nil
+		}
+
+		r := &JSONData{}
+		if err := json.Unmarshal(row.Data, r); err != nil || r.Raw.TransactionHash == "" {
+			continue
+		}
+
+		s := statusRow{status: row.Status, raw: r.Raw, id: row.ID}
+
+		block, err := hexQuantity(r.Raw.BlockNumber)
+		if err != nil {
+			unpositioned = append(unpositioned, s)
+
+			continue
+		}
+
+		s.block = block
+		// Every real log carries its index; a row without one still has its block
+		s.logIndex, _ = hexQuantity(r.Raw.LogIndex)
+		positioned = append(positioned, s)
+	}
+
+	candidates := positioned
+	if len(candidates) == 0 {
+		candidates = unpositioned
+	}
+
+	if len(candidates) == 0 {
 		return nil, nil
 	}
 
-	latest := rows[len(rows)-1]
-	if latest.Status != relayer.EventStatusDone {
+	sort.SliceStable(candidates, func(a, b int) bool {
+		x, y := candidates[a], candidates[b]
+		if x.block != y.block {
+			return x.block < y.block
+		}
+
+		if x.logIndex != y.logIndex {
+			return x.logIndex < y.logIndex
+		}
+
+		return x.id < y.id
+	})
+
+	latest := candidates[len(candidates)-1]
+	if latest.status != relayer.EventStatusDone {
 		return nil, nil
 	}
 
-	r := &JSONData{}
-	if err := json.Unmarshal(latest.Data, r); err != nil {
-		return nil, nil
+	return &latest.raw, nil
+}
+
+// hexQuantity parses a 0x-prefixed hex quantity the way the logs carry block and log indices.
+func hexQuantity(s string) (uint64, error) {
+	if len(s) < 3 || s[:2] != "0x" {
+		return 0, errNotHexQuantity
 	}
 
-	if r.Raw.TransactionHash == "" {
-		return nil, nil
-	}
-
-	return &r.Raw, nil
+	return strconv.ParseUint(s[2:], 16, 64)
 }
 
 // claimChainID is the chain a message's claim was mined on: the message's destination.

--- a/packages/relayer/pkg/http/get_events_by_address.go
+++ b/packages/relayer/pkg/http/get_events_by_address.go
@@ -116,10 +116,12 @@ func (srv *Server) GetEventsByAddress(c echo.Context) error {
 	}
 
 	// get processed message tx and claimedBy
+	headers := headerHashes{}
+
 	for i := range *page.Items.(*[]relayer.Event) {
 		v := &(*page.Items.(*[]relayer.Event))[i]
 
-		claim, err := srv.claimLog(c.Request().Context(), v.MsgHash)
+		claim, err := srv.claimLog(c.Request().Context(), v, headers)
 		if err != nil || claim == nil {
 			continue
 		}
@@ -170,32 +172,63 @@ type statusRow struct {
 	id       int
 }
 
+// headerHashes caches, for one request, the hash of the canonical header at a height on a
+// chain, so a block that several rows or messages sit in is fetched once.
+type headerHashes map[string]common.Hash
+
+// canonicalHash is the hash of the block the chain has at a height.
+func (srv *Server) canonicalHash(
+	ctx context.Context,
+	client ethClient,
+	chainID int64,
+	block uint64,
+	cache headerHashes,
+) (common.Hash, error) {
+	key := strconv.FormatInt(chainID, 10) + ":" + strconv.FormatUint(block, 10)
+	if hash, ok := cache[key]; ok {
+		return hash, nil
+	}
+
+	header, err := client.HeaderByNumber(ctx, new(big.Int).SetUint64(block))
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	hash := header.Hash()
+	cache[key] = hash
+
+	return hash, nil
+}
+
 // claimLog returns the MessageStatusChanged log to read a message's claim from, or nil when
 // the message is not currently claimed.
 //
-// The latest transition decides, in the chain's own order: block number, then log index,
-// which both writers record verbatim from the log. Row ids do not order transitions - the
-// indexer stores the logs of one filter range from independent goroutines, so the DONE at
-// block N+1 can be committed before the RETRIABLE at block N.
+// The latest canonical transition decides. Rows are walked from the latest coordinates
+// down - block number, then log index, which both writers record verbatim from the log -
+// and each is checked against the chain: the block the chain has at that height must be
+// the block the row names. Coordinates alone cannot tell a fork from a retry, and reorg
+// cleanup never removes status rows (it keys on block_id, which they do not set), so a
+// DONE mined on a fork the chain abandoned stays next to what the canonical fork recorded
+// instead, at a lower height or at the same height under another block hash. Row ids do
+// not order transitions either: the indexer stores the logs of one filter range from
+// independent goroutines.
 //
 // A message has more than one such row when the relayer claims it: the processor records
 // its own claim before the destination chain's indexer stores the log, and until now that
 // record carried nothing but the transaction hash. Taking the first row by id took that
 // stub, and a stub cannot name the claimer, so every message the relayer claimed came back
 // with neither claimer nor claim hash while every self-claim came back with both. A stub
-// has no position on the chain, so it is consulted only while the message has no
-// positioned row at all, whichever of the two was committed first.
+// has no position on the chain and nothing to check it against, so it is consulted only
+// while the message has no positioned row at all, whichever of the two was committed first.
 //
-// Only a latest transition that is DONE is a claim. The chain cannot move a message on
-// from DONE, so a later non-DONE row means the DONE was orphaned by a reorg of its block;
-// reorg cleanup never removes status rows (it keys on block_id, which they do not set), so
-// the orphaned row stays and only the order can tell. A RECALLED row anywhere means the
-// message is not claimed: a recall on the source chain proves the destination recorded
-// FAILED, which is terminal there, so the two chains' rows need no common order.
-func (srv *Server) claimLog(ctx context.Context, msgHash string) (*Raw, error) {
-	rows, err := srv.eventRepo.FindAllByEventAndMsgHash(ctx, relayer.EventNameMessageStatusChanged, msgHash)
+// Only a canonical latest transition that is DONE is a claim. A row the chain cannot vouch
+// for, because the header lookup failed, is not reported either: an open question is not a
+// claim. A RECALLED row anywhere means the message is not claimed: a recall on the source
+// chain proves the destination recorded FAILED, which is terminal there.
+func (srv *Server) claimLog(ctx context.Context, v *relayer.Event, cache headerHashes) (*Raw, error) {
+	rows, err := srv.eventRepo.FindAllByEventAndMsgHash(ctx, relayer.EventNameMessageStatusChanged, v.MsgHash)
 	if err != nil {
-		slog.Warn("could not read the status rows of a message", "msgHash", msgHash, "error", err)
+		slog.Warn("could not read the status rows of a message", "msgHash", v.MsgHash, "error", err)
 
 		return nil, err
 	}
@@ -227,17 +260,23 @@ func (srv *Server) claimLog(ctx context.Context, msgHash string) (*Raw, error) {
 		positioned = append(positioned, s)
 	}
 
-	candidates := positioned
-	if len(candidates) == 0 {
-		candidates = unpositioned
+	if len(positioned) == 0 {
+		if len(unpositioned) == 0 {
+			return nil, nil
+		}
+
+		sort.SliceStable(unpositioned, func(a, b int) bool { return unpositioned[a].id < unpositioned[b].id })
+
+		latest := unpositioned[len(unpositioned)-1]
+		if latest.status != relayer.EventStatusDone {
+			return nil, nil
+		}
+
+		return &latest.raw, nil
 	}
 
-	if len(candidates) == 0 {
-		return nil, nil
-	}
-
-	sort.SliceStable(candidates, func(a, b int) bool {
-		x, y := candidates[a], candidates[b]
+	sort.SliceStable(positioned, func(a, b int) bool {
+		x, y := positioned[a], positioned[b]
 		if x.block != y.block {
 			return x.block < y.block
 		}
@@ -249,12 +288,32 @@ func (srv *Server) claimLog(ctx context.Context, msgHash string) (*Raw, error) {
 		return x.id < y.id
 	})
 
-	latest := candidates[len(candidates)-1]
-	if latest.status != relayer.EventStatusDone {
-		return nil, nil
+	chainID := srv.claimChainID(ctx, v)
+	client := srv.clientForChain(chainID)
+
+	for i := len(positioned) - 1; i >= 0; i-- {
+		row := positioned[i]
+
+		canonical, err := srv.canonicalHash(ctx, client, chainID, row.block, cache)
+		if err != nil {
+			slog.Debug("could not check a status row against the chain", "msgHash", v.MsgHash, "error", err)
+
+			return nil, nil
+		}
+
+		// The chain has another block at this height: this row is a fork's
+		if canonical != common.HexToHash(row.raw.BlockHash) {
+			continue
+		}
+
+		if row.status != relayer.EventStatusDone {
+			return nil, nil
+		}
+
+		return &row.raw, nil
 	}
 
-	return &latest.raw, nil
+	return nil, nil
 }
 
 // hexQuantity parses a 0x-prefixed hex quantity the way the logs carry block and log indices.

--- a/packages/relayer/pkg/http/get_events_by_address_test.go
+++ b/packages/relayer/pkg/http/get_events_by_address_test.go
@@ -2,16 +2,22 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/cyberhorsey/webutils/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/taikoxyz/taiko-mono/packages/relayer"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/bindings/bridge"
+	"github.com/taikoxyz/taiko-mono/packages/relayer/pkg/mock"
 )
 
 func Test_GetEventsByAddress(t *testing.T) {
@@ -77,4 +83,206 @@ func Test_GetEventsByAddress(t *testing.T) {
 			testutils.AssertStatusAndBody(t, rec, tt.wantStatus, tt.wantBodyRegexpMatches)
 		})
 	}
+}
+
+// claimSenderClient answers every sender lookup with one address, so a test can tell which
+// chain's client the handler asked.
+type claimSenderClient struct {
+	mock.EthClient
+	sender common.Address
+}
+
+func (c *claimSenderClient) TransactionSender(
+	_ context.Context,
+	_ *types.Transaction,
+	_ common.Hash,
+	_ uint,
+) (common.Address, error) {
+	return c.sender, nil
+}
+
+// The relayer reports who claimed a message by reading the claim transaction named in the
+// message's MessageStatusChanged row. When the relayer itself claims, its processor records a
+// stub row carrying only the transaction hash before the destination-chain indexer stores the
+// full log, and the first row is the stub: every relayer-claimed message came back with neither
+// claimer nor claim hash, while self-claims had both.
+func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
+	const (
+		srcChainID   = 167001
+		destChainID  = 167002
+		owner        = "0x0000000000000000000000000000000000000123"
+		msgHash      = "0x789cd5dcc77d50bec34b6458af936a3bfa802f3aa8b8466c07b2c6b663c92575"
+		claimTxHash  = "0x27a4811c18012da320c7a1bf4d788aeca068ac2e34a5f2ff73df33fa5f0e4b44"
+		retryTxHash  = "0x1111111111111111111111111111111111111111111111111111111111111111"
+		recallTxHash = "0x2222222222222222222222222222222222222222222222222222222222222222"
+	)
+
+	srcSender := common.HexToAddress("0x000000000000000000000000000000000000AAAA")
+	relayerAddr := common.HexToAddress("0x00006ca990540F6e30e3ef05F085a033Ae67F214")
+
+	newServer := func() *Server {
+		srv := newTestServer()
+		srv.srcChainID = big.NewInt(srcChainID)
+		srv.destChainID = big.NewInt(destChainID)
+		srv.srcEthClient = &claimSenderClient{sender: srcSender}
+		srv.destEthClient = &claimSenderClient{sender: relayerAddr}
+
+		// The message, sent from the source chain to the destination chain
+		_, err := srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
+			Name:         relayer.EventNameMessageSent,
+			Event:        relayer.EventNameMessageSent,
+			Data:         fmt.Sprintf(`{"Owner": "%s"}`, owner),
+			ChainID:      big.NewInt(srcChainID),
+			DestChainID:  big.NewInt(destChainID),
+			Status:       relayer.EventStatusDone,
+			MsgHash:      msgHash,
+			MessageOwner: owner,
+		})
+		assert.Nil(t, err)
+
+		return srv
+	}
+
+	// The processor's stub: written first, filed under the source chain, nothing but the hash
+	saveStub := func(srv *Server) {
+		_, err := srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
+			Name:        relayer.EventNameMessageStatusChanged,
+			Event:       relayer.EventNameMessageStatusChanged,
+			Data:        fmt.Sprintf(`{"Raw":{"transactionHash": "%s"}}`, claimTxHash),
+			ChainID:     big.NewInt(srcChainID),
+			DestChainID: big.NewInt(destChainID),
+			Status:      relayer.EventStatusDone,
+			MsgHash:     msgHash,
+		})
+		assert.Nil(t, err)
+	}
+
+	// A status transition as the indexer stores it: the whole log
+	saveIndexed := func(srv *Server, status relayer.EventStatus, txHash string, chainID int64) {
+		_, err := srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
+			Name:  relayer.EventNameMessageStatusChanged,
+			Event: relayer.EventNameMessageStatusChanged,
+			Data: fmt.Sprintf(
+				`{"Raw":{"transactionHash": "%s", "transactionIndex": "0x1", "blockHash": "0x%s", "blockNumber": "0x10"}}`,
+				txHash,
+				strings.Repeat("ab", 32),
+			),
+			ChainID:     big.NewInt(chainID),
+			DestChainID: big.NewInt(srcChainID),
+			Status:      status,
+			MsgHash:     msgHash,
+		})
+		assert.Nil(t, err)
+	}
+
+	get := func(srv *Server) string {
+		req := testutils.NewUnauthenticatedRequest(echo.GET, fmt.Sprintf("/events?address=%v", owner), nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		return rec.Body.String()
+	}
+
+	t.Run("reads the claimer off the indexed log, not off the stub written before it", func(t *testing.T) {
+		srv := newServer()
+		saveStub(srv)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
+
+		body := get(srv)
+
+		assert.Contains(t, body, fmt.Sprintf(`"claimedBy":"%s"`, relayerAddr.Hex()))
+		assert.Contains(t, body, fmt.Sprintf(`"processedTxHash":"%s"`, claimTxHash))
+	})
+
+	t.Run("still reports the claim hash when only the stub exists", func(t *testing.T) {
+		// Nothing but the hash is known, and the sender cannot be recovered without the block
+		srv := newServer()
+		saveStub(srv)
+
+		body := get(srv)
+
+		assert.Contains(t, body, fmt.Sprintf(`"processedTxHash":"%s"`, claimTxHash))
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
+
+	t.Run("asks the destination chain for the sender whichever chain the row is filed under", func(t *testing.T) {
+		// A complete row filed under the source chain, the way the processor files its own
+		// claim: the transaction was mined on the destination chain all the same
+		srv := newServer()
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, srcChainID)
+
+		body := get(srv)
+
+		assert.Contains(t, body, fmt.Sprintf(`"claimedBy":"%s"`, relayerAddr.Hex()))
+		assert.NotContains(t, body, srcSender.Hex())
+	})
+
+	t.Run("reports the claim, not the earlier attempt that left the message retriable", func(t *testing.T) {
+		// A retried message has two complete rows, and the older one is the failed attempt
+		srv := newServer()
+		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
+
+		body := get(srv)
+
+		assert.Contains(t, body, fmt.Sprintf(`"processedTxHash":"%s"`, claimTxHash))
+		assert.NotContains(t, body, retryTxHash)
+	})
+
+	t.Run("does not mistake a recall for a claim", func(t *testing.T) {
+		// A recall is a status transition too, mined on the source chain, and it is not a claim
+		srv := newServer()
+		saveIndexed(srv, relayer.EventStatusRecalled, recallTxHash, srcChainID)
+
+		body := get(srv)
+
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
+}
+
+// The processor stores its own claim as the binding's event marshalled whole, the way the
+// indexer does. That shape is a contract between geth's log codec and this package's Raw, and
+// the handler tests above write their rows by hand.
+func Test_claimLog_readsTheRowTheProcessorWrites(t *testing.T) {
+	const msgHash = "0x789cd5dcc77d50bec34b6458af936a3bfa802f3aa8b8466c07b2c6b663c92575"
+
+	claimTxHash := common.HexToHash("0x27a4811c18012da320c7a1bf4d788aeca068ac2e34a5f2ff73df33fa5f0e4b44")
+	blockHash := common.HexToHash("0xabababababababababababababababababababababababababababababababab")
+
+	data, err := json.Marshal(&bridge.BridgeMessageStatusChanged{
+		MsgHash: common.HexToHash(msgHash),
+		Status:  uint8(relayer.EventStatusDone),
+		Raw: types.Log{
+			Address:     common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+			Topics:      []common.Hash{{}, common.HexToHash(msgHash)},
+			Data:        []byte{},
+			BlockNumber: 16,
+			TxHash:      claimTxHash,
+			BlockHash:   blockHash,
+			Index:       3,
+		},
+	})
+	assert.Nil(t, err)
+
+	srv := newTestServer()
+	_, err = srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
+		Name:        relayer.EventNameMessageStatusChanged,
+		Event:       relayer.EventNameMessageStatusChanged,
+		Data:        string(data),
+		ChainID:     big.NewInt(1),
+		DestChainID: big.NewInt(2),
+		Status:      relayer.EventStatusDone,
+		MsgHash:     msgHash,
+	})
+	assert.Nil(t, err)
+
+	claim, err := srv.claimLog(context.Background(), msgHash)
+	assert.Nil(t, err)
+	assert.NotNil(t, claim)
+	assert.Equal(t, claimTxHash.Hex(), claim.TransactionHash)
+	assert.Equal(t, blockHash.Hex(), claim.BlockHash)
+	// The first transaction in a block still names its index
+	assert.Equal(t, "0x0", claim.TransactionIndex)
 }

--- a/packages/relayer/pkg/http/get_events_by_address_test.go
+++ b/packages/relayer/pkg/http/get_events_by_address_test.go
@@ -240,6 +240,47 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		assert.Contains(t, body, `"processedTxHash":""`)
 		assert.Contains(t, body, `"claimedBy":""`)
 	})
+
+	// A DONE that a later row superseded is not the current claim. The chain cannot go from
+	// DONE to anything else, so a newer non-DONE row means the DONE was orphaned by a reorg
+	// of the block it was mined in, and the message was then retried, or recalled. Reorg
+	// cleanup does not remove either writer's status rows (it keys on block_id, which they
+	// never set), so the orphaned row stays, and the newest row has to be the one that counts.
+	t.Run("reports nothing for a claim a later retry superseded", func(t *testing.T) {
+		srv := newServer()
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
+		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID)
+
+		body := get(srv)
+
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
+
+	t.Run("reports nothing for a claim a later recall superseded", func(t *testing.T) {
+		srv := newServer()
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
+		saveIndexed(srv, relayer.EventStatusRecalled, recallTxHash, srcChainID)
+
+		body := get(srv)
+
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
+
+	t.Run("reports nothing when a legacy stub and its orphaned log are followed by a retry", func(t *testing.T) {
+		// The rows a message claimed by an older relayer carries after a reorg: the hash-only
+		// stub, the indexed DONE of the orphaned block, then the canonical RETRIABLE
+		srv := newServer()
+		saveStub(srv)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
+		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID)
+
+		body := get(srv)
+
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
 }
 
 // The processor stores its own claim as the binding's event marshalled whole, the way the

--- a/packages/relayer/pkg/http/get_events_by_address_test.go
+++ b/packages/relayer/pkg/http/get_events_by_address_test.go
@@ -157,15 +157,17 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	// A status transition as the indexer stores it: the whole log
-	saveIndexed := func(srv *Server, status relayer.EventStatus, txHash string, chainID int64) {
+	// A status transition as the indexer stores it: the whole log, at the block it sits in
+	saveIndexed := func(srv *Server, status relayer.EventStatus, txHash string, chainID int64, block uint64) {
 		_, err := srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
 			Name:  relayer.EventNameMessageStatusChanged,
 			Event: relayer.EventNameMessageStatusChanged,
 			Data: fmt.Sprintf(
-				`{"Raw":{"transactionHash": "%s", "transactionIndex": "0x1", "blockHash": "0x%s", "blockNumber": "0x10"}}`,
+				`{"Raw":{"transactionHash": "%s", "transactionIndex": "0x1", "logIndex": "0x1", `+
+					`"blockHash": "0x%s", "blockNumber": "0x%x"}}`,
 				txHash,
 				strings.Repeat("ab", 32),
+				block,
 			),
 			ChainID:     big.NewInt(chainID),
 			DestChainID: big.NewInt(srcChainID),
@@ -187,7 +189,7 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 	t.Run("reads the claimer off the indexed log, not off the stub written before it", func(t *testing.T) {
 		srv := newServer()
 		saveStub(srv)
-		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16)
 
 		body := get(srv)
 
@@ -210,7 +212,7 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		// A complete row filed under the source chain, the way the processor files its own
 		// claim: the transaction was mined on the destination chain all the same
 		srv := newServer()
-		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, srcChainID)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, srcChainID, 16)
 
 		body := get(srv)
 
@@ -221,8 +223,8 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 	t.Run("reports the claim, not the earlier attempt that left the message retriable", func(t *testing.T) {
 		// A retried message has two complete rows, and the older one is the failed attempt
 		srv := newServer()
-		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID)
-		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
+		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 16)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 17)
 
 		body := get(srv)
 
@@ -233,7 +235,7 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 	t.Run("does not mistake a recall for a claim", func(t *testing.T) {
 		// A recall is a status transition too, mined on the source chain, and it is not a claim
 		srv := newServer()
-		saveIndexed(srv, relayer.EventStatusRecalled, recallTxHash, srcChainID)
+		saveIndexed(srv, relayer.EventStatusRecalled, recallTxHash, srcChainID, 9)
 
 		body := get(srv)
 
@@ -248,8 +250,8 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 	// never set), so the orphaned row stays, and the newest row has to be the one that counts.
 	t.Run("reports nothing for a claim a later retry superseded", func(t *testing.T) {
 		srv := newServer()
-		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
-		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16)
+		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 17)
 
 		body := get(srv)
 
@@ -259,8 +261,8 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 
 	t.Run("reports nothing for a claim a later recall superseded", func(t *testing.T) {
 		srv := newServer()
-		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
-		saveIndexed(srv, relayer.EventStatusRecalled, recallTxHash, srcChainID)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16)
+		saveIndexed(srv, relayer.EventStatusRecalled, recallTxHash, srcChainID, 9)
 
 		body := get(srv)
 
@@ -273,13 +275,43 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		// stub, the indexed DONE of the orphaned block, then the canonical RETRIABLE
 		srv := newServer()
 		saveStub(srv)
-		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID)
-		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16)
+		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 17)
 
 		body := get(srv)
 
 		assert.Contains(t, body, `"processedTxHash":""`)
 		assert.Contains(t, body, `"claimedBy":""`)
+	})
+
+	// The indexer stores the logs of one filter range from independent goroutines, so the
+	// order rows were inserted in is not the order their logs sit in on the chain. The chain's
+	// own order - block number, then log index - is what both writers record, so that is the
+	// order that decides.
+	t.Run("orders by the block the status was emitted in, not by insertion", func(t *testing.T) {
+		// The claim at block 17 was stored before the failed attempt at block 16
+		srv := newServer()
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 17)
+		saveIndexed(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 16)
+
+		body := get(srv)
+
+		assert.Contains(t, body, fmt.Sprintf(`"claimedBy":"%s"`, relayerAddr.Hex()))
+		assert.Contains(t, body, fmt.Sprintf(`"processedTxHash":"%s"`, claimTxHash))
+	})
+
+	t.Run("reads the claimer off the indexed log even when a legacy stub was stored after it", func(t *testing.T) {
+		// The old processor stored its stub only once its post-transaction work was done, so
+		// the indexer could commit the full log first. A stub carries no position on the chain
+		// and cannot outrank a row that does
+		srv := newServer()
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16)
+		saveStub(srv)
+
+		body := get(srv)
+
+		assert.Contains(t, body, fmt.Sprintf(`"claimedBy":"%s"`, relayerAddr.Hex()))
+		assert.Contains(t, body, fmt.Sprintf(`"processedTxHash":"%s"`, claimTxHash))
 	})
 }
 

--- a/packages/relayer/pkg/http/get_events_by_address_test.go
+++ b/packages/relayer/pkg/http/get_events_by_address_test.go
@@ -85,24 +85,26 @@ func Test_GetEventsByAddress(t *testing.T) {
 	}
 }
 
-// canonicalHeader is the header the test chain has at a height; canonicalHash is its hash, and
-// orphanedHash the hash of a block at the same height that a reorg replaced.
-func canonicalHeader(block uint64) *types.Header {
-	return &types.Header{Number: new(big.Int).SetUint64(block), Extra: []byte("canonical")}
+// canonicalHeader is the header a test chain has at a height; canonicalHash is its hash, and
+// orphanedHash the hash of a block at the same height that a reorg replaced. Each chain has
+// its own, so a row can only be vouched for by the chain it names.
+func canonicalHeader(chainID int64, block uint64) *types.Header {
+	return &types.Header{Number: new(big.Int).SetUint64(block), Extra: fmt.Appendf(nil, "canonical:%d", chainID)}
 }
 
-func canonicalHash(block uint64) common.Hash {
-	return canonicalHeader(block).Hash()
+func canonicalHash(chainID int64, block uint64) common.Hash {
+	return canonicalHeader(chainID, block).Hash()
 }
 
-func orphanedHash(block uint64) common.Hash {
-	return (&types.Header{Number: new(big.Int).SetUint64(block), Extra: []byte("orphaned")}).Hash()
+func orphanedHash(chainID int64, block uint64) common.Hash {
+	return (&types.Header{Number: new(big.Int).SetUint64(block), Extra: fmt.Appendf(nil, "orphaned:%d", chainID)}).Hash()
 }
 
 // claimSenderClient answers every sender lookup with one address, so a test can tell which
-// chain's client the handler asked, and serves the canonical header of every height.
+// chain's client the handler asked, and serves its chain's canonical header of every height.
 type claimSenderClient struct {
 	mock.EthClient
+	chainID    int64
 	sender     common.Address
 	headersErr error
 }
@@ -121,7 +123,7 @@ func (c *claimSenderClient) HeaderByNumber(_ context.Context, number *big.Int) (
 		return nil, c.headersErr
 	}
 
-	return canonicalHeader(number.Uint64()), nil
+	return canonicalHeader(c.chainID, number.Uint64()), nil
 }
 
 // The relayer reports who claimed a message by reading the claim transaction named in the
@@ -147,8 +149,8 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		srv := newTestServer()
 		srv.srcChainID = big.NewInt(srcChainID)
 		srv.destChainID = big.NewInt(destChainID)
-		srv.srcEthClient = &claimSenderClient{sender: srcSender}
-		srv.destEthClient = &claimSenderClient{sender: relayerAddr}
+		srv.srcEthClient = &claimSenderClient{chainID: srcChainID, sender: srcSender}
+		srv.destEthClient = &claimSenderClient{chainID: destChainID, sender: relayerAddr}
 
 		// The message, sent from the source chain to the destination chain
 		_, err := srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
@@ -204,7 +206,7 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		assert.Nil(t, err)
 	}
 	saveIndexed := func(srv *Server, status relayer.EventStatus, txHash string, chainID int64, block uint64) {
-		saveAt(srv, status, txHash, chainID, block, canonicalHash(block), 1)
+		saveAt(srv, status, txHash, chainID, block, canonicalHash(chainID, block), 1)
 	}
 
 	get := func(srv *Server) string {
@@ -238,16 +240,16 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		assert.Contains(t, body, `"claimedBy":""`)
 	})
 
-	t.Run("asks the destination chain for the sender whichever chain the row is filed under", func(t *testing.T) {
-		// A complete row filed under the source chain, the way the processor files its own
-		// claim: the transaction was mined on the destination chain all the same
+	t.Run("checks a row against the chain it is filed under", func(t *testing.T) {
+		// A DONE filed under the source chain but naming a destination-chain block: the source
+		// chain has no such block at that height, so the row vouches for nothing
 		srv := newServer()
-		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, srcChainID, 16)
+		saveAt(srv, relayer.EventStatusDone, claimTxHash, srcChainID, 16, canonicalHash(destChainID, 16), 1)
 
 		body := get(srv)
 
-		assert.Contains(t, body, fmt.Sprintf(`"claimedBy":"%s"`, relayerAddr.Hex()))
-		assert.NotContains(t, body, srcSender.Hex())
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
 	})
 
 	t.Run("reports the claim, not the earlier attempt that left the message retriable", func(t *testing.T) {
@@ -350,8 +352,8 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 	// Only the chain can say which block is canonical at a height.
 	t.Run("ignores a claim whose block a reorg replaced at a lower height", func(t *testing.T) {
 		srv := newServer()
-		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 17, orphanedHash(17), 1)
-		saveAt(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 16, canonicalHash(16), 1)
+		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 17, orphanedHash(destChainID, 17), 1)
+		saveAt(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 16, canonicalHash(destChainID, 16), 1)
 
 		body := get(srv)
 
@@ -361,8 +363,8 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 
 	t.Run("ignores a claim whose block a reorg replaced at the same height", func(t *testing.T) {
 		srv := newServer()
-		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16, orphanedHash(16), 5)
-		saveAt(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 16, canonicalHash(16), 1)
+		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16, orphanedHash(destChainID, 16), 5)
+		saveAt(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 16, canonicalHash(destChainID, 16), 1)
 
 		body := get(srv)
 
@@ -373,8 +375,8 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 	t.Run("reports the canonical claim past an orphaned one", func(t *testing.T) {
 		// The claim was re-mined on the canonical fork after its first block was replaced
 		srv := newServer()
-		saveAt(srv, relayer.EventStatusDone, retryTxHash, destChainID, 17, orphanedHash(17), 1)
-		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 18, canonicalHash(18), 1)
+		saveAt(srv, relayer.EventStatusDone, retryTxHash, destChainID, 17, orphanedHash(destChainID, 17), 1)
+		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 18, canonicalHash(destChainID, 18), 1)
 
 		body := get(srv)
 
@@ -386,8 +388,35 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		// A row is a claim only once the chain confirms its block; a header lookup that fails
 		// leaves the question open, and an open question is not a claim
 		srv := newServer()
-		srv.destEthClient = &claimSenderClient{sender: relayerAddr, headersErr: errors.New("rpc down")}
+		srv.destEthClient = &claimSenderClient{chainID: destChainID, sender: relayerAddr, headersErr: errors.New("rpc down")}
 		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16)
+
+		body := get(srv)
+
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
+
+	// A recall is emitted on the source chain and vetoes a claim only while the source chain
+	// still has the block it was mined in. An orphaned recall - an old destination fork
+	// recorded FAILED, an old source fork proved it, both were replaced and the destination
+	// then recorded a canonical DONE - must not outlive its fork.
+	t.Run("does not let a recall the source chain no longer has veto a canonical claim", func(t *testing.T) {
+		srv := newServer()
+		saveAt(srv, relayer.EventStatusRecalled, recallTxHash, srcChainID, 16, orphanedHash(srcChainID, 16), 1)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 17)
+
+		body := get(srv)
+
+		assert.Contains(t, body, fmt.Sprintf(`"processedTxHash":"%s"`, claimTxHash))
+		assert.Contains(t, body, fmt.Sprintf(`"claimedBy":"%s"`, relayerAddr.Hex()))
+	})
+
+	t.Run("reports nothing while a recall cannot be checked against the source chain", func(t *testing.T) {
+		srv := newServer()
+		srv.srcEthClient = &claimSenderClient{chainID: srcChainID, sender: srcSender, headersErr: errors.New("rpc down")}
+		saveIndexed(srv, relayer.EventStatusRecalled, recallTxHash, srcChainID, 16)
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 17)
 
 		body := get(srv)
 
@@ -403,7 +432,7 @@ func Test_claimLog_readsTheRowTheProcessorWrites(t *testing.T) {
 	const msgHash = "0x789cd5dcc77d50bec34b6458af936a3bfa802f3aa8b8466c07b2c6b663c92575"
 
 	claimTxHash := common.HexToHash("0x27a4811c18012da320c7a1bf4d788aeca068ac2e34a5f2ff73df33fa5f0e4b44")
-	blockHash := canonicalHash(16)
+	blockHash := canonicalHash(2, 16)
 
 	data, err := json.Marshal(&bridge.BridgeMessageStatusChanged{
 		MsgHash: common.HexToHash(msgHash),
@@ -423,28 +452,26 @@ func Test_claimLog_readsTheRowTheProcessorWrites(t *testing.T) {
 	srv := newTestServer()
 	srv.srcChainID = big.NewInt(1)
 	srv.destChainID = big.NewInt(2)
-	srv.srcEthClient = &claimSenderClient{}
-	srv.destEthClient = &claimSenderClient{}
+	srv.srcEthClient = &claimSenderClient{chainID: 1}
+	srv.destEthClient = &claimSenderClient{chainID: 2}
+	// Filed the way the processor files it: under the chain the status was emitted on
 	_, err = srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
 		Name:        relayer.EventNameMessageStatusChanged,
 		Event:       relayer.EventNameMessageStatusChanged,
 		Data:        string(data),
-		ChainID:     big.NewInt(1),
-		DestChainID: big.NewInt(2),
+		ChainID:     big.NewInt(2),
+		DestChainID: big.NewInt(1),
 		Status:      relayer.EventStatusDone,
 		MsgHash:     msgHash,
 	})
 	assert.Nil(t, err)
 
-	claim, err := srv.claimLog(
-		context.Background(),
-		&relayer.Event{Event: relayer.EventNameMessageSent, MsgHash: msgHash, DestChainID: 2},
-		headerHashes{},
-	)
+	claim, err := srv.claimLog(context.Background(), msgHash, headerHashes{})
 	assert.Nil(t, err)
 	assert.NotNil(t, claim)
-	assert.Equal(t, claimTxHash.Hex(), claim.TransactionHash)
-	assert.Equal(t, blockHash.Hex(), claim.BlockHash)
+	assert.Equal(t, claimTxHash.Hex(), claim.raw.TransactionHash)
+	assert.Equal(t, blockHash.Hex(), claim.raw.BlockHash)
+	assert.Equal(t, int64(2), claim.chainID)
 	// The first transaction in a block still names its index
-	assert.Equal(t, "0x0", claim.TransactionIndex)
+	assert.Equal(t, "0x0", claim.raw.TransactionIndex)
 }

--- a/packages/relayer/pkg/http/get_events_by_address_test.go
+++ b/packages/relayer/pkg/http/get_events_by_address_test.go
@@ -3,11 +3,11 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/cyberhorsey/webutils/testutils"
@@ -85,11 +85,26 @@ func Test_GetEventsByAddress(t *testing.T) {
 	}
 }
 
+// canonicalHeader is the header the test chain has at a height; canonicalHash is its hash, and
+// orphanedHash the hash of a block at the same height that a reorg replaced.
+func canonicalHeader(block uint64) *types.Header {
+	return &types.Header{Number: new(big.Int).SetUint64(block), Extra: []byte("canonical")}
+}
+
+func canonicalHash(block uint64) common.Hash {
+	return canonicalHeader(block).Hash()
+}
+
+func orphanedHash(block uint64) common.Hash {
+	return (&types.Header{Number: new(big.Int).SetUint64(block), Extra: []byte("orphaned")}).Hash()
+}
+
 // claimSenderClient answers every sender lookup with one address, so a test can tell which
-// chain's client the handler asked.
+// chain's client the handler asked, and serves the canonical header of every height.
 type claimSenderClient struct {
 	mock.EthClient
-	sender common.Address
+	sender     common.Address
+	headersErr error
 }
 
 func (c *claimSenderClient) TransactionSender(
@@ -99,6 +114,14 @@ func (c *claimSenderClient) TransactionSender(
 	_ uint,
 ) (common.Address, error) {
 	return c.sender, nil
+}
+
+func (c *claimSenderClient) HeaderByNumber(_ context.Context, number *big.Int) (*types.Header, error) {
+	if c.headersErr != nil {
+		return nil, c.headersErr
+	}
+
+	return canonicalHeader(number.Uint64()), nil
 }
 
 // The relayer reports who claimed a message by reading the claim transaction named in the
@@ -158,15 +181,19 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 	}
 
 	// A status transition as the indexer stores it: the whole log, at the block it sits in
-	saveIndexed := func(srv *Server, status relayer.EventStatus, txHash string, chainID int64, block uint64) {
+	saveAt := func(
+		srv *Server, status relayer.EventStatus, txHash string, chainID int64, block uint64, blockHash common.Hash,
+		logIndex uint64,
+	) {
 		_, err := srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
 			Name:  relayer.EventNameMessageStatusChanged,
 			Event: relayer.EventNameMessageStatusChanged,
 			Data: fmt.Sprintf(
-				`{"Raw":{"transactionHash": "%s", "transactionIndex": "0x1", "logIndex": "0x1", `+
-					`"blockHash": "0x%s", "blockNumber": "0x%x"}}`,
+				`{"Raw":{"transactionHash": "%s", "transactionIndex": "0x1", "logIndex": "0x%x", `+
+					`"blockHash": "%s", "blockNumber": "0x%x"}}`,
 				txHash,
-				strings.Repeat("ab", 32),
+				logIndex,
+				blockHash.Hex(),
 				block,
 			),
 			ChainID:     big.NewInt(chainID),
@@ -175,6 +202,9 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 			MsgHash:     msgHash,
 		})
 		assert.Nil(t, err)
+	}
+	saveIndexed := func(srv *Server, status relayer.EventStatus, txHash string, chainID int64, block uint64) {
+		saveAt(srv, status, txHash, chainID, block, canonicalHash(block), 1)
 	}
 
 	get := func(srv *Server) string {
@@ -313,6 +343,57 @@ func Test_GetEventsByAddress_claimedByTheRelayer(t *testing.T) {
 		assert.Contains(t, body, fmt.Sprintf(`"claimedBy":"%s"`, relayerAddr.Hex()))
 		assert.Contains(t, body, fmt.Sprintf(`"processedTxHash":"%s"`, claimTxHash))
 	})
+
+	// Coordinates do not say which fork a row is on. Reorg cleanup never removes status rows,
+	// so a DONE mined on a fork the chain abandoned stays next to what the canonical fork
+	// recorded instead - at a lower height, or at the same height under another block hash.
+	// Only the chain can say which block is canonical at a height.
+	t.Run("ignores a claim whose block a reorg replaced at a lower height", func(t *testing.T) {
+		srv := newServer()
+		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 17, orphanedHash(17), 1)
+		saveAt(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 16, canonicalHash(16), 1)
+
+		body := get(srv)
+
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
+
+	t.Run("ignores a claim whose block a reorg replaced at the same height", func(t *testing.T) {
+		srv := newServer()
+		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16, orphanedHash(16), 5)
+		saveAt(srv, relayer.EventStatusRetriable, retryTxHash, destChainID, 16, canonicalHash(16), 1)
+
+		body := get(srv)
+
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
+
+	t.Run("reports the canonical claim past an orphaned one", func(t *testing.T) {
+		// The claim was re-mined on the canonical fork after its first block was replaced
+		srv := newServer()
+		saveAt(srv, relayer.EventStatusDone, retryTxHash, destChainID, 17, orphanedHash(17), 1)
+		saveAt(srv, relayer.EventStatusDone, claimTxHash, destChainID, 18, canonicalHash(18), 1)
+
+		body := get(srv)
+
+		assert.Contains(t, body, fmt.Sprintf(`"processedTxHash":"%s"`, claimTxHash))
+		assert.Contains(t, body, fmt.Sprintf(`"claimedBy":"%s"`, relayerAddr.Hex()))
+	})
+
+	t.Run("reports nothing it cannot check against the chain", func(t *testing.T) {
+		// A row is a claim only once the chain confirms its block; a header lookup that fails
+		// leaves the question open, and an open question is not a claim
+		srv := newServer()
+		srv.destEthClient = &claimSenderClient{sender: relayerAddr, headersErr: errors.New("rpc down")}
+		saveIndexed(srv, relayer.EventStatusDone, claimTxHash, destChainID, 16)
+
+		body := get(srv)
+
+		assert.Contains(t, body, `"processedTxHash":""`)
+		assert.Contains(t, body, `"claimedBy":""`)
+	})
 }
 
 // The processor stores its own claim as the binding's event marshalled whole, the way the
@@ -322,7 +403,7 @@ func Test_claimLog_readsTheRowTheProcessorWrites(t *testing.T) {
 	const msgHash = "0x789cd5dcc77d50bec34b6458af936a3bfa802f3aa8b8466c07b2c6b663c92575"
 
 	claimTxHash := common.HexToHash("0x27a4811c18012da320c7a1bf4d788aeca068ac2e34a5f2ff73df33fa5f0e4b44")
-	blockHash := common.HexToHash("0xabababababababababababababababababababababababababababababababab")
+	blockHash := canonicalHash(16)
 
 	data, err := json.Marshal(&bridge.BridgeMessageStatusChanged{
 		MsgHash: common.HexToHash(msgHash),
@@ -340,6 +421,10 @@ func Test_claimLog_readsTheRowTheProcessorWrites(t *testing.T) {
 	assert.Nil(t, err)
 
 	srv := newTestServer()
+	srv.srcChainID = big.NewInt(1)
+	srv.destChainID = big.NewInt(2)
+	srv.srcEthClient = &claimSenderClient{}
+	srv.destEthClient = &claimSenderClient{}
 	_, err = srv.eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
 		Name:        relayer.EventNameMessageStatusChanged,
 		Event:       relayer.EventNameMessageStatusChanged,
@@ -351,7 +436,11 @@ func Test_claimLog_readsTheRowTheProcessorWrites(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	claim, err := srv.claimLog(context.Background(), msgHash)
+	claim, err := srv.claimLog(
+		context.Background(),
+		&relayer.Event{Event: relayer.EventNameMessageSent, MsgHash: msgHash, DestChainID: 2},
+		headerHashes{},
+	)
 	assert.Nil(t, err)
 	assert.NotNil(t, claim)
 	assert.Equal(t, claimTxHash.Hex(), claim.TransactionHash)

--- a/packages/relayer/pkg/http/server.go
+++ b/packages/relayer/pkg/http/server.go
@@ -20,6 +20,7 @@ type ethClient interface {
 	ChainID(ctx context.Context) (*big.Int, error)
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error)
 	TransactionSender(ctx context.Context,
 		tx *types.Transaction,

--- a/packages/relayer/pkg/mock/event_repository.go
+++ b/packages/relayer/pkg/mock/event_repository.go
@@ -214,6 +214,22 @@ func (r *EventRepository) FirstByEventAndMsgHash(
 	return nil, nil
 }
 
+func (r *EventRepository) FindAllByEventAndMsgHash(
+	ctx context.Context,
+	event string,
+	msgHash string,
+) ([]*relayer.Event, error) {
+	events := []*relayer.Event{}
+
+	for _, e := range r.events {
+		if e.MsgHash == msgHash && e.Event == event {
+			events = append(events, e)
+		}
+	}
+
+	return events, nil
+}
+
 func (r *EventRepository) Delete(
 	ctx context.Context,
 	id int,

--- a/packages/relayer/pkg/repo/event.go
+++ b/packages/relayer/pkg/repo/event.go
@@ -165,6 +165,28 @@ func (r *EventRepository) FirstByEventAndMsgHash(
 	return e, nil
 }
 
+// FindAllByEventAndMsgHash returns every stored row of the given event for a message, oldest
+// first. A message can have more than one: the processor records its own claim before the
+// indexer sees the log, and a reader that wants the fully indexed row has to be able to see
+// past the first one.
+func (r *EventRepository) FindAllByEventAndMsgHash(
+	ctx context.Context,
+	event string,
+	msgHash string,
+) ([]*relayer.Event, error) {
+	events := []*relayer.Event{}
+
+	if err := r.db.GormDB().WithContext(ctx).
+		Where("msg_hash = ?", msgHash).
+		Where("event = ?", event).
+		Order("id ASC").
+		Find(&events).Error; err != nil {
+		return nil, errors.Wrap(err, "r.db.Find")
+	}
+
+	return events, nil
+}
+
 func (r *EventRepository) FindAllByAddress(
 	ctx context.Context,
 	req *http.Request,

--- a/packages/relayer/pkg/repo/event_test.go
+++ b/packages/relayer/pkg/repo/event_test.go
@@ -506,3 +506,54 @@ func TestIntegration_Event_FirstByMsgHash(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegration_Event_FindAllByEventAndMsgHash(t *testing.T) {
+	db, close, err := testMysql(t)
+	assert.Equal(t, nil, err)
+
+	defer close()
+
+	eventRepo, err := NewEventRepository(db)
+	assert.Equal(t, nil, err)
+
+	save := func(event string, msgHash string, data string) {
+		_, err := eventRepo.Save(context.Background(), &relayer.SaveEventOpts{
+			Name:           event,
+			Event:          event,
+			Data:           data,
+			ChainID:        big.NewInt(1),
+			DestChainID:    big.NewInt(2),
+			Status:         relayer.EventStatusDone,
+			MsgHash:        msgHash,
+			MessageOwner:   addr.Hex(),
+			EmittedBlockID: 1,
+		})
+		assert.Equal(t, nil, err)
+	}
+
+	// The message, the processor's record of its own claim, the log the indexer stored later,
+	// and another message's row
+	save(relayer.EventNameMessageSent, testMsgHash, `{"Message": {"Owner": "0x1"}}`)
+	save(relayer.EventNameMessageStatusChanged, testMsgHash, `{"Raw": {"transactionHash": "0xa"}}`)
+	save(
+		relayer.EventNameMessageStatusChanged,
+		testMsgHash,
+		`{"Raw": {"transactionHash": "0xa", "transactionIndex": "0x1"}}`,
+	)
+	save(relayer.EventNameMessageStatusChanged, testSecondMsgHash, `{"Raw": {"transactionHash": "0xb"}}`)
+
+	events, err := eventRepo.FindAllByEventAndMsgHash(
+		context.Background(),
+		relayer.EventNameMessageStatusChanged,
+		testMsgHash,
+	)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 2, len(events))
+	// Oldest first: the processor's record, then the indexed log
+	assert.Equal(t, 2, events[0].ID)
+	assert.Equal(t, 3, events[1].ID)
+
+	none, err := eventRepo.FindAllByEventAndMsgHash(context.Background(), relayer.EventNameMessageStatusChanged, "0x3")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 0, len(none))
+}

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -659,13 +659,13 @@ func (p *Processor) saveMessageStatusChangedEvent(
 	if statusLog != nil && m["status"] != nil {
 		status := m["status"].(uint8)
 
-		// The whole log, in the shape the indexer stores it, so the API can read the claim
-		// transaction's block and index off this row as well. This row lands before the
-		// indexer sees the log, and it used to carry nothing but the transaction hash: a
-		// reader taking the first row per message found this one, and no message the relayer
-		// claimed itself could name its claimer. The row is filed exactly as before: nothing
-		// here needs its keys changed, and the indexer's reorg handling groups rows by the
-		// chain columns.
+		// The whole log, in the shape the indexer stores it and keyed the way the indexer
+		// keys it - the chain the status was emitted on, the other chain, the block it was
+		// emitted in - so the API can read the claim transaction's block and index off this
+		// row as well, and the two writers' rows for a message form one series. This row
+		// lands before the indexer sees the log, and it used to carry nothing but the
+		// transaction hash: a reader taking the first row per message found this one, and no
+		// message the relayer claimed itself could name its claimer.
 		data, err := json.Marshal(&bridge.BridgeMessageStatusChanged{
 			MsgHash: event.MsgHash,
 			Status:  status,
@@ -678,9 +678,9 @@ func (p *Processor) saveMessageStatusChangedEvent(
 		_, err = p.eventRepo.Save(ctx, &relayer.SaveEventOpts{
 			Name:           relayer.EventNameMessageStatusChanged,
 			Data:           string(data),
-			EmittedBlockID: event.Raw.BlockNumber,
-			ChainID:        new(big.Int).SetUint64(event.Message.SrcChainId),
-			DestChainID:    new(big.Int).SetUint64(event.Message.DestChainId),
+			EmittedBlockID: statusLog.BlockNumber,
+			ChainID:        new(big.Int).SetUint64(event.Message.DestChainId),
+			DestChainID:    new(big.Int).SetUint64(event.Message.SrcChainId),
 			Status:         relayer.EventStatus(status),
 			MsgHash:        common.Hash(event.MsgHash).Hex(),
 			MessageOwner:   event.Message.SrcOwner.Hex(),

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -635,16 +635,14 @@ func (p *Processor) saveMessageStatusChangedEvent(
 	var statusLog *types.Log
 
 	for _, log := range receipt.Logs {
-		if log == nil || len(log.Topics) == 0 {
-			continue
-		}
-
-		if log.Topics[0] != bridgeAbi.Events["MessageStatusChanged"].ID {
-			continue
-		}
-
-		// The event indexes its message hash; the row must describe this message's transition
-		if len(log.Topics) > 1 && log.Topics[1] != common.Hash(event.MsgHash) {
+		// Only the destination bridge's own transition for this message. Anything the bridge
+		// calls while processing - the invoked contract, or destOwner when it is refunded -
+		// runs before the bridge emits its status and can emit a log with the same signature
+		// and hash; matched on the signature alone, a spoofed DONE ahead of the bridge's
+		// RETRIABLE was stored as the outcome, and would now be reported as a claim
+		if log == nil || log.Address != p.cfg.DestBridgeAddress || len(log.Topics) < 2 ||
+			log.Topics[0] != bridgeAbi.Events["MessageStatusChanged"].ID ||
+			log.Topics[1] != common.Hash(event.MsgHash) {
 			continue
 		}
 

--- a/packages/relayer/processor/process_message.go
+++ b/packages/relayer/processor/process_message.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"math"
 	"math/big"
@@ -633,33 +632,58 @@ func (p *Processor) saveMessageStatusChangedEvent(
 
 	m := make(map[string]interface{})
 
+	var statusLog *types.Log
+
 	for _, log := range receipt.Logs {
 		if log == nil || len(log.Topics) == 0 {
 			continue
 		}
 
-		topic := log.Topics[0]
-		if topic == bridgeAbi.Events["MessageStatusChanged"].ID {
-			err = bridgeAbi.UnpackIntoMap(m, "MessageStatusChanged", log.Data)
-			if err != nil {
-				return err
-			}
-
-			break
+		if log.Topics[0] != bridgeAbi.Events["MessageStatusChanged"].ID {
+			continue
 		}
+
+		// The event indexes its message hash; the row must describe this message's transition
+		if len(log.Topics) > 1 && log.Topics[1] != common.Hash(event.MsgHash) {
+			continue
+		}
+
+		err = bridgeAbi.UnpackIntoMap(m, "MessageStatusChanged", log.Data)
+		if err != nil {
+			return err
+		}
+
+		statusLog = log
+
+		break
 	}
 
-	if m["status"] != nil {
-		// keep same format as other raw events
-		data := fmt.Sprintf(`{"Raw":{"transactionHash": "%v"}}`, receipt.TxHash.Hex())
+	if statusLog != nil && m["status"] != nil {
+		status := m["status"].(uint8)
+
+		// The whole log, in the shape the indexer stores it, so the API can read the claim
+		// transaction's block and index off this row as well. This row lands before the
+		// indexer sees the log, and it used to carry nothing but the transaction hash: a
+		// reader taking the first row per message found this one, and no message the relayer
+		// claimed itself could name its claimer. The row is filed exactly as before: nothing
+		// here needs its keys changed, and the indexer's reorg handling groups rows by the
+		// chain columns.
+		data, err := json.Marshal(&bridge.BridgeMessageStatusChanged{
+			MsgHash: event.MsgHash,
+			Status:  status,
+			Raw:     *statusLog,
+		})
+		if err != nil {
+			return errors.Wrap(err, "json.Marshal")
+		}
 
 		_, err = p.eventRepo.Save(ctx, &relayer.SaveEventOpts{
 			Name:           relayer.EventNameMessageStatusChanged,
-			Data:           data,
+			Data:           string(data),
 			EmittedBlockID: event.Raw.BlockNumber,
 			ChainID:        new(big.Int).SetUint64(event.Message.SrcChainId),
 			DestChainID:    new(big.Int).SetUint64(event.Message.DestChainId),
-			Status:         relayer.EventStatus(m["status"].(uint8)),
+			Status:         relayer.EventStatus(status),
 			MsgHash:        common.Hash(event.MsgHash).Hex(),
 			MessageOwner:   event.Message.SrcOwner.Hex(),
 			Event:          relayer.EventNameMessageStatusChanged,

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -706,8 +706,8 @@ func Test_processSingleSkipsLogsThatAreNotMessageSent(t *testing.T) {
 // hash. The API reads the claimer off a MessageStatusChanged row through the block it was
 // mined in, and this row is the first one it finds for any message the relayer claimed, so
 // those messages came back with no claimer at all. The whole log is stored now, in the shape
-// the indexer stores it; the row's own keys stay as they were, and the indexer's reorg
-// handling groups rows by the chain columns.
+// the indexer stores it, and keyed the way the indexer keys it, so the two writers' rows for
+// one message are one series.
 func Test_saveMessageStatusChangedEventStoresTheWholeLog(t *testing.T) {
 	repo := mock.NewEventRepository()
 	p := newTestProcessor(false)
@@ -759,11 +759,12 @@ func Test_saveMessageStatusChangedEventStoresTheWholeLog(t *testing.T) {
 	assert.Equal(t, uint8(relayer.EventStatusDone), stored.Status)
 	assert.Equal(t, msgHash, common.Hash(stored.MsgHash))
 
-	// Filed exactly as before
+	// Keyed the way the indexer keys the same log: the chain the status was emitted on, the
+	// other chain, and the block it was emitted in
 	assert.Equal(t, relayer.EventStatusDone, saved[0].Status)
-	assert.Equal(t, int64(1), saved[0].ChainID)
-	assert.Equal(t, int64(2), saved[0].DestChainID)
-	assert.Equal(t, uint64(7), saved[0].EmittedBlockID)
+	assert.Equal(t, int64(2), saved[0].ChainID)
+	assert.Equal(t, int64(1), saved[0].DestChainID)
+	assert.Equal(t, uint64(16), saved[0].EmittedBlockID)
 	assert.Equal(t, msgHash.Hex(), saved[0].MsgHash)
 }
 

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -698,4 +700,69 @@ func Test_processSingleSkipsLogsThatAreNotMessageSent(t *testing.T) {
 	// A targeted transaction that emitted no MessageSent has nothing to claim, and that is a
 	// clean outcome rather than an error.
 	assert.NoError(t, p.processSingle(context.Background()))
+}
+
+// The row the processor writes for its own claim used to carry nothing but the transaction
+// hash. The API reads the claimer off a MessageStatusChanged row through the block it was
+// mined in, and this row is the first one it finds for any message the relayer claimed, so
+// those messages came back with no claimer at all. The whole log is stored now, in the shape
+// the indexer stores it; the row's own keys stay as they were, and the indexer's reorg
+// handling groups rows by the chain columns.
+func Test_saveMessageStatusChangedEventStoresTheWholeLog(t *testing.T) {
+	repo := mock.NewEventRepository()
+	p := newTestProcessor(false)
+	p.eventRepo = repo
+
+	bridgeAbi, err := abi.JSON(strings.NewReader(bridge.BridgeABI))
+	require.NoError(t, err)
+
+	msgHash := common.HexToHash("0x789cd5dcc77d50bec34b6458af936a3bfa802f3aa8b8466c07b2c6b663c92575")
+	claimTxHash := common.HexToHash("0x27a4811c18012da320c7a1bf4d788aeca068ac2e34a5f2ff73df33fa5f0e4b44")
+	blockHash := common.HexToHash("0xabababababababababababababababababababababababababababababababab")
+
+	statusLog := &types.Log{
+		Address:     common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+		Topics:      []common.Hash{bridgeAbi.Events["MessageStatusChanged"].ID, msgHash},
+		Data:        common.LeftPadBytes([]byte{uint8(relayer.EventStatusDone)}, 32),
+		BlockNumber: 16,
+		TxHash:      claimTxHash,
+		TxIndex:     1,
+		BlockHash:   blockHash,
+		Index:       3,
+	}
+
+	err = p.saveMessageStatusChangedEvent(
+		context.Background(),
+		&types.Receipt{TxHash: claimTxHash, Logs: []*types.Log{statusLog}},
+		&bridge.BridgeMessageSent{
+			MsgHash: msgHash,
+			Message: bridge.IBridgeMessage{
+				SrcChainId:  1,
+				DestChainId: 2,
+				SrcOwner:    common.HexToAddress("0xC4279588B8dA563D264e286E2ee7CE8c244444d6"),
+			},
+			Raw: types.Log{BlockNumber: 7},
+		},
+	)
+	require.NoError(t, err)
+
+	saved := repo.SavedEvents()
+	require.Len(t, saved, 1)
+
+	// The same shape the indexer writes, so one reader serves both
+	stored := &bridge.BridgeMessageStatusChanged{}
+	require.NoError(t, json.Unmarshal(saved[0].Data, stored), "the stored row must be a complete log")
+	assert.Equal(t, claimTxHash, stored.Raw.TxHash)
+	assert.Equal(t, uint(1), stored.Raw.TxIndex)
+	assert.Equal(t, blockHash, stored.Raw.BlockHash)
+	assert.Equal(t, uint64(16), stored.Raw.BlockNumber)
+	assert.Equal(t, uint8(relayer.EventStatusDone), stored.Status)
+	assert.Equal(t, msgHash, common.Hash(stored.MsgHash))
+
+	// Filed exactly as before
+	assert.Equal(t, relayer.EventStatusDone, saved[0].Status)
+	assert.Equal(t, int64(1), saved[0].ChainID)
+	assert.Equal(t, int64(2), saved[0].DestChainID)
+	assert.Equal(t, uint64(7), saved[0].EmittedBlockID)
+	assert.Equal(t, msgHash.Hex(), saved[0].MsgHash)
 }

--- a/packages/relayer/processor/process_message_test.go
+++ b/packages/relayer/processor/process_message_test.go
@@ -766,3 +766,65 @@ func Test_saveMessageStatusChangedEventStoresTheWholeLog(t *testing.T) {
 	assert.Equal(t, uint64(7), saved[0].EmittedBlockID)
 	assert.Equal(t, msgHash.Hex(), saved[0].MsgHash)
 }
+
+// Everything the bridge calls while processing runs before the bridge emits its own status:
+// the invoked contract, and destOwner when it is refunded. Either can emit a log with the
+// bridge event's signature and this message's hash, and a scan that matched on the signature
+// alone took the first such log - a spoofed DONE ahead of the bridge's RETRIABLE, which the
+// API would then have reported as a successful claim. Only the bridge's own log is the status.
+func Test_saveMessageStatusChangedEventIgnoresAStatusLogAnotherContractEmitted(t *testing.T) {
+	repo := mock.NewEventRepository()
+	p := newTestProcessor(false)
+	p.eventRepo = repo
+
+	bridgeAbi, err := abi.JSON(strings.NewReader(bridge.BridgeABI))
+	require.NoError(t, err)
+
+	msgHash := common.HexToHash("0x789cd5dcc77d50bec34b6458af936a3bfa802f3aa8b8466c07b2c6b663c92575")
+	claimTxHash := common.HexToHash("0x27a4811c18012da320c7a1bf4d788aeca068ac2e34a5f2ff73df33fa5f0e4b44")
+	destOwner := common.HexToAddress("0x000000000000000000000000000000000000dEaD")
+
+	statusLog := func(from common.Address, status relayer.EventStatus, index uint) *types.Log {
+		return &types.Log{
+			Address:     from,
+			Topics:      []common.Hash{bridgeAbi.Events["MessageStatusChanged"].ID, msgHash},
+			Data:        common.LeftPadBytes([]byte{uint8(status)}, 32),
+			BlockNumber: 16,
+			TxHash:      claimTxHash,
+			TxIndex:     1,
+			BlockHash:   common.HexToHash("0xabababababababababababababababababababababababababababababababab"),
+			Index:       index,
+		}
+	}
+
+	receipt := &types.Receipt{
+		TxHash: claimTxHash,
+		Logs: []*types.Log{
+			// The refund reached destOwner, a contract, before the bridge recorded the outcome
+			statusLog(destOwner, relayer.EventStatusDone, 3),
+			// A log from the bridge without the indexed hash is not this event either
+			{
+				Address: p.cfg.DestBridgeAddress,
+				Topics:  []common.Hash{bridgeAbi.Events["MessageStatusChanged"].ID},
+				Data:    common.LeftPadBytes([]byte{uint8(relayer.EventStatusDone)}, 32),
+			},
+			statusLog(p.cfg.DestBridgeAddress, relayer.EventStatusRetriable, 5),
+		},
+	}
+
+	err = p.saveMessageStatusChangedEvent(context.Background(), receipt, &bridge.BridgeMessageSent{
+		MsgHash: msgHash,
+		Message: bridge.IBridgeMessage{SrcChainId: 1, DestChainId: 2, DestOwner: destOwner},
+	})
+	require.NoError(t, err)
+
+	saved := repo.SavedEvents()
+	require.Len(t, saved, 1)
+	assert.Equal(t, relayer.EventStatusRetriable, saved[0].Status,
+		"the attempt failed; a claim reported here would be false")
+
+	stored := &bridge.BridgeMessageStatusChanged{}
+	require.NoError(t, json.Unmarshal(saved[0].Data, stored))
+	assert.Equal(t, p.cfg.DestBridgeAddress, stored.Raw.Address)
+	assert.Equal(t, uint(5), stored.Raw.Index)
+}


### PR DESCRIPTION
Fixes #22113 at its source. The bridge-UI half of the same issue is the last commit of #22114: it drives the "Relayer" label off an actual claimer address, and keeps the details dialog right against a relayer that has not been redeployed yet by reading the claim transaction itself; once this is deployed, that workaround simply stops being needed.

## What was wrong

`GET /events` computes `claimedBy` and `processedTxHash` per request: it took *one* `MessageStatusChanged` row for the message (`FirstByEventAndMsgHash`, the lowest id), read the claim transaction's hash, block hash and index off its `Raw`, and asked the chain for the sender.

When the relayer claims a message, two such rows exist. The processor records its own claim first (`saveMessageStatusChangedEvent`), and that record carried nothing but `{"Raw":{"transactionHash": …}}`; the destination-chain indexer stores the full log later. The lowest id is always the processor's, the handler bails on a row without a `transactionIndex`, and so every message the relayer claimed came back with an empty `claimedBy` and an empty `processedTxHash`, while every self-claimed message, which has only the indexer's row, came back with both. Verified on the live mainnet API for the reporter's wallet: 8 of 8 rows, and the messages with a processor row are exactly the ones with empty fields.

A second defect sat behind the first: the handler chose the RPC client from the row's `chainID`, and the processor files its row under the message's *source* chain, so even a complete processor row would have asked the wrong chain for the sender.

## The change

- `GetEventsByAddress` reads all `MessageStatusChanged` rows for the message (new `EventRepository.FindAllByEventAndMsgHash`) and lets the latest *canonical* transition decide. Rows are walked from the latest coordinates down (block number, then log index, which both writers record verbatim from the log) and each is checked against the chain: the header the claim chain has at that height must carry the row's block hash (`HeaderByNumber`, one call per candidate, cached per block within a request; the `ethClient` interface gained the method). Coordinates alone cannot tell a fork from a retry, and reorg cleanup never removes status rows (`DeleteAllAfterBlockID` keys on `block_id`, which only checkpoint rows set), so a `DONE` mined on a fork the chain abandoned stays next to what the canonical fork recorded instead, at a lower height or at the same height under another block hash; those rows are skipped. Row ids are not an order either: the indexer stores the logs of one filter range from independent goroutines, so the `DONE` at block N+1 can be committed before the `RETRIABLE` at block N. A canonical latest transition that is `DONE` is the claim (the claimer when the row is fully indexed); anything else means the message is not currently claimed, and so does a row the chain cannot vouch for because the header lookup failed. Every row is checked on the chain it is filed under, which is the chain its log was emitted on for both writers (the indexer files under the chain it watches, the processor under the message's destination): a `RECALLED` row, emitted on the source chain, vetoes a claim only while the source chain still has its block, since a canonical recall proves the destination recorded `FAILED`, which is terminal there; an orphaned recall does not outlive its fork. A legacy hash-only stub has no block hash to check and is consulted only while the message has no positioned row at all, whichever of the two was committed first.
- The processor stores the whole `MessageStatusChanged` log for its own claim, in the shape the indexer stores it and keyed the way the indexer keys it (the chain the status was emitted on, the other chain, the block it was emitted in), so the claimer can be named the moment the relayer claims and both writers' rows for a message form one series. Nothing else reads status rows by those keys: `/blockInfo` and the indexer's resume and reorg checks all query by the `MessageSent` or `MessageProcessed` event name. The log must also come from the destination bridge and carry the indexed message hash, the same checks the `MessageProcessed` lookup makes, since anything the bridge calls while processing runs before the bridge emits its own status.
- Nothing is backfilled and no migration is needed: every historical processor row has the indexer's complete row next to it (checked on the live data), and the handler now looks past the stub to it, so history reads correctly the moment this deploys. Where only a stub exists, the claim hash alone is reported, which is also what the bridge UI derives the claim date from.

## Tests

- `pkg/http`: stub first plus indexed log → claimer and hash (red before); stub only → hash only (red before); a complete row filed under the source chain → the sender is asked of the destination chain (red before: the source client answered); a retried message → the claim, not the failed attempt (red before); a recall → no claim (red before); a `DONE` superseded by a later `RETRIABLE`, by a later `RECALLED`, and the legacy stub plus orphaned `DONE` plus newer `RETRIABLE` combination → no claim (all red before); the `DONE` at block 17 inserted before the `RETRIABLE` at block 16 → the claim (red before); the full row inserted before the legacy stub → the claimer (red before); an orphaned `DONE` at 17 over a canonical `RETRIABLE` at 16, and an orphaned `DONE` at 16 over a canonical `RETRIABLE` at 16 under the canonical block hash → no claim, a claim re-mined on the canonical fork past an orphaned copy → the canonical one, a failed header lookup → no claim, an orphaned source-chain `RECALLED` next to a canonical destination `DONE` → the claim, a recall the source chain cannot be asked about → no claim, and a row filed under a chain that does not have its block → no claim (all red before; the test client serves per-chain canonical headers); and a row marshalled the way the processor now writes it round-trips through the handler's reader.
- `processor`: the stored row round-trips as a complete `BridgeMessageStatusChanged` carrying the log's block, index and hash, keyed like the indexer's (red before); a `MessageStatusChanged` with this message's hash emitted by another contract ahead of the bridge's own is ignored (red before).
- `pkg/repo`: `FindAllByEventAndMsgHash` integration test against the container MySQL.
- Full relayer suite as CI runs it, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
