### PR TITLE
fix(repo): stop the DeepSeek review failing silently, and keep one per PR

### DIFF
--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -31,6 +31,10 @@ jobs:
         && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
+    # Cap the whole job. Must exceed MAX_ATTEMPTS (3) full request timeouts
+    # (REQUEST_TIMEOUT_MS = 10 min each) plus the retry backoff and checkout
+    # overhead, so a slow attempt and its retries are never killed mid-run.
+    timeout-minutes: 35
     permissions:
       contents: read
       pull-requests: write
@@ -81,39 +85,113 @@ jobs:
               return Number.isFinite(n) && n > 0 ? n : fallback;
             };
 
-            // Fetch PR details
-            const pr = await github.rest.pulls.get({
-              owner, repo, pull_number: prNumber
-            });
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-            const title = pr.data.title;
-            const body = pr.data.body || '';
+            // Model + token budget are configurable via repo variables.
+            // NOTE: deepseek-v4-pro is a reasoning model — reasoning tokens
+            // count against max_tokens, so a small budget (e.g. 4096) can be
+            // fully consumed before any visible content is produced, yielding
+            // an empty review. Default high (65536) to leave room for output.
+            const model = process.env.DEEPSEEK_MODEL || 'deepseek-v4-pro';
+            const maxTokens = intFromEnv('DEEPSEEK_MAX_TOKENS', 8192 * 8);
 
-            // Get the diff as raw text
-            const diffResponse = await github.request({
-              method: 'GET',
-              url: `/repos/${owner}/${repo}/pulls/${prNumber}`,
-              headers: { Accept: 'application/vnd.github.v3.diff' }
-            });
+            // Sticky comment, matched on a hidden marker with the visible
+            // header as a fallback so comments posted before the marker
+            // existed are still updated in place instead of duplicated.
+            const MARKER = '<!-- deepseek-review -->';
+            const HEADER = '## 🐋 DeepSeek Code Review';
+            const triggerInfo = context.eventName === 'pull_request'
+              ? 'Automatically triggered on PR update'
+              : 'Triggered by `@deepseek` comment';
+            const footer = `*${triggerInfo} • model: \`${model}\`*`;
+            const compose = (text) => `${MARKER}\n${HEADER}\n\n${text}\n\n---\n${footer}`;
 
-            const diffText = typeof diffResponse.data === 'string'
-              ? diffResponse.data
-              : JSON.stringify(diffResponse.data);
+            // GitHub issue-comment bodies are capped at 65536 chars; stay under.
+            const MAX_COMMENT = 65000;
 
-            if (!diffText || diffText.length === 0) {
-              console.log('No diff found - skipping review');
-              return 'No diff to review.';
+            async function upsert(text) {
+              let body = compose(text);
+              if (body.length > MAX_COMMENT) {
+                const note = "\n\n... (truncated to fit GitHub's comment size limit)";
+                const room = MAX_COMMENT - compose('').length - note.length;
+                body = compose(text.substring(0, Math.max(0, room)) + note);
+              }
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: prNumber, per_page: 100
+              });
+              const existing = comments.find(c =>
+                c.user && c.user.login === 'github-actions[bot]' && c.body &&
+                (c.body.includes(MARKER) || c.body.includes(HEADER))
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                core.info(`Updated existing review comment #${existing.id}`);
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+                core.info('Posted new review comment');
+              }
             }
 
-            // Truncate diff if too large. deepseek-v4-pro has a large context
-            // window, so default high and allow overriding via repo variable.
-            const MAX_DIFF = intFromEnv('DEEPSEEK_MAX_DIFF', 2000000);
-            const truncatedDiff = diffText.length > MAX_DIFF
-              ? diffText.substring(0, MAX_DIFF) + '\n\n... (diff truncated)'
-              : diffText;
+            if (!process.env.DEEPSEEK_API_KEY) {
+              core.setFailed('DEEPSEEK_API_KEY is not set.');
+              return;
+            }
 
-            // Build the prompt
-            const systemPrompt = `You are a senior software engineer performing a code review on the Taiko monorepo.
+            // The PR/diff fetch, the model call and the comment post can all
+            // hit the network; wrap them in one try so any failure is reported
+            // as a visible comment instead of crashing the job silently.
+            try {
+              const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+              const title = pr.data.title;
+              const body = pr.data.body || '';
+
+              // The diff media type refuses PRs over 20000 diff lines with a
+              // 406, so fall back to reassembling the diff from the files API,
+              // which returns the same per-file patches page by page.
+              async function fetchDiff() {
+                try {
+                  const diffResponse = await github.request({
+                    method: 'GET',
+                    url: `/repos/${owner}/${repo}/pulls/${prNumber}`,
+                    headers: { Accept: 'application/vnd.github.v3.diff' }
+                  });
+                  return typeof diffResponse.data === 'string'
+                    ? diffResponse.data
+                    : JSON.stringify(diffResponse.data);
+                } catch (err) {
+                  if (err.status !== 406) throw err;
+                  core.warning('Diff too large for the diff media type; rebuilding it from the files API.');
+                  const files = await github.paginate(github.rest.pulls.listFiles, {
+                    owner, repo, pull_number: prNumber, per_page: 100
+                  });
+                  return files.map((f) => {
+                    const from = f.previous_filename || f.filename;
+                    const header = `diff --git a/${from} b/${f.filename}\n`
+                      + `--- ${f.status === 'added' ? '/dev/null' : 'a/' + from}\n`
+                      + `+++ ${f.status === 'removed' ? '/dev/null' : 'b/' + f.filename}`;
+                    // Binary and very large files come back without a patch.
+                    return f.patch
+                      ? `${header}\n${f.patch}`
+                      : `${header}\n(patch omitted: ${f.status}, +${f.additions}/-${f.deletions})`;
+                  }).join('\n');
+                }
+              }
+
+              const diffText = await fetchDiff();
+              if (!diffText) {
+                core.info('No diff found - skipping review.');
+                return 'No diff to review.';
+              }
+
+              // Truncate diff if too large. deepseek-v4-pro has a large context
+              // window, so default high and allow overriding via repo variable.
+              const MAX_DIFF = intFromEnv('DEEPSEEK_MAX_DIFF', 2000000);
+              const truncatedDiff = diffText.length > MAX_DIFF
+                ? diffText.substring(0, MAX_DIFF) + '\n\n... (diff truncated)'
+                : diffText;
+
+              // Build the prompt
+              const systemPrompt = `You are a senior software engineer performing a code review on the Taiko monorepo.
 
             Taiko is a based rollup on Ethereum (type-1 ZK-EVM). The repo contains:
             - Smart contracts (Solidity/Foundry) in packages/protocol
@@ -142,7 +220,7 @@ jobs:
             - Be direct and constructive. Don't be overly polite.
             - If there are no issues in a category, skip it entirely.`;
 
-            const userPrompt = `## PR #${prNumber}: ${title}
+              const userPrompt = `## PR #${prNumber}: ${title}
 
             **Description:**
             ${body || 'No description provided.'}
@@ -154,95 +232,209 @@ jobs:
 
             Review this PR thoroughly. Be direct - flag only real issues.`;
 
-            // Model + token budget are configurable via repo variables.
-            // NOTE: deepseek-v4-pro is a reasoning model — reasoning tokens
-            // count against max_tokens, so a small budget (e.g. 4096) can be
-            // fully consumed before any visible content is produced, yielding
-            // an empty review. Default high (65536) to leave room for output.
-            const model = process.env.DEEPSEEK_MODEL || 'deepseek-v4-pro';
-            const maxTokens = intFromEnv('DEEPSEEK_MAX_TOKENS', 8192 * 8);
+              // A review of this repo's diffs takes the model minutes. Ask for a
+              // stream so bytes keep flowing the whole time: a non-streaming call
+              // leaves the socket idle until the answer is complete, and an idle
+              // socket gets reaped in transit ("TypeError: terminated" /
+              // "SocketError: other side closed").
+              const REQUEST_TIMEOUT_MS = 600000; // hard cap on one attempt
+              const STALL_TIMEOUT_MS = 120000;   // no bytes for this long = dead
+              const MAX_ATTEMPTS = 3;
+              const RETRY_DELAY_MS = [5000, 15000];
 
-            // Call DeepSeek API (OpenAI-compatible endpoint).
-            async function requestReview() {
-              const response = await fetch('https://api.deepseek.com/v1/chat/completions', {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  'Authorization': `Bearer ${process.env.DEEPSEEK_API_KEY}`
-                },
-                body: JSON.stringify({
-                  model,
-                  messages: [
-                    { role: 'system', content: systemPrompt },
-                    { role: 'user', content: userPrompt }
-                  ],
-                  max_tokens: maxTokens,
-                  temperature: 0.3
-                })
-              });
-              const data = await response.json();
-              if (!response.ok) {
-                throw new Error(`DeepSeek API error (${response.status}): ${JSON.stringify(data)}`);
+              // A rejected key, an unknown model id or a malformed request fails
+              // identically on every attempt, so those are not retried.
+              const FATAL_STATUS = new Set([400, 401, 402, 403, 404, 422]);
+
+              // `stream_options` is standard on OpenAI-compatible endpoints and
+              // is what reports token usage in a stream, but it is only used for
+              // the empty-review diagnostic: if this endpoint ever rejects it,
+              // drop it and carry on rather than failing every review.
+              let includeUsage = true;
+
+              async function requestReview() {
+                const controller = new AbortController();
+                let stallTimer = null;
+                let reader = null;
+                const armStall = () => {
+                  if (stallTimer) clearTimeout(stallTimer);
+                  stallTimer = setTimeout(
+                    () => controller.abort(new Error(`DeepSeek sent no data for ${STALL_TIMEOUT_MS / 1000}s`)),
+                    STALL_TIMEOUT_MS
+                  );
+                };
+                const overallTimer = setTimeout(
+                  () => controller.abort(new Error(`DeepSeek request exceeded ${REQUEST_TIMEOUT_MS / 1000}s`)),
+                  REQUEST_TIMEOUT_MS
+                );
+
+                try {
+                  armStall();
+                  const response = await fetch('https://api.deepseek.com/v1/chat/completions', {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'Accept': 'text/event-stream',
+                      'Authorization': `Bearer ${process.env.DEEPSEEK_API_KEY}`
+                    },
+                    body: JSON.stringify({
+                      model,
+                      messages: [
+                        { role: 'system', content: systemPrompt },
+                        { role: 'user', content: userPrompt }
+                      ],
+                      max_tokens: maxTokens,
+                      temperature: 0.3,
+                      stream: true,
+                      ...(includeUsage ? { stream_options: { include_usage: true } } : {})
+                    }),
+                    signal: controller.signal
+                  });
+
+                  // An error response is JSON, not SSE. Read it as text first so
+                  // a non-JSON body (e.g. a 5xx HTML page) surfaces the real
+                  // status instead of a misleading parse error.
+                  if (!response.ok) {
+                    const raw = await response.text();
+                    let detail = raw.slice(0, 300);
+                    try {
+                      const parsed = JSON.parse(raw);
+                      detail = (parsed && parsed.error && parsed.error.message) || detail;
+                    } catch (_) { /* non-JSON body */ }
+                    const err = new Error(`DeepSeek API error (${response.status}): ${detail || 'no body'}`);
+                    err.status = response.status;
+                    throw err;
+                  }
+
+                  let content = '';
+                  let finishReason = 'unknown';
+                  let usage = 'unknown';
+                  let sawDone = false;
+
+                  // If the endpoint answers a stream request with a whole
+                  // completion, read it as one instead of finding no SSE frames
+                  // and retrying into a failure.
+                  const contentType = (response.headers.get('content-type') || '').toLowerCase();
+                  if (contentType && !contentType.includes('event-stream')) {
+                    const whole = JSON.parse(await response.text());
+                    const only = whole.choices && whole.choices[0];
+                    return {
+                      reviewText: ((only && only.message && only.message.content) || '').trim(),
+                      finishReason: (only && only.finish_reason) || 'unknown',
+                      usage: whole.usage ? JSON.stringify(whole.usage) : 'unknown'
+                    };
+                  }
+
+                  const consume = (line) => {
+                    const trimmed = line.trim();
+                    // Blank separators and `:` keep-alive comments carry no payload.
+                    if (!trimmed || !trimmed.startsWith('data:')) return;
+                    const payload = trimmed.slice(5).trim();
+                    if (payload === '[DONE]') { sawDone = true; return; }
+                    let event;
+                    try { event = JSON.parse(payload); } catch (_) { return; }
+                    if (event.error) {
+                      throw new Error(`DeepSeek stream error: ${event.error.message || JSON.stringify(event.error)}`);
+                    }
+                    const choice = event.choices && event.choices[0];
+                    if (choice) {
+                      // `delta.reasoning_content` is the model thinking out loud;
+                      // only `delta.content` is the review itself.
+                      if (choice.delta && typeof choice.delta.content === 'string') {
+                        content += choice.delta.content;
+                      }
+                      if (choice.finish_reason) finishReason = choice.finish_reason;
+                    }
+                    if (event.usage) usage = JSON.stringify(event.usage);
+                  };
+
+                  reader = response.body.getReader();
+                  const decoder = new TextDecoder();
+                  let buffer = '';
+                  for (;;) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    armStall();
+                    buffer += decoder.decode(value, { stream: true });
+                    let nl;
+                    while ((nl = buffer.indexOf('\n')) !== -1) {
+                      consume(buffer.slice(0, nl));
+                      buffer = buffer.slice(nl + 1);
+                    }
+                  }
+                  consume(buffer);
+
+                  // A stream that ends without [DONE] and without a finish reason
+                  // was cut short; treat the partial text as a failed attempt
+                  // rather than posting half a review as if it were complete.
+                  if (!sawDone && finishReason === 'unknown') {
+                    throw new Error('DeepSeek stream ended before completion');
+                  }
+
+                  return { reviewText: content.trim(), finishReason, usage };
+                } finally {
+                  if (stallTimer) clearTimeout(stallTimer);
+                  clearTimeout(overallTimer);
+                  // Release the socket when we bail out mid-stream, so a retry
+                  // doesn't open a second one while this response is still live.
+                  if (reader) {
+                    try { await reader.cancel(); } catch (_) { /* already closed */ }
+                  }
+                }
               }
-              const choice = data.choices && data.choices[0];
-              return {
-                reviewText: ((choice && choice.message && choice.message.content) || '').trim(),
-                finishReason: (choice && choice.finish_reason) || 'unknown',
-                usage: data.usage ? JSON.stringify(data.usage) : 'unknown'
-              };
+
+              // Retry both outright failures (a dropped connection, a 429, a 5xx)
+              // and empty content, which usually means the token budget was
+              // exhausted by reasoning or the model id is invalid/aliased.
+              let reviewText = '';
+              let finishReason = 'unknown';
+              let usage = 'unknown';
+              let lastError = null;
+
+              for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+                try {
+                  ({ reviewText, finishReason, usage } = await requestReview());
+                  lastError = null;
+                  if (reviewText) break;
+                  core.warning(
+                    `DeepSeek returned no content on attempt ${attempt}/${MAX_ATTEMPTS} `
+                    + `(model=${model}, finish_reason=${finishReason}, usage=${usage}).`
+                  );
+                } catch (err) {
+                  lastError = err;
+                  if (includeUsage && err.status === 400 && /stream_options/i.test(err.message)) {
+                    includeUsage = false;
+                    core.warning('DeepSeek rejected `stream_options`; retrying without usage reporting.');
+                  } else if (FATAL_STATUS.has(err.status)) {
+                    throw err;
+                  } else {
+                    core.warning(`DeepSeek request failed on attempt ${attempt}/${MAX_ATTEMPTS}: ${err.message}`);
+                  }
+                }
+                if (attempt < MAX_ATTEMPTS) {
+                  await sleep(RETRY_DELAY_MS[attempt - 1] || RETRY_DELAY_MS[RETRY_DELAY_MS.length - 1]);
+                }
+              }
+
+              // Every attempt threw: report the last failure rather than posting
+              // an empty-content diagnostic that misattributes the cause.
+              if (lastError) throw lastError;
+
+              await upsert(reviewText
+                ? reviewText
+                : `⚠️ The model returned no review content after ${MAX_ATTEMPTS} attempts `
+                  + `(model: \`${model}\`, finish_reason: \`${finishReason}\`, usage: \`${usage}\`). `
+                  + `This usually means the configured model id is invalid/aliased or the token budget was `
+                  + `exhausted before any visible output. Override via the \`DEEPSEEK_MODEL\` / `
+                  + `\`DEEPSEEK_MAX_TOKENS\` repo variables.`);
+
+              return { success: !!reviewText, reviewLength: reviewText.length, finishReason };
+            } catch (err) {
+              // Always surface failures on the PR; still fail the job.
+              try {
+                await upsert(`⚠️ Review failed: ${err.message}`);
+              } catch (e) {
+                core.warning(`Failed to post error comment: ${e.message}`);
+              }
+              core.setFailed(err.message);
             }
-
-            // Empty content usually means the token budget was exhausted by
-            // reasoning or the model id is invalid/aliased. Retry once before
-            // surfacing a diagnostic instead of posting a blank review.
-            let { reviewText, finishReason, usage } = await requestReview();
-            if (!reviewText) {
-              core.warning(
-                `DeepSeek returned no content (model=${model}, finish_reason=${finishReason}, usage=${usage}); retrying once.`
-              );
-              ({ reviewText, finishReason, usage } = await requestReview());
-            }
-
-            // Build comment body
-            const triggerInfo = context.eventName === 'pull_request'
-              ? 'Automatically triggered on PR update'
-              : 'Triggered by `@deepseek` comment';
-            const footer = `*${triggerInfo} • model: \`${model}\`*`;
-
-            const commentBody = reviewText
-              ? `## 🐋 DeepSeek Code Review\n\n${reviewText}\n\n---\n${footer}`
-              : `## 🐋 DeepSeek Code Review\n\n⚠️ The model returned no review content after a retry `
-                + `(model: \`${model}\`, finish_reason: \`${finishReason}\`, usage: \`${usage}\`). `
-                + `This usually means the configured model id is invalid/aliased or the token budget was `
-                + `exhausted before any visible output. Override via the \`DEEPSEEK_MODEL\` / `
-                + `\`DEEPSEEK_MAX_TOKENS\` repo variables.\n\n---\n${footer}`;
-
-            // Check for existing bot comment to update (sticky behavior)
-            const comments = await github.rest.issues.listComments({
-              owner, repo,
-              issue_number: prNumber,
-              per_page: 100
-            });
-
-            const existingComment = comments.data.find(c =>
-              c.body.includes('🐋 DeepSeek Code Review') &&
-              c.user.login === 'github-actions[bot]'
-            );
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner, repo,
-                comment_id: existingComment.id,
-                body: commentBody
-              });
-              console.log(`✅ Updated existing review comment #${existingComment.id}`);
-            } else {
-              await github.rest.issues.createComment({
-                owner, repo,
-                issue_number: prNumber,
-                body: commentBody
-              });
-              console.log('✅ Posted new review comment');
-            }
-
-            return { success: !!reviewText, reviewLength: reviewText.length, finishReason };

--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -38,9 +38,9 @@ jobs:
         && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
-    # Cap the whole job. Must exceed MAX_ATTEMPTS (3) full request timeouts
-    # (REQUEST_TIMEOUT_MS = 10 min each) plus the retry backoff and checkout
-    # overhead, so a slow attempt and its retries are never killed mid-run.
+    # Cap the whole job. Must exceed the review step's own TOTAL_BUDGET_MS
+    # (30 min, retries included) plus checkout and setup, so the step's budget
+    # is what stops a slow review and this is only the backstop behind it.
     timeout-minutes: 35
     permissions:
       contents: read
@@ -260,10 +260,18 @@ jobs:
               // leaves the socket idle until the answer is complete, and an idle
               // socket gets reaped in transit ("TypeError: terminated" /
               // "SocketError: other side closed").
-              const REQUEST_TIMEOUT_MS = 600000; // hard cap on one attempt
-              const STALL_TIMEOUT_MS = 120000;   // no bytes for this long = dead
+              // A healthy review of this repo's diffs legitimately runs long:
+              // the model call in successful run 33707326913 took 11m19s. So
+              // there is no per-attempt clock - a stream sending data is never
+              // interrupted for taking its time. The stall timer is what detects
+              // a dead connection, and one budget shared by every attempt bounds
+              // the step as a whole, inside the job's timeout-minutes.
+              const TOTAL_BUDGET_MS = 1800000;  // 30 min for the step, retries included
+              const STALL_TIMEOUT_MS = 120000;  // no bytes for this long = dead
+              const MIN_ATTEMPT_MS = 60000;     // too little budget left to bother retrying
               const MAX_ATTEMPTS = 3;
               const RETRY_DELAY_MS = [5000, 15000];
+              const deadline = Date.now() + TOTAL_BUDGET_MS;
 
               // A rejected key, an unknown model id or a malformed request fails
               // identically on every attempt, so those are not retried.
@@ -287,8 +295,8 @@ jobs:
                   );
                 };
                 const overallTimer = setTimeout(
-                  () => controller.abort(new Error(`DeepSeek request exceeded ${REQUEST_TIMEOUT_MS / 1000}s`)),
-                  REQUEST_TIMEOUT_MS
+                  () => controller.abort(new Error(`DeepSeek review exceeded its ${TOTAL_BUDGET_MS / 60000}-minute budget`)),
+                  Math.max(deadline - Date.now(), 1)
                 );
 
                 try {
@@ -435,7 +443,12 @@ jobs:
                   }
                 }
                 if (attempt < MAX_ATTEMPTS) {
-                  await sleep(RETRY_DELAY_MS[attempt - 1] || RETRY_DELAY_MS[RETRY_DELAY_MS.length - 1]);
+                  const delay = RETRY_DELAY_MS[attempt - 1] || RETRY_DELAY_MS[RETRY_DELAY_MS.length - 1];
+                  if (deadline - Date.now() < delay + MIN_ATTEMPT_MS) {
+                    core.warning('Too little of the time budget left for another attempt; stopping here.');
+                    break;
+                  }
+                  await sleep(delay);
                 }
               }
 

--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -155,18 +155,28 @@ jobs:
               }
             }
 
-            if (!process.env.DEEPSEEK_API_KEY) {
-              core.setFailed('DEEPSEEK_API_KEY is not set.');
-              return;
-            }
-
-            // The PR/diff fetch, the model call and the comment post can all
-            // hit the network; wrap them in one try so any failure is reported
+            // The key check, the PR/diff fetch, the model call and the comment
+            // post can all fail; wrap them in one try so any failure is reported
             // as a visible comment instead of crashing the job silently.
             try {
+              if (!process.env.DEEPSEEK_API_KEY) {
+                throw new Error('`DEEPSEEK_API_KEY` is not configured. Add it under Settings \u2192 Secrets and variables \u2192 Actions.');
+              }
+
               const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
               const title = pr.data.title;
               const body = pr.data.body || '';
+              // The commit the review is about. The diff below is whatever the
+              // PR holds right now, not the commit that triggered this run, so
+              // this is the only honest record of what was reviewed - and what
+              // the post-time staleness check compares against.
+              const reviewedSha = pr.data.head.sha;
+
+              // Truncate the diff if too large. deepseek-v4-pro has a large
+              // context window, so default high and allow overriding via a repo
+              // variable. Declared here because the files-API fallback below
+              // stops assembling once it has this much.
+              const MAX_DIFF = intFromEnv('DEEPSEEK_MAX_DIFF', 2000000);
 
               // The diff media type refuses PRs over 20000 diff lines with a
               // 406, so fall back to reassembling the diff from the files API,
@@ -187,16 +197,25 @@ jobs:
                   const files = await github.paginate(github.rest.pulls.listFiles, {
                     owner, repo, pull_number: prNumber, per_page: 100
                   });
-                  return files.map((f) => {
+                  // Assembled with a running cap rather than joined whole:
+                  // the PRs that land here are the huge ones, and everything
+                  // past MAX_DIFF is about to be cut anyway.
+                  const parts = [];
+                  let size = 0;
+                  for (const f of files) {
                     const from = f.previous_filename || f.filename;
                     const header = `diff --git a/${from} b/${f.filename}\n`
                       + `--- ${f.status === 'added' ? '/dev/null' : 'a/' + from}\n`
                       + `+++ ${f.status === 'removed' ? '/dev/null' : 'b/' + f.filename}`;
                     // Binary and very large files come back without a patch.
-                    return f.patch
+                    const part = f.patch
                       ? `${header}\n${f.patch}`
                       : `${header}\n(patch omitted: ${f.status}, +${f.additions}/-${f.deletions})`;
-                  }).join('\n');
+                    parts.push(part);
+                    size += part.length + 1;
+                    if (size > MAX_DIFF) break;
+                  }
+                  return parts.join('\n');
                 }
               }
 
@@ -206,9 +225,6 @@ jobs:
                 return 'No diff to review.';
               }
 
-              // Truncate diff if too large. deepseek-v4-pro has a large context
-              // window, so default high and allow overriding via repo variable.
-              const MAX_DIFF = intFromEnv('DEEPSEEK_MAX_DIFF', 2000000);
               const truncatedDiff = diffText.length > MAX_DIFF
                 ? diffText.substring(0, MAX_DIFF) + '\n\n... (diff truncated)'
                 : diffText;
@@ -421,8 +437,10 @@ jobs:
               let finishReason = 'unknown';
               let usage = 'unknown';
               let lastError = null;
+              let attemptsMade = 0;
 
               for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+                attemptsMade = attempt;
                 try {
                   ({ reviewText, finishReason, usage } = await requestReview());
                   lastError = null;
@@ -456,9 +474,24 @@ jobs:
               // an empty-content diagnostic that misattributes the cause.
               if (lastError) throw lastError;
 
+              // Splitting the concurrency groups let a comment-triggered review
+              // and a push-triggered one run at once, and posting deletes what
+              // came before - so the slower run could bury the newer review with
+              // one of an older diff. Actions offers no lock, so the ordering is
+              // enforced here: a run whose diff is no longer the PR's head has
+              // been overtaken, and neither posts nor deletes.
+              const { data: latest } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+              if (latest.head.sha !== reviewedSha) {
+                core.notice(
+                  `Reviewed ${reviewedSha.slice(0, 8)} but the PR now points at ${latest.head.sha.slice(0, 8)}; `
+                  + 'discarding this review so the newer run\'s stands.'
+                );
+                return { success: false, skipped: 'overtaken', reviewedSha };
+              }
+
               await upsert(reviewText
                 ? reviewText
-                : `⚠️ The model returned no review content after ${MAX_ATTEMPTS} attempts `
+                : `⚠️ The model returned no review content after ${attemptsMade} attempt${attemptsMade === 1 ? '' : 's'} `
                   + `(model: \`${model}\`, finish_reason: \`${finishReason}\`, usage: \`${usage}\`). `
                   + `This usually means the configured model id is invalid/aliased or the token budget was `
                   + `exhausted before any visible output. Override via the \`DEEPSEEK_MODEL\` / `

--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -116,6 +116,12 @@ jobs:
             // GitHub issue-comment bodies are capped at 65536 chars; stay under.
             const MAX_COMMENT = 65000;
 
+            // One review per PR, and always the newest one. A review describes
+            // one specific diff, so the run posts its own and then deletes every
+            // DeepSeek comment that came before it: a review of an older commit
+            // is stale, not history worth keeping beside the current one.
+            // Posting before deleting means a delete that fails leaves a
+            // duplicate rather than leaving the PR with no review at all.
             async function upsert(text) {
               let body = compose(text);
               if (body.length > MAX_COMMENT) {
@@ -126,16 +132,26 @@ jobs:
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: prNumber, per_page: 100
               });
-              const existing = comments.find(c =>
+              // Match the hidden marker, falling back to the visible header so
+              // comments posted before the marker existed are cleaned up too.
+              // Every match goes, not just the newest, so duplicates left by the
+              // unpaginated lookup this replaces are swept up on the next run.
+              const previous = comments.filter(c =>
                 c.user && c.user.login === 'github-actions[bot]' && c.body &&
                 (c.body.includes(MARKER) || c.body.includes(HEADER))
               );
-              if (existing) {
-                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-                core.info(`Updated existing review comment #${existing.id}`);
-              } else {
-                await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
-                core.info('Posted new review comment');
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              core.info(`Posted review comment; removing ${previous.length} earlier one(s).`);
+              for (const stale of previous) {
+                try {
+                  await github.rest.issues.deleteComment({ owner, repo, comment_id: stale.id });
+                  core.info(`Deleted previous review comment #${stale.id}`);
+                } catch (err) {
+                  // The current review is already up; a delete that cannot go
+                  // through (permissions, or the comment is already gone) is
+                  // worth a warning, not a failed run.
+                  core.warning(`Could not delete previous review comment #${stale.id}: ${err.message}`);
+                }
               }
             }
 

--- a/.github/workflows/repo--deepseek-review.yml
+++ b/.github/workflows/repo--deepseek-review.yml
@@ -7,7 +7,14 @@ on:
     types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Keyed by event, and for a comment by the comment itself. Every comment on a
+  # PR fires this workflow too, and keying both events on the PR number put the
+  # comment's run - skipped, because the comment says nothing about @deepseek -
+  # in the same group as the review of the push it commented on, which
+  # cancel-in-progress then killed. Five of the twenty-five runs before this
+  # change died that way, seconds in, leaving the previous review standing as if
+  # it were current. A push still cancels the review of the push before it.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.comment.id || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The DeepSeek reviewer had three independent ways to produce nothing, two of them without even a red check to show for it. This fixes all three, and changes the review from a comment edited forever in place to one comment that is always the current one.

Only `.github/workflows/repo--deepseek-review.yml` changes.

## What was broken

| # | Failure | Evidence | Visible as |
|---|---|---|---|
| 1 | The model call's socket was dropped and nothing caught it | [run 33704994714](https://github.com/taikoxyz/taiko-mono/actions/runs/33704994714/job/100492109512) | red check, no comment |
| 2 | A comment cancelled the review of the push it commented on | [run 33709399464](https://github.com/taikoxyz/taiko-mono/actions/runs/33709399464) killed [run 33709386346](https://github.com/taikoxyz/taiko-mono/actions/runs/33709386346) | **nothing at all** |
| 3 | A diff over 20000 lines is refused by the diff media type | [run 33639507852](https://github.com/taikoxyz/taiko-mono/actions/runs/33639507852) | red check, no comment |

**1 — the dropped socket.** The review asked for a whole completion in one non-streaming request. A review of this repo's diffs takes minutes — the model call in successful [run 33707326913](https://github.com/taikoxyz/taiko-mono/actions/runs/33707326913) took 11m19s — so the socket sat idle that whole time and was reaped in transit:

```
01:46:42  POST https://api.deepseek.com/v1/chat/completions
01:50:46  TypeError: terminated
          [cause]: SocketError: other side closed   code: 'UND_ERR_SOCKET'
          socket: { bytesWritten: 35929, bytesRead: 678 }
##[error]Unhandled error: TypeError: terminated
```

35 KB of prompt written, 678 bytes read back. The one retry the script had covered *empty content*, not a throw, so it never ran; and with no `try`/`catch` the job died unhandled. Nothing was wrong with #22115's code — the re-run eight minutes later passed.

**2 — the cancelled review.** The concurrency group keyed both triggering events on the PR number, with `cancel-in-progress: true`. Every comment on a PR fires this workflow; that run is *skipped* (the comment says nothing about `@deepseek`) but still enters the group and cancels the real review. **Five of the twenty-five runs before this change** died that way — including this PR's own first review, killed 13 seconds in by a Codex summary comment. A cancelled run posts nothing, so the previous review stays up looking current.

## What changed

**Transport**
- **Streams the completion** (`stream: true`, SSE parsed incrementally), so bytes keep moving while the model reasons. `reasoning_content` deltas hold the connection open; only `content` becomes the review.
- **Retries the whole request up to 3× with backoff** on a dropped connection, a 429 or a 5xx. A rejected key, unknown model id or malformed request fails on the first attempt instead of burning retries.
- **A stream that is sending data is never interrupted for taking its time.** There is no per-attempt clock: the stall timer — two minutes without a byte — distinguishes a dead connection from a slow one, and it is the condition that actually failed above. One 30-minute budget shared by every attempt bounds the step; a retry the remaining budget cannot pay for is not started. `timeout-minutes: 35` is the backstop behind it.
- A stream ending without `[DONE]` and without a finish reason is retried rather than posted as a complete review.

**Scheduling**
- The concurrency group carries the event, and for a comment the comment's own id: a comment can no longer cancel a push's review, and two `@deepseek` requests no longer cancel each other. A push still cancels the review of the push before it.

**Reporting**
- Everything is wrapped so a failure — including an unconfigured `DEEPSEEK_API_KEY` — reaches the PR as a comment instead of a silent red X, matching `repo--openrouter-review.yml`.
- A diff too large for the diff media type falls back to the per-file patches from the files API, assembled under the size cap, noting binary and oversized files rather than dropping them.

## One review, always the newest

The review used to be a single comment edited in place, so its position and timestamp belonged to the first run while its body belonged to the latest — an edit notifies nobody, and on a long thread the current review sits wherever the first one landed. A review describes one specific diff, so a review of an older commit is stale rather than history worth keeping.

Each run now posts its own comment and deletes the DeepSeek comments before it. Posting precedes deleting, so a delete that cannot go through leaves a duplicate rather than the PR with no review; a refused deletion warns instead of failing the run. Every match goes, so duplicates already accumulated are swept up. Only this workflow's own comments are ever touched — `github-actions[bot]` plus a hidden `<!-- deepseek-review -->` marker, with the old header as fallback so existing comments are claimed.

Because runs can now overlap, ordering is enforced where the race resolves: the commit the diff was read at is recorded, and a run whose commit is no longer the PR's head has been overtaken — it posts nothing and deletes nothing.

Two latent bugs in that lookup are fixed on the way:
- **No pagination.** `listComments` returned the *oldest* 100 comments, so past 100 the bot's own comment fell off page one and every run posted a duplicate. Now `github.paginate`.
- **`c.body.includes(...)` on a bodyless comment** threw and killed the job before anything was posted. Now guarded.

**The prompt, model, token budget and temperature are byte-identical** — verified by extracting both literals from the old and new YAML and comparing. Only transport, scheduling and error handling changed.

## Verified on this PR

[Run 33710202265](https://github.com/taikoxyz/taiko-mono/actions/runs/33710202265) ran the new workflow against this PR:

```
03:07:40  step starts
03:15:34  Posted review comment; removing 0 earlier one(s).
```

**7m54s of streaming, no retries, no `terminated`, job green, review posted** — where the code it replaces died after four minutes. ("removing 0" is correct: every earlier run on this PR failed or was cancelled, so there was nothing to replace.)

That review then found three real bugs in this branch, all fixed in `61d47ca`:
- a run overtaken by a newer push could bury the newer review under an older diff — now it discards its own;
- a missing `DEEPSEEK_API_KEY` reddened the check and said nothing on the PR — the exact failure class this PR exists to remove;
- the empty-content diagnostic claimed three attempts even when the budget stopped it after one.

The fourth warning — a failed run replacing the last good review — is intended, and was an explicit decision: a review belongs to one diff, so a stale review is worse than an honest failure notice.

## Testing

The script is extracted from the YAML and run against a fake `fetch` and a fake octokit, including an abort-honouring response body (as undici behaves) and a PR head that can move mid-run. **19 scenarios, 70 checks, all passing:**

| Scenario | Expected |
|---|---|
| Streamed review | content accumulated, reasoning excluded, comment posted |
| **Socket dropped mid-stream** (failure 1) | retried, partial text discarded, job green |
| Stream ends with no `[DONE]` | retried, partial not posted |
| Stream stalls | aborted, failure comment posted, job fails |
| **Slow but healthy stream** (the 11m19s case) | never interrupted; one attempt, whole review kept |
| Stream dribbles past the budget | stopped, no pointless retries |
| 401 / 429 | fails fast / retried then succeeds |
| Empty content | diagnostic reports the attempts actually made |
| **>20k-line diff → 406** (failure 3) | files-API fallback, patches reach the model |
| Previous review present | new comment posted, old deleted; a human's quote, an unrelated bot comment and a bodyless comment untouched |
| Several accumulated reviews | all removed, one posted |
| Deletion refused | review still stands, warning only, job green |
| **Run overtaken by a newer push** | posts nothing, deletes nothing |
| Missing API key | diagnostic on the PR, job fails |
| 70k-char review | truncated under GitHub's cap, footer intact |
| Non-SSE answer / `stream_options` rejected | degrades instead of failing |

`yaml.safe_load` parses the workflow, `node --check` passes on the script as `github-script` wraps it, and `prettier@3.2.5 --check` (the version in the pre-commit hook) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaLMagSVDZYF8veyytmBdd