### PR TITLE
feat(supplementary-contracts): add Safe batch generator for SimpleTokenUnlock recipient changes

### DIFF
--- a/packages/supplementary-contracts/script/utils/safe_batch_change_recipient.json
+++ b/packages/supplementary-contracts/script/utils/safe_batch_change_recipient.json
@@ -1,0 +1,148 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1788514525263,
+  "meta": {
+    "name": "SimpleTokenUnlock: changeRecipient x7",
+    "description": "Sets recipient() to 0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D on 7 SimpleTokenUnlock contract(s) owned by Safe 0x9CBeE534B5D8a6280e01a14844Ee8aF350399C7F.",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9CBeE534B5D8a6280e01a14844Ee8aF350399C7F",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x5f351774e59b6b6c3d62a2cb831010b699b25bcfc80f829fa010fda08a536d82"
+  },
+  "transactions": [
+    {
+      "to": "0xa2910373DD7ac2431F85AD5133A939906d794b44",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_newRecipient",
+            "type": "address"
+          }
+        ],
+        "name": "changeRecipient",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_newRecipient": "0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D"
+      }
+    },
+    {
+      "to": "0x0090ffD878336257F60F43517bE2507b0673bbd4",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_newRecipient",
+            "type": "address"
+          }
+        ],
+        "name": "changeRecipient",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_newRecipient": "0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D"
+      }
+    },
+    {
+      "to": "0xb8bCb4F3f113039626b99Fe148cef1200DB88637",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_newRecipient",
+            "type": "address"
+          }
+        ],
+        "name": "changeRecipient",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_newRecipient": "0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D"
+      }
+    },
+    {
+      "to": "0x165ecf7265fC2539a7a28E19629A0f96Ce49C971",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_newRecipient",
+            "type": "address"
+          }
+        ],
+        "name": "changeRecipient",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_newRecipient": "0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D"
+      }
+    },
+    {
+      "to": "0xEdf73B266B1c9D6C14D6B23Db91B77ff2f244EdB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_newRecipient",
+            "type": "address"
+          }
+        ],
+        "name": "changeRecipient",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_newRecipient": "0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D"
+      }
+    },
+    {
+      "to": "0x19227fe0C6f38322411b5EfcceACb2CAC2e2017c",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_newRecipient",
+            "type": "address"
+          }
+        ],
+        "name": "changeRecipient",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_newRecipient": "0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D"
+      }
+    },
+    {
+      "to": "0x7e2c062f7D363C93920c9BDCe595B4358e4e01D0",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_newRecipient",
+            "type": "address"
+          }
+        ],
+        "name": "changeRecipient",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_newRecipient": "0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D"
+      }
+    }
+  ]
+}

--- a/packages/supplementary-contracts/script/utils/safe_batch_change_recipient.md
+++ b/packages/supplementary-contracts/script/utils/safe_batch_change_recipient.md
@@ -72,3 +72,30 @@ call fails, and `MultiSendCallOnly` reverts if any sub-call fails — a successf
 The `safeTxHash` above is bound to Safe nonce 146. If another transaction
 executes first, the nonce moves and the hash changes; the batch itself stays
 valid, but re-simulate before signing.
+
+## Simulating it yourself: it only works as a DELEGATECALL
+
+`changeRecipient` is `onlyRecipientOrOwner`, so `msg.sender` has to be the owning
+Safe itself. A Safe batch achieves that by **delegatecalling** MultiSend
+(`operation = 1`), which keeps the Safe's own address as `msg.sender` for each
+sub-call. Run the same batch as a plain **call** and `msg.sender` becomes the
+MultiSend contract — neither recipient nor owner — so all seven calls revert
+`PERMISSION_DENIED`, MultiSend reverts, and the Safe reverts `GS013`.
+
+Verified against mainnet state with a real 4-of-6 quorum:
+
+| Execution path | Result |
+| --- | --- |
+| `operation = 1` DELEGATECALL → MultiSendCallOnly | success |
+| `operation = 1` DELEGATECALL → MultiSend `0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526` | success |
+| `operation = 0` CALL → MultiSendCallOnly | `GS013` |
+| `operation = 0` CALL → MultiSend `0x3886…` | `GS013` |
+| Safe → MultiSend `0x3886…`, called directly | `MultiSend should only be called via delegatecall` |
+
+So a simulator reporting `GS013` or `PERMISSION_DENIED` on this batch is running
+it as a call, not a delegatecall — a false negative rather than a defect in the
+batch. `GS025`/`GS026` instead means the simulated sender is not recognised as an
+owner, and a failure whose `from` is not the owning Safe means the batch was
+loaded into the wrong Safe.
+
+The Safe has no transaction guard set, so nothing else can intercept the batch.

--- a/packages/supplementary-contracts/script/utils/safe_batch_change_recipient.md
+++ b/packages/supplementary-contracts/script/utils/safe_batch_change_recipient.md
@@ -1,0 +1,74 @@
+# SimpleTokenUnlock — batch `changeRecipient`
+
+Repoints the `recipient()` of seven `SimpleTokenUnlock` contracts on Ethereum
+mainnet to a single Safe. Import `safe_batch_change_recipient.json` into the
+Safe UI's **Transaction Builder** app (drag & drop), or regenerate it with
+`safe_batch_change_recipient.py`.
+
+## Ownership
+
+All seven proxies resolve to the same implementation and the same owner:
+
+| Field | Value |
+| --- | --- |
+| Implementation (EIP-1967) | [`0x1223C617fe9FBC111a23879D0C31eecd7443281a`](https://etherscan.io/address/0x1223C617fe9FBC111a23879D0C31eecd7443281a) (`SimpleTokenUnlock`) |
+| `owner()` | [`0x9CBeE534B5D8a6280e01a14844Ee8aF350399C7F`](https://etherscan.io/address/0x9CBeE534B5D8a6280e01a14844Ee8aF350399C7F) |
+| Owner type | Safe (`GnosisSafeProxy`, singleton `0x4167…461a`, `VERSION()` = `1.4.1`) |
+| Owner threshold | 4 of 6 |
+
+The new recipient [`0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D`](https://etherscan.io/address/0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D)
+is itself a Safe v1.4.1 (3 of 5) that shares four of its five owners with the
+owning Safe.
+
+## Transactions
+
+Each entry calls `changeRecipient(0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D)`
+with `value = 0`.
+
+| # | Unlock contract | `recipient()` before | TKO held |
+| --: | --- | --- | --: |
+| 1 | `0xa2910373DD7ac2431F85AD5133A939906d794b44` | `0xCd593600Edd72738aa285039D791B0dc9779e9e9` | 271,877 |
+| 2 | `0x0090ffD878336257F60F43517bE2507b0673bbd4` | `0xD202a56c5e7ba279431e43d945C5Cc6F68D083b7` | 405,517 |
+| 3 | `0xb8bCb4F3f113039626b99Fe148cef1200DB88637` | `0xaa0711d32942bd6a01B27722847f7c1D7F5928b5` | 1,200,000 |
+| 4 | `0x165ecf7265fC2539a7a28E19629A0f96Ce49C971` | `0x7bb998A98f60811dEa7Df9048134e14DC3a38F97` | 228,103 |
+| 5 | `0xEdf73B266B1c9D6C14D6B23Db91B77ff2f244EdB` | `0x7adfffe518369F4824f3eCcfB4754ee5BfF6c2a7` | 100,000 |
+| 6 | `0x19227fe0C6f38322411b5EfcceACb2CAC2e2017c` | `0xBADBE033362E66c13e17888e7C7fC88B5373afbF` | 200,000 |
+| 7 | `0x7e2c062f7D363C93920c9BDCe595B4358e4e01D0` | `0x9be64D1E195900AEBa4E2b900700090E62Ea26b9` | 265,517 |
+
+`amountGranted` equals the TKO balance for every contract; the total reassigned
+is 2,671,014 TKO. Nothing is withdrawable until the cliff at
+`GRANT_TIMESTAMP + 183 days` = 2026-11-30 00:00 UTC.
+
+## Why it does not revert
+
+`changeRecipient` is guarded by `onlyRecipientOrOwner` and `nonReentrant` only —
+there is no `whenNotPaused`, and all seven contracts are unpaused anyway. The
+two `require`s both hold: the new recipient is non-zero, and it differs from
+every current recipient.
+
+Because `changeRecipient` also calls `delegate(_newRecipient)` on the TKO token,
+the batch was simulated end to end rather than reasoned about statically.
+
+## Simulation
+
+Simulated against mainnet state with `eth_call` / `eth_simulateV1` state
+overrides, reproducing the exact `execTransaction` the Safe UI would build
+(`DELEGATECALL` into `MultiSendCallOnly` v1.4.1 `0x9641d764fc13c8B624c04430C7356C1C7C8102e2`),
+with a real 4-of-6 quorum supplied via `approvedHashes` overrides.
+
+| Check | Result |
+| --- | --- |
+| `domainSeparator()` recomputed vs on-chain | match |
+| `safeTxHash` vs on-chain `getTransactionHash(...)` | match (`0x836ea924…27ebd7`, nonce 146) |
+| `execTransaction` | success, returns `true` |
+| `recipient()` on all 7 after execution | `0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D` |
+| Control: same call from a non-owner | reverts |
+| Control: same batch with 3 of 4 signatures | reverts `GS025` |
+
+`safeTxGas` and `gasPrice` are both 0, so Safe reverts with `GS013` if any inner
+call fails, and `MultiSendCallOnly` reverts if any sub-call fails — a successful
+`execTransaction` therefore proves all seven calls succeeded.
+
+The `safeTxHash` above is bound to Safe nonce 146. If another transaction
+executes first, the nonce moves and the hash changes; the batch itself stays
+valid, but re-simulate before signing.

--- a/packages/supplementary-contracts/script/utils/safe_batch_change_recipient.py
+++ b/packages/supplementary-contracts/script/utils/safe_batch_change_recipient.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Generate a Safe{Wallet} Transaction Builder batch that repoints the
+`recipient()` of one or more `SimpleTokenUnlock` contracts.
+
+`SimpleTokenUnlock.changeRecipient(address)` is guarded by `onlyRecipientOrOwner`,
+so the batch must be executed by the Safe that owns the unlock contracts.
+
+The emitted JSON is the format the Safe UI's Transaction Builder app imports
+(drag & drop). The `meta.checksum` field is computed with the same algorithm the
+Transaction Builder uses, so the UI accepts the file without a mismatch warning.
+`pycryptodome` is required for the checksum; without it the file is still emitted
+(the Safe UI tolerates a missing checksum) but unsigned.
+
+Usage:
+    python3 safe_batch_change_recipient.py \
+        --safe 0xSafeThatOwnsTheUnlockContracts \
+        --new-recipient 0xNewRecipient \
+        --chain-id 1 \
+        --out batch.json \
+        0xUnlock1 0xUnlock2 ...
+"""
+
+import argparse
+import json
+import sys
+import time
+
+TX_BUILDER_VERSION = "1.18.0"
+
+CHANGE_RECIPIENT_METHOD = {
+    "inputs": [
+        {
+            "internalType": "address",
+            "name": "_newRecipient",
+            "type": "address",
+        }
+    ],
+    "name": "changeRecipient",
+    "payable": False,
+}
+
+
+def serialize_json_object(value):
+    """Port of the Transaction Builder's `serializeJSONObject`.
+
+    Key order and the trailing comma after every value are load-bearing: the
+    Safe UI hashes this exact string, so any deviation changes the checksum.
+    """
+    if isinstance(value, list):
+        return "[{}]".format(",".join(serialize_json_object(v) for v in value))
+    if isinstance(value, dict):
+        keys = sorted(value.keys())
+        acc = "{" + json.dumps(keys, separators=(",", ":"))
+        for key in keys:
+            acc += "{},".format(serialize_json_object(value[key]))
+        return acc + "}"
+    return json.dumps(value, separators=(",", ":"))
+
+
+def calculate_checksum(batch):
+    """keccak256 of the serialized batch, with `meta.name` nulled out.
+
+    Mirrors the UI, which computes the checksum before inserting it into `meta`.
+    """
+    try:
+        from Crypto.Hash import keccak
+    except ImportError:
+        print(
+            "warning: pycryptodome not installed, emitting batch without a checksum",
+            file=sys.stderr,
+        )
+        return None
+
+    stripped = dict(batch)
+    stripped["meta"] = dict(batch["meta"], name=None)
+    stripped["meta"].pop("checksum", None)
+
+    digest = keccak.new(digest_bits=256)
+    digest.update(serialize_json_object(stripped).encode())
+    return "0x" + digest.hexdigest()
+
+
+def build_batch(safe, new_recipient, unlock_contracts, chain_id, name, description):
+    batch = {
+        "version": "1.0",
+        "chainId": str(chain_id),
+        "createdAt": int(time.time() * 1000),
+        "meta": {
+            "name": name,
+            "description": description,
+            "txBuilderVersion": TX_BUILDER_VERSION,
+            "createdFromSafeAddress": safe,
+            "createdFromOwnerAddress": "",
+        },
+        "transactions": [
+            {
+                "to": contract,
+                "value": "0",
+                "data": None,
+                "contractMethod": CHANGE_RECIPIENT_METHOD,
+                "contractInputsValues": {"_newRecipient": new_recipient},
+            }
+            for contract in unlock_contracts
+        ],
+    }
+
+    checksum = calculate_checksum(batch)
+    if checksum is not None:
+        batch["meta"]["checksum"] = checksum
+    return batch
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("unlock_contracts", nargs="+", help="SimpleTokenUnlock addresses")
+    parser.add_argument("--safe", required=True, help="Safe that owns the unlock contracts")
+    parser.add_argument("--new-recipient", required=True, help="New recipient address")
+    parser.add_argument("--chain-id", default=1, type=int, help="Chain id (default: 1)")
+    parser.add_argument("--out", default="batch.json", help="Output path")
+    parser.add_argument("--name", default="SimpleTokenUnlock: changeRecipient")
+    parser.add_argument("--description", default=None)
+    args = parser.parse_args()
+
+    description = args.description or "Sets recipient() to {} on {} SimpleTokenUnlock contract(s) owned by Safe {}.".format(
+        args.new_recipient, len(args.unlock_contracts), args.safe
+    )
+
+    batch = build_batch(
+        args.safe,
+        args.new_recipient,
+        args.unlock_contracts,
+        args.chain_id,
+        args.name,
+        description,
+    )
+
+    with open(args.out, "w") as handle:
+        json.dump(batch, handle, indent=2)
+
+    print("wrote {} ({} transactions)".format(args.out, len(batch["transactions"])))
+    print("checksum: {}".format(batch["meta"].get("checksum", "<omitted>")))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds tooling to repoint the `recipient()` of `SimpleTokenUnlock` contracts via a Safe{Wallet} Transaction Builder batch, plus the generated batch for the seven mainnet unlock contracts owned by Safe `0x9CBeE534B5D8a6280e01a14844Ee8aF350399C7F`.

New files under `packages/supplementary-contracts/script/utils/`, next to the existing `safe_batch_transfer.py`:

- **`safe_batch_change_recipient.py`** — generator. Emits Transaction Builder JSON and computes `meta.checksum` with the same serialization the Safe UI uses, so the file imports without a mismatch warning. Falls back to omitting the checksum when `pycryptodome` is unavailable, matching the existing script's dependency-free posture.
- **`safe_batch_change_recipient.json`** — the generated batch: 7 × `changeRecipient(0xB73b0FC4C0Cfc73cF6e034Af6f6b42Ebe6c8b49D)`, chainId 1, `value = 0`.
- **`safe_batch_change_recipient.md`** — the on-chain findings and the simulation record behind the batch.

## Context

All seven proxies share one implementation (`0x1223C617fe9FBC111a23879D0C31eecd7443281a`, `SimpleTokenUnlock`) and one `owner()` — a Safe v1.4.1 with a 4-of-6 threshold. `changeRecipient` is guarded by `onlyRecipientOrOwner`, so the owning Safe can execute the batch. The new recipient is itself a Safe v1.4.1 (3-of-5) sharing four of five owners with the owner Safe.

Note that `SimpleTokenUnlock` is not present in this repository at `main`; the contract was read from the verified source of the deployed implementation.

## Verification

The batch was simulated against mainnet state with `eth_call` / `eth_simulateV1` state overrides, reproducing the exact `execTransaction` the Safe UI builds (`DELEGATECALL` into `MultiSendCallOnly` v1.4.1) with a real 4-of-6 quorum supplied via `approvedHashes` overrides:

- `domainSeparator()` recomputed locally matches on-chain.
- `safeTxHash` matches the Safe's own `getTransactionHash(...)`.
- `execTransaction` succeeds and returns `true`.
- `recipient()` on all seven contracts reads back as the new address afterwards.
- Controls: the same call from a non-owner reverts, and the same batch with 3 of 4 signatures reverts `GS025`.

Since `safeTxGas` and `gasPrice` are both 0, Safe reverts with `GS013` if any inner call fails and `MultiSendCallOnly` reverts if any sub-call fails, so a successful `execTransaction` proves all seven calls succeeded.

The committed generator was re-run and its output diffed against the simulated batch: transactions are identical, and its checksum validates against a port of the Safe UI's own JS implementation.

## Notes for reviewers

- The simulated `safeTxHash` is bound to Safe nonce 146. If another Safe transaction executes first the nonce moves and the hash changes; the batch stays valid but should be re-simulated before signing.
- This batch consolidates seven separate per-grantee unlock contracts (2,671,014 TKO total) onto a single recipient Safe. Nothing is withdrawable until the cliff on 2026-11-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g4iE8Zk9qotezSb8NVrKi

---
_Generated by [Claude Code](https://claude.ai/code/session_015g4iE8Zk9qotezSb8NVrKi)_