### PR TITLE
fix(repo): repair the release-please lockfile jsonpaths

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -75,7 +75,7 @@
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"ejector\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"ejector\" && !@.source)].version"
         }
       ]
     },
@@ -111,42 +111,42 @@
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"taiko-client\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"taiko-client\" && !@.source)].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"bindings\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"bindings\" && !@.source)].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"driver\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"driver\" && !@.source)].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"whitelist-preconfirmation-driver\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"whitelist-preconfirmation-driver\" && !@.source)].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"proposer\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"proposer\" && !@.source)].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"protocol\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"protocol\" && !@.source)].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"rpc\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"rpc\" && !@.source)].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.value == \"test-harness\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"test-harness\" && !@.source)].version"
         }
       ]
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -75,7 +75,7 @@
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"ejector\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"ejector\")].version"
         }
       ]
     },
@@ -111,42 +111,42 @@
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"taiko-client\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"taiko-client\")].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"bindings\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"bindings\")].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"driver\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"driver\")].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"whitelist-preconfirmation-driver\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"whitelist-preconfirmation-driver\")].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"proposer\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"proposer\")].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"protocol\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"protocol\")].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"rpc\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"rpc\")].version"
         },
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == \"test-harness\")].version"
+          "jsonpath": "$.package[?(@.name.value == \"test-harness\")].version"
         }
       ]
     }


### PR DESCRIPTION
## Problem

The `Cargo.lock` entries under `extra-files` in `release-please-config.json` have never updated anything. release-please bumps the `Cargo.toml` files and leaves the lockfiles at the old version.

That is what blocks [#21975](https://github.com/taikoxyz/taiko-mono/pull/21975). Its `Lockfile` check runs `cargo fetch --locked` and fails:

```
error: cannot update the lock file .../packages/taiko-client-rs/Cargo.lock
       because --locked was passed to prevent this
```

The release bumps `[workspace.package] version` to `2.3.0` while `Cargo.lock` still records all eight workspace members at `2.2.0`, so cargo wants to rewrite the lock and `--locked` forbids it. `merge-gatekeeper` then fails as a consequence.

The `Lockfile` job is the only job in `taiko-client-rs--test.yml` without a `!startsWith(github.head_ref, 'release-please')` guard — deliberately, per c4786c2bc. `main` itself is green on it, so the version bump is the only delta.

## Root cause

release-please's `GenericToml` updater parses with a custom `@iarna/toml` parser that tags every scalar as `{start, end, value}` so it can splice the new version in by byte range. In that tree `@.name` is an object, not a string, so `?(@.name == "bindings")` is never true. The updater warns and returns the file untouched — from the run that produced the current tip of #21975:

```
⚠ No entries modified in $.package[?(@.name == "taiko-client")].version
⚠ No entries modified in $.package[?(@.name == "bindings")].version
...  (all eight, plus ejector's)
```

The plain jsonpaths in the same config (`$.workspace.package.version`, `$.package.version`) resolve straight to a tagged node, which is exactly why the manifests are bumped correctly while the lockfiles are not.

This has never worked. The 2.2.0 release only merged green because the lockfile was refreshed by hand on the release branch (`fix(taiko-client-rs): update release lockfile`, 2026-07-15). The v4 → v5 action bump in #21999 is unrelated — no force-push of that branch since 21 July has ever carried `Cargo.lock`.

`packages/ejector` had the same latent bug, silently shipping a stale lockfile since it has no lockfile CI job to catch it.

## Fix

Two commits:

1. **Compare against `@.name.value`** — makes the filters resolve at all.
2. **Restore the `&& !@.source` guard** from c4786c2bc, which #21790 dropped while trying to fix the bug that was really the missing `.value`. Now that the filters work, an unguarded one would also match a same-named registry or git dependency. `driver`, `protocol`, `rpc`, `bindings` and `proposer` are generic enough that this is a credible future collision, and the result would be a `Cargo.lock` whose version no longer matches its checksum.

## Verification

Ran release-please 17.11.2's real `GenericToml.updateContent()` with the jsonpaths read from this file:

- all twelve TOML `extra-files` resolve — the nine lockfile ones matched nothing before;
- `packages/taiko-client-rs/Cargo.lock` gets exactly the eight workspace version bumps and nothing else — byte-identical to the manual 2.2.0 fix;
- each filter matches exactly one entry in the real lockfiles, none of them carrying a `source`, and every source-less crate in both lockfiles is covered;
- on a synthetic lockfile holding a local `driver` alongside a registry `driver`, the unguarded predicate rewrites the registry entry from `0.4.1` to `2.3.0` while the guarded one leaves it alone and bumps only the workspace crate.

Once this merges, the release-please run on the push to `main` should regenerate #21975 with the lockfile included and clear its `Lockfile` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
